### PR TITLE
Adds expectations for smart_strip_tags in the breadcrumbs schema test.

### DIFF
--- a/tests/generators/schema/breadcrumb-test.php
+++ b/tests/generators/schema/breadcrumb-test.php
@@ -110,6 +110,18 @@ class Breadcrumb_Test extends TestCase {
 
 		$this->current_page->expects( 'is_paged' )->andReturnFalse();
 
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Home' )
+			->once()
+			->andReturnArg( 0 );
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Test post' )
+			->once()
+			->andReturnArg( 0 );
+
 		$actual = $this->instance->generate();
 
 		$expected = [
@@ -169,6 +181,12 @@ class Breadcrumb_Test extends TestCase {
 		$this->meta_tags_context->presentation->breadcrumbs = $breadcrumb_data;
 
 		$this->current_page->expects( 'is_paged' )->andReturnFalse();
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Home' )
+			->once()
+			->andReturnArg( 0 );
 
 		$actual = $this->instance->generate();
 
@@ -245,6 +263,24 @@ class Breadcrumb_Test extends TestCase {
 
 		$this->current_page->expects( 'is_paged' )->andReturnTrue();
 
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Home' )
+			->once()
+			->andReturnArg( 0 );
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Test post' )
+			->once()
+			->andReturnArg( 0 );
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Page title' )
+			->once()
+			->andReturnArg( 0 );
+
 		$expected = [
 			'@type'           => 'BreadcrumbList',
 			'@id'             => 'https://wordpress.example.com/canonical#breadcrumb',
@@ -316,6 +352,18 @@ class Breadcrumb_Test extends TestCase {
 
 		$this->current_page->expects( 'is_paged' )->andReturnFalse();
 
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Home' )
+			->once()
+			->andReturnArg( 0 );
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Test post' )
+			->once()
+			->andReturnArg( 0 );
+
 		$expected = [
 			'@type'           => 'BreadcrumbList',
 			'@id'             => 'https://wordpress.example.com/canonical#breadcrumb',
@@ -377,7 +425,8 @@ class Breadcrumb_Test extends TestCase {
 		$this->meta_tags_context->title                     = 'Page title';
 
 		$this->current_page->expects( 'is_paged' )->andReturnFalse();
-		$this->html->expects( 'smart_strip_tags' )->once()->with( 'Page title' )->andReturn( 'Page title' );
+		$this->html->expects( 'smart_strip_tags' )->once()->with( 'Home' )->andReturn( 'Home' );
+		$this->html->expects( 'smart_strip_tags' )->twice()->with( 'Page title' )->andReturn( 'Page title' );
 
 		$expected = [
 			'@type'           => 'BreadcrumbList',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the unit tests to pass.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds expectations for `smart_strip_tags`, on the `html_helper`, in the breadcrumbs schema unit tests.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `composer test`.
* Check that all the tests pass.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
