### PR TITLE
Set all variables in wpseo_frontend for the presenters

### DIFF
--- a/src/backwards-compatibility/frontend.php
+++ b/src/backwards-compatibility/frontend.php
@@ -12,6 +12,7 @@ use Yoast\WP\SEO\Presenters\Meta_Description_Presenter;
 use Yoast\WP\SEO\Presenters\Rel_Next_Presenter;
 use Yoast\WP\SEO\Presenters\Rel_Prev_Presenter;
 use Yoast\WP\SEO\Presenters\Robots_Presenter;
+use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 
 /**
  * Class WPSEO_Frontend
@@ -41,6 +42,13 @@ class WPSEO_Frontend implements Initializer_Interface {
 	private $replace_vars;
 
 	/**
+	 * The helpers surface.
+	 *
+	 * @var Helpers_Surface
+	 */
+	private $helpers;
+
+	/**
 	 * @inheritDoc
 	 */
 	public function initialize() {
@@ -58,14 +66,17 @@ class WPSEO_Frontend implements Initializer_Interface {
 	 * WPSEO_Breadcrumbs constructor.
 	 *
 	 * @param Meta_Tags_Context_Memoizer $context_memoizer The context memoizer.
-	 * @param \WPSEO_Replace_Vars        $replace_vars     The replace vars helper.
+	 * @param WPSEO_Replace_Vars         $replace_vars     The replace vars helper.
+	 * @param Helpers_Surface            $helpers          The helpers surface.
 	 */
 	public function __construct(
 		Meta_Tags_Context_Memoizer $context_memoizer,
-		WPSEO_Replace_Vars $replace_vars
+		WPSEO_Replace_Vars $replace_vars,
+		Helpers_Surface $helpers
 	) {
 		$this->context_memoizer = $context_memoizer;
 		$this->replace_vars     = $replace_vars;
+		$this->helpers          = $helpers;
 	}
 
 	/**
@@ -121,9 +132,11 @@ class WPSEO_Frontend implements Initializer_Interface {
 			return $context->presentation->canonical;
 		}
 
-		$canonical_presenter = new Canonical_Presenter();
-		$canonical_presenter->presentation = $context->presentation;
-		echo $canonical_presenter->present();
+		$presenter = new Canonical_Presenter();
+		$presenter->presentation = $context->presentation;
+		$presenter->helpers      = $this->helpers;
+		$presenter->replace_vars = $this->replace_vars;
+		echo $presenter->present();
 	}
 
 	/**
@@ -148,6 +161,8 @@ class WPSEO_Frontend implements Initializer_Interface {
 		$context   = $this->context_memoizer->for_current_page();
 		$presenter = new Robots_Presenter();
 		$presenter->presentation = $context->presentation;
+		$presenter->helpers      = $this->helpers;
+		$presenter->replace_vars = $this->replace_vars;
 		echo $presenter->present();
 	}
 
@@ -230,10 +245,14 @@ class WPSEO_Frontend implements Initializer_Interface {
 
 		$rel_prev_presenter = new Rel_Prev_Presenter();
 		$rel_prev_presenter->presentation = $context->presentation;
+		$rel_prev_presenter->helpers      = $this->helpers;
+		$rel_prev_presenter->replace_vars = $this->replace_vars;
 		echo $rel_prev_presenter->present();
 
 		$rel_next_presenter = new Rel_Next_Presenter();
 		$rel_next_presenter->presentation = $context->presentation;
+		$rel_next_presenter->helpers      = $this->helpers;
+		$rel_next_presenter->replace_vars = $this->replace_vars;
 		echo $rel_next_presenter->present();
 	}
 
@@ -255,6 +274,8 @@ class WPSEO_Frontend implements Initializer_Interface {
 
 		$presenter = new Meta_Description_Presenter();
 		$presenter->presentation = $context->presentation;
+		$presenter->helpers      = $this->helpers;
+		$presenter->replace_vars = $this->replace_vars;
 		$presenter->present();
 	}
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a fatal error when using the WPSEO_Frontend class to get the meta description.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Call `WPSEO_Frontend::get_instance()->metadesc()` in your `functions.php` file.
* It should not cause a fatal error.
* It should echo the meta description of the current page.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://wordpress.org/support/topic/14-0-1-fatal-error/
