### PR TITLE
Fix fatal for the woocommerce integration when called using old filters

### DIFF
--- a/src/integrations/third-party/woocommerce.php
+++ b/src/integrations/third-party/woocommerce.php
@@ -206,6 +206,13 @@ class WooCommerce implements Integration_Interface {
 		return \wc_get_page_id( 'shop' );
 	}
 
+	/**
+	 * Ensures a presentation is available.
+	 *
+	 * @param Indexable_Presentation $presentation The indexable presentation.
+	 *
+	 * @return Indexable_Presentation The presentation, taken from the current page if the input was invalid.
+	 */
 	protected function ensure_presentation( $presentation ) {
 		if ( \is_a( $presentation, Indexable_Presentation::class ) ) {
 			return $presentation;

--- a/src/integrations/third-party/woocommerce.php
+++ b/src/integrations/third-party/woocommerce.php
@@ -12,6 +12,7 @@ use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 
 /**
@@ -34,6 +35,13 @@ class WooCommerce implements Integration_Interface {
 	private $replace_vars;
 
 	/**
+	 * The memoizer for the meta tags context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	protected $context_memoizer;
+
+	/**
 	 * @inheritDoc
 	 */
 	public static function get_conditionals() {
@@ -43,12 +51,18 @@ class WooCommerce implements Integration_Interface {
 	/**
 	 * WooCommerce constructor.
 	 *
-	 * @param Options_Helper     $options      The options helper.
-	 * @param WPSEO_Replace_Vars $replace_vars The replace vars helper.
+	 * @param Options_Helper             $options          The options helper.
+	 * @param WPSEO_Replace_Vars         $replace_vars     The replace vars helper.
+	 * @param Meta_Tags_Context_Memoizer $context_memoizer The meta tags context memoizer.
 	 */
-	public function __construct( Options_Helper $options, WPSEO_Replace_Vars $replace_vars ) {
-		$this->options      = $options;
-		$this->replace_vars = $replace_vars;
+	public function __construct(
+		Options_Helper $options,
+		WPSEO_Replace_Vars $replace_vars,
+		Meta_Tags_Context_Memoizer $context_memoizer
+	) {
+		$this->options          = $options;
+		$this->replace_vars     = $replace_vars;
+		$this->context_memoizer = $context_memoizer;
 	}
 
 	/**
@@ -83,7 +97,9 @@ class WooCommerce implements Integration_Interface {
 	 *
 	 * @return string The title to use.
 	 */
-	public function title( $title, Indexable_Presentation $presentation ) {
+	public function title( $title, $presentation = null ) {
+		$presentation = $this->ensure_presentation( $presentation );
+
 		if ( $presentation->model->title ) {
 			return $title;
 		}
@@ -117,7 +133,9 @@ class WooCommerce implements Integration_Interface {
 	 *
 	 * @return string The description to use.
 	 */
-	public function description( $description, Indexable_Presentation $presentation ) {
+	public function description( $description, $presentation = null ) {
+		$presentation = $this->ensure_presentation( $presentation );
+
 		if ( $presentation->model->description ) {
 			return $description;
 		}
@@ -186,5 +204,14 @@ class WooCommerce implements Integration_Interface {
 		}
 
 		return \wc_get_page_id( 'shop' );
+	}
+
+	protected function ensure_presentation( $presentation ) {
+		if ( \is_a( $presentation, Indexable_Presentation::class ) ) {
+			return $presentation;
+		}
+
+		$context = $this->context_memoizer->for_current_page();
+		return $context->presentation;
 	}
 }

--- a/tests/integrations/third-party/woocommerce-test.php
+++ b/tests/integrations/third-party/woocommerce-test.php
@@ -14,6 +14,7 @@ use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Third_Party\WooCommerce;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
 use Yoast\WP\SEO\Tests\TestCase;
@@ -65,14 +66,22 @@ class WooCommerce_Test extends TestCase {
 	private $indexable;
 
 	/**
+	 * The memoizer for the meta tags context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	protected $context_memoizer;
+
+	/**
 	 * Sets an instance for test purposes.
 	 */
 	public function setUp() {
 		parent::setUp();
 
-		$this->options      = Mockery::mock( Options_Helper::class );
-		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
-		$this->instance     = Mockery::mock( WooCommerce::class, [ $this->options, $this->replace_vars ] )
+		$this->options          = Mockery::mock( Options_Helper::class );
+		$this->replace_vars     = Mockery::mock( WPSEO_Replace_Vars::class );
+		$this->context_memoizer = Mockery::mock( Meta_Tags_Context_Memoizer::class );
+		$this->instance         = Mockery::mock( WooCommerce::class, [ $this->options, $this->replace_vars, $this->context_memoizer ] )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a fatal error that could occur on WooCommerce installation when the `wpseo_metadesc` fitler was called with only 1 argument.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install WooCommerce.
* Add a call of `echo apply_filters( 'wpseo_metadesc', 'test' );` to your `functions.php`.
* While on the shop page that should output the meta description of your shop page.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://wordpress.org/support/topic/fatal-errors-issue-2/
