### PR TITLE
Fix double breadcrumb

### DIFF
--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -67,7 +67,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	public function generate( Meta_Tags_Context $context ) {
 		$static_ancestors = [];
 		$breadcrumbs_home = $this->options->get( 'breadcrumbs-home' );
-		if ( $breadcrumbs_home !== '' ) {
+		if ( $breadcrumbs_home !== '' && ! in_array( $this->current_page->get_page_type(), [ 'Home_Page', 'Static_Home_Page' ], true ) ) {
 			$front_page_id = $this->current_page->get_front_page_id();
 			if ( $front_page_id === 0 ) {
 				$static_ancestors[] = $this->repository->find_for_home_page();

--- a/tests/generators/breadcrumbs-generator-test.php
+++ b/tests/generators/breadcrumbs-generator-test.php
@@ -126,7 +126,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 				->with( $front_page_id, 'post' )
 				->andReturn( $this->indexable );
 		}
-		else {
+		else if ( $scenario !== 'on-home-page' ) {
 			$this->repository
 				->expects( 'find_for_home_page' )
 				->once()
@@ -155,15 +155,29 @@ class Breadcrumbs_Generator_Test extends TestCase {
 			->with( $this->indexable )
 			->andReturn( $this->get_ancestors() );
 
+		if ( $scenario !== 'on-home-page' ) {
+			$this->current_page
+				->expects( 'get_front_page_id' )
+				->once()
+				->andReturn( $front_page_id );
+		}
+
+		$page_type       = 'Post_Type';
+		$first_link_text = 'post-type';
+		if ( $scenario === 'on-home-page' ) {
+			$page_type       = 'Home_Page';
+			$first_link_text = 'home';
+		}
 		$this->current_page
-			->expects( 'get_front_page_id' )
+			->expects( 'get_page_type' )
 			->once()
-			->andReturn( $front_page_id );
+			->andReturn( $page_type );
+
 
 		$expected = [
 			[
 				'url'       => 'https://example.com/post-type',
-				'text'      => 'post-type',
+				'text'      => $first_link_text,
 				'ptarchive' => 'post',
 			],
 			[

--- a/tests/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/repositories/indexable-hierarchy-repository-test.php
@@ -9,8 +9,8 @@ namespace Yoast\WP\SEO\Tests\Repositories;
 
 use Brain\Monkey\Functions;
 use Mockery;
+use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder;
-use Yoast\WP\SEO\ORM\ORMWrapper;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
 use Yoast\WP\SEO\Tests\TestCase;
@@ -222,6 +222,6 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 		$query = $this->instance->query();
 
 		$this->assertAttributeEquals( '\Yoast\WP\SEO\Models\Indexable_Hierarchy', 'class_name', $query );
-		$this->assertInstanceOf( ORMWrapper::class, $query );
+		$this->assertInstanceOf( ORM::class, $query );
 	}
 }

--- a/tests/repositories/indexable-repository-test.php
+++ b/tests/repositories/indexable-repository-test.php
@@ -9,10 +9,10 @@ namespace Yoast\WP\SEO\Tests\Repositories;
 
 use Mockery;
 use Brain\Monkey;
+use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Loggers\Logger;
-use Yoast\WP\SEO\ORM\ORMWrapper;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
@@ -284,6 +284,6 @@ class Indexable_Repository_Test extends TestCase {
 		$query = $this->instance->query();
 
 		$this->assertAttributeEquals( '\Yoast\WP\SEO\Models\Indexable', 'class_name', $query );
-		$this->assertInstanceOf( ORMWrapper::class, $query );
+		$this->assertInstanceOf( ORM::class, $query );
 	}
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes the double breadcrumb on home pages.

## Relevant technical choices:

* Simple fix, check against page type, don't output on home page.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a basic site, add the breadcrumbs, go to the home page, see double breadcrumbs.
* Check out this pull, see the double breadcrumb is gone.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14961 
