### PR TITLE
Truncate tables on upgrade

### DIFF
--- a/migrations/20200429105310_TruncateIndexableTables.php
+++ b/migrations/20200429105310_TruncateIndexableTables.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package WPSEO\Migrations
+ */
+
+use Yoast\WP\Lib\Model;
+use YoastSEO_Vendor\Ruckusing_Migration_Base;
+
+/**
+ * TruncateIndexableTables
+ */
+class TruncateIndexableTables extends Ruckusing_Migration_Base {
+
+	/**
+	 * Migration up.
+	 */
+	public function up() {
+		$this->query( 'TRUNCATE TABLE ' . $this->get_indexable_table_name() );
+		$this->query( 'TRUNCATE TABLE ' . $this->get_indexable_hierarchy_table_name() );
+	}
+
+	/**
+	 * Migration down.
+	 */
+	public function down() {
+		// Nothing to do.
+	}
+
+	/**
+	 * Retrieves the table name to use for storing indexables.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_indexable_table_name() {
+		return Model::get_table_name( 'Indexable' );
+	}
+
+	/**
+	 * Retrieves the table name to use.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_indexable_hierarchy_table_name() {
+		return Model::get_table_name( 'Indexable_Hierarchy' );
+	}
+}

--- a/src/initializers/migration-runner.php
+++ b/src/initializers/migration-runner.php
@@ -8,10 +8,9 @@
 namespace Yoast\WP\SEO\Initializers;
 
 use Exception;
-use Yoast\WP\SEO\Config\Ruckusing_Framework;
-use Yoast\WP\SEO\Config\Migration_Status;
-use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\Lib\Model;
+use Yoast\WP\SEO\Config\Migration_Status;
+use Yoast\WP\SEO\Config\Ruckusing_Framework;
 
 /**
  * Triggers database migrations and handles results.
@@ -59,8 +58,6 @@ class Migration_Runner implements Initializer_Interface {
 	 * Runs this initializer.
 	 *
 	 * @throws \Exception When a migration errored.
-	 *
-	 * @return void
 	 */
 	public function initialize() {
 		$this->run_free_migrations();
@@ -72,8 +69,6 @@ class Migration_Runner implements Initializer_Interface {
 	 * Runs the free migrations.
 	 *
 	 * @throws \Exception When a migration errored.
-	 *
-	 * @return void
 	 */
 	public function run_free_migrations() {
 		$this->run_migrations( 'free', Model::get_table_name( 'migrations' ), \WPSEO_PATH . 'migrations' );

--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -21,7 +21,7 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 	 */
 	public function present() {
 		return \sprintf(
-			'<div id="yoast-indexation-warning" class="notice notice-success"><p>%1$s</p>%2$s<p>%3$s</p></div>',
+			'<div id="yoast-indexation-warning" class="notice notice-success"><p>%1$s<br/>%2$s</p>%3$s<p>%4$s</p></div>',
 			\sprintf(
 				/* translators: 1: Strong start tag, 2: Strong closing tag, 3: Yoast SEO. */
 				\esc_html__( '%1$sNEW:%2$s %3$s can now store your site’s SEO data in a smarter way!', 'wordpress-seo' ),
@@ -29,6 +29,7 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 				'</strong>',
 				'Yoast SEO'
 			),
+			\__( 'Don\'t worry: this won\'t have to be done after each update.', 'wordpress-seo' ),
 			\sprintf(
 				/* translators: 1: Button start tag to open the indexation modal, 2: Button closing tag. */
 				\esc_html__( '%1$sClick here to speed up your site now%2$s', 'wordpress-seo' ),

--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -29,7 +29,7 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 				'</strong>',
 				'Yoast SEO'
 			),
-			\__( 'Don\'t worry: this won\'t have to be done after each update.', 'wordpress-seo' ),
+			\esc_html__( 'Don\'t worry: this won\'t have to be done after each update.', 'wordpress-seo' ),
 			\sprintf(
 				/* translators: 1: Button start tag to open the indexation modal, 2: Button closing tag. */
 				\esc_html__( '%1$sClick here to speed up your site now%2$s', 'wordpress-seo' ),

--- a/tests/integrations/admin/indexation-integration-test.php
+++ b/tests/integrations/admin/indexation-integration-test.php
@@ -273,7 +273,8 @@ class Indexation_Integration_Test extends TestCase {
 			->andReturn( 'nonce' );
 
 		$expected  = '<div id="yoast-indexation-warning" class="notice notice-success"><p>';
-		$expected .= '<strong>NEW:</strong> Yoast SEO can now store your site’s SEO data in a smarter way!</p>';
+		$expected .= '<strong>NEW:</strong> Yoast SEO can now store your site’s SEO data in a smarter way!<br/>';
+		$expected .= 'Don\'t worry: this won\'t have to be done after each update.</p>';
 		$expected .= '<button type="button" class="button yoast-open-indexation" data-title="Yoast indexation status">Click here to speed up your site now</button>';
 		$expected .= '<p>Or <button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="nonce">hide this notice</button> ';
 		$expected .= '(everything will continue to function as normal).</p></div>';

--- a/tests/presenters/admin/indexation-warning-presenter-test.php
+++ b/tests/presenters/admin/indexation-warning-presenter-test.php
@@ -34,7 +34,8 @@ class Indexation_Warning_Presenter_Test extends TestCase {
 		$presenter = new Indexation_Warning_Presenter();
 
 		$expected  = '<div id="yoast-indexation-warning" class="notice notice-success"><p>';
-		$expected .= '<strong>NEW:</strong> Yoast SEO can now store your site’s SEO data in a smarter way!</p>';
+		$expected .= '<strong>NEW:</strong> Yoast SEO can now store your site’s SEO data in a smarter way!<br/>';
+		$expected .= 'Don\'t worry: this won\'t have to be done after each update.</p>';
 		$expected .= '<button type="button" class="button yoast-open-indexation" data-title="Yoast indexation status">Click here to speed up your site now</button>';
 		$expected .= '<p>Or <button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="123456789">hide this notice</button> ';
 		$expected .= '(everything will continue to function as normal).</p></div>';


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Truncate all indexable tables on upgrade.

## Relevant technical choices:

* The option wasn't removed as the version number will change when this is released which automatically invalidates the option.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Delete the `yoast_migrations_free` option ( only required if you've run 14.0.2 ) before.
* Your indexable tables should be reset ( both indexable and indexable_hierarchy ).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [1] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
