### PR TITLE
Fix the breadcrumbs and frontend classes fatalling if called before init

### DIFF
--- a/deprecated/frontend/breadcrumbs.php
+++ b/deprecated/frontend/breadcrumbs.php
@@ -5,8 +5,6 @@
  * @package Yoast\YoastSEO\Backwards_Compatibility
  */
 
-use Yoast\WP\SEO\Conditionals\No_Conditionals;
-use Yoast\WP\SEO\Initializers\Initializer_Interface;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
@@ -16,9 +14,7 @@ use Yoast\WP\SEO\Surfaces\Helpers_Surface;
  *
  * @codeCoverageIgnore Because of deprecation.
  */
-class WPSEO_Breadcrumbs implements Initializer_Interface {
-
-	use No_Conditionals;
+class WPSEO_Breadcrumbs {
 
 	/**
 	 * Instance of this class.
@@ -64,26 +60,11 @@ class WPSEO_Breadcrumbs implements Initializer_Interface {
 
 	/**
 	 * WPSEO_Breadcrumbs constructor.
-	 *
-	 * @param Meta_Tags_Context_Memoizer $context_memoizer The context memoizer.
-	 * @param Helpers_Surface            $helpers          The helpers surface.
-	 * @param WPSEO_Replace_Vars         $replace_vars     The replace vars helper.
 	 */
-	public function __construct(
-		Meta_Tags_Context_Memoizer $context_memoizer,
-		Helpers_Surface $helpers,
-		WPSEO_Replace_Vars $replace_vars
-	) {
-		$this->context_memoizer = $context_memoizer;
-		$this->helpers          = $helpers;
-		$this->replace_vars     = $replace_vars;
-	}
-
-	/**
-	 * We use an initializer so the static functions will work right as our plugin is loaded just as they normally would.
-	 */
-	public function initialize() {
-		self::$instance = $this;
+	public function __construct() {
+		$this->context_memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->helpers          = YoastSEO()->classes->get( Helpers_Surface::class );
+		$this->replace_vars     = YoastSEO()->classes->get( WPSEO_Replace_Vars::class );
 	}
 
 	/**
@@ -122,9 +103,13 @@ class WPSEO_Breadcrumbs implements Initializer_Interface {
 	/**
 	 * Retrieves an instance of the class.
 	 *
-	 * @return WPSEO_Breadcrumbs The instance.
+	 * @return static The instance.
 	 */
 	public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
 		return self::$instance;
 	}
 

--- a/deprecated/frontend/breadcrumbs.php
+++ b/deprecated/frontend/breadcrumbs.php
@@ -80,7 +80,7 @@ class WPSEO_Breadcrumbs {
 		// Remember the last used before/after for use in case the object goes __toString().
 		self::$before = $before;
 		self::$after  = $after;
-		$output       = $before . self::$instance->render() . $after;
+		$output       = $before . self::get_instance()->render() . $after;
 
 		if ( $display === true ) {
 			echo $output;

--- a/deprecated/frontend/frontend.php
+++ b/deprecated/frontend/frontend.php
@@ -5,7 +5,6 @@
  * @package Yoast\YoastSEO\Backwards_Compatibility
  */
 
-use Yoast\WP\SEO\Initializers\Initializer_Interface;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presenters\Canonical_Presenter;
 use Yoast\WP\SEO\Presenters\Meta_Description_Presenter;
@@ -19,7 +18,7 @@ use Yoast\WP\SEO\Surfaces\Helpers_Surface;
  *
  * @codeCoverageIgnore Because of deprecation.
  */
-class WPSEO_Frontend implements Initializer_Interface {
+class WPSEO_Frontend {
 	/**
 	 * Instance of this class.
 	 *
@@ -49,34 +48,12 @@ class WPSEO_Frontend implements Initializer_Interface {
 	private $helpers;
 
 	/**
-	 * @inheritDoc
+	 * WPSEO_Frontend constructor.
 	 */
-	public function initialize() {
-		self::$instance = $this;
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public static function get_conditionals() {
-		return [];
-	}
-
-	/**
-	 * WPSEO_Breadcrumbs constructor.
-	 *
-	 * @param Meta_Tags_Context_Memoizer $context_memoizer The context memoizer.
-	 * @param WPSEO_Replace_Vars         $replace_vars     The replace vars helper.
-	 * @param Helpers_Surface            $helpers          The helpers surface.
-	 */
-	public function __construct(
-		Meta_Tags_Context_Memoizer $context_memoizer,
-		WPSEO_Replace_Vars $replace_vars,
-		Helpers_Surface $helpers
-	) {
-		$this->context_memoizer = $context_memoizer;
-		$this->replace_vars     = $replace_vars;
-		$this->helpers          = $helpers;
+	public function __construct() {
+		$this->context_memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->replace_vars     = YoastSEO()->classes->get( WPSEO_Replace_Vars::class );
+		$this->helpers          = YoastSEO()->classes->get( Helpers_Surface::class );
 	}
 
 	/**
@@ -112,6 +89,10 @@ class WPSEO_Frontend implements Initializer_Interface {
 	 * @return static The instance.
 	 */
 	public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
 		return self::$instance;
 	}
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes fatals when calling `WPSEO_Frontend` or `WPSEO_Breadcrumbs` before the `init` action.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add the following code where it gets loaded before `init`.
```
add_action( 'init', 'bananarama' );
function bananarama() {
	WPSEO_Frontend::get_instance()->metadesc();
}
```

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
