### PR TITLE
Make sure removed migrations are still included empty to override them on servers.

### DIFF
--- a/migrations/20180515101200_WpYoastIndexableMeta.php
+++ b/migrations/20180515101200_WpYoastIndexableMeta.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package WPSEO\Migrations
+ */
+
+use YoastSEO_Vendor\Ruckusing_Migration_Base;
+
+/**
+ * Removed migration.
+ */
+class WpYoastIndexableMeta extends Ruckusing_Migration_Base {
+
+	/**
+	 * Migration up.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		// do nothing.
+	}
+
+	/**
+	 * Migration down.
+	 */
+	public function down() {
+		// do nothing.
+	}
+}

--- a/migrations/20190529075734_WpYoastExpandIndexable.php
+++ b/migrations/20190529075734_WpYoastExpandIndexable.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package WPSEO\Migrations
+ */
+
+use YoastSEO_Vendor\Ruckusing_Migration_Base;
+
+/**
+ * Removed migration.
+ */
+class WpYoastExpandIndexable extends Ruckusing_Migration_Base {
+
+	/**
+	 * Migration up.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		// do nothing.
+	}
+
+	/**
+	 * Migration down.
+	 */
+	public function down() {
+		// do nothing.
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
Alternative to #15009 
* Fixes a bug where running the migrations could cause fatal errors on sites where plugins are installed remotely. Some remote plugin installers don't remove files that are removed in an update. Since our migration runner goes through all migrations on the server, this could lead to fatal errors.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where running the migrations could cause fatal errors on sites where plugins are installed remotely. Some remote plugin installers don't remove files that are removed in an update. Since our migration runner goes through all migrations on the server, this could lead to fatal errors.

## Relevant technical choices:

* Never remove a migration again that was once in a release. Instead, empty the `up` and `down` so the migration simply does nothing.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install Yoast SEO 14.0.2
* Reset the indexables using Yoast test helper.
* Include [this file](https://github.com/Yoast/wordpress-seo/blob/9.2/migrations/20180515101200_WpYoastIndexableMeta.php) in your migrations directory.
* Get a fatal on the upgrade routine which triggers when you reload.
* Checkout this PR
* Reset the indexables using Yoast test helper.
* Confirm the file you previously copied is there again but the error is gone.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #