### PR TITLE
Make sure the wp_get_document_title function still gets called for BC

### DIFF
--- a/src/presenters/title-presenter.php
+++ b/src/presenters/title-presenter.php
@@ -34,6 +34,19 @@ class Title_Presenter extends Abstract_Indexable_Tag_Presenter {
 	 * @return string The raw value.
 	 */
 	public function get() {
+		// This ensures backwards compatibility with other plugins using this filter as well.
+		\add_filter( 'pre_get_document_title', [ $this, 'get_title' ], 15 );
+		$title = \wp_get_document_title();
+		\remove_filter( 'pre_get_document_title', [ $this, 'get_title' ] );
+		return $title;
+	}
+
+	/**
+	 * Returns the presentation title.
+	 *
+	 * @return string The title.
+	 */
+	public function get_title() {
 		$title = $this->replace_vars( $this->presentation->title );
 		/**
 		 * Filter: 'wpseo_title' - Allow changing the Yoast SEO generated title.

--- a/tests/presenters/title-presenter-test.php
+++ b/tests/presenters/title-presenter-test.php
@@ -73,6 +73,10 @@ class Title_Presenter_Test extends TestCase {
 			->andReturnUsing( function ( $string ) {
 				return $string;
 			} );
+
+		Monkey\Functions\expect( 'wp_get_document_title' )->andReturnUsing( function() {
+			return $this->instance->get_title();
+		} );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `pre_get_document_title` filter could be skipped when other plugins were using this filter as well.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add the following to your functions.php:
```
add_filter( 'pre_get_document_title', 'my_custom_title', 40 );
function my_custom_title( $title ) {
	return "THIS IS NOW THE TITLE ALWAYS!";
}
```
* Your title should change to the above.
* Change the priority from 40 to 10.
* Your title should revert to what it was.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14997
