### PR TITLE
Exclude line from phpcs because we are stubbing the suggested method

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -74,6 +74,7 @@ abstract class TestCase extends BaseTestCase {
 				},
 				'wp_strip_all_tags'   => function( $string, $remove_breaks = false ) {
 					$string = \preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $string );
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags -- We are stubbing the wp_strip_all_tags.
 					$string = \strip_tags( $string );
 
 					if ( $remove_breaks ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Ignores a CS rule applied within a stub. The suggested method was the method being stubbed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It excludes a specific CS rule.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* It just a comment, if travis is happy, we are happy.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
