### PR TITLE
Add previous version to options and clear indexable tables

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -109,6 +109,10 @@ class WPSEO_Upgrade {
 
 	/**
 	 * Runs the needed cleanup after an update, setting the DB version to latest version, flushing caches etc.
+	 *
+	 * @param string $previous_version The previous version.
+	 *
+	 * @return void
 	 */
 	protected function finish_up( $previous_version = null ) {
 		if ( $previous_version ) {

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -78,7 +78,7 @@ class WPSEO_Upgrade {
 		 */
 		do_action( 'wpseo_run_upgrade', $version );
 
-		$this->finish_up();
+		$this->finish_up( $version );
 	}
 
 	/**
@@ -110,7 +110,10 @@ class WPSEO_Upgrade {
 	/**
 	 * Runs the needed cleanup after an update, setting the DB version to latest version, flushing caches etc.
 	 */
-	protected function finish_up() {
+	protected function finish_up( $previous_version = null ) {
+		if ( $previous_version ) {
+			WPSEO_Options::set( 'previous_version', $previous_version );
+		}
 		WPSEO_Options::set( 'version', WPSEO_VERSION );
 
 		// Just flush rewrites, always, to at least make them work after an upgrade.

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -30,7 +30,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'ignore_indexation_warning'       => false,
 		// Non-form field, should only be set via validation routine.
 		'version'                         => '', // Leave default as empty to ensure activation/upgrade works.
-
+		'previous_version'                => '',
 		// Form fields.
 		'disableadvanced_meta'            => true,
 		'enable_headless_rest_endpoints'  => true,
@@ -229,6 +229,9 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			switch ( $key ) {
 				case 'version':
 					$clean[ $key ] = WPSEO_VERSION;
+					break;
+				case 'previous_version':
+					$clean[ $key ] = $dirty[ $key ];
 					break;
 
 				/* Verification strings. */

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -231,7 +231,9 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 					$clean[ $key ] = WPSEO_VERSION;
 					break;
 				case 'previous_version':
-					$clean[ $key ] = $dirty[ $key ];
+					if ( isset( $dirty[ $key ] ) ) {
+						$clean[ $key ] = $dirty[ $key ];
+					}
 					break;
 
 				/* Verification strings. */

--- a/integration-tests/doubles/class-upgrade-double.php
+++ b/integration-tests/doubles/class-upgrade-double.php
@@ -54,8 +54,12 @@ class WPSEO_Upgrade_Double extends WPSEO_Upgrade {
 
 	/**
 	 * Test double. Runs the needed cleanup after an update, setting the DB version to latest version, flushing caches etc.
+	 *
+	 * @param string $previous_version The previous version.
+	 *
+	 * @return void
 	 */
-	public function finish_up() {
-		parent::finish_up();
+	public function finish_up( $previous_version = null ) {
+		parent::finish_up( $previous_version );
 	}
 }

--- a/src/config/migrations/20200430150130_ClearIndexableTables.php
+++ b/src/config/migrations/20200430150130_ClearIndexableTables.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package WPSEO\Migrations
+ */
+
+use Yoast\WP\Lib\Model;
+use YoastSEO_Vendor\Ruckusing_Migration_Base;
+
+/**
+ * ClearIndexableTables
+ */
+class ClearIndexableTables extends Ruckusing_Migration_Base {
+
+	/**
+	 * Migration up.
+	 */
+	public function up() {
+		$this->query( 'TRUNCATE TABLE ' . $this->get_indexable_table_name() );
+		$this->query( 'TRUNCATE TABLE ' . $this->get_indexable_hierarchy_table_name() );
+	}
+
+	/**
+	 * Migration down.
+	 */
+	public function down() {
+		// Nothing to do.
+	}
+
+	/**
+	 * Retrieves the table name to use for storing indexables.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_indexable_table_name() {
+		return Model::get_table_name( 'Indexable' );
+	}
+
+	/**
+	 * Retrieves the table name to use.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_indexable_hierarchy_table_name() {
+		return Model::get_table_name( 'Indexable_Hierarchy' );
+	}
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Due to tags being set to be indexed even if the settings were set to not show tags in search results the indexation will have to be run again. We apologize for this.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Change the `WPSEO_VERSION`.
* You should have access to a `previous_version` from our options that shows the previous version the plugin was.
* Your indexable table should also be cleared.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
