### PR TITLE
Adds the wpseo_robots_array filter

### DIFF
--- a/src/helpers/robots-helper.php
+++ b/src/helpers/robots-helper.php
@@ -7,8 +7,6 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
-use Yoast\WP\SEO\Presentations\Indexable_Presentation;
-
 /**
  * Class Robots_Helper
  */

--- a/src/helpers/robots-helper.php
+++ b/src/helpers/robots-helper.php
@@ -13,7 +13,7 @@ namespace Yoast\WP\SEO\Helpers;
 class Robots_Helper {
 
 	/**
-	 * Sets the robots index to no index.
+	 * Sets the robots index to noindex.
 	 *
 	 * @param array $robots The current robots value.
 	 *

--- a/src/helpers/robots-helper.php
+++ b/src/helpers/robots-helper.php
@@ -17,28 +17,18 @@ class Robots_Helper {
 	/**
 	 * Sets the robots index to no index.
 	 *
-	 * @param string                 $robots       The current robots value.
-	 * @param Indexable_Presentation $presentation Presentation.
+	 * @param array $robots The current robots value.
 	 *
-	 * @return string The altered robots string.
+	 * @return array The altered robots string.
 	 */
-	public function set_robots_no_index( $robots, Indexable_Presentation $presentation ) {
-		// When robots is null just return the default but with noindex: `noindex, follow`.
-		if ( ! \is_string( $robots ) ) {
-			return 'noindex, follow';
-		}
-
-		// Already noindex.
-		if ( \strpos( $robots, 'noindex' ) !== false ) {
+	public function set_robots_no_index( $robots ) {
+		if ( ! \is_array( $robots ) ) {
+			_deprecated_argument( __METHOD__, '14.1', '$robots has to be a key-value paired array.' );
 			return $robots;
 		}
 
-		// Replace index with noindex.
-		if ( \strpos( $robots, 'index' ) !== false ) {
-			return \str_replace( 'index', 'noindex', $robots );
-		}
+		$robots['index'] = 'noindex';
 
-		// Add noindex.
-		return 'noindex, ' . $robots;
+		return $robots;
 	}
 }

--- a/src/integrations/front-end/comment-link-fixer.php
+++ b/src/integrations/front-end/comment-link-fixer.php
@@ -64,7 +64,7 @@ class Comment_Link_Fixer implements Integration_Interface {
 
 		// When users view a reply to a comment, this URL parameter is set. These should never be indexed separately.
 		if ( $this->has_replytocom_parameter() ) {
-			\add_filter( 'wpseo_robots', [ $this->robots, 'set_robots_no_index' ], 10, 2 );
+			\add_filter( 'wpseo_robots_array', [ $this->robots, 'set_robots_no_index' ] );
 		}
 	}
 

--- a/src/integrations/front-end/indexing-controls.php
+++ b/src/integrations/front-end/indexing-controls.php
@@ -50,7 +50,7 @@ class Indexing_Controls implements Integration_Interface {
 	public function register_hooks() {
 		// The option `blog_public` is set in Settings > Reading > Search Engine Visibility.
 		if ( (string) \get_option( 'blog_public' ) === '0' ) {
-			\add_filter( 'wpseo_robots', [ $this->robots, 'set_robots_no_index' ], 10, 2 );
+			\add_filter( 'wpseo_robots_array', [ $this->robots, 'set_robots_no_index' ] );
 		}
 
 		\add_action( 'template_redirect', [ $this, 'noindex_robots' ] );

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -269,14 +269,21 @@ class Indexable_Presentation extends Abstract_Presentation {
 				$robots_new[ $key ] = $value;
 			}
 
-			return \array_filter( $robots_new );
+			$robots = $robots_new;
 		}
 
 		if ( ! $robots_filtered ) {
 			return [];
 		}
 
-		return \array_filter( $robots );
+		/**
+		 * Filter: 'wpseo_robots_array' - Allows filtering of the meta robots output array of Yoast SEO.
+		 *
+		 * @api array $robots The meta robots directives to be used.
+		 *
+		 * @param Indexable_Presentation $presentation The presentation of an indexable.
+		 */
+		return \apply_filters( 'wpseo_robots_array', \array_filter( $robots ), $this );
 	}
 
 	/**

--- a/tests/helpers/robots-helper-test.php
+++ b/tests/helpers/robots-helper-test.php
@@ -2,8 +2,8 @@
 
 namespace Yoast\WP\SEO\Tests\Helpers;
 
+use Brain\Monkey;
 use Yoast\WP\SEO\Helpers\Robots_Helper;
-use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -16,6 +16,8 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Robots_Helper_Test extends TestCase {
 
 	/**
+	 * Represents the robots helper.
+	 *
 	 * @var Robots_Helper
 	 */
 	private $instance;
@@ -29,33 +31,24 @@ class Robots_Helper_Test extends TestCase {
 		$this->instance = new Robots_Helper();
 	}
 
+
 	/**
-	 * Tests setting 'index' to 'noindex' when 'index' is already set to 'noindex'.
+	 * Tests setting 'index' to 'noindex' when the array contains empty values.
 	 *
 	 * @covers ::set_robots_no_index
 	 */
-	public function test_set_robots_no_index_with_having_a_noindex_value() {
-		$presentation         = new Indexable_Presentation();
-		$presentation->robots = [ 'index' => 'noindex', 'follow' => 'follow' ];
-
+	public function test_set_robots_no_index() {
 		$this->assertEquals(
-			'noindex,follow',
-			$this->instance->set_robots_no_index( 'noindex,follow', $presentation )
-		);
-	}
-
-	/**
-	 * Tests setting 'index' to 'noindex' when 'index' is set to 'index'.
-	 *
-	 * @covers ::set_robots_no_index
-	 */
-	public function test_set_robots_no_index_when_already_set() {
-		$presentation         = new Indexable_Presentation();
-		$presentation->robots = [ 'index' => 'index', 'follow' => 'follow' ];
-
-		$this->assertEquals(
-			'noindex,follow',
-			$this->instance->set_robots_no_index( 'index,follow', $presentation )
+			[
+				'index'  => 'noindex',
+				'follow' => 'follow',
+			],
+			$this->instance->set_robots_no_index(
+				[
+					'index'  => 'index',
+					'follow' => 'follow',
+				]
+			)
 		);
 	}
 
@@ -64,18 +57,17 @@ class Robots_Helper_Test extends TestCase {
 	 *
 	 * @covers ::set_robots_no_index
 	 */
-	public function test_set_robots_no_index_with_empty_value() {
-		$presentation         = new Indexable_Presentation();
-		$presentation->robots = [
-			'index'  => 'index',
-			'follow' => 'follow',
-			0        => '',
-			1        => '',
-		];
+	public function test_set_robots_no_index_string_given() {
+		Monkey\Functions\expect( '_deprecated_argument' )
+			->with(
+				Robots_Helper::class . '::set_robots_no_index',
+				'14.1',
+				'$robots has to be a key-value paired array.'
+			);
 
 		$this->assertEquals(
 			'noindex,follow',
-			$this->instance->set_robots_no_index( 'index,follow', $presentation )
+			$this->instance->set_robots_no_index( 'noindex,follow' )
 		);
 	}
 }

--- a/tests/helpers/robots-helper-test.php
+++ b/tests/helpers/robots-helper-test.php
@@ -33,7 +33,7 @@ class Robots_Helper_Test extends TestCase {
 
 
 	/**
-	 * Tests setting 'index' to 'noindex' when the array contains empty values.
+	 * Tests setting 'index' to 'noindex' when 'index' is set to 'index'.
 	 *
 	 * @covers ::set_robots_no_index
 	 */
@@ -53,7 +53,7 @@ class Robots_Helper_Test extends TestCase {
 	}
 
 	/**
-	 * Tests setting 'index' to 'noindex' when the array contains empty values.
+	 * Tests setting 'index' to 'noindex' when a string is passed instead of an array.
 	 *
 	 * @covers ::set_robots_no_index
 	 */

--- a/tests/integrations/front-end/comment-link-fixer-test.php
+++ b/tests/integrations/front-end/comment-link-fixer-test.php
@@ -89,7 +89,7 @@ class Comment_Link_Fixer_Test extends TestCase {
 
 		$this->assertTrue( \has_filter( 'comment_reply_link', [ $this->instance, 'remove_reply_to_com' ] ) );
 		$this->assertTrue( \has_action( 'template_redirect', [ $this->instance, 'replytocom_redirect' ] ) );
-		$this->assertTrue( \has_filter( 'wpseo_robots', [ $this->robots, 'set_robots_no_index' ] ) );
+		$this->assertTrue( \has_filter( 'wpseo_robots_array', [ $this->robots, 'set_robots_no_index' ] ) );
 	}
 
 	/**

--- a/tests/presentations/indexable-presentation/robots-test.php
+++ b/tests/presentations/indexable-presentation/robots-test.php
@@ -80,8 +80,6 @@ class Robots_Test extends TestCase {
 		);
 	}
 
-
-
 	/**
 	 * Tests whether generate_robots calls the right functions of the robot helper with using the wpseo_robots_array filter.
 	 *

--- a/tests/presentations/indexable-presentation/robots-test.php
+++ b/tests/presentations/indexable-presentation/robots-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Presentation;
 
+use Brain\Monkey;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -28,6 +29,8 @@ class Robots_Test extends TestCase {
 	 * Tests whether generate_robots calls the right functions of the robot helper.
 	 *
 	 * @covers ::generate_robots
+	 * @covers ::get_base_robots
+	 * @covers ::filter_robots
 	 */
 	public function test_generate_robots() {
 		$actual   = $this->instance->generate_robots();
@@ -37,5 +40,75 @@ class Robots_Test extends TestCase {
 		];
 
 		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests whether generate_robots calls the right functions of the robot helper and the filter return false.
+	 *
+	 * @covers ::generate_robots
+	 * @covers ::get_base_robots
+	 * @covers ::filter_robots
+	 */
+	public function test_generate_robots_with_filter_return_false() {
+		Monkey\Filters\expectApplied( 'wpseo_robots' )
+			->once()
+			->with( 'index, follow', $this->instance )
+			->andReturn( false );
+
+		$this->assertEquals( [], $this->instance->generate_robots() );
+	}
+
+	/**
+	 * Tests whether generate_robots calls the right functions of the robot helper with having the filter returning duplicate types.
+	 *
+	 * @covers ::generate_robots
+	 * @covers ::get_base_robots
+	 * @covers ::filter_robots
+	 */
+	public function test_generate_robots_with_filter_returning_duplicates() {
+		Monkey\Filters\expectApplied( 'wpseo_robots' )
+			->once()
+			->with( 'index, follow', $this->instance )
+			->andReturn( 'index, noindex, follow' );
+
+		$this->assertEquals(
+			[
+				'index'  => 'noindex',
+				'follow' => 'follow',
+			],
+			$this->instance->generate_robots()
+		);
+	}
+
+
+
+	/**
+	 * Tests whether generate_robots calls the right functions of the robot helper with using the wpseo_robots_array filter.
+	 *
+	 * @covers ::generate_robots
+	 * @covers ::get_base_robots
+	 * @covers ::filter_robots
+	 */
+	public function test_generate_robots_with_array_filter() {
+		Monkey\Filters\expectApplied( 'wpseo_robots_array' )
+			->once()
+			->with( [
+					'index'  => 'index',
+					'follow' => 'follow',
+				], $this->instance )
+			->andReturn(
+				[
+					'index'  => 'noindex',
+					'follow' => 'nofollow',
+				]
+			);
+
+		$this->assertEquals(
+			[
+				'index'  => 'noindex',
+				'follow' => 'nofollow',
+			],
+			$this->instance->generate_robots()
+		);
 	}
 }

--- a/tests/presentations/indexable-presentation/robots-test.php
+++ b/tests/presentations/indexable-presentation/robots-test.php
@@ -43,7 +43,8 @@ class Robots_Test extends TestCase {
 	}
 
 	/**
-	 * Tests whether generate_robots calls the right functions of the robot helper and the filter return false.
+	 * Tests whether generate_robots calls the right functions of the robot helper,
+	 * using the wpseo_robots filter, with the filter returning false.
 	 *
 	 * @covers ::generate_robots
 	 * @covers ::get_base_robots
@@ -59,7 +60,8 @@ class Robots_Test extends TestCase {
 	}
 
 	/**
-	 * Tests whether generate_robots calls the right functions of the robot helper with having the filter returning duplicate types.
+	 * Tests whether generate_robots calls the right functions of the robot helper,
+	 * using the wpseo_robots filter, with the filter returning duplicate types.
 	 *
 	 * @covers ::generate_robots
 	 * @covers ::get_base_robots
@@ -81,7 +83,8 @@ class Robots_Test extends TestCase {
 	}
 
 	/**
-	 * Tests whether generate_robots calls the right functions of the robot helper with using the wpseo_robots_array filter.
+	 * Tests whether generate_robots calls the right functions of the robot helper,
+	 * using the wpseo_robots_array filter.
 	 *
 	 * @covers ::generate_robots
 	 * @covers ::get_base_robots


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We already have a filter for filtering the robots string. But we also wanted one for filtering the robots array.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces a new filter for altering the robots array used for the robots meta tag.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

For each step below you need a page that has set robots to index. 

### Test the filter
* You have to add the following piece of code to a file on your site (e.g. `functions.php` in your theme, `wp-seo.php`)
```php
add_filter( 'wpseo_robots_array', function( $robots ) {
    $robots['index'] = 'noindex';

   return $robots;
} );
```
* Visit the page and make sure robots has `noindex` in its value.  
* Remove the added code.

### Filter implementation: Search Engine Visibility
* Make your blog private under Settings -> Reading and then check `Search Engine Visibility`
* Visit the page and make sure robots has `noindex` in its value.  
* Make your blog public by unchecking the checkbox.

### Filter implementation: Reply to comment
* Add this piece of code somewhere:
```php
add_filter( 'wpseo_remove_reply_to_com', '__return_false' );
```
* Visit a page and add ?replytocom=1337 to the url
 * Visit the page and make sure robots has `noindex` in its value.  
* Remove the added code.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #15000
