### PR TITLE
Save inputs advanced tab

### DIFF
--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -13,7 +13,7 @@ import { Alert } from "@yoast/components";
  *
  * @returns {boolean} true if it is a post, false otherwise.
  */
-const isPost = () => window.wpseoAdminL10n.isPostType;
+const isPost = !! window.wpseoPostScraperL10n;
 
 /**
  * The values that are used for the noIndex field differ for posts and taxonomies. This function returns an array of
@@ -26,7 +26,7 @@ const getNoIndexOptions = () => {
 	const translatedYes = __( "Yes", "wordpress-seo" );
 	const noIndex = window.wpseoAdminL10n.noIndex ? translatedNo : translatedYes;
 
-	if ( isPost() ) {
+	if ( isPost ) {
 		return [
 			{
 				name: sprintf(
@@ -63,7 +63,7 @@ const getNoIndexOptions = () => {
  * @returns {Component} The Meta Robots No-Index component.
  */
 const MetaRobotsNoIndex = () => {
-	const hiddenInputId = isPost() ? "#yoast_wpseo_meta-robots-noindex" : "#wpseo_noindex";
+	const hiddenInputId = isPost ? "#yoast_wpseo_meta-robots-noindex" : "#wpseo_noindex";
 	const metaRobotsNoIndexOptions = getNoIndexOptions();
 	const value = getValueFromHiddenInput( hiddenInputId );
 	return <Fragment>
@@ -150,7 +150,7 @@ const MetaRobotsAdvanced = () => {
  * @returns {Component} The Breadcrumbs title component.
  */
 const BreadCrumbsTitle = () => {
-	const hiddenInputId = isPost() ? "#yoast_wpseo_bctitle" : "#hidden_wpseo_bctitle";
+	const hiddenInputId = isPost ? "#yoast_wpseo_bctitle" : "#hidden_wpseo_bctitle";
 	const value = getValueFromHiddenInput( hiddenInputId );
 
 	return <TextInput
@@ -170,7 +170,7 @@ const BreadCrumbsTitle = () => {
  * @returns {Component} The canonical URL component.
  */
 const CanonicalURL = () => {
-	const hiddenInputId = isPost() ? "#yoast_wpseo_canonical" : "#hidden_wpseo_canonical";
+	const hiddenInputId = isPost ? "#yoast_wpseo_canonical" : "#hidden_wpseo_canonical";
 	const value = getValueFromHiddenInput( hiddenInputId );
 
 	return <TextInput
@@ -198,8 +198,8 @@ class AdvancedSettings extends Component {
 		return (
 			<Collapsible id={ "collapsible-advanced-settings" } title={ __( "Advanced", "wordpress-seo" ) }>
 				<MetaRobotsNoIndex />
-				{ isPost() && <MetaRobotsNoFollow /> }
-				{ isPost() && <MetaRobotsAdvanced /> }
+				{ isPost && <MetaRobotsNoFollow /> }
+				{ isPost && <MetaRobotsAdvanced /> }
 				{
 					! window.wpseoAdminL10n.breadcrumbsDisabled && <BreadCrumbsTitle />
 				}

--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -150,7 +150,7 @@ const MetaRobotsAdvanced = () => {
  * @returns {Component} The Breadcrumbs title component.
  */
 const BreadCrumbsTitle = () => {
-	const hiddenInputId = isPost() ? "#yoast_wpseo_bctitle" : "#wpseo_bctitle";
+	const hiddenInputId = isPost() ? "#yoast_wpseo_bctitle" : "#hidden_wpseo_bctitle";
 	const value = getValueFromHiddenInput( hiddenInputId );
 
 	return <TextInput
@@ -170,7 +170,7 @@ const BreadCrumbsTitle = () => {
  * @returns {Component} The canonical URL component.
  */
 const CanonicalURL = () => {
-	const hiddenInputId = isPost() ? "#yoast_wpseo_canonical" : "#wpseo_canonical";
+	const hiddenInputId = isPost() ? "#yoast_wpseo_canonical" : "#hidden_wpseo_canonical";
 	const value = getValueFromHiddenInput( hiddenInputId );
 
 	return <TextInput

--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -9,9 +9,7 @@ import { Fragment } from "react";
 import { Alert } from "@yoast/components";
 
 /**
- * Function to check whether the current object refers to a post or a taxonomy.
- *
- * @returns {boolean} true if it is a post, false otherwise.
+ * Boolean that tells whether the current object refers to a post or a taxonomy.
  */
 const isPost = !! window.wpseoPostScraperL10n;
 

--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -63,7 +63,7 @@ const getNoIndexOptions = () => {
  * @returns {Component} The Meta Robots No-Index component.
  */
 const MetaRobotsNoIndex = () => {
-	const hiddenInputId = isPost ? "#yoast_wpseo_meta-robots-noindex" : "#wpseo_noindex";
+	const hiddenInputId = isPost ? "#yoast_wpseo_meta-robots-noindex" : "#hidden_wpseo_noindex";
 	const metaRobotsNoIndexOptions = getNoIndexOptions();
 	const value = getValueFromHiddenInput( hiddenInputId );
 	return <Fragment>

--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -71,7 +71,7 @@ const MetaRobotsNoIndex = () => {
 			window.wpseoAdminL10n.privateBlog &&
 			<Alert type="warning">
 				{ __(
-					"Even though you can set the meta robots setting here, the entire site is set to noindex in the sitewide privacy settings," +
+					"Even though you can set the meta robots setting here, the entire site is set to noindex in the sitewide privacy settings, " +
 					"so these settings won't have an effect.",
 					"wordpress-seo"
 				) }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix #15029 
* Missing space in alert message.
* Wrong id for selecting canonical hidden field and bread crumbs on taxonomies.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where data entered into the breadcrumbs title and canonical url fields (advanced settings) in the taxonomy metabox was not saved and loaded.

## Relevant technical choices:

* I could've either changed the queryselector id (the id "search value") or the id of the hidden field. As I was unsure, and everything was working when changing the queryselector id, I went with the former option.
* Changed the `isPost` from function to const, based on [this comment](https://github.com/Yoast/wordpress-seo/pull/14910#discussion_r417283522) on a PR in our feature branch. Basically, we can just check for presence of `wpseoPostScraperL10n`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* [Enable breadcrumbs](https://yoast.com/help/implement-wordpress-seo-breadcrumbs/#enable-and-configure-the-yoast-breadcrumbs)
* To see the noindex alert, do this:  Make sure that the Private blog warning is displayed if the site is private. This can be set in `Settings->Reading`
![image](https://user-images.githubusercontent.com/26220788/80802968-300f4200-8bb1-11ea-8da2-a1ab453a88c0.png)
* Go to a taxonomy (category/tag), enter a value in the breadcrumbs and canonical url (has to be a url) fields (advanced tab).
* Update. Reload page. Verify that everything is retained.
* Search on the frontend for your entered breadcrumbs title and canonical tag (cmd+f in elements inspector).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #15029 
