### PR TITLE
Fix having breadcrumbs of post types without an archive

### DIFF
--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -12,6 +12,7 @@ use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Generators\Generator_Interface;
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
@@ -38,23 +39,33 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 *
 	 * @var Current_Page_Helper
 	 */
-	private $current_page;
+	private $current_page_helper;
+
+	/**
+	 * The post type helper
+	 *
+	 * @var Post_Type_Helper
+	 */
+	private $post_type_helper;
 
 	/**
 	 * Breadcrumbs_Generator constructor.
 	 *
-	 * @param Indexable_Repository $repository   The repository.
-	 * @param Options_Helper       $options      The options helper.
-	 * @param Current_Page_Helper  $current_page The current page helper.
+	 * @param Indexable_Repository $repository          The repository.
+	 * @param Options_Helper       $options             The options helper.
+	 * @param Current_Page_Helper  $current_page_helper The current page helper.
+	 * @param Post_Type_Helper     $post_type_helper    The post type helper.
 	 */
 	public function __construct(
 		Indexable_Repository $repository,
 		Options_Helper $options,
-		Current_Page_Helper $current_page
+		Current_Page_Helper $current_page_helper,
+		Post_Type_Helper $post_type_helper
 	) {
-		$this->repository   = $repository;
-		$this->options      = $options;
-		$this->current_page = $current_page;
+		$this->repository          = $repository;
+		$this->options             = $options;
+		$this->current_page_helper = $current_page_helper;
+		$this->post_type_helper    = $post_type_helper;
 	}
 
 	/**
@@ -67,8 +78,8 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	public function generate( Meta_Tags_Context $context ) {
 		$static_ancestors = [];
 		$breadcrumbs_home = $this->options->get( 'breadcrumbs-home' );
-		if ( $breadcrumbs_home !== '' && ! in_array( $this->current_page->get_page_type(), [ 'Home_Page', 'Static_Home_Page' ], true ) ) {
-			$front_page_id = $this->current_page->get_front_page_id();
+		if ( $breadcrumbs_home !== '' && ! in_array( $this->current_page_helper->get_page_type(), [ 'Home_Page', 'Static_Home_Page' ], true ) ) {
+			$front_page_id = $this->current_page_helper->get_front_page_id();
 			if ( $front_page_id === 0 ) {
 				$static_ancestors[] = $this->repository->find_for_home_page();
 			}
@@ -90,12 +101,13 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			$context->indexable->object_type === 'post'
 			&& $context->indexable->object_sub_type !== 'post'
 			&& $context->indexable->object_sub_type !== 'page'
+			&& $this->post_type_helper->has_archive( $context->indexable->object_sub_type )
 		) {
 			$static_ancestors[] = $this->repository->find_for_post_type_archive( $context->indexable->object_sub_type );
 		}
 		if ( $context->indexable->object_type === 'term' ) {
 			$parent = $this->get_taxonomy_post_type_parent( $context->indexable->object_sub_type );
-			if ( $parent && $parent !== 'post' ) {
+			if ( $parent && $parent !== 'post' && $this->post_type_helper->has_archive( $parent ) ) {
 				$static_ancestors[] = $this->repository->find_for_post_type_archive( $parent );
 			}
 		}

--- a/tests/generators/breadcrumbs-generator-test.php
+++ b/tests/generators/breadcrumbs-generator-test.php
@@ -12,6 +12,7 @@ use Mockery;
 use Yoast\WP\SEO\Generators\Breadcrumbs_Generator;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
@@ -49,6 +50,13 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	private $current_page;
 
 	/**
+	 * The post type helper
+	 *
+	 * @var Post_Type_Helper
+	 */
+	private $post_type_helper;
+
+	/**
 	 * Represents the options helper.
 	 *
 	 * @var Mockery\MockInterface|Options_Helper
@@ -75,10 +83,11 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->repository   = Mockery::mock( Indexable_Repository::class );
-		$this->options      = Mockery::mock( Options_Helper::class );
-		$this->current_page = Mockery::mock( Current_Page_Helper::class );
-		$this->instance     = new Breadcrumbs_Generator( $this->repository, $this->options, $this->current_page );
+		$this->repository       = Mockery::mock( Indexable_Repository::class );
+		$this->options          = Mockery::mock( Options_Helper::class );
+		$this->current_page     = Mockery::mock( Current_Page_Helper::class );
+		$this->post_type_helper = Mockery::mock( Post_Type_Helper::class );
+		$this->instance         = new Breadcrumbs_Generator( $this->repository, $this->options, $this->current_page, $this->post_type_helper );
 
 		$this->indexable                   = Mockery::mock( Indexable::class );
 		$this->indexable->object_id        = 1;
@@ -142,6 +151,12 @@ class Breadcrumbs_Generator_Test extends TestCase {
 		}
 
 		if ( $scenario === 'show-custom-post-type' ) {
+			$this->post_type_helper
+				->expects( 'has_archive' )
+				->once()
+				->with( 'custom' )
+				->andReturnTrue();
+
 			$this->repository
 				->expects( 'find_for_post_type_archive' )
 				->once()


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes empty breadcrumbs when taxonomies where set to have a post type archive in their breadcrumb when that post type didn't have an archive.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Get a custom post type that has an archive and a taxonomy.
* Set that post type to be the parent of the taxonomy in your breadcrumbs settings.
* Set that post type to no longer have an archive.
* Clear all your indexables and indexable hierarchies.
* Visit a term of that taxonomy.
* There should not be an empty breadcrumb in the schema.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #15005
