### PR TITLE
Adapt text in help tab on (custom)post overview according to which columns are shown

### DIFF
--- a/admin/class-yoast-columns.php
+++ b/admin/class-yoast-columns.php
@@ -23,18 +23,18 @@ class WPSEO_Yoast_Columns implements WPSEO_WordPress_Integration {
 	public function add_help_tab() {
 		$link_columns_present = $this->display_links();
 		$meta_columns_present = $this->display_meta_columns();
+		if ( ! ( $link_columns_present || $meta_columns_present ) ){
+			return;
+		}
 
-		$meta_columns_help_text = '';
-		$link_columns_help_text = '';
-
-		$yoast_columns_intro = sprintf(
+		$help_tab_content = sprintf(
 			/* translators: %1$s: Yoast SEO */
 			__( '%1$s adds several columns to this page.', 'wordpress-seo' ),
 			'Yoast SEO'
 		);
 
 		if ( $meta_columns_present ) {
-			$meta_columns_help_text = sprintf(
+			$help_tab_content .= ' ' . sprintf(
 				/* translators: %1$s: Link to article about content analysis, %2$s: Anchor closing */
 				__( 'We\'ve written an article about %1$show to use the SEO score and Readability score%2$s.', 'wordpress-seo' ),
 				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/16p' ) . '">',
@@ -43,7 +43,7 @@ class WPSEO_Yoast_Columns implements WPSEO_WordPress_Integration {
 		}
 
 		if ( $link_columns_present ) {
-			$link_columns_help_text = sprintf(
+			$help_tab_content .= ' ' . sprintf(
 				/* translators: %1$s: Link to article about text links, %2$s: Anchor closing tag, %3$s: Emphasis open tag, %4$s: Emphasis close tag */
 				__( 'The links columns show the number of articles on this site linking %3$sto%4$s this article and the number of URLs linked %3$sfrom%4$s this article. Learn more about %1$show to use these features to improve your internal linking%2$s, which greatly enhances your SEO.', 'wordpress-seo' ),
 				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/16p' ) . '">',
@@ -53,18 +53,16 @@ class WPSEO_Yoast_Columns implements WPSEO_WordPress_Integration {
 			);
 		};
 
-		if ( $link_columns_present || $meta_columns_present ) {
-			$screen = get_current_screen();
-			$screen->add_help_tab(
-				[
-					/* translators: %s expands to Yoast */
-					'title'    => sprintf( __( '%s Columns', 'wordpress-seo' ), 'Yoast' ),
-					'id'       => 'yst-columns',
-					'content'  => '<p>' . $yoast_columns_intro . ' ' . $meta_columns_help_text . ' ' . $link_columns_help_text . '</p>',
-					'priority' => 15,
-				]
-			);
-		}
+		$screen = get_current_screen();
+		$screen->add_help_tab(
+			[
+				/* translators: %s expands to Yoast */
+				'title'    => sprintf( __( '%s Columns', 'wordpress-seo' ), 'Yoast' ),
+				'id'       => 'yst-columns',
+				'content'  => '<p>' . $help_tab_content . '</p>',
+				'priority' => 15,
+			]
+		);
 	}
 
 	/**

--- a/admin/class-yoast-columns.php
+++ b/admin/class-yoast-columns.php
@@ -24,28 +24,34 @@ class WPSEO_Yoast_Columns implements WPSEO_WordPress_Integration {
 		$link_columns_present = $this->display_links();
 		$meta_columns_present = $this->display_meta_columns();
 
+		$meta_columns_help_text = '';
+		$link_columns_help_text = '';
+
 		$yoast_columns_intro = sprintf(
 			/* translators: %1$s: Yoast SEO */
 			__( '%1$s adds several columns to this page.', 'wordpress-seo' ),
 			'Yoast SEO'
 		);
 
-		$meta_columns_help_text = $meta_columns_present ? sprintf(
-			/* translators: %1$s: Link to article about content analysis, %2$s: Anchor closing */
-			__( 'We\'ve written an article about %1$show to use the SEO score and Readability score%2$s.', 'wordpress-seo' ),
-			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/16p' ) . '">',
-			'</a>'
-		) : "";
+		if ( $meta_columns_present ) {
+			$meta_columns_help_text = sprintf(
+				/* translators: %1$s: Link to article about content analysis, %2$s: Anchor closing */
+				__( 'We\'ve written an article about %1$show to use the SEO score and Readability score%2$s.', 'wordpress-seo' ),
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/16p' ) . '">',
+				'</a>'
+			);
+		}
 
-		$link_columns_help_text = $link_columns_present ? sprintf(
-			/* translators: %1$s: Link to article about text links, %2$s: Anchor closing tag, %3$s: Emphasis open tag, %4$s: Emphasis close tag */
-			__( 'The links columns show the number of articles on this site linking %3$sto%4$s this article and the number of URLs linked %3$sfrom%4$s this article. Learn more about %1$show to use these features to improve your internal linking%2$s, which greatly enhances your SEO.', 'wordpress-seo' ),
-			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/16p' ) . '">',
-			'</a>',
-			'<em>',
-			'</em>'
-		) : "";
-
+		if ( $link_columns_present ) {
+			$link_columns_help_text = sprintf(
+				/* translators: %1$s: Link to article about text links, %2$s: Anchor closing tag, %3$s: Emphasis open tag, %4$s: Emphasis close tag */
+				__( 'The links columns show the number of articles on this site linking %3$sto%4$s this article and the number of URLs linked %3$sfrom%4$s this article. Learn more about %1$show to use these features to improve your internal linking%2$s, which greatly enhances your SEO.', 'wordpress-seo' ),
+				'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/16p' ) . '">',
+				'</a>',
+				'<em>',
+				'</em>'
+			);
+		};
 
 		if ( $link_columns_present || $meta_columns_present ) {
 			$screen = get_current_screen();
@@ -73,7 +79,7 @@ class WPSEO_Yoast_Columns implements WPSEO_WordPress_Integration {
 	/**
 	 * Whether or not we are showing link columns on this overview page.
 	 * This depends on the post being accessible or not.
-	 * 
+	 *
 	 * @return bool Whether or not the linking columns are shown
 	 */
 	private function display_links() {
@@ -82,7 +88,7 @@ class WPSEO_Yoast_Columns implements WPSEO_WordPress_Integration {
 		if ( empty( $current_post_type ) ) {
 			return false;
 		}
-		
+
 		return WPSEO_Post_Type::is_post_type_accessible( $current_post_type );
 	}
 

--- a/admin/class-yoast-columns.php
+++ b/admin/class-yoast-columns.php
@@ -23,7 +23,7 @@ class WPSEO_Yoast_Columns implements WPSEO_WordPress_Integration {
 	public function add_help_tab() {
 		$link_columns_present = $this->display_links();
 		$meta_columns_present = $this->display_meta_columns();
-		if ( ! ( $link_columns_present || $meta_columns_present ) ){
+		if ( ! ( $link_columns_present || $meta_columns_present ) ) {
 			return;
 		}
 

--- a/admin/class-yoast-columns.php
+++ b/admin/class-yoast-columns.php
@@ -21,23 +21,40 @@ class WPSEO_Yoast_Columns implements WPSEO_WordPress_Integration {
 	 * Adds the help tab to the help center for current screen.
 	 */
 	public function add_help_tab() {
-		if ( $this->display_metabox() ) {
+		$link_columns_present = $this->display_links();
+		$meta_columns_present = $this->display_meta_columns();
+
+		$yoast_columns_intro = sprintf(
+			/* translators: %1$s: Yoast SEO */
+			__( '%1$s adds several columns to this page.', 'wordpress-seo' ),
+			'Yoast SEO'
+		);
+
+		$meta_columns_help_text = $meta_columns_present ? sprintf(
+			/* translators: %1$s: Link to article about content analysis, %2$s: Anchor closing */
+			__( 'We\'ve written an article about %1$show to use the SEO score and Readability score%2$s.', 'wordpress-seo' ),
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/16p' ) . '">',
+			'</a>'
+		) : "";
+
+		$link_columns_help_text = $link_columns_present ? sprintf(
+			/* translators: %1$s: Link to article about text links, %2$s: Anchor closing tag, %3$s: Emphasis open tag, %4$s: Emphasis close tag */
+			__( 'The links columns show the number of articles on this site linking %3$sto%4$s this article and the number of URLs linked %3$sfrom%4$s this article. Learn more about %1$show to use these features to improve your internal linking%2$s, which greatly enhances your SEO.', 'wordpress-seo' ),
+			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/16p' ) . '">',
+			'</a>',
+			'<em>',
+			'</em>'
+		) : "";
+
+
+		if ( $link_columns_present || $meta_columns_present ) {
 			$screen = get_current_screen();
 			$screen->add_help_tab(
 				[
 					/* translators: %s expands to Yoast */
 					'title'    => sprintf( __( '%s Columns', 'wordpress-seo' ), 'Yoast' ),
 					'id'       => 'yst-columns',
-					'content'  => sprintf(
-						/* translators: %1$s: Yoast SEO, %2$s: Link to article about content analysis, %3$s: Anchor closing, %4$s: Link to article about text links, %5$s: Emphasis open tag, %6$s: Emphasis close tag */
-						'<p>' . __( '%1$s adds several columns to this page. We\'ve written an article about %2$show to use the SEO score and Readability score%3$s. The links columns show the number of articles on this site linking %5$sto%6$s this article and the number of URLs linked %5$sfrom%6$s this article. Learn more about %4$show to use these features to improve your internal linking%3$s, which greatly enhances your SEO.', 'wordpress-seo' ) . '</p>',
-						'Yoast SEO',
-						'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/16p' ) . '">',
-						'</a>',
-						'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/16q' ) . '">',
-						'<em>',
-						'</em>'
-					),
+					'content'  => '<p>' . $yoast_columns_intro . ' ' . $meta_columns_help_text . ' ' . $link_columns_help_text . '</p>',
 					'priority' => 15,
 				]
 			);
@@ -54,12 +71,28 @@ class WPSEO_Yoast_Columns implements WPSEO_WordPress_Integration {
 	}
 
 	/**
+	 * Whether or not we are showing link columns on this overview page.
+	 * This depends on the post being accessible or not.
+	 * 
+	 * @return bool Whether or not the linking columns are shown
+	 */
+	private function display_links() {
+		$current_post_type = sanitize_text_field( $this->get_current_post_type() );
+
+		if ( empty( $current_post_type ) ) {
+			return false;
+		}
+		
+		return WPSEO_Post_Type::is_post_type_accessible( $current_post_type );
+	}
+
+	/**
 	 * Wraps the WPSEO_Metabox check to determine whether the metabox should be displayed either by
 	 * choice of the admin or because the post type is not a public post type.
 	 *
 	 * @return bool Whether or not the meta box (and associated columns etc) should be hidden.
 	 */
-	private function display_metabox() {
+	private function display_meta_columns() {
 		$current_post_type = sanitize_text_field( $this->get_current_post_type() );
 
 		if ( empty( $current_post_type ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't show the help tab anymore based on whether our metabox is present (and post type is accessible ).
<img width="346" alt="table_no_help_link_tooltip" src="https://user-images.githubusercontent.com/26220788/80813951-4aeeb000-8bcb-11ea-8e77-d0e2f908a315.png">
<img width="1735" alt="table_no_help_links" src="https://user-images.githubusercontent.com/26220788/80813958-4c1fdd00-8bcb-11ea-9e6c-35b125ea41d2.png">
* #14118  introduced changes in this regard, but goes a bit too far in removing the help tab.


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where we didn't show a help tab about our internal linking columns, despite pointing to a help tab entry.

## Relevant technical choices:

* The presence of linking tabs and meta tabs seems independent of eachother.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Follow the test instructions here, **with the exception that the help tab *should* be visible if the metabox is disabled but posts are accessible:** #14118 

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
