### PR TITLE
Do not build private taxonomies

### DIFF
--- a/src/integrations/watchers/indexable-term-watcher.php
+++ b/src/integrations/watchers/indexable-term-watcher.php
@@ -102,6 +102,16 @@ class Indexable_Term_Watcher implements Integration_Interface {
 			return;
 		}
 
+		$term = \get_term( $term_id );
+
+		if ( $term === null || \is_wp_error( $term ) ) {
+			return;
+		}
+
+		if ( ! \is_taxonomy_viewable( $term->taxonomy ) ) {
+			return;
+		}
+
 		$indexable = $this->repository->find_by_id_and_type( $term_id, 'term', false );
 
 		// If we haven't found an existing indexable, create it. Otherwise update it.

--- a/tests/integrations/watchers/indexable-term-watcher-test.php
+++ b/tests/integrations/watchers/indexable-term-watcher-test.php
@@ -7,7 +7,7 @@
 
 namespace Yoast\WP\SEO\Tests\Integrations\Watchers;
 
-use Exception;
+use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
@@ -141,6 +141,23 @@ class Indexable_Term_Watcher_Test extends TestCase {
 			->expects( 'is_multisite_and_switched' )
 			->andReturnFalse();
 
+		$term = (object) [ 'taxonomy' => 'tag' ];
+
+		Monkey\Functions\expect( 'get_term' )
+			->once()
+			->with( 1 )
+			->andReturn( $term );
+
+		Monkey\Functions\expect( 'is_wp_error' )
+			->once()
+			->with( $term )
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'is_taxonomy_viewable' )
+			->once()
+			->with( $term->taxonomy )
+			->andReturnTrue();
+
 		$this->repository
 			->expects( 'find_by_id_and_type' )
 			->once()
@@ -152,6 +169,79 @@ class Indexable_Term_Watcher_Test extends TestCase {
 			->once()
 			->with( 1, 'term', $indexable )
 			->andReturn( $indexable );
+
+		$this->instance->build_indexable( 1 );
+	}
+
+	/**
+	 * Tests the build indexable function.
+	 *
+	 * @covers ::build_indexable
+	 */
+	public function test_build_indexable_with_null_term() {
+		$this->site
+			->expects( 'is_multisite_and_switched' )
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'get_term' )
+			->once()
+			->with( 1 )
+			->andReturnNull();
+
+		$this->instance->build_indexable( 1 );
+	}
+
+	/**
+	 * Tests the build indexable function.
+	 *
+	 * @covers ::build_indexable
+	 */
+	public function test_build_indexable_error_term() {
+		$this->site
+			->expects( 'is_multisite_and_switched' )
+			->andReturnFalse();
+
+		$term = 'WP_Error';
+
+		Monkey\Functions\expect( 'get_term' )
+			->once()
+			->with( 1 )
+			->andReturn( $term );
+
+		Monkey\Functions\expect( 'is_wp_error' )
+			->once()
+			->with( $term )
+			->andReturnTrue();
+
+		$this->instance->build_indexable( 1 );
+	}
+
+	/**
+	 * Tests the build indexable function.
+	 *
+	 * @covers ::build_indexable
+	 */
+	public function test_build_indexable_non_viewable_term() {
+		$this->site
+			->expects( 'is_multisite_and_switched' )
+			->andReturnFalse();
+
+		$term = (object) [ 'taxonomy' => 'tag' ];
+
+		Monkey\Functions\expect( 'get_term' )
+			->once()
+			->with( 1 )
+			->andReturn( $term );
+
+		Monkey\Functions\expect( 'is_wp_error' )
+			->once()
+			->with( $term )
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'is_taxonomy_viewable' )
+			->once()
+			->with( $term->taxonomy )
+			->andReturnFalse();
 
 		$this->instance->build_indexable( 1 );
 	}
@@ -185,6 +275,23 @@ class Indexable_Term_Watcher_Test extends TestCase {
 		$this->site
 			->expects( 'is_multisite_and_switched' )
 			->andReturnFalse();
+
+		$term = (object) [ 'taxonomy' => 'tag' ];
+
+		Monkey\Functions\expect( 'get_term' )
+			->once()
+			->with( 1 )
+			->andReturn( $term );
+
+		Monkey\Functions\expect( 'is_wp_error' )
+			->once()
+			->with( $term )
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'is_taxonomy_viewable' )
+			->once()
+			->with( $term->taxonomy )
+			->andReturnTrue();
 
 		$this->repository
 			->expects( 'find_by_id_and_type' )


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* No longer builds indexables for terms of taxonomies that aren't public.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Register a non-public taxonomy ( note as we're not giving it labels it will be called `tags`, it's the bottom one. Check your url to be sure, it will mention `private_taxonomy` in there ):
```
register_taxonomy( 'private_taxonomy', array( 'post' ), array(
	'public'   => false,
	'show_ui' => true,
) );
```
* Create a term of this taxnomy.
* Check your indexables table, there should be no matching record in there.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
