### PR TITLE
Indexation actions also check indexable existance before building

### DIFF
--- a/src/actions/indexation/indexable-general-indexation-action.php
+++ b/src/actions/indexation/indexable-general-indexation-action.php
@@ -23,21 +23,12 @@ class Indexable_General_Indexation_Action implements Indexation_Action_Interface
 	protected $indexable_repository;
 
 	/**
-	 * Represents the indexables builder.
-	 *
-	 * @var Indexable_Builder
-	 */
-	protected $indexable_builder;
-
-	/**
 	 * Indexable_General_Indexation_Action constructor.
 	 *
 	 * @param Indexable_Repository $indexable_repository The indexables repository.
-	 * @param Indexable_Builder    $indexable_builder    The indexables builder.
 	 */
-	public function __construct( Indexable_Repository $indexable_repository, Indexable_Builder $indexable_builder ) {
+	public function __construct( Indexable_Repository $indexable_repository ) {
 		$this->indexable_repository = $indexable_repository;
-		$this->indexable_builder    = $indexable_builder;
 	}
 
 	/**
@@ -57,18 +48,18 @@ class Indexable_General_Indexation_Action implements Indexation_Action_Interface
 		$indexables_to_create = $this->query();
 
 		if ( isset( $indexables_to_create['404'] ) ) {
-			$indexables[] = $this->indexable_builder->build_for_system_page( '404' );
+			$indexables[] = $this->indexable_repository->find_for_system_page( '404' );
 		}
 
 		if ( isset( $indexables_to_create['search'] ) ) {
-			$indexables[] = $this->indexable_builder->build_for_system_page( 'search-result' );
+			$indexables[] = $this->indexable_repository->find_for_system_page( 'search-result' );
 		}
 
 		if ( isset( $indexables_to_create['date_archive'] ) ) {
-			$indexables[] = $this->indexable_builder->build_for_date_archive();
+			$indexables[] = $this->indexable_repository->find_for_date_archive();
 		}
 		if ( isset( $indexables_to_create['home_page'] ) ) {
-			$indexables[] = $this->indexable_builder->build_for_home_page();
+			$indexables[] = $this->indexable_repository->find_for_home_page();
 		}
 
 		return $indexables;

--- a/src/actions/indexation/indexable-post-indexation-action.php
+++ b/src/actions/indexation/indexable-post-indexation-action.php
@@ -8,10 +8,10 @@
 namespace Yoast\WP\SEO\Actions\Indexation;
 
 use wpdb;
-use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\Lib\Model;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
  * Indexable_Post_Indexation_Action class.
@@ -26,11 +26,11 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 	protected $post_type_helper;
 
 	/**
-	 * The indexable builder.
+	 * The indexable repository.
 	 *
-	 * @var Indexable_Builder
+	 * @var Indexable_Repository
 	 */
-	protected $builder;
+	protected $repository;
 
 	/**
 	 * The WordPress database instance.
@@ -42,13 +42,13 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 	/**
 	 * Indexable_Post_Indexing_Action constructor
 	 *
-	 * @param Post_Type_Helper  $post_type_helper The post type helper.
-	 * @param Indexable_Builder $builder          The indexable builder.
-	 * @param wpdb              $wpdb             The WordPress database instance.
+	 * @param Post_Type_Helper     $post_type_helper The post type helper.
+	 * @param Indexable_Repository $repository          The indexable repository.
+	 * @param wpdb                 $wpdb             The WordPress database instance.
 	 */
-	public function __construct( Post_Type_Helper $post_type_helper, Indexable_Builder $builder, wpdb $wpdb ) {
+	public function __construct( Post_Type_Helper $post_type_helper, Indexable_Repository $repository, wpdb $wpdb ) {
 		$this->post_type_helper = $post_type_helper;
-		$this->builder          = $builder;
+		$this->repository       = $repository;
 		$this->wpdb             = $wpdb;
 	}
 
@@ -79,7 +79,7 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 
 		$indexables = [];
 		foreach ( $post_ids as $post_id ) {
-			$indexables[] = $this->builder->build_for_id_and_type( (int) $post_id, 'post' );
+			$indexables[] = $this->repository->find_by_id_and_type( (int) $post_id, 'post' );
 		}
 
 		return $indexables;

--- a/src/actions/indexation/indexable-term-indexation-action.php
+++ b/src/actions/indexation/indexable-term-indexation-action.php
@@ -8,10 +8,10 @@
 namespace Yoast\WP\SEO\Actions\Indexation;
 
 use wpdb;
-use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\Lib\Model;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
  * Indexable_Term_Indexation_Action class.
@@ -26,11 +26,11 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 	protected $taxonomy;
 
 	/**
-	 * The indexable builder.
+	 * The indexable repository.
 	 *
-	 * @var Indexable_Builder
+	 * @var Indexable_Repository
 	 */
-	protected $builder;
+	protected $repository;
 
 	/**
 	 * The WordPress database instance.
@@ -42,14 +42,14 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 	/**
 	 * Indexable_Term_Indexation_Action constructor
 	 *
-	 * @param Taxonomy_Helper   $taxonomy The taxonomy helper.
-	 * @param Indexable_Builder $builder  The indexable builder.
-	 * @param wpdb              $wpdb     The WordPress database instance.
+	 * @param Taxonomy_Helper      $taxonomy   The taxonomy helper.
+	 * @param Indexable_Repository $repository The indexable repository.
+	 * @param wpdb                 $wpdb       The WordPress database instance.
 	 */
-	public function __construct( Taxonomy_Helper $taxonomy, Indexable_Builder $builder, wpdb $wpdb ) {
-		$this->taxonomy = $taxonomy;
-		$this->builder  = $builder;
-		$this->wpdb     = $wpdb;
+	public function __construct( Taxonomy_Helper $taxonomy, Indexable_Repository $repository, wpdb $wpdb ) {
+		$this->taxonomy   = $taxonomy;
+		$this->repository = $repository;
+		$this->wpdb       = $wpdb;
 	}
 
 	/**
@@ -80,7 +80,7 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 
 		$indexables = [];
 		foreach ( $term_ids as $term_id ) {
-			$indexables[] = $this->builder->build_for_id_and_type( (int) $term_id, 'term' );
+			$indexables[] = $this->repository->find_by_id_and_type( (int) $term_id, 'term' );
 		}
 
 		return $indexables;

--- a/tests/actions/indexation/indexable-general-indexation-action-test.php
+++ b/tests/actions/indexation/indexable-general-indexation-action-test.php
@@ -5,8 +5,6 @@ namespace Yoast\WP\SEO\Tests\Actions\Indexation;
 use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_General_Indexation_Action;
-use Yoast\WP\SEO\Builders\Indexable_Builder;
-use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -35,21 +33,13 @@ class Indexable_General_Indexation_Action_Test extends TestCase {
 	protected $indexable_repository;
 
 	/**
-	 * Represents the indexable builder.
-	 *
-	 * @var Mockery\MockInterface|Indexable_Builder
-	 */
-	protected $indexable_builder;
-
-	/**
 	 * @inheritDoc
 	 */
 	public function setUp() {
 		parent::setUp();
 
 		$this->indexable_repository = Mockery::mock( Indexable_Repository::class );
-		$this->indexable_builder    = Mockery::mock( Indexable_Builder::class );
-		$this->instance             = new Indexable_General_Indexation_Action( $this->indexable_repository, $this->indexable_builder );
+		$this->instance             = new Indexable_General_Indexation_Action( $this->indexable_repository );
 	}
 
 	/**
@@ -85,22 +75,22 @@ class Indexable_General_Indexation_Action_Test extends TestCase {
 	public function test_index() {
 		$this->set_query();
 
-		$this->indexable_builder
-			->expects( 'build_for_system_page' )
+		$this->indexable_repository
+			->expects( 'find_for_system_page' )
 			->with( '404' )
 			->andReturn( '404' );
 
-		$this->indexable_builder
-			->expects( 'build_for_system_page' )
+		$this->indexable_repository
+			->expects( 'find_for_system_page' )
 			->with( 'search-result' )
 			->andReturn( 'search' );
 
-		$this->indexable_builder
-			->expects( 'build_for_date_archive' )
+		$this->indexable_repository
+			->expects( 'find_for_date_archive' )
 			->andReturn( 'date archive' );
 
-		$this->indexable_builder
-			->expects( 'build_for_home_page' )
+		$this->indexable_repository
+			->expects( 'find_for_home_page' )
 			->andReturn( 'home page' );
 
 		$this->assertEquals( [ '404', 'search', 'date archive', 'home page' ], $this->instance->index() );

--- a/tests/actions/indexation/indexable-post-indexation-action-test.php
+++ b/tests/actions/indexation/indexable-post-indexation-action-test.php
@@ -5,8 +5,8 @@ namespace Yoast\WP\SEO\Tests\Actions\Indexation;
 use Brain\Monkey\Filters;
 use Mockery;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
-use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -29,9 +29,9 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	/**
 	 * The builder mock.
 	 *
-	 * @var Indexable_Builder|Mockery\MockInterface
+	 * @var Indexable_Repository|Mockery\MockInterface
 	 */
-	protected $builder;
+	protected $repository;
 
 	/**
 	 * The wpdb mock.
@@ -55,13 +55,13 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$wpdb = (object) [ 'prefix' => 'wp_' ];
 
 		$this->post_type_helper = Mockery::mock( Post_Type_Helper::class );
-		$this->builder          = Mockery::mock( Indexable_Builder::class );
+		$this->repository          = Mockery::mock( Indexable_Repository::class );
 		$this->wpdb             = Mockery::mock( 'wpdb' );
 		$this->wpdb->posts      = 'wp_posts';
 
 		$this->instance = new Indexable_Post_Indexation_Action(
 			$this->post_type_helper,
-			$this->builder,
+			$this->repository,
 			$this->wpdb
 		);
 	}
@@ -128,9 +128,9 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$this->wpdb->expects( 'prepare' )->once()->with( $expected_query, [ 'public_post_type', 25 ] )->andReturn( 'query' );
 		$this->wpdb->expects( 'get_col' )->once()->with( 'query' )->andReturn( [ '1', '3', '8' ] );
 
-		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 1, 'post' );
-		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 3, 'post' );
-		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 8, 'post' );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 1, 'post' );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 3, 'post' );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'post' );
 
 		$this->instance->index();
 	}
@@ -148,9 +148,9 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$this->wpdb->expects( 'prepare' )->once()->andReturn( 'query' );
 		$this->wpdb->expects( 'get_col' )->once()->with( 'query' )->andReturn( [ '1', '3', '8' ] );
 
-		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 1, 'post' );
-		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 3, 'post' );
-		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 8, 'post' );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 1, 'post' );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 3, 'post' );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'post' );
 
 		$this->instance->index();
 	}

--- a/tests/actions/indexation/indexable-term-indexation-action-test.php
+++ b/tests/actions/indexation/indexable-term-indexation-action-test.php
@@ -5,8 +5,8 @@ namespace Yoast\WP\SEO\Tests\Actions\Indexation;
 use Mockery;
 use Brain\Monkey\Filters;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Term_Indexation_Action;
-use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -29,9 +29,9 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 	/**
 	 * The builder mock.
 	 *
-	 * @var Indexable_Builder|Mockery\MockInterface
+	 * @var Indexable_Repository|Mockery\MockInterface
 	 */
-	protected $builder;
+	protected $repository;
 
 	/**
 	 * The wpdb mock.
@@ -55,13 +55,13 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 		$wpdb = (object) [ 'prefix' => 'wp_' ];
 
 		$this->taxonomy            = Mockery::mock( Taxonomy_Helper::class );
-		$this->builder             = Mockery::mock( Indexable_Builder::class );
+		$this->repository          = Mockery::mock( Indexable_Repository::class );
 		$this->wpdb                = Mockery::mock( 'wpdb' );
 		$this->wpdb->term_taxonomy = 'wp_term_taxonomy';
 
 		$this->instance = new Indexable_Term_Indexation_Action(
 			$this->taxonomy,
-			$this->builder,
+			$this->repository,
 			$this->wpdb
 		);
 	}
@@ -131,9 +131,9 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 			->andReturn( 'query' );
 		$this->wpdb->expects( 'get_col' )->once()->with( 'query' )->andReturn( [ '1', '3', '8' ] );
 
-		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 1, 'term' );
-		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 3, 'term' );
-		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 8, 'term' );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 1, 'term' );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 3, 'term' );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'term' );
 
 		$this->instance->index();
 	}
@@ -151,9 +151,9 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 		$this->wpdb->expects( 'prepare' )->once()->andReturn( 'query' );
 		$this->wpdb->expects( 'get_col' )->once()->with( 'query' )->andReturn( [ '1', '3', '8' ] );
 
-		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 1, 'term' );
-		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 3, 'term' );
-		$this->builder->expects( 'build_for_id_and_type' )->once()->with( 8, 'term' );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 1, 'term' );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 3, 'term' );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'term' );
 
 		$this->instance->index();
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where double indexable entries could be build on indexation.

## Relevant technical choices:

* If an indexable was build during creating the hierarchy of another indexable it would be build again during it's own indexation pass. This would only happen if both were to be build in the same REST request. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run the indexation so everything is indexed.
* Have a post be the parent of another post with a lower ID.
* Delete the indexables from both posts.
* Run the indexation again.
* There should be no duplicate indexables.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended


Fixes #15060