### PR TITLE
Load integrations on init hook

### DIFF
--- a/src/loader.php
+++ b/src/loader.php
@@ -113,6 +113,9 @@ class Loader {
 		if ( ! did_action( 'init' ) ) {
 			add_action( 'init', [ $this, 'load_integrations' ] );
 		}
+		else {
+			$this->load_integrations();
+		}
 
 		\add_action( 'rest_api_init', [ $this, 'load_routes' ] );
 

--- a/src/loader.php
+++ b/src/loader.php
@@ -110,8 +110,8 @@ class Loader {
 	public function load() {
 		$this->load_initializers();
 
-		if ( ! did_action( 'init' ) ) {
-			add_action( 'init', [ $this, 'load_integrations' ] );
+		if ( ! \did_action( 'init' ) ) {
+			\add_action( 'init', [ $this, 'load_integrations' ] );
 		}
 		else {
 			$this->load_integrations();

--- a/src/loader.php
+++ b/src/loader.php
@@ -109,7 +109,10 @@ class Loader {
 	 */
 	public function load() {
 		$this->load_initializers();
-		$this->load_integrations();
+
+		if ( ! did_action( 'init' ) ) {
+			add_action( 'init', [ $this, 'load_integrations' ] );
+		}
 
 		\add_action( 'rest_api_init', [ $this, 'load_routes' ] );
 
@@ -151,7 +154,7 @@ class Loader {
 	 *
 	 * @return void
 	 */
-	protected function load_integrations() {
+	public function load_integrations() {
 		foreach ( $this->integrations as $class ) {
 			if ( ! $this->conditionals_are_met( $class ) ) {
 				continue;

--- a/tests/loader-test.php
+++ b/tests/loader-test.php
@@ -42,7 +42,7 @@ class Loader_Test extends TestCase {
 	}
 
 	/**
-	 * Tests loading initializers before integrations.
+	 * Tests load_initializers with load_integrations set as a hook.
 	 *
 	 * @covers ::load
 	 */

--- a/tests/loader-test.php
+++ b/tests/loader-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests;
 
+use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Conditionals\Conditional;
 use Yoast\WP\SEO\Initializers\Initializer_Interface;
@@ -30,9 +31,33 @@ class Loader_Test extends TestCase {
 		$loader_mock = Mockery::mock( Loader::class )->makePartial()
 			->shouldAllowMockingProtectedMethods();
 
+		Monkey\Functions\expect( 'did_action' )
+			->with( 'init' )
+			->andReturn( 1 );
+
 		$loader_mock->expects( 'load_initializers' )->once()->ordered();
 		$loader_mock->expects( 'load_integrations' )->once()->ordered();
 
+		$loader_mock->load();
+	}
+
+	/**
+	 * Tests loading initializers before integrations.
+	 *
+	 * @covers ::load
+	 */
+	public function test_loading_integrations_set_as_hook() {
+		$loader_mock = Mockery::mock( Loader::class )->makePartial()
+		                      ->shouldAllowMockingProtectedMethods();
+
+		Monkey\Functions\expect( 'did_action' )
+			->with( 'init' )
+			->andReturn( 0 );
+
+		Monkey\Actions\expectAdded( 'init' )
+			->with( [ $loader_mock, 'load_integrations' ] );
+
+		$loader_mock->expects( 'load_initializers' )->once()->ordered();
 		$loader_mock->load();
 	}
 
@@ -50,6 +75,10 @@ class Loader_Test extends TestCase {
 
 		$container_mock = Mockery::mock( ContainerInterface::class );
 		$container_mock->expects( 'get' )->once()->with( 'Unconditional_Integration' )->andReturn( $integration_mock );
+
+		Monkey\Functions\expect( 'did_action' )
+			->with( 'init' )
+			->andReturn( 1 );
 
 		$loader = new Loader( $container_mock );
 		$loader->register_integration( 'Unconditional_Integration' );
@@ -75,6 +104,10 @@ class Loader_Test extends TestCase {
 		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class' )->andReturn( $conditional_mock );
 		$container_mock->expects( 'get' )->once()->with( 'Met_Conditional_Integration' )->andReturn( $integration_mock );
 
+		Monkey\Functions\expect( 'did_action' )
+			->with( 'init' )
+			->andReturn( 1 );
+
 		$loader = new Loader( $container_mock );
 		$loader->register_integration( 'Met_Conditional_Integration' );
 		$loader->load();
@@ -98,6 +131,10 @@ class Loader_Test extends TestCase {
 		$container_mock = Mockery::mock( ContainerInterface::class );
 		$container_mock->expects( 'get' )->once()->with( 'Conditional_Class' )->andReturn( $conditional_mock );
 		$container_mock->expects( 'get' )->never()->with( 'Unmet_Conditional_Integration' );
+
+		Monkey\Functions\expect( 'did_action' )
+			->with( 'init' )
+			->andReturn( 1 );
 
 		$loader = new Loader( $container_mock );
 		$loader->register_integration( 'Unmet_Conditional_Integration' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Third parties may hook into our code base, but this might not work in some case because we executed too early.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the replytocom replacement can't be disabled by using the filter.

## Relevant technical choices:

* Decided (after discussing with @herregroen) to load the integrations on `init`. This was the hook we loaded at before. We hook the `src` codebase on `plugins_loaded`. By hooking the integrations into init we give themes the chance to hook into our codebase, because themes are load between `plugins_loaded` and `init`/ 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

1. Go to a post on the front end and add a comment.
2. Add a nested comment to your previous comment
3. Look the nested comment up in the source code and see that there is no mention of a ?replytocom= anywhere.
4. Add `add_filter( 'wpseo_remove_reply_to_com', '__return_false' );` to the functions.php of your theme (for example twenty twenty)
5. Checkout this branch and see it has been fixed.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #15064 ttps://github.com/Yoast/bugreports/issues/995
