### PR TITLE
Check previously used keywords against our indexable table

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -936,7 +936,7 @@ class WPSEO_Meta {
 	 * Counts the total of all the keywords being used for posts except the given one.
 	 *
 	 * @param string  $keyword The keyword to be counted.
-	 * @param integer $post_id The is of the post to which the keyword belongs.
+	 * @param integer $post_id The id of the post to which the keyword belongs.
 	 *
 	 * @return array
 	 */
@@ -947,6 +947,8 @@ class WPSEO_Meta {
 		}
 
 		/**
+		 * The indexable repository.
+		 *
 		 * @var Indexable_Repository
 		 */
 		$repository = YoastSEO()->classes->get( Indexable_Repository::class );
@@ -962,7 +964,12 @@ class WPSEO_Meta {
 			return (int) $row['object_id'];
 		}, $post_ids );
 
-		// If Yoast SEO Premium is active, get the additional keywords as well.
+		/*
+		 * If Yoast SEO Premium is active, get the additional keywords as well.
+		 * We only check for the additional keywords if we've not already found two.
+		 * In that case there's no use for an additional query as we already know
+		 * that the keyword has been used multiple times before.
+		 */
 		if ( WPSEO_Utils::is_yoast_seo_premium() && count( $post_ids ) < 2 ) {
 			$query = [
 				'meta_query'     => [
@@ -980,7 +987,7 @@ class WPSEO_Meta {
 				 * We only need to return zero, one or two results:
 				 * - Zero: keyword hasn't been used before
 				 * - One: Keyword has been used once before
-				 * - Two or more: Keyword has been used twice before
+				 * - Two or more: Keyword has been used twice or more before
 				 */
 				'posts_per_page' => 2,
 			];


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Optimizes the query used to check if a focus keyphrase has been previously used, by running it against our indexable table.

## Relevant technical choices:

* I chose not to add a new index on the `primary_focus_keyword` as this is the only query using it and the query should already be significantly faster not having to query all postmeta. Adding indexes also has a cost on database size so given our varied userbase I felt it best to not prematurely optimize.
* The query for premium related keyphrases is not optimized as these aren't yet stored in our indexables table.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

1. Merge this branch into premium to test it there as it interacts with the premium multiple focus keyphrases.
1. Have a set of 6 posts ready.
1. In the 1st post set the focus keyphrase to a term.
1. In the 2nd post set the focus keyphrase to that same term, you should see a warning under `SEO analysis` in the metabox that you've used it once before.
1. In the 3rd post set the focus keyphrase again to that same term, you should see a warning you've used it 2 times before. 
1. In the same post, add a related keyphrase that you haven't used before.
1. In the 4th post set the focus keyphrase to the related keyphrase from the previous step. You should see the same warning as in 4.
1. In the 5th post set the focus keyphrase to anything you haven't used before and add the same related keyphrase as before.
1. In the 6th post set the focus keyphrase to the related keyphrase from the previous steps. You should see the same warning as in 5.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #8297
