### PR TITLE
Add debug info details to the migration error

### DIFF
--- a/src/integrations/admin/migration-error-integration.php
+++ b/src/integrations/admin/migration-error-integration.php
@@ -57,6 +57,6 @@ class Migration_Error_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function render_migration_error() {
-		echo new Migration_Error_Presenter();
+		echo new Migration_Error_Presenter( $this->migration_status->get_error( 'free' ) );
 	}
 }

--- a/src/presenters/admin/migration-error-presenter.php
+++ b/src/presenters/admin/migration-error-presenter.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 
-use WPSEO_Paper_Presenter;
 use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
@@ -19,9 +18,10 @@ class Migration_Error_Presenter extends Abstract_Presenter {
 	/**
 	 * Holds the migration error.
 	 *
-	 * @param int|false $time    The timestamp.
-	 * @param string    $version The Yoast SEO version.
-	 * @param string    $message The error message.
+	 * The array holds the following values if filled:
+	 * - int|false $time    The timestamp.
+	 * - string    $version The Yoast SEO version.
+	 * - string    $message The error message.
 	 *
 	 * @var array
 	 */

--- a/src/presenters/admin/migration-error-presenter.php
+++ b/src/presenters/admin/migration-error-presenter.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 
+use WPSEO_Paper_Presenter;
 use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
@@ -16,30 +17,53 @@ use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 class Migration_Error_Presenter extends Abstract_Presenter {
 
 	/**
-	 * Presents the warning that your site's content is not fully indexed.
+	 * Holds the migration error.
 	 *
-	 * @return string The warning HTML.
+	 * @param int|false $time    The timestamp.
+	 * @param string    $version The Yoast SEO version.
+	 * @param string    $message The error message.
+	 *
+	 * @var array
+	 */
+	protected $migration_error;
+
+	/**
+	 * Migration_Error_Presenter constructor.
+	 *
+	 * @param array $migration_error The migration error.
+	 */
+	public function __construct( $migration_error ) {
+		$this->migration_error = $migration_error;
+	}
+
+	/**
+	 * Presents the migration error that occurred.
+	 *
+	 * @return string The error HTML.
 	 */
 	public function present() {
-		$message = \sprintf(
+		$message    = \sprintf(
 			/* translators: %s: Yoast SEO. */
 			\esc_html__( '%s was unable to create the database tables required and as such will not function correctly.', 'wordpress-seo' ),
 			'Yoast SEO'
 		);
-		$support = \sprintf(
+		$support    = \sprintf(
 			/* translators: %1$s: link to help article about solving table issue. %2$s: is anchor closing. */
 			esc_html__( 'Please read %1$sthis help article%2$s to find out how to resolve this problem.', 'wordpress-seo' ),
 			'<a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/3-6' ) . '">',
 			'</a>'
 		);
+		$debug_info = \sprintf(
+			'<details><summary>%1$s</summary><p>%2$s</p></details>',
+			\esc_html__( 'Show debug information', 'wordpress-seo' ),
+			\esc_html( $this->migration_error['message'] )
+		);
 
 		return \sprintf(
-			'<div class="notice notice-error">' .
-				'<p>%1$s</p>' .
-				'<p>%2$s</p>' .
-			'</div>',
+			'<div class="notice notice-error"><p>%1$s</p><p>%2$s</p>%3$s</div>',
 			$message,
-			$support
+			$support,
+			$debug_info
 		);
 	}
 }

--- a/tests/integrations/admin/migration-error-integration-test.php
+++ b/tests/integrations/admin/migration-error-integration-test.php
@@ -104,17 +104,22 @@ class Migration_Error_Integration_Test extends TestCase {
 	 * @covers ::render_migration_error
 	 */
 	public function test_render_migration_error() {
+		$this->migration_status->expects( 'get_error' )
+			->once()
+			->with( 'free' )
+			->andReturn( [ 'message' => 'test error' ] );
+
 		Monkey\Functions\expect( 'add_query_arg' )
 			->andReturn( 'https://yoa.st/3-6' );
 
 		$expected  = '<div class="notice notice-error">';
 		$expected .= '<p>Yoast SEO was unable to create the database tables required and as such will not function correctly.</p>';
 		$expected .= '<p>Please read <a href="' . \WPSEO_Shortlinker::get( 'https://yoa.st/3-6' ) . '">this help article</a> to find out how to resolve this problem.</p>';
+		$expected .= '<details><summary>Show debug information</summary><p>test error</p></details>';
 		$expected .= '</div>';
 
 		$this->instance->render_migration_error();
 
 		$this->expectOutput( $expected );
 	}
-
 }

--- a/tests/presenters/admin/migration-error-presenter-test.php
+++ b/tests/presenters/admin/migration-error-presenter-test.php
@@ -27,15 +27,18 @@ class Migration_Error_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present() {
+		$migration_error = [ 'message' => 'test error' ];
+
 		Monkey\Functions\expect( 'add_query_arg' )
 			->andReturn( 'https://yoa.st/3-6' );
 
 		$expected  = '<div class="notice notice-error">';
 		$expected .= '<p>Yoast SEO was unable to create the database tables required and as such will not function correctly.</p>';
 		$expected .= '<p>Please read <a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/3-6' ) . '">this help article</a> to find out how to resolve this problem.</p>';
+		$expected .= '<details><summary>Show debug information</summary><p>test error</p></details>';
 		$expected .= '</div>';
 
-		$instance = new Migration_Error_Presenter();
+		$instance = new Migration_Error_Presenter( $migration_error );
 
 		$this->assertSame( $expected, $instance->present() );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds debug information to the migration error.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install the composer packages, prefix dependencies as normal: `composer install`.
* You can not be in development mode or it will throw an exception. Switch to production: `composer install --no-dev --no-scripts`. The no scripts is to prevent building the prefix dependencies, which is why the step before was there.
* To have a migration go wrong you can:
  * Empty the `yoast_migrations_free` value in the `wp_options` table.
  * Truncate the `wp_yoast_migrations` table.
  * This will try to create the indexable table again, but it already exists.
* Visit any admin page, it should display the migration error. Now with a `Show debug information` details you can collapse.
<img width="1467" alt="migration-error-details" src="https://user-images.githubusercontent.com/35524806/81152826-9bc32780-8f82-11ea-8f9d-d115fb90672b.png">

* Perhaps (as developer) go back to development mode: `composer install`.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #15043 
