### PR TITLE
Fix primary custom taxonomies

### DIFF
--- a/src/builders/primary-term-builder.php
+++ b/src/builders/primary-term-builder.php
@@ -76,7 +76,7 @@ class Primary_Term_Builder {
 	 * @return void
 	 */
 	protected function save_primary_term( $post_id, $taxonomy ) {
-		$term_id = $this->meta->get_value( 'primary_category', $post_id );
+		$term_id = $this->meta->get_value( 'primary_' . $taxonomy, $post_id );
 
 		$term_selected = ! empty( $term_id );
 		$primary_term  = $this->repository->find_by_post_id_and_taxonomy( $post_id, $taxonomy, $term_selected );

--- a/tests/builders/primary-term-builder-test.php
+++ b/tests/builders/primary-term-builder-test.php
@@ -182,6 +182,36 @@ class Primary_Term_Builder_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the saving of a primary term, the happy path.
+	 *
+	 * @covers ::save_primary_term
+	 */
+	public function test_save_primary_term_of_custom_taxonomy() {
+		$primary_term = Mockery::mock( Primary_Term::class );
+		$primary_term->expects( 'save' )->once();
+
+		Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+
+		$this->repository
+			->expects( 'find_by_post_id_and_taxonomy' )
+			->once()
+			->with( 1, 'custom', true )
+			->andReturn( $primary_term );
+
+		$this->meta
+			->expects( 'get_value' )
+			->with( 'primary_custom', 1 )
+			->andReturn( 1337 );
+
+		$this->instance->save_primary_term( 1, 'custom' );
+
+		$this->assertEquals( 1337, $primary_term->term_id );
+		$this->assertEquals( 1, $primary_term->post_id );
+		$this->assertEquals( 'custom', $primary_term->taxonomy );
+		$this->assertEquals( 1, $primary_term->blog_id );
+	}
+
+	/**
 	 * @covers ::save_primary_term
 	 */
 	public function test_save_primary_term_with_no_term_selected() {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where primary terms of a custom taxonomy where not being reflected in the breadcrumb.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* For a custom taxonomy create multiple terms.
* Set the alphabetically last as the primary term.
* It should show up in the breadcrumb.
* Change the primary term.
* The breadcrumb should also change.
* Ideally also test with WooCommerce and a custom taxonomy from there.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #15071
Fixes https://github.com/Yoast/bugreports/issues/1005
