### PR TITLE
Fix term indexation on wpml sites

### DIFF
--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -44,7 +44,7 @@ class Indexable_Term_Builder {
 	public function build( $term_id, $indexable ) {
 		$term = WP_Term::get_instance( $term_id );
 
-		if ( $term === null || is_wp_error( $term ) ) {
+		if ( $term === null || \is_wp_error( $term ) ) {
 			return false;
 		}
 

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Builders;
 
+use WP_Term;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 
@@ -41,13 +42,9 @@ class Indexable_Term_Builder {
 	 * @return bool|Indexable The extended indexable. False when unable to build.
 	 */
 	public function build( $term_id, $indexable ) {
-		$term = \get_term( $term_id );
+		$term = WP_Term::get_instance( $term_id );
 
-		if ( $term === null ) {
-			return false;
-		}
-
-		if ( is_wp_error( $term ) ) {
+		if ( $term === null || is_wp_error( $term ) ) {
 			return false;
 		}
 

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -50,7 +50,7 @@ class Indexable_Term_Builder {
 
 		$term_link = \get_term_link( $term, $term->taxonomy );
 
-		if ( is_wp_error( $term_link ) ) {
+		if ( \is_wp_error( $term_link ) ) {
 			return false;
 		}
 

--- a/tests/admin/formatter/term-metabox-formatter-test.php
+++ b/tests/admin/formatter/term-metabox-formatter-test.php
@@ -44,7 +44,7 @@ class Term_Metabox_Formatter_Test extends TestCase {
 		parent::setUp();
 
 		$this->taxonomy           = (object) [];
-		$this->mock_term          = Mockery::mock( '\WP_Term' )->makePartial();
+		$this->mock_term          = Mockery::mock( 'alias:WP_Term' )->makePartial();
 		$this->mock_term->term_id = 1;
 
 		$this->instance = new Term_Metabox_Formatter_Double( $this->taxonomy, $this->mock_term );

--- a/tests/builders/indexable-term-builder-test.php
+++ b/tests/builders/indexable-term-builder-test.php
@@ -39,7 +39,9 @@ class Indexable_Term_Builder_Test extends TestCase {
 	public function test_build() {
 		$term = (object) [ 'taxonomy' => 'category', 'term_id' => 1 ];
 
-		Monkey\Functions\expect( 'get_term' )->once()->with( 1 )->andReturn( $term );
+		$wp_term = Mockery::mock( 'alias:WP_Term' );
+		$wp_term->expects( 'get_instance' )->once()->with( 1 )->andReturn( $term );
+
 		Monkey\Functions\expect( 'get_term_link' )->once()->with( $term, 'category' )->andReturn( 'https://example.org/category/1' );
 		Monkey\Functions\expect( 'is_wp_error' )->twice()->andReturn( false );
 
@@ -144,10 +146,8 @@ class Indexable_Term_Builder_Test extends TestCase {
 	 * @covers ::build
 	 */
 	public function test_build_term_null() {
-		Monkey\Functions\expect( 'get_term' )
-			->once()
-			->with( 1 )
-			->andReturn( null );
+		$wp_term = Mockery::mock( 'alias:WP_Term' );
+		$wp_term->expects( 'get_instance' )->once()->with( 1 )->andReturn( null );
 
 		$builder = new Indexable_Term_Builder( Mockery::mock( Taxonomy_Helper::class ) );
 
@@ -160,10 +160,8 @@ class Indexable_Term_Builder_Test extends TestCase {
 	 * @covers ::build
 	 */
 	public function test_build_term_error() {
-		Monkey\Functions\expect( 'get_term' )
-			->once()
-			->with( 1 )
-			->andReturn( Mockery::mock( '\WP_Error' ) );
+		$wp_term = Mockery::mock( 'alias:WP_Term' );
+		$wp_term->expects( 'get_instance' )->once()->with( 1 )->andReturn( Mockery::mock( 'WP_Error' ) );
 
 		$builder = new Indexable_Term_Builder( Mockery::mock( Taxonomy_Helper::class ) );
 
@@ -178,10 +176,8 @@ class Indexable_Term_Builder_Test extends TestCase {
 	public function test_build_term_link_error() {
 		$term = (object) [ 'taxonomy' => 'tax' ];
 
-		Monkey\Functions\expect( 'get_term' )
-			->once()
-			->with( 1 )
-			->andReturn( $term );
+		$wp_term = Mockery::mock( 'alias:WP_Term' );
+		$wp_term->expects( 'get_instance' )->once()->with( 1 )->andReturn( $term );
 		Monkey\Functions\expect( 'get_term_link' )
 			->once()
 			->with( $term, 'tax' )


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an issue where term indexation would keep going on forever due to plugin conflicts.

## Relevant technical choices:

* `WP_Term::get_instance` is used instead of `get_term` to avoid the `"get_{$taxonomy}"` filter which is used by, for example WPML, to return an entirely different term than was requested.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create 30 different terms.
* Delete all your indexables.
* Add a filter to `get_tag` to return a different tag:
```
add_filter( 'get_post_tag', function () {
    return WP_Term::get_instance( 1 );
} );
```
* Run the indexation.
* It should not keep going on forever.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/15050
