### PR TITLE
Fix infinite indexation with wpml

### DIFF
--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -59,7 +59,7 @@ class Indexable_Term_Builder {
 
 		$term_meta = $this->taxonomy->get_term_meta( $term );
 
-		$indexable->object_id       = $term->term_id;
+		$indexable->object_id       = $term_id;
 		$indexable->object_type     = 'term';
 		$indexable->object_sub_type = $term->taxonomy;
 		$indexable->permalink       = $term_link;

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -43,17 +43,13 @@ class Indexable_Term_Builder {
 	public function build( $term_id, $indexable ) {
 		$term = \get_term( $term_id );
 
-		if ( $term === null ) {
-			return false;
-		}
-
-		if ( is_wp_error( $term ) ) {
+		if ( $term === null || \is_wp_error( $term ) ) {
 			return false;
 		}
 
 		$term_link = \get_term_link( $term, $term->taxonomy );
 
-		if ( is_wp_error( $term_link ) ) {
+		if ( \is_wp_error( $term_link ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where term indexation would keep going on forever due to plugin conflicts.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create 30 different terms.
* Delete all your indexables.
* Add a filter to `get_tag` to return a different tag:
```
add_filter( 'get_post_tag', function () {
    return WP_Term::get_instance( 1 );
} );
```
* Run the indexation.
* It should not keep going on forever.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/15050
