### PR TITLE
Make indexation more robust

### DIFF
--- a/js/src/wp-seo-indexation.js
+++ b/js/src/wp-seo-indexation.js
@@ -8,6 +8,7 @@ const settings = yoastIndexationData;
 ( ( $ ) => {
 	let indexationInProgress = false;
 	let stoppedIndexation = false;
+	let processed = 0;
 	const indexationActions = {};
 
 	window.yoast = window.yoast || {};
@@ -43,12 +44,13 @@ const settings = yoastIndexationData;
 	async function doIndexation( endpoint, progressBar ) {
 		let url = settings.restApi.root + settings.restApi.endpoints[ endpoint ];
 
-		while ( ! stoppedIndexation && url !== false ) {
+		while ( ! stoppedIndexation && url !== false && processed <= settings.amount ) {
 			const response = await doIndexationRequest( url );
 			if ( typeof indexationActions[ endpoint ] === "function" ) {
 				await indexationActions[ endpoint ]( response.objects );
 			}
 			progressBar.update( response.objects.length );
+			processed += response.objects.length;
 			url = response.next_url;
 		}
 	}
@@ -61,6 +63,7 @@ const settings = yoastIndexationData;
 	 * @returns {Promise} The indexation promise.
 	 */
 	async function startIndexation( progressBar ) {
+		processed = 0;
 		for ( const endpoint of Object.keys( settings.restApi.endpoints ) ) {
 			await doIndexation( endpoint, progressBar );
 		}

--- a/src/integrations/admin/indexation-integration.php
+++ b/src/integrations/admin/indexation-integration.php
@@ -133,6 +133,18 @@ class Indexation_Integration implements Integration_Interface {
 			return;
 		}
 
+		/**
+		 * Filter 'wpseo_shutdown_indexation_limit' - Allow filtering the amount of objects that can be indexed during shutdown.
+		 *
+		 * @api int The maximum number of objects indexed.
+		 */
+		$shutdown_limit = \apply_filters( 'wpseo_shutdown_indexation_limit', 50 );
+
+		if ( $this->get_total_unindexed() < $shutdown_limit ) {
+			\register_shutdown_function( [ $this, 'shutdown_indexation' ] );
+			return;
+		}
+
 		\add_action( 'admin_footer', [ $this, 'render_indexation_modal' ], 20 );
 		if ( $this->options_helper->get( 'ignore_indexation_warning', false ) === false ) {
 			\add_action( 'admin_notices', [ $this, 'render_indexation_warning' ], 10 );
@@ -198,6 +210,18 @@ class Indexation_Integration implements Integration_Interface {
 	 */
 	public function render_indexation_list_item() {
 		echo new Indexation_List_Item_Presenter( $this->get_total_unindexed() );
+	}
+
+	/**
+	 * Run a single indexation pass of each indexation action. Intended for use as a shutdown function.
+	 *
+	 * @return void
+	 */
+	public function shutdown_indexation() {
+		$this->post_indexation->index();
+		$this->term_indexation->index();
+		$this->general_indexation->index();
+		$this->post_type_archive_indexation->index();
 	}
 
 	/**

--- a/src/integrations/admin/indexation-integration.php
+++ b/src/integrations/admin/indexation-integration.php
@@ -138,7 +138,7 @@ class Indexation_Integration implements Integration_Interface {
 		 *
 		 * @api int The maximum number of objects indexed.
 		 */
-		$shutdown_limit = \apply_filters( 'wpseo_shutdown_indexation_limit', 50 );
+		$shutdown_limit = \apply_filters( 'wpseo_shutdown_indexation_limit', 25 );
 
 		if ( $this->get_total_unindexed() < $shutdown_limit ) {
 			\register_shutdown_function( [ $this, 'shutdown_indexation' ] );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents the indexation from going continuing even though it has already indexed all objects.
* If a very small amount of objects remain unindexed these will automatically be indexed without needing any user interaction. The default amount is a maximum of 25. This amount can be adjusted using the `wpseo_shutdown_indexation_limit` filter. Indexation happens as a shutdown function.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* In the `Indexation_Integration::get_total_unindexed` reduce the number by 100 before returning it.
* Clear all your indexables
* Make sure you have more than 100 objects to be indexed.
* Visit the dashboard, you should see the notification to index. This should not go over the limit by more than 25 even though we've reduced the count. ( Less than 25 can happen as indexation happens in groups of 25 ).
* Remove the 100 reduction you added. The notice should show again and you should be able to complete it without issue.
* Now delete 1 indexable in your table and refresh the page.
* You should not see a notice but the indexable should be created automatically.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/15081
