### PR TITLE
Add descriptionPlaceholder and pass it to social components

### DIFF
--- a/js/src/components/social/FacebookWrapper.js
+++ b/js/src/components/social/FacebookWrapper.js
@@ -1,10 +1,18 @@
 import React, { Fragment } from "react";
 import { Slot } from "@wordpress/components";
+import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 
 import SocialForm from "../social/SocialForm";
 
 const socialMediumName = "Facebook";
+
+/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+const descriptionPlaceholder  = sprintf(
+	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+	__( "Modify your %s description by editing it right here...", "yoast-components" ),
+	socialMediumName
+);
 
 /**
  * This wrapper is connected to the facebook container. So the data is connected to both components.
@@ -17,6 +25,7 @@ const socialMediumName = "Facebook";
 const FacebookWrapper = ( props ) => {
 	const richProps = {
 		...props,
+		descriptionPlaceholder,
 		socialMediumName,
 	};
 

--- a/js/src/components/social/FacebookWrapper.js
+++ b/js/src/components/social/FacebookWrapper.js
@@ -1,18 +1,8 @@
 import React, { Fragment } from "react";
 import { Slot } from "@wordpress/components";
-import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 
 import SocialForm from "../social/SocialForm";
-
-const socialMediumName = "Facebook";
-
-/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-const descriptionPlaceholder  = sprintf(
-	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-	__( "Modify your %s description by editing it right here...", "yoast-components" ),
-	socialMediumName
-);
 
 /**
  * This wrapper is connected to the facebook container. So the data is connected to both components.
@@ -23,21 +13,15 @@ const descriptionPlaceholder  = sprintf(
  * @returns {Component} Renders the FacebookWrapper React Component.
  */
 const FacebookWrapper = ( props ) => {
-	const richProps = {
-		...props,
-		descriptionPlaceholder,
-		socialMediumName,
-	};
-
 	return (
 		<Fragment>
 			{
 				props.isPremium
 					? <Slot
 						name="YoastFacebookPremium"
-						fillProps={ richProps }
+						fillProps={ props }
 					/>
-					: <SocialForm { ...richProps } />
+					: <SocialForm { ...props } />
 			}
 		</Fragment>
 	);

--- a/js/src/components/social/SocialForm.js
+++ b/js/src/components/social/SocialForm.js
@@ -33,6 +33,7 @@ SocialForm.propTypes = {
 	imageUrl: PropTypes.string.isRequired,
 	imageFallbackUrl: PropTypes.string.isRequired,
 	description: PropTypes.string,
+	descriptionPlaceholder: PropTypes.string,
 	title: PropTypes.string,
 	imageWarnings: PropTypes.array,
 };
@@ -41,6 +42,7 @@ SocialForm.defaultProps = {
 	imageWarnings: [],
 	title: "",
 	description: "",
+	descriptionPlaceholder: "",
 };
 
 export default SocialForm;

--- a/js/src/components/social/TwitterWrapper.js
+++ b/js/src/components/social/TwitterWrapper.js
@@ -1,10 +1,18 @@
 import React, { Fragment } from "react";
 import { Slot } from "@wordpress/components";
+import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 
 import SocialForm from "../social/SocialForm";
 
 const socialMediumName = "Twitter";
+
+/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+const descriptionPlaceholder  = sprintf(
+	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+	__( "Modify your %s description by editing it right here...", "yoast-components" ),
+	socialMediumName
+);
 
 /**
  * This wrapper is connected to the twitter container. So the data is connected to both components.
@@ -17,6 +25,7 @@ const socialMediumName = "Twitter";
 const TwitterWrapper = ( props ) => {
 	const richProps = {
 		...props,
+		descriptionPlaceholder,
 		socialMediumName,
 	};
 	return (

--- a/js/src/components/social/TwitterWrapper.js
+++ b/js/src/components/social/TwitterWrapper.js
@@ -1,18 +1,8 @@
 import React, { Fragment } from "react";
 import { Slot } from "@wordpress/components";
-import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 
 import SocialForm from "../social/SocialForm";
-
-const socialMediumName = "Twitter";
-
-/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-const descriptionPlaceholder  = sprintf(
-	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-	__( "Modify your %s description by editing it right here...", "yoast-components" ),
-	socialMediumName
-);
 
 /**
  * This wrapper is connected to the twitter container. So the data is connected to both components.
@@ -23,20 +13,15 @@ const descriptionPlaceholder  = sprintf(
  * @returns {Component} Renders the TwitterWrapper React Component.
  */
 const TwitterWrapper = ( props ) => {
-	const richProps = {
-		...props,
-		descriptionPlaceholder,
-		socialMediumName,
-	};
 	return (
 		<Fragment>
 			{
 				props.isPremium
 					? <Slot
 						name="YoastTwitterPremium"
-						fillProps={ richProps }
+						fillProps={ props }
 					/>
-					: <SocialForm { ...richProps } />
+					: <SocialForm { ...props } />
 			}
 		</Fragment>
 	);

--- a/js/src/containers/FacebookEditor.js
+++ b/js/src/containers/FacebookEditor.js
@@ -1,12 +1,24 @@
 /* External dependencies */
 import { compose } from "@wordpress/compose";
 import { withDispatch, withSelect, dispatch as wpDataDispatch } from "@wordpress/data";
+import { __, sprintf } from "@wordpress/i18n";
 import domReady from "@wordpress/dom-ready";
 
 /* Internal dependencies */
 import FacebookWrapper from "../components/social/FacebookWrapper";
 
 const isPremium = window.wpseoAdminL10n.isPremium;
+
+const socialMediumName = "Facebook";
+
+const titlePlaceholder = window.wpseoPostScraperL10n ? window.wpseoPostScraperL10n.title_template : window.wpseoTermScraperL10n.title_template;
+
+/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+const descriptionPlaceholder  = sprintf(
+	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+	__( "Modify your %s description by editing it right here...", "yoast-components" ),
+	socialMediumName
+);
 
 /**
  * Container that holds the media object.
@@ -60,6 +72,9 @@ export default compose( [
 			authorName: getAuthorName(),
 			siteUrl: getSiteUrl(),
 			isPremium: !! isPremium,
+			titlePlaceholder,
+			descriptionPlaceholder,
+			socialMediumName,
 		};
 	} ),
 

--- a/js/src/containers/TwitterEditor.js
+++ b/js/src/containers/TwitterEditor.js
@@ -1,12 +1,24 @@
 /* External dependencies */
 import { compose } from "@wordpress/compose";
 import { withDispatch, withSelect, dispatch as wpDataDispatch } from "@wordpress/data";
+import { __, sprintf } from "@wordpress/i18n";
 import domReady from "@wordpress/dom-ready";
 
 /* Internal dependencies */
 import TwitterWrapper from "../components/social/TwitterWrapper";
 
 const isPremium = window.wpseoAdminL10n.isPremium;
+
+const socialMediumName = "Twitter";
+
+const titlePlaceholder = window.wpseoPostScraperL10n ? window.wpseoPostScraperL10n.title_template : window.wpseoTermScraperL10n.title_template;
+
+/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+const descriptionPlaceholder  = sprintf(
+	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+	__( "Modify your %s description by editing it right here...", "yoast-components" ),
+	socialMediumName
+);
 
 /**
  * Container that holds the media object.
@@ -62,6 +74,9 @@ export default compose( [
 			siteUrl: getSiteUrl(),
 			isPremium: !! isPremium,
 			isLarge: getTwitterImageType(),
+			titlePlaceholder,
+			descriptionPlaceholder,
+			socialMediumName,
 		};
 	} ),
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Defaults needed to be set and passed to the new Social Previews.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [non-user-facing] Pass the description placeholder, title placeholder, and social medium name in the FacebookWrapper and TwitterWrapper via the props.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout the Javascript branch `631-add-defaults-to-social=previews` (sorry about the `=` typo), and `yarn link-monorepo`
* Verify that the description input still has a placeholder when it is emptied.
* Title input does not have a placeholder, which also isn't the case in the old social previews. We are mimicking those for now.
* Also test together with the *[premium PR](https://github.com/Yoast/wordpress-seo-premium/pull/2772)* by merging this into premium branch `631-add-defaults-to-social=previews` with the `--no-commit` flag.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/javascript/issues/631
