### PR TITLE
Show warning when focus keyphrase is too long

### DIFF
--- a/js/src/components/contentAnalysis/KeywordInput.js
+++ b/js/src/components/contentAnalysis/KeywordInput.js
@@ -7,6 +7,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { KeywordInput as KeywordInputComponent } from "yoast-components";
 import styled from "styled-components";
+import { Alert } from "@yoast/components";
 
 /* Internal dependencies */
 import { setFocusKeyword } from "../../redux/actions/focusKeyword";
@@ -60,6 +61,15 @@ class KeywordInput extends Component {
 						onBlurKeyword={ this.props.onBlurKeyword }
 						onFocusKeyword={ this.props.onFocusKeyword }
 					/>
+					{
+						this.props.keyword.length > 191 &&
+						<Alert type="warning">
+							{ __(
+								"Your keyphrase is too long. It can be a maximum of 191 characters.",
+								"wordpress-seo"
+							) }
+						</Alert>
+					}
 				</KeywordInputContainer>
 			) }
 		</LocationConsumer>;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Since #14989, we truncate the focus keyphrase that is saved to the indexable to 191 characters. This means only the first 191 characters are saved in the indexables table. We should show a warning in the UI to warn users if they enter a too long keyphrase.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a warning to the metabox when a user enters a focus keyphrase that contains more than 191 characters.

## Relevant technical choices:

* It seems there are no tests yet (at all) for `KeywordInput.js`, so I didn't add any.
* With regard to the encoding of non-Latin languages (see #14998), I added a Hebrew focus keyphrase and saw in the indexables table that it showed in Hebrew. I also logged `this.props.keyword.length` to the browser and saw that it matched the number of Hebrew charachters that I had entered. Therefore, I concluded that no more work needs to be done on this.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Open a post and/or a category.
* In the metabox, enter a focus keyphrase of [191 characters](https://www.lettercount.com/) or less. Nothing should happen.
* Add extra characters to the keyphrase so that it passes 191 characters.
* Directly under the input field, you should see the following warning:
<img width="779" alt="Screenshot 2020-05-07 at 11 21 51" src="https://user-images.githubusercontent.com/20280513/81277653-fb8a0300-9054-11ea-89de-ab432f7a6ac3.png">

* Please also test with a non-Latin language to see if everything works as expected.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14998