### PR TITLE
Indexation warning should not show when updating

### DIFF
--- a/src/conditionals/yoast-admin-and-dashboard-conditional.php
+++ b/src/conditionals/yoast-admin-and-dashboard-conditional.php
@@ -18,7 +18,8 @@ class Yoast_Admin_And_Dashboard_Conditional implements Conditional {
 	public function is_met() {
 		global $pagenow;
 
-		if ( wp_installing() ) {
+		// Do not output on plugin / theme installation pages or when wordpress is upgrading.
+		if ( ( defined( 'IFRAME_REQUEST' ) && IFRAME_REQUEST ) || wp_installing() ) {
 			return false;
 		}
 

--- a/src/conditionals/yoast-admin-and-dashboard-conditional.php
+++ b/src/conditionals/yoast-admin-and-dashboard-conditional.php
@@ -19,7 +19,7 @@ class Yoast_Admin_And_Dashboard_Conditional implements Conditional {
 		global $pagenow;
 
 		// Do not output on plugin / theme installation pages or when wordpress is upgrading.
-		if ( ( defined( 'IFRAME_REQUEST' ) && IFRAME_REQUEST ) || wp_installing() ) {
+		if ( ( defined( 'IFRAME_REQUEST' ) && IFRAME_REQUEST ) || $this->on_plugin_or_theme_page() || wp_installing() ) {
 			return false;
 		}
 
@@ -32,5 +32,19 @@ class Yoast_Admin_And_Dashboard_Conditional implements Conditional {
 			'plugins.php',
 			'update-core.php',
 		], true );
+	}
+
+	/**
+	 * Checks if we are on a theme or plugin upgrade page.
+	 *
+	 * @return bool Whether we are on a theme or plugin upgrade page.
+	 */
+	private function on_plugin_or_theme_page() {
+		/*
+		 * IFRAME_REQUEST is not defined on these pages,
+		 * though these action pages do show when upgrading themes or plugins.
+		 */
+		$actions = [ 'do-theme-upgrade', 'do-plugin-upgrade' ];
+		return isset( $_GET['action'] ) && in_array( $_GET['action'], $actions, true );
 	}
 }

--- a/src/conditionals/yoast-admin-and-dashboard-conditional.php
+++ b/src/conditionals/yoast-admin-and-dashboard-conditional.php
@@ -18,6 +18,10 @@ class Yoast_Admin_And_Dashboard_Conditional implements Conditional {
 	public function is_met() {
 		global $pagenow;
 
+		if ( wp_installing() ) {
+			return false;
+		}
+
 		if ( $pagenow === 'admin.php' && isset( $_GET['page'] ) && strpos( $_GET['page'], 'wpseo' ) === 0 ) {
 			return true;
 		}

--- a/tests/conditionals/yoast-admin-and-dashboard-conditional-test.php
+++ b/tests/conditionals/yoast-admin-and-dashboard-conditional-test.php
@@ -162,4 +162,48 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 
 		$this->assertEquals( false, $is_met );
 	}
+
+	/**
+	 * Tests that the conditional is not met when on the plugin upgrade page.
+	 *
+	 * @covers ::is_met
+	 * @covers ::on_plugin_or_theme_page
+	 */
+	public function test_is_not_met_on_plugin_upgrade_page() {
+		// We are on an admin page.
+		global $pagenow;
+		$pagenow = 'admin.php';
+
+		// But WordPress is currently installing.
+		Monkey\Functions\expect( 'wp_installing' )
+			->andReturn( false );
+
+		$_GET['action'] = 'do-plugin-upgrade';
+
+		$is_met = $this->instance->is_met();
+
+		$this->assertEquals( false, $is_met );
+	}
+
+	/**
+	 * Tests that the conditional is not met when on the theme upgrade page.
+	 *
+	 * @covers ::is_met
+	 * @covers ::on_plugin_or_theme_page
+	 */
+	public function test_is_not_met_on_theme_upgrade_page() {
+		// We are on an admin page.
+		global $pagenow;
+		$pagenow = 'admin.php';
+
+		// But WordPress is currently installing.
+		Monkey\Functions\expect( 'wp_installing' )
+			->andReturn( false );
+
+		$_GET['action'] = 'do-theme-upgrade';
+
+		$is_met = $this->instance->is_met();
+
+		$this->assertEquals( false, $is_met );
+	}
 }

--- a/tests/conditionals/yoast-admin-and-dashboard-conditional-test.php
+++ b/tests/conditionals/yoast-admin-and-dashboard-conditional-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Conditionals;
 
+use Brain\Monkey;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -39,6 +40,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		global $pagenow;
 		$pagenow = 'admin.php';
 
+		Monkey\Functions\expect( 'wp_installing' )
+			->andReturn( false );
+
 		// Specifically, we are on the wpseo_dashboard page.
 		$_GET['page'] = 'wpseo_dashboard';
 
@@ -57,6 +61,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		global $pagenow;
 		$pagenow = 'update-core.php';
 
+		Monkey\Functions\expect( 'wp_installing' )
+			->andReturn( false );
+
 		$is_met = $this->instance->is_met();
 
 		$this->assertEquals( true, $is_met );
@@ -71,6 +78,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		// We are on the plugins page.
 		global $pagenow;
 		$pagenow = 'plugins.php';
+
+		Monkey\Functions\expect( 'wp_installing' )
+			->andReturn( false );
 
 		$is_met = $this->instance->is_met();
 
@@ -87,6 +97,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		global $pagenow;
 		$pagenow = 'index.php';
 
+		Monkey\Functions\expect( 'wp_installing' )
+			->andReturn( false );
+
 		$is_met = $this->instance->is_met();
 
 		$this->assertEquals( true, $is_met );
@@ -101,6 +114,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		// We are on the update core page.
 		global $pagenow;
 		$pagenow = 'some-other-page.php';
+
+		Monkey\Functions\expect( 'wp_installing' )
+			->andReturn( false );
 
 		$is_met = $this->instance->is_met();
 
@@ -117,8 +133,30 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 		global $pagenow;
 		$pagenow = 'admin.php';
 
+		Monkey\Functions\expect( 'wp_installing' )
+			->andReturn( false );
+
 		// But not on a Yoast admin page.
 		$_GET['page'] = 'other-page';
+
+		$is_met = $this->instance->is_met();
+
+		$this->assertEquals( false, $is_met );
+	}
+
+	/**
+	 * Tests that the conditional is not met when WordPress is currently installing.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_not_met_when_wordpress_is_installing() {
+		// We are on an admin page.
+		global $pagenow;
+		$pagenow = 'admin.php';
+
+		// But WordPress is currently installing.
+		Monkey\Functions\expect( 'wp_installing' )
+			->andReturn( true );
 
 		$is_met = $this->instance->is_met();
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* The indexation notification is not shown anymore when updating themes or plugins via the WordPress updates page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

## Plugins update page.
* Upload an outdated plugin.
  * For example an outdated version of Akismet (https://downloads.wordpress.org/plugin/akismet.4.1.4.zip)
* Reset your indexables database tables using the Yoast Test Helper plugin.
* Go to the WordPress updates page ( _Dashboard_ > _Updates_ in the admin sidebar menu).
* You **should** see the indexation notification at the top of your screen.
* Select the outdated plugin in the list and click the 'Update Plugins' button.
* The plugin should be installed and you should **not** see the notification.

## Themes update page.
* Upload an outdated theme.
  * For example an outdated version of twentynineteen (https://downloads.wordpress.org/theme/twentynineteen.1.4.zip)
* Reset your indexables database tables using the Yoast Test Helper plugin.
* Go to the WordPress updates page ( _Dashboard_ > _Updates_ in the admin sidebar menu).
* You **should** see the indexation notification at the top of your screen.
* Select the outdated theme in the list and click the 'Update Plugins' button.
* The theme should be installed and you should **not** see the notification.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/1007
