### PR TITLE
Fix for breadcrumb showing blank on 404 page

### DIFF
--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -135,6 +135,9 @@ class Breadcrumbs_Generator implements Generator_Interface {
 				case 'post-type-archive':
 					$crumb = $this->get_post_type_archive_crumb( $crumb, $ancestor );
 					break;
+				case 'term':
+					$crumb = $this->get_term_crumb( $crumb, $ancestor );
+					break;
 				case 'system-page':
 					$crumb = $this->get_system_page_crumb( $crumb, $ancestor );
 					break;
@@ -197,6 +200,20 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 */
 	private function get_post_type_archive_crumb( $crumb, $ancestor ) {
 		$crumb['ptarchive'] = $ancestor->object_sub_type;
+
+		return $crumb;
+	}
+
+	/**
+	 * Returns the modified term crumb.
+	 *
+	 * @param array     $crumb    The crumb.
+	 * @param Indexable $ancestor The indexable.
+	 *
+	 * @return array The crumb.
+	 */
+	private function get_term_crumb( $crumb, $ancestor ) {
+		$crumb['term_id'] = $ancestor->object_id;
 
 		return $crumb;
 	}

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -226,7 +226,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 */
 	private function get_system_page_crumb( $crumb, $ancestor ) {
 		if ( $ancestor->object_sub_type === 'search-result' ) {
-			$crumb['text'] = $this->options->get( 'breadcrumbs-searchprefix' ) . ' “' . \esc_html( \get_search_query() ) . '”';
+			$crumb['text'] = $this->options->get( 'breadcrumbs-searchprefix' ) . ' ' . \esc_html( \get_search_query() );
 			$crumb['url']  = \get_search_link();
 		}
 		elseif ( $ancestor->object_sub_type === '404' ) {
@@ -246,7 +246,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 */
 	private function get_user_crumb( $crumb, $ancestor ) {
 		$display_name = \get_the_author_meta( 'display_name', $ancestor->object_id );
-		$crumb['text'] = $this->options->get( 'breadcrumbs-archiveprefix' ) . ' “' . $display_name . '”';
+		$crumb['text'] = $this->options->get( 'breadcrumbs-archiveprefix' ) . ' ' . $display_name;
 
 		return $crumb;
 	}
@@ -263,13 +263,13 @@ class Breadcrumbs_Generator implements Generator_Interface {
 		$prefix = $this->options->get( 'breadcrumbs-archiveprefix' );
 
 		if ( \is_day() ) {
-			$crumb['text'] = $prefix . ' “' . \esc_html( \get_the_date() ) . '”';
+			$crumb['text'] = $prefix . ' ' . \esc_html( \get_the_date() );
 		}
 		elseif ( \is_month() ) {
-			$crumb['text'] = $prefix . ' “' . \esc_html( \trim( \single_month_title( ' ', false ) ) ) . '”';
+			$crumb['text'] = $prefix . ' ' . \esc_html( \trim( \single_month_title( ' ', false ) ) );
 		}
 		elseif ( \is_year() ) {
-			$crumb['text'] = $prefix . ' “' . \esc_html( \get_query_var( 'year' ) ) . '”';
+			$crumb['text'] = $prefix . ' ' . \esc_html( \get_query_var( 'year' ) );
 		}
 
 		return $crumb;

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -130,15 +130,20 @@ class Breadcrumbs_Generator implements Generator_Interface {
 
 			switch ( $ancestor->object_type ) {
 				case 'post':
-					return $this->get_post_crumb( $crumb, $ancestor );
+					$crumb = $this->get_post_crumb( $crumb, $ancestor );
+					break;
 				case 'post-type-archive':
-					return $this->get_post_type_archive_crumb( $crumb, $ancestor );
+					$crumb = $this->get_post_type_archive_crumb( $crumb, $ancestor );
+					break;
 				case 'system-page':
-					return $this->get_system_page_crumb( $crumb, $ancestor );
+					$crumb = $this->get_system_page_crumb( $crumb, $ancestor );
+					break;
 				case 'user':
-					return $this->get_user_crumb( $crumb, $ancestor );
+					$crumb = $this->get_user_crumb( $crumb, $ancestor );
+					break;
 				case 'date-archive':
-					return $this->get_date_archive_crumb( $crumb, $ancestor );
+					$crumb = $this->get_date_archive_crumb( $crumb, $ancestor );
+					break;
 			}
 
 			return $crumb;

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -127,7 +127,6 @@ class Breadcrumbs_Generator implements Generator_Interface {
 				'url'  => $ancestor->permalink,
 				'text' => $ancestor->breadcrumb_title,
 			];
-
 			switch ( $ancestor->object_type ) {
 				case 'post':
 					$crumb = $this->get_post_crumb( $crumb, $ancestor );
@@ -148,7 +147,6 @@ class Breadcrumbs_Generator implements Generator_Interface {
 					$crumb = $this->get_date_archive_crumb( $crumb, $ancestor );
 					break;
 			}
-
 			return $crumb;
 		}, $indexables );
 

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -225,7 +225,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 * @return array The crumb.
 	 */
 	private function get_user_crumb( $crumb, $ancestor ) {
-		$display_name = get_the_author_meta( 'display_name', $ancestor->object_id );
+		$display_name = \get_the_author_meta( 'display_name', $ancestor->object_id );
 		$crumb['text'] = $this->options->get( 'breadcrumbs-archiveprefix' ) . ' “' . $display_name . '”';
 
 		return $crumb;
@@ -240,14 +240,16 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 * @return array The crumb.
 	 */
 	private function get_date_archive_crumb( $crumb, $ancestor ) {
-		if ( is_day() ) {
-			$crumb['text'] = $this->options->get( 'breadcrumbs-archiveprefix' ) . ' “' . esc_html( get_the_date() ) . '”';
+		$prefix = $this->options->get( 'breadcrumbs-archiveprefix' );
+
+		if ( \is_day() ) {
+			$crumb['text'] = $prefix . ' “' . \esc_html( \get_the_date() ) . '”';
 		}
-		elseif ( is_month() ) {
-			$crumb['text'] = $this->options->get( 'breadcrumbs-archiveprefix' ) . ' “' . esc_html( trim( single_month_title( ' ', false ) ) ) . '”';
+		elseif ( \is_month() ) {
+			$crumb['text'] = $prefix . ' “' . \esc_html( \trim( \single_month_title( ' ', false ) ) ) . '”';
 		}
-		elseif ( is_year() ) {
-			$crumb['text'] = $this->options->get( 'breadcrumbs-archiveprefix' ) . ' “' . esc_html( get_query_var( 'year' ) ) . '”';
+		elseif ( \is_year() ) {
+			$crumb['text'] = $prefix . ' “' . \esc_html( \get_query_var( 'year' ) ) . '”';
 		}
 
 		return $crumb;

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -138,6 +138,9 @@ class Breadcrumbs_Generator implements Generator_Interface {
 				$crumb['text'] = $this->options->get( 'breadcrumbs-searchprefix' ) . ' “' . \esc_html( \get_search_query() ) . '”';
 				$crumb['url']  = \get_search_link();
 			}
+			if ( $ancestor->object_type === 'system-page' && $ancestor->object_sub_type === '404' ) {
+				$crumb['text'] = $this->options->get( 'breadcrumbs-404crumb' );
+			}
 			return $crumb;
 		}, $indexables );
 

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -128,19 +128,19 @@ class Breadcrumbs_Generator implements Generator_Interface {
 				'text' => $ancestor->breadcrumb_title,
 			];
 
-			if ( $ancestor->object_type === 'post' ) {
-				$crumb['id'] = $ancestor->object_id;
+			switch ( $ancestor->object_type ) {
+				case 'post':
+					return $this->get_post_crumb( $crumb, $ancestor );
+				case 'post-type-archive':
+					return $this->get_post_type_archive_crumb( $crumb, $ancestor );
+				case 'system-page':
+					return $this->get_system_page_crumb( $crumb, $ancestor );
+				case 'user':
+					return $this->get_user_crumb( $crumb, $ancestor );
+				case 'date-archive':
+					return $this->get_date_archive_crumb( $crumb, $ancestor );
 			}
-			if ( $ancestor->object_type === 'post-type-archive' ) {
-				$crumb['ptarchive'] = $ancestor->object_sub_type;
-			}
-			if ( $ancestor->object_type === 'system-page' && $ancestor->object_sub_type === 'search-result' ) {
-				$crumb['text'] = $this->options->get( 'breadcrumbs-searchprefix' ) . ' “' . \esc_html( \get_search_query() ) . '”';
-				$crumb['url']  = \get_search_link();
-			}
-			if ( $ancestor->object_type === 'system-page' && $ancestor->object_sub_type === '404' ) {
-				$crumb['text'] = $this->options->get( 'breadcrumbs-404crumb' );
-			}
+
 			return $crumb;
 		}, $indexables );
 
@@ -166,6 +166,91 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			 */
 			return apply_filters( 'wpseo_breadcrumb_single_link_info', $link_info, $index, $crumbs );
 		}, $crumbs, array_keys( $crumbs ) );
+	}
+
+	/**
+	 * Returns the modified post crumb.
+	 *
+	 * @param array     $crumb    The crumb.
+	 * @param Indexable $ancestor The indexable.
+	 *
+	 * @return array The crumb.
+	 */
+	private function get_post_crumb( $crumb, $ancestor ) {
+		$crumb['id'] = $ancestor->object_id;
+
+		return $crumb;
+	}
+
+	/**
+	 * Returns the modified post type crumb.
+	 *
+	 * @param array     $crumb    The crumb.
+	 * @param Indexable $ancestor The indexable.
+	 *
+	 * @return array The crumb.
+	 */
+	private function get_post_type_archive_crumb( $crumb, $ancestor ) {
+		$crumb['ptarchive'] = $ancestor->object_sub_type;
+
+		return $crumb;
+	}
+
+	/**
+	 * Returns the modified system page crumb.
+	 *
+	 * @param array     $crumb    The crumb.
+	 * @param Indexable $ancestor The indexable.
+	 *
+	 * @return array The crumb.
+	 */
+	private function get_system_page_crumb( $crumb, $ancestor ) {
+		if ( $ancestor->object_sub_type === 'search-result' ) {
+			$crumb['text'] = $this->options->get( 'breadcrumbs-searchprefix' ) . ' “' . \esc_html( \get_search_query() ) . '”';
+			$crumb['url']  = \get_search_link();
+		}
+		elseif ( $ancestor->object_sub_type === '404' ) {
+			$crumb['text'] = $this->options->get( 'breadcrumbs-404crumb' );
+		}
+
+		return $crumb;
+	}
+
+	/**
+	 * Returns the modified user crumb.
+	 *
+	 * @param array     $crumb    The crumb.
+	 * @param Indexable $ancestor The indexable.
+	 *
+	 * @return array The crumb.
+	 */
+	private function get_user_crumb( $crumb, $ancestor ) {
+		$display_name = get_the_author_meta( 'display_name', $ancestor->object_id );
+		$crumb['text'] = $this->options->get( 'breadcrumbs-archiveprefix' ) . ' “' . $display_name . '”';
+
+		return $crumb;
+	}
+
+	/**
+	 * Returns the modified date archive crumb.
+	 *
+	 * @param array     $crumb    The crumb.
+	 * @param Indexable $ancestor The indexable.
+	 *
+	 * @return array The crumb.
+	 */
+	private function get_date_archive_crumb( $crumb, $ancestor ) {
+		if ( is_day() ) {
+			$crumb['text'] = $this->options->get( 'breadcrumbs-archiveprefix' ) . ' “' . esc_html( get_the_date() ) . '”';
+		}
+		elseif ( is_month() ) {
+			$crumb['text'] = $this->options->get( 'breadcrumbs-archiveprefix' ) . ' “' . esc_html( trim( single_month_title( ' ', false ) ) ) . '”';
+		}
+		elseif ( is_year() ) {
+			$crumb['text'] = $this->options->get( 'breadcrumbs-archiveprefix' ) . ' “' . esc_html( get_query_var( 'year' ) ) . '”';
+		}
+
+		return $crumb;
 	}
 
 	/**


### PR DESCRIPTION
Fix for breadcrumb showing blank on 404 page.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the breadcrumb is blank on 404 page

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Goto 404 page and check the last breadcrumb.

[Added by @herregroen]
* This PR also changes the breadcrumbs for:
  * Posts
  * Post type archives
  * Terms
  * Search results
  * Author archives
  * Date archives.
* These should all be tested to ensure no regressions are present.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #