### PR TITLE
Breadcrumb title of system pages "search-result" and "404" not getting in yoast indexable table

### DIFF
--- a/src/builders/indexable-system-page-builder.php
+++ b/src/builders/indexable-system-page-builder.php
@@ -19,8 +19,14 @@ class Indexable_System_Page_Builder {
 	 * Mapping of object type to title option keys.
 	 */
 	const OPTION_MAPPING = [
-		'search-result' => 'title-search-wpseo',
-		'404'           => 'title-404-wpseo',
+		'search-result' => [
+			'title'            => 'title-search-wpseo',
+			'breadcrumb_title' => 'breadcrumbs-searchprefix'
+		],
+		'404'           => [
+			'title'            => 'title-404-wpseo',
+			'breadcrumb_title' => 'breadcrumbs-404crumb'
+		],
 	];
 
 	/**
@@ -52,7 +58,8 @@ class Indexable_System_Page_Builder {
 	public function build( $object_sub_type, Indexable $indexable ) {
 		$indexable->object_type       = 'system-page';
 		$indexable->object_sub_type   = $object_sub_type;
-		$indexable->title             = $this->options->get( static::OPTION_MAPPING[ $object_sub_type ] );
+		$indexable->title             = $this->options->get( static::OPTION_MAPPING[ $object_sub_type ][ 'title' ] );
+		$indexable->breadcrumb_title  = $this->options->get( static::OPTION_MAPPING[ $object_sub_type ][ 'breadcrumb_title' ] );
 		$indexable->is_robots_noindex = true;
 		$indexable->blog_id           = \get_current_blog_id();
 

--- a/src/integrations/watchers/indexable-system-page-watcher.php
+++ b/src/integrations/watchers/indexable-system-page-watcher.php
@@ -66,19 +66,21 @@ class Indexable_System_Page_Watcher implements Integration_Interface {
 	 * @return void
 	 */
 	public function check_option( $old_value, $new_value ) {
-		foreach ( Indexable_System_Page_Builder::OPTION_MAPPING as $type => $option ) {
-			// If both values aren't set they haven't changed.
-			if ( ! isset( $old_value[ $option ] ) && ! isset( $new_value[ $option ] ) ) {
-				return;
-			}
+		foreach ( Indexable_System_Page_Builder::OPTION_MAPPING as $type => $options ) {
+			foreach ( $options as $option ) {
+				// If both values aren't set they haven't changed.
+				if ( ! isset( $old_value[ $option ] ) && ! isset( $new_value[ $option ] ) ) {
+					return;
+				}
 
-			// If the value was set but now isn't, is set but wasn't or is not the same it has changed.
-			if (
-				! isset( $old_value[ $option ] )
-				|| ! isset( $new_value[ $option ] )
-				|| $old_value[ $option ] !== $new_value[ $option ]
-			) {
-				$this->build_indexable( $type );
+				// If the value was set but now isn't, is set but wasn't or is not the same it has changed.
+				if (
+					! isset( $old_value[ $option ] )
+					|| ! isset( $new_value[ $option ] )
+					|| $old_value[ $option ] !== $new_value[ $option ]
+				) {
+					$this->build_indexable( $type );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Breadcrumb titles of system pages not getting saved in indexable table, when we save the options in the admin. I have made changes to system page builder and watcher for that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where breadcrumb titles not getting saved in indexable table on saving options

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Goto admin at SEO -> Search Appearance -> Breadcrumbs(tab)
* Update field "Prefix for Search Page breadcrumbs"
* Update field "Breadcrumb for 404 Page"
* Save changes
* Check table "yoast_indexable" column "breadcrumb_title"
* Changes are not reflected


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
