### PR TITLE
Breadcrumb title of system pages "search-result" and "404" not getting in yoast indexable table

### DIFF
--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -8,6 +8,7 @@
 namespace Yoast\WP\SEO\Builders;
 
 use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 
 /**
@@ -27,9 +28,14 @@ class Indexable_Author_Builder {
 	 * Indexable_Author_Builder constructor.
 	 *
 	 * @param Author_Archive_Helper $author_archive The author archive helper.
+	 * @param Options_Helper        $options        The options helper.
 	 */
-	public function __construct( Author_Archive_Helper $author_archive ) {
+	public function __construct(
+		Author_Archive_Helper $author_archive,
+		Options_Helper $options
+	) {
 		$this->author_archive = $author_archive;
+		$this->options        = $options;
 	}
 
 	/**
@@ -48,6 +54,7 @@ class Indexable_Author_Builder {
 		$indexable->permalink              = \get_author_posts_url( $user_id );
 		$indexable->title                  = $meta_data['wpseo_title'];
 		$indexable->description            = $meta_data['wpseo_metadesc'];
+		$indexable->breadcrumb_title       = $this->options->get( 'breadcrumbs-archiveprefix' );
 		$indexable->is_cornerstone         = false;
 		$indexable->is_robots_noindex      = ( $meta_data['wpseo_noindex_author'] === 'on' );
 		$indexable->is_robots_nofollow     = null;

--- a/src/builders/indexable-system-page-builder.php
+++ b/src/builders/indexable-system-page-builder.php
@@ -21,11 +21,11 @@ class Indexable_System_Page_Builder {
 	const OPTION_MAPPING = [
 		'search-result' => [
 			'title'            => 'title-search-wpseo',
-			'breadcrumb_title' => 'breadcrumbs-searchprefix'
+			'breadcrumb_title' => 'breadcrumbs-searchprefix',
 		],
 		'404'           => [
 			'title'            => 'title-404-wpseo',
-			'breadcrumb_title' => 'breadcrumbs-404crumb'
+			'breadcrumb_title' => 'breadcrumbs-404crumb',
 		],
 	];
 
@@ -58,8 +58,8 @@ class Indexable_System_Page_Builder {
 	public function build( $object_sub_type, Indexable $indexable ) {
 		$indexable->object_type       = 'system-page';
 		$indexable->object_sub_type   = $object_sub_type;
-		$indexable->title             = $this->options->get( static::OPTION_MAPPING[ $object_sub_type ][ 'title' ] );
-		$indexable->breadcrumb_title  = $this->options->get( static::OPTION_MAPPING[ $object_sub_type ][ 'breadcrumb_title' ] );
+		$indexable->title             = $this->options->get( static::OPTION_MAPPING[ $object_sub_type ]['title'] );
+		$indexable->breadcrumb_title  = $this->options->get( static::OPTION_MAPPING[ $object_sub_type ]['breadcrumb_title'] );
 		$indexable->is_robots_noindex = true;
 		$indexable->blog_id           = \get_current_blog_id();
 

--- a/src/builders/indexable-system-page-builder.php
+++ b/src/builders/indexable-system-page-builder.php
@@ -19,8 +19,14 @@ class Indexable_System_Page_Builder {
 	 * Mapping of object type to title option keys.
 	 */
 	const OPTION_MAPPING = [
-		'search-result' => 'title-search-wpseo',
-		'404'           => 'title-404-wpseo',
+		'search-result' => [
+			'title'            => 'title-search-wpseo',
+			'breadcrumb_title' => 'breadcrumbs-searchprefix'
+		],
+		'404'           => [
+			'title'            => 'title-404-wpseo',
+			'breadcrumb_title' => 'breadcrumbs-404crumb'
+		],
 	];
 
 	/**
@@ -52,7 +58,8 @@ class Indexable_System_Page_Builder {
 	public function build( $object_sub_type, Indexable $indexable ) {
 		$indexable->object_type       = 'system-page';
 		$indexable->object_sub_type   = $object_sub_type;
-		$indexable->title             = $this->options->get( static::OPTION_MAPPING[ $object_sub_type ] );
+		$indexable->title             = $this->options->get( static::OPTION_MAPPING[ $object_sub_type ][ 'title' ] );
+		$indexable->breadcrumb_title  = $this->options->get( static::OPTION_MAPPING[ $object_sub_type ][ 'breadcrumb_title' ] );
 		$indexable->is_robots_noindex = true;
 		$indexable->blog_id           = \get_current_blog_id();
 

--- a/src/integrations/watchers/indexable-system-page-watcher.php
+++ b/src/integrations/watchers/indexable-system-page-watcher.php
@@ -66,19 +66,21 @@ class Indexable_System_Page_Watcher implements Integration_Interface {
 	 * @return void
 	 */
 	public function check_option( $old_value, $new_value ) {
-		foreach ( Indexable_System_Page_Builder::OPTION_MAPPING as $type => $option ) {
-			// If both values aren't set they haven't changed.
-			if ( ! isset( $old_value[ $option ] ) && ! isset( $new_value[ $option ] ) ) {
-				return;
-			}
+		foreach ( Indexable_System_Page_Builder::OPTION_MAPPING as $type => $options ) {
+			foreach ( $options as $option ) {
+				// If both values aren't set they haven't changed.
+				if ( ! isset( $old_value[ $option ] ) && ! isset( $new_value[ $option ] ) ) {
+					return;
+				}
 
-			// If the value was set but now isn't, is set but wasn't or is not the same it has changed.
-			if (
-				! isset( $old_value[ $option ] )
-				|| ! isset( $new_value[ $option ] )
-				|| $old_value[ $option ] !== $new_value[ $option ]
-			) {
-				$this->build_indexable( $type );
+				// If the value was set but now isn't, is set but wasn't or is not the same it has changed.
+				if (
+					! isset( $old_value[ $option ] )
+					|| ! isset( $new_value[ $option ] )
+					|| $old_value[ $option ] !== $new_value[ $option ]
+				) {
+					$this->build_indexable( $type );
+				}
 			}
 		}
 	}

--- a/tests/builders/indexable-author-builder-test.php
+++ b/tests/builders/indexable-author-builder-test.php
@@ -7,6 +7,7 @@ use Mockery;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Author_Builder;
 use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -29,6 +30,9 @@ class Indexable_Author_Builder_Test extends TestCase {
 	 * @covers ::build
 	 */
 	public function test_build() {
+		$options_mock = Mockery::mock( Options_Helper::class );
+		$options_mock->expects( 'get' )->with( 'breadcrumbs-archiveprefix' )->andReturn( 'breadcrumb_title' );
+
 		Monkey\Functions\expect( 'get_author_posts_url' )->once()->with( 1 )->andReturn( 'https://permalink' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_title', 1 )->andReturn( 'title' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_metadesc', 1 )->andReturn( 'description' );
@@ -41,6 +45,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'permalink', 'https://permalink' );
 		$indexable_mock->orm->expects( 'set' )->with( 'title', 'title' );
 		$indexable_mock->orm->expects( 'set' )->with( 'description', 'description' );
+		$indexable_mock->orm->expects( 'set' )->with( 'breadcrumb_title', 'breadcrumb_title' );
 		$indexable_mock->orm->expects( 'set' )->with( 'is_cornerstone', false );
 		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_noindex', true );
 		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_nofollow', null );
@@ -84,7 +89,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$author_archive = Mockery::mock( Author_Archive_Helper::class );
 		$author_archive->expects( 'author_has_public_posts' )->with( 1 )->andReturn( true );
 
-		$builder = new Indexable_Author_Builder( $author_archive );
+		$builder = new Indexable_Author_Builder( $author_archive, $options_mock );
 		$builder->build( 1, $indexable_mock );
 	}
 
@@ -94,6 +99,9 @@ class Indexable_Author_Builder_Test extends TestCase {
 	 * @covers ::build
 	 */
 	public function test_build_with_undefined() {
+		$options_mock = Mockery::mock( Options_Helper::class );
+		$options_mock->expects( 'get' )->with( 'breadcrumbs-archiveprefix' )->andReturn( '' );
+
 		Monkey\Functions\expect( 'get_author_posts_url' )->once()->with( 1 )->andReturn( 'https://permalink' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_title', 1 )->andReturn( '' );
 		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_metadesc', 1 )->andReturn( '' );
@@ -106,6 +114,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'permalink', 'https://permalink' );
 		$indexable_mock->orm->expects( 'set' )->with( 'title', null );
 		$indexable_mock->orm->expects( 'set' )->with( 'description', null );
+		$indexable_mock->orm->expects( 'set' )->with( 'breadcrumb_title', null );
 		$indexable_mock->orm->expects( 'set' )->with( 'is_cornerstone', false );
 		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_noindex', false );
 		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_nofollow', null );
@@ -149,7 +158,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$author_archive = Mockery::mock( Author_Archive_Helper::class );
 		$author_archive->expects( 'author_has_public_posts' )->with( 1 )->andReturn( true );
 
-		$builder = new Indexable_Author_Builder( $author_archive );
+		$builder = new Indexable_Author_Builder( $author_archive, $options_mock );
 		$builder->build( 1, $indexable_mock );
 	}
 }

--- a/tests/builders/indexable-system-page-builder-test.php
+++ b/tests/builders/indexable-system-page-builder-test.php
@@ -31,12 +31,14 @@ class Indexable_System_Page_Builder_Test extends TestCase {
 	public function test_build() {
 		$options_mock = Mockery::mock( Options_Helper::class );
 		$options_mock->expects( 'get' )->with( 'title-search-wpseo' )->andReturn( 'search_title' );
+		$options_mock->expects( 'get' )->with( 'breadcrumbs-searchprefix' )->andReturn( 'breadcrumb_title' );
 
 		$indexable_mock      = Mockery::mock( Indexable::class );
 		$indexable_mock->orm = Mockery::mock( ORM::class );
 		$indexable_mock->orm->expects( 'set' )->with( 'object_type', 'system-page' );
 		$indexable_mock->orm->expects( 'set' )->with( 'object_sub_type', 'search-result' );
 		$indexable_mock->orm->expects( 'set' )->with( 'title', 'search_title' );
+		$indexable_mock->orm->expects( 'set' )->with( 'breadcrumb_title', 'breadcrumb_title' );
 		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_noindex', true );
 
 		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );


### PR DESCRIPTION
Breadcrumb titles of system pages not getting saved in indexable table when we save the options in the admin. I have made changes to system page builder and watcher for that and also changed unit test of indexable system page builder.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where breadcrumb titles not getting saved in indexable table on saving options

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Goto admin at SEO -> Search Appearance -> Breadcrumbs(tab)
* Update field "Prefix for Search Page breadcrumbs"
* Update field "Breadcrumb for 404 Page"
* Save changes
* Check table "yoast_indexable" column "breadcrumb_title"
* Changes are not reflected

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have updated unittests to verify the code works as intended

Fixes #
