### PR TITLE
WP CLI index command runs migrations for each site in a multisite.

### DIFF
--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -117,6 +117,7 @@ class Index_Command implements Command_Interface {
 
 		foreach ( $blog_ids as $blog_id ) {
 			\switch_to_blog( $blog_id );
+			\do_action( '_yoast_run_migrations' );
 			$this->run_indexation_actions( isset( $assoc_args['reindex'] ) );
 			\restore_current_blog();
 		}

--- a/tests/commands/index-command-test.php
+++ b/tests/commands/index-command-test.php
@@ -208,6 +208,7 @@ class Index_Command_Test extends TestCase {
 		Monkey\Functions\expect( 'switch_to_blog' )->once()->with( 1 );
 		Monkey\Functions\expect( 'switch_to_blog' )->once()->with( 2 );
 		Monkey\Functions\expect( 'restore_current_blog' )->times( 2 );
+		Monkey\Actions\expectDone( '_yoast_run_migrations' );
 
 		$indexation_actions = [
 			$this->post_indexation_action,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the WP CLI indexable indexation command to work on multisite environments, even when the migrations have not been run yet for one or more sites in the multisite network.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `yoast index --network` WordPress Command Line Interface (CLI) command gave an error when run on multisites, when the database migrations for one or more subsites had not been run yet.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Reproducing the bug.
* Checkout the `release/14.1` branch.
* Startup a WordPress multisite environment.
  * For example, startup your local Docker multisite development environment.
* Reset the database migrations for a subsite in the multisite network.
  * Go to the database of your multisite environment en remove the following:
    * The `wp_2_yoast_indexable` table.
    * The `wp_2_yoast_indexable_hierarchy` table.
    * The `wp_2_yoast_migrations` table.
    * The `wp_2_yoast_primary_term` table.
    * The `yoast_migrations_free` option from the `wp_2_options` table.
* Run the `wp yoast index --network` WP CLI command on your multisite.
  * If you use the multisite Docker environment, you can do this by running `./wp.sh 'yoast index --network' from within the root of the `plugin-development-docker` folder on your computer.
    * Make sure that the multisite Docker is running before you run the command 😉.
* You should get an SQL error in the console similar to this one:
```
WordPress database error Table 'wordpress.wp_2_yoast_indexable' doesn't exist for query
			SELECT COUNT(ID)
			FROM wp_2_posts
			WHERE ID NOT IN (SELECT object_id FROM wp_2_yoast_indexable WHERE object_type = 'post') AND post_type IN ('post', 'page', 'attachment')
```

### Checking that the bug has been fixed.
* Checkout the branch in this PR.
* Follow the same steps as in 'Reproducing the bug' above.
* You should **not** get any errors in the console.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/15075
