### PR TITLE
Hide the button when there is nothing to index

### DIFF
--- a/src/presenters/admin/indexation-list-item-presenter.php
+++ b/src/presenters/admin/indexation-list-item-presenter.php
@@ -38,7 +38,14 @@ class Indexation_List_Item_Presenter extends Abstract_Presenter {
 	public function present() {
 		$output = \sprintf( '<li><strong>%s</strong><br/>', \esc_html__( 'Speeding up your site', 'wordpress-seo' ) );
 
-		if ( $this->total_unindexed === 0 ) {
+		/**
+		 * Filter 'wpseo_shutdown_indexation_limit' - Allow filtering the amount of objects that can be indexed during shutdown.
+		 *
+		 * @api int The maximum number of objects indexed.
+		 */
+		$shutdown_limit = \apply_filters( 'wpseo_shutdown_indexation_limit', 25 );
+
+		if ( $this->total_unindexed === 0 || $this->total_unindexed < $shutdown_limit ) {
 			$output .= '<span class="wpseo-checkmark-ok-icon"></span>' . \esc_html__( 'Great, your site has been optimized!', 'wordpress-seo' );
 		}
 		else {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We calculate the indexables in chunks on the background (shutdown). When the amount of indexables is lesser than the maximum amount of indexables that is calculated on background we shouldn't show a button to recalculate them. Because they are already indexed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the button to calculate the indexables is shown but there is nothing to index.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout the release branch
* Index your site.
* Delete one indexable row.
* Visit the SEO -> Tools page and see the Speed up your site button. It should not be there since it will be indexed in between rendering the page and the clicking of the button.
* Checkout this branch and follow the steps again
* The button should be gone and a message that everythings is okay should be given.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #15089
