### PR TITLE
Fix non-echo returns in the deprecated frontend class

### DIFF
--- a/deprecated/frontend/frontend.php
+++ b/deprecated/frontend/frontend.php
@@ -110,15 +110,16 @@ class WPSEO_Frontend {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
 		$presentation = $this->get_current_page_presentation();
-		if ( ! $echo ) {
-			return $presentation->canonical;
-		}
-
-		$presenter = new Canonical_Presenter();
+		$presenter    = new Canonical_Presenter();
 		/** This filter is documented in src/integrations/front-end-integration.php */
 		$presenter->presentation = $presentation;
 		$presenter->helpers      = $this->helpers;
 		$presenter->replace_vars = $this->replace_vars;
+
+		if ( ! $echo ) {
+			return $presenter->get();
+		}
+
 		echo $presenter->present();
 	}
 
@@ -248,16 +249,15 @@ class WPSEO_Frontend {
 	public function metadesc( $echo = true ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
 
-		$presentation = $this->get_current_page_presentation();
-
-		if ( ! $echo ) {
-			return $presentation->meta_description;
-		}
-
+		$presentation            = $this->get_current_page_presentation();
 		$presenter               = new Meta_Description_Presenter();
 		$presenter->presentation = $presentation;
 		$presenter->helpers      = $this->helpers;
 		$presenter->replace_vars = $this->replace_vars;
+
+		if ( ! $echo ) {
+			return $presenter->get();
+		}
 		$presenter->present();
 	}
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes replacement variables not being replaced when using the deprecated WPSEO_Frontend output without echo'ing it.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Call `echo WPSEO_Frontend::get_instance()->metadesc( false );`.
* Replacement variables should be replaced in the string output.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #15126
