### PR TITLE
Change translator string in the Advanced Settings tab

### DIFF
--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -28,7 +28,7 @@ const getNoIndexOptions = () => {
 		return [
 			{
 				name: sprintf(
-					/* Translators: %s translates to the Post Label in plural form, %s translates to "yes" or "no" */
+					/* Translators: %s translates to "yes" or "no", %s translates to the Post Label in plural form */
 					__( "%s (current default for %s)", "wordpress-seo" ),
 					noIndex,
 					window.wpseoAdminL10n.postTypeNamePlural,
@@ -42,7 +42,7 @@ const getNoIndexOptions = () => {
 	return [
 		{
 			name: sprintf(
-				/* Translators: %s translates to the Post Label in plural form, %s translates to the "yes" or "no" */
+				/* Translators: %s translates to the "yes" or "no" ,%s translates to the Post Label in plural form */
 				__( "%s (current default for %s)", "wordpress-seo" ),
 				noIndex,
 				window.wpseoAdminL10n.postTypeNamePlural,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* Translator strings should be in the correct order.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Fixes a bug where the translator strings would be in the wrong order.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Check that the translator strings are in the correct order in the code.

Fixes N/A
