### PR TITLE
Indexation notification does not show up on WP upgrade page.

### DIFF
--- a/src/conditionals/yoast-admin-and-dashboard-conditional.php
+++ b/src/conditionals/yoast-admin-and-dashboard-conditional.php
@@ -18,8 +18,8 @@ class Yoast_Admin_And_Dashboard_Conditional implements Conditional {
 	public function is_met() {
 		global $pagenow;
 
-		// Do not output on plugin / theme installation pages or when wordpress is upgrading.
-		if ( ( defined( 'IFRAME_REQUEST' ) && IFRAME_REQUEST ) || $this->on_plugin_or_theme_page() || wp_installing() ) {
+		// Do not output on plugin / theme upgrade pages or when wordpress is upgrading.
+		if ( ( defined( 'IFRAME_REQUEST' ) && IFRAME_REQUEST ) || $this->on_upgrade_page() || wp_installing() ) {
 			return false;
 		}
 
@@ -39,12 +39,12 @@ class Yoast_Admin_And_Dashboard_Conditional implements Conditional {
 	 *
 	 * @return bool Whether we are on a theme or plugin upgrade page.
 	 */
-	private function on_plugin_or_theme_page() {
+	private function on_upgrade_page() {
 		/*
 		 * IFRAME_REQUEST is not defined on these pages,
 		 * though these action pages do show when upgrading themes or plugins.
 		 */
-		$actions = [ 'do-theme-upgrade', 'do-plugin-upgrade' ];
+		$actions = [ 'do-theme-upgrade', 'do-plugin-upgrade', 'do-core-upgrade' ];
 		return isset( $_GET['action'] ) && in_array( $_GET['action'], $actions, true );
 	}
 }

--- a/src/conditionals/yoast-admin-and-dashboard-conditional.php
+++ b/src/conditionals/yoast-admin-and-dashboard-conditional.php
@@ -44,7 +44,7 @@ class Yoast_Admin_And_Dashboard_Conditional implements Conditional {
 		 * IFRAME_REQUEST is not defined on these pages,
 		 * though these action pages do show when upgrading themes or plugins.
 		 */
-		$actions = [ 'do-theme-upgrade', 'do-plugin-upgrade', 'do-core-upgrade' ];
+		$actions = [ 'do-theme-upgrade', 'do-plugin-upgrade', 'do-core-upgrade', 'do-core-reinstall' ];
 		return isset( $_GET['action'] ) && in_array( $_GET['action'], $actions, true );
 	}
 }

--- a/tests/conditionals/yoast-admin-and-dashboard-conditional-test.php
+++ b/tests/conditionals/yoast-admin-and-dashboard-conditional-test.php
@@ -228,4 +228,26 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 
 		$this->assertEquals( false, $is_met );
 	}
+
+	/**
+	 * Tests that the conditional is not met when on the wordpress reinstall page.
+	 *
+	 * @covers ::is_met
+	 * @covers ::on_plugin_or_theme_page
+	 */
+	public function test_is_not_met_on_wordpress_reinstall_page() {
+		// We are on an admin page.
+		global $pagenow;
+		$pagenow = 'admin.php';
+
+		// But WordPress is currently installing.
+		Monkey\Functions\expect( 'wp_installing' )
+			->andReturn( false );
+
+		$_GET['action'] = 'do-core-reinstall';
+
+		$is_met = $this->instance->is_met();
+
+		$this->assertEquals( false, $is_met );
+	}
 }

--- a/tests/conditionals/yoast-admin-and-dashboard-conditional-test.php
+++ b/tests/conditionals/yoast-admin-and-dashboard-conditional-test.php
@@ -206,4 +206,26 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 
 		$this->assertEquals( false, $is_met );
 	}
+
+	/**
+	 * Tests that the conditional is not met when on the wordpress upgrade page.
+	 *
+	 * @covers ::is_met
+	 * @covers ::on_plugin_or_theme_page
+	 */
+	public function test_is_not_met_on_wordpress_upgrade_page() {
+		// We are on an admin page.
+		global $pagenow;
+		$pagenow = 'admin.php';
+
+		// But WordPress is currently installing.
+		Monkey\Functions\expect( 'wp_installing' )
+			->andReturn( false );
+
+		$_GET['action'] = 'do-core-upgrade';
+
+		$is_met = $this->instance->is_met();
+
+		$this->assertEquals( false, $is_met );
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid users to run the indexable indexation algorithm when doing a WordPress upgrade, since this may severely impact either the indexable process or the WP upgrade.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the indexation notification is shown when WordPress is upgrading (after clicking 'upgrade' on the WordPress updates page).

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Have an outdated WordPress installation.
  * For example by setting up a docker container with an outdated WordPress image (plus a MySQL container).
    * You can use this 'docker-compose.yml' file:
      ```yml
      ---
      version: '3.3'
      services:
        db:
          container_name: 'outdated-wordpress-db'
          image: 'mysql:5.7'
          volumes:
            - './data/mysql:/var/lib/mysql'
          ports:
            - 18766:3306
          environment:
            MYSQL_ROOT_PASSWORD: somewordpress
            MYSQL_DATABASE: wordpress_db
            MYSQL_USER: wordpress_user
            MYSQL_PASSWORD: wordpress_password
        wordpress:
          container_name: 'outdated-wordpress'
          depends_on:
            - db
          image: 'wordpress:5.3'
          ports:
            - '80:80'
          environment:
            WORDPRESS_DB_HOST: 'db:3306'
            WORDPRESS_DB_USER: wordpress_user
            WORDPRESS_DB_PASSWORD: wordpress_password
            WORDPRESS_DB_NAME: wordpress_db
          volumes:
            - "./wordpress:/var/www/html"
            - "./plugins:/var/www/html/wp-content/plugins"
            - "./themes:/var/www/html/wp-content/themes"
       ```
     * Run `docker-compose up` in the folder where you saved the above `docker-compose.yml` to start the containers.
     * Run the WordPress installation process.
     * Clone the `wordpress-seo` repo in the `plugins` folder and activate the plugin on the plugins page of WordPress.
* The notification is only shown when there are 25 or more objects that need to be indexed.
  * To be able to test the notification without the need to create 26 unindexed posts, we will set this limit to 0.
    * Add this filter to your activated theme's `functions.php`:
      ```php
      add_filter( 'wpseo_post_indexation_limit', static function() {
         return 0;
      } );
      ```
* Checkout this branch in the previously cloned `plugins/wordpress-seo` repo.
* Go to the WordPress updates page (for example http://basic.wordpress.test/wp-admin/update-core.php)
* You should see a header with the text 'Your WordPress is outdated'.
* Click on the 'Update Now' button.
* You should **not** see the indexable indexation notification at the top of the page.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #15133
