### PR TITLE
Private taxonomies are now removed on `init` when running the upgrade to 14.1.

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -778,9 +778,9 @@ class WPSEO_Upgrade {
 			return;
 		}
 
-		$placeholders       = \implode( ', ', \array_fill( 0, \count( $private_taxonomies ), '%s' ) );
-		$indexable_table    = Model::get_table_name( 'Indexable' );
-		$query              = $wpdb->prepare(
+		$placeholders    = \implode( ', ', \array_fill( 0, \count( $private_taxonomies ), '%s' ) );
+		$indexable_table = Model::get_table_name( 'Indexable' );
+		$query           = $wpdb->prepare(
 			"DELETE FROM $indexable_table WHERE object_type = 'term' AND object_sub_type IN ($placeholders)",
 			$private_taxonomies
 		);

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -773,6 +773,11 @@ class WPSEO_Upgrade {
 
 		// Clean up indexables of private taxonomies.
 		$private_taxonomies = \get_taxonomies( [ 'public' => false ], 'names' );
+
+		if ( empty( $private_taxonomies ) ) {
+			return;
+		}
+
 		$placeholders       = \implode( ', ', \array_fill( 0, \count( $private_taxonomies ), '%s' ) );
 		$indexable_table    = Model::get_table_name( 'Indexable' );
 		$query              = $wpdb->prepare(

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -6,7 +6,6 @@
  */
 
 use Yoast\WP\Lib\Model;
-use Yoast\WP\SEO\Config\Migration_Status;
 
 /**
  * This code handles the option upgrades.

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -781,10 +781,6 @@ class WPSEO_Upgrade {
 		);
 		$wpdb->query( $query );
 
-		// Reset the permalinks of the attachments in the indexable table.
-		$query = "UPDATE $indexable_table SET permalink = NULL WHERE object_type = 'post' AND object_sub_type = 'attachment'";
-		$wpdb->query( $query );
-
 		$wpdb->show_errors = $show_errors;
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Terms from private taxonomies have no use in the indexables table, since they cannot be indexed by search engines. We recently fixed this, but we should remove any pre-existing private terms from the indexable table.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where terms from private taxonomies were not removed from the indexable table after upgrading from a pre-14.1 version to 14.1 (or one of its release candidates).

## Relevant technical choices:

* I decided to move the resetting of the permalinks of attachments to its own method, to clean up the `upgrade_141` a bit.
  * Since that functionality still works as expected, I decided to leave it as is for the rest. E.g. to not let it run on `init` instead of directly when doing the upgrade routine.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this branch.
* Create a private taxonomy.
   * For example by using the [Custom Post Type UI plugin](https://wordpress.org/plugins/custom-post-type-ui/).
* Alter the line in the term indexation action to:
  ```php
  $public_taxonomies = \get_taxonomies( [ 'public' => false ], 'names' );
  ```
  * This reintroduces a bug that terms from private taxonomies are indexed.
* Visit a random admin page to index the private term.
* Add a new term to the private taxonomy.
* Check your indexable table, it should have an (incorrect, since private) entry for the newly added term.
* Use the test helper to mimic a previous version of the plugin.
  * Go to _Tools_ > _Yoast Test_
  * Set the DB Version of Yoast SEO (under _Plugin options & database versions_) to 14.0.4.
  * Save the changes. This will run the 14.1 upgrade routine.
* Check the indexable table again. The term from the private taxonomy should be removed.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #15144
