### PR TITLE
Fix no index for taxonomies on the Advanced Settings tab

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1178,7 +1178,7 @@ SVG;
 
 		/* Adjust the no-index text strings based on the post type. */
 		$label_object = ( $page_type === 'post' ) ? get_post_type_object( $post_type ) : WPSEO_Taxonomy::get_labels();
-		
+
 		$no_index = false;
 		if ( $page_type === 'post' ) {
 			$no_index = WPSEO_Options::get( 'noindex-' . $post_type, false );

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1173,7 +1173,6 @@ SVG;
 	 * @return array The Adminl10n array.
 	 */
 	public static function get_admin_l10n() {
-		global $post;
 		$post_type = WPSEO_Utils::get_post_type();
 		$page_type = WPSEO_Utils::get_page_type();
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1173,15 +1173,17 @@ SVG;
 	 * @return array The Adminl10n array.
 	 */
 	public static function get_admin_l10n() {
+		global $post;
 		$post_type = WPSEO_Utils::get_post_type();
 		$page_type = WPSEO_Utils::get_page_type();
 
 		/* Adjust the no-index text strings based on the post type. */
 		$label_object = ( $page_type === 'post' ) ? get_post_type_object( $post_type ) : WPSEO_Taxonomy::get_labels();
-
+		$no_index = ( $page_type === 'post' ) ? WPSEO_Options::get( 'noindex-' . $post_type, false ) : WPSEO_Options::get( 'noindex-tax-' . $label_object->name_admin_bar );
+		
 		$wpseo_admin_l10n = [
 			'displayAdvancedTab'   => WPSEO_Capability_Utils::current_user_can( 'wpseo_edit_advanced_metadata' ) && ! ! WPSEO_Options::get( 'disableadvanced_meta' ),
-			'noIndex'              => ! ! WPSEO_Options::get( 'noindex-' . $post_type, false ),
+			'noIndex'              => ! ! $no_index,
 			'isPostType'           => ! ! get_post_type(),
 			'postTypeNamePlural'   => ( $page_type === 'post' ) ? $label_object->label : $label_object->name,
 			'postTypeNameSingular' => ( $page_type === 'post' ) ? $label_object->labels->singular_name : $label_object->singular_name,

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1178,8 +1178,8 @@ SVG;
 
 		/* Adjust the no-index text strings based on the post type. */
 		$label_object = ( $page_type === 'post' ) ? get_post_type_object( $post_type ) : WPSEO_Taxonomy::get_labels();
-		$no_index = ( $page_type === 'post' ) ? WPSEO_Options::get( 'noindex-' . $post_type, false ) : WPSEO_Options::get( 'noindex-tax-' . $label_object->name_admin_bar );
-		
+		$no_index = ( $page_type === 'post' ) ? WPSEO_Options::get( 'noindex-' . $post_type, false ) : WPSEO_Options::get( 'noindex-tax-' . strtolower( $label_object->name_admin_bar ), false );
+
 		$wpseo_admin_l10n = [
 			'displayAdvancedTab'   => WPSEO_Capability_Utils::current_user_can( 'wpseo_edit_advanced_metadata' ) && ! ! WPSEO_Options::get( 'disableadvanced_meta' ),
 			'noIndex'              => ! ! $no_index,

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1178,7 +1178,14 @@ SVG;
 
 		/* Adjust the no-index text strings based on the post type. */
 		$label_object = ( $page_type === 'post' ) ? get_post_type_object( $post_type ) : WPSEO_Taxonomy::get_labels();
-		$no_index = ( $page_type === 'post' ) ? WPSEO_Options::get( 'noindex-' . $post_type, false ) : WPSEO_Options::get( 'noindex-tax-' . strtolower( $label_object->name_admin_bar ), false );
+		
+		$no_index = false;
+		if ( $page_type === 'post' ) {
+			$no_index = WPSEO_Options::get( 'noindex-' . $post_type, false );
+		}
+		else {
+			$no_index = WPSEO_Options::get( 'noindex-tax-' . strtolower( $label_object->name_admin_bar ), false );
+		}
 
 		$wpseo_admin_l10n = [
 			'displayAdvancedTab'   => WPSEO_Capability_Utils::current_user_can( 'wpseo_edit_advanced_metadata' ) && ! ! WPSEO_Options::get( 'disableadvanced_meta' ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* See #15142 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Fix a bug where the default value for no-index for taxonomies did not reflect settings

## Relevant technical choices:
* Apparently, the no-index option can be retrieved using `WPSEO_Options::get( 'noindex-tax-' . 'YOUR_TAXONOMY_ADMIN_NAME' );`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Change the default setting for some taxonomies in Settings > Search Appearance
* Check that the default setting is displayed correct in the Advanced Settings tab for those pages
* Also check for Custom Post Types and Custom Taxonomies.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #15142
