### PR TITLE
Add logger calls for the indexables

### DIFF
--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -9,9 +9,11 @@ namespace Yoast\WP\SEO\Builders;
 
 use Exception;
 use Yoast\WP\SEO\Helpers\Post_Helper;
+use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Repositories\SEO_Meta_Repository;
+use YoastSEO_Vendor\Psr\Log\LogLevel;
 
 /**
  * Formats the post meta to indexable format.
@@ -41,16 +43,25 @@ class Indexable_Post_Builder {
 	protected $post;
 
 	/**
+	 * Holds the logger.
+	 *
+	 * @var Logger
+	 */
+	protected $logger;
+
+	/**
 	 * Indexable_Post_Builder constructor.
 	 *
 	 * @codeCoverageIgnore This is dependency injection only.
 	 *
 	 * @param SEO_Meta_Repository $seo_meta_repository The SEO Meta repository.
 	 * @param Post_Helper         $post                The post helper.
+	 * @param Logger              $logger              The logger.
 	 */
-	public function __construct( SEO_Meta_Repository $seo_meta_repository, Post_Helper $post ) {
+	public function __construct( SEO_Meta_Repository $seo_meta_repository, Post_Helper $post, Logger $logger ) {
 		$this->seo_meta_repository = $seo_meta_repository;
 		$this->post                = $post;
+		$this->logger              = $logger;
 	}
 
 	/**
@@ -316,8 +327,8 @@ class Indexable_Post_Builder {
 				$indexable->link_count          = $seo_meta->internal_link_count;
 				$indexable->incoming_link_count = $seo_meta->incoming_link_count;
 			}
-		} catch ( Exception $exception ) { // @codingStandardsIgnoreLine Generic.CodeAnalysis.EmptyStatement.DetectedCATCH -- There is nothing to do.
-			// Do nothing here.
+		} catch ( Exception $exception ) {
+			$this->logger->log( LogLevel::ERROR, $exception->getMessage() );
 		}
 
 		return $indexable;

--- a/src/builders/indexable-rebuilder.php
+++ b/src/builders/indexable-rebuilder.php
@@ -8,7 +8,9 @@
 namespace Yoast\WP\SEO\Builders;
 
 use Exception;
+use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
+use YoastSEO_Vendor\Psr\Log\LogLevel;
 
 /**
  * Class Indexable_Rebuilder.
@@ -32,16 +34,25 @@ class Indexable_Rebuilder {
 	protected $builder;
 
 	/**
+	 * Holds the logger.
+	 *
+	 * @var Logger
+	 */
+	protected $logger;
+
+	/**
 	 * Indexable_Rebuilder constructor.
 	 *
 	 * @codeCoverageIgnore No point in testing this constructor without side-effects.
 	 *
 	 * @param Indexable_Repository $repository The repository to use.
 	 * @param Indexable_Builder    $builder    The post builder to use.
+	 * @param Logger               $logger     The logger.
 	 */
-	public function __construct( Indexable_Repository $repository, Indexable_Builder $builder ) {
+	public function __construct( Indexable_Repository $repository, Indexable_Builder $builder, Logger $logger ) {
 		$this->repository = $repository;
 		$this->builder    = $builder;
+		$this->logger     = $logger;
 	}
 
 	/**
@@ -55,8 +66,8 @@ class Indexable_Rebuilder {
 			foreach ( $indexables as $indexable ) {
 				$this->builder->build_for_id_and_type( $indexable->object_id, $object_type, $indexable );
 			}
-		} catch ( Exception $exception ) { // @codingStandardsIgnoreLine Generic.CodeAnalysis.EmptyStatement.DetectedCATCH -- There is nothing to do.
-			// Do nothing.
+		} catch ( Exception $exception ) {
+			$this->logger->log( LogLevel::ERROR, $exception->getMessage() );
 		}
 	}
 
@@ -72,8 +83,8 @@ class Indexable_Rebuilder {
 			foreach ( $indexables as $indexable ) {
 				$this->builder->build_for_id_and_type( $indexable->object_id, $object_type, $indexable );
 			}
-		} catch ( Exception $exception ) { // @codingStandardsIgnoreLine Generic.CodeAnalysis.EmptyStatement.DetectedCATCH -- There is nothing to do.
-			// Do nothing.
+		} catch ( Exception $exception ) {
+			$this->logger->log( LogLevel::ERROR, $exception->getMessage() );
 		}
 	}
 
@@ -88,8 +99,8 @@ class Indexable_Rebuilder {
 		try {
 			$indexable = $this->repository->find_for_post_type_archive( $post_type, false );
 			$this->builder->build_for_post_type_archive( $post_type, $indexable );
-		} catch ( Exception $exception ) { // @codingStandardsIgnoreLine Generic.CodeAnalysis.EmptyStatement.DetectedCATCH -- There is nothing to do.
-			// Do nothing.
+		} catch ( Exception $exception ) {
+			$this->logger->log( LogLevel::ERROR, $exception->getMessage() );
 		}
 	}
 
@@ -102,8 +113,8 @@ class Indexable_Rebuilder {
 		try {
 			$indexable = $this->repository->find_for_date_archive( false );
 			$this->builder->build_for_date_archive( $indexable );
-		} catch ( Exception $exception ) { // @codingStandardsIgnoreLine Generic.CodeAnalysis.EmptyStatement.DetectedCATCH -- There is nothing to do.
-			// Do nothing.
+		} catch ( Exception $exception ) {
+			$this->logger->log( LogLevel::ERROR, $exception->getMessage() );
 		}
 	}
 }

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -13,9 +13,11 @@ use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
 use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
+use YoastSEO_Vendor\Psr\Log\LogLevel;
 
 /**
  * Fills the Indexable according to Post data.
@@ -58,6 +60,13 @@ class Indexable_Post_Watcher implements Integration_Interface {
 	private $post;
 
 	/**
+	 * Holds the logger.
+	 *
+	 * @var Logger
+	 */
+	protected $logger;
+
+	/**
 	 * @inheritDoc
 	 */
 	public static function get_conditionals() {
@@ -72,19 +81,22 @@ class Indexable_Post_Watcher implements Integration_Interface {
 	 * @param Indexable_Hierarchy_Repository $hierarchy_repository The hierarchy repository to use.
 	 * @param Author_Archive_Helper          $author_archive       The author archive helper.
 	 * @param Post_Helper                    $post                 The post helper.
+	 * @param Logger                         $logger               The logger.
 	 */
 	public function __construct(
 		Indexable_Repository $repository,
 		Indexable_Builder $builder,
 		Indexable_Hierarchy_Repository $hierarchy_repository,
 		Author_Archive_Helper $author_archive,
-		Post_Helper $post
+		Post_Helper $post,
+		Logger $logger
 	) {
 		$this->repository           = $repository;
 		$this->builder              = $builder;
 		$this->hierarchy_repository = $hierarchy_repository;
 		$this->author_archive       = $author_archive;
 		$this->post                 = $post;
+		$this->logger               = $logger;
 	}
 
 	/**
@@ -184,8 +196,8 @@ class Indexable_Post_Watcher implements Integration_Interface {
 		try {
 			$indexable = $this->repository->find_by_id_and_type( $post_id, 'post', false );
 			$this->builder->build_for_id_and_type( $post_id, 'post', $indexable );
-		} catch ( Exception $exception ) { // @codingStandardsIgnoreLine Generic.CodeAnalysis.EmptyStatement.DetectedCATCH -- There is nothing to do.
-			// Do nothing.
+		} catch ( Exception $exception ) {
+			$this->logger->log( LogLevel::ERROR, $exception->getMessage() );
 		}
 	}
 
@@ -200,8 +212,8 @@ class Indexable_Post_Watcher implements Integration_Interface {
 			$author_indexable = $this->repository->find_by_id_and_type( $indexable->author_id, 'user' );
 			$author_indexable->has_public_posts = $this->author_archive->author_has_public_posts( $author_indexable->object_id );
 			$author_indexable->save();
-		} catch ( Exception $exception ) { // @codingStandardsIgnoreLine Generic.CodeAnalysis.EmptyStatement.DetectedCATCH -- There is nothing to do.
-			// Do nothing.
+		} catch ( Exception $exception ) {
+			$this->logger->log( LogLevel::ERROR, $exception->getMessage() );
 		}
 
 		// Update possible attachment's has public posts value.

--- a/tests/builders/indexable-post-builder-test.php
+++ b/tests/builders/indexable-post-builder-test.php
@@ -10,6 +10,7 @@ use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper as Open_Graph_Image_Helper;
 use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Helpers\Twitter\Image_Helper as Twitter_Image_Helper;
+use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Repositories\SEO_Meta_Repository;
@@ -79,6 +80,13 @@ class Indexable_Post_Builder_Test extends TestCase {
 	private $post;
 
 	/**
+	 * Holds the Logger instance.
+	 *
+	 * @var Logger|Mockery\MockInterface
+	 */
+	private $logger;
+
+	/**
 	 * Holds the Indexable_Post_Builder instance.
 	 *
 	 * @var \Yoast\WP\SEO\Builders\Indexable_Post_Builder|Indexable_Post_Builder_Double|Mockery\MockInterface
@@ -96,10 +104,12 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$this->open_graph_image     = Mockery::mock( Open_Graph_Image_Helper::class );
 		$this->twitter_image        = Mockery::mock( Twitter_Image_Helper::class );
 		$this->post                 = Mockery::mock( Post_Helper::class );
+		$this->logger               = Mockery::mock( Logger::class );
 
 		$this->instance = Mockery::mock( Indexable_Post_Builder_Double::class, [
 			$this->seo_meta_repository,
 			$this->post,
+			$this->logger,
 		] )
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
@@ -446,5 +456,73 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$this->post->expects( 'get_post' )->once()->with( 1 )->andReturn( null );
 
 		$this->assertFalse( $this->instance->build( 1, false ) );
+	}
+
+	/**
+	 * Tests that build's set_link_count logs the exception.
+	 *
+	 * @covers ::build
+	 */
+	public function test_build_set_link_count_log_exception() {
+		$this->indexable      = Mockery::mock( Indexable::class );
+		$this->indexable->orm = Mockery::mock( ORM::class );
+		$this->indexable->orm->expects( 'set' )->times( 43 );
+		$this->indexable->orm->expects( 'offsetExists' )->zeroOrMoreTimes()->andReturnTrue();
+		$this->indexable->orm->expects( 'get' )->times( 11 )->andReturnArg( 0 );
+
+		$this->post->expects( 'get_post' )
+			->once()
+			->with( 1 )
+			->andReturn(
+				(object) [
+					'post_content'  => 'The content of the post',
+					'post_type'     => 'post',
+					'post_status'   => 'publish',
+					'post_password' => '',
+					'post_author'   => '1',
+					'post_parent'   => '0',
+				]
+			);
+
+		Monkey\Functions\expect( 'get_permalink' )
+			->once()
+			->with( 1 )
+			->andReturn( 'https://example.com' );
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		Monkey\Functions\expect( 'get_post_custom' )->with( 1 )->andReturn(
+			[
+				'_yoast_wpseo_focuskw'               => [ 'focuskeyword' ],
+				'_yoast_wpseo_linkdex'               => [ '100' ],
+				'_yoast_wpseo_is_cornerstone'        => [ '1' ],
+				'_yoast_wpseo_meta-robots-noindex'   => [ '1' ],
+				'_yoast_wpseo_meta-robots-adv'       => [ '' ],
+				'_yoast_wpseo_content_score'         => [ '50' ],
+				'_yoast_wpseo_canonical'             => [ 'https://canonical' ],
+				'_yoast_wpseo_meta-robots-nofollow'  => [ '1' ],
+				'_yoast_wpseo_title'                 => [ 'title' ],
+				'_yoast_wpseo_metadesc'              => [ 'description' ],
+				'_yoast_wpseo_bctitle'               => [ 'breadcrumb_title' ],
+				'_yoast_wpseo_opengraph-title'       => [ 'open_graph_title' ],
+				'_yoast_wpseo_opengraph-description' => [ 'open_graph_description' ],
+				'_yoast_wpseo_twitter-title'         => [ 'twitter_title' ],
+				'_yoast_wpseo_twitter-description'   => [ 'twitter_description' ],
+			]
+		);
+		Monkey\Functions\expect( 'maybe_unserialize' )->andReturnFirstArg();
+
+		$this->twitter_image->expects( 'get_by_id' )
+			->once()
+			->andReturnFalse();
+		$this->open_graph_image->expects( 'get_image_by_id' )
+			->once()
+			->andReturnFalse();
+
+		$this->seo_meta_repository->expects( 'find_by_post_id' )
+			->once()
+			->with( 1 )
+			->andThrows( new Exception( 'an error' ) );
+		$this->logger->expects( 'log' )->once()->with( 'error', 'an error' );
+
+		$this->instance->build( 1, $this->indexable );
 	}
 }

--- a/tests/builders/indexable-rebuilder-test.php
+++ b/tests/builders/indexable-rebuilder-test.php
@@ -6,6 +6,7 @@ use Exception;
 use Mockery;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Builders\Indexable_Rebuilder;
+use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -44,6 +45,13 @@ class Indexable_Rebuilder_Test extends TestCase {
 	private $builder;
 
 	/**
+	 * Holds the Logger instance.
+	 *
+	 * @var Logger|Mockery\MockInterface
+	 */
+	private $logger;
+
+	/**
 	 * Sets up the test class.
 	 */
 	public function setUp() {
@@ -51,7 +59,8 @@ class Indexable_Rebuilder_Test extends TestCase {
 
 		$this->repository = Mockery::mock( Indexable_Repository::class );
 		$this->builder    = Mockery::mock( Indexable_Builder::class );
-		$this->instance   = new Indexable_Rebuilder( $this->repository, $this->builder );
+		$this->logger     = Mockery::mock( Logger::class );
+		$this->instance   = new Indexable_Rebuilder( $this->repository, $this->builder, $this->logger );
 	}
 
 	/**
@@ -92,8 +101,12 @@ class Indexable_Rebuilder_Test extends TestCase {
 	 * @covers ::rebuild_for_type
 	 */
 	public function test_rebuild_for_type_catches_exceptions() {
-		$this->repository->expects( 'find_all_with_type' )->once()->with( 'user' )->andThrows( new Exception() );
+		$this->repository->expects( 'find_all_with_type' )
+			->once()
+			->with( 'user' )
+			->andThrows( new Exception( 'an error' ) );
 		$this->builder->expects( 'build_for_id_and_type' )->never();
+		$this->logger->expects( 'log' )->once()->with( 'error', 'an error' );
 
 		$this->instance->rebuild_for_type( 'user' );
 	}
@@ -136,8 +149,12 @@ class Indexable_Rebuilder_Test extends TestCase {
 	 * @covers ::rebuild_for_type_and_sub_type
 	 */
 	public function test_rebuild_for_type_and_sub_type_catches_exceptions() {
-		$this->repository->expects( 'find_all_with_type_and_sub_type' )->once()->with( 'post', 'custom-post' )->andThrows( new Exception() );
+		$this->repository->expects( 'find_all_with_type_and_sub_type' )
+			->once()
+			->with( 'post', 'custom-post' )
+			->andThrows( new Exception( 'an error' ) );
 		$this->builder->expects( 'build_for_id_and_type' )->never();
+		$this->logger->expects( 'log' )->once()->with( 'error', 'an error' );
 
 		$this->instance->rebuild_for_type_and_sub_type( 'post', 'custom-post' );
 	}
@@ -176,8 +193,12 @@ class Indexable_Rebuilder_Test extends TestCase {
 	 * @covers ::rebuild_for_post_type_archive
 	 */
 	public function test_rebuild_for_post_type_archive_catches_exceptions() {
-		$this->repository->expects( 'find_for_post_type_archive' )->once()->with( 'custom-post', false )->andThrows( new Exception() );
+		$this->repository->expects( 'find_for_post_type_archive' )
+			->once()
+			->with( 'custom-post', false )
+			->andThrows( new Exception( 'an error' ) );
 		$this->builder->expects( 'build_for_post_type_archive' )->never();
+		$this->logger->expects( 'log' )->once()->with( 'error', 'an error' );
 
 		$this->instance->rebuild_for_post_type_archive( 'custom-post' );
 	}
@@ -216,8 +237,12 @@ class Indexable_Rebuilder_Test extends TestCase {
 	 * @covers ::rebuild_for_date_archive
 	 */
 	public function test_rebuild_for_date_archive_catches_exceptions() {
-		$this->repository->expects( 'find_for_date_archive' )->once()->with( false )->andThrows( new Exception() );
+		$this->repository->expects( 'find_for_date_archive' )
+			->once()
+			->with( false )
+			->andThrows( new Exception( 'an error' ) );
 		$this->builder->expects( 'build_for_date_archive' )->never();
+		$this->logger->expects( 'log' )->once()->with( 'error', 'an error' );
 
 		$this->instance->rebuild_for_date_archive();
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Since the issue we removed quite a few of these catch statements for the indexables and went to a fake indexable solution instead. Nevertheless there are some catch statements left. With a logger we can check if these result in problems. The standard logger (null logger) is still a not doing anything though.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds logger calls to previously empty catch statements.

## Relevant technical choices:

* Not sure about the logger with dependency injection like this. Seems like a bit overhead if we start using it on a lot of places.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add the following code somewhere (theme's functions.php?) to have a logger that actually does something. In this case it will output a "notice" with the exception message.
```php
\add_filter( 'wpseo_logger', static function () {
	return new class implements \YoastSEO_Vendor\Psr\Log\LoggerInterface {
		use \YoastSEO_Vendor\Psr\Log\LoggerTrait;

		public function log( $level, $message, array $context = [] ) {
			printf( '<div class="notice notice-%1$s">%2$s</div>', $level, $message );
		}
	};
} );
```
* The following steps are best done per place in the code at a time. The place to put the exception is at the top of the `try` for which the logger is added in the corresponding `catch`, these are:
  1. [src/builders/indexable-post-builder.php line 324](https://github.com/Yoast/wordpress-seo/blob/14459-log-indexable-exceptions/src/builders/indexable-post-builder.php#L324)
  1. [src/builders/indexable-rebuilder.php line 65](https://github.com/Yoast/wordpress-seo/blob/14459-log-indexable-exceptions/src/builders/indexable-rebuilder.php#L65)
  1. [src/builders/indexable-rebuilder.php line 82](https://github.com/Yoast/wordpress-seo/blob/14459-log-indexable-exceptions/src/builders/indexable-rebuilder.php#L82)
  1. [src/builders/indexable-rebuilder.php line 100](https://github.com/Yoast/wordpress-seo/blob/14459-log-indexable-exceptions/src/builders/indexable-rebuilder.php#L100)
  1. [src/builders/indexable-rebuilder.php line 114](https://github.com/Yoast/wordpress-seo/blob/14459-log-indexable-exceptions/src/builders/indexable-rebuilder.php#L114)
  1. [src/integrations/watchers/indexable-post-watcher.php line 197](https://github.com/Yoast/wordpress-seo/blob/14459-log-indexable-exceptions/src/integrations/watchers/indexable-post-watcher.php#L197)
  1. [src/integrations/watchers/indexable-post-watcher.php line 212](https://github.com/Yoast/wordpress-seo/blob/14459-log-indexable-exceptions/src/integrations/watchers/indexable-post-watcher.php#L212)
* To trigger exceptions in the places you can add `throw new Exception( 'testing 1 2 3 4' );` in each of the places (see above). You can change the message each time to spot the difference if you like.
* Then it is time to run the code to get the exceptions. You can add the following code in your theme's functions, at the top of the setup function (`twentytwenty_theme_support`). 
  1. You can create a new post and publish it. It should fail due to invalid JSON. You can check the request to see the error notice. Or you can use the code: `YoastSEO()->classes->get( 'Yoast\WP\SEO\Builders\Indexable_Builder' )->build_for_id_and_type( 120, 'post' );`. Replace 120 with a valid post ID.
  1. `YoastSEO()->classes->get( 'Yoast\WP\SEO\Builders\Indexable_Rebuilder' )->rebuild_for_type( 'post' );`
  1. `YoastSEO()->classes->get( 'Yoast\WP\SEO\Builders\Indexable_Rebuilder' )->rebuild_for_type_and_sub_type( 'post', 'attachment' );`
  1. `YoastSEO()->classes->get( 'Yoast\WP\SEO\Builders\Indexable_Rebuilder' )->rebuild_for_post_type_archive( 'post' );`
  1. `YoastSEO()->classes->get( 'Yoast\WP\SEO\Builders\Indexable_Rebuilder' )->rebuild_for_date_archive();`
  1. You can go to a post and resave it. It should fail due to invalid JSON. You can check the network request to see the error notice.
  1. You can go to a post and resave it. It should fail due to invalid JSON. You can check the network request to see the error notice.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #14459 
