### PR TITLE
Fix indexation notification bugs

### DIFF
--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -29,8 +29,8 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'ms_defaults_set'                          => false,
 		'ignore_search_engines_discouraged_notice' => false,
 		'ignore_indexation_warning'                => false,
-		'indexation_warning_hide_until'            => 0,
-		'indexation_started'                       => 0,
+		'indexation_warning_hide_until'            => false,
+		'indexation_started'                       => false,
 		// Non-form field, should only be set via validation routine.
 		'version'                         => '', // Leave default as empty to ensure activation/upgrade works.
 		'previous_version'                => '',

--- a/js/src/wp-seo-indexation.js
+++ b/js/src/wp-seo-indexation.js
@@ -110,6 +110,9 @@ const settings = yoastIndexationData;
 					tb_remove();
 					indexationInProgress = false;
 				} ).catch( error => {
+					if ( stoppedIndexation ) {
+						return;
+					}
 					console.error( error );
 					a11ySpeak( settings.l10n.calculationFailed );
 					$( "#yoast-indexation-warning" )

--- a/src/integrations/admin/indexation-integration.php
+++ b/src/integrations/admin/indexation-integration.php
@@ -255,7 +255,7 @@ class Indexation_Integration implements Integration_Interface {
 		}
 
 		// When the indexation is started, but not completed.
-		if ( $this->options_helper->get( 'indexation_started', 0 ) > ( time() - MONTH_IN_SECONDS ) ) {
+		if ( $this->options_helper->get( 'indexation_started', false ) > ( time() - MONTH_IN_SECONDS ) ) {
 			return true;
 		}
 

--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -185,8 +185,8 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 	 * @return bool `true` if the 'indexation is incomplete' warning should be shown, `false` if not.
 	 */
 	private function show_indexation_incomplete_alert() {
-		$indexation_started = $this->options_helper->get( 'indexation_started', 0 );
-		if ( $indexation_started === 0 ) {
+		$indexation_started = $this->options_helper->get( 'indexation_started', false );
+		if ( ! $indexation_started ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where "Something went wrong while optimizing..." was shown briefly when the indexing process was stopped manually.
* Fixes a bug where an incorrect notification was shown when the indexing process had never been run before.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
### Test 1
* Reset the indexables tables with the yoast test helper.
* Start the indexing
* Click the stop button.
* Don't see "Something went wrong while optimizing..."

### Test 2
* After `Test 1`: you won't see a notification, because the indexation process has run less than a month ago.
* In `wpseo` in `wp_options` in the database set `"indexation_started";i:5`
    * See the notification containing "It looks like an indexing process was run earlier, but didn't complete. There is still some content which hasn't been indexed yet. Don't worry, you can pick up where you left off".
* In `wpseo` in `wp_options` in the database set `"indexation_started";b:0`
    * See a notification containing "To build your index, Yoast SEO needs to process all of your content. We estimate this will take less than a minute."



## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #15165
