### PR TITLE
Change the way we get taxonomy slug

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1177,7 +1177,7 @@ SVG;
 		$page_type = WPSEO_Utils::get_page_type();
 
 		/* Adjust the no-index text strings based on the post type. */
-		$label_object = ( $page_type === 'post' ) ? get_post_type_object( $post_type ) : WPSEO_Taxonomy::get_labels();
+		$label_object  = ( $page_type === 'post' ) ? get_post_type_object( $post_type ) : WPSEO_Taxonomy::get_labels();
 		$taxonomy_slug = filter_input( INPUT_GET, 'taxonomy', FILTER_DEFAULT, [ 'options' => [ 'default' => '' ] ] );
 
 		$no_index = false;

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1181,13 +1181,13 @@ SVG;
 
 		if ( $page_type === 'post' ) {
 			$label_object = get_post_type_object( $post_type );
-			$no_index = WPSEO_Options::get( 'noindex-' . $post_type, false );
+			$no_index     = WPSEO_Options::get( 'noindex-' . $post_type, false );
 		}
 		else {
 			$label_object = WPSEO_Taxonomy::get_labels();
 
 			$taxonomy_slug = filter_input( INPUT_GET, 'taxonomy', FILTER_DEFAULT, [ 'options' => [ 'default' => '' ] ] );
-			$no_index = WPSEO_Options::get( 'noindex-tax-' . $taxonomy_slug, false );
+			$no_index      = WPSEO_Options::get( 'noindex-tax-' . $taxonomy_slug, false );
 		}
 
 		$wpseo_admin_l10n = [

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1176,15 +1176,17 @@ SVG;
 		$post_type = WPSEO_Utils::get_post_type();
 		$page_type = WPSEO_Utils::get_page_type();
 
-		/* Adjust the no-index text strings based on the post type. */
-		$label_object  = ( $page_type === 'post' ) ? get_post_type_object( $post_type ) : WPSEO_Taxonomy::get_labels();
-		$taxonomy_slug = filter_input( INPUT_GET, 'taxonomy', FILTER_DEFAULT, [ 'options' => [ 'default' => '' ] ] );
+		$label_object = false;
+		$no_index     = false;
 
-		$no_index = false;
 		if ( $page_type === 'post' ) {
+			$label_object = get_post_type_object( $post_type );
 			$no_index = WPSEO_Options::get( 'noindex-' . $post_type, false );
 		}
 		else {
+			$label_object = WPSEO_Taxonomy::get_labels();
+
+			$taxonomy_slug = filter_input( INPUT_GET, 'taxonomy', FILTER_DEFAULT, [ 'options' => [ 'default' => '' ] ] );
 			$no_index = WPSEO_Options::get( 'noindex-tax-' . $taxonomy_slug, false );
 		}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1178,13 +1178,14 @@ SVG;
 
 		/* Adjust the no-index text strings based on the post type. */
 		$label_object = ( $page_type === 'post' ) ? get_post_type_object( $post_type ) : WPSEO_Taxonomy::get_labels();
+		$taxonomy_slug = filter_input( INPUT_GET, 'taxonomy', FILTER_DEFAULT, [ 'options' => [ 'default' => '' ] ] );
 
 		$no_index = false;
 		if ( $page_type === 'post' ) {
 			$no_index = WPSEO_Options::get( 'noindex-' . $post_type, false );
 		}
 		else {
-			$no_index = WPSEO_Options::get( 'noindex-tax-' . strtolower( $label_object->name_admin_bar ), false );
+			$no_index = WPSEO_Options::get( 'noindex-tax-' . $taxonomy_slug, false );
 		}
 
 		$wpseo_admin_l10n = [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* Update the way we get the taxonomy slug as the previous method was not the most reliable.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Use a filter_input to get the taxonomy_slug instead of relying on the labels_object.

## Relevant technical choices:
* The labels_object might be altered by the user in some cases, in which the old code would have errored.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Test that the default no-index option is displayed correctly in taxonomies:
	- Categories
	- Tags
	- Custom taxonomies

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes N/A
