### PR TITLE
Fix breadcrumb order

### DIFF
--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -125,9 +125,9 @@ class Indexable_Hierarchy_Builder {
 	 * @return void
 	 */
 	private function save_ancestors( $indexable ) {
-		$depth = 1;
+		$depth = \count( $indexable->ancestors );
 		foreach ( $indexable->ancestors as $ancestor ) {
-			$this->indexable_hierarchy_repository->add_ancestor( $indexable->id, $ancestor->id, $depth++ );
+			$this->indexable_hierarchy_repository->add_ancestor( $indexable->id, $ancestor->id, $depth-- );
 		}
 	}
 

--- a/src/config/migrations/20200513133401_ResetIndexableHierarchyTable.php
+++ b/src/config/migrations/20200513133401_ResetIndexableHierarchyTable.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package WPSEO\Migrations
+ */
+
+use Yoast\WP\Lib\Model;
+use YoastSEO_Vendor\Ruckusing_Migration_Base;
+
+/**
+ * TruncateIndexableTables
+ */
+class ResetIndexableHierarchyTable extends Ruckusing_Migration_Base {
+
+	/**
+	 * Migration up.
+	 */
+	public function up() {
+		$this->query( 'TRUNCATE TABLE ' . $this->get_table_name() );
+	}
+
+	/**
+	 * Migration down.
+	 */
+	public function down() {
+		// Nothing to do.
+	}
+
+	/**
+	 * Retrieves the table name to use.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Model::get_table_name( 'Indexable_Hierarchy' );
+	}
+}

--- a/src/repositories/indexable-hierarchy-repository.php
+++ b/src/repositories/indexable-hierarchy-repository.php
@@ -11,7 +11,6 @@ use Yoast\WP\Lib\Model;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder;
 use Yoast\WP\SEO\Models\Indexable;
-use Yoast\WP\SEO\Models\Indexable_Hierarchy;
 
 /**
  * Class Indexable_Hierarchy_Repository
@@ -71,25 +70,25 @@ class Indexable_Hierarchy_Repository {
 	 *
 	 * @param Indexable $indexable The indexable to get the ancestors for.
 	 *
-	 * @return Indexable_Hierarchy[] The ancestors.
+	 * @return int[] The indexable IDs of the ancestors in order of grandparent to child.
 	 */
 	public function find_ancestors( Indexable $indexable ) {
 		$ancestors = $this->query()
+			->select( 'ancestor_id' )
 			->where( 'indexable_id', $indexable->id )
 			->order_by_desc( 'depth' )
-			->find_many();
+			->find_array();
 
 		if ( ! empty( $ancestors ) ) {
-			return $ancestors;
+			return \array_map( function ( $ancestor ) {
+				return $ancestor['ancestor_id'];
+			}, $ancestors );
 		}
 
 		$indexable = $this->builder->build( $indexable );
-		$ancestors = $this->query()
-			->where( 'indexable_id', $indexable->id )
-			->order_by_desc( 'depth' )
-			->find_many();
-
-		return $ancestors;
+		return \array_map( function ( $indexable ) {
+			return $indexable->id;
+		}, $indexable->ancestors );
 	}
 
 	/**

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -347,19 +347,20 @@ class Indexable_Repository {
 	 * @return Indexable[] All ancestors of the given indexable.
 	 */
 	public function get_ancestors( Indexable $indexable ) {
-		$ancestors = $this->hierarchy_repository->find_ancestors( $indexable );
-
-		if ( is_array( $indexable->ancestors ) && ! empty( $indexable->ancestors ) ) {
+		// If we've already set ancestors on the indexable no need to get them again.
+		if ( \is_array( $indexable->ancestors ) && ! empty( $indexable->ancestors ) ) {
 			return \array_map( [ $this, 'ensure_permalink' ], $indexable->ancestors );
 		}
 
-		if ( empty( $ancestors ) ) {
-			return [];
+		$indexable_ids = $this->hierarchy_repository->find_ancestors( $indexable );
+
+		// If we've set ancestors on the indexable because we had to build them to find them.
+		if ( \is_array( $indexable->ancestors ) && ! empty( $indexable->ancestors ) ) {
+			return \array_map( [ $this, 'ensure_permalink' ], $indexable->ancestors );
 		}
 
-		$indexable_ids = [];
-		foreach ( $ancestors as $ancestor ) {
-			$indexable_ids[] = $ancestor->ancestor_id;
+		if ( empty( $indexable_ids ) ) {
+			return [];
 		}
 
 		if ( $indexable_ids[0] === 0 && \count( $indexable_ids ) === 1 ) {

--- a/tests/builders/indexable-hierarchy-builder-test.php
+++ b/tests/builders/indexable-hierarchy-builder-test.php
@@ -475,8 +475,8 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 		Monkey\Functions\expect( 'get_term' )->once()->with( 3, 'tag' )->andReturn( (object) [ 'term_id' => 3, 'taxonomy' => 'tag', 'parent' => 0 ] );
 
 		$this->indexable_hierarchy_repository->expects( 'clear_ancestors' )->with( 1 )->andReturn( true );
-		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 3, 1 );
-		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 2, 2 );
+		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 3, 2 );
+		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 2, 1 );
 
 		$this->primary_term_repository->expects( 'find_by_post_id_and_taxonomy' )->with( 1, 'tag', false )->andReturn( $primary_term );
 
@@ -556,8 +556,8 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 		Monkey\Functions\expect( 'get_post_meta' )->with( 1, WPSEO_Meta::$meta_prefix . 'primary_term', true )->andReturn( '' );
 
 		$this->indexable_hierarchy_repository->expects( 'clear_ancestors' )->with( 1 )->andReturn( true );
-		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 4, 1 );
-		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 3, 2 );
+		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 4, 2 );
+		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 3, 1 );
 
 		$this->primary_term_repository->expects( 'find_by_post_id_and_taxonomy' )->with( 1, 'tag', false )->andReturn( false );
 

--- a/tests/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/repositories/indexable-hierarchy-repository-test.php
@@ -46,7 +46,7 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 		parent::setUp();
 
 		$this->instance = Mockery::mock( Indexable_Hierarchy_Repository::class )->makePartial();
-		$this->builder  = Mockery::mock( Indexable_Hierarchy_Builder::class )->makePartial();
+		$this->builder  = Mockery::mock( Indexable_Hierarchy_Builder::class );
 	}
 
 	/**
@@ -69,15 +69,16 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 		$indexable     = Mockery::mock( Indexable::class );
 		$indexable->id = 1;
 
-		$ancestors = [
-			(object) [
-				'indexable_id' => 1,
-				'ancestor_id'  => 2,
-				'depth'        => 1,
-			],
-		];
+		$ancestors = [ 2 ];
 
-		$orm_object = Mockery::mock()->makePartial();
+		$orm_object = Mockery::mock();
+
+		$orm_object
+			->expects( 'select' )
+			->once()
+			->with( 'ancestor_id' )
+			->andReturn( $orm_object );
+
 		$orm_object
 			->expects( 'where' )
 			->once()
@@ -91,9 +92,9 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 			->andReturn( $orm_object );
 
 		$orm_object
-			->expects( 'find_many' )
+			->expects( 'find_array' )
 			->once()
-			->andReturn( $ancestors );
+			->andReturn( [ [ 'ancestor_id' => 2 ] ] );
 
 		$this->instance
 			->expects( 'query' )
@@ -111,37 +112,42 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 		$indexable     = Mockery::mock( Indexable::class );
 		$indexable->id = 1;
 
-		$ancestors = [
-			(object) [
-				'indexable_id' => 1,
-				'ancestor_id'  => 2,
-				'depth'        => 1,
-			],
-		];
+		$parent_indexable     = Mockery::mock( Indexable::class );
+		$parent_indexable->id = 2;
+		$indexable->ancestors = [ $parent_indexable ];
 
-		$orm_object = Mockery::mock()->makePartial();
+		$ancestors = [ 2 ];
+
+		$orm_object = Mockery::mock();
+
+		$orm_object
+			->expects( 'select' )
+			->once()
+			->with( 'ancestor_id' )
+			->andReturn( $orm_object );
+
 		$orm_object
 			->expects( 'where' )
-			->twice()
+			->once()
 			->with( 'indexable_id', 1 )
 			->andReturn( $orm_object );
 
 		$orm_object
 			->expects( 'order_by_desc' )
-			->twice()
+			->once()
 			->with( 'depth' )
 			->andReturn( $orm_object );
 
 		$orm_object
-			->expects( 'find_many' )
-			->twice()
-			->andReturn( [], $ancestors );
+			->expects( 'find_array' )
+			->once()
+			->andReturn( [] );
 
 		$this->instance->set_builder( $this->builder );
 
 		$this->instance
 			->expects( 'query' )
-			->twice()
+			->once()
 			->andReturn( $orm_object );
 
 		$this->builder

--- a/tests/repositories/indexable-repository-test.php
+++ b/tests/repositories/indexable-repository-test.php
@@ -72,7 +72,7 @@ class Indexable_Repository_Test extends TestCase {
 		$this->builder              = Mockery::mock( Indexable_Builder::class );
 		$this->current_page         = Mockery::mock( Current_Page_Helper::class );
 		$this->logger               = Mockery::mock( Logger::class );
-		$this->hierarchy_repository = Mockery::mock( Indexable_Hierarchy_Repository::class )->makePartial();
+		$this->hierarchy_repository = Mockery::mock( Indexable_Hierarchy_Repository::class );
 		$this->instance             = Mockery::mock( Indexable_Repository::class, [
 			$this->builder,
 			$this->current_page,
@@ -110,11 +110,11 @@ class Indexable_Repository_Test extends TestCase {
 			->expects( 'find_ancestors' )
 			->once()
 			->with( $indexable )
-			->andReturn( [
-				(object) [
-					'ancestor_id' => 0,
-				],
-			] );
+			->andReturn( [ 9 ] );
+
+		$orm_object = $this->mock_orm( [ 9 ], [] );
+
+		$this->instance->expects( 'query' )->andReturn( $orm_object );
 
 		$this->assertSame( [], $this->instance->get_ancestors( $indexable ) );
 	}
@@ -133,11 +133,7 @@ class Indexable_Repository_Test extends TestCase {
 			->expects( 'find_ancestors' )
 			->once()
 			->with( $indexable )
-			->andReturn( [
-				(object) [
-					'ancestor_id' => 1,
-				],
-			] );
+			->andReturn( [ 1 ] );
 
 		$orm_object = $this->mock_orm( [ 1 ], [ $indexable ] );
 
@@ -160,14 +156,7 @@ class Indexable_Repository_Test extends TestCase {
 			->expects( 'find_ancestors' )
 			->once()
 			->with( $indexable )
-			->andReturn( [
-				(object) [
-					'ancestor_id' => 1,
-				],
-				(object) [
-					'ancestor_id' => 2,
-				],
-			] );
+			->andReturn( [ 1, 2 ] );
 
 		$orm_object = $this->mock_orm( [ 1, 2 ], [ $indexable ] );
 
@@ -189,14 +178,7 @@ class Indexable_Repository_Test extends TestCase {
 			->expects( 'find_ancestors' )
 			->once()
 			->with( $indexable )
-			->andReturn( [
-				(object) [
-					'ancestor_id' => 1,
-				],
-				(object) [
-					'ancestor_id' => 2,
-				],
-			] );
+			->andReturn( [ 1, 2 ] );
 
 		$orm_object = $this->mock_orm( [ 1, 2 ], [ $indexable ] );
 
@@ -224,11 +206,7 @@ class Indexable_Repository_Test extends TestCase {
 			->expects( 'find_ancestors' )
 			->once()
 			->with( $indexable )
-			->andReturn( [
-				(object) [
-					'ancestor_id' => 1,
-				],
-			] );
+			->andReturn( [ 1 ] );
 
 		$orm_object = $this->mock_orm( [ 1 ], [ $indexable ] );
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an issue where breadcrumbs were being saved in reversed order.

## Relevant technical choices:

* The indexable hierarchy table is truncated in a migration. This table is only ever used as a cache and thus no reindex is required. For sites with very long breadcrumbs and/or a lot of terms the first request to each post may be slightly slower ( generating the breadcrumbs would be about the same speed as it was in 13.5 ).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure you have breadcrumbs at least 5 layers deep: home -> grandparent term -> parent term -> child term -> post.
* Save that post with the child term as the primary category. Check the breadcrumb.
* Save that post with the parent term as the primary category. Check the breadcrumb.
* Do the same with a custom post type and custom taxonomy.
* Do the same with nested pages ( home -> grandparent page -> parent page -> child page ).
* In all cases the breadcrumb shown in both schema and by adding the breadcrumb to your theme as described [here](https://yoast.com/help/implement-wordpress-seo-breadcrumbs/) should show the correct order.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/15173
