### PR TITLE
FRO 72 Restyle tabs on tools pages

### DIFF
--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -118,11 +118,12 @@ $tabs = [
 
 	<nav class="yoast-tabs" id="wpseo-tabs">
 		<ul class="yoast-tabs__list">
-		<?php foreach ( $tabs as $identifier => $tab ) : ?>
 			<li class="yoast-tabs__list-item">
-			<a class="yoast-tabs__list-item-link" id="<?php echo esc_attr( $identifier . '-tab' ); ?>" href="<?php echo esc_url( '#top#' . $identifier ); ?>"><?php echo esc_html( $tab['label'] ); ?></a>
+				<a class="yoast-tabs__list-item-link" id="title-tab" href="#top#title"><?php esc_html_e( 'Title', 'wordpress-seo' ); ?></a>
 			</li>
-		<?php endforeach; ?>
+			<li class="yoast-tabs__list-item">
+				<a class="yoast-tabs__list-item-link" id="description-tab" href="#top#description"><?php esc_html_e( 'Description', 'wordpress-seo' ); ?></a>
+			</li>
 		<ul>
 	</nav>
 

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -124,7 +124,7 @@ $tabs = [
 			<li class="yoast-tabs__list-item">
 				<a class="yoast-tabs__list-item-link" id="description-tab" href="#top#description"><?php esc_html_e( 'Description', 'wordpress-seo' ); ?></a>
 			</li>
-		<ul>
+		</ul>
 	</nav>
 
 	<?php wpseo_get_rendered_tab( $wpseo_bulk_titles_table, 'title' ); ?>

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -101,18 +101,31 @@ function wpseo_get_rendered_tab( $table, $id ) {
 	var wpseo_bulk_editor_nonce = wpseoBulkEditorNonce;
 </script>
 
-<br/><br/>
-
 <div class="wpseo_table_page">
 
-	<h2 class="nav-tab-wrapper" id="wpseo-tabs">
-		<a class="nav-tab" id="title-tab" href="#top#title"><?php esc_html_e( 'Title', 'wordpress-seo' ); ?></a>
-		<a class="nav-tab" id="description-tab"
-			href="#top#description"><?php esc_html_e( 'Description', 'wordpress-seo' ); ?></a>
-	</h2>
+<?php
 
-	<div class="tabwrapper">
-		<?php wpseo_get_rendered_tab( $wpseo_bulk_titles_table, 'title' ); ?>
-		<?php wpseo_get_rendered_tab( $wpseo_bulk_description_table, 'description' ); ?>
-	</div>
+$tabs = [
+	'title' => [
+		'label' => __( 'Title', 'wordpress-seo' ),
+	],
+	'description' => [
+		'label' => __( 'Description', 'wordpress-seo' ),
+	],
+];
+
+?>
+
+	<nav class="yoast-tabs" id="wpseo-tabs">
+		<ul class="yoast-tabs__list">
+		<?php foreach ( $tabs as $identifier => $tab ) : ?>
+			<li class="yoast-tabs__list-item">
+			<a class="yoast-tabs__list-item-link" id="<?php echo esc_attr( $identifier . '-tab' ); ?>" href="<?php echo esc_url( '#top#' . $identifier ); ?>"><?php echo esc_html( $tab['label'] ); ?></a>
+			</li>
+		<?php endforeach; ?>
+		<ul>
+	</nav>
+
+	<?php wpseo_get_rendered_tab( $wpseo_bulk_titles_table, 'title' ); ?>
+	<?php wpseo_get_rendered_tab( $wpseo_bulk_description_table, 'description' ); ?>
 </div>

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -93,20 +93,16 @@ $tabs = [
 ];
 
 ?>
-	<br/><br/>
 
-	<h2 class="nav-tab-wrapper" id="wpseo-tabs">
+	<nav class="yoast-tabs" id="wpseo-tabs">
+		<ul class="yoast-tabs__list">
 		<?php foreach ( $tabs as $identifier => $tab ) : ?>
-			<a class="nav-tab" id="<?php echo esc_attr( $identifier . '-tab' ); ?>" href="<?php echo esc_url( '#top#' . $identifier ); ?>"><?php echo esc_html( $tab['label'] ); ?></a>
+			<li class="yoast-tabs__list-item">
+			<a class="yoast-tabs__list-item-link" id="<?php echo esc_attr( $identifier . '-tab' ); ?>" href="<?php echo esc_url( '#top#' . $identifier ); ?>"><?php echo esc_html( $tab['label'] ); ?></a>
+			</li>
 		<?php endforeach; ?>
-
-		<?php
-		/**
-		 * Allow adding a custom import tab header.
-		 */
-		do_action( 'wpseo_import_tab_header' );
-		?>
-	</h2>
+		<ul>
+	</nav>
 
 <?php
 

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -101,6 +101,12 @@ $tabs = [
 			<a class="yoast-tabs__list-item-link" id="<?php echo esc_attr( $identifier . '-tab' ); ?>" href="<?php echo esc_url( '#top#' . $identifier ); ?>"><?php echo esc_html( $tab['label'] ); ?></a>
 			</li>
 		<?php endforeach; ?>
+		<?php
+			/**
+			 * Allow adding a custom import tab header.
+			 */
+			do_action( 'wpseo_import_tab_header' );
+		?>
 		<ul>
 	</nav>
 

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -107,7 +107,7 @@ $tabs = [
 			 */
 			do_action( 'wpseo_import_tab_header' );
 		?>
-		<ul>
+		</ul>
 	</nav>
 
 <?php


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Change the tabs components to fit the new Yoast styling and restore functionality to them.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Change the tabs components on the tool pages to fit the new Yoast styling.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Pull this branch.
* Build the plugin.
* Check on the tools `Import and Export` and `Bulk editor` pages if the tabs work and match the new styling.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #FRO-72
