### PR TITLE
Update conditional that was used to display the Advanced Setting tab

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1191,7 +1191,7 @@ SVG;
 		}
 
 		$wpseo_admin_l10n = [
-			'displayAdvancedTab'   => WPSEO_Capability_Utils::current_user_can( 'wpseo_edit_advanced_metadata' ) && ! ! WPSEO_Options::get( 'disableadvanced_meta' ),
+			'displayAdvancedTab'   => WPSEO_Capability_Utils::current_user_can( 'wpseo_edit_advanced_metadata' ) || ! WPSEO_Options::get( 'disableadvanced_meta' ),
 			'noIndex'              => ! ! $no_index,
 			'isPostType'           => ! ! get_post_type(),
 			'postTypeNamePlural'   => ( $page_type === 'post' ) ? $label_object->label : $label_object->name,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* The Advanced Settings tab was not being displayed on sites which had the setting `Security: no advanced settings for authors` set to `off`. This was not intentional.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Fixes a bug where setting `Security: no advanced settings for authors` to `off` would remove the Advanced Settings tab for all users.

## Relevant technical choices:
* The conditional statement was wrong.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
Test the following cases:
1. As an Admin user:
	- Set `Security: no advanced settings for authors` to `on`
	- Edit a post
	- Check that the Advanced Settings tab is visible
	- Set `Security: no advanced settings for authors` to `off`
	- Edit a post
 	- Check that the Advanced Settings tab is visible
2. As a normal user (the setting needs to be changed by an admin, prefixed _admin_):
	- _admin_: Set `Security: no advanced settings for authors` to `on`
	- Edit a post
	- Check that the Advanced Settings tab is not visible
	- _admin_: Set `Security: no advanced settings for authors` to `off`
	- Edit a post
	- Check that the Advanced Settings tab is visible

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/1021
