### PR TITLE
Bring back suggested plugins in premium and remove ACF notification

### DIFF
--- a/admin/class-plugin-availability.php
+++ b/admin/class-plugin-availability.php
@@ -92,25 +92,6 @@ class WPSEO_Plugin_Availability {
 				'version_sync'  => true,
 				'premium'       => true,
 			],
-
-			'yoast-acf-analysis' => [
-				'url'           => 'https://wordpress.org/plugins/acf-content-analysis-for-yoast-seo/',
-				'title'         => 'ACF Content Analysis for Yoast SEO',
-				'description'   => sprintf(
-					/* translators: %1$s expands to Yoast SEO, %2$s expands to Advanced Custom Fields */
-					__( 'Seamlessly integrate %2$s with %1$s for the content analysis!', 'wordpress-seo' ),
-					'Yoast SEO',
-					'Advanced Custom Fields'
-				),
-				'installed'     => false,
-				'slug'          => 'acf-content-analysis-for-yoast-seo/yoast-acf-analysis.php',
-				'_dependencies' => [
-					'Advanced Custom Fields' => [
-						'slug' => 'advanced-custom-fields/acf.php',
-					],
-				],
-				'version_sync'  => false,
-			],
 		];
 	}
 

--- a/admin/class-suggested-plugins.php
+++ b/admin/class-suggested-plugins.php
@@ -64,7 +64,7 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 			$dependency_names = $checker->get_dependency_names( $plugin );
 			$notification     = $this->get_yoast_seo_suggested_plugins_notification( $plugin_name, $plugin, $dependency_names[0] );
 
-			if ( ! WPSEO_Utils::is_yoast_seo_premium() && ( ! $checker->is_installed( $plugin ) || ! $checker->is_active( $plugin['slug'] ) ) ) {
+			if ( ! $checker->is_installed( $plugin ) || ! $checker->is_active( $plugin['slug'] ) ) {
 				$this->notification_center->add_notification( $notification );
 
 				continue;

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -764,11 +764,10 @@ class WPSEO_Upgrade {
 	/**
 	 * Performs the 14.2 upgrade.
 	 *
-	 * Removes the yoast-acf-analysis notice when its still in the database.
+	 * Removes the yoast-acf-analysis notice when it's still in the database.
 	 */
 	private function upgrade_142() {
 		add_action( 'init', [ $this, 'remove_acf_notification_for_142' ] );
-
 	}
 
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -57,6 +57,7 @@ class WPSEO_Upgrade {
 			'13.2-RC0'   => 'upgrade_132',
 			'14.0.3-RC0' => 'upgrade_1403',
 			'14.1-RC0'   => 'upgrade_141',
+			'14.2-RC0'   => 'upgrade_142',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -761,6 +762,17 @@ class WPSEO_Upgrade {
 	}
 
 	/**
+	 * Performs the 14.2 upgrade.
+	 *
+	 * Removes the yoast-acf-analysis notice when its still in the database.
+	 */
+	private function upgrade_142() {
+		add_action( 'init', [ $this, 'remove_acf_notification_for_142' ] );
+
+	}
+
+
+	/**
 	 * Cleans up the private taxonomies from the indexables table for the upgrade routine to 14.1.
 	 */
 	public function clean_up_private_taxonomies_for_141() {
@@ -816,6 +828,15 @@ class WPSEO_Upgrade {
 		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-dismiss-blog-public-notice' );
 		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-links-table-not-accessible' );
 		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-post-type-archive-notification' );
+	}
+
+	/**
+	 * Removes the wpseo-suggested-plugin-yoast-acf-analysis notification from the Notification center for the 14.2 upgrade.
+	 *
+	 * @return void
+	 */
+	public function remove_acf_notification_for_142() {
+		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-suggested-plugin-yoast-acf-analysis' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In https://github.com/Yoast/wordpress-seo-premium/issues/1632 we removed notifications like "Yoast SEO and WooCommerce can work together a lot better by adding a helper plugin. Please activate Yoast WooCommerce SEO to make your life better" from Premium. However, it was decided to bring them back. The only exception is the ACF notification, which will be removed from Free as well (slack me to ask why if you're curious ;) ).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium only] Brings back the suggested plugins notification in premium
* Removes the ACF plugin suggestion notification

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*Free*
* On trunk:
     * Install the Advanced Custom Fields plugin.
     * Make sure you don't have ACF Content Analysis for Yoast SEO installed.
     * Go to the notification center and see a notification about ACF Content Analysis for Yoast SEO.
* Switch to this branch:
     * Use the test helper to set the database version back to 14.1 to trigger the upgrade routine.
     * Go to the notification center and don't see the notification about ACF Content Analysis for Yoast SEO anymore.

*Premium*
* On trunk:
     * Install WooCommerce.
     * Make sure you don't have Yoast SEO for WooCommerce installed.
     * Go to the notification center and *don't* see a notification about Yoast SEO for WooCommerce.
* Merge this branch intro premium (but don't commit):
     * Go to the notification center and see the notification about Yoast SEO for WooCommerce.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
