### PR TITLE
Remove the AMP specific call from front-end-integration

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -202,9 +202,6 @@ class Front_End_Integration implements Integration_Interface {
 		// Filter the title for compatibility with other plugins and themes.
 		\add_filter( 'wp_title', [ $this, 'filter_title' ], 15 );
 
-		// @todo Walk through AMP post template and unhook all the stuff they don't need to because we do it.
-		\add_action( 'amp_post_template_head', [ $this, 'call_wpseo_head' ], 9 );
-
 		\add_action( 'wpseo_head', [ $this, 'present_head' ], -9999 );
 
 		\remove_action( 'wp_head', 'rel_canonical' );

--- a/tests/integrations/front-end-integration-test.php
+++ b/tests/integrations/front-end-integration-test.php
@@ -100,7 +100,6 @@ class Front_End_Integration_Test extends TestCase {
 		$this->instance->register_hooks();
 
 		$this->assertTrue( has_action( 'wp_head', [ $this->instance, 'call_wpseo_head' ] ), 'Does not have expected wp_head action' );
-		$this->assertTrue( has_action( 'amp_post_template_head', [ $this->instance, 'call_wpseo_head' ] ), 'Does not have expected amp_post_template_head action' );
 		$this->assertTrue( has_action( 'wpseo_head', [ $this->instance, 'present_head' ] ), 'Does not have expected wpseo_head action' );
 		$this->assertTrue( has_filter( 'wp_title', [ $this->instance, 'filter_title' ] ), 'Does not have expected wp_title filter' );
 	}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removed a duplicate call to add the Yoast SEO output to the AMP plugin's output.

## Relevant technical choices:

* This is done inside the integration (`integrations/third-party/amp.php`) and doesn't need to be done in front-end-integration.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set up a page with Yoast SEO meta data.
* Make sure you have the AMP plugin running.
* AMP pages should remain working as they do and should have valid Yoast SEO output.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
