### PR TITLE
QA: use strict comparisons with array functions

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -357,7 +357,7 @@ class Front_End_Integration implements Integration_Interface {
 		}
 
 		$presenters = $this->get_all_presenters();
-		if ( in_array( $page_type, [ 'Static_Home_Page', 'Home_Page' ] ) ) {
+		if ( in_array( $page_type, [ 'Static_Home_Page', 'Home_Page' ], true ) ) {
 			$presenters = \array_merge( $presenters, $this->webmaster_verification_presenters );
 		}
 


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

Strict type comparisons should be used as a rule, with loose type comparisons being the exception.

This is especially important when comparing variables which are expected to be strings, as when one of the two operands - for whatever reason, other plugins interfering, errors etc - is not a string, the other operand will be juggled to the type of the first operand which can lead to unexpected results and hard to debug bugs.

For array functions which do loose type comparisons, setting the third `$strict` parameter to `false`  can be seen as a clear indication that this is a conscious, well thought out decision by the developer.
In all other cases, `$strict` `true` should be used.

Ref: http://php.net/manual/en/function.in-array.php


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.