### PR TITLE
I18n: various small fixes

### DIFF
--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -127,7 +127,7 @@ class Article extends Abstract_Schema_Piece {
 		$terms = \array_filter( $terms, function( $term ) {
 			// We are checking against the WordPress internal translation.
 			// @codingStandardsIgnoreLine
-			return $term->name !== __( 'Uncategorized' );
+			return $term->name !== __( 'Uncategorized', 'default' );
 		} );
 
 		if ( empty( $terms ) ) {

--- a/src/presenters/admin/indexation-modal-presenter.php
+++ b/src/presenters/admin/indexation-modal-presenter.php
@@ -65,7 +65,7 @@ class Indexation_Modal_Presenter extends Abstract_Presenter {
 		return \sprintf(
 			'<div id="yoast-indexation-wrapper" class="hidden">%s<button id="yoast-indexation-stop" type="button" class="button">%s</button></div>',
 			\implode( '<hr />', $blocks ),
-			\esc_html( 'Stop indexing', 'wordpress-seo' )
+			\esc_html__( 'Stop indexing', 'wordpress-seo' )
 		);
 	}
 }


### PR DESCRIPTION
## Context

* Improved I18n support

## Summary

This PR can be summarized in the following changelog entry:

* Improved I18n support

## Relevant technical choices:

### I18n: make an untranslated string translatable

Fixes an output escaping function call to make sure they use the "translate + escape" variant instead of just escape the (untranslated) text.

`esc_html()` only escapes, `esc_html__()` escapes and translates.

### I18n: use the 'default' text domain for WP Core translations 

Plugins/themes should use their own text domain. however, in some cases, using the WP Core translation for a string is warranted, like in this case.

The WP Core text-domain is `default` and while all gettext function call have a default value of `default` for the `$domain` parameter, explicitly setting the `$domain` in a gettext function call to `default` documents that the intention for this function call was to use the WP Core translation.

For CS purposes, the line still has to be ignored (for now) as it doesn't use the WPSEO text domain. Once WPSEO upgrades to a more recent version of WordPressCS, the ignore comment can be removed as since WPCS 0.11.0, a plugin can indicate that it uses more than one text-domain.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.