### PR TITLE
CS: use self when referring to current class

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1173,8 +1173,8 @@ SVG;
 	 * @return array The Adminl10n array.
 	 */
 	public static function get_admin_l10n() {
-		$post_type = WPSEO_Utils::get_post_type();
-		$page_type = WPSEO_Utils::get_page_type();
+		$post_type = self::get_post_type();
+		$page_type = self::get_page_type();
 
 		$label_object = false;
 		$no_index     = false;


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.

Use `self` when referencing a (static) class member from within the same class


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.