### PR TITLE
Tests: fix `@covers` tags for renamed methods

### DIFF
--- a/tests/conditionals/yoast-admin-and-dashboard-conditional-test.php
+++ b/tests/conditionals/yoast-admin-and-dashboard-conditional-test.php
@@ -167,7 +167,7 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 	 * Tests that the conditional is not met when on the plugin upgrade page.
 	 *
 	 * @covers ::is_met
-	 * @covers ::on_plugin_or_theme_page
+	 * @covers ::on_upgrade_page
 	 */
 	public function test_is_not_met_on_plugin_upgrade_page() {
 		// We are on an admin page.
@@ -189,7 +189,7 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 	 * Tests that the conditional is not met when on the theme upgrade page.
 	 *
 	 * @covers ::is_met
-	 * @covers ::on_plugin_or_theme_page
+	 * @covers ::on_upgrade_page
 	 */
 	public function test_is_not_met_on_theme_upgrade_page() {
 		// We are on an admin page.
@@ -211,7 +211,7 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 	 * Tests that the conditional is not met when on the WordPress upgrade page.
 	 *
 	 * @covers ::is_met
-	 * @covers ::on_plugin_or_theme_page
+	 * @covers ::on_upgrade_page
 	 */
 	public function test_is_not_met_on_wordpress_upgrade_page() {
 		// We are on an admin page.
@@ -233,7 +233,7 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 	 * Tests that the conditional is not met when on the WordPress reinstall page.
 	 *
 	 * @covers ::is_met
-	 * @covers ::on_plugin_or_theme_page
+	 * @covers ::on_upgrade_page
 	 */
 	public function test_is_not_met_on_wordpress_reinstall_page() {
 		// We are on an admin page.

--- a/tests/presenters/canonical-presenter-test.php
+++ b/tests/presenters/canonical-presenter-test.php
@@ -24,7 +24,7 @@ class Canonical_Presenter_Test extends TestCase {
 	 * Tests the presenter of the canonical.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present() {
 		$instance               = new Canonical_Presenter();
@@ -44,7 +44,7 @@ class Canonical_Presenter_Test extends TestCase {
 	 * Tests the presenter of the canonical when it's empty.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_empty() {
 		$instance               = new Canonical_Presenter();
@@ -61,7 +61,7 @@ class Canonical_Presenter_Test extends TestCase {
 	 * Tests the presenter of the canonical with filter.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_with_filter() {
 		$instance               = new Canonical_Presenter();
@@ -86,7 +86,7 @@ class Canonical_Presenter_Test extends TestCase {
 	 * Tests the presenter of the canonical when robots is noindex.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_when_robots_is_noindex() {
 		$instance               = new Canonical_Presenter();

--- a/tests/presenters/meta-description-presenter-test.php
+++ b/tests/presenters/meta-description-presenter-test.php
@@ -73,7 +73,7 @@ class Meta_Description_Presenter_Test extends TestCase {
 	 * Tests the presenter of the meta description.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_and_filter_happy_path() {
 		$this->indexable_presentation->meta_description = 'the_meta_description';

--- a/tests/presenters/open-graph/article-author-presenter-test.php
+++ b/tests/presenters/open-graph/article-author-presenter-test.php
@@ -75,7 +75,7 @@ class Article_Author_Presenter_Test extends TestCase {
 	 * Tests whether the presenter returns the correct publisher, when the `wpseo_opengraph_author_facebook` filter is applied.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_filter() {
 		$this->presentation->open_graph_article_author = 'https://facebook.com/author';

--- a/tests/presenters/open-graph/article-publisher-presenter-test.php
+++ b/tests/presenters/open-graph/article-publisher-presenter-test.php
@@ -75,7 +75,7 @@ class Article_Publisher_Presenter_Test extends TestCase {
 	 * Tests whether the presenter returns the correct publisher, when the `wpseo_og_article_publisher` filter is applied.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_filter() {
 		$this->presentation->open_graph_article_publisher = 'https://example.com';

--- a/tests/presenters/open-graph/description-presenter-test.php
+++ b/tests/presenters/open-graph/description-presenter-test.php
@@ -94,7 +94,7 @@ class Description_Presenter_Test extends TestCase {
 	 * Tests whether the `wpseo_opengraph_desc` filter is used.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_filter() {
 		$this->presentation->open_graph_description = 'My description';

--- a/tests/presenters/open-graph/locale-presenter-test.php
+++ b/tests/presenters/open-graph/locale-presenter-test.php
@@ -61,7 +61,7 @@ class Locale_Presenter_Test extends TestCase {
 	 * Tests whether the presenter returns the correct locale, when the `wpseo_og_locale` filter is applied.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_filter() {
 		$this->presentation->open_graph_locale = 'nl_BE';

--- a/tests/presenters/open-graph/site-name-presenter-test.php
+++ b/tests/presenters/open-graph/site-name-presenter-test.php
@@ -75,7 +75,7 @@ class Site_Name_Presenter_Test extends TestCase {
 	 * Tests whether the presenter returns the correct title, when the `wpseo_title` filter is applied.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_filter() {
 		$this->presentation->open_graph_site_name = 'My Site';

--- a/tests/presenters/open-graph/title-presenter-test.php
+++ b/tests/presenters/open-graph/title-presenter-test.php
@@ -119,7 +119,7 @@ class Title_Presenter_Test extends TestCase {
 	 * Tests whether the presenter returns the correct title, when the `wpseo_opengraph_title` filter is applied.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_filter() {
 		$this->presentation->open_graph_title = 'example_title';

--- a/tests/presenters/open-graph/type-presenter-test.php
+++ b/tests/presenters/open-graph/type-presenter-test.php
@@ -77,7 +77,7 @@ class Type_Presenter_Test extends TestCase {
 	 * is applied.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_filter() {
 		$this->presentation->open_graph_type = 'website';

--- a/tests/presenters/open-graph/url-presenter-test.php
+++ b/tests/presenters/open-graph/url-presenter-test.php
@@ -72,7 +72,7 @@ class Url_Presenter_Test extends TestCase {
 	 * Tests whether the presenter returns the correct URL, when the `wpseo_opengraph_url` filter is applied.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_filter() {
 		$this->presentation->open_graph_url = 'www.example.com';

--- a/tests/presenters/rel-next-presenter-test.php
+++ b/tests/presenters/rel-next-presenter-test.php
@@ -41,7 +41,7 @@ class Rel_Next_Presenter_Test extends TestCase {
 	 * Tests the presentation of the rel next meta tag.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present() {
 		$this->instance->presentation = new Indexable_Presentation();
@@ -60,7 +60,7 @@ class Rel_Next_Presenter_Test extends TestCase {
 	 * Tests the presentation of the rel prev next tag when it's empty.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_empty() {
 		$this->instance->presentation = new Indexable_Presentation();
@@ -79,7 +79,7 @@ class Rel_Next_Presenter_Test extends TestCase {
 	 * Tests the presentation of the rel next meta tag when robots is noindex.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_when_robots_is_noindex() {
 		$this->instance->presentation = new Indexable_Presentation();
@@ -95,7 +95,7 @@ class Rel_Next_Presenter_Test extends TestCase {
 	 * Tests the presentation of the rel next meta tag with filter.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_with_filter() {
 		$this->instance->presentation = new Indexable_Presentation();

--- a/tests/presenters/rel-prev-presenter-test.php
+++ b/tests/presenters/rel-prev-presenter-test.php
@@ -41,7 +41,7 @@ class Rel_Prev_Presenter_Test extends TestCase {
 	 * Tests the presentation of the rel prev meta tag.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present() {
 		$this->instance->presentation = new Indexable_Presentation();
@@ -60,7 +60,7 @@ class Rel_Prev_Presenter_Test extends TestCase {
 	 * Tests the presentation of the rel prev meta tag when it's empty.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_empty() {
 		$this->instance->presentation = new Indexable_Presentation();
@@ -79,7 +79,7 @@ class Rel_Prev_Presenter_Test extends TestCase {
 	 * Tests the presentation of the rel prev meta tag when robots is noindex.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_when_robots_is_noindex() {
 		$this->instance->presentation = new Indexable_Presentation();
@@ -95,7 +95,7 @@ class Rel_Prev_Presenter_Test extends TestCase {
 	 * Tests the presentation of the rel next meta tag with filter.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_with_filter() {
 		$this->instance->presentation = new Indexable_Presentation();

--- a/tests/presenters/title-presenter-test.php
+++ b/tests/presenters/title-presenter-test.php
@@ -123,7 +123,7 @@ class Title_Presenter_Test extends TestCase {
 	 * Tests whether the presenter returns the correct title, when the `wpseo_title` filter is applied.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_filter() {
 		$this->indexable_presentation->title = 'example_title';

--- a/tests/presenters/twitter/card-presenter-test.php
+++ b/tests/presenters/twitter/card-presenter-test.php
@@ -35,7 +35,7 @@ class Card_Presenter_Test extends TestCase {
 	 * Tests the presentation for a set twitter creator.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present() {
 		$this->instance->presentation = new Indexable_Presentation();
@@ -52,7 +52,7 @@ class Card_Presenter_Test extends TestCase {
 	 * Tests the presentation of an empty creator.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_with_empty_twitter_creator() {
 		$this->instance->presentation = new Indexable_Presentation();

--- a/tests/presenters/twitter/description-presenter-test.php
+++ b/tests/presenters/twitter/description-presenter-test.php
@@ -46,7 +46,7 @@ class Description_Presenter_Test extends TestCase {
 	 * Tests the presenter for a set twitter description.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present() {
 		$this->instance->presentation      = new Indexable_Presentation();
@@ -68,7 +68,7 @@ class Description_Presenter_Test extends TestCase {
 	 * Tests the presenter of an empty description.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_with_empty_twitter_description() {
 		$this->instance->presentation      = new Indexable_Presentation();

--- a/tests/presenters/twitter/image-presenter-test.php
+++ b/tests/presenters/twitter/image-presenter-test.php
@@ -75,7 +75,7 @@ class Image_Presenter_Test extends TestCase {
 	 * when the `wpseo_twitter_image` filter is applied.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_filter() {
 		$this->presentation->twitter_image = 'relative_image.jpg';

--- a/tests/presenters/twitter/site-presenter-test.php
+++ b/tests/presenters/twitter/site-presenter-test.php
@@ -48,7 +48,7 @@ class Site_Presenter_Test extends TestCase {
 	 * Tests the presentation for a set twitter creator.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present() {
 		$this->presentation->twitter_site = '@TwitterHandle';
@@ -74,7 +74,7 @@ class Site_Presenter_Test extends TestCase {
 	 * Tests the presentation for a set twitter creator.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_with_filter() {
 		$this->presentation->twitter_site = '@TwitterHandle';

--- a/tests/presenters/twitter/title-presenter-test.php
+++ b/tests/presenters/twitter/title-presenter-test.php
@@ -95,7 +95,7 @@ class Title_Presenter_Test extends TestCase {
 	 * Tests whether the presenter returns the correct Twitter title, when the `wpseo_twitter_title` filter is applied.
 	 *
 	 * @covers ::present
-	 * @covers ::filter
+	 * @covers ::get
 	 */
 	public function test_present_filter() {
 		$this->indexable_presentation->twitter_title = 'twitter_example_title';


### PR DESCRIPTION
## Context

* Improve code coverage recording

## Summary

This PR can be summarized in the following changelog entry:

* Improved code coverage recording

## Relevant technical choices:

The method under test for each of these tests has been renamed, while the `@covers` tags weren't updated yet.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test documentation-only change and should have no effect on the functionality.