### PR TITLE
CS: use correct case for class names

### DIFF
--- a/tests/generators/schema/webpage-test.php
+++ b/tests/generators/schema/webpage-test.php
@@ -85,7 +85,7 @@ class WebPage_Test extends TestCase {
 		$this->meta_tags_context = Mockery::mock( Meta_Tags_Context::class );
 		$this->id                = Mockery::mock( ID_Helper::class );
 
-		$this->instance          = Mockery::mock( Webpage::class )
+		$this->instance          = Mockery::mock( WebPage::class )
 			->makePartial();
 		$this->instance->context = $this->meta_tags_context;
 		$this->instance->helpers = (object) [


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

While PHP itself is not case-sensitive, the autoloader in Composer is, so the case of class names imported should be the same as when declared. And the name when used should also be the same again.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.