### PR TITLE
Do not save indexables twice

### DIFF
--- a/src/integrations/watchers/indexable-date-archive-watcher.php
+++ b/src/integrations/watchers/indexable-date-archive-watcher.php
@@ -86,7 +86,6 @@ class Indexable_Date_Archive_Watcher implements Integration_Interface {
 	 */
 	public function build_indexable() {
 		$indexable = $this->repository->find_for_date_archive( false );
-		$indexable = $this->builder->build_for_date_archive( $indexable );
-		$indexable->save();
+		$this->builder->build_for_date_archive( $indexable );
 	}
 }

--- a/src/integrations/watchers/indexable-home-page-watcher.php
+++ b/src/integrations/watchers/indexable-home-page-watcher.php
@@ -101,5 +101,5 @@ class Indexable_Home_Page_Watcher implements Integration_Interface {
 	public function build_indexable() {
 		$indexable = $this->repository->find_for_home_page( false );
 		$this->builder->build_for_home_page( $indexable );
-		}
+	}
 }

--- a/src/integrations/watchers/indexable-home-page-watcher.php
+++ b/src/integrations/watchers/indexable-home-page-watcher.php
@@ -100,7 +100,6 @@ class Indexable_Home_Page_Watcher implements Integration_Interface {
 	 */
 	public function build_indexable() {
 		$indexable = $this->repository->find_for_home_page( false );
-		$indexable = $this->builder->build_for_home_page( $indexable );
-		$indexable->save();
-	}
+		$this->builder->build_for_home_page( $indexable );
+		}
 }

--- a/src/integrations/watchers/indexable-post-type-archive-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-archive-watcher.php
@@ -120,7 +120,6 @@ class Indexable_Post_Type_Archive_Watcher implements Integration_Interface {
 	 */
 	public function build_indexable( $post_type ) {
 		$indexable = $this->repository->find_for_post_type_archive( $post_type, false );
-		$indexable = $this->builder->build_for_post_type_archive( $post_type, $indexable );
-		$indexable->save();
+		$this->builder->build_for_post_type_archive( $post_type, $indexable );
 	}
 }

--- a/src/integrations/watchers/indexable-system-page-watcher.php
+++ b/src/integrations/watchers/indexable-system-page-watcher.php
@@ -94,7 +94,6 @@ class Indexable_System_Page_Watcher implements Integration_Interface {
 	 */
 	public function build_indexable( $type ) {
 		$indexable = $this->repository->find_for_system_page( $type, false );
-		$indexable = $this->builder->build_for_system_page( $type, $indexable );
-		$indexable->save();
+		$this->builder->build_for_system_page( $type, $indexable );
 	}
 }

--- a/tests/integrations/watchers/indexable-date-archive-watcher-test.php
+++ b/tests/integrations/watchers/indexable-date-archive-watcher-test.php
@@ -91,7 +91,6 @@ class Indexable_Date_Archive_Watcher_Test extends TestCase {
 	 */
 	public function test_update_wpseo_titles_value() {
 		$indexable_mock = Mockery::mock( Indexable::class );
-		$indexable_mock->expects( 'save' )->once();
 
 		$this->repository->expects( 'find_for_date_archive' )->once()->with( false )->andReturn( $indexable_mock );
 		$this->builder->expects( 'build_for_date_archive' )->once()->with( $indexable_mock )->andReturn( $indexable_mock );
@@ -131,7 +130,6 @@ class Indexable_Date_Archive_Watcher_Test extends TestCase {
 	 */
 	public function test_build_indexable_without_indexable() {
 		$indexable_mock = Mockery::mock( Indexable::class );
-		$indexable_mock->expects( 'save' )->once();
 
 		$this->repository->expects( 'find_for_date_archive' )->once()->with( false )->andReturn( false );
 		$this->builder->expects( 'build_for_date_archive' )->once()->with( false )->andReturn( $indexable_mock );

--- a/tests/integrations/watchers/indexable-home-page-watcher-test.php
+++ b/tests/integrations/watchers/indexable-home-page-watcher-test.php
@@ -98,7 +98,6 @@ class Indexable_Home_Page_Watcher_Test extends TestCase {
 	 */
 	public function test_update_wpseo_titles_value() {
 		$indexable_mock = Mockery::mock( Indexable::class );
-		$indexable_mock->expects( 'save' )->once();
 
 		$this->repository
 			->expects( 'find_for_home_page' )
@@ -136,7 +135,6 @@ class Indexable_Home_Page_Watcher_Test extends TestCase {
 	 */
 	public function test_update_wpseo_social_value() {
 		$indexable_mock = Mockery::mock( Indexable::class );
-		$indexable_mock->expects( 'save' )->once();
 
 		$this->repository
 			->expects( 'find_for_home_page' )
@@ -173,7 +171,6 @@ class Indexable_Home_Page_Watcher_Test extends TestCase {
 	 */
 	public function test_build_indexable_without_indexable() {
 		$indexable_mock = Mockery::mock( Indexable::class );
-		$indexable_mock->expects( 'save' )->once();
 
 		$this->repository
 			->expects( 'find_for_home_page' )

--- a/tests/integrations/watchers/indexable-post-type-archive-watcher-test.php
+++ b/tests/integrations/watchers/indexable-post-type-archive-watcher-test.php
@@ -92,7 +92,6 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 	 */
 	public function test_check_option_first_time_save() {
 		$indexable_mock = Mockery::mock( Indexable::class );
-		$indexable_mock->expects( 'save' )->once();
 
 		$this->repository
 			->expects( 'find_for_post_type_archive' )
@@ -128,7 +127,6 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 	 */
 	public function test_update_wpseo_titles_value() {
 		$indexable_mock = Mockery::mock( Indexable::class );
-		$indexable_mock->expects( 'save' )->once();
 
 		$this->repository
 			->expects( 'find_for_post_type_archive' )
@@ -154,7 +152,6 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 	 */
 	public function test_update_wpseo_titles_value_new() {
 		$indexable_mock = Mockery::mock( Indexable::class );
-		$indexable_mock->expects( 'save' )->once();
 
 		$this->repository
 			->expects( 'find_for_post_type_archive' )
@@ -179,11 +176,8 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 	 * @covers ::build_indexable
 	 */
 	public function test_update_wpseo_titles_value_switched() {
-		$indexable_mock = Mockery::mock( Indexable::class );
-		$indexable_mock->expects( 'save' )->once();
-
+		$indexable_mock       = Mockery::mock( Indexable::class );
 		$other_indexable_mock = Mockery::mock( Indexable::class );
-		$other_indexable_mock->expects( 'save' )->once();
 
 		$this->repository
 			->expects( 'find_for_post_type_archive' )
@@ -244,7 +238,6 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 	 */
 	public function test_build_indexable_without_indexable() {
 		$indexable_mock = Mockery::mock( Indexable::class );
-		$indexable_mock->expects( 'save' )->once();
 
 		$this->repository
 			->expects( 'find_for_post_type_archive' )

--- a/tests/integrations/watchers/indexable-system-page-watcher-test.php
+++ b/tests/integrations/watchers/indexable-system-page-watcher-test.php
@@ -93,7 +93,6 @@ class Indexable_System_Page_Watcher_Test extends TestCase {
 	 */
 	public function test_update_wpseo_titles_value() {
 		$indexable_mock = Mockery::mock( Indexable::class );
-		$indexable_mock->expects( 'save' )->once();
 
 		$this->repository
 			->expects( 'find_for_system_page' )
@@ -141,7 +140,6 @@ class Indexable_System_Page_Watcher_Test extends TestCase {
 	 */
 	public function test_build_indexable_without_indexable() {
 		$indexable_mock = Mockery::mock( Indexable::class );
-		$indexable_mock->expects( 'save' )->once();
 
 		$this->repository
 			->expects( 'find_for_system_page' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The builder's `build_for_id_and_type method` saves the indexable. However, `save` is still called outside of this method too in a lot of places. Those should be removed to prevent double saves.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes redundant calls to save an indexable.

## Relevant technical choices:

* Sometimes `save()` is executed when an indexable that was already built, is updated or deleted. In these cases, I didn't remove `save()`, because there is no double save. This applies to:
    * `indexable->save()` in `indexable-static-home-page-watcher.php`.
    * `$author_indexable->save()`and `indexable->save()` in `indexable-post-watcher.php`.
* I didn't remove `$indexable->save()` from `indexable-repository.php` because it is executed when a permalink is set for an indexable that was already built, but didn't have a permalink.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

_Date archives_
* Remove the row where `object_type` is `date-archive` from `wp_yoast_indexable`.
* Visit a date archive, for example `basic.wordpress.test/2020`.
* Refresh the indexables table, and see that the `date-archive` indexable is back.

_Home page (non-static)_
* Remove the row where `object_type` is `home-page` from `wp_yoast_indexable`.
* Visit the home page.
* Refresh the indexables table, and see that the `home-page` indexable is back.

_Post type archives_
* Remove a post type archive row from `wp_yoast_indexable`, for example a row where `object_sub_type` is `category`.
* Visit that post type archive.
* Refresh the indexables table, and see that the row is back.

_System pages_
* Remove the rows where `object_type` is `system-page` from `wp_yoast_indexable`.
* Visit a system page (a search result page and/or a 404 page).
* Refresh the indexables table, and see that the `system-page` indexable(s) is/are back.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14517
