### PR TITLE
CS: move multi-line arguments out of function calls

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -412,17 +412,19 @@ class WPSEO_Admin_Init {
 	 * @return bool Whether the "search engines discouraged" admin notice should be displayed.
 	 */
 	private function should_display_search_engines_discouraged_notice() {
+		$discouraged_pages = [
+			'index.php',
+			'plugins.php',
+			'update-core.php',
+		];
+
 		return (
 			$this->are_search_engines_discouraged()
 			&& WPSEO_Capability_Utils::current_user_can( 'manage_options' )
 			&& WPSEO_Options::get( 'ignore_search_engines_discouraged_notice', false ) === false
 			&& (
 				$this->on_wpseo_admin_page()
-				|| in_array( $this->pagenow, [
-					'index.php',
-					'plugins.php',
-					'update-core.php',
-				], true )
+				|| in_array( $this->pagenow, $discouraged_pages, true )
 			)
 		);
 	}

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -960,9 +960,11 @@ class WPSEO_Meta {
 			->where_not_equal( 'object_id', $post_id )
 			->limit( 2 )
 			->find_array();
-		$post_ids = array_map( function ( $row ) {
+
+		$callback = function ( $row ) {
 			return (int) $row['object_id'];
-		}, $post_ids );
+		};
+		$post_ids = array_map( $callback, $post_ids );
 
 		/*
 		 * If Yoast SEO Premium is active, get the additional keywords as well.

--- a/inc/health-check-ryte.php
+++ b/inc/health-check-ryte.php
@@ -182,21 +182,30 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 		$this->status         = self::STATUS_RECOMMENDED;
 		$this->badge['color'] = 'red';
 
+		/* translators: %1$s: Expands to 'Ryte', %2$s: Expands to 'Yoast SEO'. */
+		$description       = esc_html__(
+			'%1$s offers a free indexability check for %2$s users and right now it has trouble determining
+			whether search engines can find your site. This could have several (legitimate) reasons and
+			is not a problem in itself. If this is a live site, it is recommended that you figure out why
+			the %1$s check failed.',
+			'wordpress-seo'
+		);
 		$this->description = sprintf(
-			/* translators: %1$s: Expands to 'Ryte', %2$s: Expands to 'Yoast SEO'. */
-			esc_html__( '%1$s offers a free indexability check for %2$s users and right now it has trouble determining
-			whether search engines can find your site. This could have several (legitimate) reasons and is not a problem
-			in itself. If this is a live site, it is recommended that you figure out why the %1$s check failed.', 'wordpress-seo' ),
+			$description,
 			'Ryte',
 			'Yoast SEO'
 		);
 		$this->description .= '<br />';
 
-		$alert_content = sprintf(
-			/* translators: %1$s: Expands to 'Ryte', %2$s: Link start tag to the Yoast knowledge base, %3$s: Link closing tag. */
-			esc_html__( 'As the indexability status of your website can only be fetched from %1$s every 15 seconds,
+		/* translators: %1$s: Expands to 'Ryte', %2$s: Link start tag to the Yoast knowledge base, %3$s: Link closing tag. */
+		$alert_text    = esc_html__(
+			'As the indexability status of your website can only be fetched from %1$s every 15 seconds,
 			a first step could be to wait at least 15 seconds and refresh the Site Health page. If that did not help,
-			%2$sread more about troubleshooting search engine visibility%3$s.', 'wordpress-seo' ),
+			%2$sread more about troubleshooting search engine visibility%3$s.',
+			'wordpress-seo'
+		);
+		$alert_content = sprintf(
+			$alert_text,
 			'Ryte',
 			'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/onpagerequestfailed' ) ) . '" target="_blank">',
 			WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
@@ -218,13 +227,12 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 		$this->status         = self::STATUS_GOOD;
 		$this->badge['color'] = 'blue';
 
-		$this->description = sprintf(
-			/* translators: %1$s: Expands to 'Ryte', %2$s: Expands to 'Yoast SEO'. */
-			esc_html__( '%1$s offers a free indexability check for %2$s users, and it shows
-			that your site can be found by search engines.', 'wordpress-seo' ),
-			'Ryte',
-			'Yoast SEO'
+		/* translators: %1$s: Expands to 'Ryte', %2$s: Expands to 'Yoast SEO'. */
+		$description       = esc_html__(
+			'%1$s offers a free indexability check for %2$s users, and it shows that your site can be found by search engines.',
+			'wordpress-seo'
 		);
+		$this->description = sprintf( $description, 'Ryte', 'Yoast SEO' );
 	}
 
 	/**

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -408,11 +408,14 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			'ignore_search_engines_discouraged_notice',
 		];
 
+		$target_values = [
+			'ignore',
+			'done',
+		];
+
 		foreach ( $value_change as $key ) {
-			if ( isset( $option_value[ $key ] ) && in_array( $option_value[ $key ], [
-					'ignore',
-					'done',
-				], true )
+			if ( isset( $option_value[ $key ] )
+				&& in_array( $option_value[ $key ], $target_values, true )
 			) {
 				$option_value[ $key ] = true;
 			}

--- a/src/actions/indexation/indexable-post-type-archive-indexation-action.php
+++ b/src/actions/indexation/indexable-post-type-archive-indexation-action.php
@@ -149,8 +149,9 @@ class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action
 			->where( 'object_type', 'post-type-archive' )
 			->find_array();
 
-		return \array_map( function( $result ) {
+		$callback = function( $result ) {
 			return $result['object_sub_type'];
-		}, $results );
+		};
+		return \array_map( $callback, $results );
 	}
 }

--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -108,12 +108,13 @@ class Index_Command implements Command_Interface {
 			return;
 		}
 
-		$blog_ids = \get_sites( [
+		$criteria = [
 			'fields'   => 'ids',
 			'spam'     => 0,
 			'deleted'  => 0,
 			'archived' => 0,
-		] );
+		];
+		$blog_ids = \get_sites( $criteria );
 
 		foreach ( $blog_ids as $blog_id ) {
 			\switch_to_blog( $blog_id );

--- a/src/conditionals/yoast-admin-and-dashboard-conditional.php
+++ b/src/conditionals/yoast-admin-and-dashboard-conditional.php
@@ -27,11 +27,13 @@ class Yoast_Admin_And_Dashboard_Conditional implements Conditional {
 			return true;
 		}
 
-		return \in_array( $pagenow, [
+		$target_pages = [
 			'index.php',
 			'plugins.php',
 			'update-core.php',
-		], true );
+		];
+
+		return \in_array( $pagenow, $target_pages, true );
 	}
 
 	/**

--- a/src/config/migrations/20200420073606_AddColumnsToIndexables.php
+++ b/src/config/migrations/20200420073606_AddColumnsToIndexables.php
@@ -27,11 +27,20 @@ class AddColumnsToIndexables extends Ruckusing_Migration_Base {
 			] );
 		}
 
+		$attr_limit_32 = [
+			'null'  => true,
+			'limit' => 32,
+		];
+		$attr_limit_64 = [
+			'null'  => true,
+			'limit' => 64,
+		];
+
 		$indexable_table = $this->get_indexable_table();
-		$this->add_column( $indexable_table, 'language', 'string', [ 'null' => true, 'limit' => 32 ] );
-		$this->add_column( $indexable_table, 'region', 'string', [ 'null' => true, 'limit' => 32 ] );
-		$this->add_column( $indexable_table, 'schema_page_type', 'string', [ 'null' => true, 'limit' => 64 ] );
-		$this->add_column( $indexable_table, 'schema_article_type', 'string', [ 'null' => true, 'limit' => 64 ] );
+		$this->add_column( $indexable_table, 'language', 'string', $attr_limit_32 );
+		$this->add_column( $indexable_table, 'region', 'string', $attr_limit_32 );
+		$this->add_column( $indexable_table, 'schema_page_type', 'string', $attr_limit_64 );
+		$this->add_column( $indexable_table, 'schema_article_type', 'string', $attr_limit_64 );
 	}
 
 	/**

--- a/src/config/migrations/20200428194858_ExpandIndexableColumnLengths.php
+++ b/src/config/migrations/20200428194858_ExpandIndexableColumnLengths.php
@@ -28,35 +28,40 @@ class ExpandIndexableColumnLengths extends Ruckusing_Migration_Base {
 	 * Migration down.
 	 */
 	public function down() {
+		$attr_limit_191 = [
+			'null'  => true,
+			'limit' => 191,
+		];
+
 		$this->change_column(
 			$this->get_table_name(),
 			'title',
 			'string',
-			[ 'null' => true, 'limit' => 191 ]
+			$attr_limit_191
 		);
 		$this->change_column(
 			$this->get_table_name(),
 			'opengraph_title',
 			'string',
-			[ 'null' => true, 'limit' => 191 ]
+			$attr_limit_191
 		);
 		$this->change_column(
 			$this->get_table_name(),
 			'twitter_title',
 			'string',
-			[ 'null' => true, 'limit' => 191 ]
+			$attr_limit_191
 		);
 		$this->change_column(
 			$this->get_table_name(),
 			'open_graph_image_source',
 			'string',
-			[ 'null' => true, 'limit' => 191 ]
+			$attr_limit_191
 		);
 		$this->change_column(
 			$this->get_table_name(),
 			'twitter_image_source',
 			'string',
-			[ 'null' => true, 'limit' => 191 ]
+			$attr_limit_191
 		);
 	}
 

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -122,7 +122,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 
 		$indexables = \apply_filters( 'wpseo_breadcrumb_indexables', $indexables, $context );
 
-		$crumbs = array_map( function ( Indexable $ancestor ) {
+		$callback = function ( Indexable $ancestor ) {
 			$crumb = [
 				'url'  => $ancestor->permalink,
 				'text' => $ancestor->breadcrumb_title,
@@ -148,7 +148,8 @@ class Breadcrumbs_Generator implements Generator_Interface {
 					break;
 			}
 			return $crumb;
-		}, $indexables );
+		};
+		$crumbs   = array_map( $callback, $indexables );
 
 		if ( $breadcrumbs_home !== '' ) {
 			$crumbs[0]['text'] = $breadcrumbs_home;
@@ -161,7 +162,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 		 */
 		$crumbs = apply_filters( 'wpseo_breadcrumb_links', $crumbs );
 
-		return array_map( function( $link_info, $index ) use ( $crumbs ) {
+		$filter_callback = function( $link_info, $index ) use ( $crumbs ) {
 			/**
 			 * Filter: 'wpseo_breadcrumb_single_link_info' - Allow developers to filter the Yoast SEO Breadcrumb link information.
 			 *
@@ -171,7 +172,8 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			 * @param array $crumbs The complete list of breadcrumbs.
 			 */
 			return apply_filters( 'wpseo_breadcrumb_single_link_info', $link_info, $index, $crumbs );
-		}, $crumbs, array_keys( $crumbs ) );
+		};
+		return array_map( $filter_callback, $crumbs, array_keys( $crumbs ) );
 	}
 
 	/**

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -139,14 +139,7 @@ class Schema_Generator implements Generator_Interface {
 	 * @return Abstract_Schema_Piece[] A filtered array of graph pieces.
 	 */
 	protected function get_graph_pieces( $context ) {
-		/**
-		 * Filter: 'wpseo_schema_graph_pieces' - Allows adding pieces to the graph.
-		 *
-		 * @param Meta_Tags_Context $context An object with context variables.
-		 *
-		 * @api array $pieces The schema pieces.
-		 */
-		return \apply_filters( 'wpseo_schema_graph_pieces', [
+		$schema_pieces = [
 			new Schema\Organization(),
 			new Schema\Person(),
 			new Schema\Website(),
@@ -157,6 +150,15 @@ class Schema_Generator implements Generator_Interface {
 			new Schema\Author(),
 			new Schema\FAQ(),
 			new Schema\HowTo(),
-		], $context );
+		];
+
+		/**
+		 * Filter: 'wpseo_schema_graph_pieces' - Allows adding pieces to the graph.
+		 *
+		 * @param Meta_Tags_Context $context An object with context variables.
+		 *
+		 * @api array $pieces The schema pieces.
+		 */
+		return \apply_filters( 'wpseo_schema_graph_pieces', $schema_pieces, $context );
 	}
 }

--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -124,11 +124,12 @@ class Article extends Abstract_Schema_Piece {
 			return $data;
 		}
 
-		$terms = \array_filter( $terms, function( $term ) {
+		$callback = function( $term ) {
 			// We are checking against the WordPress internal translation.
 			// @codingStandardsIgnoreLine
 			return $term->name !== __( 'Uncategorized', 'default' );
-		} );
+		};
+		$terms    = \array_filter( $terms, $callback );
 
 		if ( empty( $terms ) ) {
 			return $data;

--- a/src/generators/schema/faq.php
+++ b/src/generators/schema/faq.php
@@ -51,12 +51,13 @@ class FAQ extends Abstract_Schema_Piece {
 			}
 		}
 
-		\array_unshift( $graph, [
+		$extra_graph_entries = [
 			'@type'            => 'ItemList',
 			'mainEntityOfPage' => [ '@id' => $this->context->main_schema_id ],
 			'numberOfItems'    => $number_of_items,
 			'itemListElement'  => $ids,
-		] );
+		];
+		\array_unshift( $graph, $extra_graph_entries );
 
 		return $graph;
 	}

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -283,14 +283,13 @@ class Front_End_Integration implements Integration_Interface {
 	public function get_presenters( $page_type ) {
 		$needed_presenters = $this->get_needed_presenters( $page_type );
 
-		$presenters = array_filter(
-			\array_map( function( $presenter ) {
-				if ( ! \class_exists( $presenter ) ) {
-					return null;
-				}
-				return new $presenter();
-			}, $needed_presenters )
-		);
+		$callback   = function( $presenter ) {
+			if ( ! \class_exists( $presenter ) ) {
+				return null;
+			}
+			return new $presenter();
+		};
+		$presenters = array_filter( \array_map( $callback, $needed_presenters ) );
 
 		/**
 		 * Filter 'wpseo_frontend_presenters' - Allow filtering the presenter instances in or out of the request.
@@ -303,9 +302,10 @@ class Front_End_Integration implements Integration_Interface {
 			$presenter_instances = $presenters;
 		}
 
-		$presenter_instances = \array_filter( $presenter_instances, function ( $presenter_instance ) {
+		$is_presenter_callback = function ( $presenter_instance ) {
 			return $presenter_instance instanceof Abstract_Indexable_Presenter;
-		} );
+		};
+		$presenter_instances   = \array_filter( $presenter_instances, $is_presenter_callback );
 
 		return \array_merge(
 			[ new Marker_Open_Presenter() ], $presenter_instances, [ new Marker_Close_Presenter() ]
@@ -327,9 +327,10 @@ class Front_End_Integration implements Integration_Interface {
 			$presenters = array_diff( $presenters, [ 'Title' ] );
 		}
 
-		$presenters = \array_map( function ( $presenter ) {
+		$callback   = function ( $presenter ) {
 			return "Yoast\WP\SEO\Presenters\\{$presenter}_Presenter";
-		}, $presenters );
+		};
+		$presenters = \array_map( $callback, $presenters );
 
 		/**
 		 * Filter 'wpseo_frontend_presenter_classes' - Allow filtering presenters in or out of the request.

--- a/src/repositories/indexable-hierarchy-repository.php
+++ b/src/repositories/indexable-hierarchy-repository.php
@@ -80,15 +80,17 @@ class Indexable_Hierarchy_Repository {
 			->find_array();
 
 		if ( ! empty( $ancestors ) ) {
-			return \array_map( function ( $ancestor ) {
+			$callback = function ( $ancestor ) {
 				return $ancestor['ancestor_id'];
-			}, $ancestors );
+			};
+			return \array_map( $callback, $ancestors );
 		}
 
 		$indexable = $this->builder->build( $indexable );
-		return \array_map( function ( $indexable ) {
+		$callback  = function ( $indexable ) {
 			return $indexable->id;
-		}, $indexable->ancestors );
+		};
+		return \array_map( $callback, $indexable->ancestors );
 	}
 
 	/**

--- a/src/routes/indexables-head-route.php
+++ b/src/routes/indexables-head-route.php
@@ -59,7 +59,7 @@ class Indexables_Head_Route implements Route_Interface {
 	 * @inheritDoc
 	 */
 	public function register_routes() {
-		\register_rest_route( Main::API_V1_NAMESPACE, self::HEAD_FOR_URL_ROUTE, [
+		$route_args = [
 			'methods'  => 'GET',
 			'callback' => [ $this, 'get_head' ],
 			'args'     => [
@@ -68,7 +68,8 @@ class Indexables_Head_Route implements Route_Interface {
 					'required'          => true,
 				],
 			],
-		] );
+		];
+		\register_rest_route( Main::API_V1_NAMESPACE, self::HEAD_FOR_URL_ROUTE, $route_args );
 	}
 
 	/**

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -125,9 +125,11 @@ class Meta {
 		$presenters = $this->front_end->get_presenters( $this->context->page_type );
 
 		if ( $this->context->page_type === 'Date_Archive' ) {
-			$presenters = \array_filter( $presenters, function ( $presenter ) {
-				return ! \is_a( $presenter, Rel_Next_Presenter::class ) && ! \is_a( $presenter, Rel_Prev_Presenter::class );
-			} );
+			$callback   = function ( $presenter ) {
+				return ! \is_a( $presenter, Rel_Next_Presenter::class )
+					&& ! \is_a( $presenter, Rel_Prev_Presenter::class );
+			};
+			$presenters = \array_filter( $presenters, $callback );
 		}
 
 		$output = '';

--- a/tests/actions/indexation/indexable-post-type-archive-indexation-action-test.php
+++ b/tests/actions/indexation/indexable-post-type-archive-indexation-action-test.php
@@ -259,9 +259,10 @@ class Indexable_Post_Type_Archive_Indexation_Action_Test extends TestCase {
 	 * @param array $post_types The post types for which to return indexables.
 	 */
 	private function set_expectations_for_repository( $post_types ) {
-		$results = \array_map( function( $post_type ) {
+		$callback = function( $post_type ) {
 			return [ 'object_sub_type' => $post_type ];
-		}, $post_types );
+		};
+		$results  = \array_map( $callback, $post_types );
 
 		$query_mock = Mockery::mock( ORM::class );
 		$query_mock->expects( 'select' )->once()->with( 'object_sub_type' )->andReturn( $query_mock );

--- a/tests/context/meta-tags-context-test.php
+++ b/tests/context/meta-tags-context-test.php
@@ -300,6 +300,11 @@ class Meta_Tags_Context_Test extends TestCase {
 		$this->instance->indexable    = 'indexable';
 		$this->instance->presentation = 'presentation';
 
-		$this->assertEquals( [ 'indexable' => 'indexable', 'presentation' => 'presentation' ], $this->instance->__debugInfo() );
+		$expected = [
+			'indexable'    => 'indexable',
+			'presentation' => 'presentation',
+		];
+
+		$this->assertEquals( $expected, $this->instance->__debugInfo() );
 	}
 }

--- a/tests/integrations/front-end-integration-test.php
+++ b/tests/integrations/front-end-integration-test.php
@@ -171,39 +171,45 @@ class Front_End_Integration_Test extends TestCase {
 		$this->options->expects( 'get' )->with( 'opengraph' )->andReturnTrue();
 		$this->options->expects( 'get' )->with( 'twitter' )->andReturnTrue();
 
+		$expected = [
+			'Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter',
+			'Yoast\WP\SEO\Presenters\Title_Presenter',
+			'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
+			'Yoast\WP\SEO\Presenters\Robots_Presenter',
+			'Yoast\WP\SEO\Presenters\Googlebot_Presenter',
+			'Yoast\WP\SEO\Presenters\Bingbot_Presenter',
+			'Yoast\WP\SEO\Presenters\Canonical_Presenter',
+			'Yoast\WP\SEO\Presenters\Rel_Prev_Presenter',
+			'Yoast\WP\SEO\Presenters\Rel_Next_Presenter',
+			'Yoast\WP\SEO\Presenters\Open_Graph\Locale_Presenter',
+			'Yoast\WP\SEO\Presenters\Open_Graph\Type_Presenter',
+			'Yoast\WP\SEO\Presenters\Open_Graph\Title_Presenter',
+			'Yoast\WP\SEO\Presenters\Open_Graph\Description_Presenter',
+			'Yoast\WP\SEO\Presenters\Open_Graph\Url_Presenter',
+			'Yoast\WP\SEO\Presenters\Open_Graph\Site_Name_Presenter',
+			'Yoast\WP\SEO\Presenters\Open_Graph\Article_Publisher_Presenter',
+			'Yoast\WP\SEO\Presenters\Open_Graph\Article_Author_Presenter',
+			'Yoast\WP\SEO\Presenters\Open_Graph\Article_Published_Time_Presenter',
+			'Yoast\WP\SEO\Presenters\Open_Graph\Article_Modified_Time_Presenter',
+			'Yoast\WP\SEO\Presenters\Open_Graph\Image_Presenter',
+			'Yoast\WP\SEO\Presenters\Open_Graph\FB_App_ID_Presenter',
+			'Yoast\WP\SEO\Presenters\Twitter\Card_Presenter',
+			'Yoast\WP\SEO\Presenters\Twitter\Title_Presenter',
+			'Yoast\WP\SEO\Presenters\Twitter\Description_Presenter',
+			'Yoast\WP\SEO\Presenters\Twitter\Image_Presenter',
+			'Yoast\WP\SEO\Presenters\Twitter\Creator_Presenter',
+			'Yoast\WP\SEO\Presenters\Twitter\Site_Presenter',
+			'Yoast\WP\SEO\Presenters\Schema_Presenter',
+			'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
+		];
+
+		$callback = function ( $presenter ) {
+			return \get_class( $presenter );
+		};
+
 		$this->assertEquals(
-			[
-				'Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter',
-				'Yoast\WP\SEO\Presenters\Title_Presenter',
-				'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
-				'Yoast\WP\SEO\Presenters\Robots_Presenter',
-				'Yoast\WP\SEO\Presenters\Googlebot_Presenter',
-				'Yoast\WP\SEO\Presenters\Bingbot_Presenter',
-				'Yoast\WP\SEO\Presenters\Canonical_Presenter',
-				'Yoast\WP\SEO\Presenters\Rel_Prev_Presenter',
-				'Yoast\WP\SEO\Presenters\Rel_Next_Presenter',
-				'Yoast\WP\SEO\Presenters\Open_Graph\Locale_Presenter',
-				'Yoast\WP\SEO\Presenters\Open_Graph\Type_Presenter',
-				'Yoast\WP\SEO\Presenters\Open_Graph\Title_Presenter',
-				'Yoast\WP\SEO\Presenters\Open_Graph\Description_Presenter',
-				'Yoast\WP\SEO\Presenters\Open_Graph\Url_Presenter',
-				'Yoast\WP\SEO\Presenters\Open_Graph\Site_Name_Presenter',
-				'Yoast\WP\SEO\Presenters\Open_Graph\Article_Publisher_Presenter',
-				'Yoast\WP\SEO\Presenters\Open_Graph\Article_Author_Presenter',
-				'Yoast\WP\SEO\Presenters\Open_Graph\Article_Published_Time_Presenter',
-				'Yoast\WP\SEO\Presenters\Open_Graph\Article_Modified_Time_Presenter',
-				'Yoast\WP\SEO\Presenters\Open_Graph\Image_Presenter',
-				'Yoast\WP\SEO\Presenters\Open_Graph\FB_App_ID_Presenter',
-				'Yoast\WP\SEO\Presenters\Twitter\Card_Presenter',
-				'Yoast\WP\SEO\Presenters\Twitter\Title_Presenter',
-				'Yoast\WP\SEO\Presenters\Twitter\Description_Presenter',
-				'Yoast\WP\SEO\Presenters\Twitter\Image_Presenter',
-				'Yoast\WP\SEO\Presenters\Twitter\Creator_Presenter',
-				'Yoast\WP\SEO\Presenters\Twitter\Site_Presenter',
-				'Yoast\WP\SEO\Presenters\Schema_Presenter',
-				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
-			],
-			array_map( function ( $presenter ) { return \get_class( $presenter ); }, $this->instance->get_presenters( 'Post_Type' ) )
+			$expected,
+			array_map( $callback, $this->instance->get_presenters( 'Post_Type' ) )
 		);
 	}
 
@@ -223,6 +229,11 @@ class Front_End_Integration_Test extends TestCase {
 			->with( 'opengraph' )
 			->andReturnTrue();
 
+		$callback = function ( $presenter ) {
+			return \get_class( $presenter );
+		};
+		$expected = array_map( $callback, $this->instance->get_presenters( 'Error_Page' ) );
+
 		$this->assertEquals(
 			[
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter',
@@ -237,7 +248,7 @@ class Front_End_Integration_Test extends TestCase {
 				'Yoast\WP\SEO\Presenters\Schema_Presenter',
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 			],
-			array_map( function ( $presenter ) { return \get_class( $presenter ); }, $this->instance->get_presenters( 'Error_Page' ) )
+			$expected
 		);
 	}
 
@@ -262,6 +273,11 @@ class Front_End_Integration_Test extends TestCase {
 			->with( 'twitter' )
 			->andReturnTrue();
 
+		$callback = function ( $presenter ) {
+			return \get_class( $presenter );
+		};
+		$expected = array_map( $callback, array_values( $this->instance->get_presenters( 'Term_Archive' ) ) );
+
 		$this->assertEquals(
 			[
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter',
@@ -289,7 +305,7 @@ class Front_End_Integration_Test extends TestCase {
 				'Yoast\WP\SEO\Presenters\Schema_Presenter',
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 			],
-			array_map( function ( $presenter ) { return \get_class( $presenter ); }, array_values( $this->instance->get_presenters( 'Term_Archive' ) ) )
+			$expected
 		);
 	}
 
@@ -315,6 +331,11 @@ class Front_End_Integration_Test extends TestCase {
 			->with( 'opengraph' )
 			->andReturnTrue();
 
+		$callback = function ( $presenter ) {
+			return \get_class( $presenter );
+		};
+		$actual   = array_map( $callback, array_values( $this->instance->get_presenters( 'Error_Page' ) ) );
+
 		$this->assertEquals(
 			[
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter',
@@ -328,7 +349,7 @@ class Front_End_Integration_Test extends TestCase {
 				'Yoast\WP\SEO\Presenters\Schema_Presenter',
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 			],
-			array_map( function ( $presenter ) { return \get_class( $presenter ); }, array_values( $this->instance->get_presenters( 'Error_Page' ) ) )
+			$actual
 		);
 	}
 
@@ -354,6 +375,11 @@ class Front_End_Integration_Test extends TestCase {
 			->with( 'opengraph' )
 			->andReturnTrue();
 
+		$callback = function ( $presenter ) {
+			return \get_class( $presenter );
+		};
+		$expected = array_map( $callback, array_values( $this->instance->get_presenters( 'Error_Page' ) ) );
+
 		$this->assertEquals(
 			[
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter',
@@ -368,7 +394,7 @@ class Front_End_Integration_Test extends TestCase {
 				'Yoast\WP\SEO\Presenters\Schema_Presenter',
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 			],
-			array_map( function ( $presenter ) { return \get_class( $presenter ); }, array_values( $this->instance->get_presenters( 'Error_Page' ) ) )
+			$expected
 		);
 	}
 }

--- a/tests/presentations/indexable-presentation/debug-info-test.php
+++ b/tests/presentations/indexable-presentation/debug-info-test.php
@@ -32,6 +32,11 @@ class Debug_Info_Test extends TestCase {
 		$this->instance->model   = 'indexable';
 		$this->instance->context = 'context';
 
-		$this->assertEquals( [ 'model' => 'indexable', 'context' => 'context' ], $this->instance->__debugInfo() );
+		$expected = [
+			'model'   => 'indexable',
+			'context' => 'context',
+		];
+
+		$this->assertEquals( $expected, $this->instance->__debugInfo() );
 	}
 }

--- a/tests/presentations/indexable-presentation/googlebot-test.php
+++ b/tests/presentations/indexable-presentation/googlebot-test.php
@@ -29,6 +29,14 @@ class Googlebot_Test extends TestCase {
 	 * @covers ::generate_googlebot
 	 */
 	public function test_generate_googlebot() {
-		$this->assertEquals( [ 'index' => 'index', 'follow' => 'follow', 'max-snippet:-1', 'max-image-preview:large', 'max-video-preview:-1' ], $this->instance->generate_googlebot() );
+		$expected = [
+			'index'  => 'index',
+			'follow' => 'follow',
+			'max-snippet:-1',
+			'max-image-preview:large',
+			'max-video-preview:-1',
+		];
+
+		$this->assertEquals( $expected, $this->instance->generate_googlebot() );
 	}
 }


### PR DESCRIPTION
Move arguments which are - or should be - multi-line out of select function calls in favour of declaring them as a variable and passing this variable to the function call.

Includes minor code de-duplication for a few arrays being re-declared time and again without any difference.

## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.
* Code style compliance.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
