### PR TITLE
CS: proper multi-line function call formatting [1]

### DIFF
--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -171,11 +171,13 @@ class Indexable_Builder {
 
 		// Something went wrong building, create a false indexable.
 		if ( $indexable === false ) {
-			$indexable = $this->indexable_repository->query()->create( [
-				'object_id'   => $object_id,
-				'object_type' => $object_type,
-				'post_status' => 'unindexed',
-			] );
+			$indexable = $this->indexable_repository->query()->create(
+				[
+					'object_id'   => $object_id,
+					'object_type' => $object_type,
+					'post_status' => 'unindexed',
+				]
+			);
 		}
 
 		$this->save_indexable( $indexable, $indexable_before );

--- a/src/config/migrations/20171228151840_WpYoastIndexable.php
+++ b/src/config/migrations/20171228151840_WpYoastIndexable.php
@@ -109,12 +109,16 @@ class WpYoastIndexable extends Ruckusing_Migration_Base {
 		$indexable_table->column( 'incoming_link_count', 'integer', [ 'null' => true, 'limit' => 11 ] );
 
 		// Prominent words.
-		$indexable_table->column( 'prominent_words_version', 'integer', [
-			'null'     => true,
-			'limit'    => 11,
-			'unsigned' => true,
-			'default'  => null,
-		] );
+		$indexable_table->column(
+			'prominent_words_version',
+			'integer',
+			[
+				'null'     => true,
+				'limit'    => 11,
+				'unsigned' => true,
+				'default'  => null,
+			]
+		);
 
 		$indexable_table->finish();
 

--- a/src/config/migrations/20191011111109_WpYoastIndexableHierarchy.php
+++ b/src/config/migrations/20191011111109_WpYoastIndexableHierarchy.php
@@ -21,18 +21,26 @@ class WpYoastIndexableHierarchy extends Ruckusing_Migration_Base {
 
 		$indexable_table = $this->create_table( $table_name, [ 'id' => false ] );
 
-		$indexable_table->column( 'indexable_id', 'integer', [
-			'primary_key' => true,
-			'unsigned'    => true,
-			'null'        => true,
-			'limit'       => 11,
-		] );
-		$indexable_table->column( 'ancestor_id', 'integer', [
-			'primary_key' => true,
-			'unsigned'    => true,
-			'null'        => true,
-			'limit'       => 11,
-		] );
+		$indexable_table->column(
+			'indexable_id',
+			'integer',
+			[
+				'primary_key' => true,
+				'unsigned'    => true,
+				'null'        => true,
+				'limit'       => 11,
+			]
+		);
+		$indexable_table->column(
+			'ancestor_id',
+			'integer',
+			[
+				'primary_key' => true,
+				'unsigned'    => true,
+				'null'        => true,
+				'limit'       => 11,
+			]
+		);
 		$indexable_table->column( 'depth', 'integer', [ 'unsigned' => true, 'null' => true, 'limit' => 11 ] );
 		$indexable_table->finish();
 

--- a/src/config/migrations/20200420073606_AddColumnsToIndexables.php
+++ b/src/config/migrations/20200420073606_AddColumnsToIndexables.php
@@ -20,11 +20,16 @@ class AddColumnsToIndexables extends Ruckusing_Migration_Base {
 		$tables  = $this->get_tables();
 		$blog_id = \get_current_blog_id();
 		foreach ( $tables as $table ) {
-			$this->add_column( $table, 'blog_id', 'biginteger', [
-				'null'    => false,
-				'limit'   => 20,
-				'default' => $blog_id,
-			] );
+			$this->add_column(
+				$table,
+				'blog_id',
+				'biginteger',
+				[
+					'null'    => false,
+					'limit'   => 20,
+					'default' => $blog_id,
+				]
+			);
 		}
 
 		$indexable_table = $this->get_indexable_table();

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -308,7 +308,9 @@ class Front_End_Integration implements Integration_Interface {
 		} );
 
 		return \array_merge(
-			[ new Marker_Open_Presenter() ], $presenter_instances, [ new Marker_Close_Presenter() ]
+			[ new Marker_Open_Presenter() ],
+			$presenter_instances,
+			[ new Marker_Close_Presenter() ]
 		);
 	}
 

--- a/src/memoizers/meta-tags-context-memoizer.php
+++ b/src/memoizers/meta-tags-context-memoizer.php
@@ -117,12 +117,15 @@ class Meta_Tags_Context_Memoizer {
 				$blocks = $this->blocks->get_all_blocks_from_content( $post->post_content );
 			}
 
-			$context = $this->context_prototype->of( [
-				'indexable' => $indexable,
-				'blocks'    => $blocks,
-				'post'      => $post,
-				'page_type' => $page_type,
-			] );
+			$context = $this->context_prototype->of(
+				[
+					'indexable' => $indexable,
+					'blocks'    => $blocks,
+					'post'      => $post,
+					'page_type' => $page_type,
+				]
+			);
+
 			$context->presentation = $this->presentation_memoizer->get( $indexable, $context, $page_type );
 
 			$this->cache[ $indexable->id ] = $context;

--- a/src/repositories/indexable-hierarchy-repository.php
+++ b/src/repositories/indexable-hierarchy-repository.php
@@ -56,12 +56,14 @@ class Indexable_Hierarchy_Repository {
 	 * @return bool Whether or not the ancestor was added succesfully.
 	 */
 	public function add_ancestor( $indexable_id, $ancestor_id, $depth ) {
-		$hierarchy = $this->query()->create( [
-			'indexable_id' => $indexable_id,
-			'ancestor_id'  => $ancestor_id,
-			'depth'        => $depth,
-			'blog_id'      => \get_current_blog_id(),
-		] );
+		$hierarchy = $this->query()->create(
+			[
+				'indexable_id' => $indexable_id,
+				'ancestor_id'  => $ancestor_id,
+				'depth'        => $depth,
+				'blog_id'      => \get_current_blog_id(),
+			]
+		);
 		return $hierarchy->save();
 	}
 

--- a/src/routes/abstract-indexation-route.php
+++ b/src/routes/abstract-indexation-route.php
@@ -23,9 +23,11 @@ abstract class Abstract_Indexation_Route implements Route_Interface {
 	 * @return WP_REST_Response The response.
 	 */
 	protected function respond_with( $objects, $next_url ) {
-		return new WP_REST_Response( [
-			'objects'  => $objects,
-			'next_url' => $next_url,
-		] );
+		return new WP_REST_Response(
+			[
+				'objects'  => $objects,
+				'next_url' => $next_url,
+			]
+		);
 	}
 }

--- a/tests/builders/indexable-post-builder-test.php
+++ b/tests/builders/indexable-post-builder-test.php
@@ -106,11 +106,14 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$this->post                 = Mockery::mock( Post_Helper::class );
 		$this->logger               = Mockery::mock( Logger::class );
 
-		$this->instance = Mockery::mock( Indexable_Post_Builder_Double::class, [
-			$this->seo_meta_repository,
-			$this->post,
-			$this->logger,
-		] )
+		$this->instance = Mockery::mock(
+			Indexable_Post_Builder_Double::class,
+			[
+				$this->seo_meta_repository,
+				$this->post,
+				$this->logger,
+			]
+		)
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
 		$this->instance->set_indexable_repository( $this->indexable_repository );

--- a/tests/generators/open-graph-image-generator-test.php
+++ b/tests/generators/open-graph-image-generator-test.php
@@ -185,10 +185,12 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 	 */
 	public function test_generate_with_image_url_from_indexable_with_open_graph_image_meta() {
 		$this->indexable->open_graph_image      = 'image.jpg';
-		$this->indexable->open_graph_image_meta = wp_json_encode( [
-			'height' => 1024,
-			'width'  => 2048,
-		] );
+		$this->indexable->open_graph_image_meta = wp_json_encode(
+			[
+				'height' => 1024,
+				'width'  => 2048,
+			]
+		);
 
 		$this->instance->expects( 'add_from_default' )->andReturnNull();
 

--- a/tests/generators/schema/article-test.php
+++ b/tests/generators/schema/article-test.php
@@ -259,11 +259,13 @@ class Article_Test extends TestCase {
 
 		$this->language->expects( 'add_piece_language' )
 			->once()
-			->andReturnUsing( function( $data ) {
-				$data['inLanguage'] = 'language';
+			->andReturnUsing(
+				function( $data ) {
+					$data['inLanguage'] = 'language';
 
-				return $data;
-			} );
+					return $data;
+				}
+			);
 
 		Monkey\Functions\expect( 'post_type_supports' )
 			->once()

--- a/tests/generators/schema/howto-test.php
+++ b/tests/generators/schema/howto-test.php
@@ -164,11 +164,13 @@ class HowTo_Test extends TestCase {
 
 		$this->language
 			->shouldReceive( 'add_piece_language' )
-			->andReturnUsing( function( $data ) {
-				$data['inLanguage'] = 'language';
+			->andReturnUsing(
+				function( $data ) {
+					$data['inLanguage'] = 'language';
 
-				return $data;
-			} );
+					return $data;
+				}
+			);
 
 		$this->post
 			->shouldReceive( 'get_post_title_with_fallback' )
@@ -296,14 +298,16 @@ class HowTo_Test extends TestCase {
 				'#schema-image-94025919e8fe3836562573a84a14a305',
 				'https://example.com/wp-content/uploads/2020/02/download.jpeg'
 			)
-			->andReturn( [
-				'@type'      => 'ImageObject',
-				'@id'        => 'https://example.com/post-1/#schema-image-72ed920b53178575afcdb59b932ad01b',
-				'inLanguage' => 'en-US',
-				'url'        => 'https://example.com/wp-content/uploads/2020/02/download.jpeg',
-				'width'      => 474,
-				'height'     => 474,
-			] );
+			->andReturn(
+				[
+					'@type'      => 'ImageObject',
+					'@id'        => 'https://example.com/post-1/#schema-image-72ed920b53178575afcdb59b932ad01b',
+					'inLanguage' => 'en-US',
+					'url'        => 'https://example.com/wp-content/uploads/2020/02/download.jpeg',
+					'width'      => 474,
+					'height'     => 474,
+				]
+			);
 
 		$schema = $this->base_schema;
 

--- a/tests/generators/schema/person-test.php
+++ b/tests/generators/schema/person-test.php
@@ -375,12 +375,14 @@ class Person_Test extends TestCase {
 
 		$this->expects_for_determine_user_id();
 		$this->expects_for_get_userdata( $user_data );
-		$this->expects_for_social_profiles( [
-			'facebook'  => 'facebook',
-			'instagram' => 1234,
-			'youtube'   => false,
-			'wikipedia' => 'wiki',
-		] );
+		$this->expects_for_social_profiles(
+			[
+				'facebook'  => 'facebook',
+				'instagram' => 1234,
+				'youtube'   => false,
+				'wikipedia' => 'wiki',
+			]
+		);
 
 		$this->assertEquals( $expected, $this->instance->generate( $this->instance->context ) );
 	}

--- a/tests/generators/schema/webpage-test.php
+++ b/tests/generators/schema/webpage-test.php
@@ -173,11 +173,13 @@ class WebPage_Test extends TestCase {
 
 		$this->language->expects( 'add_piece_language' )
 			->once()
-			->andReturnUsing( function ( $data ) {
-				$data['inLanguage'] = 'the-language';
+			->andReturnUsing(
+				function ( $data ) {
+					$data['inLanguage'] = 'the-language';
 
-				return $data;
-			} );
+					return $data;
+				}
+			);
 
 		$this->meta_tags_context
 			->expects( 'generate_schema_page_type' )

--- a/tests/generators/schema/website-test.php
+++ b/tests/generators/schema/website-test.php
@@ -101,11 +101,13 @@ class Website_Test extends TestCase {
 
 		$this->language->expects( 'add_piece_language' )
 			->once()
-			->andReturnUsing( function( $data ) {
-				$data['inLanguage'] = 'language';
+			->andReturnUsing(
+				function( $data ) {
+					$data['inLanguage'] = 'language';
 
-				return $data;
-			} );
+					return $data;
+				}
+			);
 
 		$this->options->expects( 'get' )
 			->with( 'alternate_website_name', '' )
@@ -157,11 +159,13 @@ class Website_Test extends TestCase {
 
 		$this->language->expects( 'add_piece_language' )
 			->once()
-			->andReturnUsing( function( $data ) {
-				$data['inLanguage'] = 'language';
+			->andReturnUsing(
+				function( $data ) {
+					$data['inLanguage'] = 'language';
 
-				return $data;
-			} );
+					return $data;
+				}
+			);
 
 		$this->options->expects( 'get' )
 			->with( 'alternate_website_name', '' )

--- a/tests/helpers/current-page-helper-test.php
+++ b/tests/helpers/current-page-helper-test.php
@@ -592,17 +592,19 @@ class Current_Page_Helper_Test extends TestCase {
 
 		Monkey\Functions\expect( 'get_option' )
 			->twice()
-			->andReturnUsing( function ( $option ) {
-				if ( $option === 'show_on_front' ) {
-					return 'page';
-				}
+			->andReturnUsing(
+				function ( $option ) {
+					if ( $option === 'show_on_front' ) {
+						return 'page';
+					}
 
-				if ( $option === 'page_on_front' ) {
-					return 1;
-				}
+					if ( $option === 'page_on_front' ) {
+						return 1;
+					}
 
-				return null;
-			} );
+					return null;
+				}
+			);
 
 		$this->assertTrue( $this->instance->is_home_static_page() );
 	}

--- a/tests/helpers/primary-term-helper-test.php
+++ b/tests/helpers/primary-term-helper-test.php
@@ -48,16 +48,18 @@ class Primary_Term_Helper_Test extends TestCase {
 		Monkey\Functions\expect( 'get_object_taxonomies' )
 			->once()
 			->with( 'post', 'objects' )
-			->andReturn( [
-				(object) [
-					'name'         => 'category',
-					'hierarchical' => true,
-				],
-				(object) [
-					'name'         => 'tag',
-					'hierarchical' => false,
-				],
-			] );
+			->andReturn(
+				[
+					(object) [
+						'name'         => 'category',
+						'hierarchical' => true,
+					],
+					(object) [
+						'name'         => 'tag',
+						'hierarchical' => false,
+					],
+				]
+			);
 
 		Monkey\Functions\expect( 'get_post_type' )
 			->once()
@@ -81,16 +83,18 @@ class Primary_Term_Helper_Test extends TestCase {
 		Monkey\Functions\expect( 'get_object_taxonomies' )
 			->once()
 			->with( 'post', 'objects' )
-			->andReturn( [
-				(object) [
-					'name'         => 'category',
-					'hierarchical' => false,
-				],
-				(object) [
-					'name'         => 'tag',
-					'hierarchical' => false,
-				],
-			] );
+			->andReturn(
+				[
+					(object) [
+						'name'         => 'category',
+						'hierarchical' => false,
+					],
+					(object) [
+						'name'         => 'tag',
+						'hierarchical' => false,
+					],
+				]
+			);
 
 		Monkey\Functions\expect( 'get_post_type' )
 			->once()

--- a/tests/helpers/schema/image-helper-test.php
+++ b/tests/helpers/schema/image-helper-test.php
@@ -150,11 +150,14 @@ class Image_Helper_Test extends TestCase {
 			'inLanguage' => 'language',
 		];
 
-		$this->assertEquals( $expected, $this->instance->generate_from_attachment_id(
-			'https://example.com/#logo',
-			1337,
-			'Company name'
-		) );
+		$this->assertEquals(
+			$expected,
+			$this->instance->generate_from_attachment_id(
+				'https://example.com/#logo',
+				1337,
+				'Company name'
+			)
+		);
 	}
 
 	/**
@@ -190,11 +193,14 @@ class Image_Helper_Test extends TestCase {
 			'inLanguage' => 'language',
 		];
 
-		$this->assertEquals( $expected, $this->instance->generate_from_attachment_id(
-			'https://example.com/#logo',
-			1337,
-			'Company name'
-		) );
+		$this->assertEquals(
+			$expected,
+			$this->instance->generate_from_attachment_id(
+				'https://example.com/#logo',
+				1337,
+				'Company name'
+			)
+		);
 	}
 
 	/**

--- a/tests/helpers/url-helper-test.php
+++ b/tests/helpers/url-helper-test.php
@@ -47,10 +47,12 @@ class Url_Helper_Test extends TestCase {
 
 		Monkey\Functions\expect( 'wp_parse_url' )
 			->withArgs( [ 'home_url' ] )
-			->andReturn( [
-				'scheme' => 'https',
-				'host'   => 'example.com',
-			] );
+			->andReturn(
+				[
+					'scheme' => 'https',
+					'host'   => 'example.com',
+				]
+			);
 
 		$expected = 'https://example.com/my-page';
 		$actual   = $this->instance->build_absolute_url( '/my-page' );
@@ -73,10 +75,12 @@ class Url_Helper_Test extends TestCase {
 
 		Monkey\Functions\expect( 'wp_parse_url' )
 			->withArgs( [ 'home_url' ] )
-			->andReturn( [
-				'scheme' => 'https',
-				'host'   => 'example.com',
-			] );
+			->andReturn(
+				[
+					'scheme' => 'https',
+					'host'   => 'example.com',
+				]
+			);
 
 		$expected = 'https://example.com/my-page';
 		$actual   = $this->instance->build_absolute_url( 'https://example.com/my-page' );

--- a/tests/integrations/admin/indexation-integration-test.php
+++ b/tests/integrations/admin/indexation-integration-test.php
@@ -111,11 +111,14 @@ class Indexation_Integration_Test extends TestCase {
 	 */
 	public function test_get_conditionals() {
 		$conditionals = Indexation_Integration::get_conditionals();
-		$this->assertEquals( [
-			Admin_Conditional::class,
-			Yoast_Admin_And_Dashboard_Conditional::class,
-			Migrations_Conditional::class,
-		], $conditionals );
+		$this->assertEquals(
+			[
+				Admin_Conditional::class,
+				Yoast_Admin_And_Dashboard_Conditional::class,
+				Migrations_Conditional::class,
+			],
+			$conditionals
+		);
 	}
 
 	/**

--- a/tests/integrations/third-party/woocommerce-test.php
+++ b/tests/integrations/third-party/woocommerce-test.php
@@ -351,13 +351,15 @@ class WooCommerce_Test extends TestCase {
 	 */
 	public function test_title_by_using_the_product_archive_template() {
 		// Sets the stubs.
-		Monkey\Functions\stubs( [
-			'is_shop'        => true,
-			'is_search'      => false,
-			'is_archive'     => true,
-			'wc_get_page_id' => 1337,
-			'get_post'       => [ 'post' ],
-		] );
+		Monkey\Functions\stubs(
+			[
+				'is_shop'        => true,
+				'is_search'      => false,
+				'is_archive'     => true,
+				'wc_get_page_id' => 1337,
+				'get_post'       => [ 'post' ],
+			]
+		);
 
 		$this->options
 			->expects( 'get' )
@@ -384,13 +386,15 @@ class WooCommerce_Test extends TestCase {
 	 */
 	public function test_description_by_using_the_product_archive_template() {
 		// Sets the stubs.
-		Monkey\Functions\stubs( [
-			'is_shop'        => true,
-			'is_search'      => false,
-			'is_archive'     => true,
-			'wc_get_page_id' => 1337,
-			'get_post'       => [ 'post' ],
-		] );
+		Monkey\Functions\stubs(
+			[
+				'is_shop'        => true,
+				'is_search'      => false,
+				'is_archive'     => true,
+				'wc_get_page_id' => 1337,
+				'get_post'       => [ 'post' ],
+			]
+		);
 
 		$this->options
 			->expects( 'get' )

--- a/tests/integrations/watchers/primary-term-watcher-test.php
+++ b/tests/integrations/watchers/primary-term-watcher-test.php
@@ -75,12 +75,15 @@ class Primary_Term_Watcher_Test extends TestCase {
 		$this->site                 = Mockery::mock( Site_Helper::class );
 		$this->primary_term         = Mockery::mock( Primary_Term_Helper::class );
 		$this->primary_term_builder = Mockery::mock( Primary_Term_Builder::class );
-		$this->instance             = Mockery::mock( Primary_Term_Watcher::class, [
-			$this->repository,
-			$this->site,
-			$this->primary_term,
-			$this->primary_term_builder,
-		] )
+		$this->instance             = Mockery::mock(
+			Primary_Term_Watcher::class,
+			[
+				$this->repository,
+				$this->site,
+				$this->primary_term,
+				$this->primary_term_builder,
+			]
+		)
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 	}

--- a/tests/presentations/indexable-post-type-presentation/canonical-test.php
+++ b/tests/presentations/indexable-post-type-presentation/canonical-test.php
@@ -53,9 +53,11 @@ class Canonical_Test extends TestCase {
 		$this->url
 			->expects( 'ensure_absolute_url' )
 			->once()
-			->andReturnUsing( function ( $val ) {
-				return $val;
-			} );
+			->andReturnUsing(
+				function ( $val ) {
+					return $val;
+				}
+			);
 
 		$this->assertEquals( 'https://example.com/permalink/', $this->instance->generate_canonical() );
 	}
@@ -83,9 +85,11 @@ class Canonical_Test extends TestCase {
 		$this->url
 			->expects( 'ensure_absolute_url' )
 			->once()
-			->andReturnUsing( function ( $val ) {
-				return $val;
-			} );
+			->andReturnUsing(
+				function ( $val ) {
+					return $val;
+				}
+			);
 
 		$this->assertEquals( 'https://example.com/permalink/2/', $this->instance->generate_canonical() );
 	}

--- a/tests/presentations/indexable-post-type-presentation/open-graph-description-test.php
+++ b/tests/presentations/indexable-post-type-presentation/open-graph-description-test.php
@@ -28,9 +28,11 @@ class Open_Graph_Description_Test extends TestCase {
 			->expects( 'strip_shortcodes' )
 			->withAnyArgs()
 			->once()
-			->andReturnUsing( function( $string ) {
-				return $string;
-			} );
+			->andReturnUsing(
+				function( $string ) {
+					return $string;
+				}
+			);
 	}
 
 	/**

--- a/tests/presentations/indexable-presentation/robots-test.php
+++ b/tests/presentations/indexable-presentation/robots-test.php
@@ -93,10 +93,13 @@ class Robots_Test extends TestCase {
 	public function test_generate_robots_with_array_filter() {
 		Monkey\Filters\expectApplied( 'wpseo_robots_array' )
 			->once()
-			->with( [
+			->with(
+				[
 					'index'  => 'index',
 					'follow' => 'follow',
-				], $this->instance )
+				],
+				$this->instance
+			)
 			->andReturn(
 				[
 					'index'  => 'noindex',

--- a/tests/presentations/indexable-static-home-page-presentation/canonical-test.php
+++ b/tests/presentations/indexable-static-home-page-presentation/canonical-test.php
@@ -52,9 +52,11 @@ class Canonical_Test extends TestCase {
 		$this->url
 			->expects( 'ensure_absolute_url' )
 			->once()
-			->andReturnUsing( function ( $val ) {
-				return $val;
-			} );
+			->andReturnUsing(
+				function ( $val ) {
+					return $val;
+				}
+			);
 
 		$this->assertEquals( 'https://example.com/permalink/', $this->instance->generate_canonical() );
 	}
@@ -83,9 +85,11 @@ class Canonical_Test extends TestCase {
 		$this->url
 			->expects( 'ensure_absolute_url' )
 			->once()
-			->andReturnUsing( function ( $val ) {
-				return $val;
-			} );
+			->andReturnUsing(
+				function ( $val ) {
+					return $val;
+				}
+			);
 
 		$this->assertEquals( 'https://example.com/permalink/2/', $this->instance->generate_canonical() );
 	}

--- a/tests/presenters/meta-description-presenter-test.php
+++ b/tests/presenters/meta-description-presenter-test.php
@@ -81,9 +81,11 @@ class Meta_Description_Presenter_Test extends TestCase {
 		$this->replace_vars
 			->expects( 'replace' )
 			->once()
-			->andReturnUsing( function( $string ) {
-				return $string;
-			} );
+			->andReturnUsing(
+				function( $string ) {
+					return $string;
+				}
+			);
 
 		Monkey\Filters\expectApplied( 'wpseo_metadesc' )
 			->once()
@@ -112,9 +114,11 @@ class Meta_Description_Presenter_Test extends TestCase {
 		$this->replace_vars
 			->expects( 'replace' )
 			->once()
-			->andReturnUsing( function( $string ) {
-				return $string;
-			} );
+			->andReturnUsing(
+				function( $string ) {
+					return $string;
+				}
+			);
 
 		$this->string
 			->expects( 'strip_all_tags' )
@@ -142,9 +146,11 @@ class Meta_Description_Presenter_Test extends TestCase {
 		$this->replace_vars
 			->expects( 'replace' )
 			->once()
-			->andReturnUsing( function( $string ) {
-				return $string;
-			} );
+			->andReturnUsing(
+				function( $string ) {
+					return $string;
+				}
+			);
 
 		$this->string
 			->expects( 'strip_all_tags' )

--- a/tests/presenters/open-graph/description-presenter-test.php
+++ b/tests/presenters/open-graph/description-presenter-test.php
@@ -57,9 +57,11 @@ class Description_Presenter_Test extends TestCase {
 		$this->replace_vars
 			->expects( 'replace' )
 			->once()
-			->andReturnUsing( function ( $string ) {
-				return $string;
-			} );
+			->andReturnUsing(
+				function ( $string ) {
+					return $string;
+				}
+			);
 	}
 
 	/**

--- a/tests/presenters/open-graph/title-presenter-test.php
+++ b/tests/presenters/open-graph/title-presenter-test.php
@@ -69,9 +69,11 @@ class Title_Presenter_Test extends TestCase {
 			->expects( 'strip_all_tags' )
 			->withAnyArgs()
 			->once()
-			->andReturnUsing( function( $string ) {
-				return $string;
-			} );
+			->andReturnUsing(
+				function( $string ) {
+					return $string;
+				}
+			);
 	}
 
 	/**
@@ -84,9 +86,11 @@ class Title_Presenter_Test extends TestCase {
 
 		$this->replace_vars
 			->expects( 'replace' )
-			->andReturnUsing( function ( $str ) {
-				return $str;
-			} );
+			->andReturnUsing(
+				function ( $str ) {
+					return $str;
+				}
+			);
 
 		$expected = '<meta property="og:title" content="example_title" />';
 		$actual   = $this->instance->present();
@@ -104,9 +108,11 @@ class Title_Presenter_Test extends TestCase {
 
 		$this->replace_vars
 			->expects( 'replace' )
-			->andReturnUsing( function ( $str ) {
-				return $str;
-			} );
+			->andReturnUsing(
+				function ( $str ) {
+					return $str;
+				}
+			);
 
 		$actual = $this->instance->present();
 
@@ -124,9 +130,11 @@ class Title_Presenter_Test extends TestCase {
 
 		$this->replace_vars
 			->expects( 'replace' )
-			->andReturnUsing( function ( $str ) {
-				return $str;
-			} );
+			->andReturnUsing(
+				function ( $str ) {
+					return $str;
+				}
+			);
 
 		Monkey\Filters\expectApplied( 'wpseo_opengraph_title' )
 			->once()

--- a/tests/presenters/robots-presenter-test.php
+++ b/tests/presenters/robots-presenter-test.php
@@ -87,9 +87,12 @@ class Robots_Presenter_Test extends TestCase {
 			'follow' => 'nofollow',
 		];
 
-		$this->assertSame( [
-			'index'  => 'index',
-			'follow' => 'nofollow',
-		], $this->instance->get() );
+		$this->assertSame(
+			[
+				'index'  => 'index',
+				'follow' => 'nofollow',
+			],
+			$this->instance->get()
+		);
 	}
 }

--- a/tests/presenters/title-presenter-test.php
+++ b/tests/presenters/title-presenter-test.php
@@ -71,9 +71,11 @@ class Title_Presenter_Test extends TestCase {
 			->expects( 'strip_all_tags' )
 			->withAnyArgs()
 			->once()
-			->andReturnUsing( function ( $string ) {
-				return $string;
-			} );
+			->andReturnUsing(
+				function ( $string ) {
+					return $string;
+				}
+			);
 
 		Monkey\Functions\expect( 'wp_get_document_title' )->andReturnUsing( function() {
 			return $this->instance->get_title();
@@ -90,9 +92,11 @@ class Title_Presenter_Test extends TestCase {
 
 		$this->replace_vars
 			->expects( 'replace' )
-			->andReturnUsing( function ( $str ) {
-				return $str;
-			} );
+			->andReturnUsing(
+				function ( $str ) {
+					return $str;
+				}
+			);
 
 		$expected = '<title>example_title</title>';
 		$actual   = $this->instance->present();
@@ -110,9 +114,11 @@ class Title_Presenter_Test extends TestCase {
 
 		$this->replace_vars
 			->expects( 'replace' )
-			->andReturnUsing( function ( $str ) {
-				return $str;
-			} );
+			->andReturnUsing(
+				function ( $str ) {
+					return $str;
+				}
+			);
 
 		$actual = $this->instance->present();
 
@@ -130,9 +136,11 @@ class Title_Presenter_Test extends TestCase {
 
 		$this->replace_vars
 			->expects( 'replace' )
-			->andReturnUsing( function ( $str ) {
-				return $str;
-			} );
+			->andReturnUsing(
+				function ( $str ) {
+					return $str;
+				}
+			);
 
 		Monkey\Filters\expectApplied( 'wpseo_title' )
 			->once()

--- a/tests/presenters/twitter/title-presenter-test.php
+++ b/tests/presenters/twitter/title-presenter-test.php
@@ -64,9 +64,11 @@ class Title_Presenter_Test extends TestCase {
 
 		$this->replace_vars
 			->expects( 'replace' )
-			->andReturnUsing( function( $str ) {
-				return $str;
-			} );
+			->andReturnUsing(
+				function( $str ) {
+					return $str;
+				}
+			);
 
 		$expected = '<meta name="twitter:title" content="twitter_example_title" />';
 		$actual   = $this->instance->present();
@@ -83,9 +85,11 @@ class Title_Presenter_Test extends TestCase {
 
 		$this->replace_vars
 			->expects( 'replace' )
-			->andReturnUsing( function( $str ) {
-				return $str;
-			} );
+			->andReturnUsing(
+				function( $str ) {
+					return $str;
+				}
+			);
 
 		$actual = $this->instance->present();
 		$this->assertEmpty( $actual );
@@ -102,9 +106,11 @@ class Title_Presenter_Test extends TestCase {
 
 		$this->replace_vars
 			->expects( 'replace' )
-			->andReturnUsing( function( $str ) {
-				return $str;
-			} );
+			->andReturnUsing(
+				function( $str ) {
+					return $str;
+				}
+			);
 
 		Monkey\Filters\expectApplied( 'wpseo_twitter_title' )
 			->once()

--- a/tests/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/repositories/indexable-hierarchy-repository-test.php
@@ -201,12 +201,14 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 
 		$orm_object
 			->expects( 'create' )
-			->with( [
-				'indexable_id' => 1,
-				'ancestor_id'  => 2,
-				'depth'        => 1,
-				'blog_id'      => 1,
-			] )
+			->with(
+				[
+					'indexable_id' => 1,
+					'ancestor_id'  => 2,
+					'depth'        => 1,
+					'blog_id'      => 1,
+				]
+			)
 			->andReturn( $hierarchy );
 		$this->instance->expects( 'query' )->andReturn( $orm_object );
 

--- a/tests/repositories/indexable-repository-test.php
+++ b/tests/repositories/indexable-repository-test.php
@@ -73,12 +73,15 @@ class Indexable_Repository_Test extends TestCase {
 		$this->current_page         = Mockery::mock( Current_Page_Helper::class );
 		$this->logger               = Mockery::mock( Logger::class );
 		$this->hierarchy_repository = Mockery::mock( Indexable_Hierarchy_Repository::class );
-		$this->instance             = Mockery::mock( Indexable_Repository::class, [
-			$this->builder,
-			$this->current_page,
-			$this->logger,
-			$this->hierarchy_repository,
-		] )->makePartial();
+		$this->instance             = Mockery::mock(
+			Indexable_Repository::class,
+			[
+				$this->builder,
+				$this->current_page,
+				$this->logger,
+				$this->hierarchy_repository,
+			]
+		)->makePartial();
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.
* Code style compliance.

In a multi-line function call, each parameter should start on a new line and be indented one tab from the line containing the function call keyword.
This includes multi-line parameters.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.