### PR TITLE
CS: proper multi-line function call formatting [2]

### DIFF
--- a/tests/builders/indexable-hierarchy-builder-test.php
+++ b/tests/builders/indexable-hierarchy-builder-test.php
@@ -106,7 +106,14 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 
 		$this->indexable_hierarchy_repository->expects( 'clear_ancestors' )->with( 1 )->andReturn( true );
 		$this->options->expects( 'get' )->with( 'post_types-post-maintax' )->andReturn( '0' );
-		$this->post->expects( 'get_post' )->with( 1 )->andReturn( (object) [ 'post_parent' => 0, 'post_type' => 'post' ] );
+		$this->post->expects( 'get_post' )
+			->with( 1 )
+			->andReturn(
+				(object) [
+					'post_parent' => 0,
+					'post_type'   => 'post',
+				]
+			);
 
 		$this->instance->build( $indexable );
 	}
@@ -151,8 +158,24 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 
 		$this->indexable_repository->expects( 'find_by_id_and_type' )->with( 2, 'post' )->andReturn( $parent_indexable );
 
-		$this->post->expects( 'get_post' )->once()->with( 1 )->andReturn( (object) [ 'post_parent' => 2, 'post_type' => 'post' ] );
-		$this->post->expects( 'get_post' )->twice()->with( 2 )->andReturn( (object) [ 'post_parent' => 0, 'post_type' => 'post' ] );
+		$this->post->expects( 'get_post' )
+			->once()
+			->with( 1 )
+			->andReturn(
+				(object) [
+					'post_parent' => 2,
+					'post_type'   => 'post',
+				]
+			);
+		$this->post->expects( 'get_post' )
+			->twice()
+			->with( 2 )
+			->andReturn(
+				(object) [
+					'post_parent' => 0,
+					'post_type'   => 'post',
+				]
+			);
 		$this->instance->build( $indexable );
 	}
 
@@ -366,7 +389,16 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 		$parent_indexable->object_type = 'term';
 		$parent_indexable->object_id   = 2;
 
-		Monkey\Functions\expect( 'get_term' )->twice()->with( 2 )->andReturn( (object) [ 'term_id' => 2, 'taxonomy' => 'tag', 'parent' => 0 ] );
+		Monkey\Functions\expect( 'get_term' )
+			->twice()
+			->with( 2 )
+			->andReturn(
+				(object) [
+					'term_id'  => 2,
+					'taxonomy' => 'tag',
+					'parent'   => 0,
+				]
+			);
 
 		$this->indexable_hierarchy_repository->expects( 'clear_ancestors' )->with( 1 )->andReturn( true );
 		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 2, 1 );
@@ -377,7 +409,16 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 
 		$this->indexable_repository->expects( 'find_by_id_and_type' )->with( 2, 'term' )->andReturn( $parent_indexable );
 
-		$this->post->expects( 'get_post' )->once()->with( 1 )->andReturn( (object) [ 'ID' => 1, 'post_parent' => 0, 'post_type' => 'post' ] );
+		$this->post->expects( 'get_post' )
+			->once()
+			->with( 1 )
+			->andReturn(
+				(object) [
+					'ID'          => 1,
+					'post_parent' => 0,
+					'post_type'   => 'post',
+				]
+			);
 
 		$this->instance->build( $indexable );
 	}
@@ -471,8 +512,26 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 			->with( 2 )
 			->andReturn( true );
 
-		Monkey\Functions\expect( 'get_term' )->once()->with( 2 )->andReturn( (object) [ 'term_id' => 2, 'taxonomy' => 'tag', 'parent' => 3 ] );
-		Monkey\Functions\expect( 'get_term' )->once()->with( 3, 'tag' )->andReturn( (object) [ 'term_id' => 3, 'taxonomy' => 'tag', 'parent' => 0 ] );
+		Monkey\Functions\expect( 'get_term' )
+			->once()
+			->with( 2 )
+			->andReturn(
+				(object) [
+					'term_id'  => 2,
+					'taxonomy' => 'tag',
+					'parent'   => 3,
+				]
+			);
+		Monkey\Functions\expect( 'get_term' )
+			->once()
+			->with( 3, 'tag' )
+			->andReturn(
+				(object) [
+					'term_id'  => 3,
+					'taxonomy' => 'tag',
+					'parent'   => 0,
+				]
+			);
 
 		$this->indexable_hierarchy_repository->expects( 'clear_ancestors' )->with( 1 )->andReturn( true );
 		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 3, 2 );
@@ -485,7 +544,16 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 		$this->indexable_repository->expects( 'find_by_id_and_type' )->with( 2, 'term' )->andReturn( $parent_indexable );
 		$this->indexable_repository->expects( 'find_by_id_and_type' )->with( 3, 'term' )->andReturn( $grand_parent_indexable );
 
-		$this->post->expects( 'get_post' )->once()->with( 1 )->andReturn( (object) [ 'ID' => 1, 'post_parent' => 0, 'post_type' => 'post' ] );
+		$this->post->expects( 'get_post' )
+			->once()
+			->with( 1 )
+			->andReturn(
+				(object) [
+					'ID'          => 1,
+					'post_parent' => 0,
+					'post_type'   => 'post',
+				]
+			);
 
 		$this->instance->build( $indexable );
 	}
@@ -506,8 +574,26 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 		$parent_indexable->object_type = 'term';
 		$parent_indexable->object_id   = 2;
 
-		Monkey\Functions\expect( 'get_the_terms' )->with( 1, 'tag' )->andReturn( [ (object) [ 'term_id' => 2, 'taxonomy' => 'tag', 'parent' => 0 ] ] );
-		Monkey\Functions\expect( 'get_term' )->with( 2 )->andReturn( (object) [ 'term_id' => 2, 'taxonomy' => 'tag', 'parent' => 0 ] );
+		Monkey\Functions\expect( 'get_the_terms' )
+			->with( 1, 'tag' )
+			->andReturn(
+				[
+					(object) [
+						'term_id'  => 2,
+						'taxonomy' => 'tag',
+						'parent'   => 0,
+					],
+				]
+			);
+		Monkey\Functions\expect( 'get_term' )
+			->with( 2 )
+			->andReturn(
+				(object) [
+					'term_id'  => 2,
+					'taxonomy' => 'tag',
+					'parent'   => 0,
+				]
+			);
 		Monkey\Functions\expect( 'get_post_meta' )->with( 1, WPSEO_Meta::$meta_prefix . 'primary_term', true )->andReturn( '' );
 
 		$this->indexable_hierarchy_repository->expects( 'clear_ancestors' )->with( 1 )->andReturn( true );
@@ -519,9 +605,15 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 
 		$this->indexable_repository->expects( 'find_by_id_and_type' )->with( 2, 'term' )->andReturn( $parent_indexable );
 
-		$this->post->expects( 'get_post' )->with( 1 )->andReturn(
-			(object) [ 'ID' => 1, 'post_parent' => 0, 'post_type' => 'post' ]
-		);
+		$this->post->expects( 'get_post' )
+			->with( 1 )
+			->andReturn(
+				(object) [
+					'ID'          => 1,
+					'post_parent' => 0,
+					'post_type'   => 'post',
+				]
+			);
 
 		$this->instance->build( $indexable );
 	}
@@ -547,12 +639,43 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 		$grand_parent_indexable->object_type = 'term';
 		$grand_parent_indexable->object_id   = 4;
 
-		Monkey\Functions\expect( 'get_the_terms' )->once()->with( 1, 'tag' )->andReturn( [
-			(object) [ 'term_id' => 2, 'taxonomy' => 'tag', 'parent' => 0 ],
-			(object) [ 'term_id' => 3, 'taxonomy' => 'tag', 'parent' => 4 ],
-		] );
-		Monkey\Functions\expect( 'get_term' )->once()->with( 3 )->andReturn( (object) [ 'term_id' => 3, 'taxonomy' => 'tag', 'parent' => 4 ] );
-		Monkey\Functions\expect( 'get_term' )->twice()->with( 4, 'tag' )->andReturn( (object) [ 'term_id' => 4, 'taxonomy' => 'tag', 'parent' => 0 ] );
+		Monkey\Functions\expect( 'get_the_terms' )
+			->once()
+			->with( 1, 'tag' )
+			->andReturn(
+				[
+					(object) [
+						'term_id'  => 2,
+						'taxonomy' => 'tag',
+						'parent'   => 0,
+					],
+					(object) [
+						'term_id'  => 3,
+						'taxonomy' => 'tag',
+						'parent'   => 4,
+					],
+				]
+			);
+		Monkey\Functions\expect( 'get_term' )
+			->once()
+			->with( 3 )
+			->andReturn(
+				(object) [
+					'term_id'  => 3,
+					'taxonomy' => 'tag',
+					'parent'   => 4,
+				]
+			);
+		Monkey\Functions\expect( 'get_term' )
+			->twice()
+			->with( 4, 'tag' )
+			->andReturn(
+				(object) [
+					'term_id'  => 4,
+					'taxonomy' => 'tag',
+					'parent'   => 0,
+				]
+			);
 		Monkey\Functions\expect( 'get_post_meta' )->with( 1, WPSEO_Meta::$meta_prefix . 'primary_term', true )->andReturn( '' );
 
 		$this->indexable_hierarchy_repository->expects( 'clear_ancestors' )->with( 1 )->andReturn( true );
@@ -566,7 +689,16 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 		$this->indexable_repository->expects( 'find_by_id_and_type' )->with( 3, 'term' )->andReturn( $parent_indexable );
 		$this->indexable_repository->expects( 'find_by_id_and_type' )->with( 4, 'term' )->andReturn( $grand_parent_indexable );
 
-		$this->post->expects( 'get_post' )->once()->with( 1 )->andReturn( (object) [ 'ID' => 1, 'post_parent' => 0, 'post_type' => 'post' ] );
+		$this->post->expects( 'get_post' )
+			->once()
+			->with( 1 )
+			->andReturn(
+				(object) [
+					'ID'          => 1,
+					'post_parent' => 0,
+					'post_type'   => 'post',
+				]
+			);
 
 		$this->instance->build( $indexable );
 	}
@@ -587,8 +719,26 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 		$parent_indexable->object_type = 'term';
 		$parent_indexable->object_id   = 2;
 
-		Monkey\Functions\expect( 'get_term' )->once()->with( 1 )->andReturn( (object) [ 'term_id' => 1, 'taxonomy' => 'tag', 'parent' => 2 ] );
-		Monkey\Functions\expect( 'get_term' )->once()->with( 2, 'tag' )->andReturn( (object) [ 'term_id' => 2, 'taxonomy' => 'tag', 'parent' => 0 ] );
+		Monkey\Functions\expect( 'get_term' )
+			->once()
+			->with( 1 )
+			->andReturn(
+				(object) [
+					'term_id'  => 1,
+					'taxonomy' => 'tag',
+					'parent'   => 2,
+				]
+			);
+		Monkey\Functions\expect( 'get_term' )
+			->once()
+			->with( 2, 'tag' )
+			->andReturn(
+				(object) [
+					'term_id'  => 2,
+					'taxonomy' => 'tag',
+					'parent'   => 0,
+				]
+			);
 
 		$this->indexable_hierarchy_repository->expects( 'clear_ancestors' )->with( 1 )->andReturn( true );
 		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 2, 1 );

--- a/tests/builders/indexable-post-builder-test.php
+++ b/tests/builders/indexable-post-builder-test.php
@@ -241,14 +241,19 @@ class Indexable_Post_Builder_Test extends TestCase {
 			->once()
 			->andReturn( 'twitter_image.jpg' );
 
-		$this->post->expects( 'get_post' )->once()->with( 1 )->andReturn( (object) [
-			'post_content'  => 'The content of the post',
-			'post_type'     => 'post',
-			'post_status'   => 'publish',
-			'post_password' => '',
-			'post_author'   => '1',
-			'post_parent'   => '0',
-		] );
+		$this->post->expects( 'get_post' )
+			->once()
+			->with( 1 )
+			->andReturn(
+				(object) [
+					'post_content'  => 'The content of the post',
+					'post_type'     => 'post',
+					'post_status'   => 'publish',
+					'post_password' => '',
+					'post_author'   => '1',
+					'post_parent'   => '0',
+				]
+			);
 
 		$this->instance->build( 1, $this->indexable );
 	}

--- a/tests/builders/indexable-term-builder-test.php
+++ b/tests/builders/indexable-term-builder-test.php
@@ -110,25 +110,30 @@ class Indexable_Term_Builder_Test extends TestCase {
 			->andReturn( 'image.jpg' );
 
 		$taxonomy = Mockery::mock( Taxonomy_Helper::class );
-		$taxonomy->expects( 'get_term_meta' )->once()->with( $term )->andReturn( [
-			'wpseo_focuskw'               => 'focuskeyword',
-			'wpseo_linkdex'               => '75',
-			'wpseo_noindex'               => 'noindex',
-			'wpseo_meta-robots-adv'       => '',
-			'wpseo_content_score'         => '50',
-			'wpseo_canonical'             => 'https://canonical-term',
-			'wpseo_meta-robots-nofollow'  => '1',
-			'wpseo_title'                 => 'title',
-			'wpseo_desc'                  => 'description',
-			'wpseo_bctitle'               => 'breadcrumb_title',
-			'wpseo_opengraph-title'       => 'open_graph_title',
-			'wpseo_opengraph-image'       => 'open_graph_image',
-			'wpseo_opengraph-image-id'    => 'open_graph_image_id',
-			'wpseo_opengraph-description' => 'open_graph_description',
-			'wpseo_twitter-title'         => 'twitter_title',
-			'wpseo_twitter-image'         => 'twitter_image',
-			'wpseo_twitter-description'   => 'twitter_description',
-		] );
+		$taxonomy->expects( 'get_term_meta' )
+			->once()
+			->with( $term )
+			->andReturn(
+				[
+					'wpseo_focuskw'               => 'focuskeyword',
+					'wpseo_linkdex'               => '75',
+					'wpseo_noindex'               => 'noindex',
+					'wpseo_meta-robots-adv'       => '',
+					'wpseo_content_score'         => '50',
+					'wpseo_canonical'             => 'https://canonical-term',
+					'wpseo_meta-robots-nofollow'  => '1',
+					'wpseo_title'                 => 'title',
+					'wpseo_desc'                  => 'description',
+					'wpseo_bctitle'               => 'breadcrumb_title',
+					'wpseo_opengraph-title'       => 'open_graph_title',
+					'wpseo_opengraph-image'       => 'open_graph_image',
+					'wpseo_opengraph-image-id'    => 'open_graph_image_id',
+					'wpseo_opengraph-description' => 'open_graph_description',
+					'wpseo_twitter-title'         => 'twitter_title',
+					'wpseo_twitter-image'         => 'twitter_image',
+					'wpseo_twitter-description'   => 'twitter_description',
+				]
+			);
 
 		$builder = new Indexable_Term_Builder( $taxonomy );
 

--- a/tests/commands/index-command-test.php
+++ b/tests/commands/index-command-test.php
@@ -199,12 +199,18 @@ class Index_Command_Test extends TestCase {
 	 * @covers ::run_indexation_action
 	 */
 	public function test_execute_multisite() {
-		Monkey\Functions\expect( 'get_sites' )->once()->with( [
-			'fields'   => 'ids',
-			'spam'     => 0,
-			'deleted'  => 0,
-			'archived' => 0,
-		] )->andReturn( [ 1, 2 ] );
+		Monkey\Functions\expect( 'get_sites' )
+			->once()
+			->with(
+				[
+					'fields'   => 'ids',
+					'spam'     => 0,
+					'deleted'  => 0,
+					'archived' => 0,
+				]
+			)
+			->andReturn( [ 1, 2 ] );
+
 		Monkey\Functions\expect( 'switch_to_blog' )->once()->with( 1 );
 		Monkey\Functions\expect( 'switch_to_blog' )->once()->with( 2 );
 		Monkey\Functions\expect( 'restore_current_blog' )->times( 2 );

--- a/tests/presenters/title-presenter-test.php
+++ b/tests/presenters/title-presenter-test.php
@@ -75,9 +75,12 @@ class Title_Presenter_Test extends TestCase {
 				return $string;
 			} );
 
-		Monkey\Functions\expect( 'wp_get_document_title' )->andReturnUsing( function() {
-			return $this->instance->get_title();
-		} );
+		Monkey\Functions\expect( 'wp_get_document_title' )
+			->andReturnUsing(
+				function() {
+					return $this->instance->get_title();
+				}
+			);
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.
* Code style compliance.

In a multi-line function call, each parameter should start on a new line and be indented one tab from the line containing the function call keyword.
This includes multi-line parameters.

Includes reformatting of chained function calls to have one call per line.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.