### PR TITLE
Update collapsible styling

### DIFF
--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -71,12 +71,13 @@ ul.wpseo-metabox-tabs li.active {
 .wpseo-meta-section,
 .wpseo-meta-section-react {
   display: none;
+  max-width: 600px;
   width: 100%;
   min-height: 100%;
   height: auto;
   vertical-align: top;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-  border-top: 1px solid #e8e8e8;
+  border: 1px solid rgba( 0,0,0,0.2 );
+  border-bottom: 0;
 }
 
 .wpseo-meta-section.active,

--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -188,7 +188,7 @@ ul.wpseo-metabox-tabs li.active {
 
 .wpseo-metabox-menu ul li.active a {
   height: 36px;
-  color: #444;
+  color: #a4286a;
 }
 
 .wpseo-metabox-menu ul li.active span.wpseo-buy-premium {

--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -1,4 +1,4 @@
-import Collapsible from "./SidebarCollapsible";
+import MetaboxCollapsible from "./MetaboxCollapsible";
 import { __, sprintf } from "@wordpress/i18n";
 import { MultiSelect, Select } from "@yoast/components";
 import { RadioButtonGroup } from "@yoast/components";
@@ -196,7 +196,7 @@ class AdvancedSettings extends Component {
 	 */
 	render() {
 		return (
-			<Collapsible id={ "collapsible-advanced-settings" } title={ __( "Advanced", "wordpress-seo" ) }>
+			<MetaboxCollapsible id={ "collapsible-advanced-settings" } title={ __( "Advanced", "wordpress-seo" ) }>
 				<MetaRobotsNoIndex />
 				{ isPost() && <MetaRobotsNoFollow /> }
 				{ isPost() && <MetaRobotsAdvanced /> }
@@ -204,7 +204,7 @@ class AdvancedSettings extends Component {
 					! window.wpseoAdminL10n.breadcrumbsDisabled && <BreadCrumbsTitle />
 				}
 				<CanonicalURL />
-			</Collapsible>
+			</MetaboxCollapsible>
 		);
 	}
 }

--- a/js/src/components/CollapsibleCornerstone.js
+++ b/js/src/components/CollapsibleCornerstone.js
@@ -5,7 +5,8 @@ import { __ } from "@wordpress/i18n";
 
 import { HelpText } from "@yoast/components";
 import { makeOutboundLink } from "@yoast/helpers";
-import Collapsible from "./SidebarCollapsible";
+import SidebarCollapsible from "./SidebarCollapsible";
+import MetaboxCollapsible from "./MetaboxCollapsible";
 import { default as CornerstoneToggle } from "./CornerstoneToggle";
 import { LocationConsumer } from "./contexts/location";
 const LearnMoreLink = makeOutboundLink();
@@ -19,20 +20,23 @@ const LearnMoreLink = makeOutboundLink();
 export default function CollapsibleCornerstone( { isCornerstone, onChange } ) {
 	return (
 		<LocationConsumer>
-			{ context => (
-				<Collapsible id={ `yoast-cornerstone-collapsible-${ context }` } title={ __( "Cornerstone content", "wordpress-seo" ) }>
-					<HelpText>
-						{ __( "Cornerstone content should be the most important and extensive articles on your site.", "wordpress-seo" ) + " " }
-						<LearnMoreLink href={ wpseoAdminL10n[ "shortlinks.cornerstone_content_info" ] }>
-							{ __( "Learn more about Cornerstone Content.", "wordpress-seo" ) }
-						</LearnMoreLink>
-					</HelpText>
-					<CornerstoneToggle
-						isEnabled={ isCornerstone }
-						onToggle={ onChange }
-					/>
-				</Collapsible>
-			) }
+			{ location => {
+				const Collapsible = location === "metabox" ? MetaboxCollapsible : SidebarCollapsible;
+				return (
+					<Collapsible id={ `yoast-cornerstone-collapsible-${ location }` } title={ __( "Cornerstone content", "wordpress-seo" ) }>
+						<HelpText>
+							{ __( "Cornerstone content should be the most important and extensive articles on your site.", "wordpress-seo" ) + " " }
+							<LearnMoreLink href={ wpseoAdminL10n[ "shortlinks.cornerstone_content_info" ] }>
+								{ __( "Learn more about Cornerstone Content.", "wordpress-seo" ) }
+							</LearnMoreLink>
+						</HelpText>
+						<CornerstoneToggle
+							isEnabled={ isCornerstone }
+							onToggle={ onChange }
+						/>
+					</Collapsible>
+				);
+			} }
 		</LocationConsumer>
 	);
 }

--- a/js/src/components/MetaboxCollapsible.js
+++ b/js/src/components/MetaboxCollapsible.js
@@ -1,0 +1,20 @@
+import SidebarCollapsible from "./SidebarCollapsible";
+import styled from "styled-components";
+
+const MetaboxCollapsible = styled( SidebarCollapsible )`
+	h2 > button {
+		padding-left: 24px;
+		padding-top: 24px;
+		span > span {
+			color: #A4286A;
+			line-height: 1.2em;
+		}
+	}
+	div[class^="Collapsible__Content"] {
+		padding: 24px 0;
+		margin: 0 24px;
+		border-top: 1px solid rgba(0,0,0,0.2); 
+	}
+`;
+
+export default MetaboxCollapsible;

--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -9,8 +9,7 @@ const Section = styled( StyledSection )`
 	max-width: 640px;
 	
 	&${ StyledSectionBase } {
-		padding-left: 0;
-		padding-right: 0;
+		padding: 0;
 
 		& ${ StyledHeading } {
 			${ getRtlStyle( "padding-left", "padding-right" ) }: 20px;

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -10,7 +10,8 @@ import { colors } from "@yoast/style-guide";
 
 /* Internal dependencies */
 import ScoreIconPortal from "../portals/ScoreIconPortal";
-import Collapsible from "../SidebarCollapsible";
+import SidebarCollapsible from "../SidebarCollapsible";
+import MetaboxCollapsible from "../MetaboxCollapsible";
 import Results from "./Results";
 import getIndicatorForScore from "../../analysis/getIndicatorForScore";
 import { getIconForScore } from "./mapResults";
@@ -142,10 +143,12 @@ class SeoAnalysis extends Component {
 		// Default to metabox.
 		let link    = wpseoAdminL10n[ "shortlinks.upsell.metabox.additional_link" ];
 		let buyLink = wpseoAdminL10n[ "shortlinks.upsell.metabox.additional_button" ];
+		let Collapsible = MetaboxCollapsible;
 
 		if ( location.toLowerCase() === "sidebar" ) {
 			link    = wpseoAdminL10n[ "shortlinks.upsell.sidebar.additional_link" ];
 			buyLink = wpseoAdminL10n[ "shortlinks.upsell.sidebar.additional_button" ];
+			Collapsible = SidebarCollapsible;
 		}
 
 		return (
@@ -218,36 +221,40 @@ class SeoAnalysis extends Component {
 
 		return (
 			<LocationConsumer>
-				{ location => (
-					<Fragment>
-						<Collapsible
-							title={ __( "SEO analysis", "wordpress-seo" ) }
-							titleScreenReaderText={ score.screenReaderReadabilityText }
-							prefixIcon={ getIconForScore( score.className ) }
-							prefixIconCollapsed={ getIconForScore( score.className ) }
-							subTitle={ this.props.keyword }
-							id={ `yoast-seo-analysis-collapsible-${ location }` }
-						>
-							<SynonymSlot location={ location } />
-							{ this.props.shouldUpsell && <Fragment>
-								{ this.renderSynonymsUpsell( location ) }
-								{ this.renderMultipleKeywordsUpsell( location ) }
-							</Fragment> }
-							{ this.props.shouldUpsellWordFormRecognition && this.renderWordFormsUpsell( location ) }
-							<AnalysisHeader>
-								{ __( "Analysis results", "wordpress-seo" ) }
-							</AnalysisHeader>
-							<Results
-								showLanguageNotice={ false }
-								results={ this.props.results }
-								marksButtonClassName="yoast-tooltip yoast-tooltip-w"
-								marksButtonStatus={ this.props.marksButtonStatus }
-							/>
-						</Collapsible>
-						{ this.props.shouldUpsell && this.renderKeywordUpsell( location ) }
-						{ this.renderTabIcon( location, score.className ) }
-					</Fragment>
-				) }
+				{ location => {
+					const Collapsible = location === "metabox" ? MetaboxCollapsible : SidebarCollapsible;
+
+					return (
+						<Fragment>
+							<Collapsible
+								title={ __( "SEO analysis", "wordpress-seo" ) }
+								titleScreenReaderText={ score.screenReaderReadabilityText }
+								prefixIcon={ getIconForScore( score.className ) }
+								prefixIconCollapsed={ getIconForScore( score.className ) }
+								subTitle={ this.props.keyword }
+								id={ `yoast-seo-analysis-collapsible-${ location }` }
+							>
+								<SynonymSlot location={ location } />
+								{ this.props.shouldUpsell && <Fragment>
+									{ this.renderSynonymsUpsell( location ) }
+									{ this.renderMultipleKeywordsUpsell( location ) }
+								</Fragment> }
+								{ this.props.shouldUpsellWordFormRecognition && this.renderWordFormsUpsell( location ) }
+								<AnalysisHeader>
+									{ __( "Analysis results", "wordpress-seo" ) }
+								</AnalysisHeader>
+								<Results
+									showLanguageNotice={ false }
+									results={ this.props.results }
+									marksButtonClassName="yoast-tooltip yoast-tooltip-w"
+									marksButtonStatus={ this.props.marksButtonStatus }
+								/>
+							</Collapsible>
+							{ this.props.shouldUpsell && this.renderKeywordUpsell( location ) }
+							{ this.renderTabIcon( location, score.className ) }
+						</Fragment>
+					);
+				} }
 			</LocationConsumer>
 		);
 	}

--- a/js/src/components/fills/MetaboxFill.js
+++ b/js/src/components/fills/MetaboxFill.js
@@ -11,6 +11,7 @@ import KeywordInput from "../contentAnalysis/KeywordInput";
 import ReadabilityAnalysis from "../contentAnalysis/ReadabilityAnalysis";
 import SeoAnalysis from "../contentAnalysis/SeoAnalysis";
 import Collapsible from "../SidebarCollapsible";
+import MetaboxCollapsible from "../MetaboxCollapsible";
 import SidebarItem from "../SidebarItem";
 import TopLevelProviders from "../TopLevelProviders";
 import AdvancedSettings from "../AdvancedSettings";
@@ -52,12 +53,12 @@ export default function MetaboxFill( { settings, store, theme } ) {
 					theme={ theme }
 					location={ "metabox" }
 				>
-					<Collapsible
+					<MetaboxCollapsible
 						id={ "yoast-snippet-editor-metabox" }
 						title={ __( "Google preview", "wordpress-seo" ) } initialIsOpen={ true }
 					>
 						<SnippetEditor hasPaperStyle={ false } />
-					</Collapsible>
+					</MetaboxCollapsible>
 				</TopLevelProviders>
 			</SidebarItem>
 			{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>

--- a/js/src/components/fills/MetaboxFill.js
+++ b/js/src/components/fills/MetaboxFill.js
@@ -10,7 +10,6 @@ import Warning from "../../containers/Warning";
 import KeywordInput from "../contentAnalysis/KeywordInput";
 import ReadabilityAnalysis from "../contentAnalysis/ReadabilityAnalysis";
 import SeoAnalysis from "../contentAnalysis/SeoAnalysis";
-import Collapsible from "../SidebarCollapsible";
 import MetaboxCollapsible from "../MetaboxCollapsible";
 import SidebarItem from "../SidebarItem";
 import TopLevelProviders from "../TopLevelProviders";

--- a/js/src/components/social/SocialMetadata.js
+++ b/js/src/components/social/SocialMetadata.js
@@ -1,6 +1,6 @@
 /* External dependencies */
 import { Fragment } from "@wordpress/element";
-import { Collapsible } from "@yoast/components";
+import MetaboxCollapsible from "../MetaboxCollapsible";
 
 /* Internal dependencies */
 import FacebookContainer from "../../containers/FacebookEditor";
@@ -14,20 +14,16 @@ import TwitterContainer from "../../containers/TwitterEditor";
 const SocialMetadata = () => {
 	return (
 		<Fragment>
-			<Collapsible
-				hasPadding={ true }
-				hasSeparator={ true }
+			<MetaboxCollapsible
 				title="Facebook"
 			>
 				<FacebookContainer />
-			</Collapsible>
-			<Collapsible
-				hasPadding={ true }
-				hasSeparator={ true }
+			</MetaboxCollapsible>
+			<MetaboxCollapsible
 				title="Twitter"
 			>
 				<TwitterContainer />
-			</Collapsible>
+			</MetaboxCollapsible>
 		</Fragment>
 	);
 };

--- a/js/tests/__snapshots__/advancedSettings.test.js.snap
+++ b/js/tests/__snapshots__/advancedSettings.test.js.snap
@@ -27,8 +27,24 @@ Array [
     type="hidden"
     value="https://www.google.com"
   />,
-  <div
-    className="Collapsible__StyledContainer-sc-1ahsa22-1 Collapsible__StyledContainerTopLevel-sc-1ahsa22-2 dvNeGK"
+  .c0 h2 > button {
+  padding-left: 24px;
+  padding-top: 24px;
+}
+
+.c0 h2 > button span > span {
+  color: #A4286A;
+  line-height: 1.2em;
+}
+
+.c0 div[class^="Collapsible__Content"] {
+  padding: 24px 0;
+  margin: 0 24px;
+  border-top: 1px solid rgba(0,0,0,0.2);
+}
+
+<div
+    className="Collapsible__StyledContainer-sc-1ahsa22-1 Collapsible__StyledContainerTopLevel-sc-1ahsa22-2 jZWaqb c0"
   >
     <h2
       className="Collapsible__StyledHeadingLevel-sc-1ahsa22-4 fytkxp"

--- a/js/tests/components/__snapshots__/SnippetPreviewSection.test.js.snap
+++ b/js/tests/components/__snapshots__/SnippetPreviewSection.test.js.snap
@@ -6,8 +6,7 @@ exports[`SnippetPreviewSection RTL renders the snippet editor inside of it 1`] =
 }
 
 .c0.StyledSection__StyledSectionBase-enyt8a-2 {
-  padding-left: 0;
-  padding-right: 0;
+  padding: 0;
 }
 
 .c0.StyledSection__StyledSectionBase-enyt8a-2 .StyledSection__StyledHeading-enyt8a-0 {
@@ -44,7 +43,7 @@ exports[`SnippetPreviewSection RTL renders the snippet editor inside of it 1`] =
             "rules": Array [
               "max-width:640px;&",
               ".StyledSection__StyledSectionBase-enyt8a-2",
-              "{padding-left:0;padding-right:0;& ",
+              "{padding:0;& ",
               ".StyledSection__StyledHeading-enyt8a-0",
               "{",
               [Function],
@@ -94,8 +93,7 @@ exports[`SnippetPreviewSection renders the snippet editor inside of it 1`] = `
 }
 
 .c0.StyledSection__StyledSectionBase-enyt8a-2 {
-  padding-left: 0;
-  padding-right: 0;
+  padding: 0;
 }
 
 .c0.StyledSection__StyledSectionBase-enyt8a-2 .StyledSection__StyledHeading-enyt8a-0 {
@@ -132,7 +130,7 @@ exports[`SnippetPreviewSection renders the snippet editor inside of it 1`] = `
             "rules": Array [
               "max-width:640px;&",
               ".StyledSection__StyledSectionBase-enyt8a-2",
-              "{padding-left:0;padding-right:0;& ",
+              "{padding:0;& ",
               ".StyledSection__StyledHeading-enyt8a-0",
               "{",
               [Function],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* We want to update the styling of Collapsibles inside the Metabox, see [the new design](https://www.sketch.com/s/accd731d-dfb3-493e-bb2f-d4df01c8f1e8/a/znJ3Ab/play).

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Update the styling of Collapsibles in the Metabox.

## Relevant technical choices:
- `max-width: 600px` has been added to the Metabox per [UX feedback](https://docs.google.com/document/d/1COUBBRYHClOdiqibIJNxXZe47ds1WdKNLqtPvTJ9lNo/edit?pli=1) and [the new design](https://www.sketch.com/s/accd731d-dfb3-493e-bb2f-d4df01c8f1e8/a/znJ3Ab/play).
- The color of the borders has changed slightly, to 20% #000000 as specified in the design and in the feedback. I used `rgba(0,0,0,0.2)` for this.
- `MetaboxCollapsible` has been created for the Collapsibles in the Metabox. `SidebarCollapsible` should be used for Collapsibles in the Sidebar.
- I have used the location in some components to change which Collapsible is used.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Build everything
* Go to a page with the metabox
* See that the styling has been updated
	- Check that there are no discrepancies in the design.
* Go to the social tab
	- Check that the social tab reflects [the design](https://www.sketch.com/s/accd731d-dfb3-493e-bb2f-d4df01c8f1e8/a/ZoZjAp#Inspector).

*Note: the font differs a little. This is okay per [this slack message](https://yoast.slack.com/archives/CSYSU835E/p1589890595028400).*

### Premium
Please also test premium. Use [this PR](https://github.com/Yoast/wordpress-seo-premium/pull/2799).

### Other plugins
I have checked that the following plugins are OK:
✅ News SEO
✅ Video SEO
✅ Local SEO
✅ WooCommerce SEO


## UI changes
No UI changes since this goes into a feature branch.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes N/A
