### PR TITLE
QA: rename three `double` classes to have `double` in the class name

### DIFF
--- a/tests/admin/admin-features-test.php
+++ b/tests/admin/admin-features-test.php
@@ -7,7 +7,7 @@ use WPSEO_Primary_Term_Admin;
 use Yoast_Dashboard_Widget;
 use Brain\Monkey;
 use Mockery;
-use Yoast\WP\SEO\Tests\Doubles\Shortlinker;
+use Yoast\WP\SEO\Tests\Doubles\Shortlinker_Double;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -25,7 +25,7 @@ class Admin_Features_Test extends TestCase {
 	 * @return \WPSEO_Admin Instance to test against.
 	 */
 	private function get_admin_with_expectations() {
-		$shortlinker = new Shortlinker();
+		$shortlinker = new Shortlinker_Double();
 
 		Monkey\Functions\expect( 'add_query_arg' )
 			->times( 3 )

--- a/tests/doubles/models/indexable-double.php
+++ b/tests/doubles/models/indexable-double.php
@@ -10,9 +10,9 @@ namespace Yoast\WP\SEO\Tests\Doubles\Models;
 use Yoast\WP\SEO\Models\Indexable as Indexable_Model;
 
 /**
- * Class Indexable.
+ * Class Indexable_Double.
  */
-class Indexable extends Indexable_Model {
+class Indexable_Double extends Indexable_Model {
 
 	/**
 	 * Holds the return value for has_one. Making it possible to mock that.

--- a/tests/doubles/oauth/client-double.php
+++ b/tests/doubles/oauth/client-double.php
@@ -7,10 +7,12 @@
 
 namespace Yoast\WP\SEO\Tests\Doubles\Oauth;
 
+use Yoast\WP\SEO\Oauth\Client;
+
 /**
  * Test Helper Class.
  */
-class Client extends \Yoast\WP\SEO\Oauth\Client {
+class Client_Double extends Client {
 
 	/**
 	 * Exposes the parent method which is protected.

--- a/tests/doubles/shortlinker-double.php
+++ b/tests/doubles/shortlinker-double.php
@@ -3,11 +3,11 @@
 namespace Yoast\WP\SEO\Tests\Doubles;
 
 /**
- * Class Shortlinker.
+ * Class Shortlinker_Double.
  *
  * @package Yoast\Tests\Doubles
  */
-class Shortlinker extends \WPSEO_Shortlinker {
+class Shortlinker_Double extends \WPSEO_Shortlinker {
 
 	/**
 	 * Gets the additional shortlink data.

--- a/tests/inc/language-utils-test.php
+++ b/tests/inc/language-utils-test.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Tests\Inc;
 use Brain\Monkey;
 use Mockery;
 use WPSEO_Language_Utils;
-use Yoast\WP\SEO\Tests\Doubles\Shortlinker;
+use Yoast\WP\SEO\Tests\Doubles\Shortlinker_Double;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -61,7 +61,7 @@ class WPSEO_Language_Utils_Test extends TestCase {
 	 * @covers WPSEO_Language_Utils::get_knowledge_graph_company_info_missing_l10n
 	 */
 	public function test_get_knowledge_graph_company_info_missing_l10n() {
-		$shortlinker = new Shortlinker();
+		$shortlinker = new Shortlinker_Double();
 
 		Monkey\Functions\expect( 'add_query_arg' )
 			->times( 1 )

--- a/tests/models/indexable-test.php
+++ b/tests/models/indexable-test.php
@@ -10,7 +10,7 @@ namespace Yoast\WP\SEO\Tests\Models;
 use Brain\Monkey\Functions;
 use Mockery;
 use Yoast\WP\Lib\ORM;
-use Yoast\WP\SEO\Tests\Doubles\Models\Indexable;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Double;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -26,7 +26,7 @@ class Indexable_Test extends TestCase {
 	/**
 	 * Holds the instance to test.
 	 *
-	 * @var \Yoast\WP\SEO\Models\Indexable|\Mockery\MockInterface
+	 * @var \Yoast\WP\SEO\Models\Indexable_Double|\Mockery\MockInterface
 	 */
 	protected $instance;
 
@@ -36,7 +36,7 @@ class Indexable_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->instance      = new Indexable();
+		$this->instance      = new Indexable_Double();
 		$this->instance->orm = Mockery::mock( ORM::class );
 	}
 

--- a/tests/oauth/client-test.php
+++ b/tests/oauth/client-test.php
@@ -10,7 +10,7 @@ namespace Yoast\WP\SEO\Tests\Oauth;
 use Yoast\WP\SEO\Oauth\Client;
 use YoastSEO_Vendor\League\OAuth2\Client\Provider\GenericProvider;
 use YoastSEO_Vendor\League\OAuth2\Client\Token\AccessToken;
-use Yoast\WP\SEO\Tests\Doubles\Oauth\Client as Client_Double;
+use Yoast\WP\SEO\Tests\Doubles\Oauth\Client_Double;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.

#### Rename three `double` classes to have a `_Double` suffix

Includes:
* Adjusting the file names to mirror the new class names (if necessary).
* Adjusting the `use` statement and other references to the classes in the test files which uses these Doubles.

Note: the Composer `autoload.php` file has to be regenerated after this change for those people running tests locally!


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test-only change and should have no effect on the functionality.