### PR TITLE
Tests: rename mock classes and move to Doubles directory

### DIFF
--- a/tests/actions/indexation/indexable-post-type-archive-indexation-action-test.php
+++ b/tests/actions/indexation/indexable-post-type-archive-indexation-action-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Type_Archive_Indexation_Actio
 use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/actions/indexation/indexable-post-type-archive-indexation-action-test.php
+++ b/tests/actions/indexation/indexable-post-type-archive-indexation-action-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Type_Archive_Indexation_Actio
 use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -282,7 +282,7 @@ class Indexable_Post_Type_Archive_Indexation_Action_Test extends TestCase {
 	private function set_expectations_for_builder( $post_types ) {
 		$indexable_mocks = [];
 		foreach ( $post_types as $post_type ) {
-			$indexable_mock    = Mockery::mock( Indexable::class );
+			$indexable_mock    = Mockery::mock( Indexable_Mock::class );
 			$indexable_mocks[] = $indexable_mock;
 
 			$this->builder->expects( 'build_for_post_type_archive' )

--- a/tests/builders/indexable-builder-test.php
+++ b/tests/builders/indexable-builder-test.php
@@ -20,7 +20,7 @@ use Yoast\WP\SEO\Builders\Indexable_System_Page_Builder;
 use Yoast\WP\SEO\Builders\Indexable_Term_Builder;
 use Yoast\WP\SEO\Builders\Primary_Term_Builder;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/builders/indexable-builder-test.php
+++ b/tests/builders/indexable-builder-test.php
@@ -20,7 +20,7 @@ use Yoast\WP\SEO\Builders\Indexable_System_Page_Builder;
 use Yoast\WP\SEO\Builders\Indexable_Term_Builder;
 use Yoast\WP\SEO\Builders\Primary_Term_Builder;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -156,7 +156,7 @@ class Indexable_Builder_Test extends TestCase {
 	 * @covers ::save_indexable
 	 */
 	public function test_build_for_id_and_type_with_post_given_and_no_author_indexable_found() {
-		$indexable            = Mockery::mock( Indexable::class );
+		$indexable            = Mockery::mock( Indexable_Mock::class );
 		$indexable->author_id = 1999;
 
 		$indexable
@@ -189,7 +189,7 @@ class Indexable_Builder_Test extends TestCase {
 			->with( 1999, 'user', false )
 			->andReturnFalse();
 
-		$author_indexable = Mockery::mock( Indexable::class );
+		$author_indexable = Mockery::mock( Indexable_Mock::class );
 		$author_indexable
 			->expects( 'save' )
 			->once();
@@ -227,7 +227,7 @@ class Indexable_Builder_Test extends TestCase {
 	 * @covers ::save_indexable
 	 */
 	public function test_build_for_id_and_type_with_post_given_and_author_indexable_found() {
-		$indexable            = Mockery::mock( Indexable::class );
+		$indexable            = Mockery::mock( Indexable_Mock::class );
 		$indexable->author_id = 1999;
 
 		$indexable
@@ -254,7 +254,7 @@ class Indexable_Builder_Test extends TestCase {
 			->once()
 			->with( $indexable );
 
-		$author_indexable = Mockery::mock( Indexable::class );
+		$author_indexable = Mockery::mock( Indexable_Mock::class );
 		$this->indexable_repository
 			->expects( 'find_by_id_and_type' )
 			->once()
@@ -273,7 +273,7 @@ class Indexable_Builder_Test extends TestCase {
 	 * @covers ::ensure_indexable
 	 */
 	public function test_build_for_id_and_type_with_post_given_and_no_indexable_build() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 
 		$this->post_builder
 			->expects( 'build' )
@@ -285,7 +285,7 @@ class Indexable_Builder_Test extends TestCase {
 			->expects( 'build' )
 			->never();
 
-		$fake_indexable              = Mockery::mock( Indexable::class );
+		$fake_indexable              = Mockery::mock( Indexable_Mock::class );
 		$fake_indexable->post_status = 'unindexed';
 		$fake_indexable
 			->expects( 'save' )
@@ -321,7 +321,7 @@ class Indexable_Builder_Test extends TestCase {
 	 * @covers ::save_indexable
 	 */
 	public function test_build_for_id_and_type_with_user_given() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 
 		$indexable
 			->expects( 'save' )
@@ -350,7 +350,7 @@ class Indexable_Builder_Test extends TestCase {
 	 * @covers ::save_indexable
 	 */
 	public function test_build_for_id_and_type_with_term_given() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 
 		$indexable
 			->expects( 'save' )
@@ -383,7 +383,7 @@ class Indexable_Builder_Test extends TestCase {
 	 * @covers ::ensure_indexable
 	 */
 	public function test_build_for_id_and_type_with_unknown_type_given() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 
 		$this->assertSame( $indexable, $this->instance->build_for_id_and_type( 1337, 'bicycle', $indexable ) );
 	}
@@ -398,7 +398,7 @@ class Indexable_Builder_Test extends TestCase {
 	 * @covers ::save_indexable
 	 */
 	public function test_build_for_homepage() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 
 		$this->home_page_builder
 			->expects( 'build' )
@@ -427,7 +427,7 @@ class Indexable_Builder_Test extends TestCase {
 	 * @covers ::save_indexable
 	 */
 	public function test_build_for_date_archive() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 
 		$this->date_archive_builder
 			->expects( 'build' )
@@ -452,7 +452,7 @@ class Indexable_Builder_Test extends TestCase {
 	 * @covers ::save_indexable
 	 */
 	public function test_build_for_post_type_archive() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 
 		$this->post_type_archive_builder
 			->expects( 'build' )
@@ -481,7 +481,7 @@ class Indexable_Builder_Test extends TestCase {
 	 * @covers ::save_indexable
 	 */
 	public function test_build_for_system_page() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 
 		$this->system_page_builder
 			->expects( 'build' )
@@ -506,14 +506,14 @@ class Indexable_Builder_Test extends TestCase {
 	 * @covers ::build_for_id_and_type
 	 */
 	public function test_build_for_id_and_type_returns_fake_indexable() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 
 		$this->term_builder->expects( 'build' )
 			->once()
 			->with( 1, $indexable )
 			->andReturn( false );
 
-		$fake_indexable              = Mockery::mock( Indexable::class );
+		$fake_indexable              = Mockery::mock( Indexable_Mock::class );
 		$fake_indexable->post_status = 'unindexed';
 		$fake_indexable
 			->expects( 'save' )

--- a/tests/builders/indexable-hierarchy-builder-test.php
+++ b/tests/builders/indexable-hierarchy-builder-test.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Primary_Term_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -105,7 +105,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_indexable_id
 	 */
 	public function test_no_parents() {
-		$indexable              = new Indexable();
+		$indexable              = new Indexable_Mock();
 		$indexable->id          = 1;
 		$indexable->object_type = 'post';
 		$indexable->object_id   = 1;
@@ -135,7 +135,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::add_ancestors_for_post
 	 */
 	public function test_parents_not_set() {
-		$indexable              = new Indexable();
+		$indexable              = new Indexable_Mock();
 		$indexable->id          = 1;
 		$indexable->object_type = 'post';
 		$indexable->object_id   = 1;
@@ -160,12 +160,12 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_indexable_id
 	 */
 	public function test_post_parents() {
-		$indexable              = new Indexable();
+		$indexable              = new Indexable_Mock();
 		$indexable->id          = 1;
 		$indexable->object_type = 'post';
 		$indexable->object_id   = 1;
 
-		$parent_indexable              = new Indexable();
+		$parent_indexable              = new Indexable_Mock();
 		$parent_indexable->id          = 2;
 		$parent_indexable->object_type = 'post';
 		$parent_indexable->object_id   = 2;
@@ -420,7 +420,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_primary_term_id
 	 */
 	public function test_primary_term_parents() {
-		$indexable              = new Indexable();
+		$indexable              = new Indexable_Mock();
 		$indexable->id          = 1;
 		$indexable->object_type = 'post';
 		$indexable->object_id   = 1;
@@ -428,7 +428,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 		$primary_term          = new Primary_Term_Mock();
 		$primary_term->term_id = 2;
 
-		$parent_indexable              = new Indexable();
+		$parent_indexable              = new Indexable_Mock();
 		$parent_indexable->id          = 2;
 		$parent_indexable->object_type = 'term';
 		$parent_indexable->object_id   = 2;
@@ -553,7 +553,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_primary_term_id
 	 */
 	public function test_many_primary_term_parents() {
-		$indexable              = new Indexable();
+		$indexable              = new Indexable_Mock();
 		$indexable->id          = 1;
 		$indexable->object_type = 'post';
 		$indexable->object_id   = 1;
@@ -561,12 +561,12 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 		$primary_term          = new Primary_Term_Mock();
 		$primary_term->term_id = 2;
 
-		$parent_indexable              = new Indexable();
+		$parent_indexable              = new Indexable_Mock();
 		$parent_indexable->id          = 2;
 		$parent_indexable->object_type = 'term';
 		$parent_indexable->object_id   = 2;
 
-		$grand_parent_indexable              = new Indexable();
+		$grand_parent_indexable              = new Indexable_Mock();
 		$grand_parent_indexable->id          = 3;
 		$grand_parent_indexable->object_type = 'term';
 		$grand_parent_indexable->object_id   = 3;
@@ -640,12 +640,12 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_primary_term_id
 	 */
 	public function test_term_parent() {
-		$indexable              = new Indexable();
+		$indexable              = new Indexable_Mock();
 		$indexable->id          = 1;
 		$indexable->object_type = 'post';
 		$indexable->object_id   = 1;
 
-		$parent_indexable              = new Indexable();
+		$parent_indexable              = new Indexable_Mock();
 		$parent_indexable->id          = 2;
 		$parent_indexable->object_type = 'term';
 		$parent_indexable->object_id   = 2;
@@ -708,7 +708,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_primary_term_id
 	 */
 	public function test_term_parent_where_terms_not_array() {
-		$indexable              = new Indexable();
+		$indexable              = new Indexable_Mock();
 		$indexable->id          = 1;
 		$indexable->object_type = 'post';
 		$indexable->object_id   = 1;
@@ -744,7 +744,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_primary_term_id
 	 */
 	public function test_term_parent_where_terms_empty() {
-		$indexable              = new Indexable();
+		$indexable              = new Indexable_Mock();
 		$indexable->id          = 1;
 		$indexable->object_type = 'post';
 		$indexable->object_id   = 1;
@@ -784,17 +784,17 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_primary_term_id
 	 */
 	public function test_deepest_term_parent() {
-		$indexable              = new Indexable();
+		$indexable              = new Indexable_Mock();
 		$indexable->id          = 1;
 		$indexable->object_type = 'post';
 		$indexable->object_id   = 1;
 
-		$parent_indexable              = new Indexable();
+		$parent_indexable              = new Indexable_Mock();
 		$parent_indexable->id          = 3;
 		$parent_indexable->object_type = 'term';
 		$parent_indexable->object_id   = 3;
 
-		$grand_parent_indexable              = new Indexable();
+		$grand_parent_indexable              = new Indexable_Mock();
 		$grand_parent_indexable->id          = 4;
 		$grand_parent_indexable->object_type = 'term';
 		$grand_parent_indexable->object_id   = 4;
@@ -877,12 +877,12 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_indexable_id
 	 */
 	public function test_term() {
-		$indexable              = new Indexable();
+		$indexable              = new Indexable_Mock();
 		$indexable->id          = 1;
 		$indexable->object_type = 'term';
 		$indexable->object_id   = 1;
 
-		$parent_indexable              = new Indexable();
+		$parent_indexable              = new Indexable_Mock();
 		$parent_indexable->id          = 2;
 		$parent_indexable->object_type = 'term';
 		$parent_indexable->object_id   = 2;
@@ -1118,7 +1118,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	public function test_primary_term_parents_with_no_primary_term_set() {
 		$indexable = $this->get_indexable( 1, 'post' );
 
-		$parent_indexable              = new Indexable();
+		$parent_indexable              = new Indexable_Mock();
 		$parent_indexable->id          = 3;
 		$parent_indexable->object_type = 'term';
 		$parent_indexable->object_id   = 3;
@@ -1198,10 +1198,10 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @param string $id          The id to use.
 	 * @param string $object_type The object type.
 	 *
-	 * @return Indexable
+	 * @return Indexable_Mock
 	 */
 	private function get_indexable( $id, $object_type = 'post' ) {
-		$indexable              = new Indexable();
+		$indexable              = new Indexable_Mock();
 		$indexable->id          = $id;
 		$indexable->object_type = $object_type;
 		$indexable->object_id   = $id;

--- a/tests/builders/indexable-hierarchy-builder-test.php
+++ b/tests/builders/indexable-hierarchy-builder-test.php
@@ -12,7 +12,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Primary_Term_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Primary_Term_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/builders/indexable-hierarchy-builder-test.php
+++ b/tests/builders/indexable-hierarchy-builder-test.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Models\Primary_Term_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 

--- a/tests/builders/indexable-hierarchy-builder-test.php
+++ b/tests/builders/indexable-hierarchy-builder-test.php
@@ -12,7 +12,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Primary_Term;
+use Yoast\WP\SEO\Tests\Mocks\Primary_Term_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -425,7 +425,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 		$indexable->object_type = 'post';
 		$indexable->object_id   = 1;
 
-		$primary_term          = new Primary_Term();
+		$primary_term          = new Primary_Term_Mock();
 		$primary_term->term_id = 2;
 
 		$parent_indexable              = new Indexable();
@@ -484,7 +484,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	public function test_primary_term_parents_and_term_is_unindexed() {
 		$indexable = $this->get_indexable( 1, 'post' );
 
-		$primary_term          = new Primary_Term();
+		$primary_term          = new Primary_Term_Mock();
 		$primary_term->term_id = 2;
 
 		$parent_indexable              = $this->get_indexable( 2, 'term' );
@@ -558,7 +558,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 		$indexable->object_type = 'post';
 		$indexable->object_id   = 1;
 
-		$primary_term          = new Primary_Term();
+		$primary_term          = new Primary_Term_Mock();
 		$primary_term->term_id = 2;
 
 		$parent_indexable              = new Indexable();

--- a/tests/builders/primary-term-builder-test.php
+++ b/tests/builders/primary-term-builder-test.php
@@ -8,7 +8,7 @@ use Yoast\WP\SEO\Helpers\Meta_Helper;
 use Yoast\WP\SEO\Helpers\Primary_Term_Helper;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 use Yoast\WP\SEO\Tests\Doubles\Builders\Primary_Term_Builder_Double;
-use Yoast\WP\SEO\Tests\Mocks\Primary_Term;
+use Yoast\WP\SEO\Tests\Mocks\Primary_Term_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -157,7 +157,7 @@ class Primary_Term_Builder_Test extends TestCase {
 	 * @covers ::save_primary_term
 	 */
 	public function test_save_primary_term() {
-		$primary_term = Mockery::mock( Primary_Term::class );
+		$primary_term = Mockery::mock( Primary_Term_Mock::class );
 		$primary_term->expects( 'save' )->once();
 
 		Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
@@ -187,7 +187,7 @@ class Primary_Term_Builder_Test extends TestCase {
 	 * @covers ::save_primary_term
 	 */
 	public function test_save_primary_term_of_custom_taxonomy() {
-		$primary_term = Mockery::mock( Primary_Term::class );
+		$primary_term = Mockery::mock( Primary_Term_Mock::class );
 		$primary_term->expects( 'save' )->once();
 
 		Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );

--- a/tests/builders/primary-term-builder-test.php
+++ b/tests/builders/primary-term-builder-test.php
@@ -8,7 +8,7 @@ use Yoast\WP\SEO\Helpers\Meta_Helper;
 use Yoast\WP\SEO\Helpers\Primary_Term_Helper;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 use Yoast\WP\SEO\Tests\Doubles\Builders\Primary_Term_Builder_Double;
-use Yoast\WP\SEO\Tests\Mocks\Primary_Term_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Primary_Term_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/doubles/context/meta-tags-context-mock.php
+++ b/tests/doubles/context/meta-tags-context-mock.php
@@ -5,7 +5,7 @@
  * @package Yoast\WP\SEO\Tests\Mocks
  */
 
-namespace Yoast\WP\SEO\Tests\Mocks;
+namespace Yoast\WP\SEO\Tests\Doubles\Context;
 
 /**
  * Class Meta_Tags_Context_Mock

--- a/tests/doubles/generators/schema/author-mock.php
+++ b/tests/doubles/generators/schema/author-mock.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Mocks;
+namespace Yoast\WP\SEO\Tests\Doubles\Generators\Schema;
 
 use Yoast\WP\SEO\Context\Meta_Tags_Context as Meta_Tags_Context_Original;
 

--- a/tests/doubles/models/indexable-mock.php
+++ b/tests/doubles/models/indexable-mock.php
@@ -1,13 +1,11 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Mocks;
+namespace Yoast\WP\SEO\Tests\Doubles\Models;
 
 /**
  * Class Indexable_Mock
  *
  * Indexable mock class.
- *
- * @package Yoast\WP\SEO\Tests\Mocks
  */
 class Indexable_Mock extends \Yoast\WP\SEO\Models\Indexable {
 

--- a/tests/doubles/models/primary-term-mock.php
+++ b/tests/doubles/models/primary-term-mock.php
@@ -1,13 +1,11 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Mocks;
+namespace Yoast\WP\SEO\Tests\Doubles\Models;
 
 /**
  * Class Primary_Term_Mock
  *
  * Primary_Term mock class.
- *
- * @package Yoast\WP\SEO\Tests\Mocks
  */
 class Primary_Term_Mock extends \Yoast\WP\SEO\Models\Primary_Term {
 

--- a/tests/doubles/presentations/abstract-presentation-mock.php
+++ b/tests/doubles/presentations/abstract-presentation-mock.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Mocks;
+namespace Yoast\WP\SEO\Tests\Doubles\Presentations;
 
 /**
  * Represents the Abstract_Presentation mock.

--- a/tests/doubles/routes/abstract-indexation-route-mock.php
+++ b/tests/doubles/routes/abstract-indexation-route-mock.php
@@ -5,7 +5,7 @@
  * @package Yoast\WP\SEO\Tests\Mocks
  */
 
-namespace Yoast\WP\SEO\Tests\Mocks;
+namespace Yoast\WP\SEO\Tests\Doubles\Routes;
 
 /**
  * Represents the Abstract_Indexation_Route mock.

--- a/tests/generators/breadcrumbs-generator-test.php
+++ b/tests/generators/breadcrumbs-generator-test.php
@@ -15,7 +15,7 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -66,7 +66,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	/**
 	 * Represents the meta tags context.
 	 *
-	 * @var Mockery\MockInterface|Meta_Tags_Context
+	 * @var Mockery\MockInterface|Meta_Tags_Context_Mock
 	 */
 	private $context;
 
@@ -95,7 +95,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 		$this->indexable->object_sub_type  = 'post';
 		$this->indexable->permalink        = 'https://example.com/post';
 		$this->indexable->breadcrumb_title = 'post';
-		$this->context                     = Mockery::mock( Meta_Tags_Context::class );
+		$this->context                     = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->context->indexable          = $this->indexable;
 	}
 

--- a/tests/generators/breadcrumbs-generator-test.php
+++ b/tests/generators/breadcrumbs-generator-test.php
@@ -15,7 +15,7 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/generators/breadcrumbs-generator-test.php
+++ b/tests/generators/breadcrumbs-generator-test.php
@@ -14,7 +14,7 @@ use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -73,7 +73,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	/**
 	 * Represents the indexable.
 	 *
-	 * @var Mockery\MockInterface|Indexable
+	 * @var Mockery\MockInterface|Indexable_Mock
 	 */
 	private $indexable;
 
@@ -89,7 +89,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 		$this->post_type_helper = Mockery::mock( Post_Type_Helper::class );
 		$this->instance         = new Breadcrumbs_Generator( $this->repository, $this->options, $this->current_page, $this->post_type_helper );
 
-		$this->indexable                   = Mockery::mock( Indexable::class );
+		$this->indexable                   = Mockery::mock( Indexable_Mock::class );
 		$this->indexable->object_id        = 1;
 		$this->indexable->object_type      = 'post';
 		$this->indexable->object_sub_type  = 'post';
@@ -335,10 +335,10 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	/**
 	 * Retrieves the 'ancestors'.
 	 *
-	 * @return Indexable[] The ancestors.
+	 * @return Indexable_Mock[] The ancestors.
 	 */
 	private function get_ancestors() {
-		$post_type_indexable                   = new Indexable();
+		$post_type_indexable                   = new Indexable_Mock();
 		$post_type_indexable->object_type      = 'post-type-archive';
 		$post_type_indexable->object_sub_type  = 'post';
 		$post_type_indexable->permalink        = 'https://example.com/post-type';

--- a/tests/generators/breadcrumbs-generator-test.php
+++ b/tests/generators/breadcrumbs-generator-test.php
@@ -14,7 +14,7 @@ use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 

--- a/tests/generators/open-graph-image-generator-test.php
+++ b/tests/generators/open-graph-image-generator-test.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper as Open_Graph_Image_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Values\Open_Graph\Images;
@@ -46,7 +46,7 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 	protected $instance;
 
 	/**
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
@@ -90,7 +90,7 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 			->twice()
 			->andReturn( $this->image_container );
 
-		$this->indexable          = new Indexable();
+		$this->indexable          = new Indexable_Mock();
 		$this->context            = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->context->indexable = $this->indexable;
 	}

--- a/tests/generators/open-graph-image-generator-test.php
+++ b/tests/generators/open-graph-image-generator-test.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper as Open_Graph_Image_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Values\Open_Graph\Images;

--- a/tests/generators/open-graph-image-generator-test.php
+++ b/tests/generators/open-graph-image-generator-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper as Open_Graph_Image_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Values\Open_Graph\Images;
 

--- a/tests/generators/open-graph-image-generator-test.php
+++ b/tests/generators/open-graph-image-generator-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper as Open_Graph_Image_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Values\Open_Graph\Images;
 
@@ -56,7 +56,7 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 	protected $image_container;
 
 	/**
-	 * @var Mockery\MockInterface|Meta_Tags_Context
+	 * @var Mockery\MockInterface|Meta_Tags_Context_Mock
 	 */
 	protected $context;
 
@@ -91,7 +91,7 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 			->andReturn( $this->image_container );
 
 		$this->indexable          = new Indexable();
-		$this->context            = Mockery::mock( Meta_Tags_Context::class );
+		$this->context            = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->context->indexable = $this->indexable;
 	}
 

--- a/tests/generators/open-graph-locale-generator-test.php
+++ b/tests/generators/open-graph-locale-generator-test.php
@@ -10,7 +10,7 @@ namespace Yoast\WP\SEO\Tests\Generators;
 use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Generators\Open_Graph_Locale_Generator;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/generators/open-graph-locale-generator-test.php
+++ b/tests/generators/open-graph-locale-generator-test.php
@@ -10,7 +10,7 @@ namespace Yoast\WP\SEO\Tests\Generators;
 use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Generators\Open_Graph_Locale_Generator;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -33,7 +33,7 @@ class Open_Graph_Locale_Generator_Test extends TestCase {
 	/**
 	 * Represents the metatags context.
 	 *
-	 * @var Mockery\MockInterface|Meta_Tags_Context
+	 * @var Mockery\MockInterface|Meta_Tags_Context_Mock
 	 */
 	protected $context;
 
@@ -44,7 +44,7 @@ class Open_Graph_Locale_Generator_Test extends TestCase {
 		parent::setUp();
 
 		$this->instance = new Open_Graph_Locale_Generator();
-		$this->context  = Mockery::mock( Meta_Tags_Context::class );
+		$this->context  = Mockery::mock( Meta_Tags_Context_Mock::class );
 	}
 
 	/**

--- a/tests/generators/schema-generator-test.php
+++ b/tests/generators/schema-generator-test.php
@@ -12,7 +12,7 @@ use Mockery;
 use Yoast\WP\SEO\Generators\Schema_Generator;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;

--- a/tests/generators/schema-generator-test.php
+++ b/tests/generators/schema-generator-test.php
@@ -12,7 +12,7 @@ use Mockery;
 use Yoast\WP\SEO\Generators\Schema_Generator;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
@@ -128,7 +128,7 @@ class Schema_Generator_Test extends TestCase {
 				],
 			],
 		];
-		$this->context->indexable = Mockery::mock( Indexable::class );
+		$this->context->indexable = Mockery::mock( Indexable_Mock::class );
 	}
 
 	/**

--- a/tests/generators/schema-generator-test.php
+++ b/tests/generators/schema-generator-test.php
@@ -13,7 +13,7 @@ use Yoast\WP\SEO\Generators\Schema_Generator;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;

--- a/tests/generators/schema-generator-test.php
+++ b/tests/generators/schema-generator-test.php
@@ -13,7 +13,7 @@ use Yoast\WP\SEO\Generators\Schema_Generator;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
@@ -42,7 +42,7 @@ class Schema_Generator_Test extends TestCase {
 	/**
 	 * The meta tags context.
 	 *
-	 * @var Mockery\MockInterface|Meta_Tags_Context
+	 * @var Mockery\MockInterface|Meta_Tags_Context_Mock
 	 */
 	protected $context;
 
@@ -107,7 +107,7 @@ class Schema_Generator_Test extends TestCase {
 			[ $helpers ]
 		)->shouldAllowMockingProtectedMethods()->makePartial();
 
-		$this->context            = Mockery::mock( Meta_Tags_Context::class )->makePartial();
+		$this->context            = Mockery::mock( Meta_Tags_Context_Mock::class )->makePartial();
 		$this->context->blocks    = [
 			'yoast/faq-block' => [
 				[

--- a/tests/generators/schema/article-test.php
+++ b/tests/generators/schema/article-test.php
@@ -13,7 +13,7 @@ use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 use Yoast\WP\SEO\Generators\Schema\Article;
 use Yoast\WP\SEO\Tests\Doubles\Generators\Schema\Article_Double;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 

--- a/tests/generators/schema/article-test.php
+++ b/tests/generators/schema/article-test.php
@@ -14,7 +14,7 @@ use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 use Yoast\WP\SEO\Generators\Schema\Article;
 use Yoast\WP\SEO\Tests\Doubles\Generators\Schema\Article_Double;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/generators/schema/article-test.php
+++ b/tests/generators/schema/article-test.php
@@ -13,7 +13,7 @@ use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 use Yoast\WP\SEO\Generators\Schema\Article;
 use Yoast\WP\SEO\Tests\Doubles\Generators\Schema\Article_Double;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -98,7 +98,7 @@ class Article_Test extends TestCase {
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
 		$this->context_mock            = new Meta_Tags_Context_Mock();
-		$this->context_mock->indexable = new Indexable();
+		$this->context_mock->indexable = new Indexable_Mock();
 		$this->context_mock->post      = new stdClass();
 		$this->context_mock->id        = 5;
 

--- a/tests/generators/schema/article-test.php
+++ b/tests/generators/schema/article-test.php
@@ -14,7 +14,7 @@ use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 use Yoast\WP\SEO\Generators\Schema\Article;
 use Yoast\WP\SEO\Tests\Doubles\Generators\Schema\Article_Double;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -52,7 +52,7 @@ class Article_Test extends TestCase {
 	/**
 	 * The meta tags context object.
 	 *
-	 * @var Meta_Tags_Context
+	 * @var Meta_Tags_Context_Mock
 	 */
 	private $context_mock;
 
@@ -97,7 +97,7 @@ class Article_Test extends TestCase {
 		$this->instance                = Mockery::mock( Article_Double::class )
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
-		$this->context_mock            = new Meta_Tags_Context();
+		$this->context_mock            = new Meta_Tags_Context_Mock();
 		$this->context_mock->indexable = new Indexable();
 		$this->context_mock->post      = new stdClass();
 		$this->context_mock->id        = 5;

--- a/tests/generators/schema/author-test.php
+++ b/tests/generators/schema/author-test.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Schema;
 use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
 use Yoast\WP\SEO\Tests\Mocks\Author_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -316,7 +316,7 @@ class Author_Test extends TestCase {
 		$this->instance->context->site_user_id           = 123;
 		$this->instance->context->site_url               = 'http://example.com';
 		$this->instance->context->site_represents        = 'person';
-		$this->instance->context->indexable              = new Indexable();
+		$this->instance->context->indexable              = new Indexable_Mock();
 		$this->instance->context->indexable->object_type = 'user';
 		$this->instance->context->indexable->object_id   = 123;
 
@@ -347,7 +347,7 @@ class Author_Test extends TestCase {
 		$this->instance->context->site_user_id           = 123;
 		$this->instance->context->site_url               = 'http://example.com';
 		$this->instance->context->site_represents        = 'person';
-		$this->instance->context->indexable              = new Indexable();
+		$this->instance->context->indexable              = new Indexable_Mock();
 		$this->instance->context->indexable->object_type = 'user';
 		$this->instance->context->indexable->object_id   = 123;
 

--- a/tests/generators/schema/author-test.php
+++ b/tests/generators/schema/author-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Schema;
 use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
-use Yoast\WP\SEO\Tests\Mocks\Author_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Generators\Schema\Author_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;

--- a/tests/generators/schema/author-test.php
+++ b/tests/generators/schema/author-test.php
@@ -12,7 +12,7 @@ use Yoast\WP\SEO\Helpers\Schema;
 use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
 use Yoast\WP\SEO\Tests\Mocks\Author_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -63,7 +63,7 @@ class Author_Test extends TestCase {
 	/**
 	 * Holds the meta tags context.
 	 *
-	 * @var Meta_Tags_Context
+	 * @var Meta_Tags_Context_Mock
 	 */
 	private $meta_tags_context;
 
@@ -110,7 +110,7 @@ class Author_Test extends TestCase {
 		$this->html         = Mockery::mock( Schema\HTML_Helper::class );
 		$this->id           = Mockery::mock( Schema\ID_Helper::class );
 
-		$this->meta_tags_context = new Meta_Tags_Context();
+		$this->meta_tags_context = new Meta_Tags_Context_Mock();
 
 		$this->instance = Mockery::mock( Author_Mock::class )
 			->shouldAllowMockingProtectedMethods()

--- a/tests/generators/schema/author-test.php
+++ b/tests/generators/schema/author-test.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Schema;
 use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
 use Yoast\WP\SEO\Tests\Doubles\Generators\Schema\Author_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 

--- a/tests/generators/schema/author-test.php
+++ b/tests/generators/schema/author-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Schema;
 use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
-use Yoast\WP\SEO\Tests\Mocks\Author;
+use Yoast\WP\SEO\Tests\Mocks\Author_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
 use Yoast\WP\SEO\Tests\TestCase;
@@ -70,7 +70,7 @@ class Author_Test extends TestCase {
 	/**
 	 * Holds the author schema generator under test.
 	 *
-	 * @var Author
+	 * @var Author_Mock
 	 */
 	private $instance;
 
@@ -112,7 +112,7 @@ class Author_Test extends TestCase {
 
 		$this->meta_tags_context = new Meta_Tags_Context();
 
-		$this->instance = Mockery::mock( Author::class )
+		$this->instance = Mockery::mock( Author_Mock::class )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 

--- a/tests/generators/schema/author-test.php
+++ b/tests/generators/schema/author-test.php
@@ -12,7 +12,7 @@ use Yoast\WP\SEO\Helpers\Schema;
 use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
 use Yoast\WP\SEO\Tests\Doubles\Generators\Schema\Author_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/generators/schema/breadcrumb-test.php
+++ b/tests/generators/schema/breadcrumb-test.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Generators\Schema\Breadcrumb;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -53,7 +53,7 @@ class Breadcrumb_Test extends TestCase {
 	/**
 	 * Holds the meta tags context mock instance.
 	 *
-	 * @var Mockery\MockInterface|Meta_Tags_Context
+	 * @var Mockery\MockInterface|Meta_Tags_Context_Mock
 	 */
 	private $meta_tags_context;
 
@@ -67,7 +67,7 @@ class Breadcrumb_Test extends TestCase {
 		$this->id           = Mockery::mock( ID_Helper::class );
 		$this->html         = Mockery::mock( HTML_Helper::class );
 
-		$this->meta_tags_context               = Mockery::mock( Meta_Tags_Context::class );
+		$this->meta_tags_context               = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->meta_tags_context->presentation = Mockery::mock( Indexable_Presentation::class );
 		$this->meta_tags_context->indexable    = Mockery::mock( Indexable::class );
 		$this->meta_tags_context->canonical    = 'https://wordpress.example.com/canonical';

--- a/tests/generators/schema/breadcrumb-test.php
+++ b/tests/generators/schema/breadcrumb-test.php
@@ -8,7 +8,7 @@ use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Generators\Schema\Breadcrumb;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -69,7 +69,7 @@ class Breadcrumb_Test extends TestCase {
 
 		$this->meta_tags_context               = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->meta_tags_context->presentation = Mockery::mock( Indexable_Presentation::class );
-		$this->meta_tags_context->indexable    = Mockery::mock( Indexable::class );
+		$this->meta_tags_context->indexable    = Mockery::mock( Indexable_Mock::class );
 		$this->meta_tags_context->canonical    = 'https://wordpress.example.com/canonical';
 
 		$this->instance = new Breadcrumb();

--- a/tests/generators/schema/breadcrumb-test.php
+++ b/tests/generators/schema/breadcrumb-test.php
@@ -8,7 +8,7 @@ use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Generators\Schema\Breadcrumb;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 

--- a/tests/generators/schema/breadcrumb-test.php
+++ b/tests/generators/schema/breadcrumb-test.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Generators\Schema\Breadcrumb;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/generators/schema/faq-test.php
+++ b/tests/generators/schema/faq-test.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Tests\Generators\Schema;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 use Yoast\WP\SEO\Generators\Schema\FAQ;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/generators/schema/faq-test.php
+++ b/tests/generators/schema/faq-test.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Tests\Generators\Schema;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 use Yoast\WP\SEO\Generators\Schema\FAQ;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -86,7 +86,7 @@ class FAQ_Test extends TestCase {
 			],
 		];
 
-		$meta_tags_context                 = new Meta_Tags_Context();
+		$meta_tags_context                 = new Meta_Tags_Context_Mock();
 		$meta_tags_context->blocks         = $blocks;
 		$meta_tags_context->main_schema_id = 'https://example.org/page/';
 		$meta_tags_context->canonical      = 'https://example.org/page/';
@@ -183,7 +183,7 @@ class FAQ_Test extends TestCase {
 			],
 		];
 
-		$meta_tags_context                 = new Meta_Tags_Context();
+		$meta_tags_context                 = new Meta_Tags_Context_Mock();
 		$meta_tags_context->blocks         = $blocks;
 		$meta_tags_context->main_schema_id = 'https://example.org/page/';
 		$meta_tags_context->canonical      = 'https://example.org/page/';
@@ -244,7 +244,7 @@ class FAQ_Test extends TestCase {
 	 * @covers ::is_needed
 	 */
 	public function test_is_not_needed_when_no_faq_blocks() {
-		$meta_tags_context         = new Meta_Tags_Context();
+		$meta_tags_context         = new Meta_Tags_Context_Mock();
 		$meta_tags_context->blocks = [];
 
 		$this->instance->context = $meta_tags_context;
@@ -279,7 +279,7 @@ class FAQ_Test extends TestCase {
 			],
 		];
 
-		$meta_tags_context                   = new Meta_Tags_Context();
+		$meta_tags_context                   = new Meta_Tags_Context_Mock();
 		$meta_tags_context->blocks           = $blocks;
 		$meta_tags_context->schema_page_type = 'WebPage';
 

--- a/tests/generators/schema/howto-test.php
+++ b/tests/generators/schema/howto-test.php
@@ -7,7 +7,7 @@ use Yoast\WP\SEO\Helpers\Schema\Image_Helper;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 use Yoast\WP\SEO\Generators\Schema\HowTo;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -25,7 +25,7 @@ class HowTo_Test extends TestCase {
 	/**
 	 * Holds the meta tags context mock.
 	 *
-	 * @var Meta_Tags_Context
+	 * @var Meta_Tags_Context_Mock
 	 */
 	private $meta_tags_context;
 
@@ -144,7 +144,7 @@ class HowTo_Test extends TestCase {
 
 		$id = 1234;
 
-		$this->meta_tags_context = \Mockery::mock( Meta_Tags_Context::class );
+		$this->meta_tags_context = \Mockery::mock( Meta_Tags_Context_Mock::class );
 
 		$this->meta_tags_context->id             = $id;
 		$this->meta_tags_context->main_schema_id = 'https://example.com/post-1#main-schema-id';

--- a/tests/generators/schema/howto-test.php
+++ b/tests/generators/schema/howto-test.php
@@ -7,7 +7,7 @@ use Yoast\WP\SEO\Helpers\Schema\Image_Helper;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 use Yoast\WP\SEO\Generators\Schema\HowTo;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/generators/schema/main-image-test.php
+++ b/tests/generators/schema/main-image-test.php
@@ -14,7 +14,7 @@ use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Schema;
 use Yoast\WP\SEO\Generators\Schema\Main_Image;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -58,7 +58,7 @@ class Main_Image_Test extends TestCase {
 	/**
 	 * The schema context.
 	 *
-	 * @var Meta_Tags_Context
+	 * @var Meta_Tags_Context_Mock
 	 */
 	private $meta_tags_context;
 
@@ -74,7 +74,7 @@ class Main_Image_Test extends TestCase {
 
 		$this->instance = new Main_Image();
 
-		$this->meta_tags_context            = new Meta_Tags_Context();
+		$this->meta_tags_context            = new Meta_Tags_Context_Mock();
 		$this->meta_tags_context->indexable = new Indexable();
 
 		$this->instance->context = $this->meta_tags_context;

--- a/tests/generators/schema/main-image-test.php
+++ b/tests/generators/schema/main-image-test.php
@@ -13,7 +13,7 @@ use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Schema;
 use Yoast\WP\SEO\Generators\Schema\Main_Image;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 

--- a/tests/generators/schema/main-image-test.php
+++ b/tests/generators/schema/main-image-test.php
@@ -14,7 +14,7 @@ use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Schema;
 use Yoast\WP\SEO\Generators\Schema\Main_Image;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/generators/schema/main-image-test.php
+++ b/tests/generators/schema/main-image-test.php
@@ -13,7 +13,7 @@ use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Schema;
 use Yoast\WP\SEO\Generators\Schema\Main_Image;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -75,7 +75,7 @@ class Main_Image_Test extends TestCase {
 		$this->instance = new Main_Image();
 
 		$this->meta_tags_context            = new Meta_Tags_Context_Mock();
-		$this->meta_tags_context->indexable = new Indexable();
+		$this->meta_tags_context->indexable = new Indexable_Mock();
 
 		$this->instance->context = $this->meta_tags_context;
 		$this->instance->helpers = (object) [

--- a/tests/generators/schema/organization-test.php
+++ b/tests/generators/schema/organization-test.php
@@ -15,7 +15,7 @@ use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Image_Helper;
 use Yoast\WP\SEO\Generators\Schema\Organization;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -38,7 +38,7 @@ class Organization_Test extends TestCase {
 	/**
 	 * The meta tags context.
 	 *
-	 * @var Meta_Tags_Context
+	 * @var Meta_Tags_Context_Mock
 	 */
 	protected $context;
 
@@ -80,7 +80,7 @@ class Organization_Test extends TestCase {
 		$this->options  = Mockery::mock( Options_Helper::class );
 		$this->html     = Mockery::mock( HTML_Helper::class );
 		$this->id       = new ID_Helper();
-		$this->context  = new Meta_Tags_Context();
+		$this->context  = new Meta_Tags_Context_Mock();
 		$this->instance = new Organization(
 			$this->image,
 			$this->options,

--- a/tests/generators/schema/organization-test.php
+++ b/tests/generators/schema/organization-test.php
@@ -15,7 +15,7 @@ use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Image_Helper;
 use Yoast\WP\SEO\Generators\Schema\Organization;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/generators/schema/person-test.php
+++ b/tests/generators/schema/person-test.php
@@ -17,7 +17,7 @@ use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Image_Helper as Schema_Image_Helper;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -64,7 +64,7 @@ class Person_Test extends TestCase {
 
 		$this->instance                     = new Person();
 		$this->instance->context            = new Meta_Tags_Context_Mock();
-		$this->instance->context->indexable = new Indexable();
+		$this->instance->context->indexable = new Indexable_Mock();
 		$this->instance->helpers            = (object) [
 			'image'  => Mockery::mock( Image_Helper::class ),
 			'schema' => (object) [

--- a/tests/generators/schema/person-test.php
+++ b/tests/generators/schema/person-test.php
@@ -18,7 +18,7 @@ use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Image_Helper as Schema_Image_Helper;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -63,7 +63,7 @@ class Person_Test extends TestCase {
 		parent::setUp();
 
 		$this->instance                     = new Person();
-		$this->instance->context            = new Meta_Tags_Context();
+		$this->instance->context            = new Meta_Tags_Context_Mock();
 		$this->instance->context->indexable = new Indexable();
 		$this->instance->helpers            = (object) [
 			'image'  => Mockery::mock( Image_Helper::class ),

--- a/tests/generators/schema/person-test.php
+++ b/tests/generators/schema/person-test.php
@@ -17,7 +17,7 @@ use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Image_Helper as Schema_Image_Helper;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 

--- a/tests/generators/schema/person-test.php
+++ b/tests/generators/schema/person-test.php
@@ -18,7 +18,7 @@ use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Image_Helper as Schema_Image_Helper;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/generators/schema/webpage-test.php
+++ b/tests/generators/schema/webpage-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Helpers\Date_Helper;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -68,7 +68,7 @@ class WebPage_Test extends TestCase {
 	/**
 	 * The meta tags context object.
 	 *
-	 * @var Meta_Tags_Context
+	 * @var Meta_Tags_Context_Mock
 	 */
 	private $meta_tags_context;
 
@@ -82,7 +82,7 @@ class WebPage_Test extends TestCase {
 		$this->html              = Mockery::mock( HTML_Helper::class );
 		$this->date              = Mockery::mock( Date_Helper::class );
 		$this->language          = Mockery::mock( Language_Helper::class );
-		$this->meta_tags_context = Mockery::mock( Meta_Tags_Context::class );
+		$this->meta_tags_context = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->id                = Mockery::mock( ID_Helper::class );
 
 		$this->instance          = Mockery::mock( WebPage::class )

--- a/tests/generators/schema/webpage-test.php
+++ b/tests/generators/schema/webpage-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Helpers\Date_Helper;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/generators/schema/website-test.php
+++ b/tests/generators/schema/website-test.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Generators\Schema\Website;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -53,7 +53,7 @@ class Website_Test extends TestCase {
 	/**
 	 * The meta tags context object.
 	 *
-	 * @var Meta_Tags_Context
+	 * @var Meta_Tags_Context_Mock
 	 */
 	private $meta_tags_context;
 
@@ -69,7 +69,7 @@ class Website_Test extends TestCase {
 
 		$this->instance = new Website();
 
-		$this->meta_tags_context = new Meta_Tags_Context();
+		$this->meta_tags_context = new Meta_Tags_Context_Mock();
 
 		$this->instance->context = $this->meta_tags_context;
 		$this->instance->helpers = (object) [

--- a/tests/generators/schema/website-test.php
+++ b/tests/generators/schema/website-test.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Generators\Schema\Website;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/generators/twitter-image-generator-test.php
+++ b/tests/generators/twitter-image-generator-test.php
@@ -7,7 +7,7 @@ use Yoast\WP\SEO\Generators\Twitter_Image_Generator;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Twitter\Image_Helper as Twitter_Image_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Values\Images;

--- a/tests/generators/twitter-image-generator-test.php
+++ b/tests/generators/twitter-image-generator-test.php
@@ -8,7 +8,7 @@ use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Twitter\Image_Helper as Twitter_Image_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Values\Images;
 
@@ -54,7 +54,7 @@ class Twitter_Image_Generator_Test extends TestCase {
 	protected $image_container;
 
 	/**
-	 * @var Mockery\MockInterface|Meta_Tags_Context
+	 * @var Mockery\MockInterface|Meta_Tags_Context_Mock
 	 */
 	protected $context;
 
@@ -80,7 +80,7 @@ class Twitter_Image_Generator_Test extends TestCase {
 			->andReturn( $this->image_container );
 
 		$this->indexable          = new Indexable();
-		$this->context            = Mockery::mock( Meta_Tags_Context::class );
+		$this->context            = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->context->indexable = $this->indexable;
 	}
 

--- a/tests/generators/twitter-image-generator-test.php
+++ b/tests/generators/twitter-image-generator-test.php
@@ -7,7 +7,7 @@ use Yoast\WP\SEO\Generators\Twitter_Image_Generator;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Twitter\Image_Helper as Twitter_Image_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Values\Images;
@@ -44,7 +44,7 @@ class Twitter_Image_Generator_Test extends TestCase {
 	protected $instance;
 
 	/**
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
@@ -79,7 +79,7 @@ class Twitter_Image_Generator_Test extends TestCase {
 			->once()
 			->andReturn( $this->image_container );
 
-		$this->indexable          = new Indexable();
+		$this->indexable          = new Indexable_Mock();
 		$this->context            = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->context->indexable = $this->indexable;
 	}

--- a/tests/generators/twitter-image-generator-test.php
+++ b/tests/generators/twitter-image-generator-test.php
@@ -8,7 +8,7 @@ use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Twitter\Image_Helper as Twitter_Image_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Values\Images;
 

--- a/tests/integrations/third-party/woocommerce-test.php
+++ b/tests/integrations/third-party/woocommerce-test.php
@@ -17,7 +17,7 @@ use Yoast\WP\SEO\Integrations\Third_Party\WooCommerce;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -61,7 +61,7 @@ class WooCommerce_Test extends TestCase {
 	/**
 	 * The indexable.
 	 *
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	private $indexable;
 
@@ -92,7 +92,7 @@ class WooCommerce_Test extends TestCase {
 			->makePartial();
 
 		$presentation       = new Indexable_Presentation();
-		$this->indexable    = new Indexable();
+		$this->indexable    = new Indexable_Mock();
 		$this->presentation = $presentation->of( [ 'model' => $this->indexable ] );
 	}
 

--- a/tests/integrations/third-party/woocommerce-test.php
+++ b/tests/integrations/third-party/woocommerce-test.php
@@ -17,7 +17,7 @@ use Yoast\WP\SEO\Integrations\Third_Party\WooCommerce;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/integrations/watchers/indexable-post-watcher-test.php
@@ -19,7 +19,7 @@ use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Doubles\Integrations\Watchers\Indexable_Post_Watcher_Double;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/integrations/watchers/indexable-post-watcher-test.php
@@ -19,7 +19,7 @@ use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Doubles\Integrations\Watchers\Indexable_Post_Watcher_Double;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -199,7 +199,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_is_post_revision' )->once()->with( $id )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_post_autosave' )->once()->with( $id )->andReturn( false );
 
-		$indexable_mock = Mockery::mock( Indexable::class );
+		$indexable_mock = Mockery::mock( Indexable_Mock::class );
 
 		$this->repository->expects( 'find_by_id_and_type' )->once()->with( $id, 'post', false )->andReturn( $indexable_mock );
 		$this->repository->expects( 'create_for_id_and_type' )->never();
@@ -276,7 +276,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->once()
 			->andReturnTrue();
 
-		$indexable_mock = Mockery::mock( Indexable::class );
+		$indexable_mock = Mockery::mock( Indexable_Mock::class );
 		$indexable_mock->expects( 'save' )->never();
 
 		$this->repository->expects( 'find_by_id_and_type' )
@@ -300,7 +300,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_is_post_revision' )->once()->with( $id )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_post_autosave' )->once()->with( $id )->andReturn( false );
 
-		$indexable_mock = Mockery::mock( Indexable::class );
+		$indexable_mock = Mockery::mock( Indexable_Mock::class );
 
 		$this->repository->expects( 'find_by_id_and_type' )->once()->with( $id, 'post', false )->andReturn( false );
 		$this->builder->expects( 'build_for_id_and_type' )->once()->with( $id, 'post', false )->andReturn( $indexable_mock );
@@ -318,8 +318,8 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->expects( 'update_relations' )
 			->never();
 
-		$old_indexable                  = Mockery::mock( Indexable::class );
-		$updated_indexable              = Mockery::mock( Indexable::class );
+		$old_indexable                  = Mockery::mock( Indexable_Mock::class );
+		$updated_indexable              = Mockery::mock( Indexable_Mock::class );
 		$updated_indexable->object_type = 'term';
 
 		$this->instance->updated_indexable( $updated_indexable, $old_indexable );
@@ -335,10 +335,10 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->expects( 'update_relations' )
 			->never();
 
-		$old_indexable            = Mockery::mock( Indexable::class );
+		$old_indexable            = Mockery::mock( Indexable_Mock::class );
 		$old_indexable->is_public = false;
 
-		$updated_indexable              = Mockery::mock( Indexable::class );
+		$updated_indexable              = Mockery::mock( Indexable_Mock::class );
 		$updated_indexable->object_type = 'post';
 		$updated_indexable->is_public   = false;
 
@@ -361,10 +361,10 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->with( [] )
 			->once();
 
-		$old_indexable            = Mockery::mock( Indexable::class );
+		$old_indexable            = Mockery::mock( Indexable_Mock::class );
 		$old_indexable->is_public = true;
 
-		$updated_indexable              = Mockery::mock( Indexable::class );
+		$updated_indexable              = Mockery::mock( Indexable_Mock::class );
 		$updated_indexable->object_type = 'post';
 		$updated_indexable->is_public   = false;
 		$updated_indexable->object_id   = 1;
@@ -394,7 +394,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 		$post_indexable->author_id       = 1;
 		$post_indexable->is_public       = null;
 
-		$author_indexable            = Mockery::mock( Indexable::class );
+		$author_indexable            = Mockery::mock( Indexable_Mock::class );
 		$author_indexable->object_id = 11;
 
 		$this->repository
@@ -455,7 +455,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			'ID'          => 1,
 		];
 
-		$indexable            = Mockery::mock( Indexable::class );
+		$indexable            = Mockery::mock( Indexable_Mock::class );
 		$indexable->is_public = true;
 		$indexable->expects( 'save' )->once();
 
@@ -480,7 +480,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			'ID'          => 1,
 		];
 
-		$indexable            = Mockery::mock( Indexable::class );
+		$indexable            = Mockery::mock( Indexable_Mock::class );
 		$indexable->is_public = false;
 		$indexable->expects( 'save' )->never();
 
@@ -565,7 +565,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->with( 1, 'another-taxonomy' )
 			->andReturnNull();
 
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 
 		$this->repository
 			->expects( 'find_by_id_and_type' )

--- a/tests/integrations/watchers/indexable-static-home-page-watcher-test.php
+++ b/tests/integrations/watchers/indexable-static-home-page-watcher-test.php
@@ -12,7 +12,7 @@ use Brain\Monkey;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Static_Home_Page_Watcher;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/integrations/watchers/indexable-static-home-page-watcher-test.php
+++ b/tests/integrations/watchers/indexable-static-home-page-watcher-test.php
@@ -12,7 +12,7 @@ use Brain\Monkey;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Static_Home_Page_Watcher;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -93,11 +93,11 @@ class Indexable_Static_Home_Page_Watcher_Test extends TestCase {
 			->with( 2 )
 			->andReturn( 'https://example.com/' );
 
-		$indexable_old                 = Mockery::mock( Indexable::class );
+		$indexable_old                 = Mockery::mock( Indexable_Mock::class );
 		$indexable_old->permalink      = 'https://example.com/';
 		$indexable_old->permalink_hash = 'https://example.com/';
 
-		$indexable_new                 = Mockery::mock( Indexable::class );
+		$indexable_new                 = Mockery::mock( Indexable_Mock::class );
 		$indexable_new->permalink      = 'https://example.com/old-permalink';
 		$indexable_new->permalink_hash = 'https://example.com/old-permalink';
 
@@ -139,7 +139,7 @@ class Indexable_Static_Home_Page_Watcher_Test extends TestCase {
 			->with( 1 )
 			->andReturn( 'https://example.com/permalink/' );
 
-		$indexable_old                 = Mockery::mock( Indexable::class );
+		$indexable_old                 = Mockery::mock( Indexable_Mock::class );
 		$indexable_old->permalink      = 'https://example.com/';
 		$indexable_old->permalink_hash = 'https://example.com/';
 

--- a/tests/mocks/abstract-indexation-route-mock.php
+++ b/tests/mocks/abstract-indexation-route-mock.php
@@ -10,7 +10,7 @@ namespace Yoast\WP\SEO\Tests\Mocks;
 /**
  * Represents the Abstract_Indexation_Route mock.
  */
-class Abstract_Indexation_Route extends \Yoast\WP\SEO\Routes\Abstract_Indexation_Route {
+class Abstract_Indexation_Route_Mock extends \Yoast\WP\SEO\Routes\Abstract_Indexation_Route {
 
 	/**
 	 * @inheritDoc

--- a/tests/mocks/abstract-presentation-mock.php
+++ b/tests/mocks/abstract-presentation-mock.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Tests\Mocks;
 /**
  * Represents the Abstract_Presentation mock.
  */
-class Abstract_Presentation extends \Yoast\WP\SEO\Presentations\Abstract_Presentation {
+class Abstract_Presentation_Mock extends \Yoast\WP\SEO\Presentations\Abstract_Presentation {
 
 	/**
 	 * @inheritDoc

--- a/tests/mocks/author-mock.php
+++ b/tests/mocks/author-mock.php
@@ -4,7 +4,7 @@ namespace Yoast\WP\SEO\Tests\Mocks;
 
 use Yoast\WP\SEO\Context\Meta_Tags_Context as Meta_Tags_Context_Original;
 
-class Author extends \Yoast\WP\SEO\Generators\Schema\Author {
+class Author_Mock extends \Yoast\WP\SEO\Generators\Schema\Author {
 
 	/**
 	 * @inheritDoc

--- a/tests/mocks/indexable-mock.php
+++ b/tests/mocks/indexable-mock.php
@@ -3,13 +3,13 @@
 namespace Yoast\WP\SEO\Tests\Mocks;
 
 /**
- * Class Indexable
+ * Class Indexable_Mock
  *
  * Indexable mock class.
  *
  * @package Yoast\WP\SEO\Tests\Mocks
  */
-class Indexable extends \Yoast\WP\SEO\Models\Indexable {
+class Indexable_Mock extends \Yoast\WP\SEO\Models\Indexable {
 
 	public $id;
 

--- a/tests/mocks/meta-tags-context-mock.php
+++ b/tests/mocks/meta-tags-context-mock.php
@@ -8,9 +8,9 @@
 namespace Yoast\WP\SEO\Tests\Mocks;
 
 /**
- * Class Meta_Tags_Context
+ * Class Meta_Tags_Context_Mock
  */
-class Meta_Tags_Context extends \Yoast\WP\SEO\Context\Meta_Tags_Context {
+class Meta_Tags_Context_Mock extends \Yoast\WP\SEO\Context\Meta_Tags_Context {
 
 	/**
 	 * @var string

--- a/tests/mocks/primary-term-mock.php
+++ b/tests/mocks/primary-term-mock.php
@@ -3,13 +3,13 @@
 namespace Yoast\WP\SEO\Tests\Mocks;
 
 /**
- * Class Primary_Term
+ * Class Primary_Term_Mock
  *
  * Primary_Term mock class.
  *
  * @package Yoast\WP\SEO\Tests\Mocks
  */
-class Primary_Term extends \Yoast\WP\SEO\Models\Primary_Term {
+class Primary_Term_Mock extends \Yoast\WP\SEO\Models\Primary_Term {
 
 	public $id;
 

--- a/tests/presentations/abstract-presentation-test.php
+++ b/tests/presentations/abstract-presentation-test.php
@@ -2,7 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Presentations;
 
-use Yoast\WP\SEO\Tests\Mocks\Abstract_Presentation_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Presentations\Abstract_Presentation_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/presentations/abstract-presentation-test.php
+++ b/tests/presentations/abstract-presentation-test.php
@@ -2,7 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Presentations;
 
-use Yoast\WP\SEO\Tests\Mocks\Abstract_Presentation;
+use Yoast\WP\SEO\Tests\Mocks\Abstract_Presentation_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -16,7 +16,7 @@ class Abstract_Presentation_Test extends TestCase {
 	/**
 	 * Holds the abstract presentation mock instance.
 	 *
-	 * @var Abstract_Presentation
+	 * @var Abstract_Presentation_Mock
 	 */
 	private $instance;
 
@@ -26,7 +26,7 @@ class Abstract_Presentation_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->instance = \Mockery::mock( Abstract_Presentation::class )->makePartial();
+		$this->instance = \Mockery::mock( Abstract_Presentation_Mock::class )->makePartial();
 	}
 
 	/**

--- a/tests/presentations/indexable-author-archive-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-author-archive-presentation/presentation-instance-builder.php
@@ -6,7 +6,7 @@ use Mockery;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Author_Archive_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
@@ -19,7 +19,7 @@ trait Presentation_Instance_Builder {
 	/**
 	 * Holds the Indexable instance.
 	 *
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
@@ -55,7 +55,7 @@ trait Presentation_Instance_Builder {
 	 * Builds an instance of Indexable_Author_Presentation.
 	 */
 	protected function set_instance() {
-		$this->indexable = new Indexable();
+		$this->indexable = new Indexable_Mock();
 
 		$this->post_type  = Mockery::mock( Post_Type_Helper::class );
 		$this->pagination = Mockery::mock( Pagination_Helper::class );

--- a/tests/presentations/indexable-author-archive-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-author-archive-presentation/presentation-instance-builder.php
@@ -6,7 +6,7 @@ use Mockery;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Author_Archive_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 

--- a/tests/presentations/indexable-date-archive-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-date-archive-presentation/presentation-instance-builder.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Date_Archive_Presentation;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Date_Archive_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**
@@ -15,7 +15,7 @@ trait Presentation_Instance_Builder {
 	use Presentation_Instance_Dependencies;
 
 	/**
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
@@ -35,7 +35,7 @@ trait Presentation_Instance_Builder {
 	 * Builds an instance of Indexable_Post_Type_Presentation.
 	 */
 	protected function set_instance() {
-		$this->indexable = new Indexable();
+		$this->indexable = new Indexable_Mock();
 
 		$this->pagination = Mockery::mock( Pagination_Helper::class );
 

--- a/tests/presentations/indexable-date-archive-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-date-archive-presentation/presentation-instance-builder.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Date_Archive_Presentation;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Date_Archive_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**

--- a/tests/presentations/indexable-error-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-error-page-presentation/presentation-instance-builder.php
@@ -3,7 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Error_Page_Presentation;
 
 use Yoast\WP\SEO\Presentations\Indexable_Error_Page_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**
@@ -13,7 +13,7 @@ trait Presentation_Instance_Builder {
 	use Presentation_Instance_Dependencies;
 
 	/**
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
@@ -26,7 +26,7 @@ trait Presentation_Instance_Builder {
 	 * Builds an instance of Indexable_Error_Page_Presentation.
 	 */
 	protected function set_instance() {
-		$this->indexable = new Indexable();
+		$this->indexable = new Indexable_Mock();
 
 		$instance = new Indexable_Error_Page_Presentation();
 

--- a/tests/presentations/indexable-error-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-error-page-presentation/presentation-instance-builder.php
@@ -3,7 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Error_Page_Presentation;
 
 use Yoast\WP\SEO\Presentations\Indexable_Error_Page_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**

--- a/tests/presentations/indexable-home-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-home-page-presentation/presentation-instance-builder.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Home_Page_Presentation;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Home_Page_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**

--- a/tests/presentations/indexable-home-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-home-page-presentation/presentation-instance-builder.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Home_Page_Presentation;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Home_Page_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**
@@ -15,7 +15,7 @@ trait Presentation_Instance_Builder {
 	use Presentation_Instance_Dependencies;
 
 	/**
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
@@ -35,7 +35,7 @@ trait Presentation_Instance_Builder {
 	 * Builds an instance of Indexable_Home_Page_Presentation.
 	 */
 	protected function set_instance() {
-		$this->indexable = new Indexable();
+		$this->indexable = new Indexable_Mock();
 
 		$this->pagination = Mockery::mock( Pagination_Helper::class );
 

--- a/tests/presentations/indexable-post-type-archive-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-post-type-archive-presentation/presentation-instance-builder.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Post_Type_Archive_Presentat
 use Mockery;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Archive_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**
@@ -17,7 +17,7 @@ trait Presentation_Instance_Builder {
 	/**
 	 * Holds the Indexable instance.
 	 *
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
@@ -39,7 +39,7 @@ trait Presentation_Instance_Builder {
 	 * Builds an instance of Indexable_Post_Type_Archive_Presentation.
 	 */
 	protected function set_instance() {
-		$this->indexable = new Indexable();
+		$this->indexable = new Indexable_Mock();
 
 		$this->pagination = Mockery::mock( Pagination_Helper::class );
 

--- a/tests/presentations/indexable-post-type-archive-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-post-type-archive-presentation/presentation-instance-builder.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Post_Type_Archive_Presentat
 use Mockery;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Archive_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**

--- a/tests/presentations/indexable-post-type-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-post-type-presentation/presentation-instance-builder.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**
@@ -42,7 +42,7 @@ trait Presentation_Instance_Builder {
 	/**
 	 * Represents the meta tags context.
 	 *
-	 * @var Meta_Tags_Context|Mockery\MockInterface
+	 * @var Meta_Tags_Context_Mock|Mockery\MockInterface
 	 */
 	protected $context;
 
@@ -75,7 +75,7 @@ trait Presentation_Instance_Builder {
 
 		$this->post_type  = Mockery::mock( Post_Type_Helper::class );
 		$this->post       = Mockery::mock( Post_Helper::class );
-		$this->context    = Mockery::mock( Meta_Tags_Context::class )->makePartial();
+		$this->context    = Mockery::mock( Meta_Tags_Context_Mock::class )->makePartial();
 		$this->date       = Mockery::mock( Date_Helper::class );
 		$this->pagination = Mockery::mock( Pagination_Helper::class );
 

--- a/tests/presentations/indexable-post-type-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-post-type-presentation/presentation-instance-builder.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**

--- a/tests/presentations/indexable-post-type-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-post-type-presentation/presentation-instance-builder.php
@@ -8,7 +8,7 @@ use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 

--- a/tests/presentations/indexable-post-type-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-post-type-presentation/presentation-instance-builder.php
@@ -8,7 +8,7 @@ use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
@@ -21,7 +21,7 @@ trait Presentation_Instance_Builder {
 	/**
 	 * Represents the indexable.
 	 *
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
@@ -71,7 +71,7 @@ trait Presentation_Instance_Builder {
 	 * Builds an instance of Indexable_Post_Type_Presentation.
 	 */
 	protected function set_instance() {
-		$this->indexable = new Indexable();
+		$this->indexable = new Indexable_Mock();
 
 		$this->post_type  = Mockery::mock( Post_Type_Helper::class );
 		$this->post       = Mockery::mock( Post_Helper::class );

--- a/tests/presentations/indexable-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-presentation/presentation-instance-builder.php
@@ -7,7 +7,7 @@ use Yoast\WP\SEO\Generators\Open_Graph_Image_Generator;
 use Yoast\WP\SEO\Generators\Twitter_Image_Generator;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**
@@ -27,7 +27,7 @@ trait Presentation_Instance_Builder {
 	protected $instance;
 
 	/**
-	 * @var Meta_Tags_Context|Mockery\MockInterface
+	 * @var Meta_Tags_Context_Mock|Mockery\MockInterface
 	 */
 	protected $context;
 
@@ -37,7 +37,7 @@ trait Presentation_Instance_Builder {
 	protected function set_instance() {
 		$this->indexable = new Indexable();
 
-		$this->context = Mockery::mock( Meta_Tags_Context::class );
+		$this->context = Mockery::mock( Meta_Tags_Context_Mock::class );
 
 		$instance = Mockery::mock( Indexable_Presentation::class )
 			->shouldAllowMockingProtectedMethods()

--- a/tests/presentations/indexable-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-presentation/presentation-instance-builder.php
@@ -6,7 +6,7 @@ use Mockery;
 use Yoast\WP\SEO\Generators\Open_Graph_Image_Generator;
 use Yoast\WP\SEO\Generators\Twitter_Image_Generator;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
@@ -17,7 +17,7 @@ trait Presentation_Instance_Builder {
 	use Presentation_Instance_Dependencies;
 
 	/**
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
@@ -35,7 +35,7 @@ trait Presentation_Instance_Builder {
 	 * Builds an instance of Indexable_Post_Type_Presentation.
 	 */
 	protected function set_instance() {
-		$this->indexable = new Indexable();
+		$this->indexable = new Indexable_Mock();
 
 		$this->context = Mockery::mock( Meta_Tags_Context_Mock::class );
 

--- a/tests/presentations/indexable-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-presentation/presentation-instance-builder.php
@@ -6,7 +6,7 @@ use Mockery;
 use Yoast\WP\SEO\Generators\Open_Graph_Image_Generator;
 use Yoast\WP\SEO\Generators\Twitter_Image_Generator;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 

--- a/tests/presentations/indexable-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-presentation/presentation-instance-builder.php
@@ -7,7 +7,7 @@ use Yoast\WP\SEO\Generators\Open_Graph_Image_Generator;
 use Yoast\WP\SEO\Generators\Twitter_Image_Generator;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**

--- a/tests/presentations/indexable-presentation/title-test.php
+++ b/tests/presentations/indexable-presentation/title-test.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Presentation;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/presentations/indexable-presentation/title-test.php
+++ b/tests/presentations/indexable-presentation/title-test.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Presentation;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -25,7 +25,7 @@ class Title_Test extends TestCase {
 	protected $option;
 
 	/**
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 

--- a/tests/presentations/indexable-presentation/twitter-description-test.php
+++ b/tests/presentations/indexable-presentation/twitter-description-test.php
@@ -5,7 +5,6 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Presentation;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/presentations/indexable-presentation/twitter-title-test.php
+++ b/tests/presentations/indexable-presentation/twitter-title-test.php
@@ -5,7 +5,6 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Presentation;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/presentations/indexable-search-result-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-search-result-page-presentation/presentation-instance-builder.php
@@ -3,7 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Search_Result_Page_Presentation;
 
 use Yoast\WP\SEO\Presentations\Indexable_Search_Result_Page_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**

--- a/tests/presentations/indexable-search-result-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-search-result-page-presentation/presentation-instance-builder.php
@@ -3,7 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Search_Result_Page_Presentation;
 
 use Yoast\WP\SEO\Presentations\Indexable_Search_Result_Page_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**
@@ -13,7 +13,7 @@ trait Presentation_Instance_Builder {
 	use Presentation_Instance_Dependencies;
 
 	/**
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
@@ -26,7 +26,7 @@ trait Presentation_Instance_Builder {
 	 * Builds an instance of Indexable_Search_Result_Page_Presentation.
 	 */
 	protected function set_instance() {
-		$this->indexable = new Indexable();
+		$this->indexable = new Indexable_Mock();
 
 		$instance = new Indexable_Search_Result_Page_Presentation();
 

--- a/tests/presentations/indexable-static-home-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-static-home-page-presentation/presentation-instance-builder.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation;
 use Yoast\WP\SEO\Presentations\Indexable_Static_Home_Page_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
@@ -22,7 +22,7 @@ trait Presentation_Instance_Builder {
 	/**
 	 * Represents the indexable.
 	 *
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
@@ -72,7 +72,7 @@ trait Presentation_Instance_Builder {
 	 * Builds an instance of Indexable_Static_Home_Page_Presentation.
 	 */
 	protected function set_instance() {
-		$this->indexable = new Indexable();
+		$this->indexable = new Indexable_Mock();
 
 		$this->post_type  = Mockery::mock( Post_Type_Helper::class );
 		$this->post       = Mockery::mock( Post_Helper::class );

--- a/tests/presentations/indexable-static-home-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-static-home-page-presentation/presentation-instance-builder.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation;
 use Yoast\WP\SEO\Presentations\Indexable_Static_Home_Page_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 

--- a/tests/presentations/indexable-static-home-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-static-home-page-presentation/presentation-instance-builder.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation;
 use Yoast\WP\SEO\Presentations\Indexable_Static_Home_Page_Presentation;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**

--- a/tests/presentations/indexable-static-home-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-static-home-page-presentation/presentation-instance-builder.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation;
 use Yoast\WP\SEO\Presentations\Indexable_Static_Home_Page_Presentation;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**
@@ -43,7 +43,7 @@ trait Presentation_Instance_Builder {
 	/**
 	 * Represents the meta tags context.
 	 *
-	 * @var Meta_Tags_Context|Mockery\MockInterface
+	 * @var Meta_Tags_Context_Mock|Mockery\MockInterface
 	 */
 	protected $context;
 
@@ -76,7 +76,7 @@ trait Presentation_Instance_Builder {
 
 		$this->post_type  = Mockery::mock( Post_Type_Helper::class );
 		$this->post       = Mockery::mock( Post_Helper::class );
-		$this->context    = Mockery::mock( Meta_Tags_Context::class )->makePartial();
+		$this->context    = Mockery::mock( Meta_Tags_Context_Mock::class )->makePartial();
 		$this->date       = Mockery::mock( Date_Helper::class );
 		$this->pagination = Mockery::mock( Pagination_Helper::class );
 

--- a/tests/presentations/indexable-static-posts-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-static-posts-page-presentation/presentation-instance-builder.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation;
 use Yoast\WP\SEO\Presentations\Indexable_Static_Posts_Page_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 

--- a/tests/presentations/indexable-static-posts-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-static-posts-page-presentation/presentation-instance-builder.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation;
 use Yoast\WP\SEO\Presentations\Indexable_Static_Posts_Page_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
@@ -22,7 +22,7 @@ trait Presentation_Instance_Builder {
 	/**
 	 * Represents the indexable.
 	 *
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
@@ -72,7 +72,7 @@ trait Presentation_Instance_Builder {
 	 * Builds an instance of Indexable_Search_Result_Page_Presentation.
 	 */
 	protected function set_instance() {
-		$this->indexable = new Indexable();
+		$this->indexable = new Indexable_Mock();
 
 		$this->post_type  = Mockery::mock( Post_Type_Helper::class );
 		$this->post       = Mockery::mock( Post_Helper::class );

--- a/tests/presentations/indexable-static-posts-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-static-posts-page-presentation/presentation-instance-builder.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation;
 use Yoast\WP\SEO\Presentations\Indexable_Static_Posts_Page_Presentation;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**

--- a/tests/presentations/indexable-static-posts-page-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-static-posts-page-presentation/presentation-instance-builder.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation;
 use Yoast\WP\SEO\Presentations\Indexable_Static_Posts_Page_Presentation;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 
 /**
@@ -43,7 +43,7 @@ trait Presentation_Instance_Builder {
 	/**
 	 * Represents the meta tags context.
 	 *
-	 * @var Meta_Tags_Context|Mockery\MockInterface
+	 * @var Meta_Tags_Context_Mock|Mockery\MockInterface
 	 */
 	protected $context;
 

--- a/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder.php
@@ -7,7 +7,7 @@ use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Term_Archive_Presentation;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
@@ -55,7 +55,7 @@ trait Presentation_Instance_Builder {
 	/**
 	 * The context class.
 	 *
-	 * @var \Yoast\WP\SEO\Context\Meta_Tags_Context
+	 * @var \Yoast\WP\SEO\Context\Meta_Tags_Context_Mock
 	 */
 	protected $context;
 
@@ -68,7 +68,7 @@ trait Presentation_Instance_Builder {
 		$this->wp_query_wrapper = Mockery::mock( WP_Query_Wrapper::class );
 		$this->taxonomy         = Mockery::mock( Taxonomy_Helper::class );
 		$this->pagination       = Mockery::mock( Pagination_Helper::class );
-		$this->context          = Mockery::mock( Meta_Tags_Context::class );
+		$this->context          = Mockery::mock( Meta_Tags_Context_Mock::class );
 
 		$instance = Mockery::mock(
 			Indexable_Term_Archive_Presentation::class,

--- a/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder.php
@@ -7,7 +7,7 @@ use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Term_Archive_Presentation;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 

--- a/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder.php
@@ -6,7 +6,7 @@ use Mockery;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Term_Archive_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
@@ -20,7 +20,7 @@ trait Presentation_Instance_Builder {
 	/**
 	 * Holds the Indexable instance.
 	 *
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
@@ -63,7 +63,7 @@ trait Presentation_Instance_Builder {
 	 * Builds an instance of Indexable_Term_Archive_Presentation.
 	 */
 	protected function set_instance() {
-		$this->indexable = new Indexable();
+		$this->indexable = new Indexable_Mock();
 
 		$this->wp_query_wrapper = Mockery::mock( WP_Query_Wrapper::class );
 		$this->taxonomy         = Mockery::mock( Taxonomy_Helper::class );

--- a/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder.php
+++ b/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder.php
@@ -6,7 +6,7 @@ use Mockery;
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Term_Archive_Presentation;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Presentations\Presentation_Instance_Dependencies;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;

--- a/tests/presentations/presentation-instance-dependencies.php
+++ b/tests/presentations/presentation-instance-dependencies.php
@@ -18,7 +18,6 @@ use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Robots_Helper;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
 
 trait Presentation_Instance_Dependencies {
 

--- a/tests/presenters/bingbot-presenter-test.php
+++ b/tests/presenters/bingbot-presenter-test.php
@@ -6,7 +6,6 @@ use Mockery;
 use Brain\Monkey;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Bingbot_Presenter;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/presenters/googlebot-presenter-test.php
+++ b/tests/presenters/googlebot-presenter-test.php
@@ -6,7 +6,6 @@ use Mockery;
 use Brain\Monkey;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Googlebot_Presenter;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/repositories/indexable-hierarchy-repository-test.php
@@ -12,7 +12,7 @@ use Mockery;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -66,7 +66,7 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 	 * @covers ::find_ancestors
 	 */
 	public function test_find_ancestors_having_results() {
-		$indexable     = Mockery::mock( Indexable::class );
+		$indexable     = Mockery::mock( Indexable_Mock::class );
 		$indexable->id = 1;
 
 		$ancestors = [ 2 ];
@@ -109,10 +109,10 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 	 * @covers ::find_ancestors
 	 */
 	public function test_find_ancestors_having_no_results_first_time() {
-		$indexable     = Mockery::mock( Indexable::class );
+		$indexable     = Mockery::mock( Indexable_Mock::class );
 		$indexable->id = 1;
 
-		$parent_indexable     = Mockery::mock( Indexable::class );
+		$parent_indexable     = Mockery::mock( Indexable_Mock::class );
 		$parent_indexable->id = 2;
 		$indexable->ancestors = [ $parent_indexable ];
 

--- a/tests/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/repositories/indexable-hierarchy-repository-test.php
@@ -12,7 +12,7 @@ use Mockery;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/repositories/indexable-repository-test.php
+++ b/tests/repositories/indexable-repository-test.php
@@ -15,7 +15,7 @@ use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -90,7 +90,7 @@ class Indexable_Repository_Test extends TestCase {
 	 * @covers ::get_ancestors
 	 */
 	public function test_get_ancestors_no_ancestors_found() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 
 		$this->hierarchy_repository
 			->expects( 'find_ancestors' )
@@ -107,7 +107,7 @@ class Indexable_Repository_Test extends TestCase {
 	 * @covers ::get_ancestors
 	 */
 	public function test_get_ancestors_one_ancestor_that_has_no_ancestor_id_found() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 
 		$this->hierarchy_repository
 			->expects( 'find_ancestors' )
@@ -128,7 +128,7 @@ class Indexable_Repository_Test extends TestCase {
 	 * @covers ::get_ancestors
 	 */
 	public function test_get_ancestors_one_ancestor_that_has_ancestor_id_found() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 
 		$indexable->permalink = 'https://example.org/post';
 
@@ -151,7 +151,7 @@ class Indexable_Repository_Test extends TestCase {
 	 * @covers ::get_ancestors
 	 */
 	public function test_get_ancestors_with_multiple_ancestors() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 
 		$indexable->permalink = 'https://example.org/post';
 
@@ -173,7 +173,7 @@ class Indexable_Repository_Test extends TestCase {
 	 * that the permalink of each ancestor is available.
 	 */
 	public function test_get_ancestors_ensures_permalink() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 		$indexable->expects( 'save' )->once();
 		$indexable->object_type = 'post';
 
@@ -201,7 +201,7 @@ class Indexable_Repository_Test extends TestCase {
 	 * that the permalink of each ancestor is available when there is only one ancestor.
 	 */
 	public function test_get_ancestors_one_ancestor_ensures_permalink() {
-		$indexable = Mockery::mock( Indexable::class );
+		$indexable = Mockery::mock( Indexable_Mock::class );
 		$indexable->expects( 'save' )->once();
 		$indexable->object_type = 'post';
 

--- a/tests/repositories/indexable-repository-test.php
+++ b/tests/repositories/indexable-repository-test.php
@@ -15,7 +15,7 @@ use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/routes/abstract-indexation-route-test.php
+++ b/tests/routes/abstract-indexation-route-test.php
@@ -8,7 +8,7 @@
 namespace Yoast\WP\SEO\Tests\Routes;
 
 use Mockery;
-use Yoast\WP\SEO\Tests\Mocks\Abstract_Indexation_Route;
+use Yoast\WP\SEO\Tests\Mocks\Abstract_Indexation_Route_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -27,7 +27,7 @@ class Abstract_Indexation_Route_Test extends TestCase {
 	 * @covers ::respond_with
 	 */
 	public function test_respond_with() {
-		$instance = new Abstract_Indexation_Route();
+		$instance = new Abstract_Indexation_Route_Mock();
 
 		Mockery::mock( 'overload:WP_REST_Response' );
 

--- a/tests/routes/abstract-indexation-route-test.php
+++ b/tests/routes/abstract-indexation-route-test.php
@@ -8,7 +8,7 @@
 namespace Yoast\WP\SEO\Tests\Routes;
 
 use Mockery;
-use Yoast\WP\SEO\Tests\Mocks\Abstract_Indexation_Route_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Routes\Abstract_Indexation_Route_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/surfaces/meta-surface-test.php
+++ b/tests/surfaces/meta-surface-test.php
@@ -12,7 +12,7 @@ use Mockery;
 use Yoast\WP\SEO\Surfaces\Meta_Surface;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable;
+use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Wrappers\WP_Rewrite_Wrapper;
@@ -59,7 +59,7 @@ class Meta_Surface_Test extends TestCase {
 	/**
 	 * The indexable
 	 *
-	 * @var Indexable
+	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
@@ -86,7 +86,7 @@ class Meta_Surface_Test extends TestCase {
 		$this->repository         = Mockery::mock( Indexable_Repository::class );
 		$this->context            = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->wp_rewrite_wrapper = Mockery::mock( WP_Rewrite_Wrapper::class );
-		$this->indexable          = Mockery::mock( Indexable::class );
+		$this->indexable          = Mockery::mock( Indexable_Mock::class );
 
 		$this->instance = new Meta_Surface(
 			$this->container,

--- a/tests/surfaces/meta-surface-test.php
+++ b/tests/surfaces/meta-surface-test.php
@@ -13,7 +13,7 @@ use Yoast\WP\SEO\Surfaces\Meta_Surface;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Wrappers\WP_Rewrite_Wrapper;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;

--- a/tests/surfaces/meta-surface-test.php
+++ b/tests/surfaces/meta-surface-test.php
@@ -12,7 +12,7 @@ use Mockery;
 use Yoast\WP\SEO\Surfaces\Meta_Surface;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Tests\Mocks\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Wrappers\WP_Rewrite_Wrapper;

--- a/tests/surfaces/meta-surface-test.php
+++ b/tests/surfaces/meta-surface-test.php
@@ -13,7 +13,7 @@ use Yoast\WP\SEO\Surfaces\Meta_Surface;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Mocks\Indexable;
-use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context;
+use Yoast\WP\SEO\Tests\Mocks\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 use Yoast\WP\SEO\Wrappers\WP_Rewrite_Wrapper;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
@@ -52,7 +52,7 @@ class Meta_Surface_Test extends TestCase {
 	/**
 	 * The context
 	 *
-	 * @var Meta_Tags_Context
+	 * @var Meta_Tags_Context_Mock
 	 */
 	protected $context;
 
@@ -84,7 +84,7 @@ class Meta_Surface_Test extends TestCase {
 		$this->container          = Mockery::mock( ContainerInterface::class );
 		$this->context_memoizer   = Mockery::mock( Meta_Tags_Context_Memoizer::class );
 		$this->repository         = Mockery::mock( Indexable_Repository::class );
-		$this->context            = Mockery::mock( Meta_Tags_Context::class );
+		$this->context            = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->wp_rewrite_wrapper = Mockery::mock( WP_Rewrite_Wrapper::class );
 		$this->indexable          = Mockery::mock( Indexable::class );
 


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.

### QA: rename the `mock` classes to have `mock` in the class name (as suffix)

Includes:
* Adjusting the file names to mirror the new class name (if necessary).
* Adjusting the `use` statement and other references to the classes in the test files which uses these Mocks.
* Removing some unused `use` statements referring to these mock classes.

Also note:
* The `Yoast\WP\SEO\Tests\Presentations\Indexable_Static_Posts_Page_Presentation\Presentation_Instance_Builder` does not seem to actually use the `Meta_Tags_Context_Mock`. There is a property to store it, but the property appears to be unused/nothing is assigned to it.
* The `Yoast\WP\SEO\Tests\Presentations\Indexable_Presentation\Title_Test` does not seem to actually use the `Indexable_Mock`. There is a property to store it, but the property appears to be unused/nothing is assigned to it.

### CS: move mock classes to `test/doubles` directory

As discussed with Herre.

Includes:
* Putting them in a logical path.
* Renaming the namespace.
* Adjusting any and all files in which the Mock class is being used.


Note: the Composer `autoload.php` file has to be regenerated after this change for those people running tests locally!

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test-only change and should have no effect on the functionality.