### PR TITLE
CS: Tests - various class renames

### DIFF
--- a/tests/admin/metabox/metabox-section-additional-test.php
+++ b/tests/admin/metabox/metabox-section-additional-test.php
@@ -10,7 +10,7 @@ use WPSEO_Metabox_Section_Additional;
  *
  * @group Metabox
  */
-class Metabox_Section_Additional extends TestCase {
+class Metabox_Section_Additional_Test extends TestCase {
 
 	/**
 	 * Tests the output of \WPSEO_Metabox_Section_Additional::display_content.

--- a/tests/admin/paper-presenter-test.php
+++ b/tests/admin/paper-presenter-test.php
@@ -7,11 +7,11 @@ use WPSEO_Paper_Presenter;
 use Brain\Monkey;
 
 /**
- * Class WPSEO_Paper_Presenter_Test
+ * Class Paper_Presenter_Test
  *
  * @package Yoast\WP\SEO\Tests\Admin
  */
-class WPSEO_Paper_Presenter_Test extends TestCase {
+class Paper_Presenter_Test extends TestCase {
 
 	/**
 	 * Tests whether the \WPSEO_Paper_Presenter can be used with a content option instead of a view file.

--- a/tests/inc/health-check-curl-version-test.php
+++ b/tests/inc/health-check-curl-version-test.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group health-check
  */
-class WPSEO_Health_Check_Curl_Version_Test extends TestCase {
+class Health_Check_Curl_Version_Test extends TestCase {
 
 	/**
 	 * The instance to test.

--- a/tests/inc/health-check-default-tagline-test.php
+++ b/tests/inc/health-check-default-tagline-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group health-check
  */
-class WPSEO_Health_Check_Default_Tagline_Test extends TestCase {
+class Health_Check_Default_Tagline_Test extends TestCase {
 
 	/**
 	 * Tests the run method when the WordPress tagline is the default one.

--- a/tests/inc/health-check-link-table-not-accessible-test.php
+++ b/tests/inc/health-check-link-table-not-accessible-test.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group health-check
  */
-class WPSEO_Health_Check_Link_Table_Not_Accessible_Test extends TestCase {
+class Health_Check_Link_Table_Not_Accessible_Test extends TestCase {
 
 	/**
 	 * The instance to test.

--- a/tests/inc/health-check-page-comments-test.php
+++ b/tests/inc/health-check-page-comments-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group health-check
  */
-class WPSEO_Health_Check_Page_Comments_Test extends TestCase {
+class Health_Check_Page_Comments_Test extends TestCase {
 
 	/**
 	 * Tests the run method when page_comments are disabled.

--- a/tests/inc/health-check-postname-permalink-test.php
+++ b/tests/inc/health-check-postname-permalink-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group health-check
  */
-class WPSEO_Health_Check_Postname_Permalink_Test extends TestCase {
+class Health_Check_Postname_Permalink_Test extends TestCase {
 
 	/**
 	 * Tests the run method when the permalink structure is set to "Post name".

--- a/tests/inc/health-check-ryte-test.php
+++ b/tests/inc/health-check-ryte-test.php
@@ -13,7 +13,7 @@ use WPSEO_Utils;
  * @coversDefaultClass \WPSEO_Health_Check_Ryte
  * @group health-check
  */
-class WPSEO_Health_Check_Ryte_Test extends TestCase {
+class Health_Check_Ryte_Test extends TestCase {
 
 	/**
 	 * @var \Mockery\Mock|\WPSEO_Ryte_Option

--- a/tests/inc/health-check-test.php
+++ b/tests/inc/health-check-test.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group health-check
  */
-class WPSEO_Health_Check_Test extends TestCase {
+class Health_Check_Test extends TestCase {
 
 	/**
 	 * Class instance to use for the test.

--- a/tests/inc/language-utils-test.php
+++ b/tests/inc/language-utils-test.php
@@ -13,7 +13,7 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group language-utils
  */
-class WPSEO_Language_Utils_Test extends TestCase {
+class Language_Utils_Test extends TestCase {
 
 	/**
 	 * Tests the get_language function with no argument.

--- a/tests/presentations/indexable-post-type-presentation/replace-vars-object-test.php
+++ b/tests/presentations/indexable-post-type-presentation/replace-vars-object-test.php
@@ -6,13 +6,13 @@ use Yoast\WP\SEO\Tests\TestCase;
 use Brain\Monkey;
 
 /**
- * Class Generate_Source_Test
+ * Class Replace_Vars_Object_Test
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presentations\Indexable_Post_Type_Presentation
  *
  * @group presentations
  */
-class Generate_Source_Test extends TestCase {
+class Replace_Vars_Object_Test extends TestCase {
 	use Presentation_Instance_Builder;
 
 	/**

--- a/tests/presentations/indexable-presentation/replace-vars-object-test.php
+++ b/tests/presentations/indexable-presentation/replace-vars-object-test.php
@@ -5,13 +5,13 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
- * Class Generate_Source_Test
+ * Class Replace_Vars_Object_Test
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presentations\Indexable_Presentation
  *
  * @group presentations
  */
-class Generate_Source_Test extends TestCase {
+class Replace_Vars_Object_Test extends TestCase {
 	use Presentation_Instance_Builder;
 
 	/**

--- a/tests/presentations/indexable-term-archive-presentation/replace-vars-object-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/replace-vars-object-test.php
@@ -6,13 +6,13 @@ use Yoast\WP\SEO\Tests\TestCase;
 use Brain\Monkey;
 
 /**
- * Class Generate_Source_Test
+ * Class Replace_Vars_Object_Test
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presentations\Indexable_Term_Archive_Presentation
  *
  * @group presentations
  */
-class Generate_Source_Test extends TestCase {
+class Replace_Vars_Object_Test extends TestCase {
 	use Presentation_Instance_Builder;
 
 	/**


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.

### QA: rename some test classes

The names of test classes in the new `tests` directory should not include the plugin prefix, nor should the file names be prefixed with `class-`.

### QA: rename some test classes / Replace_Vars_Object

These files were all called `replace-vars-object-test.php`, while the class contained therein was called `Generate_Source_Test`.

Per Herre:
> The `Generate_Source_Test` looks to be forgotten during a refactor.
> Originally, the files were called after the method under test and that got changed/renamed to the _values_ under test. Looks like the class name change was forgotten here.
>
> So, the file name is correct, the class name is not.

### QA: rename an incorrectly named test class / missing `_Test` suffix

All tests should have the `Test` class suffix.


Note: the Composer `autoload.php` file has to be regenerated after this change for those people running tests locally!

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test-only change and should have no effect on the functionality.