### PR TITLE
Docs: remove redundant `@package` tags [tests]

### DIFF
--- a/tests/admin/admin-features-test.php
+++ b/tests/admin/admin-features-test.php
@@ -13,8 +13,6 @@ use Yoast\WP\SEO\Tests\TestCase;
 /**
  * Class Admin_Features.
  *
- * @package Yoast\Tests\Admin
- *
  * @coversDefaultClass WPSEO_Admin
  */
 class Admin_Features_Test extends TestCase {

--- a/tests/admin/paper-presenter-test.php
+++ b/tests/admin/paper-presenter-test.php
@@ -8,8 +8,6 @@ use Brain\Monkey;
 
 /**
  * Class Paper_Presenter_Test
- *
- * @package Yoast\WP\SEO\Tests\Admin
  */
 class Paper_Presenter_Test extends TestCase {
 

--- a/tests/builders/indexable-author-builder-test.php
+++ b/tests/builders/indexable-author-builder-test.php
@@ -18,8 +18,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Author_Builder
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Builders
  */
 class Indexable_Author_Builder_Test extends TestCase {
 

--- a/tests/builders/indexable-builder-test.php
+++ b/tests/builders/indexable-builder-test.php
@@ -31,8 +31,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Builder
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Builders
  */
 class Indexable_Builder_Test extends TestCase {
 

--- a/tests/builders/indexable-date-archive-builder-test.php
+++ b/tests/builders/indexable-date-archive-builder-test.php
@@ -18,8 +18,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Date_Archive_Builder
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Builders
  */
 class Indexable_Date_Archive_Builder_Test extends TestCase {
 

--- a/tests/builders/indexable-hierarchy-builder-test.php
+++ b/tests/builders/indexable-hierarchy-builder-test.php
@@ -25,8 +25,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  * @covers ::<!public>
  * @covers ::__construct
  * @covers ::set_indexable_repository
- *
- * @package Yoast\Tests\Builders
  */
 class Indexable_Hierarchy_Builder_Test extends TestCase {
 

--- a/tests/builders/indexable-home-page-builder-test.php
+++ b/tests/builders/indexable-home-page-builder-test.php
@@ -22,8 +22,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Author_Builder
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Builders
  */
 class Indexable_Home_Page_Builder_Test extends TestCase {
 

--- a/tests/builders/indexable-post-builder-test.php
+++ b/tests/builders/indexable-post-builder-test.php
@@ -25,8 +25,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Post_Builder
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Watchers
  */
 class Indexable_Post_Builder_Test extends TestCase {
 

--- a/tests/builders/indexable-post-type-archive-builder-test.php
+++ b/tests/builders/indexable-post-type-archive-builder-test.php
@@ -18,8 +18,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Author_Builder
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Builders
  */
 class Indexable_Post_Type_Archive_Builder_Test extends TestCase {
 

--- a/tests/builders/indexable-rebuilder-test.php
+++ b/tests/builders/indexable-rebuilder-test.php
@@ -18,8 +18,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Rebuilder
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Builders
  */
 class Indexable_Rebuilder_Test extends TestCase {
 

--- a/tests/builders/indexable-system-page-builder-test.php
+++ b/tests/builders/indexable-system-page-builder-test.php
@@ -18,8 +18,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Author_Builder
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Builders
  */
 class Indexable_System_Page_Builder_Test extends TestCase {
 

--- a/tests/builders/indexable-term-builder-test.php
+++ b/tests/builders/indexable-term-builder-test.php
@@ -19,8 +19,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Term_Builder
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Builders
  */
 class Indexable_Term_Builder_Test extends TestCase {
 

--- a/tests/database/migration-runner-test.php
+++ b/tests/database/migration-runner-test.php
@@ -22,8 +22,6 @@ use YoastSEO_Vendor\Ruckusing_Task_Manager;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Initializers\Migration_Runner
  * @covers ::<!public>
- *
- * @package Yoast\Tests
  */
 class Migration_Runner_Test extends TestCase {
 

--- a/tests/database/migration-status-test.php
+++ b/tests/database/migration-status-test.php
@@ -13,8 +13,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Config\Migration_Status
  * @covers ::<!public>
- *
- * @package Yoast\Tests
  */
 class Migration_Status_Test extends TestCase {
 

--- a/tests/doubles/builders/indexable-post-builder-double.php
+++ b/tests/doubles/builders/indexable-post-builder-double.php
@@ -6,8 +6,6 @@ use Yoast\WP\SEO\Builders\Indexable_Post_Builder;
 
 /**
  * Class Indexable_Post_Builder_Double.
- *
- * @package Yoast\Tests\Doubles
  */
 class Indexable_Post_Builder_Double extends Indexable_Post_Builder {
 

--- a/tests/doubles/generators/schema/article-double.php
+++ b/tests/doubles/generators/schema/article-double.php
@@ -7,8 +7,6 @@ use Yoast\WP\SEO\Generators\Schema\Article;
 
 /**
  * Class Article_Double.
- *
- * @package Yoast\Tests\Doubles
  */
 class Article_Double extends Article {
 

--- a/tests/doubles/integrations/watchers/indexable-post-watcher-double.php
+++ b/tests/doubles/integrations/watchers/indexable-post-watcher-double.php
@@ -6,8 +6,6 @@ use Yoast\WP\SEO\Models\Indexable;
 
 /**
  * Class Indexable_Post_Watcher_Double.
- *
- * @package Yoast\Tests\Doubles
  */
 class Indexable_Post_Watcher_Double extends \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Watcher {
 

--- a/tests/doubles/shortlinker-double.php
+++ b/tests/doubles/shortlinker-double.php
@@ -4,8 +4,6 @@ namespace Yoast\WP\SEO\Tests\Doubles;
 
 /**
  * Class Shortlinker_Double.
- *
- * @package Yoast\Tests\Doubles
  */
 class Shortlinker_Double extends \WPSEO_Shortlinker {
 

--- a/tests/generators/schema/howto-test.php
+++ b/tests/generators/schema/howto-test.php
@@ -13,8 +13,6 @@ use Yoast\WP\SEO\Tests\TestCase;
 /**
  * Class HowTo_Test
  *
- * @package Yoast\WP\SEO\Tests\Generators\Schema
- *
  * @group generators
  * @group schema
  *

--- a/tests/integrations/watchers/indexable-author-watcher-test.php
+++ b/tests/integrations/watchers/indexable-author-watcher-test.php
@@ -24,8 +24,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Author_Watcher
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Watchers
  */
 class Indexable_Author_Watcher_Test extends TestCase {
 

--- a/tests/integrations/watchers/indexable-date-archive-watcher-test.php
+++ b/tests/integrations/watchers/indexable-date-archive-watcher-test.php
@@ -24,8 +24,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Date_Archive_Watcher
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Watchers
  */
 class Indexable_Date_Archive_Watcher_Test extends TestCase {
 

--- a/tests/integrations/watchers/indexable-home-page-watcher-test.php
+++ b/tests/integrations/watchers/indexable-home-page-watcher-test.php
@@ -24,8 +24,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Home_Page_Watcher
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Watchers
  */
 class Indexable_Home_Page_Watcher_Test extends TestCase {
 

--- a/tests/integrations/watchers/indexable-permalink-watcher-test.php
+++ b/tests/integrations/watchers/indexable-permalink-watcher-test.php
@@ -23,8 +23,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Permalink_Watcher
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Watchers
  */
 class Indexable_Permalink_Watcher_Test extends TestCase {
 

--- a/tests/integrations/watchers/indexable-post-meta-watcher-test.php
+++ b/tests/integrations/watchers/indexable-post-meta-watcher-test.php
@@ -22,8 +22,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  * @group watchers
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Meta_Watcher
- *
- * @package Yoast\Tests\Watchers
  */
 class Indexable_Post_Meta_Watcher_Test extends TestCase {
 

--- a/tests/integrations/watchers/indexable-post-type-archive-watcher-test.php
+++ b/tests/integrations/watchers/indexable-post-type-archive-watcher-test.php
@@ -24,8 +24,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Type_Archive_Watcher
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Watchers
  */
 class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 

--- a/tests/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/integrations/watchers/indexable-post-watcher-test.php
@@ -31,8 +31,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Watcher
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Watchers
  */
 class Indexable_Post_Watcher_Test extends TestCase {
 

--- a/tests/integrations/watchers/indexable-static-home-page-watcher-test.php
+++ b/tests/integrations/watchers/indexable-static-home-page-watcher-test.php
@@ -24,8 +24,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Static_Home_Page_Watcher
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Watchers
  */
 class Indexable_Static_Home_Page_Watcher_Test extends TestCase {
 

--- a/tests/integrations/watchers/indexable-system-page-watcher-test.php
+++ b/tests/integrations/watchers/indexable-system-page-watcher-test.php
@@ -24,8 +24,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_System_Page_Watcher
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Watchers
  */
 class Indexable_System_Page_Watcher_Test extends TestCase {
 

--- a/tests/integrations/watchers/indexable-term-watcher-test.php
+++ b/tests/integrations/watchers/indexable-term-watcher-test.php
@@ -26,8 +26,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Term_Watcher
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Watchers
  */
 class Indexable_Term_Watcher_Test extends TestCase {
 

--- a/tests/integrations/watchers/primary-term-watcher-test.php
+++ b/tests/integrations/watchers/primary-term-watcher-test.php
@@ -25,8 +25,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Primary_Term_Watcher
  * @covers ::<!public>
- *
- * @package Yoast\Tests\Watchers
  */
 class Primary_Term_Watcher_Test extends TestCase {
 

--- a/tests/loader-test.php
+++ b/tests/loader-test.php
@@ -17,8 +17,6 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @coversDefaultClass \Yoast\WP\SEO\Loader
  * @covers ::<!public>
- *
- * @package Yoast\WP\SEO\Tests
  */
 class Loader_Test extends TestCase {
 

--- a/tests/presentations/indexable-author-archive-presentation/meta-description-test.php
+++ b/tests/presentations/indexable-author-archive-presentation/meta-description-test.php
@@ -11,8 +11,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group presentations
  * @group meta-description
- *
- * @package Yoast\Tests\Presentations\Indexable_Author_Archive_Presentation
  */
 class Meta_Description_Test extends TestCase {
 	use Presentation_Instance_Builder;

--- a/tests/presentations/indexable-author-archive-presentation/title-test.php
+++ b/tests/presentations/indexable-author-archive-presentation/title-test.php
@@ -11,8 +11,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group presentations
  * @group title
- *
- * @package Yoast\Tests\Presentations\Indexable_Author_Archive_Presentation
  */
 class Title_Test extends TestCase {
 	use Presentation_Instance_Builder;

--- a/tests/presentations/indexable-date-archive-presentation/robots-test.php
+++ b/tests/presentations/indexable-date-archive-presentation/robots-test.php
@@ -7,10 +7,8 @@ use Yoast\WP\SEO\Tests\TestCase;
 /**
  * Class Robots_Test.
  *
- * @group   presentations
- * @group   robots
- *
- * @package Yoast\Tests\Presentations\Indexable_Date_Archive_Presentation
+ * @group presentations
+ * @group robots
  */
 class Robots_Test extends TestCase {
 	use Presentation_Instance_Builder;

--- a/tests/presentations/indexable-date-archive-presentation/title-test.php
+++ b/tests/presentations/indexable-date-archive-presentation/title-test.php
@@ -11,8 +11,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group presentations
  * @group title
- *
- * @package Yoast\Tests\Presentations\Indexable_Date_Archive_Presentation
  */
 class Title_Test extends TestCase {
 	use Presentation_Instance_Builder;

--- a/tests/presentations/indexable-error-page-presentation/title-test.php
+++ b/tests/presentations/indexable-error-page-presentation/title-test.php
@@ -11,8 +11,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group presentations
  * @group title
- *
- * @package Yoast\Tests\Presentations\Indexable_Error_Page_Presentation
  */
 class Title_Test extends TestCase {
 	use Presentation_Instance_Builder;

--- a/tests/presentations/indexable-search-result-page-presentation/title-test.php
+++ b/tests/presentations/indexable-search-result-page-presentation/title-test.php
@@ -11,8 +11,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group presentations
  * @group title
- *
- * @package Yoast\Tests\Presentations\Indexable_Search_Result_Page_Presentation
  */
 class Title_Test extends TestCase {
 	use Presentation_Instance_Builder;

--- a/tests/presentations/indexable-search-result-page-presentation/twitter-title-test.php
+++ b/tests/presentations/indexable-search-result-page-presentation/twitter-title-test.php
@@ -11,8 +11,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  *
  * @group presentations
  * @group twitter
- *
- * @package Yoast\Tests\Presentations\Indexable_Search_Result_Page_Presentation
  */
 class Twitter_Title_Test extends TestCase {
 	use Presentation_Instance_Builder;

--- a/tests/presenters/bingbot-presenter-test.php
+++ b/tests/presenters/bingbot-presenter-test.php
@@ -14,8 +14,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Bingbot_Presenter
  *
  * @group presenters
- *
- * @package Yoast\WP\SEO\Tests\Presenters
  */
 class Bingbot_Presenter_Test extends TestCase {
 

--- a/tests/presenters/googlebot-presenter-test.php
+++ b/tests/presenters/googlebot-presenter-test.php
@@ -14,8 +14,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Googlebot_Presenter
  *
  * @group   presenters
- *
- * @package Yoast\WP\SEO\Tests\Presenters
  */
 class Googlebot_Presenter_Test extends TestCase {
 

--- a/tests/presenters/robots-presenter-test.php
+++ b/tests/presenters/robots-presenter-test.php
@@ -14,8 +14,6 @@ use Yoast\WP\SEO\Tests\TestCase;
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Robots_Presenter
  *
  * @group presenters
- *
- * @package Yoast\WP\SEO\Tests\Presenters
  */
 class Robots_Presenter_Test extends TestCase {
 


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.

The `@package` tag (at class level) isn't necessary in namespaced files. Also, the tag was often incorrect.

Removed now.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.