### PR TITLE
QA: add missing import `use` statements for classes [src]

### DIFF
--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Dependency_Injection;
 
+use ReflectionException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -161,7 +162,7 @@ class Custom_Loader extends PhpFileLoader {
 
 			try {
 				$r = $this->container->getReflectionClass( $class );
-			} catch ( \ReflectionException $e ) {
+			} catch ( ReflectionException $e ) {
 				$classes[ $class ] = \sprintf(
 					'While discovering services from namespace "%s", an error was thrown when processing the class "%s": "%s".',
 					$namespace,

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -8,6 +8,7 @@
 namespace Yoast\WP\SEO\Builders;
 
 use Exception;
+use WPSEO_Meta;
 use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Models\Indexable;
@@ -343,7 +344,7 @@ class Indexable_Post_Builder {
 	 * @return mixed The value of the indexable entry to use.
 	 */
 	protected function get_meta_value( $post_id, $meta_key ) {
-		$value = \WPSEO_Meta::get_value( $meta_key, $post_id );
+		$value = WPSEO_Meta::get_value( $meta_key, $post_id );
 		if ( \is_string( $value ) && $value === '' ) {
 			return null;
 		}

--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Commands;
 
+use WP_CLI;
 use Yoast\WP\Lib\Model;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
@@ -133,7 +134,7 @@ class Index_Command implements Command_Interface {
 	 */
 	protected function run_indexation_actions( $reindex ) {
 		if ( $reindex ) {
-			\WP_CLI::confirm( 'This will clear all previously indexed objects. Are you certain you wish to proceed?' );
+			WP_CLI::confirm( 'This will clear all previously indexed objects. Are you certain you wish to proceed?' );
 			$this->clear();
 		}
 

--- a/src/conditionals/development-conditional.php
+++ b/src/conditionals/development-conditional.php
@@ -7,6 +7,8 @@
 
 namespace Yoast\WP\SEO\Conditionals;
 
+use WPSEO_Utils;
+
 /**
  * Conditional that is only met when in development mode.
  */
@@ -18,6 +20,6 @@ class Development_Conditional implements Conditional {
 	 * @return boolean Whether or not the conditional is met.
 	 */
 	public function is_met() {
-		return \WPSEO_Utils::is_development_mode();
+		return WPSEO_Utils::is_development_mode();
 	}
 }

--- a/src/exceptions/missing-method.php
+++ b/src/exceptions/missing-method.php
@@ -7,10 +7,12 @@
 
 namespace Yoast\WP\SEO\Exceptions;
 
+use Exception;
+
 /**
  * The exception when a method does not exists.
  */
-class Missing_Method extends \Exception {
+class Missing_Method extends Exception {
 
 	/**
 	 * Creates exception for a method that does not exists in a class.

--- a/src/generators/open-graph-image-generator.php
+++ b/src/generators/open-graph-image-generator.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Generators;
 
+use Error;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper as Open_Graph_Image_Helper;
@@ -92,7 +93,7 @@ class Open_Graph_Image_Generator implements Generator_Interface {
 			 * @api Yoast\WP\SEO\Values\Open_Graph\Images The current object.
 			 */
 			apply_filters( 'wpseo_add_opengraph_images', $image_container );
-		} catch ( \Error $error ) {
+		} catch ( Error $error ) {
 			$image_container = $backup_image_container;
 		}
 
@@ -106,7 +107,7 @@ class Open_Graph_Image_Generator implements Generator_Interface {
 			 * @api Yoast\WP\SEO\Values\Open_Graph\Images The current object.
 			 */
 			apply_filters( 'wpseo_add_opengraph_additional_images', $image_container );
-		} catch ( \Error $error ) {
+		} catch ( Error $error ) {
 			$image_container = $backup_image_container;
 		}
 

--- a/src/helpers/date-helper.php
+++ b/src/helpers/date-helper.php
@@ -7,6 +7,8 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
+use WPSEO_Date_Helper;
+
 /**
  * Class Date_Helper
  */
@@ -25,7 +27,7 @@ class Date_Helper {
 	 * @codeCoverageIgnore It only sets dependencies.
 	 */
 	public function __construct() {
-		$this->date = new \WPSEO_Date_Helper();
+		$this->date = new WPSEO_Date_Helper();
 	}
 
 	/**

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -240,7 +240,7 @@ class Image_Helper {
 	 * @return array|false Returns an array with image data on success, false on failure.
 	 */
 	public function get_image( $attachment_id, $size ) {
-		return \WPSEO_Image_Utils::get_image( $attachment_id, $size );
+		return WPSEO_Image_Utils::get_image( $attachment_id, $size );
 	}
 
 	/**
@@ -253,8 +253,8 @@ class Image_Helper {
 	 * @return bool|string The attachment url or false when no variations found.
 	 */
 	public function get_best_attachment_variation( $attachment_id ) {
-		$variations = \WPSEO_Image_Utils::get_variations( $attachment_id );
-		$variations = \WPSEO_Image_Utils::filter_usable_file_size( $variations );
+		$variations = WPSEO_Image_Utils::get_variations( $attachment_id );
+		$variations = WPSEO_Image_Utils::filter_usable_file_size( $variations );
 
 		// If we are left without variations, there is no valid variation for this attachment.
 		if ( empty( $variations ) ) {

--- a/src/helpers/meta-helper.php
+++ b/src/helpers/meta-helper.php
@@ -7,6 +7,8 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
+use WPSEO_Meta;
+
 /**
  * Class Meta_Helper
  */
@@ -35,6 +37,6 @@ class Meta_Helper {
 	 *                if the post does not exist.
 	 */
 	public function get_value( $key, $postid = 0 ) {
-		return \WPSEO_Meta::get_value( $key, $postid );
+		return WPSEO_Meta::get_value( $key, $postid );
 	}
 }

--- a/src/helpers/product-helper.php
+++ b/src/helpers/product-helper.php
@@ -7,6 +7,8 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
+use WPSEO_Utils;
+
 /**
  * Class Product_Helper
  */
@@ -33,6 +35,6 @@ class Product_Helper {
 	 * @return bool True when is premium.
 	 */
 	protected function is_premium() {
-		return \WPSEO_Utils::is_yoast_seo_premium();
+		return WPSEO_Utils::is_yoast_seo_premium();
 	}
 }

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -7,6 +7,8 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
+use WPSEO_Taxonomy_Meta;
+
 /**
  * Class Taxonomy_Helper
  */
@@ -84,6 +86,6 @@ class Taxonomy_Helper {
 	 *                    False if the term does not exist or the $meta provided is invalid.
 	 */
 	public function get_term_meta( $term ) {
-		return \WPSEO_Taxonomy_Meta::get_term_meta( $term, $term->taxonomy, null );
+		return WPSEO_Taxonomy_Meta::get_term_meta( $term, $term->taxonomy, null );
 	}
 }

--- a/src/integrations/primary-category.php
+++ b/src/integrations/primary-category.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Integrations;
 
+use WPSEO_Primary_Term;
 use Yoast\WP\SEO\Conditionals\Primary_Category_Conditional;
 
 /**
@@ -63,7 +64,7 @@ class Primary_Category implements Integration_Interface {
 	 * @return int Primary category id.
 	 */
 	protected function get_primary_category( $post ) {
-		$primary_term = new \WPSEO_Primary_Term( 'category', $post->ID );
+		$primary_term = new WPSEO_Primary_Term( 'category', $post->ID );
 
 		return $primary_term->get_primary_term();
 	}

--- a/src/loader.php
+++ b/src/loader.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO;
 
+use WP_CLI;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -133,7 +134,7 @@ class Loader {
 		foreach ( $this->commands as $class ) {
 			$command = $this->container->get( $class );
 
-			\WP_CLI::add_command( $class::get_namespace(), $command );
+			WP_CLI::add_command( $class::get_namespace(), $command );
 		}
 	}
 

--- a/src/main.php
+++ b/src/main.php
@@ -79,7 +79,7 @@ class Main {
 			}
 
 			$this->container->get( Loader::class )->load();
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			if ( $this->is_development() ) {
 				throw $e;
 			}

--- a/src/presenters/admin/alert-presenter.php
+++ b/src/presenters/admin/alert-presenter.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 
+use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
 /**
@@ -49,7 +50,7 @@ class Alert_Presenter extends Abstract_Presenter {
 		$this->type    = $type;
 
 		if ( ! $this->asset_manager ) {
-			$this->asset_manager = new \WPSEO_Admin_Asset_Manager();
+			$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 		}
 
 		$this->asset_manager->enqueue_style( 'alert' );

--- a/src/presenters/admin/indexation-list-item-presenter.php
+++ b/src/presenters/admin/indexation-list-item-presenter.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 
+use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
 /**
@@ -39,7 +40,7 @@ class Indexation_List_Item_Presenter extends Abstract_Presenter {
 		$output  = \sprintf( '<li><strong>%s</strong>', \esc_html__( 'SEO Data', 'wordpress-seo' ) );
 		$output .= \sprintf(
 			'<p><a href="%1$s" target="_blank">%2$s</a>%3$s</p>',
-			\esc_url( \WPSEO_Shortlinker::get( 'https://yoa.st/3-z' ) ),
+			\esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3-z' ) ),
 			\sprintf(
 				/* translators: 1: Expands to Yoast SEO. */
 				\esc_html__( '%1$s creates and maintains an index of all of your site\'s SEO data in order to speed up your site', 'wordpress-seo' ),

--- a/src/presenters/debug/marker-open-presenter.php
+++ b/src/presenters/debug/marker-open-presenter.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Presenters\Debug;
 
+use WPSEO_Utils;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 
 /**
@@ -37,7 +38,7 @@ final class Marker_Open_Presenter extends Abstract_Indexable_Presenter {
 			 *
 			 * @api bool
 			 */
-			( ( \apply_filters( 'wpseo_hide_version', false ) && \WPSEO_Utils::is_yoast_seo_premium() ) ? '' : 'v' . \WPSEO_VERSION )
+			( ( \apply_filters( 'wpseo_hide_version', false ) && WPSEO_Utils::is_yoast_seo_premium() ) ? '' : 'v' . \WPSEO_VERSION )
 		);
 	}
 

--- a/src/presenters/schema-presenter.php
+++ b/src/presenters/schema-presenter.php
@@ -7,6 +7,8 @@
 
 namespace Yoast\WP\SEO\Presenters;
 
+use WPSEO_Utils;
+
 /**
  * Class Schema_Presenter
  */
@@ -39,7 +41,7 @@ class Schema_Presenter extends Abstract_Indexable_Presenter {
 
 		$schema = $this->get();
 		if ( is_array( $schema ) ) {
-			$output = \WPSEO_Utils::format_json_encode( $schema );
+			$output = WPSEO_Utils::format_json_encode( $schema );
 			$output = \str_replace( "\n", PHP_EOL . "\t", $output );
 			return '<script type="application/ld+json" class="yoast-schema-graph">' . $output . '</script>';
 		}


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.

Always be explicit about which classes are being used in a namespaced file.

* Always use _unqualified_ names for classes in code.
* Always have an import `use` statement for classes, unless the class is from the same namespace.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.