### PR TITLE
QA: add missing import `use` statements for classes [tests]

### DIFF
--- a/tests/admin/admin-features-test.php
+++ b/tests/admin/admin-features-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Admin;
 
+use WP_User;
 use WPSEO_Admin;
 use WPSEO_Primary_Term_Admin;
 use Yoast_Dashboard_Widget;
@@ -38,7 +39,7 @@ class Admin_Features_Test extends TestCase {
 		// Mock the current user for notifications.
 		Monkey\Functions\expect( 'wp_get_current_user' )
 			->times( 1 )
-			->andReturn( Mockery::mock( \WP_User::class ) );
+			->andReturn( Mockery::mock( WP_User::class ) );
 
 		return new WPSEO_Admin();
 	}

--- a/tests/doubles/context/meta-tags-context-mock.php
+++ b/tests/doubles/context/meta-tags-context-mock.php
@@ -7,10 +7,12 @@
 
 namespace Yoast\WP\SEO\Tests\Doubles\Context;
 
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
+
 /**
  * Class Meta_Tags_Context_Mock
  */
-class Meta_Tags_Context_Mock extends \Yoast\WP\SEO\Context\Meta_Tags_Context {
+class Meta_Tags_Context_Mock extends Meta_Tags_Context {
 
 	/**
 	 * @var string

--- a/tests/doubles/generators/schema/author-mock.php
+++ b/tests/doubles/generators/schema/author-mock.php
@@ -3,8 +3,9 @@
 namespace Yoast\WP\SEO\Tests\Doubles\Generators\Schema;
 
 use Yoast\WP\SEO\Context\Meta_Tags_Context as Meta_Tags_Context_Original;
+use Yoast\WP\SEO\Generators\Schema\Author;
 
-class Author_Mock extends \Yoast\WP\SEO\Generators\Schema\Author {
+class Author_Mock extends Author {
 
 	/**
 	 * @inheritDoc

--- a/tests/doubles/inc/addon-manager-double.php
+++ b/tests/doubles/inc/addon-manager-double.php
@@ -2,10 +2,12 @@
 
 namespace Yoast\WP\SEO\Tests\Doubles\Inc;
 
+use WPSEO_Addon_Manager;
+
 /**
  * Test Helper Class.
  */
-class Addon_Manager_Double extends \WPSEO_Addon_Manager {
+class Addon_Manager_Double extends WPSEO_Addon_Manager {
 
 	/**
 	 * Checks if the given plugin_file belongs to a Yoast addon.

--- a/tests/doubles/integrations/watchers/indexable-post-watcher-double.php
+++ b/tests/doubles/integrations/watchers/indexable-post-watcher-double.php
@@ -2,12 +2,13 @@
 
 namespace Yoast\WP\SEO\Tests\Doubles\Integrations\Watchers;
 
+use Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Watcher;
 use Yoast\WP\SEO\Models\Indexable;
 
 /**
  * Class Indexable_Post_Watcher_Double.
  */
-class Indexable_Post_Watcher_Double extends \Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Watcher {
+class Indexable_Post_Watcher_Double extends Indexable_Post_Watcher {
 
 	/**
 	 * @inheritDoc

--- a/tests/doubles/models/indexable-mock.php
+++ b/tests/doubles/models/indexable-mock.php
@@ -2,12 +2,14 @@
 
 namespace Yoast\WP\SEO\Tests\Doubles\Models;
 
+use Yoast\WP\SEO\Models\Indexable;
+
 /**
  * Class Indexable_Mock
  *
  * Indexable mock class.
  */
-class Indexable_Mock extends \Yoast\WP\SEO\Models\Indexable {
+class Indexable_Mock extends Indexable {
 
 	public $id;
 

--- a/tests/doubles/models/primary-term-mock.php
+++ b/tests/doubles/models/primary-term-mock.php
@@ -2,12 +2,14 @@
 
 namespace Yoast\WP\SEO\Tests\Doubles\Models;
 
+use Yoast\WP\SEO\Models\Primary_Term;
+
 /**
  * Class Primary_Term_Mock
  *
  * Primary_Term mock class.
  */
-class Primary_Term_Mock extends \Yoast\WP\SEO\Models\Primary_Term {
+class Primary_Term_Mock extends Primary_Term {
 
 	public $id;
 

--- a/tests/doubles/presentations/abstract-presentation-mock.php
+++ b/tests/doubles/presentations/abstract-presentation-mock.php
@@ -2,10 +2,12 @@
 
 namespace Yoast\WP\SEO\Tests\Doubles\Presentations;
 
+use Yoast\WP\SEO\Presentations\Abstract_Presentation;
+
 /**
  * Represents the Abstract_Presentation mock.
  */
-class Abstract_Presentation_Mock extends \Yoast\WP\SEO\Presentations\Abstract_Presentation {
+class Abstract_Presentation_Mock extends Abstract_Presentation {
 
 	/**
 	 * @inheritDoc

--- a/tests/doubles/routes/abstract-indexation-route-mock.php
+++ b/tests/doubles/routes/abstract-indexation-route-mock.php
@@ -7,10 +7,12 @@
 
 namespace Yoast\WP\SEO\Tests\Doubles\Routes;
 
+use Yoast\WP\SEO\Routes\Abstract_Indexation_Route;
+
 /**
  * Represents the Abstract_Indexation_Route mock.
  */
-class Abstract_Indexation_Route_Mock extends \Yoast\WP\SEO\Routes\Abstract_Indexation_Route {
+class Abstract_Indexation_Route_Mock extends Abstract_Indexation_Route {
 
 	/**
 	 * @inheritDoc

--- a/tests/doubles/shortlinker-double.php
+++ b/tests/doubles/shortlinker-double.php
@@ -2,10 +2,12 @@
 
 namespace Yoast\WP\SEO\Tests\Doubles;
 
+use WPSEO_Shortlinker;
+
 /**
  * Class Shortlinker_Double.
  */
-class Shortlinker_Double extends \WPSEO_Shortlinker {
+class Shortlinker_Double extends WPSEO_Shortlinker {
 
 	/**
 	 * Gets the additional shortlink data.

--- a/tests/generators/open-graph-image-generator-test.php
+++ b/tests/generators/open-graph-image-generator-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Generators;
 
 use Brain\Monkey;
+use Error;
 use Mockery;
 use Yoast\WP\SEO\Generators\Open_Graph_Image_Generator;
 use Yoast\WP\SEO\Helpers\Image_Helper;
@@ -105,7 +106,7 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 		$this->indexable->open_graph_image_id = 1337;
 
 		Monkey\Filters\expectApplied( 'wpseo_add_opengraph_images' )
-			->andThrow( new \Error( 'Something went wrong' ) );
+			->andThrow( new Error( 'Something went wrong' ) );
 
 		$this->instance->expects( 'add_from_default' )->andReturnNull();
 
@@ -127,7 +128,7 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 		$this->indexable->open_graph_image_id = 1337;
 
 		Monkey\Filters\expectApplied( 'wpseo_add_opengraph_additional_images' )
-			->andThrow( new \Error( 'Something went wrong' ) );
+			->andThrow( new Error( 'Something went wrong' ) );
 
 		$this->instance->expects( 'add_from_default' )->andReturnNull();
 

--- a/tests/generators/schema/faq-test.php
+++ b/tests/generators/schema/faq-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Generators\Schema;
 
+use Mockery;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
 use Yoast\WP\SEO\Generators\Schema\FAQ;
@@ -43,8 +44,8 @@ class FAQ_Test extends TestCase {
 	 * @inheritDoc
 	 */
 	public function setUp() {
-		$this->html     = \Mockery::mock( HTML_Helper::class );
-		$this->language = \Mockery::mock( Language_Helper::class );
+		$this->html     = Mockery::mock( HTML_Helper::class );
+		$this->language = Mockery::mock( Language_Helper::class );
 
 		$this->instance = new FAQ();
 

--- a/tests/generators/schema/howto-test.php
+++ b/tests/generators/schema/howto-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Generators\Schema;
 
+use Mockery;
 use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Image_Helper;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
@@ -142,15 +143,15 @@ class HowTo_Test extends TestCase {
 
 		$id = 1234;
 
-		$this->meta_tags_context = \Mockery::mock( Meta_Tags_Context_Mock::class );
+		$this->meta_tags_context = Mockery::mock( Meta_Tags_Context_Mock::class );
 
 		$this->meta_tags_context->id             = $id;
 		$this->meta_tags_context->main_schema_id = 'https://example.com/post-1#main-schema-id';
 
-		$this->html     = \Mockery::mock( HTML_Helper::class );
-		$this->image    = \Mockery::mock( Image_Helper::class );
-		$this->post     = \Mockery::mock( Post_Helper::class );
-		$this->language = \Mockery::mock( Language_Helper::class );
+		$this->html     = Mockery::mock( HTML_Helper::class );
+		$this->image    = Mockery::mock( Image_Helper::class );
+		$this->post     = Mockery::mock( Post_Helper::class );
+		$this->language = Mockery::mock( Language_Helper::class );
 
 		$this->html
 			->shouldReceive( 'smart_strip_tags' )

--- a/tests/helpers/date-helper-test.php
+++ b/tests/helpers/date-helper-test.php
@@ -2,8 +2,9 @@
 
 namespace Yoast\WP\SEO\Tests\Helpers;
 
-use Yoast\WP\SEO\Tests\TestCase;
 use Brain\Monkey;
+use WPSEO_Date_Helper;
+use Yoast\WP\SEO\Tests\TestCase;
 
 /**
  * Unit Test Class.
@@ -27,7 +28,7 @@ class Date_Helper_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->instance = new \WPSEO_Date_Helper();
+		$this->instance = new WPSEO_Date_Helper();
 	}
 
 	/**

--- a/tests/helpers/primary-term-helper-test.php
+++ b/tests/helpers/primary-term-helper-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Helpers;
 
 use Brain\Monkey;
+use Mockery;
 use Yoast\WP\SEO\Helpers\Primary_Term_Helper;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -26,7 +27,7 @@ class Primary_Term_Helper_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->instance = \Mockery::mock( Primary_Term_Helper::class )
+		$this->instance = Mockery::mock( Primary_Term_Helper::class )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 	}

--- a/tests/inc/health-check-curl-version-test.php
+++ b/tests/inc/health-check-curl-version-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Inc;
 
 use Brain\Monkey;
 use Mockery;
+use WPSEO_Health_Check_Curl_Version;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -26,7 +27,7 @@ class Health_Check_Curl_Version_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->instance = Mockery::mock( \WPSEO_Health_Check_Curl_Version::class )
+		$this->instance = Mockery::mock( WPSEO_Health_Check_Curl_Version::class )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 	}

--- a/tests/inc/health-check-default-tagline-test.php
+++ b/tests/inc/health-check-default-tagline-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Inc;
 
 use Brain\Monkey;
+use WPSEO_Health_Check_Default_Tagline;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -32,7 +33,7 @@ class Health_Check_Default_Tagline_Test extends TestCase {
 			->once()
 			->andReturn( 'http://example.org/wp-admin/customize.php?autofocus[control]=blogdescription' );
 
-		$health_check = new \WPSEO_Health_Check_Default_Tagline();
+		$health_check = new WPSEO_Health_Check_Default_Tagline();
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "not passed" message.
@@ -51,7 +52,7 @@ class Health_Check_Default_Tagline_Test extends TestCase {
 			->with( 'blogdescription' )
 			->andReturn( '' );
 
-		$health_check = new \WPSEO_Health_Check_Default_Tagline();
+		$health_check = new WPSEO_Health_Check_Default_Tagline();
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "passed" message.
@@ -70,7 +71,7 @@ class Health_Check_Default_Tagline_Test extends TestCase {
 			->with( 'blogdescription' )
 			->andReturn( 'My custom site tagline' );
 
-		$health_check = new \WPSEO_Health_Check_Default_Tagline();
+		$health_check = new WPSEO_Health_Check_Default_Tagline();
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "passed" message.

--- a/tests/inc/health-check-link-table-not-accessible-test.php
+++ b/tests/inc/health-check-link-table-not-accessible-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Inc;
 
 use Brain\Monkey;
 use Mockery;
+use WPSEO_Health_Check_Link_Table_Not_Accessible;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -26,7 +27,7 @@ class Health_Check_Link_Table_Not_Accessible_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->instance = Mockery::mock( \WPSEO_Health_Check_Link_Table_Not_Accessible::class )
+		$this->instance = Mockery::mock( WPSEO_Health_Check_Link_Table_Not_Accessible::class )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 	}

--- a/tests/inc/health-check-page-comments-test.php
+++ b/tests/inc/health-check-page-comments-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Inc;
 
 use Brain\Monkey;
+use WPSEO_Health_Check_Page_Comments;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -24,7 +25,7 @@ class Health_Check_Page_Comments_Test extends TestCase {
 			->with( 'page_comments' )
 			->andReturn( '0' );
 
-		$health_check = new \WPSEO_Health_Check_Page_Comments();
+		$health_check = new WPSEO_Health_Check_Page_Comments();
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "passed" message.
@@ -45,7 +46,7 @@ class Health_Check_Page_Comments_Test extends TestCase {
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( '' );
 
-		$health_check = new \WPSEO_Health_Check_Page_Comments();
+		$health_check = new WPSEO_Health_Check_Page_Comments();
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "not passed" message.

--- a/tests/inc/health-check-postname-permalink-test.php
+++ b/tests/inc/health-check-postname-permalink-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Inc;
 
 use Brain\Monkey;
+use WPSEO_Health_Check_Postname_Permalink;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -24,7 +25,7 @@ class Health_Check_Postname_Permalink_Test extends TestCase {
 			->with( 'permalink_structure' )
 			->andReturn( '/%postname%/' );
 
-		$health_check = new \WPSEO_Health_Check_Postname_Permalink();
+		$health_check = new WPSEO_Health_Check_Postname_Permalink();
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "passed" message.
@@ -43,7 +44,7 @@ class Health_Check_Postname_Permalink_Test extends TestCase {
 			->with( 'permalink_structure' )
 			->andReturn( '/%category%/%postname%/' );
 
-		$health_check = new \WPSEO_Health_Check_Postname_Permalink();
+		$health_check = new WPSEO_Health_Check_Postname_Permalink();
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "passed" message.
@@ -64,7 +65,7 @@ class Health_Check_Postname_Permalink_Test extends TestCase {
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( '' );
 
-		$health_check = new \WPSEO_Health_Check_Postname_Permalink();
+		$health_check = new WPSEO_Health_Check_Postname_Permalink();
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "not passed" message.

--- a/tests/inc/health-check-ryte-test.php
+++ b/tests/inc/health-check-ryte-test.php
@@ -4,8 +4,10 @@ namespace Yoast\WP\SEO\Tests\Inc;
 
 use Brain\Monkey;
 use Mockery;
-use Yoast\WP\SEO\Tests\TestCase;
+use WPSEO_Health_Check_Ryte;
+use WPSEO_Ryte_Option;
 use WPSEO_Utils;
+use Yoast\WP\SEO\Tests\TestCase;
 
 /**
  * Unit Test Class.
@@ -28,11 +30,11 @@ class Health_Check_Ryte_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->ryte_option = Mockery::mock( \WPSEO_Ryte_Option::class )
+		$this->ryte_option = Mockery::mock( WPSEO_Ryte_Option::class )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 
-		$this->health_check = Mockery::mock( \WPSEO_Health_Check_Ryte::class )
+		$this->health_check = Mockery::mock( WPSEO_Health_Check_Ryte::class )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 	}
@@ -143,7 +145,7 @@ class Health_Check_Ryte_Test extends TestCase {
 		$this->ryte_option
 			->expects( 'get_status' )
 			->once()
-			->andReturn( \WPSEO_Ryte_Option::IS_NOT_INDEXABLE );
+			->andReturn( WPSEO_Ryte_Option::IS_NOT_INDEXABLE );
 
 		Monkey\Functions\expect( 'wp_get_schedules' )->andReturn( [] );
 		Monkey\Functions\expect( 'update_option' )->andReturn( true );
@@ -179,7 +181,7 @@ class Health_Check_Ryte_Test extends TestCase {
 		$this->ryte_option
 			->expects( 'get_status' )
 			->once()
-			->andReturn( \WPSEO_Ryte_Option::CANNOT_FETCH );
+			->andReturn( WPSEO_Ryte_Option::CANNOT_FETCH );
 
 		Monkey\Functions\expect( 'wp_get_schedules' )->andReturn( [] );
 		Monkey\Functions\expect( 'update_option' )->andReturn( true );
@@ -217,7 +219,7 @@ class Health_Check_Ryte_Test extends TestCase {
 		$this->ryte_option
 			->expects( 'get_status' )
 			->once()
-			->andReturn( \WPSEO_Ryte_Option::IS_INDEXABLE );
+			->andReturn( WPSEO_Ryte_Option::IS_INDEXABLE );
 
 		Monkey\Functions\expect( 'wp_get_schedules' )->andReturn( [] );
 		Monkey\Functions\expect( 'update_option' )->andReturn( true );

--- a/tests/inc/health-check-test.php
+++ b/tests/inc/health-check-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Inc;
 
 use Brain\Monkey;
 use Mockery;
+use WPSEO_Health_Check;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
@@ -26,7 +27,7 @@ class Health_Check_Test extends TestCase {
 	 * @return void
 	 */
 	public function setUp() {
-		$this->instance = Mockery::mock( \WPSEO_Health_Check::class )
+		$this->instance = Mockery::mock( WPSEO_Health_Check::class )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
 

--- a/tests/integrations/admin/migration-error-integration-test.php
+++ b/tests/integrations/admin/migration-error-integration-test.php
@@ -9,6 +9,7 @@ namespace Yoast\WP\SEO\Tests\Integrations\Admin;
 
 use Brain\Monkey;
 use Mockery;
+use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Config\Migration_Status;
 use Yoast\WP\SEO\Integrations\Admin\Migration_Error_Integration;
@@ -114,7 +115,7 @@ class Migration_Error_Integration_Test extends TestCase {
 
 		$expected  = '<div class="notice notice-error">';
 		$expected .= '<p>Yoast SEO had problems creating the database tables needed to speed up your site.</p>';
-		$expected .= '<p>Please read <a href="' . \WPSEO_Shortlinker::get( 'https://yoa.st/3-6' ) . '">this help article</a> to find out how to resolve this problem.</p>';
+		$expected .= '<p>Please read <a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/3-6' ) . '">this help article</a> to find out how to resolve this problem.</p>';
 		$expected .= '<p>Your site will continue to work normally, but won\'t take full advantage of Yoast SEO.</p>';
 		$expected .= '<details><summary>Show debug information</summary><p>test error</p></details>';
 		$expected .= '</div>';

--- a/tests/integrations/front-end/handle-404-test.php
+++ b/tests/integrations/front-end/handle-404-test.php
@@ -9,6 +9,7 @@ namespace Yoast\WP\SEO\Tests\Integrations\Front_End;
 
 use Brain\Monkey;
 use Mockery;
+use stdClass;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Integrations\Front_End\Handle_404;
 use Yoast\WP\SEO\Tests\TestCase;
@@ -96,7 +97,7 @@ class Handle_404_Test extends TestCase {
 			->once()
 			->andReturn( true );
 
-		$wp_query        = new \stdClass();
+		$wp_query        = new stdClass();
 		$wp_query->posts = true;
 
 		$this->query_wrapper

--- a/tests/presentations/abstract-presentation-test.php
+++ b/tests/presentations/abstract-presentation-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Presentations;
 
+use Mockery;
 use Yoast\WP\SEO\Tests\Doubles\Presentations\Abstract_Presentation_Mock;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -26,7 +27,7 @@ class Abstract_Presentation_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->instance = \Mockery::mock( Abstract_Presentation_Mock::class )->makePartial();
+		$this->instance = Mockery::mock( Abstract_Presentation_Mock::class )->makePartial();
 	}
 
 	/**

--- a/tests/presenters/meta-description-presenter-test.php
+++ b/tests/presenters/meta-description-presenter-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Presenters;
 
 use Brain\Monkey;
 use Mockery;
+use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Helpers\String_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Meta_Description_Presenter;
@@ -52,7 +53,7 @@ class Meta_Description_Presenter_Test extends TestCase {
 	 * Setup of the tests.
 	 */
 	public function setUp() {
-		$this->replace_vars = Mockery::mock( \WPSEO_Replace_Vars::class );
+		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
 		$this->string       = Mockery::mock( String_Helper::class );
 
 		$this->instance               = new Meta_Description_Presenter();

--- a/tests/presenters/open-graph/description-presenter-test.php
+++ b/tests/presenters/open-graph/description-presenter-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Presenters\Open_Graph;
 
 use Brain\Monkey;
 use Mockery;
+use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Open_Graph\Description_Presenter;
 use Yoast\WP\SEO\Tests\TestCase;
@@ -47,7 +48,7 @@ class Description_Presenter_Test extends TestCase {
 
 		$this->instance     = new Description_Presenter();
 		$this->presentation = new Indexable_Presentation();
-		$this->replace_vars = Mockery::mock( \WPSEO_Replace_Vars::class );
+		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
 
 		$this->instance->presentation = $this->presentation;
 		$this->instance->replace_vars = $this->replace_vars;

--- a/tests/presenters/open-graph/title-presenter-test.php
+++ b/tests/presenters/open-graph/title-presenter-test.php
@@ -2,8 +2,9 @@
 
 namespace Yoast\WP\SEO\Tests\Presenters\Open_Graph;
 
-use Mockery;
 use Brain\Monkey;
+use Mockery;
+use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Helpers\String_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Open_Graph\Title_Presenter;
@@ -53,7 +54,7 @@ class Title_Presenter_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->replace_vars = Mockery::mock( \WPSEO_Replace_Vars::class );
+		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
 		$this->string       = Mockery::mock( String_Helper::class );
 
 		$this->instance               = new Title_Presenter();

--- a/tests/presenters/title-presenter-test.php
+++ b/tests/presenters/title-presenter-test.php
@@ -2,8 +2,9 @@
 
 namespace Yoast\WP\SEO\Tests\Presenters;
 
-use Mockery;
 use Brain\Monkey;
+use Mockery;
+use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Helpers\String_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Title_Presenter;
@@ -53,7 +54,7 @@ class Title_Presenter_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->replace_vars = Mockery::mock( \WPSEO_Replace_Vars::class );
+		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
 		$this->string       = Mockery::mock( String_Helper::class );
 
 		$this->instance               = new Title_Presenter( $this->string );

--- a/tests/presenters/twitter/description-presenter-test.php
+++ b/tests/presenters/twitter/description-presenter-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Presenters\Twitter;
 
 use Mockery;
+use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Twitter\Description_Presenter;
 use Yoast\WP\SEO\Tests\TestCase;
@@ -34,7 +35,7 @@ class Description_Presenter_Test extends TestCase {
 	 * Setup of the tests.
 	 */
 	public function setUp() {
-		$this->replace_vars = Mockery::mock( \WPSEO_Replace_Vars::class );
+		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
 
 		$this->instance               = new Description_Presenter();
 		$this->instance->replace_vars = $this->replace_vars;

--- a/tests/presenters/twitter/title-presenter-test.php
+++ b/tests/presenters/twitter/title-presenter-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Presenters\Twitter;
 
 use Brain\Monkey;
 use Mockery;
+use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Twitter\Title_Presenter;
 use Yoast\WP\SEO\Tests\TestCase;
@@ -46,7 +47,7 @@ class Title_Presenter_Test extends TestCase {
 		$this->instance               = new Title_Presenter();
 		$this->instance->presentation = new Indexable_Presentation();
 		$this->indexable_presentation = $this->instance->presentation;
-		$this->replace_vars           = Mockery::mock( \WPSEO_Replace_Vars::class );
+		$this->replace_vars           = Mockery::mock( WPSEO_Replace_Vars::class );
 
 		$this->instance->replace_vars         = $this->replace_vars;
 		$this->indexable_presentation->source = [];


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.

Always be explicit about which classes are being used in a namespaced file.

* Always use _unqualified_ names for classes in code.
* Always have an import `use` statement for classes, unless the class is from the same namespace.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
