### PR TITLE
QA: add missing import `use` statements for classes [with aliases]

### DIFF
--- a/tests/builders/indexable-term-builder-test.php
+++ b/tests/builders/indexable-term-builder-test.php
@@ -7,7 +7,9 @@ use Mockery;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Term_Builder;
 use Yoast\WP\SEO\Helpers\Image_Helper;
+use Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper as OG_Image_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
+use Yoast\WP\SEO\Helpers\Twitter\Image_Helper as Twitter_Image_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -99,8 +101,8 @@ class Indexable_Term_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
 
 		$image            = Mockery::mock( Image_Helper::class );
-		$open_graph_image = Mockery::mock( \Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper::class );
-		$twitter_image    = Mockery::mock( \Yoast\WP\SEO\Helpers\Twitter\Image_Helper::class );
+		$open_graph_image = Mockery::mock( OG_Image_Helper::class );
+		$twitter_image    = Mockery::mock( Twitter_Image_Helper::class );
 
 		$image
 			->expects( 'get_term_content_image' )


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.

Always be explicit about which classes are being used in a namespaced file.

* Always use _unqualified_ names for classes in code. Use aliases when necessary.
* Always have an import `use` statement for classes, unless the class is from the same namespace.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.