### PR TITLE
CS: don't use FQN in documentation 

### DIFF
--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -23,7 +23,7 @@ class Actions {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @param \Composer\Script\Event $event Composer event that triggered this script.
+	 * @param Event $event Composer event that triggered this script.
 	 *
 	 * @return void
 	 */
@@ -55,7 +55,7 @@ class Actions {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @param \Composer\Script\Event $event Composer event that triggered this script.
+	 * @param Event $event Composer event that triggered this script.
 	 *
 	 * @return void
 	 */
@@ -96,7 +96,7 @@ class Actions {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @param \Composer\Script\Event $event Composer event that triggered this script.
+	 * @param Event $event Composer event that triggered this script.
 	 *
 	 * @return void
 	 */

--- a/config/dependency-injection/container-compiler.php
+++ b/config/dependency-injection/container-compiler.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Dependency_Injection;
 
+use Exception;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
@@ -21,7 +22,7 @@ class Container_Compiler {
 	 *
 	 * @param boolean $debug If false the container will only be re-compiled if it does not yet already exist.
 	 *
-	 * @throws \Exception If compiling the container fails.
+	 * @throws Exception If compiling the container fails.
 	 *
 	 * @return void
 	 */

--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -25,7 +25,7 @@ class Custom_Loader extends PhpFileLoader {
 	/**
 	 * Custom_Loader constructor.
 	 *
-	 * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container The ContainerBuilder to load classes for.
+	 * @param ContainerBuilder $container The ContainerBuilder to load classes for.
 	 */
 	public function __construct( ContainerBuilder $container ) {
 		parent::__construct( $container, new FileLocator( __DIR__ . '/../..' ) );
@@ -57,12 +57,10 @@ class Custom_Loader extends PhpFileLoader {
 	/**
 	 * Registers a set of classes as services using PSR-4 for discovery.
 	 *
-	 * @param \Symfony\Component\DependencyInjection\Definition $prototype A definition to use as template.
-	 * @param string                                            $namespace The namespace prefix of classes
-	 *                                                                     in the scanned directory.
-	 * @param string                                            $resource  The directory to look for classes,
-	 *                                                                     glob-patterns allowed.
-	 * @param string                                            $exclude   A globed path of files to exclude.
+	 * @param Definition $prototype A definition to use as template.
+	 * @param string     $namespace The namespace prefix of classes in the scanned directory.
+	 * @param string     $resource  The directory to look for classes, glob-patterns allowed.
+	 * @param string     $exclude   A globed path of files to exclude.
 	 *
 	 * @throws InvalidArgumentException If invalid arguments are supplied.
 	 *

--- a/config/dependency-injection/loader-pass.php
+++ b/config/dependency-injection/loader-pass.php
@@ -28,7 +28,7 @@ class Loader_Pass implements CompilerPassInterface {
 	 * Checks all definitions to ensure all classes implementing the Integration interface
 	 * are registered with the Loader class.
 	 *
-	 * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container The container.
+	 * @param ContainerBuilder $container The container.
 	 */
 	public function process( ContainerBuilder $container ) {
 		if ( ! $container->hasDefinition( Loader::class ) ) {
@@ -46,8 +46,8 @@ class Loader_Pass implements CompilerPassInterface {
 	/**
 	 * Processes a definition in the container.
 	 *
-	 * @param \Symfony\Component\DependencyInjection\Definition $definition        The definition to process.
-	 * @param \Symfony\Component\DependencyInjection\Definition $loader_definition The loader definition.
+	 * @param Definition $definition        The definition to process.
+	 * @param Definition $loader_definition The loader definition.
 	 */
 	private function process_definition( Definition $definition, Definition $loader_definition ) {
 		$class = $definition->getClass();

--- a/config/php-codeshift/remove-vendor-prefixing-array-key-visitor.php
+++ b/config/php-codeshift/remove-vendor-prefixing-array-key-visitor.php
@@ -20,9 +20,9 @@ class Remove_Vendor_Prefixing_Array_Key_Visitor extends NodeVisitorAbstract {
 	/**
 	 * Removes vendor prefixes from array keys.
 	 *
-	 * @param \PhpParser\Node $node The node being visited.
+	 * @param Node $node The node being visited.
 	 *
-	 * @return \PhpParser\Node The possibly modified node.
+	 * @return Node The possibly modified node.
 	 */
 	public function leaveNode( Node $node ) {
 		if ( ! $node instanceof ArrayItem ) {

--- a/config/php-codeshift/remove-vendor-prefixing-comment-visitor.php
+++ b/config/php-codeshift/remove-vendor-prefixing-comment-visitor.php
@@ -19,9 +19,9 @@ class Remove_Vendor_Prefixing_Comment_Visitor extends NodeVisitorAbstract {
 	/**
 	 * Removes vendor prefixes from comments.
 	 *
-	 * @param \PhpParser\Node $node The node being visited.
+	 * @param Node $node The node being visited.
 	 *
-	 * @return \PhpParser\Node The possibly modified node.
+	 * @return Node The possibly modified node.
 	 */
 	public function leaveNode( Node $node ) {
 		$comment = $node->getDocComment();

--- a/config/php-codeshift/remove-vendor-prefixing-visitor.php
+++ b/config/php-codeshift/remove-vendor-prefixing-visitor.php
@@ -19,9 +19,9 @@ class Remove_Vendor_Prefixing_Visitor extends NodeVisitorAbstract {
 	/**
 	 * Removes vendor prefixes from use statements.
 	 *
-	 * @param \PhpParser\Node $node The node being visited.
+	 * @param Node $node The node being visited.
 	 *
-	 * @return \PhpParser\Node The possibly modified node.
+	 * @return Node The possibly modified node.
 	 */
 	public function leaveNode( Node $node ) {
 		if ( ! $node instanceof Name ) {

--- a/src/builders/indexable-home-page-builder.php
+++ b/src/builders/indexable-home-page-builder.php
@@ -9,6 +9,7 @@ namespace Yoast\WP\SEO\Builders;
 
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
+use Yoast\WP\SEO\Models\Indexable;
 
 /**
  * Formats the homepage meta to indexable format.
@@ -47,9 +48,9 @@ class Indexable_Home_Page_Builder {
 	/**
 	 * Formats the data.
 	 *
-	 * @param \Yoast\WP\SEO\Models\Indexable $indexable The indexable to format.
+	 * @param Indexable $indexable The indexable to format.
 	 *
-	 * @return \Yoast\WP\SEO\Models\Indexable The extended indexable.
+	 * @return Indexable The extended indexable.
 	 */
 	public function build( $indexable ) {
 		$indexable->object_type      = 'home-page';

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -19,14 +19,14 @@ class Indexable_Term_Builder {
 	/**
 	 * Holds the taxonomy helper instance.
 	 *
-	 * @var \Yoast\WP\SEO\Helpers\Taxonomy_Helper
+	 * @var Taxonomy_Helper
 	 */
 	private $taxonomy;
 
 	/**
 	 * Indexable_Term_Builder constructor.
 	 *
-	 * @param \Yoast\WP\SEO\Helpers\Taxonomy_Helper $taxonomy The taxonomy helper.
+	 * @param Taxonomy_Helper $taxonomy The taxonomy helper.
 	 */
 	public function __construct( Taxonomy_Helper $taxonomy ) {
 		$this->taxonomy = $taxonomy;
@@ -35,8 +35,8 @@ class Indexable_Term_Builder {
 	/**
 	 * Formats the data.
 	 *
-	 * @param int                            $term_id   ID of the term to save data for.
-	 * @param \Yoast\WP\SEO\Models\Indexable $indexable The indexable to format.
+	 * @param int       $term_id   ID of the term to save data for.
+	 * @param Indexable $indexable The indexable to format.
 	 *
 	 * @return bool|Indexable The extended indexable. False when unable to build.
 	 */

--- a/src/config/ruckusing-framework.php
+++ b/src/config/ruckusing-framework.php
@@ -21,22 +21,22 @@ class Ruckusing_Framework {
 	/**
 	 * The database object.
 	 *
-	 * @var \wpdb
+	 * @var wpdb
 	 */
 	protected $wpdb;
 
 	/**
 	 * The dependency management checker.
 	 *
-	 * @var \Yoast\WP\SEO\Config\Dependency_Management
+	 * @var Dependency_Management
 	 */
 	protected $dependency_management;
 
 	/**
 	 * Ruckusing_Framework constructor.
 	 *
-	 * @param \wpdb                                      $wpdb                  The wpdb instance.
-	 * @param \Yoast\WP\SEO\Config\Dependency_Management $dependency_management The dependency management checker.
+	 * @param wpdb                  $wpdb                  The wpdb instance.
+	 * @param Dependency_Management $dependency_management The dependency management checker.
 	 */
 	public function __construct(
 		wpdb $wpdb,

--- a/src/config/ruckusing-framework.php
+++ b/src/config/ruckusing-framework.php
@@ -10,6 +10,8 @@ namespace Yoast\WP\SEO\Config;
 use wpdb;
 use Yoast\WP\Lib\Ruckusing_Framework_Runner;
 use Yoast\WP\SEO\Config\Dependency_Management;
+use YoastSEO_Vendor\Ruckusing_Adapter_MySQL_Base;
+use YoastSEO_Vendor\Ruckusing_Exception;
 use YoastSEO_Vendor\Ruckusing_Task_Manager;
 use YoastSEO_Vendor\Task_Db_Migrate;
 
@@ -73,12 +75,12 @@ class Ruckusing_Framework {
 	/**
 	 * Gets the ruckusing framework task manager.
 	 *
-	 * @param \YoastSEO_Vendor\Ruckusing_Adapter_MySQL_Base $adapter               The MySQL adapter.
-	 * @param string                                        $migrations_table_name The migrations table name.
-	 * @param string                                        $migrations_directory  The migrations directory.
+	 * @param Ruckusing_Adapter_MySQL_Base $adapter               The MySQL adapter.
+	 * @param string                       $migrations_table_name The migrations table name.
+	 * @param string                       $migrations_directory  The migrations directory.
 	 *
-	 * @return \YoastSEO_Vendor\Ruckusing_Task_Manager The task manager.
-	 * @throws \YoastSEO_Vendor\Ruckusing_Exception If any of the arguments are invalid.
+	 * @return Ruckusing_Task_Manager The task manager.
+	 * @throws Ruckusing_Exception If any of the arguments are invalid.
 	 */
 	public function get_framework_task_manager( $adapter, $migrations_table_name, $migrations_directory ) {
 		$task_manager = new Ruckusing_Task_Manager( $adapter, $this->get_configuration( $migrations_table_name, $migrations_directory ) );

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Generators\Schema;
 
+use WP_User;
 use Yoast\WP\SEO\Config\Schema_IDs;
 
 /**
@@ -164,8 +165,8 @@ class Person extends Abstract_Schema_Piece {
 	/**
 	 * Returns an ImageObject for the persons avatar.
 	 *
-	 * @param array    $data      The Person schema.
-	 * @param \WP_User $user_data User data.
+	 * @param array   $data      The Person schema.
+	 * @param WP_User $user_data User data.
 	 *
 	 * @return array $data The Person schema.
 	 */
@@ -208,9 +209,9 @@ class Person extends Abstract_Schema_Piece {
 	/**
 	 * Generate the person logo from gravatar.
 	 *
-	 * @param array    $data      The Person schema.
-	 * @param \WP_User $user_data User data.
-	 * @param string   $schema_id The string used in the `@id` for the schema.
+	 * @param array   $data      The Person schema.
+	 * @param WP_User $user_data User data.
+	 * @param string  $schema_id The string used in the `@id` for the schema.
 	 *
 	 * @return array The Person schema.
 	 */

--- a/src/helpers/date-helper.php
+++ b/src/helpers/date-helper.php
@@ -17,7 +17,7 @@ class Date_Helper {
 	/**
 	 * The date helper.
 	 *
-	 * @var \WPSEO_Date_Helper
+	 * @var WPSEO_Date_Helper
 	 */
 	protected $date;
 

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
+use WP_Post;
 use Yoast\WP\Lib\Model;
 
 /**
@@ -94,7 +95,7 @@ class Post_Helper {
 	 *
 	 * @codeCoverageIgnore It wraps a WordPress function.
 	 *
-	 * @return \WP_Post|null The post.
+	 * @return WP_Post|null The post.
 	 */
 	public function get_post( $post_id ) {
 		return \get_post( $post_id );

--- a/src/helpers/primary-term-helper.php
+++ b/src/helpers/primary-term-helper.php
@@ -7,6 +7,8 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
+use stdClass;
+
 /**
  * Class Primary_Term_Helper
  */
@@ -41,7 +43,7 @@ class Primary_Term_Helper {
 	/**
 	 * Returns whether or not a taxonomy is hierarchical.
 	 *
-	 * @param \stdClass $taxonomy Taxonomy object.
+	 * @param stdClass $taxonomy Taxonomy object.
 	 *
 	 * @return bool True for hierarchical taxonomy.
 	 */

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -7,6 +7,8 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
+use WP_Taxonomy;
+use WP_Term;
 use WPSEO_Taxonomy_Meta;
 
 /**
@@ -57,8 +59,8 @@ class Taxonomy_Helper {
 	 *
 	 * @param string $output The output type to use.
 	 *
-	 * @return string[]|\WP_Taxonomy[] Array with all the public taxonomies.
-	 *                                 The type depends on the specified output variable.
+	 * @return string[]|WP_Taxonomy[] Array with all the public taxonomies.
+	 *                                The type depends on the specified output variable.
 	 */
 	public function get_public_taxonomies( $output = 'names' ) {
 		return \get_taxonomies( [ 'public' => true ], $output );
@@ -78,7 +80,7 @@ class Taxonomy_Helper {
 	/**
 	 * Retrieves the taxonomy term's meta values.
 	 *
-	 * @param \WP_Term $term Term to get the meta value for.
+	 * @param WP_Term $term Term to get the meta value for.
 	 *
 	 * @codeCoverageIgnore We have to write test when this method contains own code.
 	 *

--- a/src/initializers/migration-runner.php
+++ b/src/initializers/migration-runner.php
@@ -11,6 +11,7 @@ use Exception;
 use Yoast\WP\Lib\Model;
 use Yoast\WP\SEO\Config\Migration_Status;
 use Yoast\WP\SEO\Config\Ruckusing_Framework;
+use YoastSEO_Vendor\Ruckusing_Adapter_MySQL_Base;
 
 /**
  * Triggers database migrations and handles results.
@@ -103,7 +104,7 @@ class Migration_Runner implements Initializer_Interface {
 			/**
 			 * This variable represents Ruckusing_Adapter_MySQL_Base adapter.
 			 *
-			 * @var \YoastSEO_Vendor\Ruckusing_Adapter_MySQL_Base $adapter
+			 * @var Ruckusing_Adapter_MySQL_Base $adapter
 			 */
 			$adapter = $framework_runner->get_adapter();
 

--- a/src/initializers/migration-runner.php
+++ b/src/initializers/migration-runner.php
@@ -57,7 +57,7 @@ class Migration_Runner implements Initializer_Interface {
 	/**
 	 * Runs this initializer.
 	 *
-	 * @throws \Exception When a migration errored.
+	 * @throws Exception When a migration errored.
 	 *
 	 * @return void
 	 */
@@ -70,7 +70,7 @@ class Migration_Runner implements Initializer_Interface {
 	/**
 	 * Runs the free migrations.
 	 *
-	 * @throws \Exception When a migration errored.
+	 * @throws Exception When a migration errored.
 	 *
 	 * @return void
 	 */
@@ -87,7 +87,7 @@ class Migration_Runner implements Initializer_Interface {
 	 *
 	 * @return bool True on success, false on failure.
 	 *
-	 * @throws \Exception If the migration fails and YOAST_ENVIRONMENT is not production.
+	 * @throws Exception If the migration fails and YOAST_ENVIRONMENT is not production.
 	 */
 	public function run_migrations( $name, $migrations_table_name, $migrations_directory ) {
 		if ( ! $this->migration_status->should_run_migration( $name ) ) {

--- a/src/integrations/front-end/open-graph-oembed.php
+++ b/src/integrations/front-end/open-graph-oembed.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Integrations\Front_End;
 
+use WP_Post;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Conditionals\Open_Graph_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -67,8 +68,8 @@ class Open_Graph_OEmbed implements Integration_Interface {
 	 * address the concern where some social channels/subscribed use oEmebed data over Open Graph data
 	 * if both are present.
 	 *
-	 * @param array    $data The oEmbed data.
-	 * @param \WP_Post $post The current Post object.
+	 * @param array   $data The oEmbed data.
+	 * @param WP_Post $post The current Post object.
 	 *
 	 * @return array $filter_data - An array of oEmbed data with modified values where appropriate.
 	 * @link https://developer.wordpress.org/reference/hooks/oembed_response_data/ for hook info.

--- a/src/integrations/primary-category.php
+++ b/src/integrations/primary-category.php
@@ -7,6 +7,9 @@
 
 namespace Yoast\WP\SEO\Integrations;
 
+use stdClass;
+use WP_Error;
+use WP_Post;
 use WPSEO_Primary_Term;
 use Yoast\WP\SEO\Conditionals\Primary_Category_Conditional;
 
@@ -34,11 +37,11 @@ class Primary_Category implements Integration_Interface {
 	/**
 	 * Filters post_link_category to change the category to the chosen category by the user.
 	 *
-	 * @param \stdClass $category   The category that is now used for the post link.
-	 * @param array     $categories This parameter is not used.
-	 * @param \WP_Post  $post       The post in question.
+	 * @param stdClass $category   The category that is now used for the post link.
+	 * @param array    $categories This parameter is not used.
+	 * @param WP_Post  $post       The post in question.
 	 *
-	 * @return array|null|object|\WP_Error The category we want to use for the post link.
+	 * @return array|null|object|WP_Error The category we want to use for the post link.
 	 */
 	public function post_link_category( $category, $categories = null, $post = null ) {
 		$post = \get_post( $post );
@@ -59,7 +62,7 @@ class Primary_Category implements Integration_Interface {
 	 *
 	 * @codeCoverageIgnore It justs wraps a dependency.
 	 *
-	 * @param \WP_Post $post The post in question.
+	 * @param WP_Post $post The post in question.
 	 *
 	 * @return int Primary category id.
 	 */

--- a/src/integrations/watchers/indexable-author-watcher.php
+++ b/src/integrations/watchers/indexable-author-watcher.php
@@ -20,14 +20,14 @@ class Indexable_Author_Watcher implements Integration_Interface {
 	/**
 	 * The indexable repository.
 	 *
-	 * @var \Yoast\WP\SEO\Repositories\Indexable_Repository
+	 * @var Indexable_Repository
 	 */
 	protected $repository;
 
 	/**
 	 * The indexable builder.
 	 *
-	 * @var \Yoast\WP\SEO\Builders\Indexable_Builder
+	 * @var Indexable_Builder
 	 */
 	protected $builder;
 

--- a/src/integrations/watchers/indexable-date-archive-watcher.php
+++ b/src/integrations/watchers/indexable-date-archive-watcher.php
@@ -20,12 +20,12 @@ class Indexable_Date_Archive_Watcher implements Integration_Interface {
 	/**
 	 * The indexable repository.
 	 *
-	 * @var \Yoast\WP\SEO\Repositories\Indexable_Repository
+	 * @var Indexable_Repository
 	 */
 	protected $repository;
 
 	/**
-	 * @var \Yoast\WP\SEO\Builders\Indexable_Builder
+	 * @var Indexable_Builder
 	 */
 	protected $builder;
 

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -8,6 +8,7 @@
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
 use Exception;
+use WP_Post;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
@@ -223,7 +224,7 @@ class Indexable_Post_Watcher implements Integration_Interface {
 	/**
 	 * Updates the relations on post save or post status change.
 	 *
-	 * @param \WP_Post $post The post that has been updated.
+	 * @param WP_Post $post The post that has been updated.
 	 */
 	protected function update_relations( $post ) {
 		$related_indexables = $this->get_related_indexables( $post );
@@ -242,7 +243,7 @@ class Indexable_Post_Watcher implements Integration_Interface {
 	/**
 	 * Retrieves the related indexables for given post.
 	 *
-	 * @param \WP_Post $post The post to get the indexables for.
+	 * @param WP_Post $post The post to get the indexables for.
 	 *
 	 * @return Indexable[] The indexables.
 	 */

--- a/src/integrations/watchers/indexable-static-home-page-watcher.php
+++ b/src/integrations/watchers/indexable-static-home-page-watcher.php
@@ -20,7 +20,7 @@ class Indexable_Static_Home_Page_Watcher implements Integration_Interface {
 	/**
 	 * The indexable repository.
 	 *
-	 * @var \Yoast\WP\SEO\Repositories\Indexable_Repository
+	 * @var Indexable_Repository
 	 */
 	protected $repository;
 
@@ -34,7 +34,7 @@ class Indexable_Static_Home_Page_Watcher implements Integration_Interface {
 	/**
 	 * Indexable_Static_Home_Page_Watcher constructor.
 	 *
-	 * @param \Yoast\WP\SEO\Repositories\Indexable_Repository $repository The repository to use.
+	 * @param Indexable_Repository $repository The repository to use.
 	 *
 	 * @codeCoverageIgnore
 	 */

--- a/src/integrations/watchers/indexable-system-page-watcher.php
+++ b/src/integrations/watchers/indexable-system-page-watcher.php
@@ -21,7 +21,7 @@ class Indexable_System_Page_Watcher implements Integration_Interface {
 	/**
 	 * The indexable repository.
 	 *
-	 * @var \Yoast\WP\SEO\Repositories\Indexable_Repository
+	 * @var Indexable_Repository
 	 */
 	protected $repository;
 

--- a/src/loader.php
+++ b/src/loader.php
@@ -46,14 +46,14 @@ class Loader {
 	/**
 	 * The dependency injection container.
 	 *
-	 * @var \YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface
+	 * @var ContainerInterface
 	 */
 	protected $container;
 
 	/**
 	 * Loader constructor.
 	 *
-	 * @param \YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface $container The dependency injection container.
+	 * @param ContainerInterface $container The dependency injection container.
 	 */
 	public function __construct( ContainerInterface $container ) {
 		$this->container = $container;

--- a/src/loggers/logger.php
+++ b/src/loggers/logger.php
@@ -20,7 +20,7 @@ class Logger implements LoggerInterface {
 	/**
 	 * The logger object.
 	 *
-	 * @var \YoastSEO_Vendor\Psr\Log\LoggerInterface
+	 * @var LoggerInterface
 	 */
 	protected $wrapped_logger;
 
@@ -35,7 +35,7 @@ class Logger implements LoggerInterface {
 		 *
 		 * @api \YoastSEO_Vendor\Psr\Log\LoggerInterface $logger Instance of NullLogger.
 		 *
-		 * @return \YoastSEO_Vendor\Psr\Log\LoggerInterface The logger object.
+		 * @return LoggerInterface The logger object.
 		 */
 		$this->wrapped_logger = \apply_filters( 'wpseo_logger', $this->wrapped_logger );
 	}

--- a/src/loggers/migration-logger.php
+++ b/src/loggers/migration-logger.php
@@ -17,7 +17,7 @@ class Migration_Logger extends Ruckusing_Util_Logger {
 	/**
 	 * The logger object.
 	 *
-	 * @var \Yoast\WP\SEO\Loggers\Logger
+	 * @var Logger
 	 */
 	protected $logger;
 
@@ -26,7 +26,7 @@ class Migration_Logger extends Ruckusing_Util_Logger {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @param \Yoast\WP\SEO\Loggers\Logger $logger The logger to wrap.
+	 * @param Logger $logger The logger to wrap.
 	 */
 	public function __construct( Logger $logger ) {
 		$this->logger = $logger;

--- a/src/models/indexable-extension.php
+++ b/src/models/indexable-extension.php
@@ -17,14 +17,14 @@ abstract class Indexable_Extension extends Model {
 	/**
 	 * Holds the Indexable instance.
 	 *
-	 * @var \Yoast\WP\SEO\Models\Indexable
+	 * @var Indexable
 	 */
 	protected $indexable = null;
 
 	/**
 	 * Returns the indexable this extension belongs to.
 	 *
-	 * @return \Yoast\WP\SEO\Models\Indexable The indexable.
+	 * @return Indexable The indexable.
 	 */
 	public function indexable() {
 		if ( $this->indexable === null ) {

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -134,7 +134,7 @@ class Indexable extends Model {
 	/**
 	 * The loaded indexable extensions.
 	 *
-	 * @var \Yoast\WP\SEO\Models\Indexable_Extension[]
+	 * @var Indexable_Extension[]
 	 */
 	protected $loaded_extensions = [];
 
@@ -143,7 +143,7 @@ class Indexable extends Model {
 	 *
 	 * @param string $class_name The class name of the extension to load.
 	 *
-	 * @return \Yoast\WP\SEO\Models\Indexable_Extension|bool The extension.
+	 * @return Indexable_Extension|bool The extension.
 	 */
 	public function get_extension( $class_name ) {
 		if ( ! $this->loaded_extensions[ $class_name ] ) {

--- a/src/oauth/client.php
+++ b/src/oauth/client.php
@@ -11,6 +11,7 @@ use WPSEO_Options;
 use WPSEO_Utils;
 use YoastSEO_Vendor\League\OAuth2\Client\Provider\GenericProvider;
 use YoastSEO_Vendor\League\OAuth2\Client\Token\AccessToken;
+use YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface;
 
 /**
  * Represents the oAuth client.
@@ -27,7 +28,7 @@ class Client {
 	/**
 	 * Contains the set access tokens.
 	 *
-	 * @var \YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface[]
+	 * @var AccessTokenInterface[]
 	 */
 	private $access_tokens;
 
@@ -124,8 +125,8 @@ class Client {
 	/**
 	 * Saves the access token for the given user.
 	 *
-	 * @param int                                                              $user_id      User ID to receive token for.
-	 * @param \YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface $access_token The access token to save.
+	 * @param int                  $user_id      User ID to receive token for.
+	 * @param AccessTokenInterface $access_token The access token to save.
 	 *
 	 * @return void
 	 */
@@ -139,7 +140,7 @@ class Client {
 	 *
 	 * @param null|int $user_id User ID to receive token for.
 	 *
-	 * @return bool|\YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface False if not found. Token when found.
+	 * @return bool|AccessTokenInterface False if not found. Token when found.
 	 */
 	public function get_access_token( $user_id = null ) {
 		if ( $user_id === null ) {
@@ -193,7 +194,7 @@ class Client {
 	 *
 	 * @param array $access_tokens The access tokens to format.
 	 *
-	 * @return \YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface[] The formatted access tokens.
+	 * @return AccessTokenInterface[] The formatted access tokens.
 	 */
 	protected function format_access_tokens( $access_tokens ) {
 		if ( ! \is_array( $access_tokens ) || $access_tokens === [] ) {

--- a/src/oauth/client.php
+++ b/src/oauth/client.php
@@ -55,7 +55,7 @@ class Client {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @return \Yoast\WP\SEO\Oauth\Client Instance of this class.
+	 * @return Client Instance of this class.
 	 */
 	public static function get_instance() {
 		if ( static::$instance === null ) {
@@ -173,7 +173,7 @@ class Client {
 	/**
 	 * Returns an instance of the oAuth provider.
 	 *
-	 * @return \YoastSEO_Vendor\League\OAuth2\Client\Provider\GenericProvider The provider.
+	 * @return GenericProvider The provider.
 	 */
 	public function get_provider() {
 		return new GenericProvider(

--- a/src/presentations/archive-adjacent-trait.php
+++ b/src/presentations/archive-adjacent-trait.php
@@ -8,13 +8,14 @@
 namespace Yoast\WP\SEO\Presentations;
 
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
+use Yoast\WP\SEO\Models\Indexable;
 
 /**
  * Class Archive_Adjacent
  *
- * @property \Yoast\WP\SEO\Models\Indexable          $model      The indexable.
- * @property \Yoast\WP\SEO\Helpers\Pagination_Helper $pagination The pagination helper. Should be defined in the parent
- *                                                                class because of trait issues in PHP 5.6.
+ * @property Indexable         $model      The indexable.
+ * @property Pagination_Helper $pagination The pagination helper. Should be defined in the parent
+ *                                         class because of trait issues in PHP 5.6.
  */
 trait Archive_Adjacent {
 

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -7,13 +7,14 @@
 
 namespace Yoast\WP\SEO\Presentations;
 
+use WP_Term;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
 /**
  * Class Indexable_Presentation
  *
- * @property \WP_Term $source
+ * @property WP_Term $source
  */
 class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	use Archive_Adjacent;

--- a/src/wordpress/wrapper.php
+++ b/src/wordpress/wrapper.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\WordPress;
 
+use wpdb;
 use WPSEO_Admin_Asset_Manager;
 use WPSEO_Replace_Vars;
 
@@ -19,7 +20,7 @@ class Wrapper {
 	/**
 	 * Wrapper method for returning the wpdb object for use in dependency injection.
 	 *
-	 * @return \wpdb The wpdb global.
+	 * @return wpdb The wpdb global.
 	 */
 	public static function get_wpdb() {
 		global $wpdb;

--- a/tests/actions/indexation/indexable-post-indexation-action-test.php
+++ b/tests/actions/indexation/indexable-post-indexation-action-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Actions\Indexation;
 
 use Brain\Monkey\Filters;
 use Mockery;
+use wpdb;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
@@ -36,7 +37,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	/**
 	 * The wpdb mock.
 	 *
-	 * @var \wpdb|Mockery\MockInterface
+	 * @var wpdb|Mockery\MockInterface
 	 */
 	protected $wpdb;
 

--- a/tests/actions/indexation/indexable-term-indexation-action-test.php
+++ b/tests/actions/indexation/indexable-term-indexation-action-test.php
@@ -2,8 +2,9 @@
 
 namespace Yoast\WP\SEO\Tests\Actions\Indexation;
 
-use Mockery;
 use Brain\Monkey\Filters;
+use Mockery;
+use wpdb;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
@@ -36,7 +37,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 	/**
 	 * The wpdb mock.
 	 *
-	 * @var \wpdb|Mockery\MockInterface
+	 * @var wpdb|Mockery\MockInterface
 	 */
 	protected $wpdb;
 

--- a/tests/admin/admin-features-test.php
+++ b/tests/admin/admin-features-test.php
@@ -21,7 +21,7 @@ class Admin_Features_Test extends TestCase {
 	/**
 	 * Returns an instance with set expectations for the dependencies.
 	 *
-	 * @return \WPSEO_Admin Instance to test against.
+	 * @return WPSEO_Admin Instance to test against.
 	 */
 	private function get_admin_with_expectations() {
 		$shortlinker = new Shortlinker_Double();

--- a/tests/admin/capabilities/capabilities-utils-test.php
+++ b/tests/admin/capabilities/capabilities-utils-test.php
@@ -19,7 +19,7 @@ final class Capabilities_Utils_Test extends TestCase {
 	/**
 	 * The roles object.
 	 *
-	 * @var \Mockery\LegacyMockInterface|\Mockery\MockInterface
+	 * @var Mockery\LegacyMockInterface|Mockery\MockInterface
 	 */
 	protected $roles;
 

--- a/tests/admin/formatter/post-metabox-formatter-test.php
+++ b/tests/admin/formatter/post-metabox-formatter-test.php
@@ -2,10 +2,11 @@
 
 namespace Yoast\WP\SEO\Tests\Admin\Formatter;
 
-use Yoast\WP\SEO\Tests\Doubles\Admin\Formatter\Post_Metabox_Formatter_Double;
-use Yoast\WP\SEO\Tests\TestCase;
 use Brain\Monkey;
 use Mockery;
+use WP_Post;
+use Yoast\WP\SEO\Tests\Doubles\Admin\Formatter\Post_Metabox_Formatter_Double;
+use Yoast\WP\SEO\Tests\TestCase;
 
 /**
  * Unit Test Class.
@@ -26,7 +27,7 @@ class Post_Metabox_Formatter_Test extends TestCase {
 	/**
 	 * Mocked WP_Post.
 	 *
-	 * @var \WP_Post
+	 * @var WP_Post
 	 */
 	private $mock_post;
 

--- a/tests/admin/formatter/post-metabox-formatter-test.php
+++ b/tests/admin/formatter/post-metabox-formatter-test.php
@@ -19,7 +19,7 @@ class Post_Metabox_Formatter_Test extends TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var \Yoast\WP\SEO\Tests\Doubles\Admin\Formatter\Post_Metabox_Formatter_Double
+	 * @var Post_Metabox_Formatter_Double
 	 */
 	private $instance;
 

--- a/tests/admin/formatter/term-metabox-formatter-test.php
+++ b/tests/admin/formatter/term-metabox-formatter-test.php
@@ -2,10 +2,12 @@
 
 namespace Yoast\WP\SEO\Tests\Admin\Formatter;
 
-use Yoast\WP\SEO\Tests\Doubles\Admin\Formatter\Term_Metabox_Formatter_Double;
-use Yoast\WP\SEO\Tests\TestCase;
 use Brain\Monkey;
 use Mockery;
+use stdClass;
+use WP_Term;
+use Yoast\WP\SEO\Tests\Doubles\Admin\Formatter\Term_Metabox_Formatter_Double;
+use Yoast\WP\SEO\Tests\TestCase;
 
 /**
  * Unit Test Class.
@@ -26,14 +28,14 @@ class Term_Metabox_Formatter_Test extends TestCase {
 	/**
 	 * Mocked stdClass.
 	 *
-	 * @var \stdClass
+	 * @var stdClass
 	 */
 	private $taxonomy;
 
 	/**
 	 * Mocked WP_Term.
 	 *
-	 * @var \WP_Term
+	 * @var WP_Term
 	 */
 	private $mock_term;
 

--- a/tests/admin/formatter/term-metabox-formatter-test.php
+++ b/tests/admin/formatter/term-metabox-formatter-test.php
@@ -19,7 +19,7 @@ class Term_Metabox_Formatter_Test extends TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var \Yoast\WP\SEO\Tests\Doubles\Admin\Formatter\Term_Metabox_Formatter_Double
+	 * @var Term_Metabox_Formatter_Double
 	 */
 	private $instance;
 

--- a/tests/admin/metabox/metabox-editor-test.php
+++ b/tests/admin/metabox/metabox-editor-test.php
@@ -17,7 +17,7 @@ class Metabox_Editor_Test extends TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var \WPSEO_Metabox_Editor
+	 * @var WPSEO_Metabox_Editor
 	 */
 	protected $subject;
 

--- a/tests/admin/metabox/metabox-test.php
+++ b/tests/admin/metabox/metabox-test.php
@@ -19,7 +19,7 @@ class Metabox_Test extends TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var \Yoast\WP\SEO\Tests\Doubles\Admin\Metabox\Metabox_Double
+	 * @var Metabox_Double
 	 */
 	protected $instance;
 

--- a/tests/admin/myyoast-proxy-test.php
+++ b/tests/admin/myyoast-proxy-test.php
@@ -26,7 +26,7 @@ class MyYoast_Proxy_Test extends TestCase {
 		/**
 		 * Holds the instance of the class being tested.
 		 *
-		 * @var \Yoast\WP\SEO\Tests\Doubles\Admin\MyYoast_Proxy_Double $instance
+		 * @var MyYoast_Proxy_Double $instance
 		 */
 		$instance = $this
 			->getMockBuilder( MyYoast_Proxy_Double::class )
@@ -59,7 +59,7 @@ class MyYoast_Proxy_Test extends TestCase {
 		/**
 		 * Holds the instance of the class being tested.
 		 *
-		 * @var \WPSEO_MyYoast_Proxy $instance
+		 * @var WPSEO_MyYoast_Proxy $instance
 		 */
 		$instance = $this
 			->getMockBuilder( WPSEO_MyYoast_Proxy::class )
@@ -90,7 +90,7 @@ class MyYoast_Proxy_Test extends TestCase {
 		/**
 		 * Holds the instance of the class being tested.
 		 *
-		 * @var \WPSEO_MyYoast_Proxy $instance
+		 * @var WPSEO_MyYoast_Proxy $instance
 		 */
 		$instance = $this
 			->getMockBuilder( WPSEO_MyYoast_Proxy::class )
@@ -146,7 +146,7 @@ class MyYoast_Proxy_Test extends TestCase {
 		/**
 		 * Holds the instance of the class being tested.
 		 *
-		 * @var \WPSEO_MyYoast_Proxy $instance
+		 * @var WPSEO_MyYoast_Proxy $instance
 		 */
 		$instance = $this
 			->getMockBuilder( WPSEO_MyYoast_Proxy::class )

--- a/tests/builders/indexable-post-builder-test.php
+++ b/tests/builders/indexable-post-builder-test.php
@@ -6,6 +6,7 @@ use Brain\Monkey;
 use Exception;
 use Mockery;
 use Yoast\WP\Lib\ORM;
+use Yoast\WP\SEO\Builders\Indexable_Post_Builder;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper as Open_Graph_Image_Helper;
 use Yoast\WP\SEO\Helpers\Post_Helper;
@@ -87,7 +88,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 	/**
 	 * Holds the Indexable_Post_Builder instance.
 	 *
-	 * @var \Yoast\WP\SEO\Builders\Indexable_Post_Builder|Indexable_Post_Builder_Double|Mockery\MockInterface
+	 * @var Indexable_Post_Builder|Indexable_Post_Builder_Double|Mockery\MockInterface
 	 */
 	private $instance;
 

--- a/tests/database/migration-runner-test.php
+++ b/tests/database/migration-runner-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Database;
 
 use Mockery;
+use wpdb;
 use Yoast\WP\SEO\Config\Migration_Status;
 use Yoast\WP\SEO\Config\Ruckusing_Framework;
 use Yoast\WP\SEO\Initializers\Database_Setup;
@@ -122,7 +123,7 @@ class Migration_Runner_Test extends TestCase {
 	/**
 	 * Returns a wpdb mock.
 	 *
-	 * @return \wpdb The wpdb mock.
+	 * @return wpdb The wpdb mock.
 	 */
 	protected function get_wpdb_mock() {
 		$wpdb         = Mockery::mock( 'wpdb' );

--- a/tests/doubles/admin/metabox/metabox-double.php
+++ b/tests/doubles/admin/metabox/metabox-double.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Doubles\Admin\Metabox;
 
 use WPSEO_Metabox;
+use WPSEO_Metabox_Section_Additional;
 
 /**
  * Test Helper Class.
@@ -12,7 +13,7 @@ class Metabox_Double extends WPSEO_Metabox {
 	/**
 	 * Returns metabox sections that have been added by other plugins.
 	 *
-	 * @return \WPSEO_Metabox_Section_Additional[]
+	 * @return WPSEO_Metabox_Section_Additional[]
 	 */
 	public function get_additional_meta_sections() {
 		return parent::get_additional_meta_sections();

--- a/tests/doubles/inc/addon-manager-double.php
+++ b/tests/doubles/inc/addon-manager-double.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Doubles\Inc;
 
+use stdClass;
 use WPSEO_Addon_Manager;
 
 /**
@@ -34,9 +35,9 @@ class Addon_Manager_Double extends WPSEO_Addon_Manager {
 	/**
 	 * Converts a subscription to plugin based format.
 	 *
-	 * @param \stdClass $subscription The subscription to convert.
+	 * @param stdClass $subscription The subscription to convert.
 	 *
-	 * @return \stdClass The converted subscription.
+	 * @return stdClass The converted subscription.
 	 */
 	public function convert_subscription_to_plugin( $subscription ) {
 		return parent::convert_subscription_to_plugin( $subscription );
@@ -63,7 +64,7 @@ class Addon_Manager_Double extends WPSEO_Addon_Manager {
 	/**
 	 * Checks whether a plugin expiry date has been passed.
 	 *
-	 * @param \stdClass $subscription Plugin subscription.
+	 * @param stdClass $subscription Plugin subscription.
 	 *
 	 * @return bool Has the plugin expired.
 	 */

--- a/tests/doubles/inc/options/option-social-double.php
+++ b/tests/doubles/inc/options/option-social-double.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Doubles\Inc\Options;
 
+use WPSEO_Option;
 use WPSEO_Option_Social;
 
 /**
@@ -12,7 +13,7 @@ class Option_Social_Double extends WPSEO_Option_Social {
 	/**
 	 * Adds all the actions and filters for the option.
 	 *
-	 * @return \WPSEO_Option
+	 * @return WPSEO_Option
 	 */
 	public function __construct() {
 		return parent::__construct();

--- a/tests/doubles/models/indexable-double.php
+++ b/tests/doubles/models/indexable-double.php
@@ -7,6 +7,7 @@
 
 namespace Yoast\WP\SEO\Tests\Doubles\Models;
 
+use Mockery\MockInterface;
 use Yoast\WP\SEO\Models\Indexable as Indexable_Model;
 
 /**
@@ -17,7 +18,7 @@ class Indexable_Double extends Indexable_Model {
 	/**
 	 * Holds the return value for has_one. Making it possible to mock that.
 	 *
-	 * @var null|\Mockery\MockInterface
+	 * @var null|MockInterface
 	 */
 	public $mock_has_one = null;
 

--- a/tests/doubles/oauth/client-double.php
+++ b/tests/doubles/oauth/client-double.php
@@ -8,6 +8,7 @@
 namespace Yoast\WP\SEO\Tests\Doubles\Oauth;
 
 use Yoast\WP\SEO\Oauth\Client;
+use YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface;
 
 /**
  * Test Helper Class.
@@ -19,7 +20,7 @@ class Client_Double extends Client {
 	 *
 	 * @param array $access_tokens Access tokens to format.
 	 *
-	 * @return \YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface[] Formatted AccessTokens.
+	 * @return AccessTokenInterface[] Formatted AccessTokens.
 	 */
 	public function format_access_tokens( $access_tokens ) {
 		return parent::format_access_tokens( $access_tokens );

--- a/tests/helpers/date-helper-test.php
+++ b/tests/helpers/date-helper-test.php
@@ -18,7 +18,7 @@ class Date_Helper_Test extends TestCase {
 	/**
 	 * The date helper instance.
 	 *
-	 * @var \WPSEO_Date_Helper
+	 * @var WPSEO_Date_Helper
 	 */
 	protected $instance;
 

--- a/tests/inc/addon-manager-test.php
+++ b/tests/inc/addon-manager-test.php
@@ -33,7 +33,7 @@ class Addon_Manager_Test extends TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var \Mockery\Mock|\Yoast\WP\SEO\Tests\Doubles\Inc\Addon_Manager_Double
+	 * @var Mockery\Mock|Addon_Manager_Double
 	 */
 	protected $instance;
 

--- a/tests/inc/addon-manager-test.php
+++ b/tests/inc/addon-manager-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Inc;
 
 use Mockery;
+use stdClass;
 use WPSEO_Utils;
 use Yoast\WP\SEO\Tests\Doubles\Inc\Addon_Manager_Double;
 use Yoast\WP\SEO\Tests\TestCase;
@@ -694,7 +695,7 @@ class Addon_Manager_Test extends TestCase {
 	 *
 	 * This method converts an array to an object by json encoding.
 	 *
-	 * @return \stdClass Subscriptions.
+	 * @return stdClass Subscriptions.
 	 */
 	protected function get_subscriptions() {
 		return \json_decode(

--- a/tests/inc/content-images-test.php
+++ b/tests/inc/content-images-test.php
@@ -18,7 +18,7 @@ class Content_Images_Test extends TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var \WPSEO_Content_Images
+	 * @var WPSEO_Content_Images
 	 */
 	private $instance;
 

--- a/tests/inc/health-check-curl-version-test.php
+++ b/tests/inc/health-check-curl-version-test.php
@@ -17,7 +17,7 @@ class Health_Check_Curl_Version_Test extends TestCase {
 	/**
 	 * The instance to test.
 	 *
-	 * @var Mockery\Mock|\WPSEO_Health_Check_Curl_Version
+	 * @var Mockery\Mock|WPSEO_Health_Check_Curl_Version
 	 */
 	private $instance;
 

--- a/tests/inc/health-check-link-table-not-accessible-test.php
+++ b/tests/inc/health-check-link-table-not-accessible-test.php
@@ -17,7 +17,7 @@ class Health_Check_Link_Table_Not_Accessible_Test extends TestCase {
 	/**
 	 * The instance to test.
 	 *
-	 * @var Mockery\Mock|\WPSEO_Health_Check_Link_Table_Not_Accessible
+	 * @var Mockery\Mock|WPSEO_Health_Check_Link_Table_Not_Accessible
 	 */
 	private $instance;
 

--- a/tests/inc/health-check-ryte-test.php
+++ b/tests/inc/health-check-ryte-test.php
@@ -18,12 +18,12 @@ use Yoast\WP\SEO\Tests\TestCase;
 class Health_Check_Ryte_Test extends TestCase {
 
 	/**
-	 * @var \Mockery\Mock|\WPSEO_Ryte_Option
+	 * @var Mockery\Mock|WPSEO_Ryte_Option
 	 */
 	private $ryte_option;
 
 	/**
-	 * @var \Mockery\Mock|\WPSEO_Health_Check_Ryte
+	 * @var Mockery\Mock|WPSEO_Health_Check_Ryte
 	 */
 	private $health_check;
 

--- a/tests/inc/health-check-test.php
+++ b/tests/inc/health-check-test.php
@@ -17,7 +17,7 @@ class Health_Check_Test extends TestCase {
 	/**
 	 * Class instance to use for the test.
 	 *
-	 * @var \Mockery\MockInterface
+	 * @var Mockery\MockInterface
 	 */
 	protected $instance;
 

--- a/tests/inc/image-utils-test.php
+++ b/tests/inc/image-utils-test.php
@@ -18,7 +18,7 @@ class Image_Utils_Test extends TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var \Yoast\WP\SEO\Tests\Doubles\Inc\Image_Utils_Double
+	 * @var Image_Utils_Double
 	 */
 	private $instance;
 

--- a/tests/models/indexable-test.php
+++ b/tests/models/indexable-test.php
@@ -26,7 +26,7 @@ class Indexable_Test extends TestCase {
 	/**
 	 * Holds the instance to test.
 	 *
-	 * @var \Yoast\WP\SEO\Models\Indexable_Double|\Mockery\MockInterface
+	 * @var Indexable_Double|Mockery\MockInterface
 	 */
 	protected $instance;
 

--- a/tests/oauth/client-test.php
+++ b/tests/oauth/client-test.php
@@ -23,7 +23,7 @@ class Client_Test extends TestCase {
 	/**
 	 * Holds the instance of the class being tested.
 	 *
-	 * @var \Yoast\WP\SEO\Oauth\Client
+	 * @var Client
 	 */
 	protected $class_instance;
 

--- a/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder-trait.php
+++ b/tests/presentations/indexable-term-archive-presentation/presentation-instance-builder-trait.php
@@ -55,7 +55,7 @@ trait Presentation_Instance_Builder {
 	/**
 	 * The context class.
 	 *
-	 * @var \Yoast\WP\SEO\Context\Meta_Tags_Context_Mock
+	 * @var Meta_Tags_Context_Mock
 	 */
 	protected $context;
 

--- a/tests/presenters/meta-description-presenter-test.php
+++ b/tests/presenters/meta-description-presenter-test.php
@@ -24,7 +24,7 @@ class Meta_Description_Presenter_Test extends TestCase {
 	/**
 	 * The WPSEO Replace Vars object.
 	 *
-	 * @var \WPSEO_Replace_Vars|Mockery\MockInterface
+	 * @var WPSEO_Replace_Vars|Mockery\MockInterface
 	 */
 	protected $replace_vars;
 

--- a/tests/presenters/open-graph/description-presenter-test.php
+++ b/tests/presenters/open-graph/description-presenter-test.php
@@ -22,7 +22,7 @@ class Description_Presenter_Test extends TestCase {
 	/**
 	 * The description presenter instance.
 	 *
-	 * @var \Yoast\WP\SEO\Presenters\Open_Graph\Description_Presenter
+	 * @var Description_Presenter
 	 */
 	protected $instance;
 
@@ -36,7 +36,7 @@ class Description_Presenter_Test extends TestCase {
 	/**
 	 * The WPSEO Replace Vars object.
 	 *
-	 * @var \WPSEO_Replace_Vars|Mockery\MockInterface
+	 * @var WPSEO_Replace_Vars|Mockery\MockInterface
 	 */
 	protected $replace_vars;
 

--- a/tests/presenters/open-graph/title-presenter-test.php
+++ b/tests/presenters/open-graph/title-presenter-test.php
@@ -37,7 +37,7 @@ class Title_Presenter_Test extends TestCase {
 	/**
 	 * The WPSEO Replace Vars object.
 	 *
-	 * @var \WPSEO_Replace_Vars|Mockery\MockInterface
+	 * @var WPSEO_Replace_Vars|Mockery\MockInterface
 	 */
 	protected $replace_vars;
 

--- a/tests/presenters/title-presenter-test.php
+++ b/tests/presenters/title-presenter-test.php
@@ -37,7 +37,7 @@ class Title_Presenter_Test extends TestCase {
 	/**
 	 * The WPSEO Replace Vars object.
 	 *
-	 * @var \WPSEO_Replace_Vars|Mockery\MockInterface
+	 * @var WPSEO_Replace_Vars|Mockery\MockInterface
 	 */
 	protected $replace_vars;
 

--- a/tests/presenters/twitter/description-presenter-test.php
+++ b/tests/presenters/twitter/description-presenter-test.php
@@ -22,7 +22,7 @@ class Description_Presenter_Test extends TestCase {
 	/**
 	 * The WPSEO Replace Vars object.
 	 *
-	 * @var \WPSEO_Replace_Vars|Mockery\MockInterface
+	 * @var WPSEO_Replace_Vars|Mockery\MockInterface
 	 */
 	protected $replace_vars;
 

--- a/tests/presenters/twitter/title-presenter-test.php
+++ b/tests/presenters/twitter/title-presenter-test.php
@@ -36,7 +36,7 @@ class Title_Presenter_Test extends TestCase {
 	/**
 	 * The WPSEO Replace Vars object.
 	 *
-	 * @var \WPSEO_Replace_Vars|Mockery\MockInterface
+	 * @var WPSEO_Replace_Vars|Mockery\MockInterface
 	 */
 	protected $replace_vars;
 


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.

Don't use FQN in documentation, refer to the unqualified name instead, but make sure there is a `use` import statement for the referenced name, except when the name is from the same namespace.

Includes adding import `use` statement(s) for the referenced name(s) when necessary.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.