### PR TITLE
QA: remove unused `use` statements

### DIFF
--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -13,7 +13,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\Config\Resource\GlobResource;
-use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Definition;
 
 /**

--- a/src/actions/indexation/indexable-post-type-archive-indexation-action.php
+++ b/src/actions/indexation/indexable-post-type-archive-indexation-action.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\SEO\Actions\Indexation;
 
-use WP_Post_Type;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Models\Indexable;

--- a/src/integrations/admin/indexation-integration.php
+++ b/src/integrations/admin/indexation-integration.php
@@ -16,7 +16,6 @@ use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Helpers\Redirect_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Indexation_List_Item_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Indexation_Modal_Presenter;

--- a/src/integrations/front-end/indexing-controls.php
+++ b/src/integrations/front-end/indexing-controls.php
@@ -8,10 +8,8 @@
 namespace Yoast\WP\SEO\Integrations\Front_End;
 
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
-use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Robots_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
-use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 
 /**
  * Class Indexing_Controls

--- a/src/integrations/watchers/indexable-static-home-page-watcher.php
+++ b/src/integrations/watchers/indexable-static-home-page-watcher.php
@@ -8,7 +8,6 @@
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
-use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 

--- a/src/presenters/robots-presenter.php
+++ b/src/presenters/robots-presenter.php
@@ -7,8 +7,6 @@
 
 namespace Yoast\WP\SEO\Presenters;
 
-use Yoast\WP\SEO\Presentations\Indexable_Presentation;
-
 /**
  * Class Robots_Presenter
  */

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -10,7 +10,6 @@ namespace Yoast\WP\SEO\Routes;
 
 use Yoast\WP\SEO\Actions\Indexables\Indexable_Head_Action;
 use Yoast\WP\SEO\Conditionals\Headless_Rest_Endpoints_Enabled_Conditional;
-use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 

--- a/tests/admin/myyoast-proxy-test.php
+++ b/tests/admin/myyoast-proxy-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Admin;
 
 use Brain\Monkey;
-use Mockery;
 use WPSEO_MyYoast_Proxy;
 use Yoast\WP\SEO\Tests\Doubles\Admin\MyYoast_Proxy_Double;
 use Yoast\WP\SEO\Tests\TestCase;

--- a/tests/database/migration-runner-test.php
+++ b/tests/database/migration-runner-test.php
@@ -6,8 +6,6 @@ use Mockery;
 use wpdb;
 use Yoast\WP\SEO\Config\Migration_Status;
 use Yoast\WP\SEO\Config\Ruckusing_Framework;
-use Yoast\WP\SEO\Initializers\Database_Setup;
-use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Initializers\Migration_Runner;
 use Yoast\WP\Lib\Model;
 use Yoast\WP\SEO\Tests\TestCase;

--- a/tests/doubles/generators/schema/article-double.php
+++ b/tests/doubles/generators/schema/article-double.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Tests\Doubles\Generators\Schema;
 
-use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Generators\Schema\Article;
 
 /**

--- a/tests/doubles/generators/schema/author-mock.php
+++ b/tests/doubles/generators/schema/author-mock.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Tests\Doubles\Generators\Schema;
 
-use Yoast\WP\SEO\Context\Meta_Tags_Context as Meta_Tags_Context_Original;
 use Yoast\WP\SEO\Generators\Schema\Author;
 
 class Author_Mock extends Author {

--- a/tests/helpers/product-helper-test.php
+++ b/tests/helpers/product-helper-test.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Tests\Helpers;
 
-use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Tests\TestCase;

--- a/tests/helpers/schema/image-helper-test.php
+++ b/tests/helpers/schema/image-helper-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Helpers\Schema;
 
 use Mockery;
-use Brain\Monkey;
 use Yoast\WP\SEO\Helpers\Image_Helper as Main_Image_Helper;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;

--- a/tests/presentations/indexable-author-archive-presentation/robots-test.php
+++ b/tests/presentations/indexable-author-archive-presentation/robots-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Author_Archive_Presentation;
 
 use Brain\Monkey;
-use Mockery;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/presentations/indexable-post-type-archive-presentation/canonical-test.php
+++ b/tests/presentations/indexable-post-type-archive-presentation/canonical-test.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Post_Type_Archive_Presentation;
 
-use Mockery;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/presentations/indexable-post-type-presentation/canonical-test.php
+++ b/tests/presentations/indexable-post-type-presentation/canonical-test.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Post_Type_Presentation;
 
-use Mockery;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/presentations/indexable-presentation/presentation-instance-builder-trait.php
+++ b/tests/presentations/indexable-presentation/presentation-instance-builder-trait.php
@@ -3,8 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Presentation;
 
 use Mockery;
-use Yoast\WP\SEO\Generators\Open_Graph_Image_Generator;
-use Yoast\WP\SEO\Generators\Twitter_Image_Generator;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Doubles\Context\Meta_Tags_Context_Mock;

--- a/tests/presentations/indexable-presentation/twitter-description-test.php
+++ b/tests/presentations/indexable-presentation/twitter-description-test.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Presentation;
 
 use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/presentations/indexable-presentation/twitter-title-test.php
+++ b/tests/presentations/indexable-presentation/twitter-title-test.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Presentation;
 
 use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/presentations/presentation-instance-dependencies-trait.php
+++ b/tests/presentations/presentation-instance-dependencies-trait.php
@@ -17,7 +17,6 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Helpers\Robots_Helper;
 
 trait Presentation_Instance_Dependencies {
 

--- a/tests/presenters/admin/alert-presenter-test.php
+++ b/tests/presenters/admin/alert-presenter-test.php
@@ -6,7 +6,6 @@
 namespace Yoast\WP\SEO\Tests\Presenters\Admin;
 
 use Brain\Monkey;
-use Mockery;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Presenters\Admin\Alert_Presenter;
 use Yoast\WP\SEO\Tests\TestCase;

--- a/tests/presenters/admin/indexation-list-item-presenter-test.php
+++ b/tests/presenters/admin/indexation-list-item-presenter-test.php
@@ -8,9 +8,7 @@
 namespace Yoast\WP\SEO\Tests\Presenters\Admin;
 
 use Brain\Monkey;
-use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Presenters\Admin\Indexation_List_Item_Presenter;
-use Yoast\WP\SEO\Presenters\Admin\Migration_Error_Presenter;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**

--- a/tests/presenters/open-graph/type-presenter-test.php
+++ b/tests/presenters/open-graph/type-presenter-test.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Tests\Presenters\Open_Graph;
 
-use Mockery;
 use Brain\Monkey;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Open_Graph\Type_Presenter;

--- a/tests/presenters/robots-presenter-test.php
+++ b/tests/presenters/robots-presenter-test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Presenters;
 
 use Mockery;
-use Brain\Monkey;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Robots_Presenter;
 use Yoast\WP\SEO\Tests\TestCase;


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.

Don't import classes if they're not being used, where "used" is taken in the widest sense of the term, i.e. use in docblocks is counted as "used".


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.