### PR TITLE
Xss scripting social fix

### DIFF
--- a/admin/class-yoast-input-validation.php
+++ b/admin/class-yoast-input-validation.php
@@ -308,7 +308,7 @@ class Yoast_Input_Validation {
 	 * @return string The error invalid value message or empty string.
 	 */
 	public static function get_dirty_value_message( $error_code ) {
-		$dirty_value = self::get_dirty_value( $error_code );
+		$dirty_value = esc_html(self::get_dirty_value( $error_code ));
 
 		if ( $dirty_value ) {
 			return sprintf(

--- a/readme.txt
+++ b/readme.txt
@@ -214,7 +214,7 @@ Release Date: May 26th, 2020
 
 Bugfixes:
 
-* Fixes a bug where breadcrumbs were being saved in reversed order.
+* Fixes a bug where breadcrumbs would be saved in reversed order.
 * Fixes a bug where setting `Security: no advanced settings for authors` to `off` would remove the advanced settings tab for all users.
 * Fixes a bug where replacement variables would not be replaced when using the deprecated WPSEO_Frontend output without echoing it.
 

--- a/readme.txt
+++ b/readme.txt
@@ -217,6 +217,7 @@ Bugfixes:
 * Fixes a bug where breadcrumbs would be saved in reversed order.
 * Fixes a bug where setting `Security: no advanced settings for authors` to `off` would remove the advanced settings tab for all users.
 * Fixes a bug where replacement variables would not be replaced when using the deprecated WPSEO_Frontend output without echoing it.
+* Fixes a bug where our `select2` styling would overwrite the `select2` styling of other plugins.
 
 Enhancements:
 

--- a/readme.txt
+++ b/readme.txt
@@ -214,8 +214,8 @@ Release Date: May 26th, 2020
 
 Bugfixes:
 
-* Fixes an issue where breadcrumbs were being saved in reversed order.
-* Fixes a bug where setting `Security: no advanced settings for authors` to `off` would remove the Advanced Settings tab for all users.
+* Fixes a bug where breadcrumbs were being saved in reversed order.
+* Fixes a bug where setting `Security: no advanced settings for authors` to `off` would remove the advanced settings tab for all users.
 * Fixes a bug where replacement variables would not be replaced when using the deprecated WPSEO_Frontend output without echoing it.
 
 Enhancements:


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to escape the error message value of the social tab fields to prevent XSS scripting

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where XSS scripting could be done in the social fields when entering something like `x3<img src=a onerror=alert(/Facebook-App-ID/)>%*|{}!#$^*&e3\`.

## Relevant technical choices:

* Spoke with @moorscode and validated with `esc_html`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

For Twitter Username:
- Checkout this branch (xss-social-scripting-escaping), build and activate the plugin

- Navigate to "SEO"

- Navigate to "Social" sub-menu

- Set "Twitter Username" to:
`x3<img src=a onerror=alert(/Facebook-App-ID/)>%*|{}!#$^*&e3\`

- Click "Save Changes"

- Note that no popup appears

- Repeat these steps on trunk and make sure the popup **does appear**

For Facebook App ID:
- Checkout this branch (xss-social-scripting-escaping), build and activate the plugin

- Navigate to "SEO"

- Navigate to "Social" sub-menu

- Navigate to "Facebook" tab

- Set "Facebook App ID" to:
`x3<img src=a onerror=alert(/Facebook-App-ID/)>%*|{}!#$^*&e3\`

- Click "Save Changes"

- Note that no popup appears

- Repeat these steps on trunk and make sure the popup **does appear**



## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #1033
