### PR TITLE
Escape social value to prevent xss scripting

### DIFF
--- a/admin/class-yoast-input-validation.php
+++ b/admin/class-yoast-input-validation.php
@@ -308,7 +308,7 @@ class Yoast_Input_Validation {
 	 * @return string The error invalid value message or empty string.
 	 */
 	public static function get_dirty_value_message( $error_code ) {
-		$dirty_value = self::get_dirty_value( $error_code );
+		$dirty_value = esc_html(self::get_dirty_value( $error_code ));
 
 		if ( $dirty_value ) {
 			return sprintf(

--- a/admin/class-yoast-input-validation.php
+++ b/admin/class-yoast-input-validation.php
@@ -308,13 +308,13 @@ class Yoast_Input_Validation {
 	 * @return string The error invalid value message or empty string.
 	 */
 	public static function get_dirty_value_message( $error_code ) {
-		$dirty_value = esc_html(self::get_dirty_value( $error_code ));
+		$dirty_value = self::get_dirty_value( $error_code );
 
 		if ( $dirty_value ) {
 			return sprintf(
 				/* translators: %s: form value as submitted. */
 				esc_html__( 'The submitted value was: %s', 'wordpress-seo' ),
-				$dirty_value
+				esc_html( $dirty_value )
 			);
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to escape the error message value of the social tab fields to prevent XSS scripting

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where XSS scripting could be done in the social fields when entering something like `x3<img src=a onerror=alert(/Facebook-App-ID/)>%*|{}!#$^*&e3\`.

## Relevant technical choices:

* Spoke with @moorscode and chose to validate with `esc_html`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

For Twitter Username:
- Checkout this branch (xss-social-scripting-escaping), build and activate the plugin

- Navigate to "SEO"

- Navigate to "Social" sub-menu

- Set "Twitter Username" to:
`x3<img src=a onerror=alert(/Facebook-App-ID/)>%*|{}!#$^*&e3\`

- Click "Save Changes"

- Note that no popup appears

- Repeat these steps on trunk and make sure the popup **does appear**

For Facebook App ID:
- Checkout this branch (xss-social-scripting-escaping), build and activate the plugin

- Navigate to "SEO"

- Navigate to "Social" sub-menu

- Navigate to "Facebook" tab

- Set "Facebook App ID" to:
`x3<img src=a onerror=alert(/Facebook-App-ID/)>%*|{}!#$^*&e3\`

- Click "Save Changes"

- Note that no popup appears

- Repeat these steps on trunk and make sure the popup **does appear**



## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/1033
