### PR TITLE
Add Slot after keyphrase input

### DIFF
--- a/js/src/components/contentAnalysis/KeywordInput.js
+++ b/js/src/components/contentAnalysis/KeywordInput.js
@@ -1,7 +1,8 @@
 /* global wpseoAdminL10n */
 
 /* External dependencies */
-import { Component } from "@wordpress/element";
+import { Component, Fragment } from "@wordpress/element";
+import { Slot } from "@wordpress/components";
 import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
@@ -49,30 +50,33 @@ class KeywordInput extends Component {
 	 * @returns {ReactElement} The component.
 	 */
 	render() {
-		return <LocationConsumer>
-			{ context => (
-				<KeywordInputContainer>
-					<KeywordInputComponent
-						id={ `focus-keyword-input-${ context }` }
-						onChange={ this.props.onFocusKeywordChange }
-						keyword={ this.props.keyword }
-						label={ __( "Focus keyphrase", "wordpress-seo" ) }
-						helpLink={ KeywordInput.renderHelpLink() }
-						onBlurKeyword={ this.props.onBlurKeyword }
-						onFocusKeyword={ this.props.onFocusKeyword }
-					/>
-					{
-						this.props.keyword.length > 191 &&
-						<Alert type="warning">
-							{ __(
-								"Your keyphrase is too long. It can be a maximum of 191 characters.",
-								"wordpress-seo"
-							) }
-						</Alert>
-					}
-				</KeywordInputContainer>
-			) }
-		</LocationConsumer>;
+		return <Fragment>
+			<LocationConsumer>
+				{ context => (
+					<KeywordInputContainer>
+						<KeywordInputComponent
+							id={ `focus-keyword-input-${ context }` }
+							onChange={ this.props.onFocusKeywordChange }
+							keyword={ this.props.keyword }
+							label={ __( "Focus keyphrase", "wordpress-seo" ) }
+							helpLink={ KeywordInput.renderHelpLink() }
+							onBlurKeyword={ this.props.onBlurKeyword }
+							onFocusKeyword={ this.props.onFocusKeyword }
+						/>
+						{
+							this.props.keyword.length > 191 &&
+							<Alert type="warning">
+								{ __(
+									"Your keyphrase is too long. It can be a maximum of 191 characters.",
+									"wordpress-seo"
+								) }
+							</Alert>
+						}
+					</KeywordInputContainer>
+				) }
+			</LocationConsumer>
+			<Slot name="YoastAfterKeyphraseInput" />
+		</Fragment>;
 	}
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds a Slot after the Yoast Keyphrase input where Yoast add-ons or integrators can render their own components.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a Slot after the Yoast Keyphrase input where Yoast add-ons or integrators can render their own components.

## Relevant technical choices:

* N/a

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* I'll merge as soon as the build passes, better to test the Premium PR that depends on this.

## Quality assurance

* [x] I have tested this code to the best of my abilities