### PR TITLE
Create hidden input fields for the schema tab

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -422,7 +422,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		return new WPSEO_Metabox_Section_React(
 			'schema',
 			'',
-			$content,
+			$content
 		);
 	}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -362,6 +362,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$content_sections[] = $this->get_readability_meta_section();
 		}
 
+		$content_sections[] = $this->get_schema_meta_section();
+
 		// Check if social_admin is an instance of WPSEO_Social_Admin.
 		if ( $this->social_admin instanceof WPSEO_Social_Admin ) {
 			$content_sections[] = $this->social_admin->get_meta_section();
@@ -407,6 +409,20 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			[
 				'html_after' => $html_after,
 			]
+		);
+	}
+
+	/**
+	 * Returns the metabox section for the schema tab.
+	 *
+	 * @return WPSEO_Metabox_Section_React
+	 */
+	private function get_schema_meta_section() {
+		$content = $this->get_tab_content( 'schema' );
+		return new WPSEO_Metabox_Section_React(
+			'schema',
+			'',
+			$content,
 		);
 	}
 
@@ -515,6 +531,11 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		if ( isset( $meta_field_def['description'] ) ) {
 			$aria_describedby = ' aria-describedby="' . $esc_form_key . '-desc"';
 			$description      = '<p id="' . $esc_form_key . '-desc" class="yoast-metabox__description">' . $meta_field_def['description'] . '</p>';
+		}
+
+		// Add a hide-on-pages option that returns nothing when the field is rendered on a page.
+		if ( isset( $meta_field_def['hide-on-pages'] ) && $meta_field_def['hide-on-pages'] && get_post_type() === 'page' ) {
+			return '';
 		}
 
 		switch ( $meta_field_def['type'] ) {

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -198,7 +198,8 @@ class WPSEO_Meta {
 				'type' => 'hidden',
 			],
 			'schema_article_type' => [
-				'type' => 'hidden',
+				'type'          => 'hidden',
+				'hide-on-pages' => true,
 			],
 		],
 		/* Fields we should validate & save, but not show on any form. */

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -193,6 +193,14 @@ class WPSEO_Meta {
 			],
 		],
 		'social'   => [],
+		'schema'   => [
+			'schema_page_type'    => [
+				'type' => 'hidden',
+			],
+			'schema_article_type' => [
+				'type' => 'hidden',
+			],
+		],
 		/* Fields we should validate & save, but not show on any form. */
 		'non_form' => [
 			'linkdex' => [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* We are going to add a schema tab.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Adds hidden input fields for the schema tab.

## Relevant technical choices:
* Add a new attribute to the meta_fields definitions that allows us to hide elements on pages.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Visit a post:
	* Check that `yoast_wpseo_schema_page_type` and `yoast_wpseo_schema_article_type` input fields are available.
* Visit a page:
	* Check that `yoast_wpseo_schema_page_type` is available.
	* Check that `yoast_wpseo_article_type` is not available.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #15229 
