### PR TITLE
PR-15 Exclude replacement variable values that are arrays.

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -1032,7 +1032,13 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$custom_fields = get_post_custom( $post->ID );
 
 		foreach ( $custom_fields as $custom_field_name => $custom_field ) {
+			// Skip private custom fields.
 			if ( substr( $custom_field_name, 0, 1 ) === '_' ) {
+				continue;
+			}
+
+			// Skip custom field values that are serialized.
+			if ( is_serialized( $custom_field[0] ) ) {
 				continue;
 			}
 

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -190,7 +190,12 @@ class WPSEO_Replace_Vars {
 
 		// Do the actual replacements.
 		if ( is_array( $replacements ) && $replacements !== [] ) {
-			$string = str_replace( array_keys( $replacements ), array_values( $replacements ), $string );
+			$string = str_replace(
+				array_keys( $replacements ),
+				// Exclude replacement values that are arrays e.g. coming from a custom field serialized value.
+				array_filter( array_values( $replacements ), 'is_string' ),
+				$string
+			);
 		}
 
 		/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want users to use safe values for the Google Preview and avoid PHP notices.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* FIxes a bug where replacement variable values that are a serialized array string break the Google Preview and output a PHP notice on the front end.

## Relevant technical choices:

* Filtered out replacement variable values that are array / serialized array string

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- on trunk: follow the steps from the issue https://github.com/Yoast/bugreports/issues/931
- additionally, add the custom field replacement variable also in the Meta description so that both title and description contain e.g. `%%cf_wpseo_global_identifier_values%% %%title%% `
- observe serialized array strings are displayed in the Google Preview
- go to the front end and observe there's an "Array to string conversion" PHP notice
- inspect the source and see the title and meta description contain `Array`
- switch to this branch and build
- observe the Google Preview omits to replace `%%cf_wpseo_global_identifier_values%%`
- observe `cf_wpseo_global_identifier_values` is not available any longer in the replacement variables drop down:
  - click "Insert snippet variable"
  - start typing `cf_wpseo`
  - see there's no suggestion:
<img width="735" alt="Screenshot 2020-05-26 at 14 05 35" src="https://user-images.githubusercontent.com/1682452/82898739-18ca3700-9f5a-11ea-8720-a8e75ee64405.png">

- if you end up removing the variable, manually re-add `%%cf_wpseo_global_identifier_values%% %%title%%`
- go to the front end and observe there's no PHP notice
- inspect the source and observe the title and meta description correctly output only the `%%title%%` variable
- test other places where a custom field that has an array value may be used e.g. under Search Appearance and check the output skips it

Note:
Under Search Appearance, these variables will still be available e.g. `%%cf_wpseo_global_identifier_values%%` is still in the suggestions dropdown. I think this should be better addressed in https://github.com/Yoast/wordpress-seo/issues/14470 




## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/931