### PR TITLE
Set wordFormRecognitionActive to true for all languages with word form recognition

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -69,7 +69,7 @@ class WPSEO_Metabox_Formatter {
 			'isRtl'                     => is_rtl(),
 			'isPremium'                 => WPSEO_Utils::is_yoast_seo_premium(),
 			'addKeywordUpsell'          => $this->get_add_keyword_upsell_translations(),
-			'wordFormRecognitionActive' => $this->is_word_form_recognition_active( WPSEO_Language_Utils::get_language( get_locale() ) ),
+			'wordFormRecognitionActive' => YoastSEO()->helpers->language->is_word_form_recognition_active( WPSEO_Language_Utils::get_language( get_locale() ) ),
 			'siteIconUrl'               => get_site_icon_url(),
 
 			/**
@@ -261,18 +261,5 @@ class WPSEO_Metabox_Formatter {
 		 * @param array $is_markdown Is markdown support for Yoast SEO active.
 		 */
 		return apply_filters( 'wpseo_is_markdown_enabled', $is_markdown );
-	}
-
-	/**
-	 * Checks whether word form recognition is active for the used language.
-	 *
-	 * @param string $language The used language.
-	 *
-	 * @return boolean Whether word form recognition is active for the used language.
-	 */
-	private function is_word_form_recognition_active( $language ) {
-		$supported_languages = [ 'de', 'en', 'es', 'fr', 'it', 'nl', 'ru' ];
-
-		return in_array( $language, $supported_languages, true );
 	}
 }

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -69,7 +69,7 @@ class WPSEO_Metabox_Formatter {
 			'isRtl'                     => is_rtl(),
 			'isPremium'                 => WPSEO_Utils::is_yoast_seo_premium(),
 			'addKeywordUpsell'          => $this->get_add_keyword_upsell_translations(),
-			'wordFormRecognitionActive' => ( WPSEO_Language_Utils::get_language( get_locale() ) === 'en' ),
+			'wordFormRecognitionActive' => $this->is_word_form_recognition_active( WPSEO_Language_Utils::get_language( get_locale() ) ),
 			'siteIconUrl'               => get_site_icon_url(),
 
 			/**
@@ -261,5 +261,18 @@ class WPSEO_Metabox_Formatter {
 		 * @param array $is_markdown Is markdown support for Yoast SEO active.
 		 */
 		return apply_filters( 'wpseo_is_markdown_enabled', $is_markdown );
+	}
+
+	/**
+	 * Checks whether word form recognition is active for the used language.
+	 *
+	 * @param string $language The used language.
+	 *
+	 * @return boolean Whether word form recognition is active for the used language.
+	 */
+	private function is_word_form_recognition_active( $language ) {
+		$supported_languages = [ 'de', 'en', 'es', 'fr', 'it', 'nl', 'ru' ];
+
+		return in_array( $language, $supported_languages, true );
 	}
 }

--- a/integration-tests/formatter/test-metabox-formatter.php
+++ b/integration-tests/formatter/test-metabox-formatter.php
@@ -73,4 +73,53 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 
 		$this->assertEquals( $result['translations'], [] );
 	}
+
+	/**
+	 * Test that wordFormRecognitionActive is true for English.
+	 *
+	 * @covers WPSEO_Metabox_Formatter::__construct
+	 * @covers WPSEO_Metabox_Formatter::is_word_form_recognition_active
+	 */
+	public function test_word_form_recognition_is_active() {
+		add_filter('locale', function(){ return 'en_US'; });
+
+		$class_instance = new WPSEO_Metabox_Formatter(
+			new WPSEO_Post_Metabox_Formatter(
+				$this->factory->post->create_and_get(),
+				[],
+				''
+			)
+		);
+
+		$values = $class_instance->get_values();
+		$result = $values['wordFormRecognitionActive'];
+
+		$this->assertEquals( true, $result );
+
+	}
+
+
+	/**
+	 * Test that wordFormRecognitionActive is false for Afrikaans.
+	 *
+	 * @covers WPSEO_Metabox_Formatter::__construct
+	 * @covers WPSEO_Metabox_Formatter::is_word_form_recognition_active
+	 */
+	public function test_word_form_recognition_is_not_active() {
+		add_filter('locale', function(){ return 'af_ZA'; });
+
+		$class_instance = new WPSEO_Metabox_Formatter(
+			new WPSEO_Post_Metabox_Formatter(
+				$this->factory->post->create_and_get(),
+				[],
+				''
+			)
+		);
+
+		$values = $class_instance->get_values();
+		$result = $values['wordFormRecognitionActive'];
+
+		$this->assertEquals( false, $result );
+
+	}
 }

--- a/src/helpers/language-helper.php
+++ b/src/helpers/language-helper.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * A helper object for language features.
+ *
+ * @package Yoast\YoastSEO\Helpers
+ */
+
+namespace Yoast\WP\SEO\Helpers;
+
+/**
+ * Class Language_Helper
+ */
+class Language_Helper {
+
+	/**
+	 * Checks whether word form recognition is active for the used language.
+	 *
+	 * @param string $language The used language.
+	 *
+	 * @return boolean Whether word form recognition is active for the used language.
+	 */
+	public function is_word_form_recognition_active( $language ) {
+		$supported_languages = [ 'de', 'en', 'es', 'fr', 'it', 'nl', 'ru' ];
+
+		return in_array( $language, $supported_languages, true );
+	}
+}

--- a/src/surfaces/helpers-surface.php
+++ b/src/surfaces/helpers-surface.php
@@ -19,6 +19,7 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
  * @property Helpers\Date_Helper           $date
  * @property Helpers\Home_Url_Helper       $home_url
  * @property Helpers\Image_Helper          $image
+ * @property Helpers\Language_Helper       $language
  * @property Helpers\Meta_Helper           $meta
  * @property Helpers\Options_Helper        $options
  * @property Helpers\Pagination_Helper     $pagination

--- a/tests/helpers/language-helper-test.php
+++ b/tests/helpers/language-helper-test.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Helpers;
+
+use Yoast\WP\SEO\Helpers\Language_Helper;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Language_Helper_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Helpers\Language_Helper
+ *
+ * @group helpers
+ */
+class Language_Helper_Test extends TestCase {
+
+	/**
+	 * The language helper.
+	 *
+	 * @var Language_Helper
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the tests.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->instance = new Language_Helper();
+	}
+
+	/**
+	 * Tests that a given language has word form recognition support.
+	 *
+	 * @covers ::is_word_form_recognition_active
+	 *
+	 * @dataProvider supported_language_provider
+	 *
+	 * @param string $language The language to test.
+	 */
+	public function test_is_word_form_recognition_active( $language ) {
+		$this->assertTrue( $this->instance->is_word_form_recognition_active( $language ) );
+	}
+
+	/**
+	 * Data provider for the test_is_word_form_recognition_active test.
+	 *
+	 * @return string[][] The dataset.
+	 */
+	public function supported_language_provider() {
+		return [ [ 'de' ], [ 'en' ], [ 'es' ], [ 'fr' ], [ 'it' ], [ 'nl' ], [ 'ru' ] ];
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Until now, wordFormRecognitionActive was only set to true for English. This meant that the word form support upsell was only shown when the site language was set to English. However, we have many more languages with word form support, and because the upsell (for English) is quite effective, we'd like to show them for all supported languages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Shows the word form support upsell when the website is set to any of the supported languages, not only English.

## Relevant technical choices:

* I tried porting the existing tests to brain monkey (together with Igor), but run into problems. For now I stuck with the oldskool tests. I'll contact Herre later to see if we can get the brain monkey test working. This shouldn't block merging.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set your site language to French.
* Visit the post editor
* See the following upsell:
![Edit_Post_‹_Test_website_—_WordPress](https://user-images.githubusercontent.com/17744553/83022422-c9543b80-a02b-11ea-96bf-a7aea04da418.png)
* Set your site language to Afrikaans.
* Visit the post editor
* Don't see the upsell.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
