### PR TITLE
P1-17 Create the schema tab component

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -415,12 +415,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$content = $this->get_tab_content( 'schema' );
 		return new WPSEO_Metabox_Section_React(
 			'schema',
-			'',
-<<<<<<< HEAD
-			$content
-=======
+			'<span class="wpseo-schema-icon"></span>' . __( 'Schema', 'wordpress-seo' ),
 			$content,
->>>>>>> 3ae378a62... Hide schema_article_type on pages
 		);
 	}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -528,7 +528,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		}
 
 		// Add a hide-on-pages option that returns nothing when the field is rendered on a page.
-		if ( isset( $meta_field_def['hide-on-pages'] ) && $meta_field_def['hide-on-pages'] && get_post_type() === 'page' ) {
+		if ( isset( $meta_field_def['hide_on_pages'] ) && $meta_field_def['hide_on_pages'] && get_post_type() === 'page' ) {
 			return '';
 		}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -416,7 +416,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		return new WPSEO_Metabox_Section_React(
 			'schema',
 			'<span class="wpseo-schema-icon"></span>' . __( 'Schema', 'wordpress-seo' ),
-			$content,
+			$content
 		);
 	}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -416,7 +416,11 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		return new WPSEO_Metabox_Section_React(
 			'schema',
 			'',
+<<<<<<< HEAD
 			$content
+=======
+			$content,
+>>>>>>> 3ae378a62... Hide schema_article_type on pages
 		);
 	}
 

--- a/css/src/editor/metabox.css
+++ b/css/src/editor/metabox.css
@@ -725,4 +725,15 @@ div.interface-pinned-items button.components-button.is-pressed[aria-label="Yoast
 div.interface-pinned-items button.components-button.is-pressed[aria-label="Yoast SEO Premium"] > svg path {
 	fill: #ffffff;
 }
+.wpseo-schema-icon {
+  height: 16px;
+  width: 16px;
+  margin-right: 8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-image: var(--yoast-svg-icon-schema);
+  background-size: cover;
+}
+
 /*# sourceMappingURL=metabox.css.map */

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -199,7 +199,7 @@ class WPSEO_Meta {
 			],
 			'schema_article_type' => [
 				'type'          => 'hidden',
-				'hide-on-pages' => true,
+				'hide_on_pages' => true,
 			],
 		],
 		/* Fields we should validate & save, but not show on any form. */

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -194,12 +194,14 @@ class WPSEO_Meta {
 		],
 		'social'   => [],
 		'schema'   => [
-			'schema_page_type'    => [
-				'type' => 'hidden',
+			'schema_page_type' => [
+				'type'         => 'hidden',
+				'title'        => '',
 			],
 			'schema_article_type' => [
-				'type'          => 'hidden',
-				'hide_on_pages' => true,
+				'type'            => 'hidden',
+				'title'           => '',
+				'hide_on_pages'   => true,
 			],
 		],
 		/* Fields we should validate & save, but not show on any form. */

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1195,6 +1195,7 @@ SVG;
 			'noIndex'              => ! ! $no_index,
 			'isPremium'            => self::is_yoast_seo_premium(),
 			'isPostType'           => ! ! get_post_type(),
+			'postType'             => get_post_type(),
 			'postTypeNamePlural'   => ( $page_type === 'post' ) ? $label_object->label : $label_object->name,
 			'postTypeNameSingular' => ( $page_type === 'post' ) ? $label_object->labels->singular_name : $label_object->singular_name,
 			'breadcrumbsDisabled'  => WPSEO_Options::get( 'breadcrumbs-enable', false ) !== true && ! current_theme_supports( 'yoast-seo-breadcrumbs' ),

--- a/js/src/components/SchemaTab.js
+++ b/js/src/components/SchemaTab.js
@@ -6,6 +6,7 @@ import { createPortal } from "react-dom";
 import HelpIcon from "@yoast/components/src/help-icon/HelpIcon";
 import SidebarCollapsible from "./SidebarCollapsible";
 import PropTypes from "prop-types";
+import interpolateComponents from "interpolate-components";
 
 const SchemaContainer = styled.div`
 	padding: 16px;
@@ -107,6 +108,21 @@ const schemaArticleOptions = [
 	},
 ];
 
+/* translators: %1$s and %2$s expand to a link to the Search Appearance Settings page */
+const footerText = sprintf(
+	__( "You can change the default type for Posts in your %1$sSearch Appearance Settings%2$s.", "wordpress-seo" ),
+	"{{link}}",
+	"{{/link}}"
+);
+
+const footerWithLink = interpolateComponents(
+	{
+		mixedString: footerText,
+		// eslint-disable-next-line jsx-a11y/anchor-has-content
+		components: { link: <a href="/wp-admin/admin.php?page=wpseo_titles#top#post-types" /> },
+	},
+);
+
 /**
  * Returns the content of the schema tab.
  *
@@ -126,13 +142,13 @@ const Content = ( props ) => (
 		<p>
 			{ props.helpTextDescription }
 		</p>
-		{ props.showAdditionalHelpText && <div className="yoast-field-group__title" style={ { paddingTop: 16, paddingBottom: 16 } }>
-			<b>What type of page or content is this?</b>
+		<div className="yoast-field-group__title" style={ { paddingTop: 16, paddingBottom: 16 } }>
+			<b>{ __( "What type of page or content is this?", "wordpress-seo" ) }</b>
 			<HelpIcon
 				linkTo={ props.additionalHelpTextLink }
 				linkText={ __( "Learn more about page or content types", "wordpress-seo" ) }
 			/>
-		</div> }
+		</div>
 		<Select
 			id="yoast_wpseo_schema_page_type_react"
 			name="schema_page_type"
@@ -149,16 +165,11 @@ const Content = ( props ) => (
 			onChange={ props.schemaArticleTypeChange }
 			selected={ props.schemaArticleTypeSelected }
 		/> }
-		{ props.showFooter && <p>
-			You can change the default type for Posts in your
-			<a href="/wp-admin/admin.php?page=wpseo_titles#top#post-types"> Search Appearance settings</a>.
-		</p> }
+		<p>{ footerWithLink }</p>
 	</Fragment>
 );
 
 Content.propTypes = {
-	showFooter: PropTypes.bool,
-	showAdditionalHelpText: PropTypes.bool,
 	schemaPageTypeChange: PropTypes.func,
 	schemaPageTypeSelected: PropTypes.string,
 	schemaArticleTypeChange: PropTypes.func,
@@ -171,8 +182,6 @@ Content.propTypes = {
 };
 
 Content.defaultProps = {
-	showFooter: true,
-	showAdditionalHelpText: true,
 	schemaPageTypeChange: () => {},
 	schemaPageTypeSelected: null,
 	schemaArticleTypeChange: () => {},

--- a/js/src/components/SchemaTab.js
+++ b/js/src/components/SchemaTab.js
@@ -61,6 +61,7 @@ const schemaPageOptions = [
 		value: "option-12",
 	},
 	{
+		/* translators: %1$s expands to "- " (a hyphen and a space), %2$s expands to " -" (a space and a hyphen) */
 		name: sprintf( __( "%1$sNone%2$s", "wordpress-seo" ), "- ", " -" ),
 		value: "option-13",
 	},
@@ -100,6 +101,7 @@ const schemaArticleOptions = [
 		value: "option-8",
 	},
 	{
+		/* translators: %1$s expands to "- " (a hyphen and a space), %2$s expands to " -" (a space and a hyphen) */
 		name: sprintf( __( "%1$sNone%2$s", "wordpress-seo" ), "- ", " -" ),
 		value: "option-9",
 	},

--- a/js/src/components/SchemaTab.js
+++ b/js/src/components/SchemaTab.js
@@ -108,16 +108,17 @@ const schemaArticleOptions = [
 	},
 ];
 
-/* translators: %1$s and %2$s expand to a link to the Search Appearance Settings page */
-const footerText = sprintf(
-	__( "You can change the default type for Posts in your %1$sSearch Appearance Settings%2$s.", "wordpress-seo" ),
+/* translators: %1$s expands to the plural name of the current post type, %2$s and %3$s expand to a link to the Search Appearance Settings page */
+const footerText = ( postTypeName ) => sprintf(
+	__( "You can change the default type for %1$s in your %2$sSearch Appearance Settings%3$s.", "wordpress-seo" ),
+	postTypeName,
 	"{{link}}",
-	"{{/link}}"
+	"{{/link}}",
 );
 
-const footerWithLink = interpolateComponents(
+const footerWithLink = ( postTypeName ) => interpolateComponents(
 	{
-		mixedString: footerText,
+		mixedString: footerText( postTypeName ),
 		// eslint-disable-next-line jsx-a11y/anchor-has-content
 		components: { link: <a href="/wp-admin/admin.php?page=wpseo_titles#top#post-types" /> },
 	},
@@ -136,7 +137,7 @@ const Content = ( props ) => (
 			<b>{ props.helpTextTitle }</b>
 			<HelpIcon
 				linkTo={ props.helpTextLink }
-				linkText={ __( "Ultimate structured data guide", "wordpress-seo" ) }
+				linkText={ __( "Learn more about structured data with Schema.org", "wordpress-seo" ) }
 			/>
 		</div>
 		<p>
@@ -165,7 +166,7 @@ const Content = ( props ) => (
 			onChange={ props.schemaArticleTypeChange }
 			selected={ props.schemaArticleTypeSelected }
 		/> }
-		<p>{ footerWithLink }</p>
+		<p>{ footerWithLink( props.postTypeName ) }</p>
 	</Fragment>
 );
 
@@ -179,6 +180,7 @@ Content.propTypes = {
 	helpTextLink: PropTypes.string.isRequired,
 	helpTextTitle: PropTypes.string.isRequired,
 	helpTextDescription: PropTypes.string.isRequired,
+	postTypeName: PropTypes.string.isRequired,
 };
 
 Content.defaultProps = {
@@ -223,6 +225,7 @@ SchemaTab.propTypes = {
 	helpTextTitle: PropTypes.string.isRequired,
 	helpTextDescription: PropTypes.string.isRequired,
 	isMetabox: PropTypes.bool.isRequired,
+	postTypeName: PropTypes.string.isRequired,
 };
 
 SchemaTab.defaultProps = {

--- a/js/src/components/SchemaTab.js
+++ b/js/src/components/SchemaTab.js
@@ -1,0 +1,223 @@
+import React, { Fragment } from "react";
+import styled from "styled-components";
+import { Select } from "@yoast/components/src/select/Select";
+import { __, sprintf } from "@wordpress/i18n";
+import { createPortal } from "react-dom";
+import HelpIcon from "@yoast/components/src/help-icon/HelpIcon";
+import SidebarCollapsible from "./SidebarCollapsible";
+import PropTypes from "prop-types";
+
+const SchemaContainer = styled.div`
+	padding: 16px;
+`;
+
+const schemaPageOptions = [
+	{
+		name: __( "Web Page", "wordpress-seo" ),
+		value: "option-1",
+	},
+	{
+		name: __( "Item Page", "wordpress-seo" ),
+		value: "option-2",
+	},
+	{
+		name: __( "About Page", "wordpress-seo" ),
+		value: "option-3",
+	},
+	{
+		name: __( "FAQ Page", "wordpress-seo" ),
+		value: "option-4",
+	},
+	{
+		name: __( "QA Page", "wordpress-seo" ),
+		value: "option-5",
+	},
+	{
+		name: __( "Profile Page", "wordpress-seo" ),
+		value: "option-6",
+	},
+	{
+		name: __( "Contact Page", "wordpress-seo" ),
+		value: "option-7",
+	},
+	{
+		name: __( "Medical Web Page", "wordpress-seo" ),
+		value: "option-8",
+	},
+	{
+		name: __( "Collection Page", "wordpress-seo" ),
+		value: "option-9",
+	},
+	{
+		name: __( "Checkout Page", "wordpress-seo" ),
+		value: "option-10",
+	},
+	{
+		name: __( "Real Estate Listing", "wordpress-seo" ),
+		value: "option-11",
+	},
+	{
+		name: __( "Search Results Page", "wordpress-seo" ),
+		value: "option-12",
+	},
+	{
+		name: sprintf( __( "%1$sNone%2$s", "wordpress-seo" ), "- ", " -" ),
+		value: "option-13",
+	},
+];
+
+const schemaArticleOptions = [
+	{
+		name: __( "Article", "wordpress-seo" ),
+		value: "option-1",
+	},
+	{
+		name: __( "Social Media Posting", "wordpress-seo" ),
+		value: "option-2",
+	},
+	{
+		name: __( "News Article", "wordpress-seo" ),
+		value: "option-3",
+	},
+	{
+		name: __( "Advertiser Content Article", "wordpress-seo" ),
+		value: "option-4",
+	},
+	{
+		name: __( "Satirical Article", "wordpress-seo" ),
+		value: "option-5",
+	},
+	{
+		name: __( "Scholary Article", "wordpress-seo" ),
+		value: "option-6",
+	},
+	{
+		name: __( "Tech Article", "wordpress-seo" ),
+		value: "option-7",
+	},
+	{
+		name: __( "Report", "wordpress-seo" ),
+		value: "option-8",
+	},
+	{
+		name: sprintf( __( "%1$sNone%2$s", "wordpress-seo" ), "- ", " -" ),
+		value: "option-9",
+	},
+];
+
+/**
+ * Returns the content of the schema tab.
+ *
+ * @param {object} props Component props.
+ *
+ * @returns {React.Component} The schema tab content.
+ */
+const Content = ( props ) => (
+	<Fragment>
+		<div className="yoast-field-group__title">
+			<b>{ props.helpTextTitle }</b>
+			<HelpIcon
+				linkTo={ props.helpTextLink }
+				linkText={ __( "Ultimate structured data guide", "wordpress-seo" ) }
+			/>
+		</div>
+		<p>
+			{ props.helpTextDescription }
+		</p>
+		{ props.showAdditionalHelpText && <div className="yoast-field-group__title" style={ { paddingTop: 16, paddingBottom: 16 } }>
+			<b>What type of page or content is this?</b>
+			<HelpIcon
+				linkTo={ props.additionalHelpTextLink }
+				linkText={ __( "Learn more about page or content types", "wordpress-seo" ) }
+			/>
+		</div> }
+		<Select
+			id="yoast_wpseo_schema_page_type_react"
+			name="schema_page_type"
+			options={ schemaPageOptions }
+			label={ __( "Page type", "wordpress-seo" ) }
+			onChange={ props.schemaPageTypeChange }
+			selected={ props.schemaPageTypeSelected }
+		/>
+		{ props.showArticleTypeInput && <Select
+			id="yoast_wpseo_schema_article_type_react"
+			name="schema_article_type"
+			options={ schemaArticleOptions }
+			label={ __( "Article type", "wordpress-seo" ) }
+			onChange={ props.schemaArticleTypeChange }
+			selected={ props.schemaArticleTypeSelected }
+		/> }
+		{ props.showFooter && <p>
+			You can change the default type for Posts in your
+			<a href="/wp-admin/admin.php?page=wpseo_titles#top#post-types"> Search Appearance settings</a>.
+		</p> }
+	</Fragment>
+);
+
+Content.propTypes = {
+	showFooter: PropTypes.bool,
+	showAdditionalHelpText: PropTypes.bool,
+	schemaPageTypeChange: PropTypes.func,
+	schemaPageTypeSelected: PropTypes.string,
+	schemaArticleTypeChange: PropTypes.func,
+	schemaArticleTypeSelected: PropTypes.string,
+	showArticleTypeInput: PropTypes.bool.isRequired,
+	additionalHelpTextLink: PropTypes.string.isRequired,
+	helpTextLink: PropTypes.string.isRequired,
+	helpTextTitle: PropTypes.string.isRequired,
+	helpTextDescription: PropTypes.string.isRequired,
+};
+
+Content.defaultProps = {
+	showFooter: true,
+	showAdditionalHelpText: true,
+	schemaPageTypeChange: () => {},
+	schemaPageTypeSelected: null,
+	schemaArticleTypeChange: () => {},
+	schemaArticleTypeSelected: null,
+};
+
+/**
+ * Renders the schema tab.
+ *
+ * @param {object} props The component props.
+ *
+ * @returns {React.Component} The schema tab.
+ */
+const SchemaTab = ( props ) => {
+	if ( props.isMetabox ) {
+		return createPortal(
+			<SchemaContainer>
+				<Content { ...props } />
+			</SchemaContainer>,
+			document.getElementById( "wpseo-meta-section-schema" )
+		);
+	}
+
+	return (
+		<SidebarCollapsible
+			title={ __( "Schema", "wordpress-seo" ) }
+		>
+			<Content { ...props } />
+		</SidebarCollapsible>
+	);
+};
+
+SchemaTab.propTypes = {
+	showArticleTypeInput: PropTypes.bool,
+	articleTypeLabel: PropTypes.string,
+	additionalHelpTextLink: PropTypes.string,
+	pageTypeLabel: PropTypes.string.isRequired,
+	helpTextLink: PropTypes.string.isRequired,
+	helpTextTitle: PropTypes.string.isRequired,
+	helpTextDescription: PropTypes.string.isRequired,
+	isMetabox: PropTypes.bool.isRequired,
+};
+
+SchemaTab.defaultProps = {
+	showArticleTypeInput: false,
+	articleTypeLabel: "",
+	additionalHelpTextLink: "",
+};
+
+export default SchemaTab;

--- a/js/src/components/fills/MetaboxFill.js
+++ b/js/src/components/fills/MetaboxFill.js
@@ -15,6 +15,7 @@ import SidebarItem from "../SidebarItem";
 import TopLevelProviders from "../TopLevelProviders";
 import AdvancedSettings from "../AdvancedSettings";
 import SocialMetadataPortal from "../portals/SocialMetadataPortal";
+import SchemaTabContainer from "../../containers/SchemaTab";
 
 /**
  * Creates the Metabox component.
@@ -99,6 +100,15 @@ export default function MetaboxFill( { settings, store, theme } ) {
 					<AdvancedSettings />
 				</TopLevelProviders>
 			</SidebarItem> }
+			<SidebarItem renderPriority={ 50 }>
+				<TopLevelProviders
+					store={ store }
+					theme={ theme }
+					location={ "metabox" }
+				>
+					<SchemaTabContainer />
+				</TopLevelProviders>
+			</SidebarItem>
 			<TopLevelProviders
 				renderPriority={ -1 }
 				store={ store }

--- a/js/src/components/fills/SidebarFill.js
+++ b/js/src/components/fills/SidebarFill.js
@@ -12,6 +12,7 @@ import SeoAnalysis from "../contentAnalysis/SeoAnalysis";
 import SidebarItem from "../SidebarItem";
 import SnippetPreviewModal from "../SnippetPreviewModal";
 import TopLevelProviders from "../TopLevelProviders";
+import SchemaTabContainer from "../../containers/SchemaTab";
 
 /**
  * Creates the SidebarFill component.
@@ -86,6 +87,15 @@ export default function SidebarFill( { settings, store, theme } ) {
 					</TopLevelProviders>
 				</SidebarItem>
 				}
+				<SidebarItem renderPriority={ 40 }>
+					<TopLevelProviders
+						store={ store }
+						theme={ theme }
+						location={ "sidebar" }
+					>
+						<SchemaTabContainer />
+					</TopLevelProviders>
+				</SidebarItem>
 			</Fill>
 		</Fragment>
 	);

--- a/js/src/containers/SchemaTab.js
+++ b/js/src/containers/SchemaTab.js
@@ -109,6 +109,7 @@ const SchemaTabContainer = () => {
 		pageTypeLabel: __( "Page type", "wordpress-seo" ),
 		schemaPageTypeChange: setPageType,
 		schemaPageTypeSelected: getPageType(),
+		postTypeName: window.wpseoAdminL10n.postTypeNamePlural,
 	};
 
 	return (

--- a/js/src/containers/SchemaTab.js
+++ b/js/src/containers/SchemaTab.js
@@ -1,0 +1,133 @@
+import React from "react";
+import SchemaTab from "../components/SchemaTab";
+import { __ } from "@wordpress/i18n";
+import { LocationConsumer } from "../components/contexts/location";
+
+const articleTypeInputId = "yoast_wpseo_schema_article_type";
+const pageTypeInputId = "yoast_wpseo_schema_page_type";
+
+/**
+ * Gets the ArticleType from the hidden input.
+ *
+ * @returns {string} The ArticleType.
+ */
+const getArticleType = () => document.getElementById( articleTypeInputId ).value;
+
+/**
+ * Sets the ArticleType on the hidden input.
+ *
+ * @param {string} articleType The selected ArticleType.
+ *
+ * @returns {void}
+ */
+const setArticleType = ( articleType ) => {
+	document.getElementById( articleTypeInputId ).value = articleType;
+};
+
+/**
+ * Gets the PageType from the hidden input.
+ *
+ * @returns {string} The PageType.
+ */
+const getPageType = () => document.getElementById( pageTypeInputId ).value;
+
+/**
+ * Sets the PageType on the hidden input.
+ *
+ * @param {string} pageType The selected PageType.
+ *
+ * @returns {void}
+ */
+const setPageType = ( pageType ) => {
+	document.getElementById( pageTypeInputId ).value = pageType;
+};
+
+/**
+ * Function to get props based on the postType.
+ *
+ * @param {bool} isPost Whether it's a post or a page.
+ *
+ * @returns {object} Props for this postType.
+ */
+const getPostBasedProps = ( isPost ) => {
+	if ( isPost ) {
+		return {
+			showArticleTypeInput: true,
+			helpTextTitle: __( "Yoast SEO automatically describes your posts using schema.org", "wordpress-seo" ),
+			helpTextDescription: __(
+				"This helps search engines understand your website and your content. You can change some of your settings for this post below",
+				"wordpress-seo"
+			),
+			schemaArticleTypeChange: setArticleType,
+			schemaArticleTypeSelected: getArticleType(),
+		};
+	}
+
+	return {
+		showArticleTypeInput: false,
+		helpTextTitle: __( "Yoast SEO automatically describes your pages using schema.org", "wordpress-seo" ),
+		helpTextDescription: __(
+			"This helps search engines understand your website and your content. You can change some of your settings for this page below",
+			"wordpress-seo"
+		),
+	};
+};
+
+/**
+ * Function to get props based on the location.
+ *
+ * @param {string} location The location in which the component is rendered.
+ *
+ * @returns {object} Props for this location.
+ */
+const getLocationBasedProps = ( location ) => {
+	if ( location === "metabox" ) {
+		return {
+			helpTextLink: "https://yoa.st/400",
+			additionalHelpTextLink: "https://yoa.st/402",
+			isMetabox: true,
+		};
+	}
+
+	return {
+		helpTextLink: "https://yoa.st/401",
+		additionalHelpTextLink: "https://yoa.st/403",
+		isMetabox: false,
+	};
+};
+
+/**
+ * Renders the SchemaComponent.
+ *
+ * @returns {React.Component} The SchemaTab.
+ */
+const SchemaTabContainer = () => {
+	const isPost = window.wpseoAdminL10n.postType === "post";
+
+	const baseProps = {
+		articleTypeLabel: __( "Article type", "wordpress-seo" ),
+		pageTypeLabel: __( "Page type", "wordpress-seo" ),
+		schemaPageTypeChange: setPageType,
+		schemaPageTypeSelected: getPageType(),
+	};
+
+	return (
+		<LocationConsumer>
+			{ location => {
+				const props = {
+					...baseProps,
+					...getPostBasedProps( isPost ),
+					...getLocationBasedProps( location ),
+				};
+
+				return (
+					<SchemaTab
+						{ ...props }
+					/>
+				);
+			} }
+		</LocationConsumer>
+	);
+};
+
+export default SchemaTabContainer;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* We are adding a Schema tab to provide more insights into what Yoast SEO does with schema in the back-end.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Adds the JS side for the new schema tab.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Check that the Schema tab renders on Posts and Pages
* In Pages: Only the page type select box should be visible.
* In Posts: The article and page type select boxes should be visible.
* Check that values are set and fetched from the hidden input fields:
	* Setting:
		1. Change a value in schema tab
		2. Check that the corresponding hidden input is changed
		1. This can be done in the browser's console with the following selector: `document.getElementById(componentId).value` where component id is one of the following:
			- ArticleType: `yoast_wpseo_schema_article_type`
			- PageType: `yoast_wpseo_schema_page_type`
	* Getting:
		1. In `class-wpseo-meta.php` in the definition of the social tab (currently line 196). Add `'default_value' => 'option-2',` to both fields (or another option if you like).
		2. Check that the preselected options in the schema tab match the option set above.
		3. Please don't commit these changes :p
* Check that the component matches the design.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-17 
