### PR TITLE
Refactor: render all hidden meta fields in the same place

### DIFF
--- a/src/presenters/admin/meta-fields-presenter.php
+++ b/src/presenters/admin/meta-fields-presenter.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Presenter class for meta fields in the post editor.
+ *
+ * @package Yoast\YoastSEO\Presenters\Admin
+ */
+
+namespace Yoast\WP\SEO\Presenters\Admin;
+
+use WPSEO_Meta;
+use Yoast\WP\SEO\Presenters\Abstract_Presenter;
+
+/**
+ * Outputs the hidden fields for a particular field group and post.
+ */
+class Meta_Fields_Presenter extends Abstract_Presenter {
+	/**
+	 * @var array The meta fields for which we are going to output hidden input.
+	 */
+	private $meta_fields;
+
+	/**
+	 * @var \WP_Post the metabox post.
+	 */
+	private $post;
+
+	/**
+	 * Meta_Fields_Presenter constructor.
+	 *
+	 * @param \WP_Post $post        The metabox post.
+	 * @param string   $field_group The key under which a group of fields is grouped.
+	 */
+	public function __construct( $post, $field_group ) {
+		$this->post = $post;
+		$this->meta_fields =  WPSEO_Meta::get_meta_field_defs( $field_group );
+	}
+
+	/**
+	 * Presents the Meta Fields.
+	 *
+	 * @return string The styled Alert.
+	 */
+	public function present() {
+		$output = '';
+
+		foreach ( $this->meta_fields as $key => $meta_field ) {
+			$form_key   = esc_attr( WPSEO_Meta::$form_prefix . $key );
+			$meta_value = WPSEO_Meta::get_value( $key, $this->post->ID );
+			$output    .= '<input type="hidden" id="' . $form_key . '" name="' . $form_key . '" value="' . esc_attr( $meta_value ) . '"/>' . "\n";
+		}
+
+		return $output;
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* As we reactify our metabox, the PHP side of things renders less and less things. As we're moving into the React future for our Metabox, we need to start isolating the concerns of the backend better. This PR is a first step towards that. It makes sure all hidden fields are rendered in one place, instead of scattered across multiple tabs. This clears the way to move the rendering of the actual interface entirely to React.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor: Moves the hidden meta fields in the post editor to a single place in the DOM.
* Deprecated `wpseo_content_meta_section_content` filter.

## Relevant technical choices:

* Deprecated `wpseo_content_meta_section_content` filter as I can't see a remaining usecase for it. 
* `'wpseo_do_meta_box_field_' . $key` filter also starts to lose its value with the new setup. We should consider deprecating that as well. For now leaving it in.
* Introduced a `Meta_Fields_Presenter` responsible for outputting the hidden fields for a fieldgroup and post.
* While making the changes I noticed a lot of methods of `WPSEO_Metabox` call `get_metabox_post` to fetch the post object. I DRY'd this to a property set once in the constructor. This also allowed me to more easily pass the post to the `Meta_Fields_Presenter`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Confirm all input in the metabox still works as expected.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
