### PR TITLE
Fix CS in the lib folder

### DIFF
--- a/lib/model.php
+++ b/lib/model.php
@@ -325,7 +325,7 @@ class Model implements JsonSerializable {
 	 *
 	 * @throws \Exception When ID of current model has a null value.
 	 *
-	 * @return ORM
+	 * @return ORM Instance of the ORM.
 	 */
 	protected function has_one_or_many( $associated_class_name, $foreign_key_name = null, $foreign_key_name_in_current_models_table = null ) {
 		$base_table_name  = static::get_table_name_for_class( \get_class( $this ) );

--- a/lib/model.php
+++ b/lib/model.php
@@ -463,7 +463,8 @@ class Model implements JsonSerializable {
 		$key_to_base_table       = static::build_foreign_key_name( $key_to_base_table, $base_table_name );
 		$key_to_associated_table = static::build_foreign_key_name( $key_to_associated_table, $associated_table_name );
 
-		/*
+		// @codingStandardsIgnoreLine
+		/* // phpcs:ignore Squiz.PHP.CommentedOutCode.Found -- Reason: This is commented out code.
 			"   SELECT {$associated_table_name}.*
 				FROM {$associated_table_name} JOIN {$join_table_name}
 					ON {$associated_table_name}.{$associated_table_id_column} = {$join_table_name}.{$key_to_associated_table}

--- a/lib/model.php
+++ b/lib/model.php
@@ -255,6 +255,7 @@ class Model implements JsonSerializable {
 
 		$class_name = \ltrim( $class_name, '\\' );
 		$class_name = \preg_replace( $find, $replacements, $class_name );
+
 		return \strtolower( $class_name );
 	}
 
@@ -305,7 +306,7 @@ class Model implements JsonSerializable {
 	public static function factory( $class_name ) {
 		$class_name = static::$auto_prefix_models . $class_name;
 		$table_name = static::get_table_name_for_class( $class_name );
-		$wrapper = ORM::for_table( $table_name );
+		$wrapper    = ORM::for_table( $table_name );
 		$wrapper->set_class_name( $class_name );
 		$wrapper->use_id_column( static::get_id_column_name( $class_name ) );
 
@@ -322,8 +323,9 @@ class Model implements JsonSerializable {
 	 * @param null|string $foreign_key_name                         The foreign key name in the associated table.
 	 * @param null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
 	 *
-	 * @return ORM
 	 * @throws \Exception When ID of current model has a null value.
+	 *
+	 * @return ORM
 	 */
 	protected function has_one_or_many( $associated_class_name, $foreign_key_name = null, $foreign_key_name_in_current_models_table = null ) {
 		$base_table_name  = static::get_table_name_for_class( \get_class( $this ) );
@@ -353,8 +355,9 @@ class Model implements JsonSerializable {
 	 * @param null|string $foreign_key_name                         The foreign key name in the associated table.
 	 * @param null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
 	 *
-	 * @return ORM Instance of the ORM.
 	 * @throws \Exception  When ID of current model has a null value.
+	 *
+	 * @return ORM Instance of the ORM.
 	 */
 	protected function has_one( $associated_class_name, $foreign_key_name = null, $foreign_key_name_in_current_models_table = null ) {
 		return $this->has_one_or_many( $associated_class_name, $foreign_key_name, $foreign_key_name_in_current_models_table );
@@ -368,8 +371,9 @@ class Model implements JsonSerializable {
 	 * @param null|string $foreign_key_name                         The foreign key name in the associated table.
 	 * @param null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
 	 *
-	 * @return ORM Instance of the ORM.
 	 * @throws \Exception When ID has a null value.
+	 *
+	 * @return ORM Instance of the ORM.
 	 */
 	protected function has_many( $associated_class_name, $foreign_key_name = null, $foreign_key_name_in_current_models_table = null ) {
 		$this->set_table_name( $associated_class_name );
@@ -404,7 +408,8 @@ class Model implements JsonSerializable {
 		}
 
 		// Comparison: "{$associated_table_name}.{$foreign_key_name_in_associated_models_table} = {$associated_object_id}".
-		return static::factory( $associated_class_name )->where( $foreign_key_name_in_associated_models_table, $associated_object_id );
+		return static::factory( $associated_class_name )
+			->where( $foreign_key_name_in_associated_models_table, $associated_object_id );
 	}
 
 	/**
@@ -464,6 +469,7 @@ class Model implements JsonSerializable {
 					ON {$associated_table_name}.{$associated_table_id_column} = {$join_table_name}.{$key_to_associated_table}
 				WHERE {$join_table_name}.{$key_to_base_table} = {$this->$base_table_id_column} ;"
 		*/
+
 		return static::factory( $associated_class_name )
 			->select( "{$associated_table_name}.*" )
 			->join(
@@ -665,8 +671,9 @@ class Model implements JsonSerializable {
 	/**
 	 * Get the database ID of this model instance.
 	 *
-	 * @return int The database ID of the models instance.
 	 * @throws \Exception When the ID is a null value.
+	 *
+	 * @return int The database ID of the models instance.
 	 */
 	public function id() {
 		return $this->orm->id();

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -1125,7 +1125,7 @@ class ORM implements \ArrayAccess {
 					$db_fields[] = $value;
 				}
 				else {
-					$db_fields[] = '%s';
+					$db_fields[] = ( $value === null ) ? 'NULL' : '%s';
 				}
 			}
 

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -534,7 +534,8 @@ class ORM implements \ArrayAccess {
 			if ( ! \is_numeric( $result->{$alias} ) ) {
 				$return_value = $result->{$alias};
 			}
-			elseif ( (int) $result->{$alias} == (float) $result->{$alias} ) {
+			// @codingStandardsIgnoreLine
+			elseif ( (int) $result->{$alias} == (float) $result->{$alias} ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison -- Reason: This loose comparison seems intended.
 				$return_value = (int) $result->{$alias};
 			}
 			else {

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -14,7 +14,7 @@ use Yoast\WP\SEO\Config\Migration_Status;
  *
  * Based on Idiorm
  *
- * http://github.com/j4mie/idiorm/
+ * URL: http://github.com/j4mie/idiorm/
  *
  * A single-class super-simple database abstraction layer for PHP.
  * Provides (nearly) zero-configuration object-relational mapping
@@ -57,42 +57,43 @@ class ORM implements \ArrayAccess {
 	// ----------------------- //
 	// --- CLASS CONSTANTS --- //
 	// ----------------------- //
-	// WHERE and HAVING condition array keys
+	// WHERE and HAVING condition array keys.
 	const CONDITION_FRAGMENT = 0;
 	const CONDITION_VALUES = 1;
+
 	// --------------------------- //
 	// --- INSTANCE PROPERTIES --- //
 	// --------------------------- //
 	/**
-	 * The wrapped find_one and find_many classes will return an instance or
-	 * instances of this class.
+	 * Holds the class name. Wrapped find_one and find_many classes will return an instance or instances of this class.
 	 *
 	 * @var string
 	 */
 	protected $class_name;
+
 	/**
-	 * The name of the table the current ORM instance is associated with.
+	 * Holds the name of the table the current ORM instance is associated with.
 	 *
 	 * @var string
 	 */
 	protected $_table_name;
 
 	/**
-	 * Alias for the table to be used in SELECT queries
+	 * Holds the alias for the table to be used in SELECT queries.
 	 *
 	 * @var string
 	 */
 	protected $_table_alias = null;
 
 	/**
-	 * Values to be bound to the query
+	 * Values to be bound to the query.
 	 *
 	 * @var array
 	 */
 	protected $_values = [];
 
 	/**
-	 * Columns to select in the result
+	 * Columns to select in the result.
 	 *
 	 * @var array
 	 */
@@ -106,7 +107,7 @@ class ORM implements \ArrayAccess {
 	protected $_using_default_result_columns = true;
 
 	/**
-	 * Join sources
+	 * Holds the join sources.
 	 *
 	 * @var array
 	 */
@@ -127,77 +128,77 @@ class ORM implements \ArrayAccess {
 	protected $_is_raw_query = false;
 
 	/**
-	 * The raw query
+	 * The raw query.
 	 *
 	 * @var string
 	 */
 	protected $_raw_query = '';
 
 	/**
-	 * The raw query parameters
+	 * The raw query parameters.
 	 *
 	 * @var array
 	 */
 	protected $_raw_parameters = [];
 
 	/**
-	 * Array of WHERE clauses
+	 * Array of WHERE clauses.
 	 *
 	 * @var array
 	 */
 	protected $_where_conditions = [];
 
 	/**
-	 * LIMIT
+	 * LIMIT.
 	 *
 	 * @var int
 	 */
 	protected $_limit = null;
 
 	/**
-	 * OFFSET
+	 * OFFSET.
 	 *
 	 * @var int
 	 */
 	protected $_offset = null;
 
 	/**
-	 * ORDER BY
+	 * ORDER BY.
 	 *
 	 * @var array
 	 */
 	protected $_order_by = [];
 
 	/**
-	 * GROUP BY
+	 * GROUP BY.
 	 *
 	 * @var array
 	 */
 	protected $_group_by = [];
 
 	/**
-	 * HAVING
+	 * HAVING.
 	 *
 	 * @var array
 	 */
 	protected $_having_conditions = [];
 
 	/**
-	 * The data for a hydrated instance of the class
+	 * The data for a hydrated instance of the class.
 	 *
 	 * @var array
 	 */
 	protected $_data = [];
 
 	/**
-	 * lifetime of the object
+	 * Lifetime of the object.
 	 *
 	 * @var array
 	 */
 	protected $_dirty_fields = [];
 
 	/**
-	 * Fields that are to be inserted in the DB raw
+	 * Fields that are to be inserted in the DB raw.
 	 *
 	 * @var array
 	 */
@@ -217,6 +218,7 @@ class ORM implements \ArrayAccess {
 	 * @var string
 	 */
 	protected $_instance_id_column = null;
+
 	// ---------------------- //
 	// --- STATIC METHODS --- //
 	// ---------------------- //
@@ -239,13 +241,13 @@ class ORM implements \ArrayAccess {
 	 * Useful for queries that can't be accomplished through Idiorm,
 	 * particularly those using engine-specific features.
 	 *
-	 * @param string $query      The raw SQL query
-	 * @param array  $parameters Optional bound parameters
+	 * @param string $query      The raw SQL query.
+	 * @param array  $parameters Optional bound parameters.
 	 *
-	 * @return bool Success
-	 * @example raw_execute('SELECT `name`, AVG(`order`) FROM `customer` GROUP BY `name` HAVING AVG(`order`) > 10')
-	 *
+	 * @return bool Success.
 	 * @example raw_execute('INSERT OR REPLACE INTO `widget` (`id`, `name`) SELECT `id`, `name` FROM `other_table`')
+	 *
+	 * @example raw_execute('SELECT `name`, AVG(`order`) FROM `customer` GROUP BY `name` HAVING AVG(`order`) > 10')
 	 */
 	public static function raw_execute( $query, $parameters = [] ) {
 		return self::_execute( $query, $parameters );
@@ -261,7 +263,9 @@ class ORM implements \ArrayAccess {
 	 */
 	protected static function _execute( $query, $parameters = [] ) {
 		/**
-		 * @var wpdb wpdb
+		 * The global WordPress database variable.
+		 *
+		 * @var wpdb
 		 */
 		global $wpdb;
 
@@ -275,7 +279,7 @@ class ORM implements \ArrayAccess {
 			return $parameter !== null;
 		} );
 		if ( ! empty( $parameters ) ) {
-			$query  = $wpdb->prepare( $query, $parameters );
+			$query = $wpdb->prepare( $query, $parameters );
 		}
 
 		$result = $wpdb->query( $query );
@@ -301,8 +305,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Set the name of the class which the wrapped methods should return
-	 * instances of.
+	 * Sets the name of the class which the wrapped methods should return instances of.
 	 *
 	 * @param string $class_name The classname to set.
 	 *
@@ -313,12 +316,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Create a new, empty instance of the class. Used
-	 * to add a new row to your database. May optionally
-	 * be passed an associative array of data to populate
-	 * the instance. If so, all fields will be flagged as
-	 * dirty so all will be saved to the database when
-	 * save() is called.
+	 * Creates a new, empty instance of the class. Used to add a new row to your database. May optionally be passed an
+	 * associative array of data to populate the instance. If so, all fields will be flagged as dirty so all will be
+	 * saved to the database when save() is called.
 	 *
 	 * @param array|null $data Data to populate table.
 	 *
@@ -334,12 +334,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Specify the ID column to use for this instance or array of instances only.
+	 * Specifies the ID column to use for this instance or array of instances only.
 	 * This overrides the id_column and id_column_overrides settings.
 	 *
-	 * This is mostly useful for libraries built on top of Idiorm, and will
-	 * not normally be used in manually built queries. If you don't know why
-	 * you would want to use this, you should probably just ignore it.
+	 * This is mostly useful for libraries built on top of Idiorm, and will not normally be used in manually built
+	 * queries. If you don't know why you would want to use this, you should probably just ignore it.
 	 *
 	 * @param string $id_column The ID column.
 	 *
@@ -352,8 +351,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Create an ORM instance from the given row (an associative
-	 * array of data fetched from the database)
+	 * Creates an ORM instance from the given row (an associative array of data fetched from the database).
 	 *
 	 * @param array $row A row from the database.
 	 *
@@ -368,13 +366,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Tell the ORM that you are expecting a single result
-	 * back from your query, and execute it. Will return
-	 * a single instance of the ORM class, or false if no
-	 * rows were returned.
-	 * As a shortcut, you may supply an ID as a parameter
-	 * to this method. This will perform a primary key
-	 * lookup on the table.
+	 * Tells the ORM that you are expecting a single result back from your query, and execute it. Will return a single
+	 * instance of the ORM class, or false if no rows were returned. As a shortcut, you may supply an ID as a parameter
+	 * to this method. This will perform a primary key lookup on the table.
 	 *
 	 * @param null|int $id An (optional) ID.
 	 *
@@ -394,10 +388,8 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Tell the ORM that you are expecting multiple results
-	 * from your query, and execute it. Will return an array
-	 * of instances of the ORM class, or an empty array if
-	 * no rows were returned.
+	 * Tells the ORM that you are expecting multiple results from your query, and execute it. Will return an array of
+	 * instances of the ORM class, or an empty array if no rows were returned.
 	 *
 	 * @return array
 	 */
@@ -412,8 +404,8 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Method to create an instance of the model class associated with this
-	 * wrapper and populate it with the supplied Idiorm instance.
+	 * Creates an instance of the model class associated with this wrapper and populate it with the supplied Idiorm
+	 * instance.
 	 *
 	 * @param ORM $orm The ORM used by model.
 	 *
@@ -436,9 +428,8 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Tell the ORM that you are expecting multiple results
-	 * from your query, and execute it. Will return an array,
-	 * or an empty array if no rows were returned.
+	 * Tells the ORM that you are expecting multiple results from your query, and execute it. Will return an array, or
+	 * an empty array if no rows were returned.
 	 *
 	 * @return array The query results.
 	 */
@@ -447,7 +438,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Tell the ORM that you wish to execute a COUNT query.
+	 * Tells the ORM that you wish to execute a COUNT query.
 	 *
 	 * @param string $column The table column.
 	 *
@@ -458,7 +449,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Tell the ORM that you wish to execute a MAX query.
+	 * Tells the ORM that you wish to execute a MAX query.
 	 *
 	 * @param string $column The table column.
 	 *
@@ -469,7 +460,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Tell the ORM that you wish to execute a MIN query.
+	 * Tells the ORM that you wish to execute a MIN query.
 	 *
 	 * @param string $column The table column.
 	 *
@@ -480,7 +471,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Tell the ORM that you wish to execute a AVG query.
+	 * Tells the ORM that you wish to execute a AVG query.
 	 *
 	 * @param string $column The table column.
 	 *
@@ -491,7 +482,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Tell the ORM that you wish to execute a SUM query.
+	 * Tells the ORM that you wish to execute a SUM query.
 	 *
 	 * @param string $column The table column.
 	 *
@@ -520,17 +511,17 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Execute an aggregate query on the current connection.
+	 * Executes an aggregate query on the current connection.
 	 *
-	 * @param string $sql_function The aggregate function to call eg. MIN, COUNT, etc
-	 * @param string $column       The column to execute the aggregate query against
+	 * @param string $sql_function The aggregate function to call eg. MIN, COUNT, etc.
+	 * @param string $column       The column to execute the aggregate query against.
 	 *
 	 * @return int
 	 */
 	protected function _call_aggregate_db_function( $sql_function, $column ) {
 		$alias        = \strtolower( $sql_function );
 		$sql_function = \strtoupper( $sql_function );
-		if ( '*' != $column ) {
+		if ( '*' !== $column ) {
 			$column = $this->_quote_identifier( $column );
 		}
 		$result_columns        = $this->_result_columns;
@@ -542,9 +533,11 @@ class ORM implements \ArrayAccess {
 		if ( $result !== false && isset( $result->{$alias} ) ) {
 			if ( ! \is_numeric( $result->{$alias} ) ) {
 				$return_value = $result->{$alias};
-			} elseif ( (int) $result->{$alias} == (float) $result->{$alias} ) {
+			}
+			elseif ( (int) $result->{$alias} == (float) $result->{$alias} ) {
 				$return_value = (int) $result->{$alias};
-			} else {
+			}
+			else {
 				$return_value = (float) $result->{$alias};
 			}
 		}
@@ -553,10 +546,8 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * This method can be called to hydrate (populate) this
-	 * instance of the class from an associative array of data.
-	 * This will usually be called only from inside the class,
-	 * but it's public in case you need to call it directly.
+	 * Hydrates (populate) this instance of the class from an associative array of data. This will usually be called
+	 * only from inside the class, but it's public in case you need to call it directly.
 	 *
 	 * @param array $data Data to populate table.
 	 *
@@ -569,8 +560,8 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Force the ORM to flag all the fields in the $data array
-	 * as "dirty" and therefore update them when save() is called.
+	 * Forces the ORM to flag all the fields in the $data array as "dirty" and therefore update them when save() is
+	 * called.
 	 *
 	 * @return ORM
 	 */
@@ -581,14 +572,12 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Perform a raw query. The query can contain placeholders in
-	 * either named or question mark style. If placeholders are
-	 * used, the parameters should be an array of values which will
-	 * be bound to the placeholders in the query. If this method
-	 * is called, all other query building methods will be ignored.
+	 * Performs a raw query. The query can contain placeholders in either named or question mark style. If placeholders
+	 * are used, the parameters should be an array of values which will be bound to the placeholders in the query.
+	 * If this method is called, all other query building methods will be ignored.
 	 *
-	 * @param array $query The query.
-	 * @param array $parameters
+	 * @param array $query      The query.
+	 * @param array $parameters The parameters. Defaults to an empty array.
 	 *
 	 * @return ORM
 	 */
@@ -601,9 +590,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add an alias for the main table to be used in SELECT queries
+	 * Adds an alias for the main table to be used in SELECT queries.
 	 *
-	 * @param string $alias
+	 * @param string $alias The alias.
 	 *
 	 * @return ORM
 	 */
@@ -614,12 +603,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Internal method to add an unquoted expression to the set
-	 * of columns returned by the SELECT query. The second optional
-	 * argument is the alias to return the expression as.
+	 * Adds an unquoted expression to the set of columns returned by the SELECT query. Internal method.
 	 *
-	 * @param string      $expr
-	 * @param null|string $alias
+	 * @param string      $expr  The expression.
+	 * @param null|string $alias The alias to return the expression as. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -630,7 +617,8 @@ class ORM implements \ArrayAccess {
 		if ( $this->_using_default_result_columns ) {
 			$this->_result_columns               = [ $expr ];
 			$this->_using_default_result_columns = false;
-		} else {
+		}
+		else {
 			$this->_result_columns[] = $expr;
 		}
 
@@ -638,28 +626,27 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Counts the number of columns that belong to the primary
-	 * key and their value is null.
+	 * Counts the number of columns that belong to the primary key and their value is null.
 	 *
-	 * @return int
+	 * @throws \Exception Primary key ID contains null value(s).
+	 * @throws \Exception Primary key ID missing from row or is null.
 	 *
-	 * @throws \Exception
+	 * @return int The amount of null columns.
 	 */
 	public function count_null_id_columns() {
 		if ( \is_array( $this->_get_id_column_name() ) ) {
 			return \count( \array_filter( $this->id(), 'is_null' ) );
-		} else {
+		}
+		else {
 			return \is_null( $this->id() ) ? 1 : 0;
 		}
 	}
 
 	/**
-	 * Add a column to the list of columns returned by the SELECT
-	 * query. This defaults to '*'. The second optional argument is
-	 * the alias to return the column as.
+	 * Adds a column to the list of columns returned by the SELECT query.
 	 *
-	 * @param string      $column
-	 * @param null|string $alias
+	 * @param string      $column The column. Defaults to '*'.
+	 * @param null|string $alias  The alias to return the column as. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -670,12 +657,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add an unquoted expression to the list of columns returned
-	 * by the SELECT query. The second optional argument is
-	 * the alias to return the column as.
+	 * Adds an unquoted expression to the list of columns returned by the SELECT query.
 	 *
-	 * @param string      $expr
-	 * @param null|string $alias
+	 * @param string      $expr  The expression.
+	 * @param null|string $alias The alias to return the column as. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -684,18 +669,18 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add columns to the list of columns returned by the SELECT
-	 * query. This defaults to '*'. Many columns can be supplied
-	 * as either an array or as a list of parameters to the method.
+	 * Adds columns to the list of columns returned by the SELECT query.
 	 *
-	 * Note that the alias must not be numeric - if you want a
-	 * numeric alias then prepend it with some alpha chars. eg. a1
-	 *
-	 * @example select_many(array('column', 'column2', 'column3'), 'column4', 'column5');
-	 * @example select_many(array('alias' => 'column', 'column2', 'alias2' => 'column3'), 'column4', 'column5');
-	 * @example select_many('column', 'column2', 'column3');
+	 * This defaults to '*'.
+	 * Many columns can be supplied as either an array or as a list of parameters to the method.
+	 * Note that the alias must not be numeric - if you want a numeric alias then prepend it with some alpha chars. eg.
+	 * a1.
 	 *
 	 * @return ORM
+	 * @example select_many(array('column', 'column2', 'column3'), 'column4', 'column5');
+	 * @example select_many(array('alias' => 'column', 'column2', 'alias2' => 'column3'), 'column4', 'column5');
+	 *
+	 * @example select_many('column', 'column2', 'column3');
 	 */
 	public function select_many() {
 		$columns = \func_get_args();
@@ -713,18 +698,17 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add an unquoted expression to the list of columns returned
-	 * by the SELECT query. Many columns can be supplied as either
-	 * an array or as a list of parameters to the method.
+	 * Adds an unquoted expression to the list of columns returned by the SELECT query.
 	 *
-	 * Note that the alias must not be numeric - if you want a
-	 * numeric alias then prepend it with some alpha chars. eg. a1
+	 * Many columns can be supplied as either an array or as a list of parameters to the method.
+	 * Note that the alias must not be numeric - if you want a numeric alias then prepend it with some alpha chars. eg.
+	 * a1
 	 *
 	 * @return ORM
-	 * @example select_many_expr(array('column', 'column2', 'column3'), 'column4', 'column5')
 	 * @example select_many_expr(array('alias' => 'column', 'column2', 'alias2' => 'column3'), 'column4', 'column5')
-	 *
 	 * @example select_many_expr('column', 'column2', 'column3')
+	 *
+	 * @example select_many_expr(array('column', 'column2', 'column3'), 'column4', 'column5')
 	 */
 	public function select_many_expr() {
 		$columns = \func_get_args();
@@ -742,14 +726,13 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Take a column specification for the select many methods and convert it
-	 * into a normalised array of columns and aliases.
+	 * Takes a column specification for the select many methods and convert it into a normalised array of columns and
+	 * aliases.
 	 *
 	 * It is designed to turn the following styles into a normalised array:
-	 *
 	 * array(array('alias' => 'column', 'column2', 'alias2' => 'column3'), 'column4', 'column5'))
 	 *
-	 * @param array $columns
+	 * @param array $columns The columns.
 	 *
 	 * @return array
 	 */
@@ -760,11 +743,13 @@ class ORM implements \ArrayAccess {
 				foreach ( $column as $key => $value ) {
 					if ( ! \is_numeric( $key ) ) {
 						$return[ $key ] = $value;
-					} else {
+					}
+					else {
 						$return[] = $value;
 					}
 				}
-			} else {
+			}
+			else {
 				$return[] = $column;
 			}
 		}
@@ -773,7 +758,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a DISTINCT keyword before the list of columns in the SELECT query
+	 * Adds a DISTINCT keyword before the list of columns in the SELECT query.
 	 *
 	 * @return ORM
 	 */
@@ -784,7 +769,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Internal method to add a JOIN source to the query.
+	 * Add a JOIN source to the query. Internal method.
 	 *
 	 * The join_operator should be one of INNER, LEFT OUTER, CROSS etc - this
 	 * will be prepended to JOIN.
@@ -805,22 +790,23 @@ class ORM implements \ArrayAccess {
 	 *
 	 * The final (optional) argument specifies an alias for the joined table.
 	 *
-	 * @param string $join_operator
-	 * @param string $table
-	 * @param string $constraint
-	 * @param null   $table_alias
+	 * @param string      $join_operator The join_operator should be one of INNER, LEFT OUTER, CROSS etc - this will be
+	 *                                   prepended to JOIN.
+	 * @param string      $table         The table should be the name of the table to join to.
+	 * @param string      $constraint    The constraint.
+	 * @param string|null $table_alias   The alias for the joined table. Defaults to null.
 	 *
 	 * @return ORM
 	 */
 	protected function _add_join_source( $join_operator, $table, $constraint, $table_alias = null ) {
 		$join_operator = \trim( "{$join_operator} JOIN" );
 		$table         = $this->_quote_identifier( $table );
-		// Add table alias if present
+		// Add table alias if present.
 		if ( ! \is_null( $table_alias ) ) {
 			$table_alias = $this->_quote_identifier( $table_alias );
 			$table       .= " {$table_alias}";
 		}
-		// Build the constraint
+		// Build the constraint.
 		if ( \is_array( $constraint ) ) {
 			list( $first_column, $operator, $second_column ) = $constraint;
 			$first_column  = $this->_quote_identifier( $first_column );
@@ -833,23 +819,23 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a RAW JOIN source to the query
+	 * Adds a RAW JOIN source to the query.
 	 *
-	 * @param string $table
-	 * @param string $constraint
-	 * @param string $table_alias
-	 * @param array  $parameters
+	 * @param string $table       The table name.
+	 * @param string $constraint  The constraint.
+	 * @param string $table_alias The table alias.
+	 * @param array  $parameters  The parameters. Defaults to an empty array.
 	 *
 	 * @return ORM
 	 */
 	public function raw_join( $table, $constraint, $table_alias, $parameters = [] ) {
-		// Add table alias if present
+		// Add table alias if present.
 		if ( ! \is_null( $table_alias ) ) {
 			$table_alias = $this->_quote_identifier( $table_alias );
 			$table       .= " {$table_alias}";
 		}
 		$this->_values = \array_merge( $this->_values, $parameters );
-		// Build the constraint
+		// Build the constraint.
 		if ( \is_array( $constraint ) ) {
 			list( $first_column, $operator, $second_column ) = $constraint;
 			$first_column  = $this->_quote_identifier( $first_column );
@@ -862,11 +848,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a simple JOIN source to the query
+	 * Adds a simple JOIN source to the query.
 	 *
-	 * @param string $table
-	 * @param string $constraint
-	 * @param null   $table_alias
+	 * @param string      $table       The table name.
+	 * @param string      $constraint  The constraint.
+	 * @param string|null $table_alias The table alias. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -875,11 +861,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add an INNER JOIN souce to the query
+	 * Adds an INNER JOIN source to the query.
 	 *
-	 * @param string $table
-	 * @param string $constraint
-	 * @param null   $table_alias
+	 * @param string      $table       The table name.
+	 * @param string      $constraint  The constraint.
+	 * @param string|null $table_alias The table alias. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -888,11 +874,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a LEFT OUTER JOIN souce to the query
+	 * Adds a LEFT OUTER JOIN source to the query.
 	 *
-	 * @param string $table
-	 * @param string $constraint
-	 * @param null   $table_alias
+	 * @param string      $table       The table name.
+	 * @param string      $constraint  The constraint.
+	 * @param string|null $table_alias The table alias. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -901,11 +887,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add an RIGHT OUTER JOIN souce to the query
+	 * Adds a RIGHT OUTER JOIN source to the query.
 	 *
-	 * @param string $table
-	 * @param string $constraint
-	 * @param null   $table_alias
+	 * @param string      $table       The table name.
+	 * @param string      $constraint  The constraint.
+	 * @param string|null $table_alias The table alias. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -914,11 +900,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add an FULL OUTER JOIN souce to the query
+	 * Adds a FULL OUTER JOIN source to the query.
 	 *
-	 * @param string $table
-	 * @param string $constraint
-	 * @param null   $table_alias
+	 * @param string      $table       The table name.
+	 * @param string      $constraint  The constraint.
+	 * @param string|null $table_alias The table alias. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -927,10 +913,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Internal method to add a HAVING condition to the query
+	 * Adds a HAVING condition to the query. Internal method.
 	 *
-	 * @param string $fragment
-	 * @param array  $values
+	 * @param string $fragment The fragment.
+	 * @param array  $values   The values. Defaults to an empty array.
 	 *
 	 * @return ORM
 	 */
@@ -939,11 +925,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Internal method to add a HAVING condition to the query
+	 * Adds a HAVING condition to the query. Internal method.
 	 *
 	 * @param string $column_name The table column.
-	 * @param string $separator
-	 * @param        $value
+	 * @param string $separator   The separator.
+	 * @param mixed  $value       The value.
 	 *
 	 * @return ORM
 	 */
@@ -952,18 +938,19 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Internal method to add a HAVING clause with multiple values (like IN and NOT IN)
+	 * Adds a HAVING clause with multiple values (like IN and NOT IN). Internal method.
 	 *
 	 * @param string|array $column_name The table column.
-	 * @param string       $separator
-	 * @param              $values
+	 * @param string       $separator   The separator.
+	 * @param array        $values      The values.
 	 *
 	 * @return ORM
 	 */
 	public function _add_having_placeholder( $column_name, $separator, $values ) {
 		if ( ! \is_array( $column_name ) ) {
 			$data = [ $column_name => $values ];
-		} else {
+		}
+		else {
 			$data = $column_name;
 		}
 		$result = $this;
@@ -977,10 +964,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Internal method to add a HAVING clause with no parameters(like IS NULL and IS NOT NULL)
+	 * Adds a HAVING clause with no parameters(like IS NULL and IS NOT NULL). Internal method.
 	 *
-	 * @param string $column_name
-	 * @param        $operator
+	 * @param string $column_name The column name.
+	 * @param string $operator    The operator.
 	 *
 	 * @return ORM
 	 */
@@ -996,10 +983,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Internal method to add a WHERE condition to the query
+	 * Adds a WHERE condition to the query. Internal method.
 	 *
-	 * @param string $fragment
-	 * @param array  $values
+	 * @param string $fragment The fragment.
+	 * @param array  $values   The values. Defaults to an empty array.
 	 *
 	 * @return ORM
 	 */
@@ -1008,11 +995,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Internal method to add a WHERE condition to the query
+	 * Adds a WHERE condition to the query. Internal method.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param string       $separator
-	 * @param              $value
+	 * @param string|array $column_name The table column.
+	 * @param string       $separator   The separator.
+	 * @param mixed        $value       The value.
 	 *
 	 * @return ORM
 	 */
@@ -1021,18 +1008,19 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a WHERE clause with multiple values (like IN and NOT IN)
+	 * Adds a WHERE clause with multiple values (like IN and NOT IN).
 	 *
-	 * @param string|array $column_name The table column
-	 * @param string       $separator
-	 * @param              $values
+	 * @param string|array $column_name The table column.
+	 * @param string       $separator   The separator.
+	 * @param array        $values      The values.
 	 *
 	 * @return ORM
 	 */
 	public function _add_where_placeholder( $column_name, $separator, $values ) {
 		if ( ! \is_array( $column_name ) ) {
 			$data = [ $column_name => $values ];
-		} else {
+		}
+		else {
 			$data = $column_name;
 		}
 		$result = $this;
@@ -1046,10 +1034,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a WHERE clause with no parameters(like IS NULL and IS NOT NULL)
+	 * Adds a WHERE clause with no parameters(like IS NULL and IS NOT NULL).
 	 *
-	 * @param string $column_name
-	 * @param        $operator
+	 * @param string $column_name The column name.
+	 * @param string $operator    The operator.
 	 *
 	 * @return ORM
 	 */
@@ -1065,11 +1053,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Internal method to add a HAVING or WHERE condition to the query
+	 * Adds a HAVING or WHERE condition to the query. Internal method.
 	 *
-	 * @param        $type
-	 * @param string $fragment
-	 * @param array  $values
+	 * @param string $type     The type.
+	 * @param string $fragment The fragment.
+	 * @param array  $values   The values. Defaults to empty array.
 	 *
 	 * @return ORM
 	 */
@@ -1087,17 +1075,16 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Helper method to compile a simple COLUMN SEPARATOR VALUE
-	 * style HAVING or WHERE condition into a string and value ready to
-	 * be passed to the _add_condition method. Avoids duplication
-	 * of the call to _quote_identifier
+	 * Compiles a simple COLUMN SEPARATOR VALUE style HAVING or WHERE condition into a string and value ready to be
+	 * passed to the _add_condition method.
 	 *
-	 * If column_name is an associative array, it will add a condition for each column
+	 * Avoids duplication of the call to _quote_identifier.
+	 * If column_name is an associative array, it will add a condition for each column.
 	 *
-	 * @param              $type
-	 * @param string|array $column_name The table column
-	 * @param string       $separator
-	 * @param              $value
+	 * @param string       $type        The type.
+	 * @param string|array $column_name The table column.
+	 * @param string       $separator   The separator.
+	 * @param mixed        $value       The value.
 	 *
 	 * @return ORM
 	 */
@@ -1105,7 +1092,7 @@ class ORM implements \ArrayAccess {
 		$multiple = \is_array( $column_name ) ? $column_name : [ $column_name => $value ];
 		$result   = $this;
 		foreach ( $multiple as $key => $val ) {
-			// Add the table name in case of ambiguous columns
+			// Add the table name in case of ambiguous columns.
 			if ( \count( $result->_join_sources ) > 0 && \strpos( $key, '.' ) === false ) {
 				$table = $result->_table_name;
 				if ( ! \is_null( $result->_table_alias ) ) {
@@ -1122,8 +1109,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Return a string containing the given number of question marks,
-	 * separated by commas. Eg "?, ?, ?"
+	 * Returns a string containing the given number of question marks, separated by commas. Eg "?, ?, ?".
 	 *
 	 * @param array $fields Fields to create placeholder for.
 	 *
@@ -1133,11 +1119,12 @@ class ORM implements \ArrayAccess {
 		if ( ! empty( $fields ) ) {
 			$db_fields = [];
 			foreach ( $fields as $key => $value ) {
-				// Process expression fields directly into the query
+				// Process expression fields directly into the query.
 				if ( \array_key_exists( $key, $this->_expr_fields ) ) {
 					$db_fields[] = $value;
-				} else {
-					$db_fields[] = ( $value === null ) ? 'NULL' : '%s';
+				}
+				else {
+					$db_fields[] = '%s';
 				}
 			}
 
@@ -1148,13 +1135,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Helper method that filters a column/value array returning only those
-	 * columns that belong to a compound primary key.
+	 * Filters a column/value array returning only those columns that belong to a compound primary key.
 	 *
-	 * If the key contains a column that does not exist in the given array,
-	 * a null value will be returned for it.
+	 * If the key contains a column that does not exist in the given array, a null value will be returned for it.
 	 *
-	 * @param $value
+	 * @param mixed $value The value.
 	 *
 	 * @return array
 	 */
@@ -1168,10 +1153,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Helper method that filters an array containing compound column/value
-	 * arrays.
+	 * Filters an array containing compound column/value arrays.
 	 *
-	 * @param $values
+	 * @param array $values The values.
 	 *
 	 * @return array
 	 */
@@ -1185,16 +1169,14 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a WHERE column = value clause to your query. Each time
-	 * this is called in the chain, an additional WHERE will be
-	 * added, and these will be ANDed together when the final query
-	 * is built.
+	 * Add a WHERE column = value clause to your query. Each time this is called in the chain, an additional WHERE will
+	 * be added, and these will be ANDed together when the final query is built.
 	 *
-	 * If you use an array in $column_name, a new clause will be
-	 * added for each element. In this case, $value is ignored.
+	 * If you use an array in $column_name, a new clause will be added for each element. In this case, $value is
+	 * ignored.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param mixed|null   $value       The value. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -1203,11 +1185,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * More explicitly named version of for the where() method.
-	 * Can be used if preferred.
+	 * More explicitly named version of for the where() method. Can be used if preferred.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param mixed|null   $value       The value. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -1218,8 +1199,8 @@ class ORM implements \ArrayAccess {
 	/**
 	 * Add a WHERE column != value clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param mixed|null   $value       The value. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -1228,12 +1209,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Special method to query the table by its primary key
+	 * Queries the table by its primary key. Special method.
 	 *
-	 * If primary key is compound, only the columns that
-	 * belong to they key will be used for the query
+	 * If primary key is compound, only the columns that belong to they key will be used for the query.
 	 *
-	 * @param $id
+	 * @param string $id The ID.
 	 *
 	 * @return ORM
 	 */
@@ -1242,17 +1222,16 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Allows adding a WHERE clause that matches any of the conditions
-	 * specified in the array. Each element in the associative array will
-	 * be a different condition, where the key will be the column name.
+	 * Allows adding a WHERE clause that matches any of the conditions specified in the array. Each element in the
+	 * associative array will be a different condition, where the key will be the column name.
 	 *
-	 * By default, an equal operator will be used against all columns, but
-	 * it can be overriden for any or every column using the second parameter.
+	 * By default, an equal operator will be used against all columns, but it can be overriden for any or every column
+	 * using the second parameter.
 	 *
 	 * Each condition will be ORed together when added to the final query.
 	 *
-	 * @param        $values
-	 * @param string $operator
+	 * @param array  $values   The values.
+	 * @param string $operator The operator.
 	 *
 	 * @return ORM
 	 */
@@ -1263,7 +1242,8 @@ class ORM implements \ArrayAccess {
 		foreach ( $values as $value ) {
 			if ( $first ) {
 				$first = false;
-			} else {
+			}
+			else {
 				$query[] = ') OR (';
 			}
 			$firstsub = true;
@@ -1271,7 +1251,8 @@ class ORM implements \ArrayAccess {
 				$op = \is_string( $operator ) ? $operator : ( isset( $operator[ $key ] ) ? $operator[ $key ] : '=' );
 				if ( $firstsub ) {
 					$firstsub = false;
-				} else {
+				}
+				else {
 					$query[] = 'AND';
 				}
 				$query[] = $this->_quote_identifier( $key );
@@ -1281,16 +1262,16 @@ class ORM implements \ArrayAccess {
 		}
 		$query[] = '))';
 
-		return $this->where_raw( \join( $query, ' ' ), $data );
+		return $this->where_raw( \join( ' ', $query ), $data );
 	}
 
 	/**
+	 * Queries the table by its primary key.
+	 *
 	 * Similar to where_id_is() but allowing multiple primary keys.
+	 * If primary key is compound, only the columns that belong to they key will be used for the query.
 	 *
-	 * If primary key is compound, only the columns that
-	 * belong to they key will be used for the query
-	 *
-	 * @param $ids
+	 * @param string[] $ids The IDs.
 	 *
 	 * @return ORM
 	 */
@@ -1299,10 +1280,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a WHERE ... LIKE clause to your query.
+	 * Adds a WHERE ... LIKE clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param mixed|null   $value       The value. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -1311,10 +1292,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add where WHERE ... NOT LIKE clause to your query.
+	 * Adds where WHERE ... NOT LIKE clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param mixed|null   $value       The value. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -1323,10 +1304,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a WHERE ... > clause to your query
+	 * Adds a WHERE ... > clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param mixed|null   $value       The value. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -1335,10 +1316,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a WHERE ... < clause to your query
+	 * Adds a WHERE ... < clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param mixed|null   $value       The value. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -1347,10 +1328,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a WHERE ... >= clause to your query
+	 * Adds a WHERE ... >= clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param mixed|null   $value       The value. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -1359,10 +1340,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a WHERE ... <= clause to your query
+	 * Adds a WHERE ... <= clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param mixed|null   $value       The value. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -1371,10 +1352,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a WHERE ... IN clause to your query
+	 * Adds a WHERE ... IN clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param              $values
+	 * @param string|array $column_name The table column.
+	 * @param array        $values      The values.
 	 *
 	 * @return ORM
 	 */
@@ -1383,10 +1364,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a WHERE ... NOT IN clause to your query
+	 * Adds a WHERE ... NOT IN clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param              $values
+	 * @param string|array $column_name The table column.
+	 * @param array        $values      The values.
 	 *
 	 * @return ORM
 	 */
@@ -1395,9 +1376,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a WHERE column IS NULL clause to your query
+	 * Adds a WHERE column IS NULL clause to your query.
 	 *
-	 * @param string|array $column_name The table column
+	 * @param string|array $column_name The table column.
 	 *
 	 * @return ORM
 	 */
@@ -1406,9 +1387,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a WHERE column IS NOT NULL clause to your query
+	 * Adds a WHERE column IS NOT NULL clause to your query.
 	 *
-	 * @param string|array $column_name The table column
+	 * @param string|array $column_name The table column.
 	 *
 	 * @return ORM
 	 */
@@ -1417,12 +1398,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a raw WHERE clause to the query. The clause should
-	 * contain question mark placeholders, which will be bound
+	 * Adds a raw WHERE clause to the query. The clause should contain question mark placeholders, which will be bound
 	 * to the parameters supplied in the second argument.
 	 *
-	 * @param       $clause
-	 * @param array $parameters
+	 * @param string $clause     The clause that should contain question mark placeholders.
+	 * @param array  $parameters The parameters to include in the query.
 	 *
 	 * @return ORM
 	 */
@@ -1431,9 +1411,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a LIMIT to the query
+	 * Adds a LIMIT to the query.
 	 *
-	 * @param $limit
+	 * @param int $limit The limit.
 	 *
 	 * @return ORM
 	 */
@@ -1444,9 +1424,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add an OFFSET to the query
+	 * Adds an OFFSET to the query.
 	 *
-	 * @param $offset
+	 * @param int $offset The offset.
 	 *
 	 * @return ORM
 	 */
@@ -1457,10 +1437,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add an ORDER BY clause to the query
+	 * Adds an ORDER BY clause to the query.
 	 *
-	 * @param string $column_name
-	 * @param        $ordering
+	 * @param string $column_name The column name.
+	 * @param string $ordering    The ordering. DESC or ASC.
 	 *
 	 * @return ORM
 	 */
@@ -1472,9 +1452,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add an ORDER BY column DESC clause
+	 * Adds an ORDER BY column DESC clause.
 	 *
-	 * @param string|array $column_name The table column
+	 * @param string|array $column_name The table column.
 	 *
 	 * @return ORM
 	 */
@@ -1483,9 +1463,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add an ORDER BY column ASC clause
+	 * Adds an ORDER BY column ASC clause.
 	 *
-	 * @param string|array $column_name The table column
+	 * @param string|array $column_name The table column.
 	 *
 	 * @return ORM
 	 */
@@ -1494,9 +1474,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add an unquoted expression as an ORDER BY clause
+	 * Adds an unquoted expression as an ORDER BY clause.
 	 *
-	 * @param $clause
+	 * @param string $clause The clause.
 	 *
 	 * @return ORM
 	 */
@@ -1507,9 +1487,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a column to the list of columns to GROUP BY
+	 * Adds a column to the list of columns to GROUP BY.
 	 *
-	 * @param string|array $column_name The table column
+	 * @param string|array $column_name The table column.
 	 *
 	 * @return ORM
 	 */
@@ -1521,9 +1501,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add an unquoted expression to the list of columns to GROUP BY
+	 * Adds an unquoted expression to the list of columns to GROUP BY.
 	 *
-	 * @param string $expr
+	 * @param string $expr The expression.
 	 *
 	 * @return ORM
 	 */
@@ -1534,16 +1514,16 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a HAVING column = value clause to your query. Each time
-	 * this is called in the chain, an additional HAVING will be
-	 * added, and these will be ANDed together when the final query
-	 * is built.
+	 * Adds a HAVING column = value clause to your query.
 	 *
-	 * If you use an array in $column_name, a new clause will be
-	 * added for each element. In this case, $value is ignored.
+	 * Each time this is called in the chain, an additional HAVING will be added, and these will be ANDed together when
+	 * the final query is built.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * If you use an array in $column_name, a new clause will be added for each element. In this case, $value is
+	 * ignored.
+	 *
+	 * @param string|array $column_name The table column.
+	 * @param mixed|null   $value       The value.
 	 *
 	 * @return ORM
 	 */
@@ -1552,11 +1532,12 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * More explicitly named version of for the having() method.
-	 * Can be used if preferred.
+	 * Adds a having equal to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * More explicitly named version of for the having() method. Can be used if preferred.
+	 *
+	 * @param string|array $column_name The table column.
+	 * @param mixed|null   $value       The value.
 	 *
 	 * @return ORM
 	 */
@@ -1565,10 +1546,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a HAVING column != value clause to your query.
+	 * Adds a HAVING column != value clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param mixed|null   $value       The value.
 	 *
 	 * @return ORM
 	 */
@@ -1577,12 +1558,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Special method to query the table by its primary key.
+	 * Queries the table by its primary key. Special method.
 	 *
-	 * If primary key is compound, only the columns that
-	 * belong to they key will be used for the query
+	 * If primary key is compound, only the columns that belong to they key will be used for the query.
 	 *
-	 * @param $id
+	 * @param string $id The ID.
 	 *
 	 * @return ORM
 	 */
@@ -1591,10 +1571,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a HAVING ... LIKE clause to your query.
+	 * Adds a HAVING ... LIKE clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param null         $value       The value.
 	 *
 	 * @return ORM
 	 */
@@ -1603,10 +1583,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add where HAVING ... NOT LIKE clause to your query.
+	 * Adds where HAVING ... NOT LIKE clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param null         $value       The value.
 	 *
 	 * @return ORM
 	 */
@@ -1615,10 +1595,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a HAVING ... > clause to your query
+	 * Adds a HAVING ... > clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param null         $value       The value.
 	 *
 	 * @return ORM
 	 */
@@ -1627,10 +1607,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a HAVING ... < clause to your query
+	 * Adds a HAVING ... < clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param null         $value       The value.
 	 *
 	 * @return ORM
 	 */
@@ -1639,10 +1619,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a HAVING ... >= clause to your query
+	 * Adds a HAVING ... >= clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param null         $value       The value. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -1651,10 +1631,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a HAVING ... <= clause to your query
+	 * Adds a HAVING ... <= clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $value
+	 * @param string|array $column_name The table column.
+	 * @param null         $value       The value.
 	 *
 	 * @return ORM
 	 */
@@ -1663,10 +1643,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a HAVING ... IN clause to your query
+	 * Adds a HAVING ... IN clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $values
+	 * @param string|array $column_name The table column.
+	 * @param null         $values      The values. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -1675,10 +1655,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a HAVING ... NOT IN clause to your query
+	 * Adds a HAVING ... NOT IN clause to your query.
 	 *
-	 * @param string|array $column_name The table column
-	 * @param null         $values
+	 * @param string|array $column_name The table column.
+	 * @param null         $values      The values. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -1687,9 +1667,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a HAVING column IS NULL clause to your query
+	 * Adds a HAVING column IS NULL clause to your query.
 	 *
-	 * @param string|array $column_name The table column
+	 * @param string|array $column_name The table column.
 	 *
 	 * @return ORM
 	 */
@@ -1698,9 +1678,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a HAVING column IS NOT NULL clause to your query
+	 * Adds a HAVING column IS NOT NULL clause to your query.
 	 *
-	 * @param string|array $column_name The table column
+	 * @param string|array $column_name The table column.
 	 *
 	 * @return ORM
 	 */
@@ -1709,12 +1689,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a raw HAVING clause to the query. The clause should
-	 * contain question mark placeholders, which will be bound
+	 * Adds a raw HAVING clause to the query. The clause should contain question mark placeholders, which will be bound
 	 * to the parameters supplied in the second argument.
 	 *
-	 * @param       $clause
-	 * @param array $parameters
+	 * @param string $clause     The clause that should contain question mark placeholders.
+	 * @param array  $parameters The parameters to include in the query.
 	 *
 	 * @return ORM
 	 */
@@ -1723,21 +1702,19 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Build a SELECT statement based on the clauses that have
-	 * been passed to this instance by chaining method calls.
+	 * Builds a SELECT statement based on the clauses that have been passed to this instance by chaining method calls.
 	 *
 	 * @return string
 	 */
 	protected function _build_select() {
-		// If the query is raw, just set the $this->_values to be
-		// the raw query parameters and return the raw query
+		// If the query is raw, just set the $this->_values to be the raw query parameters and return the raw query.
 		if ( $this->_is_raw_query ) {
 			$this->_values = $this->_raw_parameters;
 
 			return $this->_raw_query;
 		}
-		// Build and return the full SELECT statement by concatenating
-		// the results of calling each separate builder method.
+
+		// Build and return the full SELECT statement by concatenating the results of calling each separate builder method.
 		return $this->_join_if_not_empty( ' ', [
 			$this->_build_select_start(),
 			$this->_build_join(),
@@ -1751,7 +1728,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Build the start of the SELECT statement
+	 * Builds the start of the SELECT statement.
 	 *
 	 * @return string
 	 */
@@ -1770,7 +1747,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Build the JOIN sources
+	 * Builds the JOIN sources.
 	 *
 	 * @return string
 	 */
@@ -1783,7 +1760,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Build the WHERE clause(s)
+	 * Builds the WHERE clause(s).
 	 *
 	 * @return string
 	 */
@@ -1801,7 +1778,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Build GROUP BY
+	 * Builds GROUP BY.
 	 *
 	 * @return string
 	 */
@@ -1814,15 +1791,15 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Build a WHERE or HAVING clause
+	 * Builds a WHERE or HAVING clause.
 	 *
-	 * @param string $type
+	 * @param string $type Where or having.
 	 *
 	 * @return string
 	 */
 	protected function _build_conditions( $type ) {
 		$conditions_class_property_name = "_{$type}_conditions";
-		// If there are no clauses, return empty string
+		// If there are no clauses, return empty string.
 		if ( \count( $this->{$conditions_class_property_name} ) === 0 ) {
 			return '';
 		}
@@ -1836,7 +1813,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Build ORDER BY
+	 * Builds ORDER BY.
 	 */
 	protected function _build_order_by() {
 		if ( \count( $this->_order_by ) === 0 ) {
@@ -1847,7 +1824,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Build LIMIT
+	 * Builds LIMIT.
 	 */
 	protected function _build_limit() {
 		if ( ! \is_null( $this->_limit ) ) {
@@ -1858,7 +1835,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Build OFFSET
+	 * Builds OFFSET.
 	 */
 	protected function _build_offset() {
 		if ( ! \is_null( $this->_offset ) ) {
@@ -1869,11 +1846,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Wrapper around PHP's join function which
-	 * only adds the pieces if they are not empty.
+	 * Joins strings if they are not empty.
 	 *
-	 * @param $glue
-	 * @param $pieces
+	 * @param string   $glue   Glue.
+	 * @param string[] $pieces Pieces to join.
 	 *
 	 * @return string
 	 */
@@ -1892,11 +1868,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Quote a string that is used as an identifier
-	 * (table names, column names etc). This method can
-	 * also deal with dot-separated identifiers eg table.column
+	 * Quotes a string that is used as an identifier (table names, column names etc).
+	 * This method can also deal with dot-separated identifiers eg table.column.
 	 *
-	 * @param $identifier
+	 * @param string|string[] $identifier One or more identifiers.
 	 *
 	 * @return string
 	 */
@@ -1908,12 +1883,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Quote a string that is used as an identifier
-	 * (table names, column names etc) or an array containing
-	 * multiple identifiers. This method can also deal with
-	 * dot-separated identifiers eg table.column
+	 * Quotes a string that is used as an identifier (table names, column names etc) or an array containing multiple
+	 * identifiers. This method can also deal with dot-separated identifiers eg table.column.
 	 *
-	 * @param $identifier
+	 * @param string|string[] $identifier One or more identifiers.
 	 *
 	 * @return string
 	 */
@@ -1922,17 +1895,17 @@ class ORM implements \ArrayAccess {
 			$result = \array_map( [ $this, '_quote_one_identifier' ], $identifier );
 
 			return \join( ', ', $result );
-		} else {
+		}
+		else {
 			return $this->_quote_one_identifier( $identifier );
 		}
 	}
 
 	/**
-	 * This method performs the actual quoting of a single
-	 * part of an identifier, using the identifier quote
-	 * character specified in the config (or autodetected).
+	 * Quotes a single part of an identifier, using the identifier quote character specified in the config
+	 * (or autodetected).
 	 *
-	 * @param $part
+	 * @param string $part The part to quote.
 	 *
 	 * @return string
 	 */
@@ -1942,13 +1915,13 @@ class ORM implements \ArrayAccess {
 		}
 		$quote_character = '`';
 
-		// double up any identifier quotes to escape them
+		// Double up any identifier quotes to escape them.
 		return $quote_character . \str_replace( $quote_character, $quote_character . $quote_character, $part ) . $quote_character;
 	}
 
 	/**
-	 * Execute the SELECT query that has been built up by chaining methods
-	 * on this class. Return an array of rows as associative arrays.
+	 * Executes the SELECT query that has been built up by chaining methods on this class.
+	 * Return an array of rows as associative arrays.
 	 *
 	 * @return array|false The result rows. False if the query failed.
 	 */
@@ -1980,7 +1953,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Reset the Idiorm instance state
+	 * Resets the Idiorm instance state.
 	 */
 	private function _reset_idiorm_state() {
 		$this->_values                       = [];
@@ -1989,10 +1962,10 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Return the raw data wrapped by this ORM
-	 * instance as an associative array. Column
-	 * names may optionally be supplied as arguments,
-	 * if so, only those keys will be returned.
+	 * Returns the raw data wrapped by this ORM instance as an associative array. Column names may optionally be
+	 * supplied as arguments, if so, only those keys will be returned.
+	 *
+	 * @return array Associative array of the raw data.
 	 */
 	public function as_array() {
 		if ( \func_num_args() === 0 ) {
@@ -2004,13 +1977,12 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Return the value of a property of this object (database row)
-	 * or null if not present.
+	 * Returns the value of a property of this object (database row) or null if not present.
 	 *
-	 * If a column-names array is passed, it will return a associative array
-	 * with the value of each column or null if it is not present.
+	 * If a column-names array is passed, it will return a associative array with the value of each column or null if
+	 * it is not present.
 	 *
-	 * @param $key
+	 * @param string|array $key Key.
 	 *
 	 * @return array|mixed|null
 	 */
@@ -2022,14 +1994,16 @@ class ORM implements \ArrayAccess {
 			}
 
 			return $result;
-		} else {
+		}
+		else {
 			return isset( $this->_data[ $key ] ) ? $this->_data[ $key ] : null;
 		}
 	}
 
 	/**
-	 * Return the name of the column in the database table which contains
-	 * the primary key ID of the row.
+	 * Returns the name of the column in the database table which contains the primary key ID of the row.
+	 *
+	 * @return string The primary key ID of the row.
 	 */
 	protected function _get_id_column_name() {
 		if ( ! \is_null( $this->_instance_id_column ) ) {
@@ -2040,12 +2014,14 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Get the primary key ID of this object.
+	 * Gets the primary key ID of this object.
 	 *
-	 * @param bool $disallow_null
+	 * @param bool $disallow_null Whether to allow null IDs.
+	 *
+	 * @throws \Exception Primary key ID contains null value(s).
+	 * @throws \Exception Primary key ID missing from row or is null.
 	 *
 	 * @return array|mixed|null
-	 * @throws \Exception
 	 */
 	public function id( $disallow_null = false ) {
 		$id = $this->get( $this->_get_id_column_name() );
@@ -2056,7 +2032,8 @@ class ORM implements \ArrayAccess {
 						throw new \Exception( 'Primary key ID contains null value(s)' );
 					}
 				}
-			} else {
+			}
+			else {
 				if ( $id === null ) {
 					throw new \Exception( 'Primary key ID missing from row or is null' );
 				}
@@ -2067,14 +2044,13 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Set a property to a particular value on this object.
-	 * To set multiple properties at once, pass an associative array
-	 * as the first parameter and leave out the second parameter.
-	 * Flags the properties as 'dirty' so they will be saved to the
-	 * database when save() is called.
+	 * Sets a property to a particular value on this object.
 	 *
-	 * @param      $key
-	 * @param null $value
+	 * To set multiple properties at once, pass an associative array as the first parameter and leave out the second
+	 * parameter. Flags the properties as 'dirty' so they will be saved to the database when save() is called.
+	 *
+	 * @param string|array $key   Key.
+	 * @param string|null  $value Value.
 	 *
 	 * @return ORM
 	 */
@@ -2083,14 +2059,13 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Set a property to a particular value on this object.
-	 * To set multiple properties at once, pass an associative array
-	 * as the first parameter and leave out the second parameter.
-	 * Flags the properties as 'dirty' so they will be saved to the
-	 * database when save() is called.
+	 * Set a property to a particular value on this object as expression.
 	 *
-	 * @param string|array $key
-	 * @param string|null  $value
+	 * To set multiple properties at once, pass an associative array as the first parameter and leave out the second
+	 * parameter. Flags the properties as 'dirty' so they will be saved to the database when save() is called.
+	 *
+	 * @param string|array $key   Key.
+	 * @param string|null  $value Value.
 	 *
 	 * @return ORM
 	 */
@@ -2099,11 +2074,11 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Set a property on the ORM object.
+	 * Sets a property on the ORM object.
 	 *
-	 * @param string|array $key
-	 * @param string|null  $value
-	 * @param bool         $expr
+	 * @param string|array $key   Key.
+	 * @param string|null  $value Value.
+	 * @param bool         $expr  Expression.
 	 *
 	 * @return ORM
 	 */
@@ -2116,7 +2091,8 @@ class ORM implements \ArrayAccess {
 			$this->_dirty_fields[ $field ] = $value;
 			if ( false === $expr and isset( $this->_expr_fields[ $field ] ) ) {
 				unset( $this->_expr_fields[ $field ] );
-			} else {
+			}
+			else {
 				if ( true === $expr ) {
 					$this->_expr_fields[ $field ] = true;
 				}
@@ -2127,10 +2103,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Check whether the given field has been changed since this
-	 * object was saved.
+	 * Checks whether the given field has been changed since this object was saved.
 	 *
-	 * @param $key
+	 * @param mixed $key Key.
 	 *
 	 * @return bool
 	 */
@@ -2139,7 +2114,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Check whether the model was the result of a call to create() or not
+	 * Checks whether the model was the result of a call to create() or not.
 	 *
 	 * @return bool
 	 */
@@ -2148,17 +2123,21 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Save any fields which have been modified on this object
-	 * to the database.
+	 * Saves any fields which have been modified on this object to the database.
+	 *
+	 * @throws \Exception Primary key ID contains null value(s).
+	 * @throws \Exception Primary key ID missing from row or is null.
+	 *
+	 * @return bool True on success.
 	 */
 	public function save() {
 		global $wpdb;
 
-		// remove any expression fields as they are already baked into the query
+		// Remove any expression fields as they are already baked into the query.
 		$values = \array_values( \array_diff_key( $this->_dirty_fields, $this->_expr_fields ) );
 		if ( ! $this->_is_new ) {
-			// UPDATE
-			// If there are no dirty values, do nothing
+			// UPDATE.
+			// If there are no dirty values, do nothing.
 			if ( empty( $values ) && empty( $this->_expr_fields ) ) {
 				return true;
 			}
@@ -2166,21 +2145,22 @@ class ORM implements \ArrayAccess {
 			$id    = $this->id( true );
 			if ( \is_array( $id ) ) {
 				$values = \array_merge( $values, \array_values( $id ) );
-			} else {
+			}
+			else {
 				$values[] = $id;
 			}
-		} else {
-			// INSERT
+		}
+		else {
+			// INSERT.
 			$query = $this->_build_insert();
 		}
 		$success = self::_execute( $query, $values );
-		// If we've just inserted a new record, set the ID of this object
+		// If we've just inserted a new record, set the ID of this object.
 		if ( $this->_is_new ) {
 			$this->_is_new = false;
-			if ( $this->count_null_id_columns() != 0 ) {
+			if ( $this->count_null_id_columns() !== 0 ) {
 				$column = $this->_get_id_column_name();
-				// if the primary key is compound, assign the last inserted id
-				// to the first column
+				// If the primary key is compound, assign the last inserted id to the first column.
 				if ( \is_array( $column ) ) {
 					$column = \reset( $column );
 				}
@@ -2193,11 +2173,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Add a WHERE clause for every column that belongs to the primary key
+	 * Adds a WHERE clause for every column that belongs to the primary key.
 	 *
 	 * @param array $query The query.
-	 *
-	 * @return void
 	 */
 	public function _add_id_column_conditions( &$query ) {
 		$query[] = 'WHERE';
@@ -2206,7 +2184,8 @@ class ORM implements \ArrayAccess {
 		foreach ( $keys as $key ) {
 			if ( $first ) {
 				$first = false;
-			} else {
+			}
+			else {
 				$query[] = 'AND';
 			}
 			$query[] = $this->_quote_identifier( $key );
@@ -2215,7 +2194,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Build an UPDATE query
+	 * Builds an UPDATE query.
 	 *
 	 * @return string The update query.
 	 */
@@ -2236,7 +2215,7 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Build an INSERT query
+	 * Builds an INSERT query.
 	 *
 	 * @return string The insert query.
 	 */
@@ -2253,11 +2232,12 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Delete this record from the database
+	 * Deletes this record from the database.
+	 *
+	 * @throws \Exception Primary key ID contains null value(s).
+	 * @throws \Exception Primary key ID missing from row or is null.
 	 *
 	 * @return string The delete query.
-	 *
-	 * @throws \Exception
 	 */
 	public function delete() {
 		$query = [ 'DELETE FROM', $this->_quote_identifier( $this->_table_name ) ];
@@ -2267,7 +2247,9 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * Delete many records from the database
+	 * Deletes many records from the database.
+	 *
+	 * @return bool|int Response of wpdb::query.
 	 */
 	public function delete_many() {
 		// Build and return the full DELETE statement by concatenating
@@ -2280,30 +2262,37 @@ class ORM implements \ArrayAccess {
 
 		return self::_execute( $query, $this->_values );
 	}
+
 	// --------------------- //
 	// ---  ArrayAccess  --- //
 	// --------------------- //
 	/**
-	 * @param mixed $key
+	 * Checks whether the data has the key.
 	 *
-	 * @return bool
+	 * @param mixed $key Key.
+	 *
+	 * @return bool Whether the data has the key.
 	 */
 	public function offsetExists( $key ) {
 		return \array_key_exists( $key, $this->_data );
 	}
 
 	/**
-	 * @param mixed $key
+	 * Retrieves the value of the key.
 	 *
-	 * @return array|mixed|null
+	 * @param mixed $key Key.
+	 *
+	 * @return array|mixed|null The value.
 	 */
 	public function offsetGet( $key ) {
 		return $this->get( $key );
 	}
 
 	/**
-	 * @param mixed $key
-	 * @param mixed $value
+	 * Sets the value of the key.
+	 *
+	 * @param string|int $key   Key.
+	 * @param mixed      $value Value.
 	 */
 	public function offsetSet( $key, $value ) {
 		if ( \is_null( $key ) ) {
@@ -2313,43 +2302,54 @@ class ORM implements \ArrayAccess {
 	}
 
 	/**
-	 * @param mixed $key
+	 * Removes the given key from the data.
+	 *
+	 * @param mixed $key Key.
 	 */
 	public function offsetUnset( $key ) {
 		unset( $this->_data[ $key ] );
 		unset( $this->_dirty_fields[ $key ] );
 	}
+
 	// --------------------- //
 	// --- MAGIC METHODS --- //
 	// --------------------- //
 	/**
-	 * @param $key
+	 * Handles magic get via offset.
 	 *
-	 * @return array|mixed|null
+	 * @param mixed $key Key.
+	 *
+	 * @return array|mixed|null The value in the offset.
 	 */
 	public function __get( $key ) {
 		return $this->offsetGet( $key );
 	}
 
 	/**
-	 * @param $key
-	 * @param $value
+	 * Handles magic set via offset.
+	 *
+	 * @param string|int $key   Key.
+	 * @param mixed      $value Value.
 	 */
 	public function __set( $key, $value ) {
 		$this->offsetSet( $key, $value );
 	}
 
 	/**
-	 * @param $key
+	 * Handles magic unset via offset.
+	 *
+	 * @param mixed $key Key.
 	 */
 	public function __unset( $key ) {
 		$this->offsetUnset( $key );
 	}
 
 	/**
-	 * @param $key
+	 * Handles magic isset via offset.
 	 *
-	 * @return bool
+	 * @param mixed $key Key.
+	 *
+	 * @return bool Whether the offset has the key.
 	 */
 	public function __isset( $key ) {
 		return $this->offsetExists( $key );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,10 +4,6 @@
 
     <file>.</file>
 
-    <!-- Temporary exclude for the lib dir -->
-    <exclude-pattern>lib/model.php</exclude-pattern>
-    <exclude-pattern>lib/orm.php</exclude-pattern>
-
     <exclude-pattern>tests/*</exclude-pattern>
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>vendor_prefixed/*</exclude-pattern>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* After https://github.com/Yoast/wordpress-seo/pull/15314 only the ORM and model files remained.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes CS issues in the CS folder.
* Un-excludes the lib folder from CS checks.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### More of a CR
* CS should be fixed.
* Ignored warnings:
  * Code comment warning in model. The comment IS commented out code.
  * Warning about a loose comparison. This seems very intended. Integer whenever the float is loosely the same as the integer value. But I could not get the ignore to work, so I left it.
* Ignored the CS error about the usage of `MYSQL_MAX_IDENTIFIER_LENGTH`. Does not seem relevant to an adapter to me. But I could be terribly wrong here.
* Have an opinion on: the strict check changes in `lib/orm.php`:
  * Line 524  `if ( '*' !== $column ) {`
    * I don't think this can be anything other than a string. So changing to a strict check should be safe here.
  * Line 2162 `if ( $this->count_null_id_columns() !== 0 ) {`
    * This method only returns an integer, so a strict check should be safe here.

### Safety checks
* Remove all the Yoast SEO tables as well as the migrations option ( probably best to use the test helper ).
* All our tables should be succesfully created as they were previously.
* Index everything again.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14996 
