### PR TITLE
FRO-70 Style the info table of the RSS tab

### DIFF
--- a/admin/views/tabs/metas/paper-content/rss-content.php
+++ b/admin/views/tabs/metas/paper-content/rss-content.php
@@ -22,7 +22,7 @@ $rss_variables_help = new WPSEO_Admin_Help_Button(
 
 echo '<h2 class="help-button-inline">' . esc_html__( 'Available variables', 'wordpress-seo' ) . $rss_variables_help . '</h2>';
 ?>
-<table class="wpseo yoast_help yoast-table-scrollable widefat striped">
+<table class="wpseo yoast_help yoast-table yoast-table-scrollable widefat striped">
 	<thead>
 	<tr>
 		<th scope="col"><?php esc_html_e( 'Variable', 'wordpress-seo' ); ?></th>

--- a/admin/views/tabs/metas/paper-content/rss-content.php
+++ b/admin/views/tabs/metas/paper-content/rss-content.php
@@ -22,7 +22,7 @@ $rss_variables_help = new WPSEO_Admin_Help_Button(
 
 echo '<h2 class="help-button-inline">' . esc_html__( 'Available variables', 'wordpress-seo' ) . $rss_variables_help . '</h2>';
 ?>
-<table class="wpseo yoast_help yoast-table-scrollable">
+<table class="wpseo yoast_help yoast-table-scrollable widefat striped">
 	<thead>
 	<tr>
 		<th scope="col"><?php esc_html_e( 'Variable', 'wordpress-seo' ); ?></th>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Style the info table in the RSS tab conform the new Yoast styling

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Style the info table in the RSS tab conform the new Yoast styling

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this branch
* Build the plugin
* Go to the `RSS` tab in `Search Appearance`
* Check if the `Available variables` table matches the new styling


## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/FRO-70
