### PR TITLE
Fix zero index

### DIFF
--- a/src/generators/schema/faq.php
+++ b/src/generators/schema/faq.php
@@ -45,9 +45,9 @@ class FAQ extends Abstract_Schema_Piece {
 				if ( ! isset( $question['jsonAnswer'] ) || empty( $question['jsonAnswer'] ) ) {
 					continue;
 				}
-				$ids[]   = [ '@id' => $this->context->canonical . '#' . \esc_attr( $question['id'] ) ];
+				$ids[] = [ '@id' => $this->context->canonical . '#' . \esc_attr( $question['id'] ) ];
 				// Index + 1 below so we start at 1 and count from there.
-				$graph[] = $this->generate_question_block( $question, $index + 1 );
+				$graph[] = $this->generate_question_block( $question, ( $index + 1 ) );
 				++$number_of_items;
 			}
 		}

--- a/src/generators/schema/faq.php
+++ b/src/generators/schema/faq.php
@@ -46,7 +46,8 @@ class FAQ extends Abstract_Schema_Piece {
 					continue;
 				}
 				$ids[]   = [ '@id' => $this->context->canonical . '#' . \esc_attr( $question['id'] ) ];
-				$graph[] = $this->generate_question_block( $question, $index );
+				// Index + 1 below so we start at 1 and count from there.
+				$graph[] = $this->generate_question_block( $question, $index + 1 );
 				++$number_of_items;
 			}
 		}

--- a/tests/generators/schema-generator-test.php
+++ b/tests/generators/schema-generator-test.php
@@ -332,7 +332,7 @@ class Schema_Generator_Test extends TestCase {
 					[
 						'@type'          => 'Question',
 						'@id'            => '#id-1',
-						'position'       => 0,
+						'position'       => 1,
 						'url'            => '#id-1',
 						'name'           => 'This is a question',
 						'answerCount'    => 1,
@@ -406,7 +406,7 @@ class Schema_Generator_Test extends TestCase {
 				[
 					'@type'          => 'Question',
 					'@id'            => '#id-1',
-					'position'       => 0,
+					'position'       => 1,
 					'url'            => '#id-1',
 					'name'           => 'This is a question',
 					'answerCount'    => 1,

--- a/tests/generators/schema/faq-test.php
+++ b/tests/generators/schema/faq-test.php
@@ -124,7 +124,7 @@ class FAQ_Test extends TestCase {
 			[
 				'@id'            => 'https://example.org/page/#id-1',
 				'@type'          => 'Question',
-				'position'       => 0,
+				'position'       => 1,
 				'url'            => 'https://example.org/page/#id-1',
 				'name'           => 'This is a question',
 				'answerCount'    => 1,
@@ -138,7 +138,7 @@ class FAQ_Test extends TestCase {
 			[
 				'@id'            => 'https://example.org/page/#id-2',
 				'@type'          => 'Question',
-				'position'       => 1,
+				'position'       => 2,
 				'url'            => 'https://example.org/page/#id-2',
 				'name'           => 'This is the second question',
 				'answerCount'    => 1,
@@ -220,7 +220,7 @@ class FAQ_Test extends TestCase {
 			[
 				'@id'            => 'https://example.org/page/#id-1',
 				'@type'          => 'Question',
-				'position'       => 0,
+				'position'       => 1,
 				'url'            => 'https://example.org/page/#id-1',
 				'name'           => 'This is a question',
 				'answerCount'    => 1,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Make sure we start a list at 1 instead of 0 in FAQ output.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the FAQ schema list item's position would start at 0 instead of 1.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add an FAQ block to a page.
* View the source code.
* See that the {{itemList}} is no longer zero-indexed. Now starting at 1.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/QAK-1849
