### PR TITLE
P3-31 Use the Gutenberg modal for the related keyphrases synonyms upsell modals

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -599,6 +599,7 @@ class WPSEO_Admin_Asset_Manager {
 				'deps' => [
 					self::PREFIX . 'select2',
 					self::PREFIX . 'admin-css',
+					'wp-components',
 				],
 			],
 			[

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -20,6 +20,7 @@ import MultipleKeywords from "../modals/MultipleKeywords";
 import { LocationConsumer } from "../contexts/location";
 import AnalysisUpsell from "../AnalysisUpsell";
 import { ModalContainer, ModalIcon } from "../modals/Container";
+import YoastIcon from "../../../../images/Yoast_icon_kader.svg";
 
 const AnalysisHeader = styled.span`
 	font-size: 1em;
@@ -125,6 +126,8 @@ class SeoAnalysis extends Component {
 							)
 						}
 						onRequestClose={ this.closeSynonymsModal }
+						className="yoast-gutenberg-modal"
+						icon={ <YoastIcon /> }
 					>
 						<ModalContainer>
 							<ModalIcon icon={ YoastSeoIcon } />
@@ -176,6 +179,8 @@ class SeoAnalysis extends Component {
 							)
 						}
 						onRequestClose={ this.closeKeyphrasesModal }
+						className="yoast-gutenberg-modal"
+						icon={ <YoastIcon /> }
 					>
 						<ModalContainer>
 							<ModalIcon icon={ YoastSeoIcon } />

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -32,6 +32,13 @@ const AnalysisHeader = styled.span`
  * Redux container for the seo analysis.
  */
 class SeoAnalysis extends Component {
+	/**
+	 * Constructs the SeoAnalysis component.
+	 *
+	 * @param {Object} props The component properties.
+	 *
+	 * @returns {void}
+	 */
 	constructor( props ) {
 		super( props );
 
@@ -46,18 +53,38 @@ class SeoAnalysis extends Component {
 		this.closeSynonymsModal   = this.closeSynonymsModal.bind( this );
 	}
 
+	/**
+	 * Opens the Keyphrases modal.
+	 *
+	 * @returns {void}
+	 */
 	openKeyphrasesModal() {
 		this.setState( { isKeyphrasesModalOpen: true } );
 	}
 
+	/**
+	 * Closes the Keyphrases modal.
+	 *
+	 * @returns {void}
+	 */
 	closeKeyphrasesModal() {
 		this.setState( { isKeyphrasesModalOpen: false } );
 	}
 
+	/**
+	 * Opens the Synonyms modal.
+	 *
+	 * @returns {void}
+	 */
 	openSynonymsModal() {
 		this.setState( { isSynonymsModalOpen: true } );
 	}
 
+	/**
+	 * Closes the Synonyms modal.
+	 *
+	 * @returns {void}
+	 */
 	closeSynonymsModal() {
 		this.setState( { isSynonymsModalOpen: false } );
 	}

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -4,7 +4,7 @@ import { Component, Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import styled from "styled-components";
-import { Slot } from "@wordpress/components";
+import { Slot, Button, Modal } from "@wordpress/components";
 import { __, sprintf } from "@wordpress/i18n";
 import { YoastSeoIcon } from "@yoast/components";
 import { colors } from "@yoast/style-guide";
@@ -16,7 +16,6 @@ import Results from "./Results";
 import getIndicatorForScore from "../../analysis/getIndicatorForScore";
 import { getIconForScore } from "./mapResults";
 import KeywordSynonyms from "../modals/KeywordSynonyms";
-import Modal from "../modals/Modal";
 import MultipleKeywords from "../modals/MultipleKeywords";
 import { LocationConsumer } from "../contexts/location";
 import AnalysisUpsell from "../AnalysisUpsell";
@@ -33,6 +32,36 @@ const AnalysisHeader = styled.span`
  * Redux container for the seo analysis.
  */
 class SeoAnalysis extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			isKeyphrasesModalOpen: false,
+			isSynonymsModalOpen: false,
+		};
+
+		this.openKeyphrasesModal  = this.openKeyphrasesModal.bind( this );
+		this.closeKeyphrasesModal = this.closeKeyphrasesModal.bind( this );
+		this.openSynonymsModal    = this.openSynonymsModal.bind( this );
+		this.closeSynonymsModal   = this.closeSynonymsModal.bind( this );
+	}
+
+	openKeyphrasesModal() {
+		this.setState( { isKeyphrasesModalOpen: true } );
+	}
+
+	closeKeyphrasesModal() {
+		this.setState( { isKeyphrasesModalOpen: false } );
+	}
+
+	openSynonymsModal() {
+		this.setState( { isSynonymsModalOpen: true } );
+	}
+
+	closeSynonymsModal() {
+		this.setState( { isSynonymsModalOpen: false } );
+	}
+
 	/**
 	 * Renders the keyword synonyms upsell modal.
 	 *
@@ -41,25 +70,6 @@ class SeoAnalysis extends Component {
 	 * @returns {ReactElement} A modalButtonContainer component with the modal for a keyword synonyms upsell.
 	 */
 	renderSynonymsUpsell( location ) {
-		const modalProps = {
-			classes: {
-				openButton: "wpseo-keyword-synonyms button-link",
-			},
-			labels: {
-				open: "+ " + __( "Add synonyms", "wordpress-seo" ),
-				modalAriaLabel: sprintf(
-					/* translators: %s expands to 'Yoast SEO Premium'. */
-					__( "Get %s", "wordpress-seo" ),
-					"Yoast SEO Premium"
-				),
-				heading: sprintf(
-					/* translators: %s expands to 'Yoast SEO Premium'. */
-					__( "Get %s", "wordpress-seo" ),
-					"Yoast SEO Premium"
-				),
-			},
-		};
-
 		// Defaults to metabox.
 		let link    = wpseoAdminL10n[ "shortlinks.upsell.metabox.focus_keyword_synonyms_link" ];
 		let buyLink = wpseoAdminL10n[ "shortlinks.upsell.metabox.focus_keyword_synonyms_button" ];
@@ -70,14 +80,36 @@ class SeoAnalysis extends Component {
 		}
 
 		return (
-			<Modal { ...modalProps }>
-				<ModalContainer>
-					<ModalIcon icon={ YoastSeoIcon } />
-					<h2>{ __( "Would you like to add keyphrase synonyms?", "wordpress-seo" ) }</h2>
-
-					<KeywordSynonyms link={ link } buyLink={ buyLink } />
-				</ModalContainer>
-			</Modal>
+			<Fragment>
+				<Button
+					isLink={ true }
+					onClick={ this.openSynonymsModal }
+					className="wpseo-keyword-synonyms"
+				>
+					{ "+ " + __( "Add synonyms", "wordpress-seo" ) }
+				</Button>
+				{ this.state.isSynonymsModalOpen &&
+					<Modal
+						title={
+							sprintf(
+								/* translators: %s expands to 'Yoast SEO Premium'. */
+								__( "Get %s", "wordpress-seo" ),
+								"Yoast SEO Premium"
+							)
+						}
+						onRequestClose={ this.closeSynonymsModal }
+					>
+						<ModalContainer>
+							<ModalIcon icon={ YoastSeoIcon } />
+							<h2>{ __( "Would you like to add keyphrase synonyms?", "wordpress-seo" ) }</h2>
+							<KeywordSynonyms
+								link={ link }
+								buyLink={ buyLink }
+							/>
+						</ModalContainer>
+					</Modal>
+				}
+			</Fragment>
 		);
 	}
 
@@ -89,25 +121,6 @@ class SeoAnalysis extends Component {
 	 * @returns {ReactElement} A modalButtonContainer component with the modal for a multiple keywords upsell.
 	 */
 	renderMultipleKeywordsUpsell( location ) {
-		const modalProps = {
-			classes: {
-				openButton: "wpseo-multiple-keywords button-link",
-			},
-			labels: {
-				open: "+ " + __( "Add related keyphrase", "wordpress-seo" ),
-				modalAriaLabel: sprintf(
-					/* translators: %s expands to 'Yoast SEO Premium'. */
-					__( "Get %s", "wordpress-seo" ),
-					"Yoast SEO Premium"
-				),
-				heading: sprintf(
-					/* translators: %s expands to 'Yoast SEO Premium'. */
-					__( "Get %s", "wordpress-seo" ),
-					"Yoast SEO Premium"
-				),
-			},
-		};
-
 		// Defaults to metabox
 		let link    = wpseoAdminL10n[ "shortlinks.upsell.metabox.focus_keyword_additional_link" ];
 		let buyLink = wpseoAdminL10n[ "shortlinks.upsell.metabox.focus_keyword_additional_button" ];
@@ -118,16 +131,36 @@ class SeoAnalysis extends Component {
 		}
 
 		return (
-			<Modal { ...modalProps }>
-				<ModalContainer>
-					<ModalIcon icon={ YoastSeoIcon } />
-					<h2>{ __( "Would you like to add a related keyphrase?", "wordpress-seo" ) }</h2>
-					<MultipleKeywords
-						link={ link }
-						buyLink={ buyLink }
-					/>
-				</ModalContainer>
-			</Modal>
+			<Fragment>
+				<Button
+					isLink={ true }
+					onClick={ this.openKeyphrasesModal }
+					className="wpseo-multiple-keywords"
+				>
+					{ "+ " + __( "Add related keyphrase", "wordpress-seo" ) }
+				</Button>
+				{ this.state.isKeyphrasesModalOpen &&
+					<Modal
+						title={
+							sprintf(
+								/* translators: %s expands to 'Yoast SEO Premium'. */
+								__( "Get %s", "wordpress-seo" ),
+								"Yoast SEO Premium"
+							)
+						}
+						onRequestClose={ this.closeKeyphrasesModal }
+					>
+						<ModalContainer>
+							<ModalIcon icon={ YoastSeoIcon } />
+							<h2>{ __( "Would you like to add a related keyphrase?", "wordpress-seo" ) }</h2>
+							<MultipleKeywords
+								link={ link }
+								buyLink={ buyLink }
+							/>
+						</ModalContainer>
+					</Modal>
+				}
+			</Fragment>
 		);
 	}
 
@@ -231,6 +264,7 @@ class SeoAnalysis extends Component {
 							<Slot name={ `yoast-synonyms-${ location }` } />
 							{ this.props.shouldUpsell && <Fragment>
 								{ this.renderSynonymsUpsell( location ) }
+								<br />
 								{ this.renderMultipleKeywordsUpsell( location ) }
 							</Fragment> }
 							{ this.props.shouldUpsellWordFormRecognition && this.renderWordFormsUpsell( location ) }

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -4,7 +4,7 @@ import { Component, Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import styled from "styled-components";
-import { Slot, Button, Modal } from "@wordpress/components";
+import { Slot, Modal } from "@wordpress/components";
 import { __, sprintf } from "@wordpress/i18n";
 import { YoastSeoIcon } from "@yoast/components";
 import { colors } from "@yoast/style-guide";
@@ -81,13 +81,13 @@ class SeoAnalysis extends Component {
 
 		return (
 			<Fragment>
-				<Button
-					isLink={ true }
+				<button
+					type="button"
 					onClick={ this.openSynonymsModal }
-					className="wpseo-keyword-synonyms"
+					className="wpseo-keyword-synonyms button-link"
 				>
 					{ "+ " + __( "Add synonyms", "wordpress-seo" ) }
-				</Button>
+				</button>
 				{ this.state.isSynonymsModalOpen &&
 					<Modal
 						title={
@@ -132,13 +132,13 @@ class SeoAnalysis extends Component {
 
 		return (
 			<Fragment>
-				<Button
-					isLink={ true }
+				<button
+					type="button"
 					onClick={ this.openKeyphrasesModal }
-					className="wpseo-multiple-keywords"
+					className="wpseo-multiple-keywords button-link"
 				>
 					{ "+ " + __( "Add related keyphrase", "wordpress-seo" ) }
-				</Button>
+				</button>
 				{ this.state.isKeyphrasesModalOpen &&
 					<Modal
 						title={


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to have beter UI consistency and reduce the amount of component / packages used.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes the Related keyphrases and Synonyms upsell modal dialogs use the Gutenberg Modal component.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- edit a post
- go the the meta box, open the SEO analysis panel
- click on the buttons "+ Add synonyms" and "+ Add related keyphrase" (visually, they look like links)
- observe they use our Modal component

**Test the modals with Classic Editor:**
 - install and activate the Classic Editor plugin
- edit a post
- expand the SEO analysis panel
- click the links to open the modals and observe the modal styling is OK

Note: the visual difference is that the Gutenberg Modal uses an animation and "slides in" from the bottom of the page. More differences are in the underlying code / packages used.

**To test the modals header title styling::**
- switch your JavaScript repo to the `P3-5-create-related-keyphrases-component` branch from https://github.com/Yoast/javascript/pull/710
- on Yoast SEO, run `yarn link-monorepo` and then build
- open the two modals and check:
  - the modal title has the Yoast icon with the Yoast purple color
  - the modal title text is bigger, _not_ bold, and purple


Three more small visual differences are that the Gutenberg modal:
- uses a thin border at the bottom of the header
- the X close button is not bold
- the overlay is slightly darker

Screenshot before:

<img width="1279" alt="Screenshot 2020-06-05 at 10 04 51" src="https://user-images.githubusercontent.com/1682452/83855733-ce467880-a718-11ea-82ee-81435b4f82de.png">


Screenshot after:

<img width="1281" alt="Screenshot 2020-06-10 at 11 34 40" src="https://user-images.githubusercontent.com/1682452/84252084-7344c500-ab0e-11ea-9f3d-f510047880c1.png">


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-31]
