### PR TITLE
Admin Bar: fix link to Facebook Debugger

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -332,7 +332,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			[
 				'id'     => 'wpseo-facebookdebug',
 				'title'  => __( 'Facebook Debugger', 'wordpress-seo' ),
-				'href'   => '//developers.facebook.com/tools/debug/og/object?q=' . $encoded_url,
+				'href'   => '//developers.facebook.com/tools/debug/?q=' . $encoded_url,
 			],
 			[
 				'id'     => 'wpseo-pinterestvalidator',


### PR DESCRIPTION
Fixes #14731

## Context

* The link in the Admin Bar to the Facebook Debugger is not up to date.

## Summary

This PR can be summarized in the following changelog entry:

* Admin Bar: fix link to Facebook Debugger

## Test instructions

This PR can be tested by following these steps:

* View a post in the front end.
* Go to the Yoast menu button in Admin Bar, then Analyze this page, and click Facebook Debugger
    <img width="513" alt="Screen Shot 2020-06-06 at 15 50 27" src="https://user-images.githubusercontent.com/1041600/83952463-60c94380-a80f-11ea-8f18-0ae1982319fa.png">
* It should navigate to the correct Facebook Debugger page

Fixes #14731
