### PR TITLE
Clear the category permalinks when stripcategorybase option changes

### DIFF
--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Overal Option Management class.
+ * Overall Option Management class.
  *
  * Instantiates all the options and offers a number of utility methods to work with the options.
  */

--- a/src/actions/indexation/indexable-term-indexation-action.php
+++ b/src/actions/indexation/indexable-term-indexation-action.php
@@ -53,7 +53,7 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 	}
 
 	/**
-	 * The total number of unindexed terms.
+	 * Gets the total number of unindexed terms.
 	 *
 	 * @return int|false The amount of unindexed terms. False if the query fails.
 	 */

--- a/src/actions/indexation/indexable-term-indexation-action.php
+++ b/src/actions/indexation/indexable-term-indexation-action.php
@@ -139,40 +139,14 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 	}
 
 	/**
-	 * Gets the total number of unindexed terms.
+	 * Gets the number of terms where the permalink is set to NULL.
 	 *
-	 * @return int|false The amount of unindexed terms. False if the query fails.
+	 * @return int The number of terms where the permalink is set to NULL.
 	 */
 	public function get_total_term_permalinks_null() {
-		$query = $this->get_query_term_permalinks_null();
-
-		$result = $this->wpdb->get_var( $query );
-
-		if ( \is_null( $result ) ) {
-			return false;
-		}
-
-		return (int) $result;
-	}
-
-	/**
-	 * Queries the database for terms whose permalink is NULL.
-	 *
-	 * @return string The query.
-	 */
-	public function get_query_term_permalinks_null() {
-		$public_taxonomies = $this->taxonomy->get_public_taxonomies();
-		$placeholders      = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
-		$indexable_table   = Model::get_table_name( 'Indexable' );
-		$replacements      = $public_taxonomies;
-
-		return $this->wpdb->prepare(
-			"
-			SELECT COUNT(term_id)
-			FROM {$this->wpdb->term_taxonomy}
-			WHERE term_id IN (SELECT object_id FROM $indexable_table WHERE object_type = 'term' && permalink IS NULL) AND taxonomy IN ($placeholders)
-			",
-			$replacements
-		);
+		return Model::of_type( 'Indexable' )
+			->where( 'object_type', 'term' )
+			->where( 'permalink', null )
+			->count( 'id' );
 	}
 }

--- a/src/actions/indexation/indexable-term-indexation-action.php
+++ b/src/actions/indexation/indexable-term-indexation-action.php
@@ -146,7 +146,7 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 	public function get_total_term_permalinks_null() {
 		return Model::of_type( 'Indexable' )
 			->where( 'object_type', 'term' )
-			->where( 'permalink', null )
+			->where_null( 'permalink' )
 			->count( 'id' );
 	}
 }

--- a/src/integrations/admin/indexation-integration.php
+++ b/src/integrations/admin/indexation-integration.php
@@ -19,6 +19,7 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Indexation_List_Item_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Indexation_Modal_Presenter;
+use Yoast\WP\SEO\Presenters\Admin\Indexation_Permalink_Warning_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Indexation_Warning_Presenter;
 use Yoast\WP\SEO\Routes\Indexable_Indexation_Route;
 
@@ -151,6 +152,10 @@ class Indexation_Integration implements Integration_Interface {
 			\add_action( 'admin_notices', [ $this, 'render_indexation_warning' ], 10 );
 		}
 
+		if ( $this->term_indexation->get_total_term_permalinks_null() > $shutdown_limit ) {
+			\add_action( 'admin_notices', [ $this, 'render_indexation_permalink_warning' ], 10 );
+		}
+
 		$this->asset_manager->enqueue_script( 'indexation' );
 		$this->asset_manager->enqueue_style( 'admin-css' );
 
@@ -216,6 +221,15 @@ class Indexation_Integration implements Integration_Interface {
 	}
 
 	/**
+	 * Renders the indexation permalink warning.
+	 *
+	 * @return void
+	 */
+	public function render_indexation_permalink_warning() {
+		echo new Indexation_Permalink_Warning_Presenter( $this->get_total_unindexed(), $this->options_helper );
+	}
+
+	/**
 	 * Run a single indexation pass of each indexation action. Intended for use as a shutdown function.
 	 *
 	 * @return void
@@ -234,7 +248,7 @@ class Indexation_Integration implements Integration_Interface {
 	 */
 	protected function get_total_unindexed() {
 		if ( \is_null( $this->total_unindexed ) ) {
-			$this->total_unindexed  = $this->post_indexation->get_total_unindexed();
+			$this->total_unindexed = $this->post_indexation->get_total_unindexed();
 			$this->total_unindexed += $this->term_indexation->get_total_unindexed();
 			$this->total_unindexed += $this->general_indexation->get_total_unindexed();
 			$this->total_unindexed += $this->post_type_archive_indexation->get_total_unindexed();
@@ -259,6 +273,7 @@ class Indexation_Integration implements Integration_Interface {
 		}
 
 		$hide_until = (int) $this->options_helper->get( 'indexation_warning_hide_until' );
+
 		return ( $hide_until !== 0 && $hide_until >= \time() );
 	}
 }

--- a/src/integrations/admin/indexation-integration.php
+++ b/src/integrations/admin/indexation-integration.php
@@ -151,8 +151,7 @@ class Indexation_Integration implements Integration_Interface {
 		if ( $this->is_indexation_warning_hidden() === false ) {
 			\add_action( 'admin_notices', [ $this, 'render_indexation_warning' ], 10 );
 		}
-
-		if ( $this->term_indexation->get_total_term_permalinks_null() > $shutdown_limit ) {
+		elseif ( $this->term_indexation->get_total_term_permalinks_null() > $shutdown_limit ) {
 			\add_action( 'admin_notices', [ $this, 'render_indexation_permalink_warning' ], 10 );
 		}
 

--- a/src/integrations/watchers/indexable-category-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-category-permalink-watcher.php
@@ -94,7 +94,7 @@ class Indexable_Category_Permalink_Watcher implements Integration_Interface {
 	protected function clear_category_permalinks() {
 		Wrapper::get_wpdb()->update(
 			Model::get_table_name( 'Indexable' ),
-			[ 'permalink' => null, ],
+			[ 'permalink' => null ],
 			[ 'object_type' => 'term', 'object_sub_type' => 'category' ]
 		);
 	}

--- a/src/integrations/watchers/indexable-category-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-category-permalink-watcher.php
@@ -86,6 +86,11 @@ class Indexable_Category_Permalink_Watcher implements Integration_Interface {
 		}
 	}
 
+	/**
+	 * Clears the permalinks for category indexables.
+	 *
+	 * @return void
+	 */
 	protected function clear_category_permalinks() {
 		Wrapper::get_wpdb()->update(
 			Model::get_table_name( 'Indexable' ),

--- a/src/integrations/watchers/indexable-category-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-category-permalink-watcher.php
@@ -94,9 +94,7 @@ class Indexable_Category_Permalink_Watcher implements Integration_Interface {
 	protected function clear_category_permalinks() {
 		Wrapper::get_wpdb()->update(
 			Model::get_table_name( 'Indexable' ),
-			[
-				'permalink' => null,
-			],
+			[ 'permalink' => null, ],
 			[ 'object_type' => 'term', 'object_sub_type' => 'category' ]
 		);
 	}

--- a/src/integrations/watchers/indexable-category-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-category-permalink-watcher.php
@@ -94,7 +94,9 @@ class Indexable_Category_Permalink_Watcher implements Integration_Interface {
 	protected function clear_category_permalinks() {
 		Wrapper::get_wpdb()->update(
 			Model::get_table_name( 'Indexable' ),
-			[ 'permalink' => null ],
+			[
+				'permalink' => null,
+			],
 			[ 'object_type' => 'term', 'object_sub_type' => 'category' ]
 		);
 	}

--- a/src/integrations/watchers/indexable-category-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-category-permalink-watcher.php
@@ -68,7 +68,7 @@ class Indexable_Category_Permalink_Watcher implements Integration_Interface {
 			$old_value = [];
 		}
 
-		// If either value is not an array, return false.
+		// If either value is not an array, return.
 		if ( ! \is_array( $old_value ) || ! \is_array( $new_value ) ) {
 			return;
 		}
@@ -78,6 +78,7 @@ class Indexable_Category_Permalink_Watcher implements Integration_Interface {
 			return;
 		}
 
+		// If a new value has been set for 'stripcategorybase', clear the category permalinks.
 		if ( $old_value['stripcategorybase'] !== $new_value['stripcategorybase'] ) {
 			$this->clear_category_permalinks();
 

--- a/src/integrations/watchers/indexable-category-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-category-permalink-watcher.php
@@ -14,7 +14,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\WordPress\Wrapper;
 
 /**
- * Represents the option titles watcher.
+ * Watches the stripcategorybase key in wpseo_titles, in order to clear the permalink of the category indexables.
  */
 class Indexable_Category_Permalink_Watcher implements Integration_Interface {
 	/**
@@ -63,7 +63,7 @@ class Indexable_Category_Permalink_Watcher implements Integration_Interface {
 	 * @return void
 	 */
 	public function check_option( $old_value, $new_value ) {
-		// If this is the first time saving the option, thus when value is false.
+		// If this is the first time saving the option, in which case its value would be false.
 		if ( $old_value === false ) {
 			$old_value = [];
 		}

--- a/src/presenters/admin/indexation-permalink-warning-presenter.php
+++ b/src/presenters/admin/indexation-permalink-warning-presenter.php
@@ -27,7 +27,7 @@ class Indexation_Permalink_Warning_Presenter extends Indexation_Warning_Presente
 		$output .= '<hr />';
 		$output .= '<p>';
 		$output .= \sprintf(
-		/* translators: 1: Button start tag to dismiss the warning, 2: Button closing tag. */
+			/* translators: 1: Button start tag to dismiss the warning, 2: Button closing tag. */
 			\esc_html__( '%1$sHide this notice%2$s (everything will continue to function normally)', 'wordpress-seo' ),
 			\sprintf(
 				'<button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="%s">',

--- a/src/presenters/admin/indexation-permalink-warning-presenter.php
+++ b/src/presenters/admin/indexation-permalink-warning-presenter.php
@@ -14,32 +14,7 @@ use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 /**
  * Indexation_Permalink_Warning_Presenter class.
  */
-class Indexation_Permalink_Warning_Presenter extends Abstract_Presenter {
-
-	/**
-	 * The number of objects that needs to be indexed.
-	 *
-	 * @var int
-	 */
-	protected $total_unindexed;
-
-	/**
-	 * The options helper.
-	 *
-	 * @var Options_Helper
-	 */
-	private $options_helper;
-
-	/**
-	 * Indexation_Permalink_Warning_Presenter constructor.
-	 *
-	 * @param int            $total_unindexed The number of objects that needs to be indexed.
-	 * @param Options_Helper $options_helper  The options helper.
-	 */
-	public function __construct( $total_unindexed, Options_Helper $options_helper ) {
-		$this->total_unindexed = $total_unindexed;
-		$this->options_helper  = $options_helper;
-	}
+class Indexation_Permalink_Warning_Presenter extends Indexation_Warning_Presenter {
 
 	/**
 	 * Presents the warning that your site's content is not fully indexed.
@@ -84,49 +59,5 @@ class Indexation_Permalink_Warning_Presenter extends Abstract_Presenter {
 		);
 
 		return $output;
-	}
-
-	/**
-	 * Determines the message given for the estimation of the time that calculation might take.
-	 *
-	 * @return string The message.
-	 */
-	private function get_estimate() {
-		if ( $this->total_unindexed > 2500 ) {
-			$estimate = '<p>';
-			$estimate .= \esc_html__( 'We estimate this could take a long time, due to the size of your site. As an alternative to waiting, you could:', 'wordpress-seo' );
-			$estimate .= '<ul class="ul-disc">';
-			$estimate .= '<li>';
-			$estimate .= \sprintf(
-			/* translators: 1: Expands to Yoast SEO, 2: Button start tag for the reminder, 3: Button closing tag */
-				\esc_html__( 'Wait for a week or so, until %1$s automatically processes most of your content in the background. %2$sRemind me in a week.%3$s', 'wordpress-seo' ),
-				'Yoast SEO',
-				\sprintf(
-					'<button type="button" id="yoast-indexation-remind-button" class="button-link hide-if-no-js" data-nonce="%s">',
-					\esc_js( \wp_create_nonce( 'wpseo-indexation-remind' ) )
-				),
-				'</button>'
-			);
-			$estimate .= '</li>';
-			$estimate .= '<li>';
-			$estimate .= \sprintf(
-			/* translators: 1: Link to article about indexation command, 2: Anchor closing tag, 3: Link to WP CLI. */
-				\esc_html__( '%1$sRun the indexation process on your server%2$s using %3$sWP CLI%2$s', 'wordpress-seo' ),
-				'<a href="' . \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3-w' ) ) . '" target="_blank">',
-				'</a>',
-				'<a href="https://wp-cli.org/" target="_blank">'
-			);
-			$estimate .= '</li>';
-			$estimate .= '</ul>';
-			$estimate .= '</p>';
-
-			return $estimate;
-		}
-
-		if ( $this->total_unindexed >= 400 ) {
-			return '<p>' . \esc_html__( 'We estimate this will take a couple of minutes.', 'wordpress-seo' ) . '</p>';
-		}
-
-		return '<p>' . \esc_html__( 'We estimate this will take less than a minute.', 'wordpress-seo' ) . '</p>';
 	}
 }

--- a/src/presenters/admin/indexation-permalink-warning-presenter.php
+++ b/src/presenters/admin/indexation-permalink-warning-presenter.php
@@ -46,7 +46,7 @@ class Indexation_Permalink_Warning_Presenter extends Indexation_Warning_Presente
 	 *
 	 * @return string The generated alert.
 	 */
-	private function get_base_alert() {
+	protected function get_base_alert() {
 		$output = '<p>';
 		$output .= \esc_html__( 'Because you changed the category URL setting, some of your SEO data need to be reprocessed.', 'wordpress-seo' );
 		$output .= '</p>';

--- a/src/presenters/admin/indexation-permalink-warning-presenter.php
+++ b/src/presenters/admin/indexation-permalink-warning-presenter.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Presenter class for the warning that is given when the Category URLs (stripcategorybase) option is touched.
+ *
+ * @package Yoast\YoastSEO\Presenters\Admin
+ */
+
+namespace Yoast\WP\SEO\Presenters\Admin;
+
+use WPSEO_Shortlinker;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Presenters\Abstract_Presenter;
+
+/**
+ * Indexation_Permalink_Warning_Presenter class.
+ */
+class Indexation_Permalink_Warning_Presenter extends Abstract_Presenter {
+
+	/**
+	 * The number of objects that needs to be indexed.
+	 *
+	 * @var int
+	 */
+	protected $total_unindexed;
+
+	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options_helper;
+
+	/**
+	 * Indexation_Permalink_Warning_Presenter constructor.
+	 *
+	 * @param int            $total_unindexed The number of objects that needs to be indexed.
+	 * @param Options_Helper $options_helper  The options helper.
+	 */
+	public function __construct( $total_unindexed, Options_Helper $options_helper ) {
+		$this->total_unindexed = $total_unindexed;
+		$this->options_helper  = $options_helper;
+	}
+
+	/**
+	 * Presents the warning that your site's content is not fully indexed.
+	 *
+	 * @return string The warning HTML.
+	 */
+	public function present() {
+		$output = '<div id="yoast-indexation-warning" class="notice notice-success">';
+		$output .= $this->get_base_alert();
+		$output .= '<hr />';
+		$output .= '<p>';
+		$output .= \sprintf(
+		/* translators: 1: Button start tag to dismiss the warning, 2: Button closing tag. */
+			\esc_html__( '%1$sHide this notice%2$s (everything will continue to function normally)', 'wordpress-seo' ),
+			\sprintf(
+				'<button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="%s">',
+				\esc_js( \wp_create_nonce( 'wpseo-ignore' ) )
+			),
+			'</button>'
+		);
+		$output .= '</p>';
+		$output .= '</div>';
+
+		return $output;
+	}
+
+	/**
+	 * Retrieves the base alert.
+	 *
+	 * @return string The generated alert.
+	 */
+	private function get_base_alert() {
+		$output = '<p>';
+		$output .= \esc_html__( 'Because you changed the category URL setting, some of your SEO data need to be reprocessed.', 'wordpress-seo' );
+		$output .= '</p>';
+		$output .= $this->get_estimate();
+		$output .= \sprintf(
+			'<button type="button" class="button yoast-open-indexation" data-title="<strong>%1$s</strong>">%2$s</button>',
+			/* translators: 1: Expands to Yoast. */
+			\sprintf( \esc_html__( '%1$s indexing status', 'wordpress-seo' ), 'Yoast' ),
+			\esc_html__( 'Start processing and speed up your site now', 'wordpress-seo' )
+		);
+
+		return $output;
+	}
+
+	/**
+	 * Determines the message given for the estimation of the time that calculation might take.
+	 *
+	 * @return string The message.
+	 */
+	private function get_estimate() {
+		if ( $this->total_unindexed > 2500 ) {
+			$estimate = '<p>';
+			$estimate .= \esc_html__( 'We estimate this could take a long time, due to the size of your site. As an alternative to waiting, you could:', 'wordpress-seo' );
+			$estimate .= '<ul class="ul-disc">';
+			$estimate .= '<li>';
+			$estimate .= \sprintf(
+			/* translators: 1: Expands to Yoast SEO, 2: Button start tag for the reminder, 3: Button closing tag */
+				\esc_html__( 'Wait for a week or so, until %1$s automatically processes most of your content in the background. %2$sRemind me in a week.%3$s', 'wordpress-seo' ),
+				'Yoast SEO',
+				\sprintf(
+					'<button type="button" id="yoast-indexation-remind-button" class="button-link hide-if-no-js" data-nonce="%s">',
+					\esc_js( \wp_create_nonce( 'wpseo-indexation-remind' ) )
+				),
+				'</button>'
+			);
+			$estimate .= '</li>';
+			$estimate .= '<li>';
+			$estimate .= \sprintf(
+			/* translators: 1: Link to article about indexation command, 2: Anchor closing tag, 3: Link to WP CLI. */
+				\esc_html__( '%1$sRun the indexation process on your server%2$s using %3$sWP CLI%2$s', 'wordpress-seo' ),
+				'<a href="' . \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3-w' ) ) . '" target="_blank">',
+				'</a>',
+				'<a href="https://wp-cli.org/" target="_blank">'
+			);
+			$estimate .= '</li>';
+			$estimate .= '</ul>';
+			$estimate .= '</p>';
+
+			return $estimate;
+		}
+
+		if ( $this->total_unindexed >= 400 ) {
+			return '<p>' . \esc_html__( 'We estimate this will take a couple of minutes.', 'wordpress-seo' ) . '</p>';
+		}
+
+		return '<p>' . \esc_html__( 'We estimate this will take less than a minute.', 'wordpress-seo' ) . '</p>';
+	}
+}

--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -107,7 +107,7 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 	}
 
 	/**
-	 * Retrieves the incompleted indexation alert.
+	 * Retrieves the incomplete indexation alert.
 	 *
 	 * @return string The generated alert.
 	 */

--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -140,7 +140,7 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 	 *
 	 * @return string The message.
 	 */
-	private function get_estimate() {
+	protected function get_estimate() {
 		if ( $this->total_unindexed > 2500 ) {
 			$estimate  = '<p>';
 			$estimate .= \esc_html__( 'We estimate this could take a long time, due to the size of your site. As an alternative to waiting, you could:', 'wordpress-seo' );

--- a/tests/actions/indexation/indexable-term-indexation-action-test.php
+++ b/tests/actions/indexation/indexable-term-indexation-action-test.php
@@ -79,7 +79,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 		$expected_query    = "
 			SELECT COUNT(term_id)
 			FROM wp_term_taxonomy
-			WHERE term_id NOT IN (SELECT object_id FROM wp_yoast_indexable WHERE object_type = 'term') AND taxonomy IN (%s)
+			WHERE term_id NOT IN (SELECT object_id FROM wp_yoast_indexable WHERE object_type = 'term' && permalink IS NOT NULL) AND taxonomy IN (%s)
 			$limit_placeholder";
 
 		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturn( [ 'public_taxonomy' ] );
@@ -118,7 +118,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 		$expected_query = '
 			SELECT term_id
 			FROM wp_term_taxonomy
-			WHERE term_id NOT IN (SELECT object_id FROM wp_yoast_indexable WHERE object_type = \'term\') AND taxonomy IN (%s)
+			WHERE term_id NOT IN (SELECT object_id FROM wp_yoast_indexable WHERE object_type = \'term\' && permalink IS NOT NULL) AND taxonomy IN (%s)
 			LIMIT %d';
 
 		Filters\expectApplied( 'wpseo_term_indexation_limit' )->andReturn( 25 );

--- a/tests/integrations/admin/indexation-integration-test.php
+++ b/tests/integrations/admin/indexation-integration-test.php
@@ -175,12 +175,14 @@ class Indexation_Integration_Test extends TestCase {
 			Monkey\Actions\expectAdded( 'admin_notices' );
 		}
 
-		$this->term_indexation
-			->expects( 'get_total_term_permalinks_null' )
-			->once()
-			->andReturn( 35 );
+		if ( $ignore_warning ) {
+			$this->term_indexation
+				->expects( 'get_total_term_permalinks_null' )
+				->once()
+				->andReturn(35);
 
-		Monkey\Actions\expectAdded( 'admin_notices' );
+			Monkey\Actions\expectAdded( 'admin_notices' );
+		}
 
 		// Expect that the script and style for the modal is enqueued.
 		$this->asset_manager

--- a/tests/integrations/admin/indexation-integration-test.php
+++ b/tests/integrations/admin/indexation-integration-test.php
@@ -175,6 +175,13 @@ class Indexation_Integration_Test extends TestCase {
 			Monkey\Actions\expectAdded( 'admin_notices' );
 		}
 
+		$this->term_indexation
+			->expects( 'get_total_term_permalinks_null' )
+			->once()
+			->andReturn( 35 );
+
+		Monkey\Actions\expectAdded( 'admin_notices' );
+
 		// Expect that the script and style for the modal is enqueued.
 		$this->asset_manager
 			->expects( 'enqueue_script' )

--- a/tests/integrations/admin/indexation-integration-test.php
+++ b/tests/integrations/admin/indexation-integration-test.php
@@ -299,7 +299,7 @@ class Indexation_Integration_Test extends TestCase {
 
 		Monkey\Functions\expect( 'add_query_arg' )->andReturn( '' );
 
-		$expected  = '<div id="yoast-indexation-warning" class="notice notice-success"><p>';
+		$expected = '<div id="yoast-indexation-warning" class="notice notice-success"><p>';
 		$expected .= '<a href="" target="_blank">Yoast SEO creates and maintains an index of all of your site\'s SEO data in order to speed up your site.</a></p>';
 		$expected .= '<p>To build your index, Yoast SEO needs to process all of your content.</p>';
 		$expected .= '<p>We estimate this will take less than a minute.</p>';
@@ -352,7 +352,7 @@ class Indexation_Integration_Test extends TestCase {
 
 		Monkey\Functions\expect( 'add_query_arg' )->andReturn( '' );
 
-		$expected  = '<li><strong>SEO Data</strong>';
+		$expected = '<li><strong>SEO Data</strong>';
 		$expected .= '<p><a href="" target="_blank">Yoast SEO creates and maintains an index of all of your site\'s SEO data in order to speed up your site</a>.';
 		$expected .= ' To build your index, Yoast SEO needs to process all of your content.</p>';
 		$expected .= '<span id="yoast-indexation"><button type="button" class="button yoast-open-indexation" data-title="Speeding up your site">';

--- a/tests/integrations/watchers/indexable-category-permalink-watcher-test.php
+++ b/tests/integrations/watchers/indexable-category-permalink-watcher-test.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package Yoast\WP\SEO\Tests\Integrations\Watchers
+ */
+
+namespace Yoast\WP\SEO\Tests\Integrations\Watchers;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Integrations\Watchers\Indexable_Category_Permalink_Watcher;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Indexable_Category_Permalink_Watcher_Test.
+ *
+ * @group integrations
+ * @group watchers
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Watchers\Indexable_Category_Permalink_Watcher
+ * @covers ::<!public>
+ */
+class Indexable_Category_Permalink_Watcher_Test extends TestCase {
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Indexable_Category_Permalink_Watcher
+	 */
+	private $instance;
+
+	/**
+	 * Represents the indexable repository.
+	 *
+	 * @var Mockery\MockInterface|Indexable_Repository
+	 */
+	private $indexable_repository;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->indexable_repository = Mockery::mock( Indexable_Repository::class );
+		$this->instance             = new Indexable_Category_Permalink_Watcher( $this->indexable_repository );
+	}
+
+	/**
+	 * Tests if the expected conditionals are in place.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals(
+			[ Migrations_Conditional::class ],
+			Indexable_Category_Permalink_Watcher::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertTrue( Monkey\Actions\has( 'update_option_wpseo_titles', [ $this->instance, 'check_option' ] ) );
+	}
+
+	/**
+	 * Tests with the old value being false. This is the case when the option is saved the first time.
+	 *
+	 * @covers ::__construct
+	 * @covers ::check_option
+	 */
+	public function test_check_option_with_old_value_being_false() {
+		$this->instance->check_option( false, [] );
+	}
+
+	/**
+	 * Tests the method with one argument not being an array.
+	 *
+	 * @covers ::__construct
+	 * @covers ::check_option
+	 */
+	public function test_check_option_with_one_value_not_being_an_array() {
+		$this->instance->check_option( 'string', [] );
+	}
+
+	/**
+	 * Tests the method when the value for stripcategory base has changed.
+	 *
+	 * @covers ::__construct
+	 * @covers ::check_option
+	 */
+	public function test_check_option_stripcategorybase_changed() {
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When the categories prefix option (called `stripcategorybase`) is switched between `Keep` and `Remove`, the permalink for category indexables should be updated. In this PR, we set it to `NULL`. It will be rebuilt whenever that category is visited, or when someone indexes all of their content.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an indexable's permalink remained unchanged when the categories prefix option was changed.

## Relevant technical choices:

* I copied some code (part of the content of `clear_category_permalinks`) from the `indexables-permalink-watcher`. Because it's so small, creating a helper, passing the `indexable-permalink-watcher` class to my new class, or extending the `indexable-permalink-watcher` class seemed overkill.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Before you start testing, make sure your site is fully indexed by clicking `Start processing and speed up your site now` under `SEO` --> `Tools` (if you don't see it, first click `Reset Indexables tables & migrations` in the Yoast Test Helper).

**Test whether the category permalinks are cleared, and whether the indexation warning is shown when the shutdown limit is passed**
* In `wp_yoast_indexable`, inspect the rows where the `object_sub_type` is `category`. See that they have a permalink.
* Since the shutdown limit is set to 25, the following test will only work when you have 25 or more categories. If not, change the `25` in `indexation-integration.php` to a number that is lower than the number of categories you have on your website:
    * `$shutdown_limit = \apply_filters( 'wpseo_shutdown_indexation_limit', 25 );`
* In the plugin, navigate to `SEO` --> `Search appearance` --> `Taxonomies` and toggle between `Keep` and `Remove`. Then `Save changes`.
* Click the Category URLs toggle and save changes.
* See the following warning in the top of your screen:
<img width="420" alt="Screenshot 2020-06-11 at 15 39 18" src="https://user-images.githubusercontent.com/20280513/84391833-c8a9d080-abf9-11ea-8887-45c0b8d59694.png">

* Under `SEO` --> `Tools`, see that the button "Start processing and speed up your site now" has reappeared.
* Refresh `wp_yoast_indexable`, and see that the rows where the `object_sub_type` is `category`, now have `NULL` as value for their permalink.

**Test whether the category URL's are rebuilt automatically when their number is lower than the shutdown limit**
* In `wp_yoast_indexable`, inspect the rows where the `object_sub_type` is `category`. See that their permalink is set to `NULL`.
* Make sure the shutdown limit in `indexation-integration.php` is set to a number that is higher than the number of categories you have on your website (see above for a how-to).
* Click the Category URLs toggle and save changes.
* Refresh `wp_yoast_indexable`, and inspect the rows where the `object_sub_type` is `category`. See that their permalink is set a value which corresponds to the toggle value you just chose (for example, if you chose `Keep`, the permalinks will contain `/category` and otherwise they won't).

**Test whether only one notice is shown**
* Clear your indexables table with "Reset Indexables tables & migrations" in the site helper.
* Refresh the indexables table, see that it is (mostly) empty.
    * If there are a few indexables from pages you just visited, it's not a problem.
* On admin pages, such as `SEO` --> `Search Appearance` --> `Taxonomies`, you should now see the following warning (don't click the button):
<img width="420" alt="Screenshot 2020-06-12 at 09 23 10" src="https://user-images.githubusercontent.com/20280513/84487946-cbf79780-ac9f-11ea-9008-1100b60ae216.png">

* If you don't see it, that's probably because you chose to hide it at some point in the past. In that case, go to the `wp_options` table in your database, and set the following `option_values` from `wpseo` to `0`: `ignore_indexation_warning`, `indexation_warning_hide_until`, `indexation_started`. You should now see the warning.
* Manually visit two category pages, so that their indexables will be built.
* Set the shutdown limit in `indexation-integration.php` to `1` (i.e., a number smaller than the number of category indexables you have in your table).
* In the plugin, click the category URL's toggle and save.
* You should still only see the general warning that was already there, and _not_ the warning that is specific to category URL's.
* Now, hide the general warning (note that it will be gone forever, but that you can restore it for future use with the steps mentioned earlier).
* Click the category URL's toggle and save.
* You should now only see the warning that is specific to category URL's.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #15333
