### PR TITLE
Introduces a field to have clear the indexable contains ancestors

### DIFF
--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -180,11 +180,11 @@ class Indexable_Builder {
 			);
 		}
 
-		$this->save_indexable( $indexable, $indexable_before );
-
 		if ( \in_array( $object_type, [ 'post', 'term' ], true ) && $indexable->post_status !== 'unindexed' ) {
-			$this->hierarchy_builder->build( $indexable );
+			$indexable = $this->hierarchy_builder->build( $indexable );
 		}
+
+		$this->save_indexable( $indexable, $indexable_before );
 
 		return $indexable;
 	}

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -181,7 +181,7 @@ class Indexable_Builder {
 		}
 
 		if ( \in_array( $object_type, [ 'post', 'term' ], true ) && $indexable->post_status !== 'unindexed' ) {
-			$indexable = $this->hierarchy_builder->build( $indexable );
+			$this->hierarchy_builder->build( $indexable );
 		}
 
 		$this->save_indexable( $indexable, $indexable_before );

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -96,7 +96,9 @@ class Indexable_Hierarchy_Builder {
 	 * @return Indexable The indexable.
 	 */
 	public function build( Indexable $indexable ) {
-		$this->indexable_hierarchy_repository->clear_ancestors( $indexable->id );
+		if ( $indexable->has_ancestors ) {
+			$this->indexable_hierarchy_repository->clear_ancestors( $indexable->id );
+		}
 
 		$indexable_id = $this->get_indexable_id( $indexable );
 		$ancestors    = [];
@@ -107,7 +109,6 @@ class Indexable_Hierarchy_Builder {
 		if ( $indexable->object_type === 'term' ) {
 			$this->add_ancestors_for_term( $indexable_id, $indexable->object_id, $ancestors );
 		}
-
 		$indexable->ancestors = \array_reverse( \array_values( $ancestors ) );
 		if ( ! \is_null( $indexable->id ) ) {
 			$this->save_ancestors( $indexable );

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -109,7 +109,8 @@ class Indexable_Hierarchy_Builder {
 		if ( $indexable->object_type === 'term' ) {
 			$this->add_ancestors_for_term( $indexable_id, $indexable->object_id, $ancestors );
 		}
-		$indexable->ancestors = \array_reverse( \array_values( $ancestors ) );
+		$indexable->ancestors     = \array_reverse( \array_values( $ancestors ) );
+		$indexable->has_ancestors = ! empty( $ancestors );
 		if ( ! \is_null( $indexable->id ) ) {
 			$this->save_ancestors( $indexable );
 		}

--- a/src/config/migrations/20200609154515_AddHasAncestorsColumn.php
+++ b/src/config/migrations/20200609154515_AddHasAncestorsColumn.php
@@ -9,6 +9,7 @@ namespace Yoast\WP\SEO\Config\Migrations;
 
 use Yoast\WP\Lib\Migrations\Migration;
 use Yoast\WP\Lib\Model;
+use Yoast\WP\SEO\WordPress\Wrapper;
 
 /**
  * Class AddHasAncestorsColumn.
@@ -34,6 +35,12 @@ class AddHasAncestorsColumn extends Migration {
 				'default' => false,
 			]
 		);
+
+		Wrapper::get_wpdb()->query( '
+			UPDATE ' . Model::get_table_name( 'Indexable' ) . '
+			SET has_ancestors = 1
+			WHERE id IN ( SELECT indexable_id FROM ' . Model::get_table_name( 'Indexable_Hierarchy' ) . ' )	
+		');
 	}
 
 	/**

--- a/src/config/migrations/20200609154515_AddHasAncestorsColumn.php
+++ b/src/config/migrations/20200609154515_AddHasAncestorsColumn.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package WPSEO\Migrations
+ */
+
+namespace Yoast\WP\SEO\Config\Migrations;
+
+use Yoast\WP\Lib\Migrations\Migration;
+use Yoast\WP\Lib\Model;
+
+/**
+ * Class AddHasAncestorsColumn.
+ */
+class AddHasAncestorsColumn extends Migration {
+
+	/**
+	 * The plugin this migration belongs to.
+	 *
+	 * @var string
+	 */
+	public static $plugin = 'free';
+
+	/**
+	 * Migration up.
+	 */
+	public function up() {
+		$this->add_column(
+			Model::get_table_name( 'Indexable' ),
+			'has_ancestors',
+			'boolean',
+			[
+				'default' => false,
+			]
+		);
+	}
+
+	/**
+	 * Migration down.
+	 */
+	public function down() {
+		$this->remove_column( Model::get_table_name( 'Indexable' ), 'has_ancestors' );
+	}
+}

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -167,8 +167,6 @@ class Indexable extends Model {
 			$this->primary_focus_keyword = \substr( $this->primary_focus_keyword, 0, 191 );
 		}
 
-		$this->has_ancestors = ( is_array( $this->ancestors ) && ! empty( $this->ancestors ) );
-
 		return parent::save();
 	}
 

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -76,6 +76,8 @@ use Yoast\WP\Lib\Model;
  *
  * @property string  $schema_page_type
  * @property string  $schema_article_type
+ *
+ * @property bool    $has_ancestors
  */
 class Indexable extends Model {
 
@@ -164,6 +166,8 @@ class Indexable extends Model {
 		if ( \strlen( $this->primary_focus_keyword ) > 191 ) {
 			$this->primary_focus_keyword = \substr( $this->primary_focus_keyword, 0, 191 );
 		}
+
+		$this->has_ancestors = ( is_array( $this->ancestors ) && ! empty( $this->ancestors ) );
 
 		return parent::save();
 	}

--- a/tests/builders/indexable-hierarchy-builder-test.php
+++ b/tests/builders/indexable-hierarchy-builder-test.php
@@ -105,14 +105,55 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_indexable_id
 	 */
 	public function test_no_parents() {
-		$indexable              = new Indexable_Mock();
-		$indexable->id          = 1;
-		$indexable->object_type = 'post';
-		$indexable->object_id   = 1;
+		$indexable                = new Indexable_Mock();
+		$indexable->id            = 1;
+		$indexable->object_type   = 'post';
+		$indexable->object_id     = 1;
+		$indexable->has_ancestors = true;
 
 		$this->indexable_hierarchy_repository->expects( 'clear_ancestors' )->with( 1 )->andReturnTrue();
 		$this->options->expects( 'get' )->with( 'post_types-post-maintax' )->andReturn( '0' );
 		$this->post->expects( 'get_post' )
+			->with( 1 )
+			->andReturn(
+				(object) [
+					'post_parent' => 0,
+					'post_type'   => 'post',
+				]
+			);
+
+		$actual = $this->instance->build( $indexable );
+		$this->assertEmpty( $actual->ancestors );
+	}
+
+
+
+	/**
+	 * Tests building the hierarchy of a post where the post parent is set to 0.
+	 *
+	 * @covers ::__construct
+	 * @covers ::set_indexable_repository
+	 * @covers ::build
+	 * @covers ::save_ancestors
+	 * @covers ::add_ancestors_for_post
+	 * @covers ::find_primary_term_id_for_post
+	 * @covers ::get_indexable_id
+	 */
+	public function test_no_parents_and_has_ancestors_set_to_false() {
+		$indexable                = $this->get_indexable( 1, 'post' );
+		$indexable->has_ancestors = false;
+
+		$this->indexable_hierarchy_repository
+			->expects( 'clear_ancestors' )
+			->never();
+
+		$this->options
+			->expects( 'get' )
+			->with( 'post_types-post-maintax' )
+			->andReturn( '0' );
+
+		$this->post
+			->expects( 'get_post' )
 			->with( 1 )
 			->andReturn(
 				(object) [
@@ -135,10 +176,11 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::add_ancestors_for_post
 	 */
 	public function test_parents_not_set() {
-		$indexable              = new Indexable_Mock();
-		$indexable->id          = 1;
-		$indexable->object_type = 'post';
-		$indexable->object_id   = 1;
+		$indexable                = new Indexable_Mock();
+		$indexable->id            = 1;
+		$indexable->object_type   = 'post';
+		$indexable->object_id     = 1;
+		$indexable->has_ancestors = true;
 
 		$this->indexable_hierarchy_repository->expects( 'clear_ancestors' )->with( 1 )->andReturnTrue();
 		$this->post->expects( 'get_post' )->with( 1 )->andReturn( (object) [ 'post_type' => 'post' ] );
@@ -160,15 +202,17 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_indexable_id
 	 */
 	public function test_post_parents() {
-		$indexable              = new Indexable_Mock();
-		$indexable->id          = 1;
-		$indexable->object_type = 'post';
-		$indexable->object_id   = 1;
+		$indexable                = new Indexable_Mock();
+		$indexable->id            = 1;
+		$indexable->object_type   = 'post';
+		$indexable->object_id     = 1;
+		$indexable->has_ancestors = true;
 
-		$parent_indexable              = new Indexable_Mock();
-		$parent_indexable->id          = 2;
-		$parent_indexable->object_type = 'post';
-		$parent_indexable->object_id   = 2;
+		$parent_indexable                = new Indexable_Mock();
+		$parent_indexable->id            = 2;
+		$parent_indexable->object_type   = 'post';
+		$parent_indexable->object_id     = 2;
+		$parent_indexable->has_ancestors = true;
 
 		$this->indexable_hierarchy_repository->expects( 'clear_ancestors' )->with( 1 )->andReturnTrue();
 		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 2, 1 );
@@ -436,18 +480,20 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_primary_term_id
 	 */
 	public function test_primary_term_parents() {
-		$indexable              = new Indexable_Mock();
-		$indexable->id          = 1;
-		$indexable->object_type = 'post';
-		$indexable->object_id   = 1;
+		$indexable                = new Indexable_Mock();
+		$indexable->id            = 1;
+		$indexable->object_type   = 'post';
+		$indexable->object_id     = 1;
+		$indexable->has_ancestors = true;
 
 		$primary_term          = new Primary_Term_Mock();
 		$primary_term->term_id = 2;
 
-		$parent_indexable              = new Indexable_Mock();
-		$parent_indexable->id          = 2;
-		$parent_indexable->object_type = 'term';
-		$parent_indexable->object_id   = 2;
+		$parent_indexable                = new Indexable_Mock();
+		$parent_indexable->id            = 2;
+		$parent_indexable->object_type   = 'term';
+		$parent_indexable->object_id     = 2;
+		$parent_indexable->has_ancestors = true;
 
 		Monkey\Functions\expect( 'get_term' )
 			->twice()
@@ -569,23 +615,26 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_primary_term_id
 	 */
 	public function test_many_primary_term_parents() {
-		$indexable              = new Indexable_Mock();
-		$indexable->id          = 1;
-		$indexable->object_type = 'post';
-		$indexable->object_id   = 1;
+		$indexable                = new Indexable_Mock();
+		$indexable->id            = 1;
+		$indexable->object_type   = 'post';
+		$indexable->object_id     = 1;
+		$indexable->has_ancestors = true;
 
 		$primary_term          = new Primary_Term_Mock();
 		$primary_term->term_id = 2;
 
-		$parent_indexable              = new Indexable_Mock();
-		$parent_indexable->id          = 2;
-		$parent_indexable->object_type = 'term';
-		$parent_indexable->object_id   = 2;
+		$parent_indexable                = new Indexable_Mock();
+		$parent_indexable->id            = 2;
+		$parent_indexable->object_type   = 'term';
+		$parent_indexable->object_id     = 2;
+		$parent_indexable->has_ancestors = true;
 
-		$grand_parent_indexable              = new Indexable_Mock();
-		$grand_parent_indexable->id          = 3;
-		$grand_parent_indexable->object_type = 'term';
-		$grand_parent_indexable->object_id   = 3;
+		$grand_parent_indexable                = new Indexable_Mock();
+		$grand_parent_indexable->id            = 3;
+		$grand_parent_indexable->object_type   = 'term';
+		$grand_parent_indexable->object_id     = 3;
+		$grand_parent_indexable->has_ancestors = true;
 
 		Monkey\Functions\expect( 'get_term' )
 			->once()
@@ -656,15 +705,17 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_primary_term_id
 	 */
 	public function test_term_parent() {
-		$indexable              = new Indexable_Mock();
-		$indexable->id          = 1;
-		$indexable->object_type = 'post';
-		$indexable->object_id   = 1;
+		$indexable                = new Indexable_Mock();
+		$indexable->id            = 1;
+		$indexable->object_type   = 'post';
+		$indexable->object_id     = 1;
+		$indexable->has_ancestors = true;
 
-		$parent_indexable              = new Indexable_Mock();
-		$parent_indexable->id          = 2;
-		$parent_indexable->object_type = 'term';
-		$parent_indexable->object_id   = 2;
+		$parent_indexable                = new Indexable_Mock();
+		$parent_indexable->id            = 2;
+		$parent_indexable->object_type   = 'term';
+		$parent_indexable->object_id     = 2;
+		$parent_indexable->has_ancestors = true;
 
 		Monkey\Functions\expect( 'get_the_terms' )
 			->with( 1, 'tag' )
@@ -724,10 +775,11 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_primary_term_id
 	 */
 	public function test_term_parent_where_terms_not_array() {
-		$indexable              = new Indexable_Mock();
-		$indexable->id          = 1;
-		$indexable->object_type = 'post';
-		$indexable->object_id   = 1;
+		$indexable                = new Indexable_Mock();
+		$indexable->id            = 1;
+		$indexable->object_type   = 'post';
+		$indexable->object_id     = 1;
+		$indexable->has_ancestors = true;
 
 		Monkey\Functions\expect( 'get_the_terms' )->with( 1, 'tag' )->andReturn( 'string-not-array' );
 		Monkey\Functions\expect( 'get_term' )
@@ -774,10 +826,11 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_primary_term_id
 	 */
 	public function test_term_parent_where_terms_empty() {
-		$indexable              = new Indexable_Mock();
-		$indexable->id          = 1;
-		$indexable->object_type = 'post';
-		$indexable->object_id   = 1;
+		$indexable                = new Indexable_Mock();
+		$indexable->id            = 1;
+		$indexable->object_type   = 'post';
+		$indexable->object_id     = 1;
+		$indexable->has_ancestors = true;
 
 		Monkey\Functions\expect( 'get_the_terms' )->with( 1, 'tag' )->andReturn();
 		Monkey\Functions\expect( 'get_term' )
@@ -828,20 +881,23 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_primary_term_id
 	 */
 	public function test_deepest_term_parent() {
-		$indexable              = new Indexable_Mock();
-		$indexable->id          = 1;
-		$indexable->object_type = 'post';
-		$indexable->object_id   = 1;
+		$indexable               = new Indexable_Mock();
+		$indexable->id           = 1;
+		$indexable->object_type  = 'post';
+		$indexable->object_id    = 1;
+		$indexable->has_ancestors = true;
 
-		$parent_indexable              = new Indexable_Mock();
-		$parent_indexable->id          = 3;
-		$parent_indexable->object_type = 'term';
-		$parent_indexable->object_id   = 3;
+		$parent_indexable                = new Indexable_Mock();
+		$parent_indexable->id            = 3;
+		$parent_indexable->object_type   = 'term';
+		$parent_indexable->object_id     = 3;
+		$parent_indexable->has_ancestors = true;
 
-		$grand_parent_indexable              = new Indexable_Mock();
-		$grand_parent_indexable->id          = 4;
-		$grand_parent_indexable->object_type = 'term';
-		$grand_parent_indexable->object_id   = 4;
+		$grand_parent_indexable                = new Indexable_Mock();
+		$grand_parent_indexable->id            = 4;
+		$grand_parent_indexable->object_type   = 'term';
+		$grand_parent_indexable->object_id     = 4;
+		$grand_parent_indexable->has_ancestors = true;
 
 		Monkey\Functions\expect( 'get_the_terms' )
 			->once()
@@ -921,15 +977,17 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @covers ::get_indexable_id
 	 */
 	public function test_term() {
-		$indexable              = new Indexable_Mock();
-		$indexable->id          = 1;
-		$indexable->object_type = 'term';
-		$indexable->object_id   = 1;
+		$indexable                = new Indexable_Mock();
+		$indexable->id            = 1;
+		$indexable->object_type   = 'term';
+		$indexable->object_id     = 1;
+		$indexable->has_ancestors = true;
 
-		$parent_indexable              = new Indexable_Mock();
-		$parent_indexable->id          = 2;
-		$parent_indexable->object_type = 'term';
-		$parent_indexable->object_id   = 2;
+		$parent_indexable                = new Indexable_Mock();
+		$parent_indexable->id            = 2;
+		$parent_indexable->object_type   = 'term';
+		$parent_indexable->object_id     = 2;
+		$parent_indexable->has_ancestors = true;
 
 		Monkey\Functions\expect( 'get_term' )
 			->once()
@@ -1162,10 +1220,11 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	public function test_primary_term_parents_with_no_primary_term_set() {
 		$indexable = $this->get_indexable( 1, 'post' );
 
-		$parent_indexable              = new Indexable_Mock();
-		$parent_indexable->id          = 3;
-		$parent_indexable->object_type = 'term';
-		$parent_indexable->object_id   = 3;
+		$parent_indexable                = new Indexable_Mock();
+		$parent_indexable->id            = 3;
+		$parent_indexable->object_type   = 'term';
+		$parent_indexable->object_id     = 3;
+		$parent_indexable->has_ancestors = true;
 
 		$this->indexable_hierarchy_repository
 			->expects( 'clear_ancestors' )
@@ -1245,10 +1304,11 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	 * @return Indexable_Mock
 	 */
 	private function get_indexable( $id, $object_type = 'post' ) {
-		$indexable              = new Indexable_Mock();
-		$indexable->id          = $id;
-		$indexable->object_type = $object_type;
-		$indexable->object_id   = $id;
+		$indexable                = new Indexable_Mock();
+		$indexable->id            = $id;
+		$indexable->object_type   = $object_type;
+		$indexable->object_id     = $id;
+		$indexable->has_ancestors = true;
 
 		return $indexable;
 	}

--- a/tests/doubles/models/indexable-mock.php
+++ b/tests/doubles/models/indexable-mock.php
@@ -96,4 +96,6 @@ class Indexable_Mock extends Indexable {
 	public $post_status;
 
 	public $has_public_posts;
+
+	public $has_ancestors;
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* A lot of unnecessary delete queries are performed for records that can't exists. Added a field to determine if the indexable contains ancestors.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a lot of delete queries are performed after clearing all indexables from the database

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* The best way to test this is on the frontend.
* Make sure you have the breadcrumbs visible on your theme. For help with this see: https://yoast.com/help/implement-wordpress-seo-breadcrumbs/
* Have the query monitor enabled
* Checkout release/14.4
* Truncate the indexables and the indexables hierarchy tables in your database (or use the test helper with that)
* Visit a term page and see in the query monitor that a delete query on the indexable hierarchy table is executed.
* Refresh the term page and see the query still being executed.
* Do the same for a post. The ongoing execution for the post depends on the case if there is a category as breadcrumb item (in the breadcrumbs settings)
* Checkout this branch
* Remove the option named `yoast_migrations_free` - this will trigger a migration that adds an field.
* Perform the previous steps, no delete query should be executed.
* The same should happen on the backend, but because of execution on the shutdown background this is hard to notice and catch within the query monitor plugin. I have no clue how to achive this visibly.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #15381
