### PR TITLE
P3-33 Fix configuration wizard local seo link

### DIFF
--- a/admin/config-ui/components/class-component-suggestions.php
+++ b/admin/config-ui/components/class-component-suggestions.php
@@ -81,7 +81,7 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 				[
 					'label' => 'Local SEO',
 					'type'  => 'link',
-					'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/wizard-suggestion-localseo' ),
+					'href'  => WPSEO_Shortlinker::get( 'https://yoa.st/wizard-suggestion-local-seo' ),
 				],
 				[
 					'url'   => WPSEO_Shortlinker::get( 'https://yoa.st/video-localseo' ),

--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 143,
+			maxWarnings: 141,
 		},
 	},
 	tests: {
@@ -15,7 +15,7 @@ module.exports = {
 	grunt: {
 		src: [ "<%= files.grunt %>", "<%= files.config %>" ],
 		options: {
-			maxWarnings: 10,
+			maxWarnings: 0,
 		},
 	},
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Fixes a bug where the link for Local SEO was missing in the Configuration Wizard "Continue learning" step.

## Relevant technical choices:

* Updates the ESLint `maxWarnings`. Note that the `eslint:grunt` task doesn't report any warning because all of them were fixed in https://github.com/Yoast/wordpress-seo/commit/e9fb5a590957299ff5352ea917ce9ba3e1857db6 but the `maxWarnings` wasn't updated.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

The code for this feature is in Free but it affects Premium. To test it either copy the tiny change over to Premium or alter the code in 

https://github.com/Yoast/wordpress-seo/blob/18161f12edb55885439f5179f19e452e7ca19850/admin/config-ui/components/class-component-suggestions.php#L76

and change it to `if ( ! WPSEO_Utils::is_yoast_seo_premium() && ...`
- make sure you don't have Local SEO installed and activated
- build 
- go to the Configuration Wizard (the link to access the Wizard is in the SEO Dashboard page)
- go to the Configuration Wizard step 7: "Continue learning"
- scroll the page and observe under the section "Attract more customers near you" there's a link (it looks like a button) to the Local SEO page on yoast.com 

<img width="1180" alt="Screenshot 2020-06-10 at 10 35 05" src="https://user-images.githubusercontent.com/1682452/84246050-50161780-ab06-11ea-99d5-572f40794699.png">

- click the link and check it opens in a new browser tab
- check the link points to the correct page https://yoast.com/wordpress/plugins/local-seo/
- run `grunt eslint` and check it passes reporting:
  - eslint:plugin 141 warnings (decreased from 143)
  - eslint:grunt no warnings (decreased from 10)
  - eslint:tests 3 warnings (unchanged)

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-33]