### PR TITLE
Add read_more_url for admin bar menu and advanced settings toggles

### DIFF
--- a/admin/views/class-yoast-feature-toggles.php
+++ b/admin/views/class-yoast-feature-toggles.php
@@ -117,14 +117,14 @@ class Yoast_Feature_Toggles {
 				'name'            => __( 'Admin bar menu', 'wordpress-seo' ),
 				'setting'         => 'enable_admin_bar_menu',
 				'read_more_label' => __( 'Read more about the use of the admin bar menu.', 'wordpress-seo' ),
-				'read_more_url'   => 'https://example.com',// @todo add a URL once this article has been written.
+				'read_more_url'   => 'https://yoa.st/40q',
 				'order'           => 80,
 			],
 			(object) [
 				'name'            => __( 'Security: no advanced settings for authors', 'wordpress-seo' ),
 				'setting'         => 'disableadvanced_meta',
 				'read_more_label' => __( 'Read more about this security setting.', 'wordpress-seo' ),
-				'read_more_url'   => 'https://example.com',// @todo add a URL once this article has been written.
+				'read_more_url'   => 'https://yoa.st/40r',
 				'order'           => 90,
 			],
 			(object) [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add read_more_url for admin bar menu and advanced settings toggles

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
