### PR TITLE
Introduce RC JavaScript-dependency version-level control

### DIFF
--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -119,14 +119,6 @@ clean:build-assets:
 'ensure-clean-branch':
   - 'shell:check-for-uncommitted-changes'
 
-'ensure-rc-dependencies':
-  - 'shell:unlink-monorepo'
-  - 'shell:install-monorepo'
-  - 'shell:get-monorepo-versions'
-  - 'prompt:monorepoVersions'
-  - 'shell:composer-install'
-  - 'shell:composer-update-yoast-dependencies'
-
 'bump-the-rc-version':
   - 'bump-rc-version'
   - 'shell:git-add-version-bump-files'

--- a/grunt/config/prompt.js
+++ b/grunt/config/prompt.js
@@ -22,7 +22,11 @@ module.exports = {
 			 */
 			then: function( results ) {
 				if ( results[ "config.monorepoVersions" ] === false ) {
-					throw "The script has been aborted because the monorepo versions are incorrect. Ask team Lingo to release the monorepo packages.";
+					throw "The script has been aborted because the monorepo versions are incorrect." +
+						  "\n" +
+						  "Use --yoast-components-no-rc and --yoastseo-no-rc if you need to use the non-rc version of these packages." +
+						  "\n\n" +
+						  "Otherwise, ask team Lingo to release the monorepo packages.";
 				}
 			},
 		},

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -203,8 +203,20 @@ module.exports = function( grunt ) {
 			command: "yarn unlink-monorepo",
 		},
 
-		"install-monorepo": {
-			command: "yarn add yoastseo@rc && yarn add yoast-components@rc",
+		"yarn-add-yoast-components-rc": {
+			command: "yarn add yoast-components@rc",
+		},
+
+		"yarn-add-yoast-components": {
+			command: "yarn add yoast-components",
+		},
+
+		"yarn-add-yoastseo-rc": {
+			command: "yarn add yoastseo@rc",
+		},
+
+		"yarn-add-yoastseo": {
+			command: "yarn add yoastseo",
 		},
 
 		"get-monorepo-versions": {

--- a/grunt/custom/ensure-rc-dependencies.js
+++ b/grunt/custom/ensure-rc-dependencies.js
@@ -1,0 +1,37 @@
+module.exports = function( grunt ) {
+	grunt.registerTask(
+		"ensure-rc-dependencies",
+		"Ensures the JavaScript packages are up-to-date.",
+
+		/**
+		 * Ensures that the JavaScript packages are updated.
+		 *
+		 * @returns {void}
+		 */
+		function() {
+			const gruntFlags = grunt.option.flags();
+
+			const componentsRC = -1 === gruntFlags.indexOf( '--yoast-components-no-rc' );
+			const yoastSEORC   = -1 === gruntFlags.indexOf( '--yoastseo-no-rc' );
+
+			let installComponents = "shell:yarn-add-yoast-components";
+			if ( componentsRC ) {
+				installComponents += "-rc";
+			}
+
+			let installYoastSEO = "shell:yarn-add-yoastseo";
+			if ( yoastSEORC ) {
+				installYoastSEO += "-rc";
+			}
+
+			grunt.task.run( "shell:unlink-monorepo" );
+			grunt.task.run( installComponents );
+			grunt.task.run( installYoastSEO );
+			grunt.task.run( "shell:get-monorepo-versions" );
+			grunt.task.run( "prompt:monorepoVersions" );
+			grunt.task.run( "shell:composer-install" );
+			grunt.task.run( "shell:composer-update-yoast-dependencies" );
+		}
+	);
+};
+


### PR DESCRIPTION
Inroduces two flags to use, when non-RC versions of the dependencies need to be installed.

--yoast-components-no-rc
--yoastseo-no-rc

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The `yoastseo` and `yoast-components` packages sometimes don't have an RC version released for the current release. This causes the script to think that the previous RC needs to be released, but there is a stable version available (14.0@rc.0 vs 14.0) The flags introduced give you control to pick the RC or non-RC version of these packages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [non-user-facing] Introduces two flags to control RC or stable version of YoastSEO & Yoast-component packages when creating an RC using the grunt command.

## Relevant technical choices:

* n/a

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

For each of the following commands, the specific components should be installed according to the flag. With the flag the stable version should be installed, otherwise the latest RC version is expected.

* `grunt ensure-rc-dependencies --yoast-components-no-rc`
* `grunt ensure-rc-dependences --yoastseo-no-rc`
* `grunt ensure-rc-dependencies --yoast-components-no-rc --yoastseo-no-rc`

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14403
