### PR TITLE
Sync the Gutenberg version to the PHP file

### DIFF
--- a/admin/class-gutenberg-compatibility.php
+++ b/admin/class-gutenberg-compatibility.php
@@ -15,14 +15,14 @@ class WPSEO_Gutenberg_Compatibility {
 	 *
 	 * @var string
 	 */
-	const CURRENT_RELEASE = '8.2.1';
+	const CURRENT_RELEASE = '8.3.0';
 
 	/**
 	 * The minimally supported version of Gutenberg by the plugin.
 	 *
 	 * @var string
 	 */
-	const MINIMUM_SUPPORTED = '8.2.1';
+	const MINIMUM_SUPPORTED = '8.3.0';
 
 	/**
 	 * Holds the current version.

--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -107,6 +107,7 @@ clean:build-assets:
   - 'ensure-rc-dependencies'
   - 'update-readme'
   - 'bump-the-rc-version'
+  - 'sync-gutenberg-version'
   - 'artifact'
   - 'github-pre-release'
   - 'notify-slack:rc'

--- a/grunt/custom/sync-gutenberg-version.js
+++ b/grunt/custom/sync-gutenberg-version.js
@@ -1,0 +1,37 @@
+const fetch = require( "node-fetch" );
+
+module.exports = function( grunt ) {
+	grunt.registerTask(
+		"sync-gutenberg-version",
+		"Makes sure the Gutenberg-supported version is set to the latest release.",
+		async function() {
+			const done = this.async();
+
+			const targetFile = "admin/class-gutenberg-compatibility.php";
+
+			const gutenbergInfo = await fetch( "https://api.wordpress.org/plugins/info/1.0/gutenberg.json" );
+			const gutenbergInfoJSON = await gutenbergInfo.json();
+
+			setVersion( targetFile, /(\s?)(const CURRENT_RELEASE = ')(\d+(\.\d+){0,3})(';\n)/, "$1$2" + gutenbergInfoJSON.version + "$5");
+			setVersion( targetFile, /(\s?)(const MINIMUM_SUPPORTED = ')(\d+(\.\d+){0,3})(';\n)/, "$1$2" + gutenbergInfoJSON.version + "$5");
+
+			return done();
+		}
+	);
+
+	/**
+	 * Helper function to update the content of the file.
+	 *
+	 * @param file
+	 * @param search
+	 * @param version
+	 */
+	function setVersion( file, search, version ) {
+		let contents = grunt.file.read( file ).replace(
+			search,
+			version
+		);
+
+		grunt.file.write( file, contents );
+	}
+}

--- a/grunt/custom/sync-gutenberg-version.js
+++ b/grunt/custom/sync-gutenberg-version.js
@@ -12,8 +12,24 @@ module.exports = function( grunt ) {
 			const gutenbergInfo = await fetch( "https://api.wordpress.org/plugins/info/1.0/gutenberg.json" );
 			const gutenbergInfoJSON = await gutenbergInfo.json();
 
-			setVersion( targetFile, /(\s?)(const CURRENT_RELEASE = ')(\d+(\.\d+){0,3})(';\n)/, "$1$2" + gutenbergInfoJSON.version + "$5");
-			setVersion( targetFile, /(\s?)(const MINIMUM_SUPPORTED = ')(\d+(\.\d+){0,3})(';\n)/, "$1$2" + gutenbergInfoJSON.version + "$5");
+			const currentVersion = getVersion( targetFile, /(\s?)(const CURRENT_RELEASE = ')(\d+(\.\d+){0,3})(';\n)/, 3 );
+
+			// Only change the file if the version does not match.
+			if ( currentVersion !== gutenbergInfoJSON.version ) {
+				setVersion( targetFile, /(\s?)(const CURRENT_RELEASE = ')(\d+(\.\d+){0,3})(';\n)/, "$1$2" + gutenbergInfoJSON.version + "$5" );
+				setVersion( targetFile, /(\s?)(const MINIMUM_SUPPORTED = ')(\d+(\.\d+){0,3})(';\n)/, "$1$2" + gutenbergInfoJSON.version + "$5" );
+
+				// Add the file to commit the version bump.
+				grunt.config( "gitadd.gutenbergFiles", { files: { src: [targetFile] } } );
+				grunt.task.run( "gitadd:gutenbergFiles" );
+
+				// Commit the version bump.
+				grunt.config( "gitcommit.gutenbergFiles", {
+					options: { message: "Bump Gutenberg supported version." },
+					files: { src: [targetFile] }
+				} );
+				grunt.task.run( "gitcommit:gutenbergFiles" );
+			}
 
 			return done();
 		}
@@ -22,16 +38,29 @@ module.exports = function( grunt ) {
 	/**
 	 * Helper function to update the content of the file.
 	 *
-	 * @param file
-	 * @param search
-	 * @param version
+	 * @param {string} file Target file.
+	 * @param {RegExp} pattern Pattern to search for.
+	 * @param {string} version Version to insert.
 	 */
-	function setVersion( file, search, version ) {
+	function setVersion( file, pattern, version ) {
 		let contents = grunt.file.read( file ).replace(
-			search,
+			pattern,
 			version
 		);
 
 		grunt.file.write( file, contents );
 	}
-}
+
+	/**
+	 * Reads the current Gutenberg version from the file.
+	 *
+	 * @param {string} file Target file.
+	 * @param {RegExp} pattern Pattern to search for.
+	 * @param {int} index Index to return.
+	 *
+	 * @return {string} The version from the file.
+	 */
+	function getVersion( file, pattern, index ) {
+		return pattern.exec( grunt.file.read( file ) )[ index ];
+	}
+};


### PR DESCRIPTION
Fetches the latest version using the WordPress API and updates the PHP file containing the constants for the Gutenberg-supported version.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Gutenberg plugin versions get released regularly, we want to keep the latest supported version in sync with the latest version upon RC creation. This should automatically be updated to the PHP file that contains the version checks.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [non-user-facing] This will fetch the current Gutenberg version from the WordPress plugins directory and update the constants we check against in our code.

## Relevant technical choices:

* n/a

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use `grunt sync-gutenberg-version`; and see
  * The file `admin/class-gutenberg-compatibility.php` being updated with the current Gutenberg version.
  * The changes being committed to the current branch (if there are changes)

(See https://api.wordpress.org/plugins/info/1.0/gutenberg.json for current version)

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14404
