### PR TITLE
QAK-1874 Use standard plugin document panel

### DIFF
--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -2,12 +2,12 @@
 /* External dependencies */
 import React from "react";
 import styled from "styled-components";
-import { Slot, Fill, PanelBody } from "@wordpress/components";
+import { Slot } from "@wordpress/components";
 import { Fragment } from "@wordpress/element";
 import { combineReducers, registerStore } from "@wordpress/data";
 import { decodeEntities } from "@wordpress/html-entities";
 import { __ } from "@wordpress/i18n";
-import { PluginPrePublishPanel, PluginPostPublishPanel } from "@wordpress/edit-post";
+import { PluginPrePublishPanel, PluginPostPublishPanel, PluginDocumentSettingPanel } from "@wordpress/edit-post";
 import { registerFormatType, applyFormat, isCollapsed } from "@wordpress/rich-text";
 import { isURL } from "@wordpress/url";
 import {
@@ -207,15 +207,14 @@ class Edit {
 				>
 					<PostPublish />
 				</PluginPostPublishPanel>
-				{ analysesEnabled && <Fill name="PluginDocumentSettingPanel">
-					<PanelBody
-						className="yoast-seo-sidebar-panel"
-						title={ __( "Yoast SEO", "wordpress-seo" ) }
-						initialOpen={ true }
-					>
-						<DocumentSidebar />
-					</PanelBody>
-				</Fill> }
+				{ analysesEnabled && <PluginDocumentSettingPanel
+					name="document-panel"
+					className="yoast-seo-sidebar-panel"
+					title={ __( "Yoast SEO", "wordpress-seo" ) }
+					icon={ <Fragment /> }
+				>
+					<DocumentSidebar />
+				</PluginDocumentSettingPanel> }
 			</Fragment>
 		);
 

--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -4,7 +4,7 @@ import React from "react";
 import styled from "styled-components";
 import { Slot } from "@wordpress/components";
 import { Fragment } from "@wordpress/element";
-import { combineReducers, registerStore } from "@wordpress/data";
+import { combineReducers, registerStore, select, dispatch } from "@wordpress/data";
 import { decodeEntities } from "@wordpress/html-entities";
 import { __ } from "@wordpress/i18n";
 import { PluginPrePublishPanel, PluginPostPublishPanel, PluginDocumentSettingPanel } from "@wordpress/edit-post";
@@ -168,6 +168,7 @@ class Edit {
 		};
 		const preferences = store.getState().preferences;
 		const analysesEnabled = preferences.isKeywordAnalysisActive || preferences.isContentAnalysisActive;
+		this.initiallyOpenDocumentSettings();
 
 		const YoastSidebar = () => (
 			<Fragment>
@@ -305,6 +306,18 @@ class Edit {
 	 */
 	getData() {
 		return this._data;
+	}
+
+	/**
+	 * Makes sure the Yoast SEO document panel is toggled open on the first time users see it.
+	 *
+	 * @returns {void}
+	 */
+	initiallyOpenDocumentSettings() {
+		const firstLoad = ! select( "core/edit-post" ).getPreferences().panels[ "yoast-seo/document-panel" ];
+		if ( firstLoad ) {
+			dispatch( "core/edit-post" ).toggleEditorPanelOpened( "yoast-seo/document-panel" );
+		}
 	}
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In Options within default editor there is no option to enable/disable Yoast SEO in Document panel. This PR makes sure there is.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Bugfix: makes sure there is an option to enable/disable the Yoast SEO panel in the document sidebar.

## Relevant technical choices:

* Initially I used a normal Fill to get our panel in the sidebar, not realizing I would be breaking interoperability with how Gutenberg takes care of plugin panels. I reverted back to using the standard Gutenberg panel for this. 
* The reason I didn't go for the standard panel in the first place is because there was no way to have it be open on initial usage. I now added a function that checks upon initialization if our panel is loaded for the first time. If it is, it toggles it open. From then on, the user setting is always respected. So the next time you reload the editor. The panel should remain at the state it was the previous time the user interacted with it. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Notice the panel can now be disabled.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
