### PR TITLE
Clear permalinks on taxonomy settings change

### DIFF
--- a/src/conditionals/yoast-admin-and-dashboard-conditional.php
+++ b/src/conditionals/yoast-admin-and-dashboard-conditional.php
@@ -31,6 +31,7 @@ class Yoast_Admin_And_Dashboard_Conditional implements Conditional {
 			'index.php',
 			'plugins.php',
 			'update-core.php',
+			'options-permalink.php',
 		];
 
 		return \in_array( $pagenow, $target_pages, true );

--- a/src/integrations/watchers/indexable-category-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-category-permalink-watcher.php
@@ -95,7 +95,7 @@ class Indexable_Category_Permalink_Watcher implements Integration_Interface {
 		Wrapper::get_wpdb()->update(
 			Model::get_table_name( 'Indexable' ),
 			[
-				'permalink' => null,
+				'permalink'      => null,
 				'permalink_hash' => null,
 			],
 			[ 'object_type' => 'term', 'object_sub_type' => 'category' ]

--- a/src/integrations/watchers/indexable-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-permalink-watcher.php
@@ -7,10 +7,10 @@
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
+use Yoast\WP\Lib\Model;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
-use Yoast\WP\Lib\Model;
 use Yoast\WP\SEO\WordPress\Wrapper;
 
 /**
@@ -117,7 +117,8 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 		Wrapper::get_wpdb()->update(
 			Model::get_table_name( 'Indexable' ),
 			[
-				'permalink' => null,
+				'permalink'      => null,
+				'permalink_hash' => null,
 			],
 			$where
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This is only the indexation part of the issue. There should be a notification part too.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Ensures the indexation spots the indexables without a permalink.

## Relevant technical choices:

* https://github.com/Yoast/wordpress-seo/pull/15427 already changed the term indexation action to count the permalink_hash as unindexed
* Add the permalinks options page to the conditional so the indexation runs on that page too. This will need to be split up later in https://github.com/Yoast/wordpress-seo/issues/15438

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the WP permalink settings page.
* When you have more than 25 categories this will not run in shutdown function, but if you less than 25 you will not see the notice and it will autocorrect. Lower the limit to prevent this by adding: `\add_filter( 'wpseo_shutdown_indexation_limit', function() { return 25; } )` in your theme's functions.php.
* Change the category base.
* You should now see the indexation notice.
* Check the `wp_yoast_indexable` table in your database. The `object_sub_type` `category` should have a `permalink` and `permalink_hash` of `NULL`.
* Run the indexation.
* Check your database again. They should now be filled again.
* Repeat the steps for the tag base. The `object_sub_type` is now `post_tag`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Partially Fixes #15334 
