### PR TITLE
Don't show it when an email address is already on the mailing list

### DIFF
--- a/js/src/components/MailchimpSignup.js
+++ b/js/src/components/MailchimpSignup.js
@@ -91,6 +91,16 @@ class MailchimpSignup extends React.Component {
 		result
 			.then(
 				( response ) => {
+					// For privacy reasons, don't show it when an email address is already on the mailing list.
+					if ( response.msg.indexOf( "is already subscribed" ) !== -1  ) {
+						this.setState( {
+							isLoading: false,
+							successfulSignup: true,
+							message: "Almost finished... We need to confirm your email address." +
+							"To complete the subscription process, please click the link in the email we just sent you.",
+						} );
+						return;
+					}
 					if ( response.result === "error" ) {
 						this.setState( {
 							isLoading: false,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When you enter an email address of someone else, you can see whether that person is subscribed. Due to privacy reasons, we should not show if a particular email address is added to our list. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* For privacy reasons, no longer shows whether an email address is already subscribed to the newsletter.

## Relevant technical choices:

* It feels very hacky, but this is the only way I could think of to get the desired result. The problem is that there is no difference between the MailChimp response you get when the email address is already on the list and when something else is wrong, except for the message (see below). If you know a better solution, please let me know 😄 

```
{ msg: "[email address] is already subscribed to list Yoast Newsletter. <a href="https://yoast.us1.list-manage.com/subscribe/send-email?e=aXJlbmVAeW9hc3QuY29t&u=ffa93edfe21752c921f860358&id=972f1c9122">Click here to update your profile</a>",
result: "error" }
```

```
{ msg: "0 - An email address must contain a single @",
result: "error" }
```

```
{ msg: "0 - The domain portion of the email address is invalid (the portion after the @: yoast)",
result: "error" }
```

```
{ msg: "Almost finished... We need to confirm your email address. To complete the subscription process, please click the link in the email we just sent you.",
result: "success" }
```

* I chose to search for `is already subscribed` in the message (instead for the absence of  `0 -`) to make the code more readable.
* I also set `successfulSignup` to true, to make sure the message is shown in green instead of red.
* I double-checked that the message in the API response isn't translated based on the locale. Because all MailChimp message we show are in English, I didn't make the string I added translatable.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to step 7 of the configuration wizard
* Fill in an email address that is not subscribed yet (for example [gibberish]@yoast.com)
* Subscribe and see a green message: "Almost finished... We need to confirm your email address. To complete the subscription process, please click the link in the email we just sent you."
* Fill in an email address that is already subscribed (feel free to use my email address 😄)
* Subscribe and see a green message: "Almost finished... We need to confirm your email address. To complete the subscription process, please click the link in the email we just sent you."
* Fill in gibberish that doesn't look like an email address.
* Subscribe and see a red message about what's wrong with your email address.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-21
