### PR TITLE
Remove COUNT(*) from query in author_has_a_public_post() and author_has_a_post_with_is_public_null()

### DIFF
--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -62,14 +62,14 @@ class Author_Archive_Helper {
 	 */
 	protected function author_has_a_public_post( $author_id ) {
 		$indexable_exists = Model::of_type( 'Indexable' )
+			->select( 'id' )
 			->where( 'object_type', 'post' )
 			->where_in( 'object_sub_type', $this->get_author_archive_post_types() )
 			->where( 'author_id', $author_id )
 			->where( 'is_public', 1 )
-			->limit( 1 )
-			->count();
+			->find_one();
 
-		return $indexable_exists > 0;
+		return (bool) $indexable_exists;
 	}
 
 	/**
@@ -83,13 +83,13 @@ class Author_Archive_Helper {
 	 */
 	protected function author_has_a_post_with_is_public_null( $author_id ) {
 		$indexable_exists = Model::of_type( 'Indexable' )
+			->select( 'id' )
 			->where( 'object_type', 'post' )
 			->where_in( 'object_sub_type', $this->get_author_archive_post_types() )
 			->where( 'author_id', $author_id )
 			->where_null( 'is_public' )
-			->limit( 1 )
-			->count();
+			->find_one();
 
-		return $indexable_exists > 0;
+		return (bool) $indexable_exists;
 	}
 }


### PR DESCRIPTION
## Context
* On sites with large posts, we are seeing 503s occur from this query which scans a large number of rows:

```
SELECT COUNT(*) AS `count` FROM `wp_yoast_indexable` WHERE `object_type` = 'post' AND `object_sub_type` IN ('post') AND `author_id` = 'x' AND `is_public` = '1' LIMIT 1
```

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry: 

* Improves performance by selecting the first ID, rather than getting the total count in query of author_has_a_post_with_is_public_null and author_has_a_public_post.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #15389.
