### PR TITLE
Introduce skip confirmation to the Yoast reindex CLI

### DIFF
--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -138,7 +138,7 @@ class Index_Command implements Command_Interface {
 	protected function run_indexation_actions( $assoc_args ) {
 		if ( isset( $assoc_args['reindex'] ) ) {
 			if ( ! isset( $assoc_args['skip-confirmation'] ) ) {
-				WP_CLI::confirm('This will clear all previously indexed objects. Are you certain you wish to proceed?');
+				WP_CLI::confirm( 'This will clear all previously indexed objects. Are you certain you wish to proceed?' );
 			}
 			$this->clear();
 		}

--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -167,7 +167,7 @@ class Index_Command implements Command_Interface {
 		$total = $indexation_action->get_total_unindexed();
 		if ( $total > 0 ) {
 			$limit    = $indexation_action->get_limit();
-				$progress = \WP_CLI\Utils\make_progress_bar( 'Indexing ' . $name, $total );
+			$progress = \WP_CLI\Utils\make_progress_bar( 'Indexing ' . $name, $total );
 			do {
 				$indexables = $indexation_action->index();
 				$count      = \count( $indexables );


### PR DESCRIPTION
## Context

* To enable users to run the `wp yoast index --reindex` command with an extra argument, `--skip-confirmation`. This prevents confirmation prompts and allows automated scripts to use this command.

⚠️  There is a test in `tests/commands/index-command-test.php` for the `--reindex` command and the prompt. However, I am not sure if and how this should be modified. If this needs changes, please let me know as I'd like to know how to do this.

## Summary

This PR can be summarized in the following changelog entry:

* Introduces the `--skip-confirmation` argument to run our wp-cli reindex command without confirmation prompt.

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

1. Run the following command: `wp yoast index --reindex` and see the confirmation prompt.
1. Now run: `wp yoast index --reindex --skip-confirmation` and see no confirmation prompt and the reindexation starts immediately.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/15421
