### PR TITLE
Redesign notification (dismissable)

### DIFF
--- a/src/conditionals/yoast-admin-page-conditional.php
+++ b/src/conditionals/yoast-admin-page-conditional.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Yoast SEO plugin file.
+ *
+ * @package Yoast\YoastSEO\Conditionals
+ */
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Conditional that is only met when in the admin on a Yoast SEO page.
+ */
+class Yoast_Admin_Page_Conditional implements Conditional {
+
+	/**
+	 * Checks if we are on a Yoast SEO admin page.
+	 *
+	 * @return bool True if we are on a Yoast SEO admin page
+	 */
+	public function is_met() {
+		global $pagenow;
+
+		// Do not output on iFrame requests.
+		if ( ( \defined( 'IFRAME_REQUEST' ) && \IFRAME_REQUEST ) ) {
+			return false;
+		}
+
+		if ( \defined( 'DOING_AJAX' ) && \DOING_AJAX ) {
+			return false;
+		}
+
+		// Don't display when upgrading/installing.
+		if ( \wp_installing() ) {
+			return false;
+		}
+
+		return ( $pagenow === 'admin.php' && isset( $_GET['page'] ) && \strpos( $_GET['page'], 'wpseo' ) === 0 );
+	}
+}

--- a/src/integrations/admin/dismissable-notification-integration.php
+++ b/src/integrations/admin/dismissable-notification-integration.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package Yoast\WP\SEO\Integrations\Admin
+ */
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Yoast_Admin_Page_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Presenters\Admin\Dismissable_Notification_Presenter;
+
+/**
+ * Dismissable_Notification_Integration class
+ */
+abstract class Dismissable_Notification_Integration implements Integration_Interface {
+
+	/**
+	 * The identifier of the notification.
+	 *
+	 * @var string
+	 */
+	protected $identifier = '';
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_conditionals() {
+		return [ Admin_Conditional::class, Yoast_Admin_Page_Conditional::class ];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register_hooks() {
+		\add_action( 'admin_init', [ $this, 'dismiss_notification' ] );
+
+		if ( ! $this->can_show_notification() ) {
+			return;
+		}
+
+		\add_action( 'admin_notices', [ $this, 'render_admin_notice' ], 20 );
+	}
+
+	/**
+	 * Provides the identifier for this notification.
+	 *
+	 * @return string The identifier for this notification.
+	 */
+	abstract protected function get_identifier();
+
+	/**
+	 * Determines if the notification should be shown.
+	 *
+	 * @return bool True if the notification should be shown.
+	 */
+	abstract protected function can_show_notification();
+
+	/**
+	 * Dismisses the notification.
+	 *
+	 * @return void
+	 */
+	public function dismiss_notification() {
+		if ( ! \wp_verify_nonce(
+			\filter_input( INPUT_GET, 'nonce', FILTER_SANITIZE_STRING ),
+			Dismissable_Notification_Presenter::NONCE_KEY
+		) ) {
+			return;
+		}
+
+		if ( \filter_input( INPUT_GET, 'identifier', FILTER_SANITIZE_STRING ) !== $this->get_identifier() ) {
+			return;
+		}
+
+		$user_id = \get_current_user_id();
+		if ( 0 === $user_id ) {
+			return;
+		}
+
+		// Store the meta setting, this prevents the message showing again.
+		\update_user_meta( $user_id, $this->get_identifier(), 'dismissed' );
+	}
+
+	/**
+	 * Provides the message to be displayed in the notification.
+	 *
+	 * @return string The message to be displayed.
+	 */
+	abstract protected function get_message();
+
+	/**
+	 * Provides the label to be shown on the dismiss button.
+	 *
+	 * @return string The label to be shown on the dismiss button.
+	 */
+	abstract protected function get_dismiss_label();
+
+	/**
+	 * Provides the type of notification that will be shown.
+	 *
+	 * Should be one of 'info', 'warning' or 'error'.
+	 *
+	 * @return string The type of notification to show.
+	 */
+	abstract protected function get_notification_type();
+
+	/**
+	 * Renders the notification.
+	 *
+	 * @return void
+	 */
+	public function render_admin_notice() {
+		// Dismissed cannot be checked in the register_hooks, as the dismissal could be on the current request.
+		if ( ! $this->can_show_notification() ) {
+			return;
+		}
+
+		echo new Dismissable_Notification_Presenter(
+			$this->get_message(),
+			$this->get_identifier(),
+			$this->get_notification_type(),
+			$this->get_dismiss_label()
+		);
+	}
+}

--- a/src/integrations/admin/redesign-notification-integration.php
+++ b/src/integrations/admin/redesign-notification-integration.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package Yoast\WP\SEO\Integrations\Admin
+ */
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Yoast_Admin_Page_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Presenters\Admin\Dismissable_Notification_Presenter;
+
+/**
+ * Redesign_Notification_Integration class
+ */
+class Redesign_Notification_Integration implements Integration_Interface {
+
+	/**
+	 * The notification identifier.
+	 *
+	 * @var string
+	 */
+	private $identifier = 'wpseo-notification-redesign-14.5';
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function get_conditionals() {
+		return [ Admin_Conditional::class, Yoast_Admin_Page_Conditional::class ];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register_hooks() {
+		\add_action( 'admin_init', [ $this, 'dismiss_notification' ] );
+
+		// Update was after 14.5 release; don't show a notification.
+		if ( ! $this->is_installed_before_redesign() ) {
+			return;
+		}
+
+		\add_action( 'admin_notices', [ $this, 'render_admin_notice' ], 20 );
+	}
+
+	/**
+	 * Checks if the notification is dismissed.
+	 *
+	 * @return bool True if the notification is dismissed.
+	 */
+	private function is_notification_dismissed() {
+		$user_id = \get_current_user_id();
+		if ( 0 === $user_id ) {
+			return true;
+		}
+
+		$notification_dismissed = \get_user_meta( $user_id, $this->identifier, true );
+
+		return ! empty( $notification_dismissed );
+	}
+
+	/**
+	 * Dismisses the notification.
+	 *
+	 * @return void
+	 */
+	public function dismiss_notification() {
+		if ( ! \wp_verify_nonce(
+			\filter_input( INPUT_GET, 'nonce', FILTER_SANITIZE_STRING ),
+			'wpseo-dismiss-notification'
+		) ) {
+			return;
+		}
+
+		if ( \filter_input( INPUT_GET, 'identifier', FILTER_SANITIZE_STRING ) !== $this->identifier ) {
+			return;
+		}
+
+		$user_id = \get_current_user_id();
+		if ( 0 === $user_id ) {
+			return;
+		}
+
+		// Store the meta setting, this prevents the message showing again.
+		\update_user_meta( $user_id, $this->identifier, 'dismissed' );
+	}
+
+	/**
+	 * Renders the notification.
+	 *
+	 * @return void
+	 */
+	public function render_admin_notice() {
+		// Dismissed cannot be checked in the register_hooks, as the dismissal could be on the current request.
+		if ( $this->is_notification_dismissed() ) {
+			return;
+		}
+
+		$copy = \sprintf(
+			__(
+				'We decided to give %1$s a new look. Don’t worry, all your settings are secure and can still be found in the same place as before.',
+				'wordpress-seo'
+			),
+			'Yoast SEO'
+		);
+
+		echo new Dismissable_Notification_Presenter( $copy, $this->identifier, \__( 'I understand, remove this message.', 'wordpress-seo' ) );
+	}
+
+	/**
+	 * Checks if the plugin was activated before the redesign release.
+	 *
+	 * @return bool True if it was installed before the release date.
+	 */
+	private function is_installed_before_redesign() {
+		// July 7th 2020, 12:00 CEST
+		$redesign_release_date = 1594116000;
+		$activation_time       = \WPSEO_Options::get( 'first_activated_on' );
+
+		return ( $activation_time < $redesign_release_date );
+	}
+}

--- a/src/integrations/admin/redesign-notification-integration.php
+++ b/src/integrations/admin/redesign-notification-integration.php
@@ -29,6 +29,39 @@ class Redesign_Notification_Integration extends Dismissable_Notification_Integra
 	}
 
 	/**
+	 * Provides the message to be displayed in the notification.
+	 *
+	 * @return string The message to be displayed.
+	 */
+	protected function get_message() {
+		return \sprintf(
+			__(
+				'We decided to give %1$s a new look. Don’t worry, all your settings are secure and can still be found in the same place as before.',
+				'wordpress-seo'
+			),
+			'Yoast SEO'
+		);
+	}
+
+	/**
+	 * Provides the label to be shown on the dismiss button.
+	 *
+	 * @return string The label to be shown on the dismiss button.
+	 */
+	protected function get_dismiss_label() {
+		return \__( 'I understand, remove this message.', 'wordpress-seo' );
+	}
+
+	/**
+	 * Provides the type of notification that will be shown.
+	 *
+	 * @return string The type of notification to show.
+	 */
+	protected function get_notification_type() {
+		return 'info';
+	}
+
+	/**
 	 * Determines if the notification should be shown.
 	 *
 	 * @return bool True if the notification should be shown.
@@ -63,43 +96,10 @@ class Redesign_Notification_Integration extends Dismissable_Notification_Integra
 	 * @return bool True if it was installed before the release date.
 	 */
 	private function is_installed_before_redesign() {
-		// July 7th 2020, 12:00 CEST
+		// July 7th 2020, 12:00 CEST.
 		$redesign_release_date = 1594116000;
 		$activation_time       = \WPSEO_Options::get( 'first_activated_on' );
 
 		return ( $activation_time < $redesign_release_date );
-	}
-
-	/**
-	 * Provides the message to be displayed in the notification.
-	 *
-	 * @return string The message to be displayed.
-	 */
-	protected function get_message() {
-		return \sprintf(
-			__(
-				'We decided to give %1$s a new look. Don’t worry, all your settings are secure and can still be found in the same place as before.',
-				'wordpress-seo'
-			),
-			'Yoast SEO'
-		);
-	}
-
-	/**
-	 * Provides the label to be shown on the dismiss button.
-	 *
-	 * @return string The label to be shown on the dismiss button.
-	 */
-	protected function get_dismiss_label() {
-		return \__( 'I understand, remove this message.', 'wordpress-seo' );
-	}
-
-	/**
-	 * Provides the type of notification that will be shown.
-	 *
-	 * @return string The type of notification to show.
-	 */
-	protected function get_notification_type() {
-		return 'info';
 	}
 }

--- a/src/integrations/admin/redesign-notification-integration.php
+++ b/src/integrations/admin/redesign-notification-integration.php
@@ -49,7 +49,7 @@ class Redesign_Notification_Integration extends Dismissable_Notification_Integra
 	 * @return string The label to be shown on the dismiss button.
 	 */
 	protected function get_dismiss_label() {
-		return \__( 'I understand, remove this message.', 'wordpress-seo' );
+		return \__( 'Hide this notice', 'wordpress-seo' );
 	}
 
 	/**

--- a/src/presenters/admin/dismissable-notification-presenter.php
+++ b/src/presenters/admin/dismissable-notification-presenter.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Presenter class for the indexation warning.
+ *
+ * @package Yoast\YoastSEO\Presenters\Admin
+ */
+
+namespace Yoast\WP\SEO\Presenters\Admin;
+
+use Yoast\WP\SEO\Presenters\Abstract_Presenter;
+
+/**
+ * Migration_Error_Presenter class.
+ */
+class Dismissable_Notification_Presenter extends Abstract_Presenter {
+
+	/**
+	 * Holds the notification messsage.
+	 *
+	 * @var string
+	 */
+	protected $message;
+
+	/**
+	 * Holds the notification identifier, to dismiss it.
+	 *
+	 * @var string
+	 */
+	protected $identifier;
+
+	/**
+	 * The label to show on the dismiss button.
+	 *
+	 * @var string
+	 */
+	protected $dismiss_label;
+
+	/**
+	 * Migration_Error_Presenter constructor.
+	 *
+	 * @param string $message       The notification message.
+	 * @param string $identifier    The message identifier.
+	 * @param string $dismiss_label Optional. Custom label to show on the dismiss button.
+	 */
+	public function __construct( $message, $identifier, $dismiss_label = '' ) {
+		$this->message       = $message;
+		$this->identifier    = $identifier;
+		$this->dismiss_label = $dismiss_label;
+	}
+
+	/**
+	 * Presents the migration error that occurred.
+	 *
+	 * @return string The error HTML.
+	 */
+	public function present() {
+		$nonce      = \esc_attr( \wp_create_nonce( 'wpseo-dismiss-notification' ) );
+		$identifier = \esc_attr( $this->identifier );
+
+		// Fetch the current page, so we can stay on it.
+		$page = \esc_attr( \filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) );
+
+		$message = \esc_html( $this->message );
+
+		$dismiss_label = $this->dismiss_label;
+		if ( empty ( $this->dismiss_label ) ) {
+			$dismiss_label = \__( 'Dismiss', 'wordpress-seo' );
+		}
+		$dismiss_label = \esc_html( $dismiss_label );
+
+		$html = <<<PHP_EOL
+<div class="notice notice-info"><p>$message</p>
+<form method="GET" action="">
+<input type="hidden" name="identifier" value="$identifier">
+<input type="hidden" name="page" value="$page">
+<input type="hidden" name="action" value="wpseo-dismiss-notification">
+<input type="hidden" name="nonce" value="$nonce">
+<input type="submit" value="$dismiss_label">
+</form>
+</div>
+PHP_EOL;
+
+		return $html;
+	}
+}

--- a/src/presenters/admin/dismissable-notification-presenter.php
+++ b/src/presenters/admin/dismissable-notification-presenter.php
@@ -82,7 +82,7 @@ class Dismissable_Notification_Presenter extends Abstract_Presenter {
 		}
 
 		$dismiss_label = $this->dismiss_label;
-		if ( empty ( $this->dismiss_label ) ) {
+		if ( empty( $this->dismiss_label ) ) {
 			$dismiss_label = \__( 'Dismiss', 'wordpress-seo' );
 		}
 		$dismiss_label = \esc_html( $dismiss_label );

--- a/src/presenters/admin/dismissable-notification-presenter.php
+++ b/src/presenters/admin/dismissable-notification-presenter.php
@@ -29,6 +29,13 @@ class Dismissable_Notification_Presenter extends Abstract_Presenter {
 	protected $identifier;
 
 	/**
+	 * The type of notification to show.
+	 *
+	 * @var string
+	 */
+	protected $type;
+
+	/**
 	 * The label to show on the dismiss button.
 	 *
 	 * @var string
@@ -36,15 +43,22 @@ class Dismissable_Notification_Presenter extends Abstract_Presenter {
 	protected $dismiss_label;
 
 	/**
+	 * Declares the nonce key to be used.
+	 */
+	const NONCE_KEY = 'wpseo-dismiss-notification';
+
+	/**
 	 * Migration_Error_Presenter constructor.
 	 *
 	 * @param string $message       The notification message.
 	 * @param string $identifier    The message identifier.
+	 * @param string $type          Optional. The type of notification.
 	 * @param string $dismiss_label Optional. Custom label to show on the dismiss button.
 	 */
-	public function __construct( $message, $identifier, $dismiss_label = '' ) {
+	public function __construct( $message, $identifier, $type = 'info', $dismiss_label = '' ) {
 		$this->message       = $message;
 		$this->identifier    = $identifier;
+		$this->type          = $type;
 		$this->dismiss_label = $dismiss_label;
 	}
 
@@ -54,13 +68,18 @@ class Dismissable_Notification_Presenter extends Abstract_Presenter {
 	 * @return string The error HTML.
 	 */
 	public function present() {
-		$nonce      = \esc_attr( \wp_create_nonce( 'wpseo-dismiss-notification' ) );
+		$nonce      = \esc_attr( \wp_create_nonce( self::NONCE_KEY ) );
 		$identifier = \esc_attr( $this->identifier );
 
 		// Fetch the current page, so we can stay on it.
 		$page = \esc_attr( \filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) );
 
 		$message = \esc_html( $this->message );
+
+		$type = $this->type;
+		if ( ! in_array( $type, [ 'info', 'warning', 'error' ], true ) ) {
+			$type = 'info';
+		}
 
 		$dismiss_label = $this->dismiss_label;
 		if ( empty ( $this->dismiss_label ) ) {
@@ -69,11 +88,10 @@ class Dismissable_Notification_Presenter extends Abstract_Presenter {
 		$dismiss_label = \esc_html( $dismiss_label );
 
 		$html = <<<PHP_EOL
-<div class="notice notice-info"><p>$message</p>
+<div class="notice notice-$type"><p>$message</p>
 <form method="GET" action="">
 <input type="hidden" name="identifier" value="$identifier">
 <input type="hidden" name="page" value="$page">
-<input type="hidden" name="action" value="wpseo-dismiss-notification">
 <input type="hidden" name="nonce" value="$nonce">
 <input type="submit" value="$dismiss_label">
 </form>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make sure people are not scared that the redesign/new visuals have any impact on their settings.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Added a notification on all Yoast SEO admin-pages for installations done before this release explaining that the redesign is only visual, not functional.

## Relevant technical choices:

* Created a new conditional to check for Yoast SEO-admin page
* Created a generic dismissable-notification-presenter

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Have an install that is activated before July 7th 2020
* Go to any Yoast SEO-admin page
* See the message being displayed at the top of the page
* Use the "Hide this notice" button to dismiss the notification and don't see it again
* Log in as a different user and see the notification

To restore the notification as a programmer; use the following line in the `register_hooks` method:
* `\delete_user_meta( \get_current_user_id(), $this->identifier );`

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes FRO-113
