### PR TITLE
Add caching for authors with no posts to prevent full table scanning in author_has_a_public_post and author_has_a_post_with_is_public_null 

### DIFF
--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -56,18 +56,27 @@ class Author_Archive_Helper {
 	 *
 	 * @param int $author_id The author ID.
 	 *
-	 * @codeCoverageIgnore It only performs a count query through the ORM and converts it to a boolean.
+	 * @codeCoverageIgnore It looks for the first ID through the ORM and converts it to a boolean.
 	 *
 	 * @return bool Whether the author has at least one public post.
 	 */
 	protected function author_has_a_public_post( $author_id ) {
-		$indexable_exists = Model::of_type( 'Indexable' )
+		$cache_key = 'author_has_a_public_post_' . $author_id;
+		$indexable_exists = wp_cache_get( $cache_key );
+
+		if ( false === $indexable_exists ) {
+			$indexable_exists = Model::of_type( 'Indexable' )
 			->select( 'id' )
 			->where( 'object_type', 'post' )
 			->where_in( 'object_sub_type', $this->get_author_archive_post_types() )
 			->where( 'author_id', $author_id )
 			->where( 'is_public', 1 )
 			->find_one();
+
+			if ( false === $indexable_exists ) {
+				wp_cache_set( $cache_key, 0, '', wp_rand( 2 * HOUR_IN_SECONDS, 4 * HOUR_IN_SECONDS ) ); // Cache no results to prevent full table scanning on authors with no public posts.
+			}
+		}
 
 		return (bool) $indexable_exists;
 	}
@@ -77,18 +86,27 @@ class Author_Archive_Helper {
 	 *
 	 * @param int $author_id The author ID.
 	 *
-	 * @codeCoverageIgnore It only performs a count query through the ORM and converts it to a boolean.
+	 * @codeCoverageIgnore It looks for the first ID through the ORM and converts it to a boolean.
 	 *
 	 * @return bool Whether the author has at least one post with the is public null.
 	 */
 	protected function author_has_a_post_with_is_public_null( $author_id ) {
-		$indexable_exists = Model::of_type( 'Indexable' )
-			->select( 'id' )
-			->where( 'object_type', 'post' )
-			->where_in( 'object_sub_type', $this->get_author_archive_post_types() )
-			->where( 'author_id', $author_id )
-			->where_null( 'is_public' )
-			->find_one();
+		$cache_key = 'author_has_a_post_with_is_public_null_' . $author_id;
+		$indexable_exists = wp_cache_get( $cache_key );
+
+		if ( false === $indexable_exists ) {
+			$indexable_exists = Model::of_type( 'Indexable' )
+				->select( 'id' )
+				->where( 'object_type', 'post' )
+				->where_in( 'object_sub_type', $this->get_author_archive_post_types() )
+				->where( 'author_id', $author_id )
+				->where_null( 'is_public' )
+				->find_one();
+
+			if ( false === $indexable_exists ) {
+				wp_cache_set( $cache_key, 0, '', wp_rand( 2 * HOUR_IN_SECONDS, 4 * HOUR_IN_SECONDS ) ); // Cache no results to prevent full table scanning on authors with no is public null posts.
+			}
+		}
 
 		return (bool) $indexable_exists;
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Per #15450, this is an expensive query and for authors that have no posts, the query will end up scanning all the rows.  We should add some caching around it to ensure the expensive query isn't called consistently if a false value is expected.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves performance by adding caching around false values for authors with no posts in author_has_a_post_with_is_public_null and author_has_a_public_post. Props rebeccahum.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #15389.
