### PR TITLE
Simplify value parsing for userID

### DIFF
--- a/js/src/components/WordPressUserSelectorSearchAppearance.js
+++ b/js/src/components/WordPressUserSelectorSearchAppearance.js
@@ -35,14 +35,7 @@ class WordPressUserSelectorSearchAppearance extends Component {
 	 * @returns {number} The user id.
 	 */
 	getInitialValue() {
-		const value = this.element.value;
-
-		let userId = null;
-		if ( value !== "false" ) {
-			userId = parseInt( value, 10 );
-		}
-
-		return userId;
+		return parseInt( this.element.value, 10 );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* As parsing a string (like "false") to an integer, this will result in `0`.
This keeps the current functionality intact, but avoids the `state.value` being read as not set, though it is just set to no user.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents a console error when no user is selected in the Company or Person selector

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #15461
