### PR TITLE
PHPCS: enable caching between runs (Premium)

### DIFF
--- a/.cache/.gitkeep
+++ b/.cache/.gitkeep
@@ -1,0 +1,1 @@
+# This directory has to exist to allow cache files to be written to it.

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 # Set default behaviour, in case users don't have core.autocrlf set.
 * text=auto
 
+.cache export-ignore
 .github export-ignore
 deploy_keys export-ignore
 grunt export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tmp/
 *.bak
 *.log
 *.[Cc]ache
+!.cache
 *.cpr
 *.orig
 *.php.in

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,7 @@ cache:
   yarn: true
   directories:
     - $HOME/.composer/cache
+    - .cache
     - node_modules
 
 before_install:


### PR DESCRIPTION
## Context

* Dev environment improvement

## Summary

This PR can be summarized in the following changelog entry:

* Enable PHPCS caching (Premium)

## Relevant technical choices:

Since PHPCS 3.0.0, PHPCS has a caching feature available. While this feature cannot be used for the Free repo yet, it will be enabled for the Premium repo and to do so, certain changes are needed to shared files.

This commit makes those changes.

Note: this is a sister-PR to the PR in the Premium repo which adds the caching configuration to the PHPCS ruleset. This PR **has** to be merged first!!

### Commit details:

`/.cache/` directory:
* Create the directory and place a `.gitkeep` file in it to allow it to be committed.

`.gitignore`:
* Prevent committing of cache files (already in place), but allow committing of the `.cache` directory.

`.gitattributes`:
* Do not include the `.cache` directory in distributable archives.

Travis:
* Use the Travis caching feature to cache the new `.cache` directory (including the cache file) between runs to allow Travis to benefit from the PHPCS caching as well.


## Test instructions

This PR can be tested by following these steps:

* Once this PR has been merged and Free has been merged back into Premium, this can be tested via the sister-PR in the Premium repo: https://github.com/Yoast/wordpress-seo-premium/pull/2844.
