### PR TITLE
QA: no need for a closure when there is a native PHP function

### DIFF
--- a/lib/migrations/adapter.php
+++ b/lib/migrations/adapter.php
@@ -899,11 +899,8 @@ class Adapter {
 	 * @return string[] The version numbers that have been migrated.
 	 */
 	public function get_migrated_versions() {
-		return \array_map(
-			function ( $row ) {
-				return $row['version'];
-			}, $this->select_all( \sprintf( 'SELECT version FROM %s', $this->get_schema_version_table_name() ) )
-		);
+		$result = $this->select_all( \sprintf( 'SELECT version FROM %s', $this->get_schema_version_table_name() ) );
+		return \array_column( $result, 'version' );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

No need for a closure when there is a PHP native function which does exactly the same.

Ref: https://www.php.net/manual/en/function.array-column.php

POC: http://sandbox.onlinephpfunctions.com/code/b3e5374a8e4340dac407e85498c30eb2c1a9c8ae



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
