### PR TITLE
QA: tweak some prepared SQL statements

### DIFF
--- a/admin/import/plugins/class-abstract-plugin-importer.php
+++ b/admin/import/plugins/class-abstract-plugin-importer.php
@@ -156,14 +156,16 @@ abstract class WPSEO_Plugin_Importer {
 	protected function detect() {
 		global $wpdb;
 
-		$meta_keys    = wp_list_pluck( $this->clone_keys, 'old_key' );
-		$placeholders = implode( ', ', array_fill( 0, count( $meta_keys ), '%s' ) );
-		$result       = $wpdb->get_var(
+		$meta_keys = wp_list_pluck( $this->clone_keys, 'old_key' );
+		$result    = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT(*) AS `count` FROM {$wpdb->postmeta} WHERE meta_key IN ( $placeholders )",
+				"SELECT COUNT(*) AS `count`
+					FROM {$wpdb->postmeta}
+					WHERE meta_key IN ( " . implode( ', ', array_fill( 0, count( $meta_keys ), '%s' ) ) . ' )',
 				$meta_keys
 			)
 		);
+
 		if ( $result === '0' ) {
 			return false;
 		}

--- a/admin/import/plugins/class-import-squirrly.php
+++ b/admin/import/plugins/class-import-squirrly.php
@@ -187,11 +187,16 @@ class WPSEO_Import_Squirrly extends WPSEO_Plugin_Importer {
 		if ( ! is_numeric( $post_identifier ) ) {
 			$query_where = 'URL = %s';
 		}
+
+		$replacements = [
+			get_current_blog_id(),
+			$post_identifier,
+		];
+
 		$data = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT seo FROM {$this->table_name} WHERE blog_id = %d AND " . $query_where,
-				get_current_blog_id(),
-				$post_identifier
+				$replacements
 			)
 		);
 		if ( ! $data || is_wp_error( $data ) ) {

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -787,10 +787,13 @@ class WPSEO_Upgrade {
 			return;
 		}
 
-		$placeholders    = \implode( ', ', \array_fill( 0, \count( $private_taxonomies ), '%s' ) );
 		$indexable_table = Model::get_table_name( 'Indexable' );
 		$query           = $wpdb->prepare(
-			"DELETE FROM $indexable_table WHERE object_type = 'term' AND object_sub_type IN ($placeholders)",
+			"DELETE FROM $indexable_table
+			WHERE object_type = 'term'
+			AND object_sub_type IN ("
+				. \implode( ', ', \array_fill( 0, \count( $private_taxonomies ), '%s' ) )
+				. ')',
 			$private_taxonomies
 		);
 		$wpdb->query( $query );

--- a/src/actions/indexation/indexable-post-indexation-action.php
+++ b/src/actions/indexation/indexable-post-indexation-action.php
@@ -113,7 +113,6 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 	 */
 	protected function get_query( $count, $limit = 1 ) {
 		$public_post_types = $this->post_type_helper->get_public_post_types();
-		$placeholders      = \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) );
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$replacements      = $public_post_types;
 
@@ -131,7 +130,12 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 			"
 			SELECT $select
 			FROM {$this->wpdb->posts}
-			WHERE ID NOT IN (SELECT object_id FROM $indexable_table WHERE object_type = 'post') AND post_type IN ($placeholders)
+			WHERE ID NOT IN (
+				SELECT object_id
+				FROM $indexable_table
+				WHERE object_type = 'post'
+			)
+			AND post_type IN (" . \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) ) . ")
 			$limit_query",
 			$replacements
 		);

--- a/src/actions/indexation/indexable-term-indexation-action.php
+++ b/src/actions/indexation/indexable-term-indexation-action.php
@@ -114,7 +114,6 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 	 */
 	protected function get_query( $count, $limit = 1 ) {
 		$public_taxonomies = $this->taxonomy->get_public_taxonomies();
-		$placeholders      = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$replacements      = $public_taxonomies;
 
@@ -132,7 +131,12 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 			"
 			SELECT $select
 			FROM {$this->wpdb->term_taxonomy}
-			WHERE term_id NOT IN (SELECT object_id FROM $indexable_table WHERE object_type = 'term') AND taxonomy IN ($placeholders)
+			WHERE term_id NOT IN (
+				SELECT object_id
+				FROM $indexable_table
+				WHERE object_type = 'term'
+			)
+			AND taxonomy IN (" . \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) ) . ")
 			$limit_query",
 			$replacements
 		);

--- a/src/integrations/watchers/option-titles-watcher.php
+++ b/src/integrations/watchers/option-titles-watcher.php
@@ -109,8 +109,6 @@ class Option_Titles_Watcher implements Integration_Interface {
 
 		$wpdb            = Wrapper::get_wpdb();
 		$total           = \count( $post_types );
-		$placeholders    = \array_fill( 0, $total, '%s' );
-		$placeholders    = \implode( ', ', $placeholders );
 		$hierarchy_table = Model::get_table_name( 'Indexable_Hierarchy' );
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
@@ -119,8 +117,11 @@ class Option_Titles_Watcher implements Integration_Interface {
 				"
 				DELETE FROM `$hierarchy_table`
 				WHERE indexable_id IN(
-					SELECT id FROM `$indexable_table` WHERE object_type = 'post' AND object_sub_type IN( $placeholders )
-				)",
+					SELECT id
+					FROM `$indexable_table`
+					WHERE object_type = 'post'
+					AND object_sub_type IN( " . \implode( ', ', \array_fill( 0, $total, '%s' ) ) . ' )
+				)',
 				$post_types
 			)
 		);

--- a/tests/actions/indexation/indexable-post-indexation-action-test.php
+++ b/tests/actions/indexation/indexable-post-indexation-action-test.php
@@ -79,7 +79,12 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$expected_query    = "
 			SELECT COUNT(ID)
 			FROM wp_posts
-			WHERE ID NOT IN (SELECT object_id FROM wp_yoast_indexable WHERE object_type = 'post') AND post_type IN (%s)
+			WHERE ID NOT IN (
+				SELECT object_id
+				FROM wp_yoast_indexable
+				WHERE object_type = 'post'
+			)
+			AND post_type IN (%s)
 			$limit_placeholder";
 
 		$this->post_type_helper->expects( 'get_public_post_types' )->once()->andReturn( [ 'public_post_type' ] );
@@ -118,7 +123,12 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$expected_query = '
 			SELECT ID
 			FROM wp_posts
-			WHERE ID NOT IN (SELECT object_id FROM wp_yoast_indexable WHERE object_type = \'post\') AND post_type IN (%s)
+			WHERE ID NOT IN (
+				SELECT object_id
+				FROM wp_yoast_indexable
+				WHERE object_type = \'post\'
+			)
+			AND post_type IN (%s)
 			LIMIT %d';
 
 		Filters\expectApplied( 'wpseo_post_indexation_limit' )->andReturn( 25 );

--- a/tests/actions/indexation/indexable-term-indexation-action-test.php
+++ b/tests/actions/indexation/indexable-term-indexation-action-test.php
@@ -79,7 +79,12 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 		$expected_query    = "
 			SELECT COUNT(term_id)
 			FROM wp_term_taxonomy
-			WHERE term_id NOT IN (SELECT object_id FROM wp_yoast_indexable WHERE object_type = 'term') AND taxonomy IN (%s)
+			WHERE term_id NOT IN (
+				SELECT object_id
+				FROM wp_yoast_indexable
+				WHERE object_type = 'term'
+			)
+			AND taxonomy IN (%s)
 			$limit_placeholder";
 
 		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturn( [ 'public_taxonomy' ] );
@@ -118,7 +123,12 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 		$expected_query = '
 			SELECT term_id
 			FROM wp_term_taxonomy
-			WHERE term_id NOT IN (SELECT object_id FROM wp_yoast_indexable WHERE object_type = \'term\') AND taxonomy IN (%s)
+			WHERE term_id NOT IN (
+				SELECT object_id
+				FROM wp_yoast_indexable
+				WHERE object_type = \'term\'
+			)
+			AND taxonomy IN (%s)
 			LIMIT %d';
 
 		Filters\expectApplied( 'wpseo_term_indexation_limit' )->andReturn( 25 );

--- a/tests/integrations/watchers/option-titles-watcher-test.php
+++ b/tests/integrations/watchers/option-titles-watcher-test.php
@@ -138,7 +138,10 @@ class Option_Titles_Watcher_Test extends TestCase {
 				"
 				DELETE FROM `wp_yoast_indexable_hierarchy`
 				WHERE indexable_id IN(
-					SELECT id FROM `wp_yoast_indexable` WHERE object_type = 'post' AND object_sub_type IN( %s )
+					SELECT id
+					FROM `wp_yoast_indexable`
+					WHERE object_type = 'post'
+					AND object_sub_type IN( %s )
 				)",
 				[ 'post' ]
 			)
@@ -146,7 +149,10 @@ class Option_Titles_Watcher_Test extends TestCase {
 				"
 				DELETE FROM `wp_yoast_indexable_hierarchy`
 				WHERE indexable_id IN(
-					SELECT id FROM `wp_yoast_indexable` WHERE object_type = 'post' AND object_sub_type IN( 'post' )
+					SELECT id
+					FROM `wp_yoast_indexable`
+					WHERE object_type = 'post'
+					AND object_sub_type IN( 'post' )
 				)"
 			);
 
@@ -157,7 +163,10 @@ class Option_Titles_Watcher_Test extends TestCase {
 				"
 				DELETE FROM `wp_yoast_indexable_hierarchy`
 				WHERE indexable_id IN(
-					SELECT id FROM `wp_yoast_indexable` WHERE object_type = 'post' AND object_sub_type IN( 'post' )
+					SELECT id
+					FROM `wp_yoast_indexable`
+					WHERE object_type = 'post'
+					AND object_sub_type IN( 'post' )
 				)"
 			)
 			->andReturn( 2 );
@@ -200,7 +209,10 @@ class Option_Titles_Watcher_Test extends TestCase {
 				"
 				DELETE FROM `wp_yoast_indexable_hierarchy`
 				WHERE indexable_id IN(
-					SELECT id FROM `wp_yoast_indexable` WHERE object_type = 'post' AND object_sub_type IN( %s )
+					SELECT id
+					FROM `wp_yoast_indexable`
+					WHERE object_type = 'post'
+					AND object_sub_type IN( %s )
 				)",
 				[ 'post' ]
 			)


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

* No functional changes.

[1] Placing the placeholder creation for `WHERE ... IN ()` type clauses in the `$wpdb->prepare()` function call, allows for static analysis tools to verify these type of clauses are set up correctly.

Includes updating the expectations in the unit tests to match.

[2] Small tweak: Passing the DB query replacements as an array allows to bypass an "Incorrect number of replacements passed" notice.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
