### PR TITLE
Use get to test for experimentalLinkControl presence

### DIFF
--- a/js/src/edit.js
+++ b/js/src/edit.js
@@ -77,7 +77,7 @@ class Edit {
 
 		this._registerPlugin();
 
-		if ( typeof window.wp.blockEditor.__experimentalLinkControl === "function" ) {
+		if ( typeof get( window, "wp.blockEditor.__experimentalLinkControl" ) === "function" ) {
 			this._registerFormats();
 		} else {
 			console.warn(


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
![image](https://user-images.githubusercontent.com/26220788/85279057-21912880-b486-11ea-9962-16a21914bf57.png)
Got the error above when on term edit and classic editor, because `blockEditor` was not present. Lodash `get` searches more gracefully.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where an error would occur when on edit pages without a block editor.

