### PR TITLE
P3-46 Create Upsell info Alert content for the modal

### DIFF
--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 141,
+			maxWarnings: 140,
 		},
 	},
 	tests: {

--- a/js/src/components/RelatedKeyPhrasesModal.js
+++ b/js/src/components/RelatedKeyPhrasesModal.js
@@ -15,6 +15,7 @@ import KeyphrasesTable from "./modals/KeyphrasesTable";
 import YoastIcon from "../../../images/Yoast_icon_kader.svg";
 import SemRushLimitReached from "./modals/SemRushLimitReached";
 import SemRushLoading from "./modals/SemRushLoading";
+import SemRushUpsellAlert from "./modals/SemRushUpsellAlert"
 
 /**
  * Redux container for the RelatedKeyPhrasesModal modal.
@@ -104,6 +105,7 @@ class RelatedKeyPhrasesModal extends Component {
 						>
 							{ this.state.isLoading && <SemRushLoading /> }
 
+							<SemRushUpsellAlert />
 							<SemRushLimitReached />
 							<CountrySelector />
 							<KeyphrasesTable />

--- a/js/src/components/RelatedKeyPhrasesModal.js
+++ b/js/src/components/RelatedKeyPhrasesModal.js
@@ -15,7 +15,7 @@ import KeyphrasesTable from "./modals/KeyphrasesTable";
 import YoastIcon from "../../../images/Yoast_icon_kader.svg";
 import SemRushLimitReached from "./modals/SemRushLimitReached";
 import SemRushLoading from "./modals/SemRushLoading";
-import SemRushUpsellAlert from "./modals/SemRushUpsellAlert"
+import SemRushUpsellAlert from "./modals/SemRushUpsellAlert";
 
 /**
  * Redux container for the RelatedKeyPhrasesModal modal.

--- a/js/src/components/modals/SemRushLimitReached.js
+++ b/js/src/components/modals/SemRushLimitReached.js
@@ -1,8 +1,10 @@
 /* External dependencies */
 import React from "react";
-import { makeOutboundLink } from "@yoast/helpers";
 import { __, sprintf } from "@wordpress/i18n";
 import { Fragment } from "@wordpress/element";
+
+/* Yoast dependencies */
+import { makeOutboundLink } from "@yoast/helpers";
 
 const UpdateSemRushPlanLink = makeOutboundLink();
 

--- a/js/src/components/modals/SemRushLoading.js
+++ b/js/src/components/modals/SemRushLoading.js
@@ -1,6 +1,8 @@
 /* External dependencies */
 import React from "react";
 import { __, sprintf } from "@wordpress/i18n";
+
+/* Yoast dependencies */
 import { SvgIcon } from "@yoast/components";
 
 /**

--- a/js/src/components/modals/SemRushUpsellAlert.js
+++ b/js/src/components/modals/SemRushUpsellAlert.js
@@ -2,35 +2,37 @@
 import React from "react";
 import { __, sprintf } from "@wordpress/i18n";
 
-/* Internal dependencies */
+/* Yoast dependencies */
 import { Alert } from "@yoast/components";
 import { makeOutboundLink } from "@yoast/helpers";
 
 const PremiumLandingPageLink = makeOutboundLink();
 
 /**
- * Creates the content for the Yoast SEO Premium upsell alert in SEMrush modal
+ * Creates the content for the Yoast SEO Premium upsell alert in SEMrush modal.
  *
- * @returns {React.Element} The Yoast SEO Premium upsell alert
+ * @returns {React.Element} The Yoast SEO Premium upsell alert.
  */
 const SemRushUpsellAlert = () => {
-
 	return (
 		<Alert type="info">
 			{
 				sprintf(
-					/* translators: %s : Expands to "Yoast SEO". */
-					__( "Would you like to be able to add these related keyphrases to the %s analysis so you can optimize your content even further?", "wordpress-seo" ),
+					/* translators: %s: Expands to "Yoast SEO". */
+					__(
+						"Would you like to be able to add these related keyphrases to the %s analysis so you can optimize your content even further?",
+						"wordpress-seo"
+					),
 					"Yoast SEO"
-				)
-				+ " "
+				) + " "
 			}
 			<PremiumLandingPageLink
-				href="https://yoa.st/413">
+				href="https://yoa.st/413"
+			>
 				{
 					sprintf(
-						/* translators: %s : Expands to "Yoast SEO Premium". */
-						__( "Check out %s!", "wordpress-seo"),
+						/* translators: %s: Expands to "Yoast SEO Premium". */
+						__( "Check out %s!", "wordpress-seo" ),
 						"Yoast SEO Premium"
 					)
 				}

--- a/js/src/components/modals/SemRushUpsellAlert.js
+++ b/js/src/components/modals/SemRushUpsellAlert.js
@@ -1,0 +1,42 @@
+/* External dependencies */
+import React from "react";
+import { __, sprintf } from "@wordpress/i18n";
+
+/* Internal dependencies */
+import { Alert } from "@yoast/components";
+import { makeOutboundLink } from "@yoast/helpers";
+
+const PremiumLandingPageLink = makeOutboundLink();
+
+/**
+ * Creates the content for the Yoast SEO Premium upsell alert in SEMrush modal
+ *
+ * @returns {React.Element} The Yoast SEO Premium upsell alert
+ */
+const SemRushUpsellAlert = () => {
+
+	return (
+		<Alert type="info">
+			{
+				sprintf(
+					/* translators: %s : Expands to "Yoast SEO". */
+					__( "Would you like to be able to add these related keyphrases to the %s analysis so you can optimize your content even further?", "wordpress-seo" ),
+					"Yoast SEO"
+				)
+				+ " "
+			}
+			<PremiumLandingPageLink
+				href="https://yoa.st/413">
+				{
+					sprintf(
+						/* translators: %s : Expands to "Yoast SEO Premium". */
+						__( "Check out %s!", "wordpress-seo"),
+						"Yoast SEO Premium"
+					)
+				}
+			</PremiumLandingPageLink>
+		</Alert>
+	);
+};
+
+export default SemRushUpsellAlert;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Users of the free plugin can use the SEMrush integration to look for related keyphrases but they can't add them to the Yoast SEO analysis. They should switch to Yoast SEO Premium to be able to do this.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add an Yoast SEO Premium upsell info alert on top of the SEMrush modal 

## Relevant technical choices:

* Introduce a simple SemRushUpsellAlert component in the components/modals directory

## Screenshot
![Schermata a 2020-06-22 16-29-23](https://user-images.githubusercontent.com/15989132/85299559-b35c5e00-b4a5-11ea-9581-17541ed65eee.png)

## Test instructions

This PR can be tested by following these steps:

* Edit a post
* Enter some focus keyphrase in the Yoast sidebar or in the Yoast metabox
* Click the button to open the modal dialog
* Observe the upsell info alert box
* Verify the link is working

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-46]
