### PR TITLE
Only add link buttons for non-hidden fields

### DIFF
--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -61,7 +61,7 @@ class WPSEO_Taxonomy_Fields_Presenter {
 		$label            = $this->get_label( $field_configuration['label'], $esc_field_name );
 		$field            = $this->get_field( $field_configuration['type'], $esc_field_name, $this->get_field_value( $field_name ), $options );
 		$help_button_text = isset( $field_configuration['options']['help-button'] ) ? $field_configuration['options']['help-button'] : '';
-		$help             = $field_configuration['type'] === 'hidden' ? '' : new WPSEO_Admin_Help_Button( 'https://yoast.com/show-x-in-search-results/', $help_button_text );
+		$help             = ( $field_configuration['type'] === 'hidden' ) ? '' : new WPSEO_Admin_Help_Button( 'https://yoast.com/show-x-in-search-results/', $help_button_text );
 
 		return $this->parse_row( $label, $help, $field );
 	}

--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -61,7 +61,7 @@ class WPSEO_Taxonomy_Fields_Presenter {
 		$label            = $this->get_label( $field_configuration['label'], $esc_field_name );
 		$field            = $this->get_field( $field_configuration['type'], $esc_field_name, $this->get_field_value( $field_name ), $options );
 		$help_button_text = isset( $field_configuration['options']['help-button'] ) ? $field_configuration['options']['help-button'] : '';
-		$help             = new WPSEO_Admin_Help_Button( 'https://yoast.com/show-x-in-search-results/', $help_button_text );
+		$help             = $field_configuration['type'] === 'hidden' ? '' : new WPSEO_Admin_Help_Button( 'https://yoast.com/show-x-in-search-results/', $help_button_text );
 
 		return $this->parse_row( $label, $help, $field );
 	}
@@ -210,7 +210,7 @@ class WPSEO_Taxonomy_Fields_Presenter {
 	 *
 	 * @return string
 	 */
-	private function parse_row( $label, WPSEO_Admin_Help_Button $help, $field ) {
+	private function parse_row( $label, $help, $field ) {
 		if ( $label !== '' || $help !== '' ) {
 			return $label . $help . $field;
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In [this commit](https://github.com/Yoast/wordpress-seo/commit/a0034a53d3c07c29af748abb22940f121f70cd66#diff-4a28d28b5c9cf861ebe0a4e82231f591R64) a help link was added to all fields. Unfortunately, it also adds that link to all hidden fields, which causes problems (styling issues and lots of duplicate links):
![image (4)](https://user-images.githubusercontent.com/26220788/85395633-ba8c7600-b550-11ea-90a5-d4e4114e481b.png)

This fix will only render links for non-hidden fields. 

But besides fixing the bug, I wonder why we always add that specific URL to our input fields on taxonomies.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where too many links to help articles would render in the metabox.

## Relevant technical choices:

* I've only disabled the help button for hidden fields.
* I am not sure we should hard-code the URL introduced in [this commit](https://github.com/Yoast/wordpress-seo/commit/a0034a53d3c07c29af748abb22940f121f70cd66#diff-4a28d28b5c9cf861ebe0a4e82231f591R64) but I don't have enough context to decide. Perhaps @jdevalk can comment on what the goal was here.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout `trunk`, verify that there are styling issues in the metabox when editing a term/taxonomy. Search in your browser's inspector for "show-x-in-search-results" and notice that there are a lot of links at the top of the metabox (with different names but always that same href).
* Checkout this branch `only-add-help-button-for-non-hidden-fields` and verify that the links and styling errors are gone.


