### PR TITLE
Add SEMrush "request failed" content

### DIFF
--- a/js/src/components/RelatedKeyPhrasesModal.js
+++ b/js/src/components/RelatedKeyPhrasesModal.js
@@ -14,6 +14,7 @@ import CountrySelector from "./modals/CountrySelector";
 import KeyphrasesTable from "./modals/KeyphrasesTable";
 import YoastIcon from "../../../images/Yoast_icon_kader.svg";
 import SemRushLimitReached from "./modals/SemRushLimitReached";
+import SemRushRequestFailed from "./modals/SemRushRequestFailed";
 
 /**
  * Redux container for the RelatedKeyPhrasesModal modal.
@@ -101,6 +102,7 @@ class RelatedKeyPhrasesModal extends Component {
 							className="yoast-gutenberg-modal__content yoast-related-keyphrases-modal__content"
 						>
 							<SemRushLimitReached />
+							<SemRushRequestFailed />
 							<CountrySelector />
 							<KeyphrasesTable />
 							<h2>Debug info</h2>

--- a/js/src/components/modals/SemRushRequestFailed.js
+++ b/js/src/components/modals/SemRushRequestFailed.js
@@ -1,0 +1,25 @@
+/* External dependencies */
+import React from "react";
+import { Fragment } from "@wordpress/element";
+import { __ } from "@wordpress/i18n";
+import { Alert } from "@yoast/components";
+
+/**
+ * Creates the content for the SEMrush request failed modal.
+ *
+ * @returns {React.Element} The SEMrush request failed modal content.
+ */
+const SemRushRequestFailed = () => {
+	return (
+		<p>
+			<Alert type="error">
+				{ __(
+					"We've encountered a problem trying to get related keyphrases. Please try again later.",
+					"wordpress-seo"
+				) }
+			</Alert>
+		</p>
+	);
+};
+
+export default SemRushRequestFailed;

--- a/js/src/components/modals/SemRushRequestFailed.js
+++ b/js/src/components/modals/SemRushRequestFailed.js
@@ -1,6 +1,5 @@
 /* External dependencies */
 import React from "react";
-import { Fragment } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Alert } from "@yoast/components";
 

--- a/js/src/components/modals/SemRushRequestFailed.js
+++ b/js/src/components/modals/SemRushRequestFailed.js
@@ -1,6 +1,8 @@
 /* External dependencies */
 import React from "react";
 import { __ } from "@wordpress/i18n";
+
+/* Yoast dependencies */
 import { Alert } from "@yoast/components";
 
 /**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds content for the SEMrush modal dialog for the scenario where the request to get related keyphrases from SEMrush fails. 

## Relevant technical choices:

* Introduces a simple `SemRushRequestFailed` component in the `components/modals` directory
* The component is added to the `RelatedKeyPhrasesModal` for testing purposes.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* In `wordpress-seo/js/src/components/RelatedKeyPhrasesModal.js`, in `ModalContainer`, comment out all but `<SemRushRequestFailed />`
* Run `grunt build:js`
* In the backend, go to `Posts` and edit a post
* In the Yoast sidebar or metabox, click "Get related keyphrases"
* Verify the content follows the design as shown below:

<img width="300" alt="Screenshot 2020-06-23 at 13 31 23" src="https://user-images.githubusercontent.com/43582255/85398660-d9d9d200-b555-11ea-9cba-825589d28f7d.png">


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-38]
