### PR TITLE
FRO-126 Remove strong tag in Content types

### DIFF
--- a/admin/views/tabs/metas/paper-content/post_type/post-type.php
+++ b/admin/views/tabs/metas/paper-content/post_type/post-type.php
@@ -27,7 +27,7 @@ $yform->show_hide_switch(
 $yform->show_hide_switch(
 	'display-metabox-pt-' . $wpseo_post_type->name,
 	/* translators: %s expands to an indexable object's name, like a post type or taxonomy */
-	sprintf( __( 'Show SEO settings for %1$s', 'wordpress-seo' ), '<strong>' . $wpseo_post_type->labels->name . '</strong>' )
+	sprintf( __( 'Show SEO settings for %1$s', 'wordpress-seo' ), $wpseo_post_type->labels->name )
 );
 
 $editor = new WPSEO_Replacevar_Editor(

--- a/admin/views/tabs/metas/paper-content/taxonomy-content.php
+++ b/admin/views/tabs/metas/paper-content/taxonomy-content.php
@@ -50,7 +50,7 @@ if ( $wpseo_taxonomy->name !== 'post_format' ) {
 	$yform->show_hide_switch(
 		'display-metabox-tax-' . $wpseo_taxonomy->name,
 		/* translators: %s expands to an indexable object's name, like a post type or taxonomy */
-		sprintf( __( 'Show SEO settings for %1$s', 'wordpress-seo' ), '<strong>' . $title . '</strong>' )
+		sprintf( __( 'Show SEO settings for %1$s', 'wordpress-seo' ), $title )
 	);
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Removes the unnecessary `strong` tag in the `Content Types` tabs

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the unnecessary `strong` tag in the `Content Types` tabs

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Pull this branch
* Pull the `developer` branch of the `javascript` repo
* Link the `monorepo`
* Build the plugin
* In the `Content Types` tab in the `Search Appearance` page check if the `strong` tag isn't visible anymore in the `Show SEO settings for Posts` text

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/FRO-126
