### PR TITLE
P3-3 Create "Max number related keyphrases entered" content

### DIFF
--- a/js/src/components/RelatedKeyPhrasesModal.js
+++ b/js/src/components/RelatedKeyPhrasesModal.js
@@ -17,6 +17,7 @@ import SemRushLimitReached from "./modals/SemRushLimitReached";
 import SemRushRequestFailed from "./modals/SemRushRequestFailed";
 import SemRushLoading from "./modals/SemRushLoading";
 import SemRushUpsellAlert from "./modals/SemRushUpsellAlert";
+import SemRushMaxRelatedKeyphrases from "./modals/SemRushMaxRelatedKeyphrases";
 
 /**
  * Redux container for the RelatedKeyPhrasesModal modal.
@@ -82,7 +83,7 @@ class RelatedKeyPhrasesModal extends Component {
 	 * @returns {React.Element} The RelatedKeyPhrasesModal modal component.
 	 */
 	render() {
-		const { keyphrase, location } = this.props;
+		const { keyphrase, location, maxRelatedKeyphrasesEntered } = this.props;
 
 		return (
 			<Fragment>
@@ -105,7 +106,9 @@ class RelatedKeyPhrasesModal extends Component {
 							className="yoast-gutenberg-modal__content yoast-related-keyphrases-modal__content"
 						>
 							{ this.state.isLoading && <SemRushLoading /> }
-
+							{ maxRelatedKeyphrasesEntered && (
+								<SemRushMaxRelatedKeyphrases />
+							) }
 							<SemRushUpsellAlert />
 							<SemRushLimitReached />
 							<SemRushRequestFailed />
@@ -127,11 +130,13 @@ class RelatedKeyPhrasesModal extends Component {
 RelatedKeyPhrasesModal.propTypes = {
 	keyphrase: PropTypes.string,
 	location: PropTypes.string,
+	maxRelatedKeyphrasesEntered: PropTypes.bool,
 };
 
 RelatedKeyPhrasesModal.defaultProps = {
 	keyphrase: "",
 	location: "",
+	maxRelatedKeyphrasesEntered: false,
 };
 
 /**

--- a/js/src/components/modals/SemRushMaxRelatedKeyphrases.js
+++ b/js/src/components/modals/SemRushMaxRelatedKeyphrases.js
@@ -1,0 +1,31 @@
+/* External dependencies */
+import React from "react";
+import { __, sprintf } from "@wordpress/i18n";
+
+/* Yoast dependencies */
+import { Alert } from "@yoast/components";
+
+/**
+ * Creates the content for the Maximum related keyphrases alert.
+ *
+ * @returns {React.Element} The Maximum related keyphrases alert.
+ */
+const SemRushMaxRelatedKeyphrases = () => {
+	return (
+		<Alert type="warning">
+			{
+				sprintf(
+					/* translators: %s: Expands to "Yoast SEO". */
+					__(
+						// eslint-disable-next-line max-len
+						"You've reached the maximum amount of 4 related keyphrases. You can change or remove related keyphrases in the %s metabox or sidebar.",
+						"wordpress-seo",
+					),
+					"Yoast SEO",
+				)
+			}
+		</Alert>
+	);
+};
+
+export default SemRushMaxRelatedKeyphrases;


### PR DESCRIPTION
## Context

* Users of the premium plugin can use the SEMrush integration to look for related keyphrases and add them to the Yoast SEO analysis. A maximum number of 4 related keyphrases (whether they've been added via SEM rush or not) can be added.

## Summary

This PR can be summarized in the following changelog entry:

* Add a alert box to be displayed conditionally in the SEMrush modal for Premium, if user can't add any new related keyphrase.

## Relevant technical choices:

* Introduce a simple SemRushMaxRelatedKeyphrases in the `modals` directory.
* The alert will be conditionally displayed based of what we get from the Redux store about the number of related keyphrases.
* It shouldn't be rendered at all on the free plugin.

## Screenshot:

![Schermata a 2020-06-23 16-59-35](https://user-images.githubusercontent.com/15989132/85420052-08b27100-b573-11ea-832b-5c22eed5ea4e.png)


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* build the JS with `grunt build:js`
* Edit a post
* Enter some focus keyphrase in the Yoast sidebar or in the Yoast metabox
* Click the button to open the modal dialog
* Observe the "max related keyphrases" alert missing
* edit `js/src/components/RelatedKeyPhrasesModal.js` 
* at line 139, change the default value of `maxRelatedKeyphrasesEntered` from `false` to `true`  
* build the JS with `grunt build:js`
* Edit a post
* Enter some focus keyphrase in the Yoast sidebar or in the Yoast metabox
* Click the button to open the modal dialog
* Observe the "max related keyphrases" alert.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-3]
