### PR TITLE
Moved the import of window.wp.blockEditor components to the render funtions where they are used.

### DIFF
--- a/js/src/inline-links/edit-link.js
+++ b/js/src/inline-links/edit-link.js
@@ -12,10 +12,6 @@ import {
 	isCollapsed,
 } from "@wordpress/rich-text";
 import { isURL, isEmail } from "@wordpress/url";
-import {
-	RichTextToolbarButton,
-	RichTextShortcut,
-} from "@wordpress/block-editor";
 import { decodeEntities } from "@wordpress/html-entities";
 
 /**
@@ -116,6 +112,19 @@ export const link = {
 					value,
 					onChange,
 				} = this.props;
+
+				/*
+				 * We need to import this right here, since we can only know for sure
+				 * that we are in the block editor when rendering this component.
+				 *
+				 * We can't tell WordPress that "wp-block-editor" script is a dependency
+				 * when loading this JavaScript, since we cannot tell if the edit
+				 * page is using the classic or block editor.
+				 */
+				const {
+					RichTextToolbarButton,
+					RichTextShortcut,
+				} = window.wp.blockEditor;
 
 				return (
 					<Fragment>

--- a/js/src/inline-links/inline.js
+++ b/js/src/inline-links/inline.js
@@ -11,7 +11,6 @@ import { __, sprintf } from "@wordpress/i18n";
 import { withSpokenMessages, Popover } from "@wordpress/components";
 import { prependHTTP } from "@wordpress/url";
 import { create, insert, isCollapsed, applyFormat } from "@wordpress/rich-text";
-import { __experimentalLinkControl as LinkControl } from "@wordpress/block-editor";
 
 /**
  * Internal dependencies
@@ -233,6 +232,16 @@ function InlineLinkUI( {
 			title: sponsoredLabel,
 		},
 	];
+
+	/*
+	 * We need to import this right here, since we can only know for sure
+	 * that we are in the block editor when rendering this component.
+	 *
+	 * We can't tell WordPress that "wp-block-editor" script is a dependency
+	 * when loading this JavaScript, since we cannot tell if the edit
+	 * page is using the classic or block editor.
+	 */
+	const { __experimentalLinkControl: LinkControl } = window.wp.blockEditor;
 
 	return (
 		<Popover


### PR DESCRIPTION

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This fixes a bug where a block in the block editor would crash because some React components could not be loaded from `window.wp.blockEditor`.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where certain React components could not be loaded in the block editor, leading to blocks crashing when they were selected.

## Relevant technical choices:

* We need to import them in the render functions, since we can only know for sure that we are in the block editor when rendering the components.
  * We can't tell WordPress that `wp-block-editor` script is a dependency when loading this JavaScript, since we cannot tell if the edit page is using the classic or block editor before loading the JavaScript files.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Reproducing the bug:
* Checkout `trunk`.
* Go to a post edit page.
* Click on a block in the editor.
* The block should crash, replacing the contents with an error message.
* The console should give this error message:
  ```
  TypeError: Cannot read property 'RichTextShortcut' of undefined
    at LinkEdit.render (edit-link.js?cff4:124)
  ```

### Checking that the bug has been fixed:
* Checkout this branch.
* Go to a post edit page.
* Click on a block in the editor.
* The block should not crash.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
