### PR TITLE
Remove scoring style enqueueing to prevent yst_seo_score error

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -526,10 +526,6 @@ class WPSEO_Admin_Asset_Manager {
 				'src'  => 'dashboard-' . $flat_version,
 			],
 			[
-				'name' => 'scoring',
-				'src'  => 'yst_seo_score-' . $flat_version,
-			],
-			[
 				'name' => 'adminbar',
 				'src'  => 'adminbar-' . $flat_version,
 				'deps' => [

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -815,7 +815,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		}
 
 		$asset_manager->enqueue_style( 'metabox-css' );
-		$asset_manager->enqueue_style( 'scoring' );
 		$asset_manager->enqueue_style( 'select2' );
 		$asset_manager->enqueue_style( 'monorepo' );
 

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -124,7 +124,6 @@ class WPSEO_Taxonomy {
 		}
 
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
-		$asset_manager->enqueue_style( 'scoring' );
 		$asset_manager->enqueue_style( 'monorepo' );
 
 		$tag_id = filter_input( INPUT_GET, 'tag_ID' );
@@ -135,7 +134,6 @@ class WPSEO_Taxonomy {
 			wp_enqueue_media(); // Enqueue files needed for upload functionality.
 
 			$asset_manager->enqueue_style( 'metabox-css' );
-			$asset_manager->enqueue_style( 'scoring' );
 			$asset_manager->enqueue_script( 'term-edit' );
 
 			$yoast_components_l10n = new WPSEO_Admin_Asset_Yoast_Components_L10n();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* There is an error in the console, because the metabox and taxonomy classes cannot find `yst_seo_score` (because it is flagged for removal). I have removed the enqueueing of the style, because I believe it is no longer used. The frontend devteam should check whether that is the case.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where an error relating to `yst_seo_score` css would appear in the console on post and term edit pages.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Verify that the error is gone on post and term edit.
* Verify that there are no styling issues due to the removal of `yst_seo_score` on post-edit and term-edit.

