### PR TITLE
P2 22 Introduce indexables indexation completed option

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -158,6 +158,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'youtube_url',
 		'wikipedia_url',
 		'fbadminapp',
+		'indexables_indexation_completed',
 	];
 
 	/**
@@ -186,6 +187,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 	 * Anonimizes the WPSEO_Options array by replacing all $anonymous_settings values to 'used'.
 	 *
 	 * @param array $settings The settings.
+	 *
 	 * @return array The anonymized settings.
 	 */
 	private function anonymize_settings( $settings ) {
@@ -194,6 +196,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 				$settings[ $setting ] = 'used';
 			}
 		}
+
 		return $settings;
 	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -6,6 +6,7 @@
  */
 
 use Yoast\WP\Lib\Model;
+use Yoast\WP\SEO\Integrations\Admin\Indexation_Integration;
 
 /**
  * This code handles the option upgrades.
@@ -58,6 +59,7 @@ class WPSEO_Upgrade {
 			'14.0.3-RC0' => 'upgrade_1403',
 			'14.1-RC0'   => 'upgrade_141',
 			'14.2-RC0'   => 'upgrade_142',
+			'14.5-RC0'   => 'upgrade_145',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -768,6 +770,27 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_142() {
 		add_action( 'init', [ $this, 'remove_acf_notification_for_142' ] );
+	}
+
+	/**
+	 * Performs the 14.5 upgrade.
+	 */
+	private function upgrade_145() {
+		add_action( 'init', [ $this, 'set_indexation_completed_option_for_145' ] );
+	}
+
+	/**
+	 * Checks if the indexable indexation is completed.
+	 * If so, sets the `indexables_indexation_completed` option to `true`,
+	 * else to `false`.
+	 */
+	public function set_indexation_completed_option_for_145() {
+		/**
+		 * @var Indexation_Integration
+		 */
+		$indexation_integration = YoastSEO()->classes->get( Indexation_Integration::class );
+
+		WPSEO_Options::set( 'indexables_indexation_completed', $indexation_integration->get_total_unindexed() === 0 );
 	}
 
 	/**

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -32,6 +32,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'ignore_indexation_warning'                => false,
 		'indexation_warning_hide_until'            => false,
 		'indexation_started'                       => false,
+		'indexables_indexation_completed'          => false,
 		// Non-form field, should only be set via validation routine.
 		'version'                                  => '', // Leave default as empty to ensure activation/upgrade works.
 		'previous_version'                         => '',

--- a/src/actions/indexables/indexable-complete-indexation-action.php
+++ b/src/actions/indexables/indexable-complete-indexation-action.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Indexation action to call when the indexable indexation process is completed.
+ *
+ * @package Yoast\WP\SEO\Actions\Indexation
+ */
+
+namespace Yoast\WP\SEO\Actions\Indexation;
+
+use Yoast\WP\SEO\Helpers\Options_Helper;
+
+/**
+ * Indexation action to call when the indexable indexation process is completed.
+ */
+class Indexable_Complete_Indexation_Action {
+
+	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options;
+
+	/**
+	 * Indexable_Complete_Indexation_Action constructor.
+	 *
+	 * @param Options_Helper $options The options helper.
+	 */
+	public function __construct( Options_Helper $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * Wraps up the indexation process.
+	 *
+	 * @return array An empty array.
+	 */
+	public function complete() {
+		$this->options->set( 'indexation_started', 0 );
+		$this->options->set( 'indexables_indexation_reason', '' );
+		$this->options->set( 'indexables_indexation_completed', true );
+
+		return [];
+	}
+}

--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -13,6 +13,7 @@ use Yoast\WP\SEO\Actions\Indexation\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Type_Archive_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Term_Indexation_Action;
+use Yoast\WP\SEO\Actions\Indexation\Indexable_Complete_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexation_Action_Interface;
 use Yoast\WP\SEO\Main;
 
@@ -50,6 +51,13 @@ class Index_Command implements Command_Interface {
 	private $general_indexation_action;
 
 	/**
+	 * The complete indexation action.
+	 *
+	 * @var Indexable_Complete_Indexation_Action
+	 */
+	private $complete_indexation_action;
+
+	/**
 	 * Generate_Indexables_Command constructor.
 	 *
 	 * @param Indexable_Post_Indexation_Action              $post_indexation_action              The post indexation
@@ -60,17 +68,21 @@ class Index_Command implements Command_Interface {
 	 *                                                                                           indexation action.
 	 * @param Indexable_General_Indexation_Action           $general_indexation_action           The general indexation
 	 *                                                                                           action.
+	 * @param Indexable_Complete_Indexation_Action          $complete_indexation_action          The complete indexation
+	 *                                                                                           action.
 	 */
 	public function __construct(
 		Indexable_Post_Indexation_Action $post_indexation_action,
 		Indexable_Term_Indexation_Action $term_indexation_action,
 		Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation_action,
-		Indexable_General_Indexation_Action $general_indexation_action
+		Indexable_General_Indexation_Action $general_indexation_action,
+		Indexable_Complete_Indexation_Action $complete_indexation_action
 	) {
 		$this->post_indexation_action              = $post_indexation_action;
 		$this->term_indexation_action              = $term_indexation_action;
 		$this->post_type_archive_indexation_action = $post_type_archive_indexation_action;
 		$this->general_indexation_action           = $general_indexation_action;
+		$this->complete_indexation_action          = $complete_indexation_action;
 	}
 
 	/**
@@ -148,6 +160,8 @@ class Index_Command implements Command_Interface {
 		foreach ( $indexation_actions as $name => $indexation_action ) {
 			$this->run_indexation_action( $name, $indexation_action );
 		}
+
+		$this->complete_indexation_action->complete();
 	}
 
 	/**

--- a/src/integrations/admin/indexation-integration.php
+++ b/src/integrations/admin/indexation-integration.php
@@ -8,6 +8,7 @@
 namespace Yoast\WP\SEO\Integrations\Admin;
 
 use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Actions\Indexation\Indexable_Complete_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Type_Archive_Indexation_Action;
@@ -63,6 +64,13 @@ class Indexation_Integration implements Integration_Interface {
 	protected $general_indexation;
 
 	/**
+	 * Represented the indexation completed action.
+	 *
+	 * @var Indexable_Complete_Indexation_Action
+	 */
+	protected $complete_indexation_action;
+
+	/**
 	 * Represents tha admin asset manager.
 	 *
 	 * @var WPSEO_Admin_Asset_Manager
@@ -94,6 +102,7 @@ class Indexation_Integration implements Integration_Interface {
 	 * @param Indexable_Term_Indexation_Action              $term_indexation              The term indexation action.
 	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation The archive indexation action.
 	 * @param Indexable_General_Indexation_Action           $general_indexation           The general indexation action.
+	 * @param Indexable_Complete_Indexation_Action          $complete_indexation_action   The complete indexation action.
 	 * @param Options_Helper                                $options_helper               The options helper.
 	 * @param WPSEO_Admin_Asset_Manager                     $asset_manager                The admin asset manager.
 	 */
@@ -102,6 +111,7 @@ class Indexation_Integration implements Integration_Interface {
 		Indexable_Term_Indexation_Action $term_indexation,
 		Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation,
 		Indexable_General_Indexation_Action $general_indexation,
+		Indexable_Complete_Indexation_Action $complete_indexation_action,
 		Options_Helper $options_helper,
 		WPSEO_Admin_Asset_Manager $asset_manager
 	) {
@@ -109,6 +119,7 @@ class Indexation_Integration implements Integration_Interface {
 		$this->term_indexation              = $term_indexation;
 		$this->post_type_archive_indexation = $post_type_archive_indexation;
 		$this->general_indexation           = $general_indexation;
+		$this->complete_indexation_action   = $complete_indexation_action;
 		$this->options_helper               = $options_helper;
 		$this->asset_manager                = $asset_manager;
 	}
@@ -130,6 +141,8 @@ class Indexation_Integration implements Integration_Interface {
 		// We aren't able to determine whether or not anything needs to happen at register_hooks as post types aren't registered yet.
 		// So we do most of our add_action calls here.
 		if ( $this->get_total_unindexed() === 0 ) {
+			$this->complete_indexation_action->complete();
+
 			return;
 		}
 
@@ -145,6 +158,8 @@ class Indexation_Integration implements Integration_Interface {
 
 			return;
 		}
+
+		$this->options_helper->set( 'indexables_indexation_completed', false );
 
 		\add_action( 'admin_footer', [ $this, 'render_indexation_modal' ], 20 );
 		if ( $this->is_indexation_warning_hidden() === false ) {
@@ -238,7 +253,7 @@ class Indexation_Integration implements Integration_Interface {
 	 *
 	 * @return int
 	 */
-	protected function get_total_unindexed() {
+	public function get_total_unindexed() {
 		if ( \is_null( $this->total_unindexed ) ) {
 			$this->total_unindexed  = $this->post_indexation->get_total_unindexed();
 			$this->total_unindexed += $this->term_indexation->get_total_unindexed();

--- a/src/routes/indexable-indexation-route.php
+++ b/src/routes/indexable-indexation-route.php
@@ -8,6 +8,7 @@
 namespace Yoast\WP\SEO\Routes;
 
 use WP_REST_Response;
+use Yoast\WP\SEO\Actions\Indexation\Indexable_Complete_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Term_Indexation_Action;
@@ -137,6 +138,13 @@ class Indexable_Indexation_Route extends Abstract_Indexation_Route {
 	private $general_indexation_action;
 
 	/**
+	 * The complete indexation action.
+	 *
+	 * @var Indexable_Complete_Indexation_Action
+	 */
+	private $complete_indexation_action;
+
+	/**
 	 * Represents the options helper.
 	 *
 	 * @var Options_Helper
@@ -150,6 +158,7 @@ class Indexable_Indexation_Route extends Abstract_Indexation_Route {
 	 * @param Indexable_Term_Indexation_Action              $term_indexation_action              The term indexation action.
 	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation_action The post type archive indexation action.
 	 * @param Indexable_General_Indexation_Action           $general_indexation_action           The general indexation action.
+	 * @param Indexable_Complete_Indexation_Action          $complete_indexation_action          The complete indexation action. Called when the indexation is completed.
 	 * @param Options_Helper                                $options_helper                      The options helper.
 	 */
 	public function __construct(
@@ -157,12 +166,14 @@ class Indexable_Indexation_Route extends Abstract_Indexation_Route {
 		Indexable_Term_Indexation_Action $term_indexation_action,
 		Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation_action,
 		Indexable_General_Indexation_Action $general_indexation_action,
+		Indexable_Complete_Indexation_Action $complete_indexation_action,
 		Options_Helper $options_helper
 	) {
 		$this->post_indexation_action              = $post_indexation_action;
 		$this->term_indexation_action              = $term_indexation_action;
 		$this->post_type_archive_indexation_action = $post_type_archive_indexation_action;
 		$this->general_indexation_action           = $general_indexation_action;
+		$this->complete_indexation_action          = $complete_indexation_action;
 		$this->options_helper                      = $options_helper;
 	}
 
@@ -242,9 +253,7 @@ class Indexable_Indexation_Route extends Abstract_Indexation_Route {
 	 * Completes the indexation.
 	 */
 	public function complete() {
-		$this->options_helper->set( 'indexation_started', 0 );
-
-		return $this->respond_with( [], false );
+		return $this->respond_with( $this->complete_indexation_action->complete(), false );
 	}
 
 	/**

--- a/tests/actions/indexables/indexable-complete-indexation-action-test.php
+++ b/tests/actions/indexables/indexable-complete-indexation-action-test.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Actions\Indexation;
+
+use Yoast\WP\SEO\Actions\Indexation\Indexable_Complete_Indexation_Action;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Indexable_Complete_Indexation_Action_Test
+ *
+ * @group actions
+ * @group indexation
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Actions\Indexation\Indexable_Complete_Indexation_Action
+ */
+class Indexable_Complete_Indexation_Action_Test extends TestCase {
+
+	/**
+	 * The indexable indexation complete action under test.
+	 *
+	 * @var Indexable_Complete_Indexation_Action
+	 */
+	private $instance;
+
+	/**
+	 * The mocked options helper.
+	 *
+	 * @var \Mockery\MockInterface|Options_Helper
+	 */
+	private $options;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->options = \Mockery::mock( Options_Helper::class );
+
+		$this->instance = new Indexable_Complete_Indexation_Action(
+			$this->options
+		);
+	}
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$instance = new Indexable_Complete_Indexation_Action(
+			$this->options
+		);
+
+		$this->assertAttributeInstanceOf( Options_Helper::class, 'options', $instance );
+	}
+
+	/**
+	 * Tests the `complete` method.
+	 *
+	 * @covers ::complete
+	 */
+	public function test_complete_method() {
+		$this->options->expects( 'set' )->with( 'indexation_started', 0 );
+		$this->options->expects( 'set' )->with( 'indexables_indexation_reason', '' );
+		$this->options->expects( 'set' )->with( 'indexables_indexation_completed', true );
+
+		$this->assertEmpty( $this->instance->complete() );
+	}
+
+}

--- a/tests/commands/index-command-test.php
+++ b/tests/commands/index-command-test.php
@@ -9,6 +9,7 @@ namespace Yoast\WP\SEO\Tests\Commands;
 
 use Brain\Monkey;
 use Mockery;
+use Yoast\WP\SEO\Actions\Indexation\Indexable_Complete_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Type_Archive_Indexation_Action;
@@ -56,6 +57,13 @@ class Index_Command_Test extends TestCase {
 	private $general_indexation_action;
 
 	/**
+	 * The complete indexation action.
+	 *
+	 * @var Indexable_Complete_Indexation_Action
+	 */
+	private $complete_indexation_action;
+
+	/**
 	 * The instance
 	 *
 	 * @var Index_Command
@@ -70,12 +78,14 @@ class Index_Command_Test extends TestCase {
 		$this->term_indexation_action              = Mockery::mock( Indexable_Term_Indexation_Action::class );
 		$this->post_type_archive_indexation_action = Mockery::mock( Indexable_Post_Type_Archive_Indexation_Action::class );
 		$this->general_indexation_action           = Mockery::mock( Indexable_General_Indexation_Action::class );
+		$this->complete_indexation_action          = Mockery::mock( Indexable_Complete_Indexation_Action::class );
 
 		$this->instance = new Index_Command(
 			$this->post_indexation_action,
 			$this->term_indexation_action,
 			$this->post_type_archive_indexation_action,
-			$this->general_indexation_action
+			$this->general_indexation_action,
+			$this->complete_indexation_action
 		);
 	}
 
@@ -113,6 +123,8 @@ class Index_Command_Test extends TestCase {
 				->andReturn( \array_fill( 0, 25, true ), \array_fill( 0, 5, true ) );
 		}
 
+		$this->complete_indexation_action->expects( 'complete' )->once();
+
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
 			->times( 4 )
@@ -147,6 +159,8 @@ class Index_Command_Test extends TestCase {
 				->times( 2 )
 				->andReturn( \array_fill( 0, 25, true ), \array_fill( 0, 5, true ) );
 		}
+
+		$this->complete_indexation_action->expects( 'complete' )->once();
 
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
@@ -235,6 +249,9 @@ class Index_Command_Test extends TestCase {
 					\array_fill( 0, 5, true )
 				);
 		}
+
+		// Expect the complete action twice: once for each site in the multisite.
+		$this->complete_indexation_action->expects( 'complete' )->twice();
 
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )

--- a/tests/integrations/admin/indexation-integration-test.php
+++ b/tests/integrations/admin/indexation-integration-test.php
@@ -10,6 +10,7 @@ namespace Yoast\WP\SEO\Tests\Integrations\Admin;
 use Brain\Monkey;
 use Mockery;
 use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Actions\Indexation\Indexable_Complete_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Type_Archive_Indexation_Action;
@@ -67,6 +68,13 @@ class Indexation_Integration_Test extends TestCase {
 	private $general_indexation;
 
 	/**
+	 * Holds the general indexation action mock.
+	 *
+	 * @var Mockery\MockInterface|Indexable_Complete_Indexation_Action
+	 */
+	private $complete_indexation;
+
+	/**
 	 * Holds the options helper mock.
 	 *
 	 * @var Mockery\MockInterface|Options_Helper
@@ -88,6 +96,7 @@ class Indexation_Integration_Test extends TestCase {
 		$this->post_indexation              = Mockery::mock( Indexable_Post_Indexation_Action::class );
 		$this->term_indexation              = Mockery::mock( Indexable_Term_Indexation_Action::class );
 		$this->general_indexation           = Mockery::mock( Indexable_General_Indexation_Action::class );
+		$this->complete_indexation          = Mockery::mock( Indexable_Complete_Indexation_Action::class );
 		$this->options                      = Mockery::mock( Options_Helper::class );
 		$this->asset_manager                = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
 
@@ -96,6 +105,7 @@ class Indexation_Integration_Test extends TestCase {
 			$this->term_indexation,
 			$this->post_type_archive_indexation,
 			$this->general_indexation,
+			$this->complete_indexation,
 			$this->options,
 			$this->asset_manager
 		);
@@ -158,6 +168,10 @@ class Indexation_Integration_Test extends TestCase {
 			->expects( 'get' )
 			->with( 'ignore_indexation_warning', false )
 			->andReturn( $ignore_warning );
+
+		$this->options
+			->expects( 'set' )
+			->with( 'indexables_indexation_completed', false );
 
 		if ( ! $ignore_warning ) {
 			$this->options
@@ -268,6 +282,10 @@ class Indexation_Integration_Test extends TestCase {
 				'term'              => 0,
 			]
 		);
+
+		$this->complete_indexation
+			->expects( 'complete' )
+			->once();
 
 		// The warning and modal should not be rendered.
 		Monkey\Actions\expectAdded( 'admin_footer' )->never();

--- a/tests/routes/indexable-indexation-route-test.php
+++ b/tests/routes/indexable-indexation-route-test.php
@@ -9,6 +9,7 @@ namespace Yoast\WP\SEO\Tests\Routes;
 
 use Brain\Monkey;
 use Mockery;
+use Yoast\WP\SEO\Actions\Indexation\Indexable_Complete_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Type_Archive_Indexation_Action;
@@ -57,6 +58,13 @@ class Indexable_Indexation_Route_Test extends TestCase {
 	protected $general_indexation_action;
 
 	/**
+	 * Represents the indexation complete action.
+	 * 
+	 * @var Mockery\MockInterface|Indexable_Complete_Indexation_Action
+	 */
+	protected $complete_indexation_action;
+
+	/**
 	 * Represents the instance to test.
 	 *
 	 * @var Indexable_Indexation_Route
@@ -80,6 +88,7 @@ class Indexable_Indexation_Route_Test extends TestCase {
 		$this->term_indexation_action              = Mockery::mock( Indexable_Term_Indexation_Action::class );
 		$this->post_type_archive_indexation_action = Mockery::mock( Indexable_Post_Type_Archive_Indexation_Action::class );
 		$this->general_indexation_action           = Mockery::mock( Indexable_General_Indexation_Action::class );
+		$this->complete_indexation_action          = Mockery::mock( Indexable_Complete_Indexation_Action::class );
 		$this->options_helper                      = Mockery::mock( Options_Helper::class );
 
 		$this->instance = new Indexable_Indexation_Route(
@@ -87,6 +96,7 @@ class Indexable_Indexation_Route_Test extends TestCase {
 			$this->term_indexation_action,
 			$this->post_type_archive_indexation_action,
 			$this->general_indexation_action,
+			$this->complete_indexation_action,
 			$this->options_helper
 		);
 	}
@@ -101,6 +111,7 @@ class Indexable_Indexation_Route_Test extends TestCase {
 		$this->assertAttributeInstanceOf( Indexable_Term_Indexation_Action::class, 'term_indexation_action', $this->instance );
 		$this->assertAttributeInstanceOf( Indexable_Post_Type_Archive_Indexation_Action::class, 'post_type_archive_indexation_action', $this->instance );
 		$this->assertAttributeInstanceOf( Indexable_General_Indexation_Action::class, 'general_indexation_action', $this->instance );
+		$this->assertAttributeInstanceOf( Indexable_Complete_Indexation_Action::class, 'complete_indexation_action', $this->instance );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to set a flag to indicate that the indexation process is completed. This makes it easy to tell when it is.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets an `indexable_indexation_completed` flag in the `wpseo` option when the indexable indexation process has been completed.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this branch.
* Visit a Yoast SEO admin page (for example the SEO tools page: _SEO_ > _Tools_)
  * If you have currently more then 25 unindexed indexable, you should see a notification saying you should index your site.
  * If not, reset the indexables tables (e.g. by using the Yoast Test Helper plugin).
* In your database, check the `wpseo` option in the `wp_options` table.
  * It should have an entry for `indexables_indexation_completed` and it should be set to `0`, unless you have already run the indexation on your website.
  * **Tip**: [you can use this site to unserialize the data](https://www.unserialize.com/).
* Reset the indexables (e.g. by using the Yoast Test Helper plugin).
* Rerun the indexable indexation process.
* In your database, check the `wpseo` option again.
  * It should have an entry for `indexables_indexation_completed` and it should be set to `1`.

### To check whether the option is sent as tracking data
* Add this code to your theme's `functions.php` file.
  ```php
  add_action( 'init', function() {
    $tracker = new WPSEO_Tracking('', 1 );
    // Collect data.
    $collector = $tracker->get_collector();
    // Get as JSON data and print it.
    var_export( $collector->get_as_json() );
  } );
  ``
* Visit an admin page.
* Look in the source code of your page, you should see a JSON string at the top of the `body` element with the data that is sent.
* This data should include a `indexables_indexation_completed` option under `settings`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-22
