### PR TITLE
Make cornerstone visibility depend on both general setting AND post/term

### DIFF
--- a/js/src/containers/MetaboxFill.js
+++ b/js/src/containers/MetaboxFill.js
@@ -1,5 +1,6 @@
 import MetaboxFill from "../components/fills/MetaboxFill";
 import { connect } from "react-redux";
+import { get } from "lodash-es";
 
 /**
  * Maps the state to props.
@@ -12,6 +13,8 @@ import { connect } from "react-redux";
 function mapStateToProps( state, ownProps ) {
 	const settings = {
 		...state.preferences,
+		// Because cornerstone is only applicable to posts, not terms. Despite the general setting.
+		isCornerstoneActive: get( window, "wpseoScriptData.isPost", false ) && state.preferences.isCornerstoneActive,
 		// Because this value is initiated as an empty string.
 		displayAdvancedTab: !! window.wpseoAdminL10n.displayAdvancedTab,
 	};


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Terms now have a collapsible for the setting of cornerstone content. This is due to a misinterpretation of `isCornerstoneActive`, which is the general setting. But irrespective of that setting, cornerstone content does not apply to terms.
* Thanks @andizer for spotting.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the cornerstone content collapsible was visible when editing taxonomies, while taxonomies cannot be cornerstone content.

## Relevant technical choices:

* In the metabox fill, I've added a check that firsts tests whether we are on a post, so the isCornerstoneActive should return false for term metaboxes.
* Initially I adjusted the preferences selector `isCornerstoneContentActive()` in `isCornerstoneContentActive.js` to include the check, but I figured that selector should reflect the settings purely.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* `yarn link-monorepo` to `release/14.5` (no monorepo changes but as a workaround to another problem).
* Verify that on `wordpress-seo` `release/14.5`, there is a collapsible for cornerstone content in both posts edit and term edit metaboxes. (Also Pages etc ).
* Checkout this branch and build everything.
* Verify that for terms, the cornerstone collapsible is gone. For Posts and Pages it should still be present.


Fixes https://yoast.atlassian.net/browse/P1-31?atlOrigin=eyJpIjoiYmYzM2YwODQwYjJhNDk1M2EwZjlkMDY2MGNmNTZjMmYiLCJwIjoiaiJ9
