### PR TITLE
FRO-129 Make the input field show as one line in plugin

### DIFF
--- a/.cache/.gitkeep
+++ b/.cache/.gitkeep
@@ -1,0 +1,1 @@
+# This directory has to exist to allow cache files to be written to it.

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 # Set default behaviour, in case users don't have core.autocrlf set.
 * text=auto
 
+.cache export-ignore
 .github export-ignore
 deploy_keys export-ignore
 grunt export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tmp/
 *.bak
 *.log
 *.[Cc]ache
+!.cache
 *.cpr
 *.orig
 *.php.in

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,7 @@ cache:
   yarn: true
   directories:
     - $HOME/.composer/cache
+    - .cache
     - node_modules
 
 before_install:

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -413,12 +413,12 @@ class Yoast_Form {
 		Yoast_Input_Validation::set_error_descriptions();
 		$aria_attributes .= Yoast_Input_Validation::get_the_aria_describedby_attribute( $var );
 
-		echo '<input' . $attributes . $aria_attributes . ' class="yoast-field-group__inputfield ' . esc_attr( $attr['class'] ) . '
-		" placeholder="' . esc_attr( $attr['placeholder'] ) . '
-		" type="' . $type . '
-		" id="', esc_attr( $var ), '
-		" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']
-		" value="', esc_attr( $val ), '"', disabled( $this->is_control_disabled( $var ), true, false ), '/>', '</div>';
+		echo '<input' . $attributes . $aria_attributes . ' class="yoast-field-group__inputfield ' . esc_attr( $attr['class'] ) . '"
+		placeholder="' . esc_attr( $attr['placeholder'] ) . '"
+		type="' . $type . '"
+		id="', esc_attr( $var ), '"
+		name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']"
+		value="', esc_attr( $val ), '"', disabled( $this->is_control_disabled( $var ), true, false ), '/>', '</div>';
 
 		echo Yoast_Input_Validation::get_the_error_description( $var );
 	}

--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -83,7 +83,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 
 		if ( has_post_thumbnail( $post_id ) ) {
 			$featured_image_info = wp_get_attachment_image_src( get_post_thumbnail_id( $post_id ), 'thumbnail' );
-			return $featured_image_info[0];
+			return isset( $featured_image_info[0] ) ? $featured_image_info[0] : null;
 		}
 
 		return WPSEO_Image_Utils::get_first_usable_content_image_for_post( $post_id );

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -400,6 +400,9 @@ class WPSEO_Addon_Manager {
 	 * @return array The plugins.
 	 */
 	protected function get_plugins() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
 		return get_plugins();
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Make the input fields show on one line in the code

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes the input fields show on one line in the code

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Pull this branch
* Pull the develop branch of the javascript repo and link it
* Build the plugin
* Check the Linkedin input field on the social page if it's on one line in the code

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/FRO-129
