### PR TITLE
Disable WP core sitemaps

### DIFF
--- a/src/integrations/disable-core-sitemaps.php
+++ b/src/integrations/disable-core-sitemaps.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Frontend
+ */
+
+namespace Yoast\WP\SEO\Integrations;
+
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+
+/**
+ * Triggers database migrations and handles results.
+ */
+class Disable_Core_Sitemaps implements Integration_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * Disable the WP core XML sitemaps.
+	 */
+	public function register_hooks() {
+		add_filter( 'wp_sitemaps_is_enabled', '__return_false' );
+	}
+}

--- a/src/integrations/disable-core-sitemaps.php
+++ b/src/integrations/disable-core-sitemaps.php
@@ -20,6 +20,6 @@ class Disable_Core_Sitemaps implements Integration_Interface {
 	 * Disable the WP core XML sitemaps.
 	 */
 	public function register_hooks() {
-		add_filter( 'wp_sitemaps_is_enabled', '__return_false' );
+		\add_filter( 'wp_sitemaps_is_enabled', '__return_false' );
 	}
 }

--- a/src/integrations/disable-core-sitemaps.php
+++ b/src/integrations/disable-core-sitemaps.php
@@ -20,6 +20,6 @@ class Disable_Core_Sitemaps implements Integration_Interface {
 	 * Disable the WP core XML sitemaps.
 	 */
 	public function register_hooks() {
-		\add_filter( 'wp_sitemaps_is_enabled', '__return_false' );
+		\add_filter( 'wp_sitemaps_enabled', '__return_false' );
 	}
 }

--- a/tests/integrations/disable-core-sitemaps-test.php
+++ b/tests/integrations/disable-core-sitemaps-test.php
@@ -42,7 +42,7 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 	public function test_register_hooks() {
 		$this->instance->register_hooks();
 
-		$this->assertTrue( \has_filter( 'wp_sitemaps_is_enabled', '__return_false' ), 'Does not have expected wp_sitemaps_is_enabled filter' );
+		$this->assertTrue( \has_filter( 'wp_sitemaps_enabled', '__return_false' ), 'Does not have expected wp_sitemaps_is_enabled filter' );
 	}
 
 }

--- a/tests/integrations/disable-core-sitemaps-test.php
+++ b/tests/integrations/disable-core-sitemaps-test.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package Yoast\YoastSEO\Integrations
+ */
+
+namespace Yoast\WP\SEO\Tests\Integrations;
+
+use Mockery;
+use Yoast\WP\SEO\Integrations\Disable_Core_Sitemaps;
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Unit Test Class.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Disable_Core_Sitemaps
+ *
+ * @group integrations
+ */
+class Disable_Core_Sitemaps_Test extends TestCase {
+	/**
+	 * Represents the instance we are testing.
+	 *
+	 * @var Mockery\MockInterface|Disable_Core_Sitemaps
+	 */
+	private $instance;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = Mockery::mock( Disable_Core_Sitemaps::class )->makePartial();
+	}
+
+	/**
+	 * Tests the situation when primary term id isn't to the category id, the id should get updated.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertTrue( \has_filter( 'wp_sitemaps_is_enabled', '__return_false' ), 'Does not have expected wp_sitemaps_is_enabled filter' );
+	}
+
+}

--- a/tests/integrations/disable-core-sitemaps-test.php
+++ b/tests/integrations/disable-core-sitemaps-test.php
@@ -7,7 +7,6 @@
 
 namespace Yoast\WP\SEO\Tests\Integrations;
 
-use Mockery;
 use Yoast\WP\SEO\Integrations\Disable_Core_Sitemaps;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -22,7 +21,7 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 	/**
 	 * Represents the instance we are testing.
 	 *
-	 * @var Mockery\MockInterface|Disable_Core_Sitemaps
+	 * @var Disable_Core_Sitemaps
 	 */
 	private $instance;
 
@@ -32,7 +31,7 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->instance = Mockery::mock( Disable_Core_Sitemaps::class )->makePartial();
+		$this->instance = new Disable_Core_Sitemaps();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the WP Core sitemaps as introduced in WordPress 5.5.

## Relevant technical choices:

* Ours are better.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check out 5.5, see that the core sitemaps are disabled.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes PROD-190
