### PR TITLE
Refactor: remove React references in favor of @wordpress/element

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,15 +18,21 @@ rules:
   react/prop-types: 1
   react/require-default-props: 1
   no-restricted-imports:
-	  - error
-	  - name: react
-        message: Please use @wordpress/element instead. No need to import just for JSX.
-	  - name: react-dom
-	    message: Please use @wordpress/element instead.
+    - error
+    - name: react
+      message: Please use @wordpress/element instead. No need to import just for JSX.
+    - name: react-dom
+      message: Please use @wordpress/element instead.
 
   # Disabled rules
   # In the editor, we're using the pragma `wp.element.createElement`
   react/react-in-jsx-scope: 0
+
+overrides:
+  - files:
+    - "js/tests/**/*.js"
+    rules:
+      no-restricted-imports: "off"
 
 settings:
   react:

--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,12 @@ rules:
   react/no-unused-prop-types: 1
   react/prop-types: 1
   react/require-default-props: 1
+  no-restricted-imports:
+	  - error
+	  - name: react
+        message: Please use @wordpress/element instead. No need to import just for JSX.
+	  - name: react-dom
+	    message: Please use @wordpress/element instead.
 
   # Disabled rules
   # In the editor, we're using the pragma `wp.element.createElement`

--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 137,
+			maxWarnings: 126,
 		},
 	},
 	tests: {

--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -4,8 +4,7 @@ import { MultiSelect, Select } from "@yoast/components";
 import { RadioButtonGroup } from "@yoast/components";
 import { TextInput } from "@yoast/components";
 import { curryUpdateToHiddenInput, getValueFromHiddenInput } from "@yoast/helpers";
-import { Component } from "@wordpress/element";
-import { Fragment } from "react";
+import { Component, Fragment } from "@wordpress/element";
 import { Alert } from "@yoast/components";
 
 /**

--- a/js/src/components/AnalysisUpsell.js
+++ b/js/src/components/AnalysisUpsell.js
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { __, sprintf } from "@wordpress/i18n";
@@ -39,7 +38,7 @@ const OutboundLinkButton = makeOutboundLink( UpsellLinkButton );
  *
  * @param {Object} props The component's props.
  *
- * @returns {ReactElement} The rendered AnalysisUpsell component.
+ * @returns {wp.Element} The rendered AnalysisUpsell component.
  */
 const AnalysisUpsell = ( props ) => {
 	const {

--- a/js/src/components/CollapsibleCornerstone.js
+++ b/js/src/components/CollapsibleCornerstone.js
@@ -1,5 +1,4 @@
 /* globals wpseoAdminL10n */
-import React from "react";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 
@@ -14,7 +13,7 @@ const LearnMoreLink = makeOutboundLink();
 /**
  * Renders the collapsible cornerstone toggle.
  *
- * @returns {ReactElement} The collapsible cornerstone toggle component.
+ * @returns {wp.Element} The collapsible cornerstone toggle component.
  * @constructor
  */
 export default function CollapsibleCornerstone( { isCornerstone, onChange } ) {

--- a/js/src/components/CompanyInfoMissing.js
+++ b/js/src/components/CompanyInfoMissing.js
@@ -2,7 +2,6 @@
 import { sprintf } from "@wordpress/i18n";
 import interpolateComponents from "interpolate-components";
 import PropTypes from "prop-types";
-import React from "react";
 
 /* Yoast dependencies */
 import { Alert } from "@yoast/components";
@@ -17,7 +16,7 @@ const OutboundLink = makeOutboundLink();
  *
  * @param {Object} props The properties to use.
  *
- * @returns {React.Component} The Alert component.
+ * @returns {wp.Element} The Alert component.
  */
 const CompanyInfoMissing = ( props ) => {
 	return <Alert type={ props.type }>

--- a/js/src/components/CompanyInfoMissingOnboardingWizard.js
+++ b/js/src/components/CompanyInfoMissingOnboardingWizard.js
@@ -1,7 +1,6 @@
 /* External dependencies */
 import { isEmpty } from "lodash-es";
 import PropTypes from "prop-types";
-import React from "react";
 
 /* Yoast dependencies */
 import CompanyInfoMissing from "./CompanyInfoMissing";
@@ -13,7 +12,7 @@ import CompanyInfoMissing from "./CompanyInfoMissing";
  *
  * @param {Object} props The properties to use.
  *
- * @returns {React.Component} The Alert component.
+ * @returns {wp.Element} The Alert component.
  */
 const CompanyInfoMissingOnboardingWizard = ( { properties, stepState } ) => {
 	const isCompanyInfoMissing = isEmpty( stepState.fieldValues[ "publishing-entity" ].publishingEntityCompanyName ) ||

--- a/js/src/components/CornerstoneToggle.js
+++ b/js/src/components/CornerstoneToggle.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { Toggle } from "@yoast/components";
@@ -12,11 +12,11 @@ const Cornerstone = styled.div`
 /**
  * The CornerstoneToggle Component.
  */
-class CornerstoneToggle extends React.Component {
+class CornerstoneToggle extends Component {
 	/**
 	 * Renders the CornerstoneToggle component.
 	 *
-	 * @returns {ReactElement} the CornerstoneToggle component.
+	 * @returns {wp.Element} the CornerstoneToggle component.
 	 */
 	render() {
 		return (

--- a/js/src/components/FinalStep.js
+++ b/js/src/components/FinalStep.js
@@ -1,14 +1,14 @@
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 
 /**
  * @summary Final step in the wizard component.
  */
-class FinalStep extends React.Component {
+class FinalStep extends Component {
 	/**
 	 * Renders the video next to the final congratulation message for completing the wizard
 	 *
-	 * @returns {JSX.Element} A HTML paragraph element containing the Final Step response.
+	 * @returns {wp.Element} A HTML paragraph element containing the Final Step response.
 	 */
 	render() {
 		return (

--- a/js/src/components/IntlProvider.js
+++ b/js/src/components/IntlProvider.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { IntlProvider as IntlProviderOriginal } from "react-intl";
 
@@ -7,7 +7,7 @@ import { IntlProvider as IntlProviderOriginal } from "react-intl";
  *
  * This component will render an IntlProvider when the locale-data promise is resolved.
  */
-class IntlProvider extends React.Component {
+class IntlProvider extends Component {
 	/**
 	 * Renders the provider component.
 	 *

--- a/js/src/components/LocalSEOUpsell.js
+++ b/js/src/components/LocalSEOUpsell.js
@@ -63,7 +63,7 @@ const OutboundLink = styled( utils.makeOutboundLink() )`
  * @param {string} props.url           The url the outbound link goes to.
  * @param {string} props.backgroundUrl The url for the background image of the container.
  *
- * @returns {ReactElement} The rendered LocalSEOUpsell component.
+ * @returns {wp.Element} The rendered LocalSEOUpsell component.
  */
 const LocalSEOUpsell = props => {
 	const { url, backgroundUrl } = props;

--- a/js/src/components/MailchimpSignup.js
+++ b/js/src/components/MailchimpSignup.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { localize } from "yoast-components";
 import { LoadingIndicator } from "@yoast/configuration-wizard";
@@ -7,7 +7,7 @@ import { sendRequest } from "@yoast/helpers";
 /**
  * @summary Mailchimp signup component.
  */
-class MailchimpSignup extends React.Component {
+class MailchimpSignup extends Component {
 	/**
 	 * @summary Constructs the Mailchimp signup component.
 	 *
@@ -191,7 +191,7 @@ class MailchimpSignup extends React.Component {
 	/**
 	 * @summary Renders the Mailchimp component.
 	 *
-	 * @returns {JSX.Element} Rendered Mailchimp Component.
+	 * @returns {wp.Element} Rendered Mailchimp Component.
 	 */
 	render() {
 		if ( this.skipRendering() ) {

--- a/js/src/components/MediaUpload.js
+++ b/js/src/components/MediaUpload.js
@@ -1,5 +1,5 @@
 /* global wp */
-import React, { createRef } from "react";
+import { Component, createRef } from "@wordpress/element";
 import PropTypes from "prop-types";
 import RaisedButton from "material-ui/RaisedButton";
 import { localize } from "yoast-components";
@@ -7,7 +7,7 @@ import { localize } from "yoast-components";
 /**
  * @summary Media upload component.
  */
-class MediaUpload extends React.Component {
+class MediaUpload extends Component {
 	constructor( props ) {
 		super( props );
 
@@ -88,7 +88,7 @@ class MediaUpload extends React.Component {
 	/**
 	 * Renders a remove button when an image is set.
 	 *
-	 * @returns {ReactElement} The button element.
+	 * @returns {wp.Element} The button element.
 	 */
 	renderRemoveButton() {
 		if ( ! this.state.currentUpload ) {
@@ -108,7 +108,7 @@ class MediaUpload extends React.Component {
 	/**
 	 * Renders the image when available.
 	 *
-	 * @returns {ReactElement} The image element.
+	 * @returns {wp.Element} The image element.
 	 */
 	renderImage() {
 		if ( ! this.state.currentUpload ) {
@@ -127,7 +127,7 @@ class MediaUpload extends React.Component {
 	/**
 	 * Renders the output.
 	 *
-	 * @returns {JSX.Element} The rendered HTML.
+	 * @returns {wp.Element} The rendered HTML.
 	 */
 	render() {
 		return (

--- a/js/src/components/ModalButtonContainer.js
+++ b/js/src/components/ModalButtonContainer.js
@@ -1,4 +1,3 @@
-import React from "react";
 import ModalIntl from "./modals/Modal";
 import IntlProvider from "./IntlProvider";
 import PropTypes from "prop-types";

--- a/js/src/components/PrimaryTaxonomyFilter.js
+++ b/js/src/components/PrimaryTaxonomyFilter.js
@@ -1,8 +1,7 @@
 /* global window */
 /* External dependencies */
-import React from "react";
 import PropTypes from "prop-types";
-import { Fragment } from "@wordpress/element";
+import { Component, Fragment } from "@wordpress/element";
 import {
 	get,
 	values,
@@ -21,7 +20,7 @@ const ErrorContainer = styled.div`
 	margin: 16px 0 8px;
 `;
 
-class PrimaryTaxonomyFilter extends React.Component {
+class PrimaryTaxonomyFilter extends Component {
 	constructor() {
 		super();
 
@@ -61,7 +60,7 @@ class PrimaryTaxonomyFilter extends React.Component {
 	/**
 	 * Renders the PrimaryTaxonomyFilter component.
 	 *
-	 * @returns {ReactElement} The rendered PrimaryTaxonomyFilter.
+	 * @returns {wp.Element} The rendered PrimaryTaxonomyFilter.
 	 */
 	render() {
 		const {

--- a/js/src/components/PrimaryTaxonomyPicker.js
+++ b/js/src/components/PrimaryTaxonomyPicker.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 import {
 	withSelect,
@@ -22,7 +22,7 @@ const PrimaryTaxonomyPickerField = styled.div`
 /**
  * A component for selecting a primary taxonomy term.
  */
-class PrimaryTaxonomyPicker extends React.Component {
+class PrimaryTaxonomyPicker extends Component {
 	constructor( props ) {
 		super( props );
 
@@ -216,7 +216,7 @@ class PrimaryTaxonomyPicker extends React.Component {
 	/**
 	 * Renders the PrimaryTaxonomyPicker component.
 	 *
-	 * @returns {ReactElement} The rendered component.
+	 * @returns {wp.Element} The rendered component.
 	 */
 	render() {
 		const {

--- a/js/src/components/RaisedDefaultButton.js
+++ b/js/src/components/RaisedDefaultButton.js
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 import RaisedButton from "material-ui/RaisedButton";
 

--- a/js/src/components/RaisedNextStepButton.js
+++ b/js/src/components/RaisedNextStepButton.js
@@ -1,4 +1,3 @@
-import React from "react";
 import RaisedDefaultButton from "./RaisedDefaultButton";
 import ArrowForwardIcon from "material-ui/svg-icons/navigation/arrow-forward";
 

--- a/js/src/components/RaisedURLButton.js
+++ b/js/src/components/RaisedURLButton.js
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 import RaisedDefaultButton from "./RaisedDefaultButton";
 import InfoIcon from "material-ui/svg-icons/action/info";
@@ -7,7 +6,7 @@ import InfoIcon from "material-ui/svg-icons/action/info";
  * Raised Button with a default info icon and a required URL
  *
  * @param {Object} props The list of props for this element.
- * @returns {JSX.Element} A RaisedDefaultButton element with supplied URL and Icon.
+ * @returns {wp.Element} A RaisedDefaultButton element with supplied URL and Icon.
  * @constructor
  */
 const RaisedURLButton = ( props ) => {

--- a/js/src/components/RaisedURLNewWindowButton.js
+++ b/js/src/components/RaisedURLNewWindowButton.js
@@ -1,5 +1,4 @@
 // External dependencies.
-import React from "react";
 import PropTypes from "prop-types";
 import InfoIcon from "material-ui/svg-icons/action/info";
 import { makeOutboundLink } from "@yoast/helpers";

--- a/js/src/components/SettingsReplacementVariableEditor.js
+++ b/js/src/components/SettingsReplacementVariableEditor.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { SettingsSnippetEditor } from "@yoast/search-metadata-previews";
 import { __ } from "@wordpress/i18n";
@@ -12,11 +12,15 @@ import {
 import SnippetPreviewSection from "./SnippetPreviewSection";
 import linkHiddenFields, { linkFieldsShape } from "./higherorder/linkHiddenField";
 
-class SettingsReplacementVariableEditor extends React.Component {
-	constructor( props ) {
-		super( props );
-	}
-
+/**
+ * Component class for the Settings replacement variable editor.
+ */
+class SettingsReplacementVariableEditor extends Component {
+	/**
+	 * Renders the component.
+	 *
+	 * @returns {wp.Element} The component.
+	 */
 	render() {
 		const {
 			title,

--- a/js/src/components/SettingsReplacementVariableEditors.js
+++ b/js/src/components/SettingsReplacementVariableEditors.js
@@ -52,7 +52,7 @@ class SettingsReplacementVariableEditors extends Component {
 	 * DOM.
 	 *
 	 * @returns {Array<wp.Element>} An array of portals to instances of the
-	 *                                settings replacement variable editor.
+	 *                              settings replacement variable editor.
 	 */
 	renderEditors() {
 		return map( this.props.editorElements, ( targetElement ) => {
@@ -93,7 +93,7 @@ class SettingsReplacementVariableEditors extends Component {
 	 * existing (hidden) input in the DOM.
 	 *
 	 * @returns {Array<wp.Element>} An array of portals to instances of the
-	 *                                settings replacement variable field.
+	 *                              settings replacement variable field.
 	 */
 	renderSingleFields() {
 		return map( this.props.singleFieldElements, ( targetElement ) => {

--- a/js/src/components/SettingsReplacementVariableEditors.js
+++ b/js/src/components/SettingsReplacementVariableEditors.js
@@ -51,7 +51,7 @@ class SettingsReplacementVariableEditors extends Component {
 	 * The *-field-id attributes should point to existing (hidden) inputs in the
 	 * DOM.
 	 *
-	 * @returns {Array<ReactElement>} An array of portals to instances of the
+	 * @returns {Array<wp.Element>} An array of portals to instances of the
 	 *                                settings replacement variable editor.
 	 */
 	renderEditors() {
@@ -92,7 +92,7 @@ class SettingsReplacementVariableEditors extends Component {
 	 * properly. The data-react-replacevar-field-id attribute should point to an
 	 * existing (hidden) input in the DOM.
 	 *
-	 * @returns {Array<ReactElement>} An array of portals to instances of the
+	 * @returns {Array<wp.Element>} An array of portals to instances of the
 	 *                                settings replacement variable field.
 	 */
 	renderSingleFields() {
@@ -124,7 +124,7 @@ class SettingsReplacementVariableEditors extends Component {
 	/**
 	 * Renders the SettingsReplacementVariableEditors element.
 	 *
-	 * @returns {ReactElement} A fragment containing all editor instances.
+	 * @returns {wp.Element} A fragment containing all editor instances.
 	 */
 	render() {
 		return (

--- a/js/src/components/SettingsReplacementVariableField.js
+++ b/js/src/components/SettingsReplacementVariableField.js
@@ -1,5 +1,5 @@
 /* External dpendencies */
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 import {
 	ReplacementVariableEditor,
@@ -19,7 +19,15 @@ const SnippetEditorWidthContainer = styled.div`
 	max-width: 640px;
 `;
 
-class SettingsReplacementVariableField extends React.Component {
+/**
+ * Component class for the Settings replacement variable field.
+ */
+class SettingsReplacementVariableField extends Component {
+	/**
+	 * Constructor.
+	 *
+	 * @param {object} props The props.
+	 */
 	constructor( props ) {
 		super( props );
 
@@ -31,10 +39,20 @@ class SettingsReplacementVariableField extends React.Component {
 		this.focus = this.focus.bind( this );
 	}
 
+	/**
+	 * Focus the input ref.
+	 *
+	 * @returns {void}
+	 */
 	focus() {
 		this.inputRef.focus();
 	}
 
+	/**
+	 * Renders the field.
+	 *
+	 * @returns {wp.Element} The field.
+	 */
 	render() {
 		const {
 			label,

--- a/js/src/components/SidebarCollapsible.js
+++ b/js/src/components/SidebarCollapsible.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { Collapsible } from "@yoast/components";
 
 /**
@@ -6,7 +5,7 @@ import { Collapsible } from "@yoast/components";
  *
  * @param {Object} props The properties for the component.
  *
- * @returns {ReactElement} The Collapsible component.
+ * @returns {wp.Element} The Collapsible component.
  */
 const SidebarCollapsible = ( props ) => {
 	return <Collapsible hasPadding={ true } hasSeparator={ true } { ...props } />;

--- a/js/src/components/SidebarItem.js
+++ b/js/src/components/SidebarItem.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import PropTypes from "prop-types";
 
 const SidebarItem = ( { children } ) => {

--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -1,5 +1,4 @@
 // External dependencies.
-import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { StyledSection, StyledHeading, StyledSectionBase } from "@yoast/components";
@@ -22,12 +21,12 @@ const Section = styled( StyledSection )`
  * Creates the Snippet Preview Section.
  *
  * @param {Object}         props               The component props.
- * @param {ReactComponent} props.children      The component's children.
+ * @param {wp.Element}     props.children      The component's children.
  * @param {string}         props.title         The heading title.
  * @param {string}         props.icon          The heading icon.
  * @param {bool}           props.hasPaperStyle Whether the section should have a paper style.
  *
- * @returns {ReactElement} Snippet Preview Section.
+ * @returns {wp.Element} Snippet Preview Section.
  */
 const SnippetPreviewSection = ( { children, title, icon, hasPaperStyle } ) => {
 	return (

--- a/js/src/components/Suggestion.js
+++ b/js/src/components/Suggestion.js
@@ -1,11 +1,14 @@
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 
-class Suggestion extends React.Component {
+/**
+ * Renders suggestions for next steps in the config wizard.
+ */
+class Suggestion extends Component {
 	/**
 	 * @summary Renders the Suggestion component.
 	 *
-	 * @returns {JSX.Element} Rendered Component.
+	 * @returns {wp.Element} Rendered Component.
 	 */
 	render() {
 		let buttonClass = "yoast-button yoast-button--secondary";

--- a/js/src/components/Suggestions.js
+++ b/js/src/components/Suggestions.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 
 import Suggestion from "./Suggestion";
@@ -6,11 +6,11 @@ import Suggestion from "./Suggestion";
 /**
  * @summary Suggestions component for config wizard.
  */
-class Suggestions extends React.Component {
+class Suggestions extends Component {
 	/**
 	 * @summary Renders the Suggestions component.
 	 *
-	 * @returns {JSX.Element} Rendered Choices Component.
+	 * @returns {wp.Element} Rendered Choices Component.
 	 */
 	render() {
 		return (

--- a/js/src/components/TaxonomyPicker.js
+++ b/js/src/components/TaxonomyPicker.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { unescape } from "lodash-es";
@@ -13,7 +12,7 @@ const SelectContainer = styled.div`
  *
  * @param {Object} props The component's props.
  *
- * @returns {ReactElement} The rendered TaxonomyPicker component.
+ * @returns {wp.Element} The rendered TaxonomyPicker component.
  */
 const TaxonomyPicker = ( props ) => {
 	const {

--- a/js/src/components/TopLevelProviders.js
+++ b/js/src/components/TopLevelProviders.js
@@ -12,9 +12,9 @@ import { LocationProvider } from "../components/contexts/location";
  * @param {object}       store    The redux store.
  * @param {object}       theme    The styled-components theme.
  * @param {string}       location The place where the wrapped component is rendered.
- * @param {ReactElement} children The element that should be wrapped.
+ * @param {wp.Element} children The element that should be wrapped.
  *
- * @returns {ReactElement} The wrapped element.
+ * @returns {wp.Element} The wrapped element.
  */
 const TopLevelProviders = ( { store, theme, location, children } ) => {
 	return (

--- a/js/src/components/UpsellBox.js
+++ b/js/src/components/UpsellBox.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React from "react";
+import { Component } from "@wordpress/element";
 import interpolateComponents from "interpolate-components";
 import PropTypes from "prop-types";
 import styled from "styled-components";
@@ -32,9 +32,9 @@ const UpsellButton = makeOutboundLink();
 /**
  * Returns the UpsellBox component.
  *
- * @returns {ReactElement} The UpsellBox component.
+ * @returns {wp.Element} The UpsellBox component.
  */
-class UpsellBox extends React.Component {
+class UpsellBox extends Component {
 	/**
 	 * The constructor.
 	 *
@@ -88,7 +88,7 @@ class UpsellBox extends React.Component {
 	/**
 	 * Renders a UpsellBox component.
 	 *
-	 * @returns {ReactElement} The rendered UpsellBox component.
+	 * @returns {wp.Element} The rendered UpsellBox component.
 	 */
 	render() {
 		return (

--- a/js/src/components/WordPressUserSelector.js
+++ b/js/src/components/WordPressUserSelector.js
@@ -12,7 +12,7 @@ import { sendRequest } from "yoast-components";
 /**
  * Styles to overwrite react-select styles.
  *
- * @type React.Component
+ * @type wp.Element
  */
 const Styles = createGlobalStyle`
 	.yoast-person-selector-container {
@@ -67,7 +67,7 @@ const REST_ROUTE = wpApiSettings.root;
 /**
  * Component to replace the react-select dropdown icon.
  *
- * @returns {React.Element} The rendered element.
+ * @returns {wp.Element} The rendered element.
  */
 const Icon = () => (
 	<SvgIcon
@@ -103,7 +103,7 @@ class WordPressUserSelector extends Component {
 	/**
 	 * Renders the WordPressUserSelector component.
 	 *
-	 * @returns {React.Element} The rendered component.
+	 * @returns {wp.Element} The rendered component.
 	 */
 	render() {
 		return (

--- a/js/src/components/WordPressUserSelectorOnboardingWizard.js
+++ b/js/src/components/WordPressUserSelectorOnboardingWizard.js
@@ -11,7 +11,7 @@ import WordPressUserSelector, { WordPressUserSelectorPropTypes } from "./WordPre
 /**
  * Container for the user selector.
  *
- * @type {React.Component}
+ * @type {wp.Element}
  */
 const Container = styled.div`
 	max-width: 250px;
@@ -30,7 +30,7 @@ class WordPressUserSelectorOnboardingWizard extends Component {
 	/**
 	 * Renders the WordPressUserSelectorOnboardingWizard component.
 	 *
-	 * @returns {React.Element} The rendered component.
+	 * @returns {wp.Element} The rendered component.
 	 */
 	render() {
 		return (

--- a/js/src/components/WordPressUserSelectorSearchAppearance.js
+++ b/js/src/components/WordPressUserSelectorSearchAppearance.js
@@ -57,7 +57,7 @@ class WordPressUserSelectorSearchAppearance extends Component {
 	/**
 	 * Renders an error message when no user has been selected.
 	 *
-	 * @returns {React.Element} The rendered error message.
+	 * @returns {wp.Element} The rendered error message.
 	 */
 	renderError() {
 		if ( this.state.value ) {
@@ -74,7 +74,7 @@ class WordPressUserSelectorSearchAppearance extends Component {
 	/**
 	 * Renders a message about the selected user when a user has been selected.
 	 *
-	 * @returns {React.Element} The rendered message.
+	 * @returns {wp.Element} The rendered message.
 	 */
 	renderAuthorInfo() {
 		if ( ! this.state.value || ! this.state.name ) {
@@ -105,7 +105,7 @@ class WordPressUserSelectorSearchAppearance extends Component {
 	/**
 	 * Renders the WordPressUserSelectorSearchAppearance component.
 	 *
-	 * @returns {React.Element} The rendered component.
+	 * @returns {wp.Element} The rendered component.
 	 */
 	render() {
 		return (

--- a/js/src/components/contentAnalysis/KeywordInput.js
+++ b/js/src/components/contentAnalysis/KeywordInput.js
@@ -29,7 +29,7 @@ class KeywordInput extends Component {
 	/**
 	 * Renders a help link.
 	 *
-	 * @returns {ReactElement} The help link component.
+	 * @returns {wp.Element} The help link component.
 	 */
 	static renderHelpLink() {
 		return (
@@ -47,7 +47,7 @@ class KeywordInput extends Component {
 	/**
 	 * Renders the component.
 	 *
-	 * @returns {ReactElement} The component.
+	 * @returns {wp.Element} The component.
 	 */
 	render() {
 		return <Fragment>

--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -41,7 +41,7 @@ class ReadabilityAnalysis extends Component {
 	/**
 	 * Renders the Readability Analysis results.
 	 *
-	 * @returns {React.Element} The Readability Analysis results.
+	 * @returns {wp.Element} The Readability Analysis results.
 	 */
 	renderResults() {
 		return (
@@ -73,7 +73,7 @@ class ReadabilityAnalysis extends Component {
 	/**
 	 * Renders the Readability Analysis component.
 	 *
-	 * @returns {React.Element} The Readability Analysis component.
+	 * @returns {wp.Element} The Readability Analysis component.
 	 */
 	render() {
 		const score = getIndicatorForScore( this.props.overallScore );

--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -1,8 +1,7 @@
-import React from "react";
 import PropTypes from "prop-types";
 import { LanguageNotice } from "@yoast/components";
 import { ContentAnalysis } from "@yoast/analysis-report";
-import { Fragment } from "@wordpress/element";
+import { Component, Fragment } from "@wordpress/element";
 import { compose } from "@wordpress/compose";
 import { withDispatch, withSelect } from "@wordpress/data";
 import { Paper } from "yoastseo";
@@ -12,7 +11,7 @@ import mapResults from "./mapResults";
 /**
  * Wrapper to provide functionality to the ContentAnalysis component.
  */
-class Results extends React.Component {
+class Results extends Component {
 	/**
 	 * The component's constructor.
 	 *
@@ -91,7 +90,7 @@ class Results extends React.Component {
 	/**
 	 * Renders the Results component.
 	 *
-	 * @returns {ReactElement} The react element.
+	 * @returns {wp.Element} The React element.
 	 */
 	render() {
 		const { mappedResults } = this.state;

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -39,7 +39,7 @@ class SeoAnalysis extends Component {
 	 *
 	 * @param {string} location The location of the upsell component. Used to determine the shortlinks in the component.
 	 *
-	 * @returns {ReactElement} A modalButtonContainer component with the modal for a keyword synonyms upsell.
+	 * @returns {wp.Element} A modalButtonContainer component with the modal for a keyword synonyms upsell.
 	 */
 	renderSynonymsUpsell( location ) {
 		const modalProps = {
@@ -87,7 +87,7 @@ class SeoAnalysis extends Component {
 	 *
 	 * @param {string} location The location of the upsell component. Used to determine the shortlinks in the component.
 	 *
-	 * @returns {ReactElement} A modalButtonContainer component with the modal for a multiple keywords upsell.
+	 * @returns {wp.Element} A modalButtonContainer component with the modal for a multiple keywords upsell.
 	 */
 	renderMultipleKeywordsUpsell( location ) {
 		const modalProps = {
@@ -137,7 +137,7 @@ class SeoAnalysis extends Component {
 	 *
 	 * @param {string} location The location of the upsell component. Used to determine the shortlinks in the component.
 	 *
-	 * @returns {ReactElement} The UpsellBox component.
+	 * @returns {wp.Element} The UpsellBox component.
 	 */
 	renderKeywordUpsell( location ) {
 		// Default to metabox.
@@ -171,7 +171,7 @@ class SeoAnalysis extends Component {
 	 *
 	 * @param {string} location The location of the upsell component. Used to determine the shortlink in the component.
 	 *
-	 * @returns {ReactElement} The AnalysisUpsell component.
+	 * @returns {wp.Element} The AnalysisUpsell component.
 	 */
 	renderWordFormsUpsell( location ) {
 		return (
@@ -190,7 +190,7 @@ class SeoAnalysis extends Component {
 	 * @param {string} location       Where this component is rendered.
 	 * @param {string} scoreIndicator String indicating the score.
 	 *
-	 * @returns {React.Element} The rendered score icone portal element.
+	 * @returns {wp.Element} The rendered score icone portal element.
 	 */
 	renderTabIcon( location, scoreIndicator ) {
 		// The tab icon should only be rendered for the metabox.
@@ -209,7 +209,7 @@ class SeoAnalysis extends Component {
 	/**
 	 * Renders the SEO Analysis component.
 	 *
-	 * @returns {React.Element} The SEO Analysis component.
+	 * @returns {wp.Element} The SEO Analysis component.
 	 */
 	render() {
 		const score = getIndicatorForScore( this.props.overallScore );

--- a/js/src/components/fills/MetaboxFill.js
+++ b/js/src/components/fills/MetaboxFill.js
@@ -23,7 +23,7 @@ import SocialMetadataPortal from "../portals/SocialMetadataPortal";
  * @param {Object} store    The Redux store.
  * @param {Object} theme    The theme to use.
  *
- * @returns {ReactElement} The Metabox component.
+ * @returns {wp.Element} The Metabox component.
  */
 export default function MetaboxFill( { settings, store, theme } ) {
 	return (

--- a/js/src/components/fills/SidebarFill.js
+++ b/js/src/components/fills/SidebarFill.js
@@ -20,7 +20,7 @@ import TopLevelProviders from "../TopLevelProviders";
  * @param {Object} store    The Redux store.
  * @param {Object} theme    The theme to use.
  *
- * @returns {ReactElement} The Sidebar component.
+ * @returns {wp.Element} The Sidebar component.
  *
  * @constructor
  */

--- a/js/src/components/higherorder/appendSpace.js
+++ b/js/src/components/higherorder/appendSpace.js
@@ -1,17 +1,17 @@
-import React, { Fragment } from "react";
+import { Component, Fragment } from "@wordpress/element";
 
 /**
  * A higher order component that appends a space to the given component.
  *
- * @param {ReactComponent} WrappedComponent The component to append a space to.
- * @returns {ReactComponent} The component with an appended space.
+ * @param {wp.Component} WrappedComponent The component to append a space to.
+ * @returns {wp.Component} The component with an appended space.
  */
 const appendSpace = function( WrappedComponent ) {
-	return class ComponentWithAppendedSpace extends React.Component {
+	return class ComponentWithAppendedSpace extends Component {
 		/**
 		 * Renders the React component.
 		 *
-		 * @returns {ReactElement} The rendered component.
+		 * @returns {wp.Element} The rendered component.
 		 */
 		render() {
 			return (

--- a/js/src/components/higherorder/linkHiddenField.js
+++ b/js/src/components/higherorder/linkHiddenField.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 
 /**
@@ -12,7 +12,7 @@ import PropTypes from "prop-types";
  */
 const linkHiddenFields = ( mapFieldsFromProps ) => {
 	return ( WrappedComponent ) => {
-		class LinkHiddenFields extends React.Component {
+		class LinkHiddenFields extends Component {
 			constructor( props ) {
 				super( props );
 

--- a/js/src/components/higherorder/valueToNativeEvent.js
+++ b/js/src/components/higherorder/valueToNativeEvent.js
@@ -4,9 +4,9 @@ import { Component, forwardRef } from "@wordpress/element";
  * Higher order that maps an onChange that only returns a value to an "Event" object,
  * just as a native element would return.
  *
- * @param {React.Component} WrappedComponent The component to be wrapped.
+ * @param {wp.Component} WrappedComponent The component to be wrapped.
  *
- * @returns {React.Component} Higher order component.
+ * @returns {wp.Component} Higher order component.
  */
 export default ( WrappedComponent ) => {
 	/**
@@ -43,7 +43,7 @@ export default ( WrappedComponent ) => {
 		/**
 		 * Renders the Wrapper component, and intercepts props that shouldn't be passed down.
 		 *
-		 * @returns {React.Element} The rendered component.
+		 * @returns {wp.Element} The rendered component.
 		 */
 		render() {
 			// Extract props that shouldn't be passed down.

--- a/js/src/components/higherorder/withYoastSidebarPriority.js
+++ b/js/src/components/higherorder/withYoastSidebarPriority.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import PropTypes from "prop-types";
 
 const withYoastSidebarPriority = ( WrappedComponent ) => {

--- a/js/src/components/modals/KeywordSynonyms.js
+++ b/js/src/components/modals/KeywordSynonyms.js
@@ -1,4 +1,3 @@
-import React from "react";
 import interpolateComponents from "interpolate-components";
 import { __, sprintf } from "@wordpress/i18n";
 
@@ -13,7 +12,7 @@ const PremiumLandingPageLink = makeOutboundLink();
  *
  * @param {Object} props The props for the component.
  *
- * @returns {ReactElement} The Keyword Synonyms upsell component.
+ * @returns {wp.Element} The Keyword Synonyms upsell component.
  */
 const KeywordSynonyms = ( props ) => {
 	const intro = sprintf(

--- a/js/src/components/modals/Modal.js
+++ b/js/src/components/modals/Modal.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component, Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { __ } from "@wordpress/i18n";
@@ -21,9 +21,9 @@ const StyledButton = styled.button`
 /**
  * Returns the Modal component.
  *
- * @returns {ReactElement} The Modal component.
+ * @returns {wp.Element} The Modal component.
  */
-class Modal extends React.Component {
+class Modal extends Component {
 	/**
 	 * Constructs the Modal component.
 	 *
@@ -69,7 +69,7 @@ class Modal extends React.Component {
 	/**
 	 * Renders the Modal component.
 	 *
-	 * @returns {ReactElement} The rendered react element.
+	 * @returns {wp.Element} The rendered react element.
 	 */
 	render() {
 		const defaultLabels = {
@@ -82,7 +82,7 @@ class Modal extends React.Component {
 		const modalLabels = Object.assign( {}, defaultLabels, this.props.labels );
 
 		return (
-			<React.Fragment>
+			<Fragment>
 				<StyledButton
 					type="button"
 					onClick={ this.openModal }
@@ -105,7 +105,7 @@ class Modal extends React.Component {
 				>
 					{ this.props.children }
 				</YoastModal>
-			</React.Fragment>
+			</Fragment>
 		);
 	}
 }

--- a/js/src/components/modals/MultipleKeywords.js
+++ b/js/src/components/modals/MultipleKeywords.js
@@ -1,4 +1,3 @@
-import React from "react";
 import interpolateComponents from "interpolate-components";
 import { makeOutboundLink } from "@yoast/helpers";
 import { __, sprintf } from "@wordpress/i18n";
@@ -12,7 +11,7 @@ const PremiumLandingPageLink = makeOutboundLink();
  *
  * @param {Object} props The props for the component.
  *
- * @returns {ReactElement} The Multiple Keywords upsell component.
+ * @returns {wp.Element} The Multiple Keywords upsell component.
  */
 const MultipleKeywords = ( props ) => {
 	const intro = sprintf(

--- a/js/src/components/portals/CompanyInfoMissingPortal.js
+++ b/js/src/components/portals/CompanyInfoMissingPortal.js
@@ -10,7 +10,7 @@ import Portal from "./Portal";
  * @param {string} message The message to show in the notice.
  * @param {string} url The url to link to in the notice.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function CompanyInfoMissingPortal( { target, message, link } ) {
 	return (

--- a/js/src/components/portals/LocalSEOUpsellPortal.js
+++ b/js/src/components/portals/LocalSEOUpsellPortal.js
@@ -11,7 +11,7 @@ import Portal from "./Portal";
  * @param {string} url The url to link to in the notice.
  * @param {string} backgroundUrl The Url for the background image.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function LocalSEOUpsellPortal( { target, url, backgroundUrl } ) {
 	return (

--- a/js/src/components/portals/MetaboxPortal.js
+++ b/js/src/components/portals/MetaboxPortal.js
@@ -11,7 +11,7 @@ import Portal from "./Portal";
  * @param {Object} store  The Redux store.
  * @param {Object} theme  The theme to use.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function MetaboxPortal( { target, store, theme } ) {
 	return (

--- a/js/src/components/portals/Portal.js
+++ b/js/src/components/portals/Portal.js
@@ -5,9 +5,9 @@ import PropTypes from "prop-types";
  * Renders a portal.
  *
  * @param {string|object} target A target element ID in which to render the portal.
- * @param {React.Element} children The child components.
+ * @param {wp.Element} children The child components.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function Portal( { target, children } ) {
 	let targetElement = target;

--- a/js/src/components/portals/ReadabilityResultsPortal.js
+++ b/js/src/components/portals/ReadabilityResultsPortal.js
@@ -5,9 +5,9 @@ import PropTypes from "prop-types";
  * Renders a portal for the readability results in the editor.
  *
  * @param {string} target A target element ID in which to render the portal.
- * @param {React.Element} children The child components.
+ * @param {wp.Element} children The child components.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function ReadabilityResultsPortal( { target, children } ) {
 	return (

--- a/js/src/components/portals/ScoreIconPortal.js
+++ b/js/src/components/portals/ScoreIconPortal.js
@@ -12,7 +12,7 @@ import Portal from "./Portal";
  * @param {string} target A target element ID in which to render the portal.
  * @param {string} scoreIndicator The score indicator.
  *
- * @returns {React.Element} The score element.
+ * @returns {wp.Element} The score element.
  */
 const ScoreIconPortal = ( { target, scoreIndicator } ) => {
 	return (

--- a/js/src/components/portals/SettingsEditorPortal.js
+++ b/js/src/components/portals/SettingsEditorPortal.js
@@ -1,6 +1,5 @@
 import PropTypes from "prop-types";
 import SettingsReplacementVariableEditor from "../SettingsReplacementVariableEditor";
-import React from "react";
 import {
 	replacementVariablesShape,
 	recommendedReplacementVariablesShape,
@@ -18,7 +17,7 @@ import Portal from "./Portal";
  * @param {string} descriptionTarget The id of the description field.
  * @param {boolean} hasPaperStyle Whether the editor should be styled as a paper.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function SettingsEditorPortal( {
 	target,

--- a/js/src/components/portals/SettingsFieldPortal.js
+++ b/js/src/components/portals/SettingsFieldPortal.js
@@ -1,5 +1,4 @@
 import PropTypes from "prop-types";
-import React from "react";
 import {
 	replacementVariablesShape,
 	recommendedReplacementVariablesShape,
@@ -17,7 +16,7 @@ import Portal from "./Portal";
  * @param {string[]} recommendedReplacementVariables the recommended replacement variables for the field.
  * @param {string} fieldId The field ID.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function SettingsFieldPortal( { target, label, replacementVariables, recommendedReplacementVariables, fieldId } ) {
 	return (

--- a/js/src/components/portals/SocialMetadataPortal.js
+++ b/js/src/components/portals/SocialMetadataPortal.js
@@ -8,7 +8,7 @@ import Portal from "./Portal";
  *
  * @param {string} target A target element ID in which to render the portal.
  *
- * @returns {React.Component} The social metadata collapsibles.
+ * @returns {wp.Element} The social metadata collapsibles.
  */
 export default function SocialMetadataPortal( { target } ) {
 	const isFacebookEnabled = window.wpseoScriptData.metabox.showSocial.facebook;

--- a/js/src/components/portals/UserSelectPortal.js
+++ b/js/src/components/portals/UserSelectPortal.js
@@ -8,7 +8,7 @@ import Portal from "./Portal";
  *
  * @param {string} target A target element ID in which to render the portal.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function UserSelectPortal( { target } ) {
 	return (

--- a/js/src/components/slots/FacebookPreviewSlot.js
+++ b/js/src/components/slots/FacebookPreviewSlot.js
@@ -1,10 +1,9 @@
 import { Slot } from "@wordpress/components";
-import React from "react";
 
 /**
  * Renders a slot for the Facebook preview.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function FacebookPreviewSlot() {
 	return ( <Slot name="YoastFacebookPreview" /> );

--- a/js/src/components/slots/MetaboxSlot.js
+++ b/js/src/components/slots/MetaboxSlot.js
@@ -4,7 +4,7 @@ import sortComponentsByRenderPriority from "../../helpers/sortComponentsByRender
 /**
  * Renders the metabox portal.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function MetaboxSlot() {
 	return (

--- a/js/src/components/slots/SidebarSlot.js
+++ b/js/src/components/slots/SidebarSlot.js
@@ -1,11 +1,10 @@
 import { Slot } from "@wordpress/components";
 import sortComponentsByRenderPriority from "../../helpers/sortComponentsByRenderPriority";
-import React from "react";
 
 /**
  * Renders the Sidebar slot.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function SidebarSlot() {
 	return (

--- a/js/src/components/slots/SynonymSlot.js
+++ b/js/src/components/slots/SynonymSlot.js
@@ -1,12 +1,11 @@
 import { Slot } from "@wordpress/components";
-import React from "react";
 import PropTypes from "prop-types";
 
 /**
  * Renders a Synonym slot.
  * @param {string} location the tablocation of the keyphrase the synonyms belong to.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function SynonymSlot( { location } ) {
 	return ( <Slot name={ `yoast-synonyms-${ location }` } /> );

--- a/js/src/components/slots/TwitterPreviewSlot.js
+++ b/js/src/components/slots/TwitterPreviewSlot.js
@@ -1,10 +1,9 @@
 import { Slot } from "@wordpress/components";
-import React from "react";
 
 /**
  * Renders a slot for the Twitter preview.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function TwitterPreviewSlot() {
 	return ( <Slot name="YoastTwitterPreview" /> );

--- a/js/src/components/social/FacebookWrapper.js
+++ b/js/src/components/social/FacebookWrapper.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { Fragment } from "@wordpress/element";
 import { Slot } from "@wordpress/components";
 import PropTypes from "prop-types";
 

--- a/js/src/components/social/SocialForm.js
+++ b/js/src/components/social/SocialForm.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React, { Component } from "react";
+import { Component, Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 
 /* Internal dependencies */
@@ -129,7 +129,7 @@ class SocialPreviewEditor extends Component {
 		} = this.props;
 
 		return (
-			<React.Fragment>
+			<Fragment>
 				<SocialUpsell socialMediumName={ socialMediumName } />
 				<SocialMetadataPreviewForm
 					onDescriptionChange={ onDescriptionChange }
@@ -153,7 +153,7 @@ class SocialPreviewEditor extends Component {
 					isPremium={ isPremium }
 					setEditorRef={ this.setEditorRef }
 				/>
-			</React.Fragment>
+			</Fragment>
 		);
 	}
 }

--- a/js/src/components/social/SocialMetadata.js
+++ b/js/src/components/social/SocialMetadata.js
@@ -13,7 +13,7 @@ import TwitterContainer from "../../containers/TwitterEditor";
  *
  * @param {Object} props The props object.
  *
- * @returns {React.Component} The social metadata collapsibles.
+ * @returns {wp.Element} The social metadata collapsibles.
  */
 const SocialMetadata = ( { isFacebookEnabled, isTwitterEnabled } ) => {
 	return (

--- a/js/src/components/social/SocialUpsell.js
+++ b/js/src/components/social/SocialUpsell.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { Fragment } from "@wordpress/element";
 import styled from "styled-components";
 import interpolateComponents from "interpolate-components";
 import PropTypes from "prop-types";
@@ -27,7 +27,7 @@ const upgradeText = sprintf(
  * @param {Object} props The properties passed to this component.
  * @param {string} props.socialMedium The socialmedium platform.
  *
- * @returns {Component} The FacebookView Component.
+ * @returns {wp.Element} The FacebookView Component.
  */
 const SocialUpsell = ( props ) => {
 	const previewText = sprintf(

--- a/js/src/components/social/TwitterWrapper.js
+++ b/js/src/components/social/TwitterWrapper.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { Fragment } from "@wordpress/element";
 import { Slot } from "@wordpress/components";
 import PropTypes from "prop-types";
 
@@ -10,7 +10,7 @@ import SocialForm from "../social/SocialForm";
  *
  * @param {Object} props The properties object.
  *
- * @returns {Component} Renders the TwitterWrapper React Component.
+ * @returns {wp.Element} Renders the TwitterWrapper React Component.
  */
 const TwitterWrapper = ( props ) => {
 	return (

--- a/js/src/configuration-wizard.js
+++ b/js/src/configuration-wizard.js
@@ -1,7 +1,6 @@
 /* global yoastWizardConfig */
 // External dependencies.
-import React from "react";
-import ReactDOM from "react-dom";
+import { Component, render } from "@wordpress/element";
 import ConfigurationWizard, { MessageBox } from "@yoast/configuration-wizard";
 import { setTranslations } from "yoast-components";
 import { isUndefined } from "lodash-es";
@@ -22,7 +21,7 @@ const PluginConflictLink = makeOutboundLink();
 /**
  * @summary Configuration wizard component.
  */
-class App extends React.Component {
+class App extends Component {
 	/**
 	 * Constructs the App component.
 	 *
@@ -116,7 +115,7 @@ class App extends React.Component {
 	/**
 	 * Renders the App component.
 	 *
-	 * @returns {JSX.Element|null} The rendered app component.
+	 * @returns {wp.Element|null} The rendered app component.
 	 */
 	render() {
 		// When the wizard is loading, don't do anything.
@@ -154,4 +153,4 @@ class App extends React.Component {
 
 setYoastComponentsL10n();
 
-ReactDOM.render( <App />, document.getElementById( "wizard" ) );
+render( <App />, document.getElementById( "wizard" ) );

--- a/js/src/containers/SnippetEditor.js
+++ b/js/src/containers/SnippetEditor.js
@@ -1,6 +1,6 @@
-import React from "react";
 import { connect } from "react-redux";
 import { SnippetEditor } from "@yoast/search-metadata-previews";
+import { Fragment } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { dispatch as wpDataDispatch } from "@wordpress/data";
 
@@ -46,7 +46,7 @@ export const mapEditorDataToPreview = function( data, context ) {
 };
 
 const SnippetEditorWrapper = ( props ) => (
-	<React.Fragment>
+	<Fragment>
 		<SnippetPreviewSection
 			icon="eye"
 			hasPaperStyle={ props.hasPaperStyle }
@@ -57,7 +57,7 @@ const SnippetEditorWrapper = ( props ) => (
 				mapEditorDataToPreview={ mapEditorDataToPreview }
 			/>
 		</SnippetPreviewSection>
-	</React.Fragment>
+	</Fragment>
 );
 
 /**

--- a/js/src/dashboard-widget.js
+++ b/js/src/dashboard-widget.js
@@ -1,7 +1,6 @@
 /* global wpseoDashboardWidgetL10n, wpseoApi, jQuery */
 // External dependencies.
-import React from "react";
-import ReactDOM from "react-dom";
+import { Component, render } from "@wordpress/element";
 import { ArticleList as WordpressFeed } from "@yoast/components";
 import { colors } from "@yoast/style-guide";
 import { SiteSEOReport as SeoAssessment } from "@yoast/analysis-report";
@@ -13,7 +12,7 @@ import { setYoastComponentsL10n } from "./helpers/i18n";
 /**
  * The Yoast dashboardwidget component used on the WordPress admin dashboard.
  */
-class DashboardWidget extends React.Component {
+class DashboardWidget extends Component {
 	/**
 	 * Creates the components and initializes its state.
 	 */
@@ -91,7 +90,7 @@ class DashboardWidget extends React.Component {
 	/**
 	 * Returns the SEO Assessment sub-component.
 	 *
-	 * @returns {ReactElement} The SEO Assessment component.
+	 * @returns {wp.Element} The SEO Assessment component.
 	 */
 	getSeoAssessment() {
 		if ( this.state.statistics === null ) {
@@ -108,7 +107,7 @@ class DashboardWidget extends React.Component {
 	/**
 	 * Returns the yoast.com feed sub-component.
 	 *
-	 * @returns {ReactElement} The yoast.com feed component.
+	 * @returns {wp.Element} The yoast.com feed component.
 	 */
 	getYoastFeed() {
 		if ( this.state.feed === null ) {
@@ -127,7 +126,7 @@ class DashboardWidget extends React.Component {
 	/**
 	 * Renders the component.
 	 *
-	 * @returns {ReactElement} The component.
+	 * @returns {wp.Element} The component.
 	 */
 	render() {
 		const contents = [
@@ -148,5 +147,5 @@ const element = document.getElementById( "yoast-seo-dashboard-widget" );
 if ( element ) {
 	setYoastComponentsL10n();
 
-	ReactDOM.render( <DashboardWidget />, element );
+	render( <DashboardWidget />, element );
 }

--- a/js/src/help-scout-beacon.js
+++ b/js/src/help-scout-beacon.js
@@ -13,7 +13,7 @@ const BeaconOffset = createGlobalStyle`
 /**
  * Render a component in a newly created div.
  *
- * @param {React.Component} component The component to render.
+ * @param {wp.Component} component The component to render.
  *
  * @returns {void}
  */
@@ -146,7 +146,7 @@ function loadHelpScoutConsent( beaconId, sessionData = null ) {
 	 *
 	 * @constructor
 	 *
-	 * @returns {React.Element} A SpeechBubble element.
+	 * @returns {wp.Element} A SpeechBubble element.
 	 */
 	const SpeechBubble = () => {
 		return (
@@ -193,7 +193,7 @@ function loadHelpScoutConsent( beaconId, sessionData = null ) {
 	 *
 	 * @constructor
 	 *
-	 * @returns {React.Element} A HelpScoutBeaconAskConsentButton element.
+	 * @returns {wp.Element} A HelpScoutBeaconAskConsentButton element.
 	 */
 	const HelpScoutBeaconAskConsentButton = () => {
 		const [ show, setShow ] = useState( true );

--- a/js/src/helpers/classicEditor.js
+++ b/js/src/helpers/classicEditor.js
@@ -1,4 +1,4 @@
-import { render, Component, createRef } from "@wordpress/element";
+import { render, Component as wpComponent, createRef } from "@wordpress/element";
 import { SlotFillProvider } from "@wordpress/components";
 import MetaboxPortal from "../components/portals/MetaboxPortal";
 import getL10nObject from "../analysis/getL10nObject";
@@ -6,7 +6,7 @@ import getL10nObject from "../analysis/getL10nObject";
 const registeredComponents = [];
 let containerRef = null;
 
-class RegisteredComponentsContainer extends Component {
+class RegisteredComponentsContainer extends wpComponent {
 	/**
 	 * Constructs a container for registered components.
 	 *
@@ -26,7 +26,7 @@ class RegisteredComponentsContainer extends Component {
 	 *
 	 * @param {string}          key       Unique key to give to React to render
 	 *                                    within a list of components.
-	 * @param {React.Component} Component A valid React component to render.
+	 * @param {wp.Component} Component A valid React component to render.
 	 *
 	 * @returns {void}
 	 */
@@ -45,7 +45,7 @@ class RegisteredComponentsContainer extends Component {
 	/**
 	 * Renders all the registered components.
 	 *
-	 * @returns {React.Element[]} The rendered components in an array.
+	 * @returns {wp.Element[]} The rendered components in an array.
 	 */
 	render() {
 		return this.state.registeredComponents.map( ( { Component, key } ) => {
@@ -94,7 +94,7 @@ export function renderClassicEditorMetabox( store ) {
  *
  * @param {string}          key       Unique key to give to React to render
  *                                    within a list of components.
- * @param {React.Component} Component A valid React component to render.
+ * @param {wp.Component} Component A valid React component to render.
  *
  * @returns {void}
  */

--- a/js/src/helpers/createInterpolateElement.js
+++ b/js/src/helpers/createInterpolateElement.js
@@ -10,7 +10,7 @@
 /**
  * External dependencies
  */
-import { createElement, cloneElement, Fragment, isValidElement } from "react";
+import { createElement, cloneElement, Fragment, isValidElement } from "@wordpress/element";
 
 /** @typedef {import('./react').WPElement} WPElement */
 

--- a/js/src/helpers/sortComponentsByRenderPriority.js
+++ b/js/src/helpers/sortComponentsByRenderPriority.js
@@ -7,9 +7,9 @@ import { flatten } from "lodash-es";
  * a collection are also included. This is to allow sorting multiple fills of
  * which at least one includes an array of components.
  *
- * @param {ReactElement|array} components The component(s) to be sorted.
+ * @param {wp.Element|array} components The component(s) to be sorted.
  *
- * @returns {ReactElement|array} The sorted component(s).
+ * @returns {wp.Element|array} The sorted component(s).
  */
 export default function sortComponentsByRenderPriority( components ) {
 	if ( typeof components.length === "undefined" ) {

--- a/js/src/initializers/edit.js
+++ b/js/src/initializers/edit.js
@@ -1,6 +1,5 @@
 /* global window wp */
 /* External dependencies */
-import React from "react";
 import styled from "styled-components";
 import { Fragment } from "@wordpress/element";
 import { combineReducers, registerStore, select, dispatch } from "@wordpress/data";

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -1,6 +1,5 @@
 /* global yoastModalConfig */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "@wordpress/element";
 import ModalButtonContainer from "./components/ModalButtonContainer";
 
 if ( window.yoastModalConfig ) {
@@ -13,7 +12,7 @@ if ( window.yoastModalConfig ) {
 			const element = document.querySelector( config.mountHook );
 
 			if ( element ) {
-				ReactDOM.render(
+				render(
 					<ModalButtonContainer { ...config } />,
 					element
 				);

--- a/js/src/structured-data-blocks/faq/block.js
+++ b/js/src/structured-data-blocks/faq/block.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import { __ } from "@wordpress/i18n";
 
 /* Internal dependencies */

--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 import { isShallowEqualObjects } from "@wordpress/is-shallow-equal";
@@ -44,7 +43,7 @@ export default class Question extends Component {
 	 * @param {Object}   props      The received props.
 	 * @param {function} props.open Opens the media upload dialog.
 	 *
-	 * @returns {ReactElement} The media upload button.
+	 * @returns {wp.Element} The media upload button.
 	 */
 	getMediaUploadButton( props ) {
 		return (

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -19,7 +19,7 @@ const RichTextWithAppendedSpace = appendSpace( RichText.Content );
 /**
  * Modified Text Control to provide a better layout experience.
  *
- * @returns {ReactElement} The TextControl with additional spacing below.
+ * @returns {wp.Element} The TextControl with additional spacing below.
  */
 const SpacedTextControl = styled( TextControl )`
 	&&& {

--- a/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -166,7 +166,7 @@ export default class HowToStep extends Component {
 	 * @param {object} props      The receive props.
 	 * @param {func}   props.open Opens the media upload dialog.
 	 *
-	 * @returns {ReactElement} The media upload button.
+	 * @returns {wp.Element} The media upload button.
 	 */
 	getMediaUploadButton( props ) {
 		return (
@@ -183,7 +183,7 @@ export default class HowToStep extends Component {
 	/**
 	 * The insert and remove step buttons.
 	 *
-	 * @returns {ReactElement} The buttons.
+	 * @returns {wp.Element} The buttons.
 	 */
 	getButtons() {
 		const {
@@ -304,7 +304,7 @@ export default class HowToStep extends Component {
 	 *
 	 * @param {object} step The how-to step.
 	 *
-	 * @returns {ReactElement} The component to be rendered.
+	 * @returns {wp.Element} The component to be rendered.
 	 */
 	static Content( step ) {
 		return (
@@ -328,7 +328,7 @@ export default class HowToStep extends Component {
 	/**
 	 * Renders this component.
 	 *
-	 * @returns {ReactElement} The how-to step editor.
+	 * @returns {wp.Element} The how-to step editor.
 	 */
 	render() {
 		const {

--- a/js/src/structured-data-blocks/how-to/legacy/11.4.js
+++ b/js/src/structured-data-blocks/how-to/legacy/11.4.js
@@ -17,7 +17,7 @@ import buildDurationString from "./utils/8.2";
  *
  * @param {Object} step The how-to step.
  *
- * @returns {React.Component} The component to be rendered.
+ * @returns {wp.Element} The component to be rendered.
  */
 function LegacyHowToStep( step ) {
 	return (
@@ -46,7 +46,7 @@ function LegacyHowToStep( step ) {
  *
  * @param {Object} props the attributes of the How-to block.
  *
- * @returns {React.Component} The component representing a How-to block.
+ * @returns {wp.Element} The component representing a How-to block.
  */
 export default function LegacyHowTo( props ) {
 	const {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Currently we have a mix of `react` imports and `@wordpress/element` imports. In documentation we refer to React elements as `wp.Element`, `React.Element`, `ReactElement`, `React.Component` etc. This PR makes sure we consistently use `@wordpress/element` and every component is documented with either `wp.Element` or `wp.Component` for component functions.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor: removes all React references in the plugin in favor of @wordpress/element

## Relevant technical choices:

* See summary.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Nothing much really. Check all of our dynamic interfaces still function as expected. Mostly a question if they render.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes P3-55