### PR TITLE
Issue #15082 - Expected parameter 2 to be an array, bool given

### DIFF
--- a/src/actions/indexation/indexable-post-type-archive-indexation-action.php
+++ b/src/actions/indexation/indexable-post-type-archive-indexation-action.php
@@ -151,6 +151,6 @@ class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action
 		$callback = function( $result ) {
 			return $result['object_sub_type'];
 		};
-		return \array_map( $callback, $results );
+		return \array_map( $callback, ( ($results) ?: [] ) );
 	}
 }


### PR DESCRIPTION
## Context
More information is in issue: #15082 Basically, there are shown errors after updating plugins.

## Summary

Due to the code documentation `find_array` method can returns `array|false`, but here we putting result of this method directly to `array_map`. This code is the way how to fix this warnings.

```
print_r(false ?: []); // array()
print_r([5,10] ?: []); // array(5, 10)
print_r([] ?: []); / array()
```
This PR can be summarized in the following changelog entry:

* Fixes a warning that occurs when a query is unsuccessful while indexing post type archives. 

## Relevant technical choices:
Should be compatible with PHP >= 5.4


## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #15082
