### PR TITLE
Aligns input field to one line in html code

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -413,12 +413,12 @@ class Yoast_Form {
 		Yoast_Input_Validation::set_error_descriptions();
 		$aria_attributes .= Yoast_Input_Validation::get_the_aria_describedby_attribute( $var );
 
-		echo '<input' . $attributes . $aria_attributes . ' class="yoast-field-group__inputfield ' . esc_attr( $attr['class'] ) . '
-		" placeholder="' . esc_attr( $attr['placeholder'] ) . '
-		" type="' . $type . '
-		" id="', esc_attr( $var ), '
-		" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']
-		" value="', esc_attr( $val ), '"', disabled( $this->is_control_disabled( $var ), true, false ), '/>', '</div>';
+		echo '<input' . $attributes . $aria_attributes . ' class="yoast-field-group__inputfield ' . esc_attr( $attr['class'] ) . '"
+		placeholder="' . esc_attr( $attr['placeholder'] ) . '"
+		type="' . $type . '"
+		id="', esc_attr( $var ), '"
+		name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']"
+		value="', esc_attr( $val ), '"', disabled( $this->is_control_disabled( $var ), true, false ), '/>', '</div>';;
 
 		echo Yoast_Input_Validation::get_the_error_description( $var );
 	}

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -418,7 +418,8 @@ class Yoast_Form {
 		type="' . $type . '"
 		id="', esc_attr( $var ), '"
 		name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']"
-		value="', esc_attr( $val ), '"', disabled( $this->is_control_disabled( $var ), true, false ), '/>', '</div>';;
+		value="', esc_attr( $val ), '"',
+		disabled( $this->is_control_disabled( $var ), true, false ), '/>', '</div>';
 
 		echo Yoast_Input_Validation::get_the_error_description( $var );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Aligns input fields to one line in html code for automated tests.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Aligns input fields to one line in html code for automated tests.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Pull this branch
* Pull the javascript repo develop branch and link the monorepo
* Build the plugin
* Check in the source code if on the `Social` page the `Linkedin` field is one row

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/FRO-129
