### PR TITLE
Add styling search appearance again

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -560,6 +560,10 @@ class WPSEO_Admin_Asset_Manager {
 				'src'  => 'filter-explanation-' . $flat_version,
 			],
 			[
+				'name' => 'search-appearance',
+				'src'  => 'search-appearance-' . $flat_version,
+			],
+			[
 				'name' => 'monorepo',
 				'src'  => 'monorepo-' . $flat_version,
 			],

--- a/css/src/editor/search-appearance.css
+++ b/css/src/editor/search-appearance.css
@@ -1,0 +1,310 @@
+@import "../../node_modules/draft-js-mention-plugin/lib/plugin.css";
+/*rtl:begin:ignore*/
+@import "../../node_modules/draft-js/dist/Draft.css";
+/*rtl:end:ignore*/
+
+.draftJsMentionPlugin__mention__29BEd, .draftJsMentionPlugin__mention__29BEd:visited {
+	color: #575f67;
+	cursor: pointer;
+	display: inline-block;
+	background: #e6f3ff;
+	padding-left: 2px;
+	padding-right: 2px;
+	border-radius: 2px;
+	text-decoration: none;
+}
+
+.draftJsMentionPlugin__mention__29BEd:hover, .draftJsMentionPlugin__mention__29BEd:focus {
+	color: #677584;
+	background: #edf5fd;
+	outline: 0;
+	/* reset for :focus */
+}
+
+.draftJsMentionPlugin__mention__29BEd:active {
+	color: #222;
+	background: #455261;
+}
+
+.draftJsMentionPlugin__mentionSuggestionsEntry__3mSwm {
+	padding: 7px 10px 3px 10px;
+	transition: background-color 0.4s cubic-bezier(0.27, 1.27, 0.48, 0.56);
+}
+
+.draftJsMentionPlugin__mentionSuggestionsEntry__3mSwm:active {
+	background-color: #cce7ff;
+}
+
+.draftJsMentionPlugin__mentionSuggestionsEntryFocused__3LcTd {
+	background-color: #e6f3ff;
+}
+
+.draftJsMentionPlugin__mentionSuggestionsEntryText__3Jobq {
+	display: inline-block;
+	margin-left: 8px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 368px;
+	font-size: 0.9em;
+	margin-bottom: 0.2em;
+}
+
+.draftJsMentionPlugin__mentionSuggestionsEntryAvatar__1xgA9 {
+	display: inline-block;
+	width: 24px;
+	height: 24px;
+	border-radius: 12px;
+}
+
+.draftJsMentionPlugin__mentionSuggestions__2DWjA {
+	border: 1px solid #eee;
+	margin-top: 0.4em;
+	position: absolute;
+	min-width: 220px;
+	max-width: 440px;
+	background: #fff;
+	border-radius: 2px;
+	box-shadow: 0px 4px 30px 0px gainsboro;
+	cursor: pointer;
+	padding-top: 8px;
+	padding-bottom: 8px;
+	z-index: 2;
+	display: -webkit-box;
+	display: flex;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	flex-direction: column;
+	box-sizing: border-box;
+	-webkit-transform: scale(0);
+	transform: scale(0);
+}
+
+/*rtl:begin:ignore*/
+/**
+ * Draft v0.10.5
+ *
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+.DraftEditor-editorContainer, .DraftEditor-root, .public-DraftEditor-content {
+	height: inherit;
+	text-align: initial;
+}
+
+.public-DraftEditor-content[contenteditable=true] {
+	-webkit-user-modify: read-write-plaintext-only;
+}
+
+.DraftEditor-root {
+	position: relative;
+}
+
+.DraftEditor-editorContainer {
+	background-color: rgba(255, 255, 255, 0);
+	border-left: .1px solid transparent;
+	position: relative;
+	z-index: 1;
+}
+
+.public-DraftEditor-block {
+	position: relative;
+}
+
+.DraftEditor-alignLeft .public-DraftStyleDefault-block {
+	text-align: left;
+}
+
+.DraftEditor-alignLeft .public-DraftEditorPlaceholder-root {
+	left: 0;
+	text-align: left;
+}
+
+.DraftEditor-alignCenter .public-DraftStyleDefault-block {
+	text-align: center;
+}
+
+.DraftEditor-alignCenter .public-DraftEditorPlaceholder-root {
+	margin: 0 auto;
+	text-align: center;
+	width: 100%;
+}
+
+.DraftEditor-alignRight .public-DraftStyleDefault-block {
+	text-align: right;
+}
+
+.DraftEditor-alignRight .public-DraftEditorPlaceholder-root {
+	right: 0;
+	text-align: right;
+}
+
+.public-DraftEditorPlaceholder-root {
+	color: #9197a3;
+	position: absolute;
+	z-index: 1;
+}
+
+.public-DraftEditorPlaceholder-hasFocus {
+	color: #bdc1c9;
+}
+
+.DraftEditorPlaceholder-hidden {
+	display: none;
+}
+
+.public-DraftStyleDefault-block {
+	position: relative;
+	white-space: pre-wrap;
+}
+
+.public-DraftStyleDefault-ltr {
+	direction: ltr;
+	text-align: left;
+}
+
+.public-DraftStyleDefault-rtl {
+	direction: rtl;
+	text-align: right;
+}
+
+.public-DraftStyleDefault-listLTR {
+	direction: ltr;
+}
+
+.public-DraftStyleDefault-listRTL {
+	direction: rtl;
+}
+
+.public-DraftStyleDefault-ol, .public-DraftStyleDefault-ul {
+	margin: 16px 0;
+	padding: 0;
+}
+
+.public-DraftStyleDefault-depth0.public-DraftStyleDefault-listLTR {
+	margin-left: 1.5em;
+}
+
+.public-DraftStyleDefault-depth0.public-DraftStyleDefault-listRTL {
+	margin-right: 1.5em;
+}
+
+.public-DraftStyleDefault-depth1.public-DraftStyleDefault-listLTR {
+	margin-left: 3em;
+}
+
+.public-DraftStyleDefault-depth1.public-DraftStyleDefault-listRTL {
+	margin-right: 3em;
+}
+
+.public-DraftStyleDefault-depth2.public-DraftStyleDefault-listLTR {
+	margin-left: 4.5em;
+}
+
+.public-DraftStyleDefault-depth2.public-DraftStyleDefault-listRTL {
+	margin-right: 4.5em;
+}
+
+.public-DraftStyleDefault-depth3.public-DraftStyleDefault-listLTR {
+	margin-left: 6em;
+}
+
+.public-DraftStyleDefault-depth3.public-DraftStyleDefault-listRTL {
+	margin-right: 6em;
+}
+
+.public-DraftStyleDefault-depth4.public-DraftStyleDefault-listLTR {
+	margin-left: 7.5em;
+}
+
+.public-DraftStyleDefault-depth4.public-DraftStyleDefault-listRTL {
+	margin-right: 7.5em;
+}
+
+.public-DraftStyleDefault-unorderedListItem {
+	list-style-type: square;
+	position: relative;
+}
+
+.public-DraftStyleDefault-unorderedListItem.public-DraftStyleDefault-depth0 {
+	list-style-type: disc;
+}
+
+.public-DraftStyleDefault-unorderedListItem.public-DraftStyleDefault-depth1 {
+	list-style-type: circle;
+}
+
+.public-DraftStyleDefault-orderedListItem {
+	list-style-type: none;
+	position: relative;
+}
+
+.public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-listLTR:before {
+	left: -36px;
+	position: absolute;
+	text-align: right;
+	width: 30px;
+}
+
+.public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-listRTL:before {
+	position: absolute;
+	right: -36px;
+	text-align: left;
+	width: 30px;
+}
+
+.public-DraftStyleDefault-orderedListItem:before {
+	content: counter(ol0) ". ";
+	counter-increment: ol0;
+}
+
+.public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-depth1:before {
+	content: counter(ol1) ". ";
+	counter-increment: ol1;
+}
+
+.public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-depth2:before {
+	content: counter(ol2) ". ";
+	counter-increment: ol2;
+}
+
+.public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-depth3:before {
+	content: counter(ol3) ". ";
+	counter-increment: ol3;
+}
+
+.public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-depth4:before {
+	content: counter(ol4) ". ";
+	counter-increment: ol4;
+}
+
+.public-DraftStyleDefault-depth0.public-DraftStyleDefault-reset {
+	counter-reset: ol0;
+}
+
+.public-DraftStyleDefault-depth1.public-DraftStyleDefault-reset {
+	counter-reset: ol1;
+}
+
+.public-DraftStyleDefault-depth2.public-DraftStyleDefault-reset {
+	counter-reset: ol2;
+}
+
+.public-DraftStyleDefault-depth3.public-DraftStyleDefault-reset {
+	counter-reset: ol3;
+}
+
+.public-DraftStyleDefault-depth4.public-DraftStyleDefault-reset {
+	counter-reset: ol4;
+}
+
+/*rtl:end:ignore*/
+#person-selector {
+	width: 100%;
+}
+
+/*# sourceMappingURL=search-appearance.css.map */

--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -10,6 +10,7 @@ const Section = styled( StyledSection )`
 	
 	&${ StyledSectionBase } {
 		padding: 0;
+		padding-bottom: 16px;
 
 		& ${ StyledHeading } {
 			${ getRtlStyle( "padding-left", "padding-right" ) }: 20px;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* There was some CSS missing that was only used on the search appearance page. This PR adds that CSS again

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds missing stylesheet for search appearance page

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this branch with the corresponding branch on the monorepo
* Make sure the dropdown for `insert variable` on the `search appearance - content types` and `search appearance - taxonomies` tabs are working as intended

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/FRO-127
