### PR TITLE
Output comment count in Article schema when relevant

### DIFF
--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -43,7 +43,6 @@ class Article extends Abstract_Schema_Piece {
 	 * @return array $data Article data.
 	 */
 	public function generate() {
-		$comment_count = \get_comment_count( $this->context->id );
 		$data          = [
 			'@type'            => 'Article',
 			'@id'              => $this->context->canonical . Schema_IDs::ARTICLE_HASH,
@@ -52,9 +51,15 @@ class Article extends Abstract_Schema_Piece {
 			'headline'         => $this->helpers->schema->html->smart_strip_tags( $this->helpers->post->get_post_title_with_fallback( $this->context->id ) ),
 			'datePublished'    => $this->helpers->date->format( $this->context->post->post_date_gmt ),
 			'dateModified'     => $this->helpers->date->format( $this->context->post->post_modified_gmt ),
-			'commentCount'     => $comment_count['approved'],
 			'mainEntityOfPage' => [ '@id' => $this->context->canonical . Schema_IDs::WEBPAGE_HASH ],
 		];
+
+		// If the comments are open -or- there are comments approved, show the count.
+		$comments_open = \comments_open( $this->context->id );
+		$comment_count = \get_comment_count( $this->context->id );
+		if ( $comments_open || $comment_count['approved'] > 0 ) {
+			$data['commentCount'] = $comment_count['approved'];
+		}
 
 		if ( $this->context->site_represents_reference ) {
 			$data['publisher'] = $this->context->site_represents_reference;

--- a/tests/generators/schema/article-test.php
+++ b/tests/generators/schema/article-test.php
@@ -197,7 +197,12 @@ class Article_Test extends TestCase {
 		Monkey\Functions\expect( 'get_comment_count' )
 			->once()
 			->with( 5 )
-			->andReturn( [ 'approved' => 7 ] );
+			->andReturn( [ 'approved' => $values_to_test['approved_comments' ]] );
+
+		Monkey\Functions\expect( 'comments_open' )
+			->once()
+			->with( 5 )
+			->andReturn( $values_to_test['post_comment_status' ] === 'open' );
 
 		$this->context_mock->canonical                 = 'https://permalink';
 		$this->context_mock->has_image                 = true;
@@ -353,6 +358,7 @@ class Article_Test extends TestCase {
 					'site_represents_reference'     => false, // Whether the site represents a company/person.
 					'mock_value_post_type_supports' => true, // Whether the post type supports a certain feature.
 					'post_comment_status'           => 'open',
+					'approved_comments'             => 7,
 					'data_for_add_keywords'         => [
 						'@type'            => 'Article',
 						'@id'              => 'https://permalink#article',
@@ -410,6 +416,7 @@ class Article_Test extends TestCase {
 					'site_represents_reference'     => true,
 					'mock_value_post_type_supports' => true,
 					'post_comment_status'           => 'open',
+					'approved_comments'             => 7,
 					'data_for_add_keywords'         => [
 						'@type'            => 'Article',
 						'@id'              => 'https://permalink#article',
@@ -470,6 +477,7 @@ class Article_Test extends TestCase {
 					'site_represents_reference'     => false,
 					'mock_value_post_type_supports' => false,
 					'post_comment_status'           => 'open',
+					'approved_comments'             => 7,
 					'data_for_add_keywords'         => [
 						'@type'            => 'Article',
 						'@id'              => 'https://permalink#article',
@@ -518,6 +526,7 @@ class Article_Test extends TestCase {
 					'site_represents_reference'     => false,
 					'mock_value_post_type_supports' => false,
 					'post_comment_status'           => 'closed',
+					'approved_comments'             => 7,
 					'data_for_add_keywords'         => [
 						'@type'            => 'Article',
 						'@id'              => 'https://permalink#article',
@@ -554,6 +563,52 @@ class Article_Test extends TestCase {
 					'datePublished'    => '2345-12-12 12:12:12',
 					'dateModified'     => '2345-12-12 23:23:23',
 					'commentCount'     => 7,
+					'mainEntityOfPage' => [ '@id' => 'https://permalink#webpage' ],
+					'keywords'         => 'Tag1,Tag2',
+					'articleSection'   => 'Category1',
+					'inLanguage'       => 'language',
+				],
+				'message'        => 'The comment status for the post is set to closed.',
+			],
+			[
+				'values_to_test' => [
+					'site_represents_reference'     => false,
+					'mock_value_post_type_supports' => false,
+					'post_comment_status'           => 'closed',
+					'approved_comments'             => 0,
+					'data_for_add_keywords'         => [
+						'@type'            => 'Article',
+						'@id'              => 'https://permalink#article',
+						'isPartOf'         => [ '@id' => 'https://permalink#webpage' ],
+						'author'           => [ '@id' => 'https://permalink#author-id-hash' ],
+						'image'            => [ '@id' => 'https://permalink#primaryimage' ],
+						'headline'         => 'the-title',
+						'datePublished'    => '2345-12-12 12:12:12',
+						'dateModified'     => '2345-12-12 23:23:23',
+						'mainEntityOfPage' => [ '@id' => 'https://permalink#webpage' ],
+					],
+					'data_for_add_sections'         => [
+						'@type'            => 'Article',
+						'@id'              => 'https://permalink#article',
+						'isPartOf'         => [ '@id' => 'https://permalink#webpage' ],
+						'author'           => [ '@id' => 'https://permalink#author-id-hash' ],
+						'image'            => [ '@id' => 'https://permalink#primaryimage' ],
+						'headline'         => 'the-title',
+						'datePublished'    => '2345-12-12 12:12:12',
+						'dateModified'     => '2345-12-12 23:23:23',
+						'mainEntityOfPage' => [ '@id' => 'https://permalink#webpage' ],
+						'keywords'         => 'Tag1,Tag2',
+					],
+				],
+				'expected_value' => [
+					'@type'            => 'Article',
+					'@id'              => 'https://permalink#article',
+					'isPartOf'         => [ '@id' => 'https://permalink#webpage' ],
+					'author'           => [ '@id' => 'https://permalink#author-id-hash' ],
+					'image'            => [ '@id' => 'https://permalink#primaryimage' ],
+					'headline'         => 'the-title',
+					'datePublished'    => '2345-12-12 12:12:12',
+					'dateModified'     => '2345-12-12 23:23:23',
 					'mainEntityOfPage' => [ '@id' => 'https://permalink#webpage' ],
 					'keywords'         => 'Tag1,Tag2',
 					'articleSection'   => 'Category1',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Only if the page is open for comments -or- closed for comments, but there are comments present, show the number of comments in the schema output.
* Props to https://github.com/gr8shivam for pulling this in https://github.com/Yoast/wordpress-seo/pull/13588
* The original file was deleted, so I was unable to move the commit in the way that would keep the committer name in it, sorry.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the comment count would be output for Articles that did not accept comments. Props to [gr8shivam](https://github.com/gr8shivam).

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a page which comments are not open for; see the comment count not output
* Create a page with an approved comment, close the comments; see the comment count being present
* Create a page with an approved comment and leave it open for comments; see the comment count being present

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #13587
Replaces https://github.com/Yoast/wordpress-seo/pull/13588
