### PR TITLE
P2-57 Fixes a bug where the webpack config env would not exist

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -126,8 +126,12 @@ function addBundleAnalyzer( plugins ) {
 }
 
 module.exports = function( env ) {
-	const mode = env.environment || process.env.NODE_ENV || "production";
-
+	if ( ! env ) {
+		env = {};
+	}
+	if ( ! env.environment ) {
+		env.environment = process.env.NODE_ENV || "production";
+	}
 	if ( ! env.pluginVersion ) {
 		// eslint-disable-next-line global-require
 		env.pluginVersion = require( "../package.json" ).yoast.pluginVersion;
@@ -154,8 +158,8 @@ module.exports = function( env ) {
 	];
 
 	const base = {
-		mode: mode,
-		devtool: mode === "development" ? "cheap-module-eval-source-map" : false,
+		mode: env.environment,
+		devtool: env.environment === "development" ? "cheap-module-eval-source-map" : false,
 		context: root,
 		output: {
 			path: paths.jsDist,
@@ -301,7 +305,7 @@ module.exports = function( env ) {
 		},
 	];
 
-	if ( mode === "development" ) {
+	if ( env.environment === "development" ) {
 		config[ 0 ].devServer = {
 			publicPath: "/",
 			allowedHosts,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Not really sure when this broke. But the `build` and `webpack-analyze-bundle` scripts are broken (due to missing `env` variable). 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the webpack config would error when running the `build` or `webpack-analyze-bundle` scripts.

## Relevant technical choices:

* We seem to mostly use the webpack config via the grunt task. There the env is created (see `grunt/config/webpack.js`. Which is why we did not notice.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Reproduce

* Switch to the release branch.
* Run `yarn build` and/or `yarn webpack-analyze-bundle`.
* Both should stop with an error similar to this:
```
wordpress-seo/node_modules/webpack-cli/bin/cli.js:244
				throw err;
				^

TypeError: Cannot read property 'environment' of undefined
    at module.exports (wordpress-seo/webpack/webpack.config.js:129:19)
```

### Test
* Switch to this branch.
* Run `yarn build`.
* The error should be gone and webpack should build normally.
* Run `yarn webpack-analyze-bundle`.
* The error should be gone, you should get the bundle analyzer.

### Regression
* Test the grunt commands to see if they still function:
  * `grunt webpack:buildDev`
  * `grunt webpack:buildProd`

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
