### PR TITLE
FRO-132 Updates radio and legend to new styling

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -224,7 +224,9 @@ class Yoast_Form {
 		$attr     = wp_parse_args( $attr, $defaults );
 
 		$id = ( $attr['id'] === '' ) ? '' : ' id="' . esc_attr( $attr['id'] ) . '"';
-		echo '<legend class="yoast-form-legend ' . esc_attr( $attr['class'] ) . '"' . $id . '>' . $text . '</legend>';
+		echo '<div class="yoast-field-group__title">';
+		echo '<legend class="' . esc_attr( $attr['class'] ) . '"' . $id . '>' . $text . '</legend>';
+		echo '</div>';
 	}
 
 	/**
@@ -361,7 +363,7 @@ class Yoast_Form {
 		'<span class="yoast-toggle--inactive" aria-hidden="true">', esc_html( $off_button ), '</span>',
 		'<span class="yoast-toggle--active" aria-hidden="true">', esc_html( $on_button ), '</span>',
 		'</div>',
-		'<a href="', $url, '" class="yoast-button yoast-button--buy yoast-button--buy-small">', __( 'Upgrade to Premium', 'wordpress-seo' ) ,'<span class="yoast-button--buy__caret"></span></a>',
+		'<a href="', $url, '" class="yoast-button yoast-button--buy yoast-button--buy-small">', __( 'Upgrade to premium', 'wordpress-seo' ) ,'<span class="yoast-button--buy__caret"></span></a>',
 		'</div>';
 	}
 
@@ -648,6 +650,7 @@ class Yoast_Form {
 
 		echo '<fieldset class="yoast-form-fieldset wpseo_radio_block" id="' . $var_esc . '">';
 
+
 		if ( is_string( $legend ) && $legend !== '' ) {
 
 			$defaults = [
@@ -661,6 +664,7 @@ class Yoast_Form {
 		}
 
 		foreach ( $values as $key => $value ) {
+			echo '<div class="yoast-field-group__radiobutton  yoast-field-group__radiobutton--vertical">';
 			$label      = $value;
 			$aria_label = '';
 
@@ -671,15 +675,11 @@ class Yoast_Form {
 
 			$key_esc = esc_attr( $key );
 			echo '<input type="radio" class="radio" id="' . $var_esc . '-' . $key_esc . '" name="' . esc_attr( $this->option_name ) . '[' . $var_esc . ']" value="' . $key_esc . '" ' . checked( $val, $key_esc, false ) . disabled( $this->is_control_disabled( $var ), true, false ) . ' />';
-			$this->label(
-				$label,
-				[
-					'for'        => $var_esc . '-' . $key_esc,
-					'class'      => 'radio',
-					'aria_label' => $aria_label,
-				]
-			);
+			echo '<label for=' . $var_esc . '-' . $key_esc . '>' . $label . '</label>';
+			echo '</div>';
 		}
+
+
 		echo '</fieldset>';
 	}
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -650,7 +650,6 @@ class Yoast_Form {
 
 		echo '<fieldset class="yoast-form-fieldset wpseo_radio_block" id="' . $var_esc . '">';
 
-
 		if ( is_string( $legend ) && $legend !== '' ) {
 
 			$defaults = [
@@ -664,7 +663,7 @@ class Yoast_Form {
 		}
 
 		foreach ( $values as $key => $value ) {
-			echo '<div class="yoast-field-group__radiobutton  yoast-field-group__radiobutton--vertical">';
+			echo '<div class="yoast-field-group__radiobutton yoast-field-group__radiobutton--vertical">';
 			$label      = $value;
 			$aria_label = '';
 
@@ -678,7 +677,6 @@ class Yoast_Form {
 			echo '<label for=' . $var_esc . '-' . $key_esc . '>' . $label . '</label>';
 			echo '</div>';
 		}
-
 
 		echo '</fieldset>';
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Updates the radio input and legend to the new styling

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the radio input and legend to the new styling

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Pull this branch
* Pull the javascript repo
* Pull this premium branch FRO-132-premium-import-export-pages
* Link the monorepo to the premium branch
* Merge this branch with a `--no-commit`
* Build the plugin
* Check under `SEO` -> `Tools` -> `Import/export` under the `Import redirects` if the radio's are correct.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/FRO-132
