### PR TITLE
Changed readfile to get_contents from wp_filesystem

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -435,9 +435,9 @@ class WPSEO_Sitemaps {
 		header( 'Cache-Control: max-age=' . $expires );
 		header( 'Expires: ' . $this->date->format_timestamp( ( time() + $expires ), 'D, d M Y H:i:s' ) . ' GMT' );
 
-		$isInitialized = WP_Filesystem();
+		$is_initialized = WP_Filesystem();
 
-		if ( $isInitialized ) {
+		if ( $is_initialized ) {
 			global $wp_filesystem;
 			$wp_filesystem->get_contents( WPSEO_PATH . 'css/main-sitemap.xsl' );
 		}

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -434,8 +434,9 @@ class WPSEO_Sitemaps {
 		header( 'Pragma: public' );
 		header( 'Cache-Control: max-age=' . $expires );
 		header( 'Expires: ' . $this->date->format_timestamp( ( time() + $expires ), 'D, d M Y H:i:s' ) . ' GMT' );
-
-		readfile( WPSEO_PATH . 'css/main-sitemap.xsl' );
+		
+		global $wp_filesystem;
+		$wp_filesystem->get_contents( WPSEO_PATH . 'css/main-sitemap.xsl' );
 	}
 
 	/**

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -434,7 +434,7 @@ class WPSEO_Sitemaps {
 		header( 'Pragma: public' );
 		header( 'Cache-Control: max-age=' . $expires );
 		header( 'Expires: ' . $this->date->format_timestamp( ( time() + $expires ), 'D, d M Y H:i:s' ) . ' GMT' );
-		
+
 		global $wp_filesystem;
 		$wp_filesystem->get_contents( WPSEO_PATH . 'css/main-sitemap.xsl' );
 	}

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -435,8 +435,12 @@ class WPSEO_Sitemaps {
 		header( 'Cache-Control: max-age=' . $expires );
 		header( 'Expires: ' . $this->date->format_timestamp( ( time() + $expires ), 'D, d M Y H:i:s' ) . ' GMT' );
 
-		global $wp_filesystem;
-		$wp_filesystem->get_contents( WPSEO_PATH . 'css/main-sitemap.xsl' );
+		$isInitialized = WP_Filesystem();
+
+		if ( $isInitialized ) {
+			global $wp_filesystem;
+			$wp_filesystem->get_contents( WPSEO_PATH . 'css/main-sitemap.xsl' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
CC @enricobattocchi 

* We changed the `readfile` function to `get_contents()` from `wp_filesystem` to fix the cs error in `class-sitemaps.php`

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* CS fix

## Relevant technical choices:

* Chose for WP_Filesystem because this was recommended by wordpress and the error message

## Testing instructions

* On trunk: build and activate the plugin
* Go to http://basic.wordpress.test/wp-content/plugins/wordpress-seo/css/main-sitemap.xsl
* Make sure the sitemap gets downloaded and looks fine
* Repeat the steps on this branch

