### PR TITLE
Add a generic class to allow styling inside of metabox tab section

### DIFF
--- a/css/src/editor/metabox.css
+++ b/css/src/editor/metabox.css
@@ -97,6 +97,10 @@ ul.wpseo-metabox-tabs li.active {
   margin-bottom: 10px;
 }
 
+.wpseo-meta-section-content {
+  padding: 16px;
+}
+
 .wpseo-metabox-content {
   max-width: 800px;
   padding-top: 16px;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This very simple PR will allow removing the CSS file that `wpseo-news` has.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add `.wpseo-meta-section-content` class with 16px padding to use in add-ons within their specific metabox tabs.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
