### PR TITLE
P3-55 Removed references to React in favor of @wordpress/element

### DIFF
--- a/.cache/.gitkeep
+++ b/.cache/.gitkeep
@@ -1,0 +1,1 @@
+# This directory has to exist to allow cache files to be written to it.

--- a/.eslintrc
+++ b/.eslintrc
@@ -17,10 +17,22 @@ rules:
   react/no-unused-prop-types: 1
   react/prop-types: 1
   react/require-default-props: 1
+  no-restricted-imports:
+    - error
+    - name: react
+      message: Please use @wordpress/element instead. No need to import just for JSX.
+    - name: react-dom
+      message: Please use @wordpress/element instead.
 
   # Disabled rules
   # In the editor, we're using the pragma `wp.element.createElement`
   react/react-in-jsx-scope: 0
+
+overrides:
+  - files:
+    - "js/tests/**/*.js"
+    rules:
+      no-restricted-imports: "off"
 
 settings:
   react:

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 # Set default behaviour, in case users don't have core.autocrlf set.
 * text=auto
 
+.cache export-ignore
 .github export-ignore
 deploy_keys export-ignore
 grunt export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tmp/
 *.bak
 *.log
 *.[Cc]ache
+!.cache
 *.cpr
 *.orig
 *.php.in

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,7 @@ cache:
   yarn: true
   directories:
     - $HOME/.composer/cache
+    - .cache
     - node_modules
 
 before_install:

--- a/admin/class-gutenberg-compatibility.php
+++ b/admin/class-gutenberg-compatibility.php
@@ -15,14 +15,14 @@ class WPSEO_Gutenberg_Compatibility {
 	 *
 	 * @var string
 	 */
-	const CURRENT_RELEASE = '8.3.0';
+	const CURRENT_RELEASE = '8.4.0';
 
 	/**
 	 * The minimally supported version of Gutenberg by the plugin.
 	 *
 	 * @var string
 	 */
-	const MINIMUM_SUPPORTED = '8.3.0';
+	const MINIMUM_SUPPORTED = '8.4.0';
 
 	/**
 	 * Holds the current version.

--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -83,7 +83,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 
 		if ( has_post_thumbnail( $post_id ) ) {
 			$featured_image_info = wp_get_attachment_image_src( get_post_thumbnail_id( $post_id ), 'thumbnail' );
-			return $featured_image_info[0];
+			return isset( $featured_image_info[0] ) ? $featured_image_info[0] : null;
 		}
 
 		return WPSEO_Image_Utils::get_first_usable_content_image_for_post( $post_id );

--- a/admin/links/class-link-reindex-dashboard.php
+++ b/admin/links/class-link-reindex-dashboard.php
@@ -123,7 +123,7 @@ class WPSEO_Link_Reindex_Dashboard {
 				echo implode( '<hr />', $blocks );
 			?>
 			<button onclick="tb_remove();" type="button"
-					class="button"><?php esc_html_e( 'Stop counting', 'wordpress-seo' ); ?></button>
+					class="yoast-button yoast-button--secondary"><?php esc_html_e( 'Stop counting', 'wordpress-seo' ); ?></button>
 		</div>
 		<?php
 	}

--- a/admin/taxonomy/class-taxonomy-fields-presenter.php
+++ b/admin/taxonomy/class-taxonomy-fields-presenter.php
@@ -61,7 +61,7 @@ class WPSEO_Taxonomy_Fields_Presenter {
 		$label            = $this->get_label( $field_configuration['label'], $esc_field_name );
 		$field            = $this->get_field( $field_configuration['type'], $esc_field_name, $this->get_field_value( $field_name ), $options );
 		$help_button_text = isset( $field_configuration['options']['help-button'] ) ? $field_configuration['options']['help-button'] : '';
-		$help             = new WPSEO_Admin_Help_Button( 'https://yoast.com/show-x-in-search-results/', $help_button_text );
+		$help             = ( $field_configuration['type'] === 'hidden' ) ? '' : new WPSEO_Admin_Help_Button( 'https://yoast.com/show-x-in-search-results/', $help_button_text );
 
 		return $this->parse_row( $label, $help, $field );
 	}
@@ -210,7 +210,7 @@ class WPSEO_Taxonomy_Fields_Presenter {
 	 *
 	 * @return string
 	 */
-	private function parse_row( $label, WPSEO_Admin_Help_Button $help, $field ) {
+	private function parse_row( $label, $help, $field ) {
 		if ( $label !== '' || $help !== '' ) {
 			return $label . $help . $field;
 		}

--- a/admin/views/tabs/metas/paper-content/post_type/post-type.php
+++ b/admin/views/tabs/metas/paper-content/post_type/post-type.php
@@ -27,7 +27,7 @@ $yform->show_hide_switch(
 $yform->show_hide_switch(
 	'display-metabox-pt-' . $wpseo_post_type->name,
 	/* translators: %s expands to an indexable object's name, like a post type or taxonomy */
-	sprintf( __( 'Show SEO settings for %1$s', 'wordpress-seo' ), '<strong>' . $wpseo_post_type->labels->name . '</strong>' )
+	sprintf( __( 'Show SEO settings for %1$s', 'wordpress-seo' ), $wpseo_post_type->labels->name )
 );
 
 $editor = new WPSEO_Replacevar_Editor(

--- a/admin/views/tabs/metas/paper-content/taxonomy-content.php
+++ b/admin/views/tabs/metas/paper-content/taxonomy-content.php
@@ -50,7 +50,7 @@ if ( $wpseo_taxonomy->name !== 'post_format' ) {
 	$yform->show_hide_switch(
 		'display-metabox-tax-' . $wpseo_taxonomy->name,
 		/* translators: %s expands to an indexable object's name, like a post type or taxonomy */
-		sprintf( __( 'Show SEO settings for %1$s', 'wordpress-seo' ), '<strong>' . $title . '</strong>' )
+		sprintf( __( 'Show SEO settings for %1$s', 'wordpress-seo' ), $title )
 	);
 }
 

--- a/composer.json
+++ b/composer.json
@@ -81,16 +81,23 @@
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/yoast/yoastcs,../../../vendor/phpcompatibility/php-compatibility,../../../vendor/phpcompatibility/phpcompatibility-paragonie,../../../vendor/phpcompatibility/phpcompatibility-wp",
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set default_standard Yoast"
 		],
+		"cs": [
+			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
+		],
 		"check-cs": [
+			"@check-cs-warnings -n"
+		],
+		"check-cs-errors": [
+			"echo You can now just use check-cs, running that command now.",
+			"composer check-cs"
+		],
+		"check-cs-warnings": [
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs"
 		],
 		"premium-check-cs": [
 			"@before-premium-cs",
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set ignore_warnings_on_exit 1",
 			"@after-premium-cs"
-		],
-		"check-cs-errors": [
-			"@check-cs -n"
 		],
 		"check-staged-cs": [
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_staged_cs"

--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -50,6 +50,46 @@ class Actions {
 	}
 
 	/**
+	 * Provides a coding standards option choice.
+	 *
+	 * @param Event $event Composer event.
+	 */
+	public static function check_coding_standards( Event $event ) {
+		$io = $event->getIO();
+
+		$choices = [
+			'1' => [ 'label' => 'Check staged files for coding standard warnings & errors.', 'command' => 'check-staged-cs' ],
+			'2' => [ 'label' => 'Check current branch\'s changed files for coding standard warnings & errors.', 'command' => 'check-branch-cs' ],
+			'3' => [ 'label' => 'Check for all coding standard errors.', 'command' => 'check-cs' ],
+			'4' => [ 'label' => 'Check for all coding standard warnings & errors.', 'command' => 'check-cs-warnings' ],
+			'5' => [ 'label' => 'Fix auto-fixable coding standards.', 'command' => 'fix-cs' ],
+			'6' => [ 'label' => '[Premium] Check for coding standard warnings and errors.', 'command' => 'premium-check-cs' ],
+			'7' => [ 'label' => '[Premium] Fix auto-fixable coding standards.', 'command' => 'premium-fix-cs' ],
+			'8' => [ 'label' => 'Load coding standards configuration.', 'command' => 'config-yoastcs' ],
+		];
+
+		$args = $event->getArguments();
+		if ( empty( $args ) ) {
+			foreach ( $choices as $choice => $data ) {
+				$io->write( sprintf( '%d. %s', $choice, $data['label'] ) );
+			}
+
+			$choice = $io->ask( 'What do you want to do? ' );
+		}
+		else {
+			$choice = $args[0];
+		}
+
+		if ( isset( $choices[ $choice ] ) ) {
+			$event_dispatcher = $event->getComposer()->getEventDispatcher();
+			$event_dispatcher->dispatchScript( $choices[ $choice ]['command'] );
+		}
+		else {
+			$io->write( 'Unknown choice.' );
+		}
+	}
+
+	/**
 	 * Compiles the dependency injection container.
 	 *
 	 * Used the composer compile-dependency-injection-container command.
@@ -105,6 +145,7 @@ class Actions {
 		$args = $event->getArguments();
 		if ( empty( $args ) ) {
 			self::check_cs_for_changed_files( 'trunk' );
+
 			return;
 		}
 		self::check_cs_for_changed_files( $args[0] );
@@ -123,13 +164,14 @@ class Actions {
 		\exec( 'git diff --name-only --diff-filter=d ' . \escapeshellarg( $compare ), $files );
 		$files = \array_filter(
 			$files,
-			function ( $file ) {
+			function( $file ) {
 				return \substr( $file, -4 ) === '.php';
 			}
 		);
 
 		if ( empty( $files ) ) {
-			echo 'No files to compare! Exiting.';
+			echo 'No files to compare! Exiting.' . PHP_EOL;
+
 			return;
 		}
 

--- a/css/src/admin/admin.css
+++ b/css/src/admin/admin.css
@@ -35,3 +35,30 @@
     background: none;
     color: var(--yoast-primary-color);
 }
+
+#wpseo_progressbar {
+	height: 25px;
+	border: 1px solid var(--yoast-color-primary);
+}
+
+#wpseo_progressbar .ui-progressbar-value {
+	height: 25px;
+	background: var(--yoast-color-primary);
+}
+
+.wpseo-progressbar-wrapper {
+	display: inline;
+	width: 100%;
+}
+
+.wpseo-progressbar {
+	display: block;
+	width: 100%;
+	height: 25px;
+	border: 1px solid var(--yoast-color-primary);
+}
+
+.wpseo-progressbar .ui-progressbar-value {
+	height: 25px;
+	background: var(--yoast-color-primary);
+}

--- a/css/src/components/configuration-wizard.css
+++ b/css/src/components/configuration-wizard.css
@@ -1,8 +1,8 @@
 /* This file is meant to be used exclusively for the Configuration Wizard. */
 /* WordPress-specific styling to be used only for single-page apps like the Onboarding Wizard. */
-@import url("../../node_modules/@yoast/components/src/title-separator/title-separator.css");
-@import url("../../node_modules/@yoast/components/src/button/buttons.css");
-@import url("../../node_modules/@yoast/components/src/inputs/input.css");
+@import url("@yoast/components/src/title-separator/title-separator.css");
+@import url("@yoast/components/src/button/buttons.css");
+@import url("@yoast/components/src/inputs/input.css");
 
 .screen-reader-text {
 	position: absolute !important;

--- a/css/src/editor/metabox.css
+++ b/css/src/editor/metabox.css
@@ -1,7 +1,7 @@
-@import "../../node_modules/@yoast/components/src/base/icons.css";
-@import "../../node_modules/draft-js-mention-plugin/lib/plugin.css";
+@import "@yoast/components/src/base/icons.css";
+@import "draft-js-mention-plugin/lib/plugin.css";
 /*!rtl:begin:ignore*/
-@import "../../node_modules/draft-js/dist/Draft.css";
+@import "draft-js/dist/Draft.css";
 /*!rtl:end:ignore*/
 
 #wpseo_meta {

--- a/css/src/editor/post-overview-global.css
+++ b/css/src/editor/post-overview-global.css
@@ -1,5 +1,5 @@
-@import "../../node_modules/@yoast/components/src/base/icons.css";
-@import "../../node_modules/yoastseo/css/_tooltips.scss";
+@import "@yoast/components/src/base/icons.css";
+@import "yoastseo/css/_tooltips.scss";
 
 
 /* Icons in the posts and taxonomies table cells. */

--- a/css/src/editor/yst_plugin_tools.css
+++ b/css/src/editor/yst_plugin_tools.css
@@ -1,4 +1,4 @@
-@import "../../node_modules/@yoast/components/src/base/icons.css";
+@import "@yoast/components/src/base/icons.css";
 
 /* Settings pages layout based on CSS table model. */
 .wpseo_content_wrapper {

--- a/deprecated/admin/class-social-admin.php
+++ b/deprecated/admin/class-social-admin.php
@@ -8,7 +8,7 @@
 /**
  * This class adds the Social tab to the Yoast SEO metabox and makes sure the settings are saved.
  *
- * @deprecated 14.4
+ * @deprecated 14.5
  *
  * @codeCoverageIgnore
  */
@@ -17,12 +17,12 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	/**
 	 * Class constructor.
 	 *
-	 * @deprecated 14.4
+	 * @deprecated 14.5
 	 *
 	 * @codeCoverageIgnore
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'WPSEO 14.4' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.5' );
 	}
 
 	/**
@@ -31,25 +31,25 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	 * IMPORTANT: if you want to add a new string (option) somewhere, make sure you add that array key to
 	 * the main meta box definition array in the class WPSEO_Meta() as well!!!!
 	 *
-	 * @deprecated 14.4
+	 * @deprecated 14.5
 	 *
 	 * @codeCoverageIgnore
 	 */
 	public static function translate_meta_boxes() {
-		_deprecated_function( __METHOD__, 'WPSEO 14.4' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.5' );
 	}
 
 	/**
 	 * Returns the metabox section for the social settings.
 	 *
-	 * @deprecated 14.4
+	 * @deprecated 14.5
 	 *
 	 * @codeCoverageIgnore
 	 *
 	 * @return WPSEO_Metabox_Collapsibles_Sections
 	 */
 	public function get_meta_section() {
-		_deprecated_function( __METHOD__, 'WPSEO 14.4' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.5' );
 
 		return null;
 	}
@@ -57,7 +57,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	/**
 	 * Returns the Upgrade to Premium notice.
 	 *
-	 * @deprecated 14.4
+	 * @deprecated 14.5
 	 *
 	 * @codeCoverageIgnore
 	 *
@@ -66,7 +66,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	 * @return string The notice HTML on the free version, empty string on premium.
 	 */
 	public function get_premium_notice( $network ) {
-		_deprecated_function( __METHOD__, 'WPSEO 14.4' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.5' );
 
 		return 'class_social_admin';
 	}
@@ -74,7 +74,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	/**
 	 * Filter over the meta boxes to save, this function adds the Social meta boxes.
 	 *
-	 * @deprecated 14.4
+	 * @deprecated 14.5
 	 *
 	 * @codeCoverageIgnore
 	 *
@@ -83,7 +83,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	 * @return array
 	 */
 	public function save_meta_boxes( $field_defs ) {
-		_deprecated_function( __METHOD__, 'WPSEO 14.4' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.5' );
 
 		return [];
 	}
@@ -93,13 +93,13 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	 *
 	 * When fields are changed, the facebook cache will be purged.
 	 *
-	 * @deprecated 14.4
+	 * @deprecated 14.5
 	 *
 	 * @codeCoverageIgnore
 	 *
 	 * @param WP_Post $post Post instance.
 	 */
 	public function og_data_compare( $post ) {
-		_deprecated_function( __METHOD__, 'WPSEO 14.4' );
+		_deprecated_function( __METHOD__, 'WPSEO 14.5' );
 	}
 }

--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 140,
+			maxWarnings: 126,
 		},
 	},
 	tests: {

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -400,6 +400,9 @@ class WPSEO_Addon_Manager {
 	 * @return array The plugins.
 	 */
 	protected function get_plugins() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
 		return get_plugins();
 	}
 

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -545,7 +545,7 @@ class WPSEO_Replace_Vars {
 		$replacement = null;
 
 		if ( is_string( $this->args->post_title ) && $this->args->post_title !== '' ) {
-			$replacement = stripslashes( $this->args->post_title );
+			$replacement = $this->args->post_title;
 		}
 
 		return $replacement;

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -435,7 +435,12 @@ class WPSEO_Sitemaps {
 		header( 'Cache-Control: max-age=' . $expires );
 		header( 'Expires: ' . $this->date->format_timestamp( ( time() + $expires ), 'D, d M Y H:i:s' ) . ' GMT' );
 
-		readfile( WPSEO_PATH . 'css/main-sitemap.xsl' );
+		$is_initialized = WP_Filesystem();
+
+		if ( $is_initialized ) {
+			global $wp_filesystem;
+			$wp_filesystem->get_contents( WPSEO_PATH . 'css/main-sitemap.xsl' );
+		}
 	}
 
 	/**

--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -4,8 +4,7 @@ import { MultiSelect, Select } from "@yoast/components";
 import { RadioButtonGroup } from "@yoast/components";
 import { TextInput } from "@yoast/components";
 import { curryUpdateToHiddenInput, getValueFromHiddenInput } from "@yoast/helpers";
-import { Component } from "@wordpress/element";
-import { Fragment } from "react";
+import { Component, Fragment } from "@wordpress/element";
 import { Alert } from "@yoast/components";
 
 /**

--- a/js/src/components/AnalysisUpsell.js
+++ b/js/src/components/AnalysisUpsell.js
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { __, sprintf } from "@wordpress/i18n";
@@ -39,7 +38,7 @@ const OutboundLinkButton = makeOutboundLink( UpsellLinkButton );
  *
  * @param {Object} props The component's props.
  *
- * @returns {ReactElement} The rendered AnalysisUpsell component.
+ * @returns {wp.Element} The rendered AnalysisUpsell component.
  */
 const AnalysisUpsell = ( props ) => {
 	const {

--- a/js/src/components/CollapsibleCornerstone.js
+++ b/js/src/components/CollapsibleCornerstone.js
@@ -1,5 +1,4 @@
 /* globals wpseoAdminL10n */
-import React from "react";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 
@@ -14,7 +13,7 @@ const LearnMoreLink = makeOutboundLink();
 /**
  * Renders the collapsible cornerstone toggle.
  *
- * @returns {ReactElement} The collapsible cornerstone toggle component.
+ * @returns {wp.Element} The collapsible cornerstone toggle component.
  * @constructor
  */
 export default function CollapsibleCornerstone( { isCornerstone, onChange } ) {

--- a/js/src/components/CompanyInfoMissing.js
+++ b/js/src/components/CompanyInfoMissing.js
@@ -2,7 +2,6 @@
 import { sprintf } from "@wordpress/i18n";
 import interpolateComponents from "interpolate-components";
 import PropTypes from "prop-types";
-import React from "react";
 
 /* Yoast dependencies */
 import { Alert } from "@yoast/components";
@@ -17,7 +16,7 @@ const OutboundLink = makeOutboundLink();
  *
  * @param {Object} props The properties to use.
  *
- * @returns {React.Component} The Alert component.
+ * @returns {wp.Element} The Alert component.
  */
 const CompanyInfoMissing = ( props ) => {
 	return <Alert type={ props.type }>

--- a/js/src/components/CompanyInfoMissingOnboardingWizard.js
+++ b/js/src/components/CompanyInfoMissingOnboardingWizard.js
@@ -1,7 +1,6 @@
 /* External dependencies */
 import { isEmpty } from "lodash-es";
 import PropTypes from "prop-types";
-import React from "react";
 
 /* Yoast dependencies */
 import CompanyInfoMissing from "./CompanyInfoMissing";
@@ -13,7 +12,7 @@ import CompanyInfoMissing from "./CompanyInfoMissing";
  *
  * @param {Object} props The properties to use.
  *
- * @returns {React.Component} The Alert component.
+ * @returns {wp.Element} The Alert component.
  */
 const CompanyInfoMissingOnboardingWizard = ( { properties, stepState } ) => {
 	const isCompanyInfoMissing = isEmpty( stepState.fieldValues[ "publishing-entity" ].publishingEntityCompanyName ) ||

--- a/js/src/components/CornerstoneToggle.js
+++ b/js/src/components/CornerstoneToggle.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { Toggle } from "@yoast/components";
@@ -12,11 +12,11 @@ const Cornerstone = styled.div`
 /**
  * The CornerstoneToggle Component.
  */
-class CornerstoneToggle extends React.Component {
+class CornerstoneToggle extends Component {
 	/**
 	 * Renders the CornerstoneToggle component.
 	 *
-	 * @returns {ReactElement} the CornerstoneToggle component.
+	 * @returns {wp.Element} the CornerstoneToggle component.
 	 */
 	render() {
 		return (

--- a/js/src/components/FinalStep.js
+++ b/js/src/components/FinalStep.js
@@ -1,14 +1,14 @@
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 
 /**
  * @summary Final step in the wizard component.
  */
-class FinalStep extends React.Component {
+class FinalStep extends Component {
 	/**
 	 * Renders the video next to the final congratulation message for completing the wizard
 	 *
-	 * @returns {JSX.Element} A HTML paragraph element containing the Final Step response.
+	 * @returns {wp.Element} A HTML paragraph element containing the Final Step response.
 	 */
 	render() {
 		return (

--- a/js/src/components/IntlProvider.js
+++ b/js/src/components/IntlProvider.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { IntlProvider as IntlProviderOriginal } from "react-intl";
 
@@ -7,7 +7,7 @@ import { IntlProvider as IntlProviderOriginal } from "react-intl";
  *
  * This component will render an IntlProvider when the locale-data promise is resolved.
  */
-class IntlProvider extends React.Component {
+class IntlProvider extends Component {
 	/**
 	 * Renders the provider component.
 	 *

--- a/js/src/components/LocalSEOUpsell.js
+++ b/js/src/components/LocalSEOUpsell.js
@@ -63,7 +63,7 @@ const OutboundLink = styled( utils.makeOutboundLink() )`
  * @param {string} props.url           The url the outbound link goes to.
  * @param {string} props.backgroundUrl The url for the background image of the container.
  *
- * @returns {ReactElement} The rendered LocalSEOUpsell component.
+ * @returns {wp.Element} The rendered LocalSEOUpsell component.
  */
 const LocalSEOUpsell = props => {
 	const { url, backgroundUrl } = props;

--- a/js/src/components/MailchimpSignup.js
+++ b/js/src/components/MailchimpSignup.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { localize } from "yoast-components";
 import { LoadingIndicator } from "@yoast/configuration-wizard";
@@ -7,7 +7,7 @@ import { sendRequest } from "@yoast/helpers";
 /**
  * @summary Mailchimp signup component.
  */
-class MailchimpSignup extends React.Component {
+class MailchimpSignup extends Component {
 	/**
 	 * @summary Constructs the Mailchimp signup component.
 	 *
@@ -191,7 +191,7 @@ class MailchimpSignup extends React.Component {
 	/**
 	 * @summary Renders the Mailchimp component.
 	 *
-	 * @returns {JSX.Element} Rendered Mailchimp Component.
+	 * @returns {wp.Element} Rendered Mailchimp Component.
 	 */
 	render() {
 		if ( this.skipRendering() ) {

--- a/js/src/components/MediaUpload.js
+++ b/js/src/components/MediaUpload.js
@@ -1,5 +1,5 @@
 /* global wp */
-import React, { createRef } from "react";
+import { Component, createRef } from "@wordpress/element";
 import PropTypes from "prop-types";
 import RaisedButton from "material-ui/RaisedButton";
 import { localize } from "yoast-components";
@@ -7,7 +7,7 @@ import { localize } from "yoast-components";
 /**
  * @summary Media upload component.
  */
-class MediaUpload extends React.Component {
+class MediaUpload extends Component {
 	constructor( props ) {
 		super( props );
 
@@ -88,7 +88,7 @@ class MediaUpload extends React.Component {
 	/**
 	 * Renders a remove button when an image is set.
 	 *
-	 * @returns {ReactElement} The button element.
+	 * @returns {wp.Element} The button element.
 	 */
 	renderRemoveButton() {
 		if ( ! this.state.currentUpload ) {
@@ -108,7 +108,7 @@ class MediaUpload extends React.Component {
 	/**
 	 * Renders the image when available.
 	 *
-	 * @returns {ReactElement} The image element.
+	 * @returns {wp.Element} The image element.
 	 */
 	renderImage() {
 		if ( ! this.state.currentUpload ) {
@@ -127,7 +127,7 @@ class MediaUpload extends React.Component {
 	/**
 	 * Renders the output.
 	 *
-	 * @returns {JSX.Element} The rendered HTML.
+	 * @returns {wp.Element} The rendered HTML.
 	 */
 	render() {
 		return (

--- a/js/src/components/ModalButtonContainer.js
+++ b/js/src/components/ModalButtonContainer.js
@@ -1,4 +1,3 @@
-import React from "react";
 import ModalIntl from "./modals/Modal";
 import IntlProvider from "./IntlProvider";
 import PropTypes from "prop-types";

--- a/js/src/components/PrimaryTaxonomyFilter.js
+++ b/js/src/components/PrimaryTaxonomyFilter.js
@@ -1,8 +1,7 @@
 /* global window */
 /* External dependencies */
-import React from "react";
 import PropTypes from "prop-types";
-import { Fragment } from "@wordpress/element";
+import { Component, Fragment } from "@wordpress/element";
 import {
 	get,
 	values,
@@ -21,7 +20,7 @@ const ErrorContainer = styled.div`
 	margin: 16px 0 8px;
 `;
 
-class PrimaryTaxonomyFilter extends React.Component {
+class PrimaryTaxonomyFilter extends Component {
 	constructor() {
 		super();
 
@@ -61,7 +60,7 @@ class PrimaryTaxonomyFilter extends React.Component {
 	/**
 	 * Renders the PrimaryTaxonomyFilter component.
 	 *
-	 * @returns {ReactElement} The rendered PrimaryTaxonomyFilter.
+	 * @returns {wp.Element} The rendered PrimaryTaxonomyFilter.
 	 */
 	render() {
 		const {

--- a/js/src/components/PrimaryTaxonomyPicker.js
+++ b/js/src/components/PrimaryTaxonomyPicker.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 import {
 	withSelect,
@@ -22,7 +22,7 @@ const PrimaryTaxonomyPickerField = styled.div`
 /**
  * A component for selecting a primary taxonomy term.
  */
-class PrimaryTaxonomyPicker extends React.Component {
+class PrimaryTaxonomyPicker extends Component {
 	constructor( props ) {
 		super( props );
 
@@ -216,7 +216,7 @@ class PrimaryTaxonomyPicker extends React.Component {
 	/**
 	 * Renders the PrimaryTaxonomyPicker component.
 	 *
-	 * @returns {ReactElement} The rendered component.
+	 * @returns {wp.Element} The rendered component.
 	 */
 	render() {
 		const {

--- a/js/src/components/RaisedDefaultButton.js
+++ b/js/src/components/RaisedDefaultButton.js
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 import RaisedButton from "material-ui/RaisedButton";
 

--- a/js/src/components/RaisedNextStepButton.js
+++ b/js/src/components/RaisedNextStepButton.js
@@ -1,4 +1,3 @@
-import React from "react";
 import RaisedDefaultButton from "./RaisedDefaultButton";
 import ArrowForwardIcon from "material-ui/svg-icons/navigation/arrow-forward";
 

--- a/js/src/components/RaisedURLButton.js
+++ b/js/src/components/RaisedURLButton.js
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 import RaisedDefaultButton from "./RaisedDefaultButton";
 import InfoIcon from "material-ui/svg-icons/action/info";
@@ -7,7 +6,7 @@ import InfoIcon from "material-ui/svg-icons/action/info";
  * Raised Button with a default info icon and a required URL
  *
  * @param {Object} props The list of props for this element.
- * @returns {JSX.Element} A RaisedDefaultButton element with supplied URL and Icon.
+ * @returns {wp.Element} A RaisedDefaultButton element with supplied URL and Icon.
  * @constructor
  */
 const RaisedURLButton = ( props ) => {

--- a/js/src/components/RaisedURLNewWindowButton.js
+++ b/js/src/components/RaisedURLNewWindowButton.js
@@ -1,5 +1,4 @@
 // External dependencies.
-import React from "react";
 import PropTypes from "prop-types";
 import InfoIcon from "material-ui/svg-icons/action/info";
 import { makeOutboundLink } from "@yoast/helpers";

--- a/js/src/components/RelatedKeyPhrasesModal.js
+++ b/js/src/components/RelatedKeyPhrasesModal.js
@@ -80,7 +80,7 @@ class RelatedKeyPhrasesModal extends Component {
 	/**
 	 * Renders the RelatedKeyPhrasesModal modal component.
 	 *
-	 * @returns {React.Element} The RelatedKeyPhrasesModal modal component.
+	 * @returns {wp.Element} The RelatedKeyPhrasesModal modal component.
 	 */
 	render() {
 		const { keyphrase, location, maxRelatedKeyphrasesEntered } = this.props;

--- a/js/src/components/SettingsReplacementVariableEditor.js
+++ b/js/src/components/SettingsReplacementVariableEditor.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { SettingsSnippetEditor } from "@yoast/search-metadata-previews";
 import { __ } from "@wordpress/i18n";
@@ -12,11 +12,15 @@ import {
 import SnippetPreviewSection from "./SnippetPreviewSection";
 import linkHiddenFields, { linkFieldsShape } from "./higherorder/linkHiddenField";
 
-class SettingsReplacementVariableEditor extends React.Component {
-	constructor( props ) {
-		super( props );
-	}
-
+/**
+ * Component class for the Settings replacement variable editor.
+ */
+class SettingsReplacementVariableEditor extends Component {
+	/**
+	 * Renders the component.
+	 *
+	 * @returns {wp.Element} The component.
+	 */
 	render() {
 		const {
 			title,

--- a/js/src/components/SettingsReplacementVariableEditors.js
+++ b/js/src/components/SettingsReplacementVariableEditors.js
@@ -51,8 +51,8 @@ class SettingsReplacementVariableEditors extends Component {
 	 * The *-field-id attributes should point to existing (hidden) inputs in the
 	 * DOM.
 	 *
-	 * @returns {Array<ReactElement>} An array of portals to instances of the
-	 *                                settings replacement variable editor.
+	 * @returns {Array<wp.Element>} An array of portals to instances of the
+	 *                              settings replacement variable editor.
 	 */
 	renderEditors() {
 		return map( this.props.editorElements, ( targetElement ) => {
@@ -92,8 +92,8 @@ class SettingsReplacementVariableEditors extends Component {
 	 * properly. The data-react-replacevar-field-id attribute should point to an
 	 * existing (hidden) input in the DOM.
 	 *
-	 * @returns {Array<ReactElement>} An array of portals to instances of the
-	 *                                settings replacement variable field.
+	 * @returns {Array<wp.Element>} An array of portals to instances of the
+	 *                              settings replacement variable field.
 	 */
 	renderSingleFields() {
 		return map( this.props.singleFieldElements, ( targetElement ) => {
@@ -124,7 +124,7 @@ class SettingsReplacementVariableEditors extends Component {
 	/**
 	 * Renders the SettingsReplacementVariableEditors element.
 	 *
-	 * @returns {ReactElement} A fragment containing all editor instances.
+	 * @returns {wp.Element} A fragment containing all editor instances.
 	 */
 	render() {
 		return (

--- a/js/src/components/SettingsReplacementVariableField.js
+++ b/js/src/components/SettingsReplacementVariableField.js
@@ -1,5 +1,5 @@
 /* External dpendencies */
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 import {
 	ReplacementVariableEditor,
@@ -19,7 +19,15 @@ const SnippetEditorWidthContainer = styled.div`
 	max-width: 640px;
 `;
 
-class SettingsReplacementVariableField extends React.Component {
+/**
+ * Component class for the Settings replacement variable field.
+ */
+class SettingsReplacementVariableField extends Component {
+	/**
+	 * Constructor.
+	 *
+	 * @param {object} props The props.
+	 */
 	constructor( props ) {
 		super( props );
 
@@ -31,10 +39,20 @@ class SettingsReplacementVariableField extends React.Component {
 		this.focus = this.focus.bind( this );
 	}
 
+	/**
+	 * Focus the input ref.
+	 *
+	 * @returns {void}
+	 */
 	focus() {
 		this.inputRef.focus();
 	}
 
+	/**
+	 * Renders the field.
+	 *
+	 * @returns {wp.Element} The field.
+	 */
 	render() {
 		const {
 			label,

--- a/js/src/components/SidebarCollapsible.js
+++ b/js/src/components/SidebarCollapsible.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { Collapsible } from "@yoast/components";
 
 /**
@@ -6,7 +5,7 @@ import { Collapsible } from "@yoast/components";
  *
  * @param {Object} props The properties for the component.
  *
- * @returns {ReactElement} The Collapsible component.
+ * @returns {wp.Element} The Collapsible component.
  */
 const SidebarCollapsible = ( props ) => {
 	return <Collapsible hasPadding={ true } hasSeparator={ true } { ...props } />;

--- a/js/src/components/SidebarItem.js
+++ b/js/src/components/SidebarItem.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import PropTypes from "prop-types";
 
 const SidebarItem = ( { children } ) => {

--- a/js/src/components/SnippetPreviewSection.js
+++ b/js/src/components/SnippetPreviewSection.js
@@ -1,5 +1,4 @@
 // External dependencies.
-import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { StyledSection, StyledHeading, StyledSectionBase } from "@yoast/components";
@@ -22,12 +21,12 @@ const Section = styled( StyledSection )`
  * Creates the Snippet Preview Section.
  *
  * @param {Object}         props               The component props.
- * @param {ReactComponent} props.children      The component's children.
+ * @param {wp.Element}     props.children      The component's children.
  * @param {string}         props.title         The heading title.
  * @param {string}         props.icon          The heading icon.
  * @param {bool}           props.hasPaperStyle Whether the section should have a paper style.
  *
- * @returns {ReactElement} Snippet Preview Section.
+ * @returns {wp.Element} Snippet Preview Section.
  */
 const SnippetPreviewSection = ( { children, title, icon, hasPaperStyle } ) => {
 	return (

--- a/js/src/components/Suggestion.js
+++ b/js/src/components/Suggestion.js
@@ -1,11 +1,14 @@
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 
-class Suggestion extends React.Component {
+/**
+ * Renders suggestions for next steps in the config wizard.
+ */
+class Suggestion extends Component {
 	/**
 	 * @summary Renders the Suggestion component.
 	 *
-	 * @returns {JSX.Element} Rendered Component.
+	 * @returns {wp.Element} Rendered Component.
 	 */
 	render() {
 		let buttonClass = "yoast-button yoast-button--secondary";

--- a/js/src/components/Suggestions.js
+++ b/js/src/components/Suggestions.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 
 import Suggestion from "./Suggestion";
@@ -6,11 +6,11 @@ import Suggestion from "./Suggestion";
 /**
  * @summary Suggestions component for config wizard.
  */
-class Suggestions extends React.Component {
+class Suggestions extends Component {
 	/**
 	 * @summary Renders the Suggestions component.
 	 *
-	 * @returns {JSX.Element} Rendered Choices Component.
+	 * @returns {wp.Element} Rendered Choices Component.
 	 */
 	render() {
 		return (

--- a/js/src/components/TaxonomyPicker.js
+++ b/js/src/components/TaxonomyPicker.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { unescape } from "lodash-es";
@@ -13,7 +12,7 @@ const SelectContainer = styled.div`
  *
  * @param {Object} props The component's props.
  *
- * @returns {ReactElement} The rendered TaxonomyPicker component.
+ * @returns {wp.Element} The rendered TaxonomyPicker component.
  */
 const TaxonomyPicker = ( props ) => {
 	const {

--- a/js/src/components/TopLevelProviders.js
+++ b/js/src/components/TopLevelProviders.js
@@ -12,9 +12,9 @@ import { LocationProvider } from "../components/contexts/location";
  * @param {object}       store    The redux store.
  * @param {object}       theme    The styled-components theme.
  * @param {string}       location The place where the wrapped component is rendered.
- * @param {ReactElement} children The element that should be wrapped.
+ * @param {wp.Element} children The element that should be wrapped.
  *
- * @returns {ReactElement} The wrapped element.
+ * @returns {wp.Element} The wrapped element.
  */
 const TopLevelProviders = ( { store, theme, location, children } ) => {
 	return (

--- a/js/src/components/UpsellBox.js
+++ b/js/src/components/UpsellBox.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React from "react";
+import { Component } from "@wordpress/element";
 import interpolateComponents from "interpolate-components";
 import PropTypes from "prop-types";
 import styled from "styled-components";
@@ -32,9 +32,9 @@ const UpsellButton = makeOutboundLink();
 /**
  * Returns the UpsellBox component.
  *
- * @returns {ReactElement} The UpsellBox component.
+ * @returns {wp.Element} The UpsellBox component.
  */
-class UpsellBox extends React.Component {
+class UpsellBox extends Component {
 	/**
 	 * The constructor.
 	 *
@@ -88,7 +88,7 @@ class UpsellBox extends React.Component {
 	/**
 	 * Renders a UpsellBox component.
 	 *
-	 * @returns {ReactElement} The rendered UpsellBox component.
+	 * @returns {wp.Element} The rendered UpsellBox component.
 	 */
 	render() {
 		return (

--- a/js/src/components/WordPressUserSelector.js
+++ b/js/src/components/WordPressUserSelector.js
@@ -12,7 +12,7 @@ import { sendRequest } from "yoast-components";
 /**
  * Styles to overwrite react-select styles.
  *
- * @type React.Component
+ * @type wp.Element
  */
 const Styles = createGlobalStyle`
 	.yoast-person-selector-container {
@@ -67,7 +67,7 @@ const REST_ROUTE = wpApiSettings.root;
 /**
  * Component to replace the react-select dropdown icon.
  *
- * @returns {React.Element} The rendered element.
+ * @returns {wp.Element} The rendered element.
  */
 const Icon = () => (
 	<SvgIcon
@@ -103,7 +103,7 @@ class WordPressUserSelector extends Component {
 	/**
 	 * Renders the WordPressUserSelector component.
 	 *
-	 * @returns {React.Element} The rendered component.
+	 * @returns {wp.Element} The rendered component.
 	 */
 	render() {
 		return (

--- a/js/src/components/WordPressUserSelectorOnboardingWizard.js
+++ b/js/src/components/WordPressUserSelectorOnboardingWizard.js
@@ -11,7 +11,7 @@ import WordPressUserSelector, { WordPressUserSelectorPropTypes } from "./WordPre
 /**
  * Container for the user selector.
  *
- * @type {React.Component}
+ * @type {wp.Element}
  */
 const Container = styled.div`
 	max-width: 250px;
@@ -30,7 +30,7 @@ class WordPressUserSelectorOnboardingWizard extends Component {
 	/**
 	 * Renders the WordPressUserSelectorOnboardingWizard component.
 	 *
-	 * @returns {React.Element} The rendered component.
+	 * @returns {wp.Element} The rendered component.
 	 */
 	render() {
 		return (

--- a/js/src/components/WordPressUserSelectorSearchAppearance.js
+++ b/js/src/components/WordPressUserSelectorSearchAppearance.js
@@ -57,7 +57,7 @@ class WordPressUserSelectorSearchAppearance extends Component {
 	/**
 	 * Renders an error message when no user has been selected.
 	 *
-	 * @returns {React.Element} The rendered error message.
+	 * @returns {wp.Element} The rendered error message.
 	 */
 	renderError() {
 		if ( this.state.value ) {
@@ -74,7 +74,7 @@ class WordPressUserSelectorSearchAppearance extends Component {
 	/**
 	 * Renders a message about the selected user when a user has been selected.
 	 *
-	 * @returns {React.Element} The rendered message.
+	 * @returns {wp.Element} The rendered message.
 	 */
 	renderAuthorInfo() {
 		if ( ! this.state.value || ! this.state.name ) {
@@ -105,7 +105,7 @@ class WordPressUserSelectorSearchAppearance extends Component {
 	/**
 	 * Renders the WordPressUserSelectorSearchAppearance component.
 	 *
-	 * @returns {React.Element} The rendered component.
+	 * @returns {wp.Element} The rendered component.
 	 */
 	render() {
 		return (

--- a/js/src/components/contentAnalysis/KeywordInput.js
+++ b/js/src/components/contentAnalysis/KeywordInput.js
@@ -30,7 +30,7 @@ class KeywordInput extends Component {
 	/**
 	 * Renders a help link.
 	 *
-	 * @returns {ReactElement} The help link component.
+	 * @returns {wp.Element} The help link component.
 	 */
 	static renderHelpLink() {
 		return (
@@ -48,7 +48,7 @@ class KeywordInput extends Component {
 	/**
 	 * Renders the component.
 	 *
-	 * @returns {ReactElement} The component.
+	 * @returns {wp.Element} The component.
 	 */
 	render() {
 		return <Fragment>

--- a/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -41,7 +41,7 @@ class ReadabilityAnalysis extends Component {
 	/**
 	 * Renders the Readability Analysis results.
 	 *
-	 * @returns {React.Element} The Readability Analysis results.
+	 * @returns {wp.Element} The Readability Analysis results.
 	 */
 	renderResults() {
 		return (
@@ -73,7 +73,7 @@ class ReadabilityAnalysis extends Component {
 	/**
 	 * Renders the Readability Analysis component.
 	 *
-	 * @returns {React.Element} The Readability Analysis component.
+	 * @returns {wp.Element} The Readability Analysis component.
 	 */
 	render() {
 		const score = getIndicatorForScore( this.props.overallScore );

--- a/js/src/components/contentAnalysis/Results.js
+++ b/js/src/components/contentAnalysis/Results.js
@@ -1,8 +1,7 @@
-import React from "react";
 import PropTypes from "prop-types";
 import { LanguageNotice } from "@yoast/components";
 import { ContentAnalysis } from "@yoast/analysis-report";
-import { Fragment } from "@wordpress/element";
+import { Component, Fragment } from "@wordpress/element";
 import { compose } from "@wordpress/compose";
 import { withDispatch, withSelect } from "@wordpress/data";
 import { Paper } from "yoastseo";
@@ -12,7 +11,7 @@ import mapResults from "./mapResults";
 /**
  * Wrapper to provide functionality to the ContentAnalysis component.
  */
-class Results extends React.Component {
+class Results extends Component {
 	/**
 	 * The component's constructor.
 	 *
@@ -91,7 +90,7 @@ class Results extends React.Component {
 	/**
 	 * Renders the Results component.
 	 *
-	 * @returns {ReactElement} The react element.
+	 * @returns {wp.Element} The React element.
 	 */
 	render() {
 		const { mappedResults } = this.state;

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -97,7 +97,7 @@ class SeoAnalysis extends Component {
 	 *
 	 * @param {string} location The location of the upsell component. Used to determine the shortlinks in the component.
 	 *
-	 * @returns {ReactElement} A modalButtonContainer component with the modal for a keyword synonyms upsell.
+	 * @returns {wp.Element} A modalButtonContainer component with the modal for a keyword synonyms upsell.
 	 */
 	renderSynonymsUpsell( location ) {
 		// Defaults to metabox.
@@ -150,7 +150,7 @@ class SeoAnalysis extends Component {
 	 *
 	 * @param {string} location The location of the upsell component. Used to determine the shortlinks in the component.
 	 *
-	 * @returns {ReactElement} A modalButtonContainer component with the modal for a multiple keywords upsell.
+	 * @returns {wp.Element} A modalButtonContainer component with the modal for a multiple keywords upsell.
 	 */
 	renderMultipleKeywordsUpsell( location ) {
 		// Defaults to metabox
@@ -203,7 +203,7 @@ class SeoAnalysis extends Component {
 	 *
 	 * @param {string} location The location of the upsell component. Used to determine the shortlinks in the component.
 	 *
-	 * @returns {ReactElement} The UpsellBox component.
+	 * @returns {wp.Element} The UpsellBox component.
 	 */
 	renderKeywordUpsell( location ) {
 		// Default to metabox.
@@ -237,7 +237,7 @@ class SeoAnalysis extends Component {
 	 *
 	 * @param {string} location The location of the upsell component. Used to determine the shortlink in the component.
 	 *
-	 * @returns {ReactElement} The AnalysisUpsell component.
+	 * @returns {wp.Element} The AnalysisUpsell component.
 	 */
 	renderWordFormsUpsell( location ) {
 		return (
@@ -256,7 +256,7 @@ class SeoAnalysis extends Component {
 	 * @param {string} location       Where this component is rendered.
 	 * @param {string} scoreIndicator String indicating the score.
 	 *
-	 * @returns {React.Element} The rendered score icone portal element.
+	 * @returns {wp.Element} The rendered score icone portal element.
 	 */
 	renderTabIcon( location, scoreIndicator ) {
 		// The tab icon should only be rendered for the metabox.
@@ -275,7 +275,7 @@ class SeoAnalysis extends Component {
 	/**
 	 * Renders the SEO Analysis component.
 	 *
-	 * @returns {React.Element} The SEO Analysis component.
+	 * @returns {wp.Element} The SEO Analysis component.
 	 */
 	render() {
 		const score = getIndicatorForScore( this.props.overallScore );

--- a/js/src/components/fills/MetaboxFill.js
+++ b/js/src/components/fills/MetaboxFill.js
@@ -23,7 +23,7 @@ import SocialMetadataPortal from "../portals/SocialMetadataPortal";
  * @param {Object} store    The Redux store.
  * @param {Object} theme    The theme to use.
  *
- * @returns {ReactElement} The Metabox component.
+ * @returns {wp.Element} The Metabox component.
  */
 export default function MetaboxFill( { settings, store, theme } ) {
 	return (

--- a/js/src/components/fills/SidebarFill.js
+++ b/js/src/components/fills/SidebarFill.js
@@ -20,7 +20,7 @@ import TopLevelProviders from "../TopLevelProviders";
  * @param {Object} store    The Redux store.
  * @param {Object} theme    The theme to use.
  *
- * @returns {ReactElement} The Sidebar component.
+ * @returns {wp.Element} The Sidebar component.
  *
  * @constructor
  */

--- a/js/src/components/higherorder/appendSpace.js
+++ b/js/src/components/higherorder/appendSpace.js
@@ -1,17 +1,17 @@
-import React, { Fragment } from "react";
+import { Component, Fragment } from "@wordpress/element";
 
 /**
  * A higher order component that appends a space to the given component.
  *
- * @param {ReactComponent} WrappedComponent The component to append a space to.
- * @returns {ReactComponent} The component with an appended space.
+ * @param {wp.Component} WrappedComponent The component to append a space to.
+ * @returns {wp.Component} The component with an appended space.
  */
 const appendSpace = function( WrappedComponent ) {
-	return class ComponentWithAppendedSpace extends React.Component {
+	return class ComponentWithAppendedSpace extends Component {
 		/**
 		 * Renders the React component.
 		 *
-		 * @returns {ReactElement} The rendered component.
+		 * @returns {wp.Element} The rendered component.
 		 */
 		render() {
 			return (

--- a/js/src/components/higherorder/linkHiddenField.js
+++ b/js/src/components/higherorder/linkHiddenField.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React from "react";
+import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 
 /**
@@ -12,7 +12,7 @@ import PropTypes from "prop-types";
  */
 const linkHiddenFields = ( mapFieldsFromProps ) => {
 	return ( WrappedComponent ) => {
-		class LinkHiddenFields extends React.Component {
+		class LinkHiddenFields extends Component {
 			constructor( props ) {
 				super( props );
 

--- a/js/src/components/higherorder/valueToNativeEvent.js
+++ b/js/src/components/higherorder/valueToNativeEvent.js
@@ -4,9 +4,9 @@ import { Component, forwardRef } from "@wordpress/element";
  * Higher order that maps an onChange that only returns a value to an "Event" object,
  * just as a native element would return.
  *
- * @param {React.Component} WrappedComponent The component to be wrapped.
+ * @param {wp.Component} WrappedComponent The component to be wrapped.
  *
- * @returns {React.Component} Higher order component.
+ * @returns {wp.Component} Higher order component.
  */
 export default ( WrappedComponent ) => {
 	/**
@@ -43,7 +43,7 @@ export default ( WrappedComponent ) => {
 		/**
 		 * Renders the Wrapper component, and intercepts props that shouldn't be passed down.
 		 *
-		 * @returns {React.Element} The rendered component.
+		 * @returns {wp.Element} The rendered component.
 		 */
 		render() {
 			// Extract props that shouldn't be passed down.

--- a/js/src/components/higherorder/withYoastSidebarPriority.js
+++ b/js/src/components/higherorder/withYoastSidebarPriority.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import PropTypes from "prop-types";
 
 const withYoastSidebarPriority = ( WrappedComponent ) => {

--- a/js/src/components/modals/CountrySelector.js
+++ b/js/src/components/modals/CountrySelector.js
@@ -1,12 +1,11 @@
 /* External dependencies */
-import React from "react";
 import PropTypes from "prop-types";
-import { Fragment } from "@wordpress/element";
+import { Fragment, Component } from "@wordpress/element";
 
 /**
  * The Country selector component.
  */
-class CountrySelector extends React.Component {
+class CountrySelector extends Component {
 	/**
 	 * Constructs the country selector.
 	 *

--- a/js/src/components/modals/CountrySelector.js
+++ b/js/src/components/modals/CountrySelector.js
@@ -20,7 +20,7 @@ class CountrySelector extends Component {
 	/**
 	 * Renders the country selector.
 	 *
-	 * @returns {React.Element} The country selector.
+	 * @returns {wp.Element} The country selector.
 	 */
 	render() {
 		// This `fakeProp` within the h2 is temporary in this component first basic implementation and should be removed.

--- a/js/src/components/modals/KeyphrasesTable.js
+++ b/js/src/components/modals/KeyphrasesTable.js
@@ -1,12 +1,11 @@
 /* External dependencies */
-import React from "react";
 import PropTypes from "prop-types";
-import { Fragment } from "@wordpress/element";
+import { Fragment, Component } from "@wordpress/element";
 
 /**
  * The Related Keyphrases table component.
  */
-class KeyphrasesTable extends React.Component {
+class KeyphrasesTable extends Component {
 	/**
 	 * Constructs the Related Keyphrases table.
 	 *

--- a/js/src/components/modals/KeyphrasesTable.js
+++ b/js/src/components/modals/KeyphrasesTable.js
@@ -20,7 +20,7 @@ class KeyphrasesTable extends Component {
 	/**
 	 * Renders the Related Keyphrases table.
 	 *
-	 * @returns {React.Element} The Related Keyphrases table.
+	 * @returns {wp.Element} The Related Keyphrases table.
 	 */
 	render() {
 		// This `fakeProp` within the h2 is temporary in this component first basic implementation and should be removed.

--- a/js/src/components/modals/KeywordSynonyms.js
+++ b/js/src/components/modals/KeywordSynonyms.js
@@ -1,4 +1,3 @@
-import React from "react";
 import interpolateComponents from "interpolate-components";
 import { __, sprintf } from "@wordpress/i18n";
 
@@ -13,7 +12,7 @@ const PremiumLandingPageLink = makeOutboundLink();
  *
  * @param {Object} props The props for the component.
  *
- * @returns {ReactElement} The Keyword Synonyms upsell component.
+ * @returns {wp.Element} The Keyword Synonyms upsell component.
  */
 const KeywordSynonyms = ( props ) => {
 	const intro = sprintf(

--- a/js/src/components/modals/Modal.js
+++ b/js/src/components/modals/Modal.js
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component, Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { __ } from "@wordpress/i18n";
@@ -21,9 +21,9 @@ const StyledButton = styled.button`
 /**
  * Returns the Modal component.
  *
- * @returns {ReactElement} The Modal component.
+ * @returns {wp.Element} The Modal component.
  */
-class Modal extends React.Component {
+class Modal extends Component {
 	/**
 	 * Constructs the Modal component.
 	 *
@@ -69,7 +69,7 @@ class Modal extends React.Component {
 	/**
 	 * Renders the Modal component.
 	 *
-	 * @returns {ReactElement} The rendered react element.
+	 * @returns {wp.Element} The rendered react element.
 	 */
 	render() {
 		const defaultLabels = {
@@ -82,7 +82,7 @@ class Modal extends React.Component {
 		const modalLabels = Object.assign( {}, defaultLabels, this.props.labels );
 
 		return (
-			<React.Fragment>
+			<Fragment>
 				<StyledButton
 					type="button"
 					onClick={ this.openModal }
@@ -105,7 +105,7 @@ class Modal extends React.Component {
 				>
 					{ this.props.children }
 				</YoastModal>
-			</React.Fragment>
+			</Fragment>
 		);
 	}
 }

--- a/js/src/components/modals/MultipleKeywords.js
+++ b/js/src/components/modals/MultipleKeywords.js
@@ -1,4 +1,3 @@
-import React from "react";
 import interpolateComponents from "interpolate-components";
 import { makeOutboundLink } from "@yoast/helpers";
 import { __, sprintf } from "@wordpress/i18n";
@@ -12,7 +11,7 @@ const PremiumLandingPageLink = makeOutboundLink();
  *
  * @param {Object} props The props for the component.
  *
- * @returns {ReactElement} The Multiple Keywords upsell component.
+ * @returns {wp.Element} The Multiple Keywords upsell component.
  */
 const MultipleKeywords = ( props ) => {
 	const intro = sprintf(

--- a/js/src/components/modals/SemRushLimitReached.js
+++ b/js/src/components/modals/SemRushLimitReached.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import { __, sprintf } from "@wordpress/i18n";
 import { Fragment } from "@wordpress/element";
 
@@ -11,7 +10,7 @@ const UpdateSemRushPlanLink = makeOutboundLink();
 /**
  * Creates the content for the SEMrush limit exceeded modal.
  *
- * @returns {React.Element} The SEMrush limit exceeded modal content.
+ * @returns {wp.Element} The SEMrush limit exceeded modal content.
  */
 const SemRushLimitReached = () => {
 	return (

--- a/js/src/components/modals/SemRushLoading.js
+++ b/js/src/components/modals/SemRushLoading.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import { __, sprintf } from "@wordpress/i18n";
 
 /* Yoast dependencies */
@@ -8,7 +7,7 @@ import { SvgIcon } from "@yoast/components";
 /**
  * Creates the loading content for the SEMrush related keywords modal.
  *
- * @returns {React.Element} The SEMrush loading content.
+ * @returns {wp.Element} The SEMrush loading content.
  */
 const SemRushLoading = () => {
 	return (

--- a/js/src/components/modals/SemRushMaxRelatedKeyphrases.js
+++ b/js/src/components/modals/SemRushMaxRelatedKeyphrases.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import { __, sprintf } from "@wordpress/i18n";
 
 /* Yoast dependencies */
@@ -8,7 +7,7 @@ import { Alert } from "@yoast/components";
 /**
  * Creates the content for the Maximum related keyphrases alert.
  *
- * @returns {React.Element} The Maximum related keyphrases alert.
+ * @returns {wp.Element} The Maximum related keyphrases alert.
  */
 const SemRushMaxRelatedKeyphrases = () => {
 	return (

--- a/js/src/components/modals/SemRushRequestFailed.js
+++ b/js/src/components/modals/SemRushRequestFailed.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import { __ } from "@wordpress/i18n";
 
 /* Yoast dependencies */
@@ -8,7 +7,7 @@ import { Alert } from "@yoast/components";
 /**
  * Creates the content for the SEMrush request failed modal.
  *
- * @returns {React.Element} The SEMrush request failed modal content.
+ * @returns {wp.Element} The SEMrush request failed modal content.
  */
 const SemRushRequestFailed = () => {
 	return (

--- a/js/src/components/modals/SemRushUpsellAlert.js
+++ b/js/src/components/modals/SemRushUpsellAlert.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import { __, sprintf } from "@wordpress/i18n";
 
 /* Yoast dependencies */
@@ -11,7 +10,7 @@ const PremiumLandingPageLink = makeOutboundLink();
 /**
  * Creates the content for the Yoast SEO Premium upsell alert in SEMrush modal.
  *
- * @returns {React.Element} The Yoast SEO Premium upsell alert.
+ * @returns {wp.Element} The Yoast SEO Premium upsell alert.
  */
 const SemRushUpsellAlert = () => {
 	return (

--- a/js/src/components/portals/CompanyInfoMissingPortal.js
+++ b/js/src/components/portals/CompanyInfoMissingPortal.js
@@ -10,7 +10,7 @@ import Portal from "./Portal";
  * @param {string} message The message to show in the notice.
  * @param {string} url The url to link to in the notice.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function CompanyInfoMissingPortal( { target, message, link } ) {
 	return (

--- a/js/src/components/portals/LocalSEOUpsellPortal.js
+++ b/js/src/components/portals/LocalSEOUpsellPortal.js
@@ -11,7 +11,7 @@ import Portal from "./Portal";
  * @param {string} url The url to link to in the notice.
  * @param {string} backgroundUrl The Url for the background image.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function LocalSEOUpsellPortal( { target, url, backgroundUrl } ) {
 	return (

--- a/js/src/components/portals/MetaboxPortal.js
+++ b/js/src/components/portals/MetaboxPortal.js
@@ -11,7 +11,7 @@ import Portal from "./Portal";
  * @param {Object} store  The Redux store.
  * @param {Object} theme  The theme to use.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function MetaboxPortal( { target, store, theme } ) {
 	return (

--- a/js/src/components/portals/Portal.js
+++ b/js/src/components/portals/Portal.js
@@ -5,9 +5,9 @@ import PropTypes from "prop-types";
  * Renders a portal.
  *
  * @param {string|object} target A target element ID in which to render the portal.
- * @param {React.Element} children The child components.
+ * @param {wp.Element} children The child components.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function Portal( { target, children } ) {
 	let targetElement = target;

--- a/js/src/components/portals/ReadabilityResultsPortal.js
+++ b/js/src/components/portals/ReadabilityResultsPortal.js
@@ -5,9 +5,9 @@ import PropTypes from "prop-types";
  * Renders a portal for the readability results in the editor.
  *
  * @param {string} target A target element ID in which to render the portal.
- * @param {React.Element} children The child components.
+ * @param {wp.Element} children The child components.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function ReadabilityResultsPortal( { target, children } ) {
 	return (

--- a/js/src/components/portals/ScoreIconPortal.js
+++ b/js/src/components/portals/ScoreIconPortal.js
@@ -12,7 +12,7 @@ import Portal from "./Portal";
  * @param {string} target A target element ID in which to render the portal.
  * @param {string} scoreIndicator The score indicator.
  *
- * @returns {React.Element} The score element.
+ * @returns {wp.Element} The score element.
  */
 const ScoreIconPortal = ( { target, scoreIndicator } ) => {
 	return (

--- a/js/src/components/portals/SettingsEditorPortal.js
+++ b/js/src/components/portals/SettingsEditorPortal.js
@@ -1,6 +1,5 @@
 import PropTypes from "prop-types";
 import SettingsReplacementVariableEditor from "../SettingsReplacementVariableEditor";
-import React from "react";
 import {
 	replacementVariablesShape,
 	recommendedReplacementVariablesShape,
@@ -18,7 +17,7 @@ import Portal from "./Portal";
  * @param {string} descriptionTarget The id of the description field.
  * @param {boolean} hasPaperStyle Whether the editor should be styled as a paper.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function SettingsEditorPortal( {
 	target,

--- a/js/src/components/portals/SettingsFieldPortal.js
+++ b/js/src/components/portals/SettingsFieldPortal.js
@@ -1,5 +1,4 @@
 import PropTypes from "prop-types";
-import React from "react";
 import {
 	replacementVariablesShape,
 	recommendedReplacementVariablesShape,
@@ -17,7 +16,7 @@ import Portal from "./Portal";
  * @param {string[]} recommendedReplacementVariables the recommended replacement variables for the field.
  * @param {string} fieldId The field ID.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function SettingsFieldPortal( { target, label, replacementVariables, recommendedReplacementVariables, fieldId } ) {
 	return (

--- a/js/src/components/portals/SocialMetadataPortal.js
+++ b/js/src/components/portals/SocialMetadataPortal.js
@@ -8,7 +8,7 @@ import Portal from "./Portal";
  *
  * @param {string} target A target element ID in which to render the portal.
  *
- * @returns {React.Component} The social metadata collapsibles.
+ * @returns {wp.Element} The social metadata collapsibles.
  */
 export default function SocialMetadataPortal( { target } ) {
 	const isFacebookEnabled = window.wpseoScriptData.metabox.showSocial.facebook;

--- a/js/src/components/portals/UserSelectPortal.js
+++ b/js/src/components/portals/UserSelectPortal.js
@@ -8,7 +8,7 @@ import Portal from "./Portal";
  *
  * @param {string} target A target element ID in which to render the portal.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function UserSelectPortal( { target } ) {
 	return (

--- a/js/src/components/slots/FacebookPreviewSlot.js
+++ b/js/src/components/slots/FacebookPreviewSlot.js
@@ -1,10 +1,9 @@
 import { Slot } from "@wordpress/components";
-import React from "react";
 
 /**
  * Renders a slot for the Facebook preview.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function FacebookPreviewSlot() {
 	return ( <Slot name="YoastFacebookPreview" /> );

--- a/js/src/components/slots/MetaboxSlot.js
+++ b/js/src/components/slots/MetaboxSlot.js
@@ -4,7 +4,7 @@ import sortComponentsByRenderPriority from "../../helpers/sortComponentsByRender
 /**
  * Renders the metabox portal.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function MetaboxSlot() {
 	return (

--- a/js/src/components/slots/SidebarSlot.js
+++ b/js/src/components/slots/SidebarSlot.js
@@ -1,11 +1,10 @@
 import { Slot } from "@wordpress/components";
 import sortComponentsByRenderPriority from "../../helpers/sortComponentsByRenderPriority";
-import React from "react";
 
 /**
  * Renders the Sidebar slot.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function SidebarSlot() {
 	return (

--- a/js/src/components/slots/SynonymSlot.js
+++ b/js/src/components/slots/SynonymSlot.js
@@ -1,12 +1,11 @@
 import { Slot } from "@wordpress/components";
-import React from "react";
 import PropTypes from "prop-types";
 
 /**
  * Renders a Synonym slot.
  * @param {string} location the tablocation of the keyphrase the synonyms belong to.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function SynonymSlot( { location } ) {
 	return ( <Slot name={ `yoast-synonyms-${ location }` } /> );

--- a/js/src/components/slots/TwitterPreviewSlot.js
+++ b/js/src/components/slots/TwitterPreviewSlot.js
@@ -1,10 +1,9 @@
 import { Slot } from "@wordpress/components";
-import React from "react";
 
 /**
  * Renders a slot for the Twitter preview.
  *
- * @returns {null|ReactElement} The element.
+ * @returns {null|wp.Element} The element.
  */
 export default function TwitterPreviewSlot() {
 	return ( <Slot name="YoastTwitterPreview" /> );

--- a/js/src/components/social/FacebookWrapper.js
+++ b/js/src/components/social/FacebookWrapper.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { Fragment } from "@wordpress/element";
 import { Slot } from "@wordpress/components";
 import PropTypes from "prop-types";
 

--- a/js/src/components/social/SocialForm.js
+++ b/js/src/components/social/SocialForm.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import React, { Component } from "react";
+import { Component, Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 
 /* Internal dependencies */
@@ -129,7 +129,7 @@ class SocialPreviewEditor extends Component {
 		} = this.props;
 
 		return (
-			<React.Fragment>
+			<Fragment>
 				<SocialUpsell socialMediumName={ socialMediumName } />
 				<SocialMetadataPreviewForm
 					onDescriptionChange={ onDescriptionChange }
@@ -153,7 +153,7 @@ class SocialPreviewEditor extends Component {
 					isPremium={ isPremium }
 					setEditorRef={ this.setEditorRef }
 				/>
-			</React.Fragment>
+			</Fragment>
 		);
 	}
 }

--- a/js/src/components/social/SocialMetadata.js
+++ b/js/src/components/social/SocialMetadata.js
@@ -13,7 +13,7 @@ import TwitterContainer from "../../containers/TwitterEditor";
  *
  * @param {Object} props The props object.
  *
- * @returns {React.Component} The social metadata collapsibles.
+ * @returns {wp.Element} The social metadata collapsibles.
  */
 const SocialMetadata = ( { isFacebookEnabled, isTwitterEnabled } ) => {
 	return (

--- a/js/src/components/social/SocialUpsell.js
+++ b/js/src/components/social/SocialUpsell.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { Fragment } from "@wordpress/element";
 import styled from "styled-components";
 import interpolateComponents from "interpolate-components";
 import PropTypes from "prop-types";
@@ -27,7 +27,7 @@ const upgradeText = sprintf(
  * @param {Object} props The properties passed to this component.
  * @param {string} props.socialMedium The socialmedium platform.
  *
- * @returns {Component} The FacebookView Component.
+ * @returns {wp.Element} The FacebookView Component.
  */
 const SocialUpsell = ( props ) => {
 	const previewText = sprintf(

--- a/js/src/components/social/TwitterWrapper.js
+++ b/js/src/components/social/TwitterWrapper.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { Fragment } from "@wordpress/element";
 import { Slot } from "@wordpress/components";
 import PropTypes from "prop-types";
 
@@ -10,7 +10,7 @@ import SocialForm from "../social/SocialForm";
  *
  * @param {Object} props The properties object.
  *
- * @returns {Component} Renders the TwitterWrapper React Component.
+ * @returns {wp.Element} Renders the TwitterWrapper React Component.
  */
 const TwitterWrapper = ( props ) => {
 	return (

--- a/js/src/configuration-wizard.js
+++ b/js/src/configuration-wizard.js
@@ -1,7 +1,6 @@
 /* global yoastWizardConfig */
 // External dependencies.
-import React from "react";
-import ReactDOM from "react-dom";
+import { Component, render } from "@wordpress/element";
 import ConfigurationWizard, { MessageBox } from "@yoast/configuration-wizard";
 import { setTranslations } from "yoast-components";
 import { isUndefined } from "lodash-es";
@@ -22,7 +21,7 @@ const PluginConflictLink = makeOutboundLink();
 /**
  * @summary Configuration wizard component.
  */
-class App extends React.Component {
+class App extends Component {
 	/**
 	 * Constructs the App component.
 	 *
@@ -116,7 +115,7 @@ class App extends React.Component {
 	/**
 	 * Renders the App component.
 	 *
-	 * @returns {JSX.Element|null} The rendered app component.
+	 * @returns {wp.Element|null} The rendered app component.
 	 */
 	render() {
 		// When the wizard is loading, don't do anything.
@@ -154,4 +153,4 @@ class App extends React.Component {
 
 setYoastComponentsL10n();
 
-ReactDOM.render( <App />, document.getElementById( "wizard" ) );
+render( <App />, document.getElementById( "wizard" ) );

--- a/js/src/containers/SnippetEditor.js
+++ b/js/src/containers/SnippetEditor.js
@@ -1,6 +1,6 @@
-import React from "react";
 import { connect } from "react-redux";
 import { SnippetEditor } from "@yoast/search-metadata-previews";
+import { Fragment } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { dispatch as wpDataDispatch } from "@wordpress/data";
 
@@ -46,7 +46,7 @@ export const mapEditorDataToPreview = function( data, context ) {
 };
 
 const SnippetEditorWrapper = ( props ) => (
-	<React.Fragment>
+	<Fragment>
 		<SnippetPreviewSection
 			icon="eye"
 			hasPaperStyle={ props.hasPaperStyle }
@@ -57,7 +57,7 @@ const SnippetEditorWrapper = ( props ) => (
 				mapEditorDataToPreview={ mapEditorDataToPreview }
 			/>
 		</SnippetPreviewSection>
-	</React.Fragment>
+	</Fragment>
 );
 
 /**

--- a/js/src/dashboard-widget.js
+++ b/js/src/dashboard-widget.js
@@ -1,7 +1,6 @@
 /* global wpseoDashboardWidgetL10n, wpseoApi, jQuery */
 // External dependencies.
-import React from "react";
-import ReactDOM from "react-dom";
+import { Component, render } from "@wordpress/element";
 import { ArticleList as WordpressFeed } from "@yoast/components";
 import { colors } from "@yoast/style-guide";
 import { SiteSEOReport as SeoAssessment } from "@yoast/analysis-report";
@@ -13,7 +12,7 @@ import { setYoastComponentsL10n } from "./helpers/i18n";
 /**
  * The Yoast dashboardwidget component used on the WordPress admin dashboard.
  */
-class DashboardWidget extends React.Component {
+class DashboardWidget extends Component {
 	/**
 	 * Creates the components and initializes its state.
 	 */
@@ -91,7 +90,7 @@ class DashboardWidget extends React.Component {
 	/**
 	 * Returns the SEO Assessment sub-component.
 	 *
-	 * @returns {ReactElement} The SEO Assessment component.
+	 * @returns {wp.Element} The SEO Assessment component.
 	 */
 	getSeoAssessment() {
 		if ( this.state.statistics === null ) {
@@ -108,7 +107,7 @@ class DashboardWidget extends React.Component {
 	/**
 	 * Returns the yoast.com feed sub-component.
 	 *
-	 * @returns {ReactElement} The yoast.com feed component.
+	 * @returns {wp.Element} The yoast.com feed component.
 	 */
 	getYoastFeed() {
 		if ( this.state.feed === null ) {
@@ -127,7 +126,7 @@ class DashboardWidget extends React.Component {
 	/**
 	 * Renders the component.
 	 *
-	 * @returns {ReactElement} The component.
+	 * @returns {wp.Element} The component.
 	 */
 	render() {
 		const contents = [
@@ -148,5 +147,5 @@ const element = document.getElementById( "yoast-seo-dashboard-widget" );
 if ( element ) {
 	setYoastComponentsL10n();
 
-	ReactDOM.render( <DashboardWidget />, element );
+	render( <DashboardWidget />, element );
 }

--- a/js/src/help-scout-beacon.js
+++ b/js/src/help-scout-beacon.js
@@ -13,7 +13,7 @@ const BeaconOffset = createGlobalStyle`
 /**
  * Render a component in a newly created div.
  *
- * @param {React.Component} component The component to render.
+ * @param {wp.Component} component The component to render.
  *
  * @returns {void}
  */
@@ -146,7 +146,7 @@ function loadHelpScoutConsent( beaconId, sessionData = null ) {
 	 *
 	 * @constructor
 	 *
-	 * @returns {React.Element} A SpeechBubble element.
+	 * @returns {wp.Element} A SpeechBubble element.
 	 */
 	const SpeechBubble = () => {
 		return (
@@ -193,7 +193,7 @@ function loadHelpScoutConsent( beaconId, sessionData = null ) {
 	 *
 	 * @constructor
 	 *
-	 * @returns {React.Element} A HelpScoutBeaconAskConsentButton element.
+	 * @returns {wp.Element} A HelpScoutBeaconAskConsentButton element.
 	 */
 	const HelpScoutBeaconAskConsentButton = () => {
 		const [ show, setShow ] = useState( true );

--- a/js/src/helpers/classicEditor.js
+++ b/js/src/helpers/classicEditor.js
@@ -1,4 +1,4 @@
-import { render, Component, createRef } from "@wordpress/element";
+import { render, Component as wpComponent, createRef } from "@wordpress/element";
 import { SlotFillProvider } from "@wordpress/components";
 import MetaboxPortal from "../components/portals/MetaboxPortal";
 import getL10nObject from "../analysis/getL10nObject";
@@ -6,7 +6,7 @@ import getL10nObject from "../analysis/getL10nObject";
 const registeredComponents = [];
 let containerRef = null;
 
-class RegisteredComponentsContainer extends Component {
+class RegisteredComponentsContainer extends wpComponent {
 	/**
 	 * Constructs a container for registered components.
 	 *
@@ -26,7 +26,7 @@ class RegisteredComponentsContainer extends Component {
 	 *
 	 * @param {string}          key       Unique key to give to React to render
 	 *                                    within a list of components.
-	 * @param {React.Component} Component A valid React component to render.
+	 * @param {wp.Component} Component A valid React component to render.
 	 *
 	 * @returns {void}
 	 */
@@ -45,7 +45,7 @@ class RegisteredComponentsContainer extends Component {
 	/**
 	 * Renders all the registered components.
 	 *
-	 * @returns {React.Element[]} The rendered components in an array.
+	 * @returns {wp.Element[]} The rendered components in an array.
 	 */
 	render() {
 		return this.state.registeredComponents.map( ( { Component, key } ) => {
@@ -94,7 +94,7 @@ export function renderClassicEditorMetabox( store ) {
  *
  * @param {string}          key       Unique key to give to React to render
  *                                    within a list of components.
- * @param {React.Component} Component A valid React component to render.
+ * @param {wp.Component} Component A valid React component to render.
  *
  * @returns {void}
  */

--- a/js/src/helpers/createInterpolateElement.js
+++ b/js/src/helpers/createInterpolateElement.js
@@ -10,7 +10,7 @@
 /**
  * External dependencies
  */
-import { createElement, cloneElement, Fragment, isValidElement } from "react";
+import { createElement, cloneElement, Fragment, isValidElement } from "@wordpress/element";
 
 /** @typedef {import('./react').WPElement} WPElement */
 

--- a/js/src/helpers/sortComponentsByRenderPriority.js
+++ b/js/src/helpers/sortComponentsByRenderPriority.js
@@ -7,9 +7,9 @@ import { flatten } from "lodash-es";
  * a collection are also included. This is to allow sorting multiple fills of
  * which at least one includes an array of components.
  *
- * @param {ReactElement|array} components The component(s) to be sorted.
+ * @param {wp.Element|array} components The component(s) to be sorted.
  *
- * @returns {ReactElement|array} The sorted component(s).
+ * @returns {wp.Element|array} The sorted component(s).
  */
 export default function sortComponentsByRenderPriority( components ) {
 	if ( typeof components.length === "undefined" ) {

--- a/js/src/initializers/edit.js
+++ b/js/src/initializers/edit.js
@@ -1,6 +1,5 @@
 /* global window wp */
 /* External dependencies */
-import React from "react";
 import styled from "styled-components";
 import { Fragment } from "@wordpress/element";
 import { combineReducers, registerStore, select, dispatch } from "@wordpress/data";

--- a/js/src/inline-links/edit-link.js
+++ b/js/src/inline-links/edit-link.js
@@ -12,10 +12,6 @@ import {
 	isCollapsed,
 } from "@wordpress/rich-text";
 import { isURL, isEmail } from "@wordpress/url";
-import {
-	RichTextToolbarButton,
-	RichTextShortcut,
-} from "@wordpress/block-editor";
 import { decodeEntities } from "@wordpress/html-entities";
 
 /**
@@ -30,11 +26,11 @@ export const link = {
 	name,
 	title,
 	tagName: "a",
-	className: "yoast-seo-link",
+	className: null,
 	attributes: {
 		url: "href",
-		type: "data-type",
 		target: "target",
+		rel: "rel",
 	},
 	replaces: "core/link",
 	__unstablePasteRule( value, { html, plainText } ) {
@@ -116,6 +112,19 @@ export const link = {
 					value,
 					onChange,
 				} = this.props;
+
+				/*
+				 * We need to import this right here, since we can only know for sure
+				 * that we are in the block editor when rendering this component.
+				 *
+				 * We can't tell WordPress that "wp-block-editor" script is a dependency
+				 * when loading this JavaScript, since we cannot tell if the edit
+				 * page is using the classic or block editor.
+				 */
+				const {
+					RichTextToolbarButton,
+					RichTextShortcut,
+				} = window.wp.blockEditor;
 
 				return (
 					<Fragment>

--- a/js/src/inline-links/inline.js
+++ b/js/src/inline-links/inline.js
@@ -11,7 +11,6 @@ import { __, sprintf } from "@wordpress/i18n";
 import { withSpokenMessages, Popover } from "@wordpress/components";
 import { prependHTTP } from "@wordpress/url";
 import { create, insert, isCollapsed, applyFormat } from "@wordpress/rich-text";
-import { __experimentalLinkControl as LinkControl } from "@wordpress/block-editor";
 
 /**
  * Internal dependencies
@@ -233,6 +232,16 @@ function InlineLinkUI( {
 			title: sponsoredLabel,
 		},
 	];
+
+	/*
+	 * We need to import this right here, since we can only know for sure
+	 * that we are in the block editor when rendering this component.
+	 *
+	 * We can't tell WordPress that "wp-block-editor" script is a dependency
+	 * when loading this JavaScript, since we cannot tell if the edit
+	 * page is using the classic or block editor.
+	 */
+	const { __experimentalLinkControl: LinkControl } = window.wp.blockEditor;
 
 	return (
 		<Popover

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -1,6 +1,5 @@
 /* global yoastModalConfig */
-import React from "react";
-import ReactDOM from "react-dom";
+import { render } from "@wordpress/element";
 import ModalButtonContainer from "./components/ModalButtonContainer";
 
 if ( window.yoastModalConfig ) {
@@ -13,7 +12,7 @@ if ( window.yoastModalConfig ) {
 			const element = document.querySelector( config.mountHook );
 
 			if ( element ) {
-				ReactDOM.render(
+				render(
 					<ModalButtonContainer { ...config } />,
 					element
 				);

--- a/js/src/structured-data-blocks/faq/block.js
+++ b/js/src/structured-data-blocks/faq/block.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import { __ } from "@wordpress/i18n";
 
 /* Internal dependencies */

--- a/js/src/structured-data-blocks/faq/components/Question.js
+++ b/js/src/structured-data-blocks/faq/components/Question.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-import React from "react";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 import { isShallowEqualObjects } from "@wordpress/is-shallow-equal";
@@ -44,7 +43,7 @@ export default class Question extends Component {
 	 * @param {Object}   props      The received props.
 	 * @param {function} props.open Opens the media upload dialog.
 	 *
-	 * @returns {ReactElement} The media upload button.
+	 * @returns {wp.Element} The media upload button.
 	 */
 	getMediaUploadButton( props ) {
 		return (

--- a/js/src/structured-data-blocks/how-to/components/HowTo.js
+++ b/js/src/structured-data-blocks/how-to/components/HowTo.js
@@ -19,7 +19,7 @@ const RichTextWithAppendedSpace = appendSpace( RichText.Content );
 /**
  * Modified Text Control to provide a better layout experience.
  *
- * @returns {ReactElement} The TextControl with additional spacing below.
+ * @returns {wp.Element} The TextControl with additional spacing below.
  */
 const SpacedTextControl = styled( TextControl )`
 	&&& {

--- a/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -166,7 +166,7 @@ export default class HowToStep extends Component {
 	 * @param {object} props      The receive props.
 	 * @param {func}   props.open Opens the media upload dialog.
 	 *
-	 * @returns {ReactElement} The media upload button.
+	 * @returns {wp.Element} The media upload button.
 	 */
 	getMediaUploadButton( props ) {
 		return (
@@ -183,7 +183,7 @@ export default class HowToStep extends Component {
 	/**
 	 * The insert and remove step buttons.
 	 *
-	 * @returns {ReactElement} The buttons.
+	 * @returns {wp.Element} The buttons.
 	 */
 	getButtons() {
 		const {
@@ -304,7 +304,7 @@ export default class HowToStep extends Component {
 	 *
 	 * @param {object} step The how-to step.
 	 *
-	 * @returns {ReactElement} The component to be rendered.
+	 * @returns {wp.Element} The component to be rendered.
 	 */
 	static Content( step ) {
 		return (
@@ -328,7 +328,7 @@ export default class HowToStep extends Component {
 	/**
 	 * Renders this component.
 	 *
-	 * @returns {ReactElement} The how-to step editor.
+	 * @returns {wp.Element} The how-to step editor.
 	 */
 	render() {
 		const {

--- a/js/src/structured-data-blocks/how-to/legacy/11.4.js
+++ b/js/src/structured-data-blocks/how-to/legacy/11.4.js
@@ -17,7 +17,7 @@ import buildDurationString from "./utils/8.2";
  *
  * @param {Object} step The how-to step.
  *
- * @returns {React.Component} The component to be rendered.
+ * @returns {wp.Element} The component to be rendered.
  */
 function LegacyHowToStep( step ) {
 	return (
@@ -46,7 +46,7 @@ function LegacyHowToStep( step ) {
  *
  * @param {Object} props the attributes of the How-to block.
  *
- * @returns {React.Component} The component representing a How-to block.
+ * @returns {wp.Element} The component representing a How-to block.
  */
 export default function LegacyHowTo( props ) {
 	const {

--- a/package.json
+++ b/package.json
@@ -108,8 +108,8 @@
     "@yoast/components": "^2.5.0-rc.3",
     "@yoast/configuration-wizard": "^2.7.0-rc.3",
     "@yoast/helpers": "^0.13.0-rc.3",
-    "@yoast/search-metadata-previews": "^2.7.0-rc.3",
-    "@yoast/social-metadata-forms": "^1.0.0-rc.3",
+    "@yoast/search-metadata-previews": "^2.7.0-rc.4",
+    "@yoast/social-metadata-forms": "^1.0.0-rc.6",
     "@yoast/style-guide": "^0.12.0-rc.3",
     "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#master",
     "babel-polyfill": "^6.26.0",
@@ -134,13 +134,13 @@
     "redux-thunk": "^2.2.0",
     "select2": "^4.0.5",
     "styled-components": "^4.2.0",
-    "yoast-components": "^5.7.0-rc.3",
+    "yoast-components": "^5.7.0-rc.6",
     "yoastseo": "^1.78.0-rc.3"
   },
   "browserslist": [
     "extends @yoast/browserslist-config"
   ],
   "yoast": {
-    "pluginVersion": "14.4"
+    "pluginVersion": "14.5-RC1"
   }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ License URI: http://www.gnu.org/licenses/gpl.html
 Tags: SEO, XML sitemap, Content analysis, Readability, Schema
 Requires at least: 5.3
 Tested up to: 5.4.1
-Stable tag: 14.4
+Stable tag: 14.4.1
 Requires PHP: 5.6.20
 
 Improve your WordPress SEO: Write better content and have a fully optimized WordPress site using the Yoast SEO plugin.
@@ -209,6 +209,44 @@ Your question has most likely been answered on our knowledge base: [kb.yoast.com
 
 == Changelog ==
 
+= 14.5 =
+Release Date: July 7th, 2020
+
+Enhancements:
+
+* Makes the plugin icon in the editor reflect the SEO and Readability score.
+* The Social tab has been re-written using React. Other than a dab of fresh paint, this should result in a snappier editing experience.
+* For privacy reasons, no longer shows whether an email address is already subscribed to the newsletter.
+* Fixes the fact that we sometimes did multiple calls to `my.yoast.com` if you had multiple Yoast products running, when we could do it in one call.
+* Shows a more specific notification when the permalinks are reset or when the category base setting is changed.
+* Implements the redesign of the admin settings pages.
+* Changes the help links to external pages instead of on page help text.
+* Improves accessibility.
+* Shows which features will be added by Wordpress SEO Premium.
+* Introduces the `--skip-confirmation` argument to run our wp-cli reindex command without confirmation prompt.
+* Improves transition words analysis for Russian.
+* Improves keyphrase recognition in Indonesian by filtering the function words such as `atau`, `dan`, `demikian`, `tersebut`.
+* Updates the progress-bar in the indexing process to the new styling.
+
+Bugfixes:
+
+* Fixes a bug where “array_merge(): Argument #1 is not an array” issues could appear under specific circumstances. Props to [chteuchteu](https://github.com/chteuchteu).
+* Fixes a bug where an indexable’s permalink remained unchanged when the categories prefix option was changed.
+* Fixes a bug where an indexable’s permalink remained unchanged when the category base or tag base was changed.
+* Fixes a bug where the link for Local SEO was missing in the Configuration Wizard “Continue learning” step.
+
+Other:
+
+* Moves the running of the SEO data indexing process to the Yoast Tools page.
+
+= 14.4.1 =
+Release Date: June 23rd, 2020
+
+Bugfixes:
+
+* Fixes a bug where existing links were no longer editable with Yoast SEO active.
+* Fixes a bug where the editor wouldn't remember `rel` values set on a link after refresh.
+
 = 14.4 =
 Release Date: June 23rd, 2020
 
@@ -234,17 +272,6 @@ Enhancements:
 Other:
 
 * Adds headers to the main plugin file for the minimum supported WordPress version and minimum supported PHP version. WordPress will not activate the plugin anymore if incompatibilities are found. Props to [spacedmonkey](https://github.com/spacedmonkey)
-
-= 14.3 =
-Release Date: June 9th, 2020
-
-In every release of Yoast SEO, we fix bugs and find other ways to enhance our code. For instance, we’re always working on quality assurance, code style and other behind the scenes work. In Yoast SEO 14.3, you’ll find many of these improvements plus some bugfixes. Read more about those changes in [our release post](https://yoa.st/release-14-3)!
-
-Bugfixes:
-
-* Fixes a bug where the FAQ schema list item's position would start at 0 instead of 1.
-* Fixes a bug where the filters `wpseo_metadesc` and `wpseo_title` weren't called with the right argument, which could lead to errors.
-* Fixes a bug where our global CSS variables could conflict with global CSS variables of themes.
 
 = Earlier versions =
 For the changelog of earlier versions, please refer to [the changelog on yoast.com](https://yoa.st/yoast-seo-changelog).

--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -43,7 +43,6 @@ class Article extends Abstract_Schema_Piece {
 	 * @return array $data Article data.
 	 */
 	public function generate() {
-		$comment_count = \get_comment_count( $this->context->id );
 		$data          = [
 			'@type'            => 'Article',
 			'@id'              => $this->context->canonical . Schema_IDs::ARTICLE_HASH,
@@ -52,9 +51,15 @@ class Article extends Abstract_Schema_Piece {
 			'headline'         => $this->helpers->schema->html->smart_strip_tags( $this->helpers->post->get_post_title_with_fallback( $this->context->id ) ),
 			'datePublished'    => $this->helpers->date->format( $this->context->post->post_date_gmt ),
 			'dateModified'     => $this->helpers->date->format( $this->context->post->post_modified_gmt ),
-			'commentCount'     => $comment_count['approved'],
 			'mainEntityOfPage' => [ '@id' => $this->context->canonical . Schema_IDs::WEBPAGE_HASH ],
 		];
+
+		// If the comments are open -or- there are comments approved, show the count.
+		$comments_open = \comments_open( $this->context->id );
+		$comment_count = \get_comment_count( $this->context->id );
+		if ( $comments_open || $comment_count['approved'] > 0 ) {
+			$data['commentCount'] = $comment_count['approved'];
+		}
 
 		if ( $this->context->site_represents_reference ) {
 			$data['publisher'] = $this->context->site_represents_reference;

--- a/src/presenters/admin/indexation-modal-presenter.php
+++ b/src/presenters/admin/indexation-modal-presenter.php
@@ -63,7 +63,7 @@ class Indexation_Modal_Presenter extends Abstract_Presenter {
 		);
 
 		return \sprintf(
-			'<div id="yoast-indexation-wrapper" class="hidden">%s<button id="yoast-indexation-stop" type="button" class="button">%s</button></div>',
+			'<div id="yoast-indexation-wrapper" class="hidden">%s<button id="yoast-indexation-stop" type="button" class="yoast-button yoast-button--secondary">%s</button></div>',
 			\implode( '<hr />', $blocks ),
 			\esc_html__( 'Stop indexing', 'wordpress-seo' )
 		);

--- a/tests/generators/schema/article-test.php
+++ b/tests/generators/schema/article-test.php
@@ -197,7 +197,12 @@ class Article_Test extends TestCase {
 		Monkey\Functions\expect( 'get_comment_count' )
 			->once()
 			->with( 5 )
-			->andReturn( [ 'approved' => 7 ] );
+			->andReturn( [ 'approved' => $values_to_test['approved_comments' ]] );
+
+		Monkey\Functions\expect( 'comments_open' )
+			->once()
+			->with( 5 )
+			->andReturn( $values_to_test['post_comment_status' ] === 'open' );
 
 		$this->context_mock->canonical                 = 'https://permalink';
 		$this->context_mock->has_image                 = true;
@@ -353,6 +358,7 @@ class Article_Test extends TestCase {
 					'site_represents_reference'     => false, // Whether the site represents a company/person.
 					'mock_value_post_type_supports' => true, // Whether the post type supports a certain feature.
 					'post_comment_status'           => 'open',
+					'approved_comments'             => 7,
 					'data_for_add_keywords'         => [
 						'@type'            => 'Article',
 						'@id'              => 'https://permalink#article',
@@ -410,6 +416,7 @@ class Article_Test extends TestCase {
 					'site_represents_reference'     => true,
 					'mock_value_post_type_supports' => true,
 					'post_comment_status'           => 'open',
+					'approved_comments'             => 7,
 					'data_for_add_keywords'         => [
 						'@type'            => 'Article',
 						'@id'              => 'https://permalink#article',
@@ -470,6 +477,7 @@ class Article_Test extends TestCase {
 					'site_represents_reference'     => false,
 					'mock_value_post_type_supports' => false,
 					'post_comment_status'           => 'open',
+					'approved_comments'             => 7,
 					'data_for_add_keywords'         => [
 						'@type'            => 'Article',
 						'@id'              => 'https://permalink#article',
@@ -518,6 +526,7 @@ class Article_Test extends TestCase {
 					'site_represents_reference'     => false,
 					'mock_value_post_type_supports' => false,
 					'post_comment_status'           => 'closed',
+					'approved_comments'             => 7,
 					'data_for_add_keywords'         => [
 						'@type'            => 'Article',
 						'@id'              => 'https://permalink#article',
@@ -554,6 +563,52 @@ class Article_Test extends TestCase {
 					'datePublished'    => '2345-12-12 12:12:12',
 					'dateModified'     => '2345-12-12 23:23:23',
 					'commentCount'     => 7,
+					'mainEntityOfPage' => [ '@id' => 'https://permalink#webpage' ],
+					'keywords'         => 'Tag1,Tag2',
+					'articleSection'   => 'Category1',
+					'inLanguage'       => 'language',
+				],
+				'message'        => 'The comment status for the post is set to closed.',
+			],
+			[
+				'values_to_test' => [
+					'site_represents_reference'     => false,
+					'mock_value_post_type_supports' => false,
+					'post_comment_status'           => 'closed',
+					'approved_comments'             => 0,
+					'data_for_add_keywords'         => [
+						'@type'            => 'Article',
+						'@id'              => 'https://permalink#article',
+						'isPartOf'         => [ '@id' => 'https://permalink#webpage' ],
+						'author'           => [ '@id' => 'https://permalink#author-id-hash' ],
+						'image'            => [ '@id' => 'https://permalink#primaryimage' ],
+						'headline'         => 'the-title',
+						'datePublished'    => '2345-12-12 12:12:12',
+						'dateModified'     => '2345-12-12 23:23:23',
+						'mainEntityOfPage' => [ '@id' => 'https://permalink#webpage' ],
+					],
+					'data_for_add_sections'         => [
+						'@type'            => 'Article',
+						'@id'              => 'https://permalink#article',
+						'isPartOf'         => [ '@id' => 'https://permalink#webpage' ],
+						'author'           => [ '@id' => 'https://permalink#author-id-hash' ],
+						'image'            => [ '@id' => 'https://permalink#primaryimage' ],
+						'headline'         => 'the-title',
+						'datePublished'    => '2345-12-12 12:12:12',
+						'dateModified'     => '2345-12-12 23:23:23',
+						'mainEntityOfPage' => [ '@id' => 'https://permalink#webpage' ],
+						'keywords'         => 'Tag1,Tag2',
+					],
+				],
+				'expected_value' => [
+					'@type'            => 'Article',
+					'@id'              => 'https://permalink#article',
+					'isPartOf'         => [ '@id' => 'https://permalink#webpage' ],
+					'author'           => [ '@id' => 'https://permalink#author-id-hash' ],
+					'image'            => [ '@id' => 'https://permalink#primaryimage' ],
+					'headline'         => 'the-title',
+					'datePublished'    => '2345-12-12 12:12:12',
+					'dateModified'     => '2345-12-12 23:23:23',
 					'mainEntityOfPage' => [ '@id' => 'https://permalink#webpage' ],
 					'keywords'         => 'Tag1,Tag2',
 					'articleSection'   => 'Category1',

--- a/tests/integrations/admin/indexation-integration-test.php
+++ b/tests/integrations/admin/indexation-integration-test.php
@@ -477,7 +477,7 @@ class Indexation_Integration_Test extends TestCase {
 			]
 		);
 
-		$this->expectOutputString( '<div id="yoast-indexation-wrapper" class="hidden"><div><p>We\'re processing all of your content to speed it up! This may take a few minutes.</p><div id="yoast-indexation-progress-bar" class="wpseo-progressbar"></div><p>Object <span id="yoast-indexation-current-count">0</span> of <strong id="yoast-indexation-total-count">40</strong> processed.</p></div><button id="yoast-indexation-stop" type="button" class="button">Stop indexing</button></div>' );
+		$this->expectOutputString( '<div id="yoast-indexation-wrapper" class="hidden"><div><p>We\'re processing all of your content to speed it up! This may take a few minutes.</p><div id="yoast-indexation-progress-bar" class="wpseo-progressbar"></div><p>Object <span id="yoast-indexation-current-count">0</span> of <strong id="yoast-indexation-total-count">40</strong> processed.</p></div><button id="yoast-indexation-stop" type="button" class="yoast-button yoast-button--secondary">Stop indexing</button></div>' );
 
 		$this->instance->render_indexation_modal();
 	}

--- a/tests/presenters/admin/indexation-modal-presenter-test.php
+++ b/tests/presenters/admin/indexation-modal-presenter-test.php
@@ -24,7 +24,7 @@ class Indexation_Modal_Presenter_Test extends TestCase {
 	 */
 	public function test_present() {
 		$instance = new Indexation_Modal_Presenter( 123 );
-		$expected = '<div id="yoast-indexation-wrapper" class="hidden"><div><p>We\'re processing all of your content to speed it up! This may take a few minutes.</p><div id="yoast-indexation-progress-bar" class="wpseo-progressbar"></div><p>Object <span id="yoast-indexation-current-count">0</span> of <strong id="yoast-indexation-total-count">123</strong> processed.</p></div><button id="yoast-indexation-stop" type="button" class="button">Stop indexing</button></div>';
+		$expected = '<div id="yoast-indexation-wrapper" class="hidden"><div><p>We\'re processing all of your content to speed it up! This may take a few minutes.</p><div id="yoast-indexation-progress-bar" class="wpseo-progressbar"></div><p>Object <span id="yoast-indexation-current-count">0</span> of <strong id="yoast-indexation-total-count">123</strong> processed.</p></div><button id="yoast-indexation-stop" type="button" class="yoast-button yoast-button--secondary">Stop indexing</button></div>';
 
 		$this->assertSame( $expected, $instance->present() );
 	}
@@ -37,7 +37,7 @@ class Indexation_Modal_Presenter_Test extends TestCase {
 	 */
 	public function test_present_without_unindexed() {
 		$instance = new Indexation_Modal_Presenter( 0 );
-		$expected = '<div id="yoast-indexation-wrapper" class="hidden"><div><p>We\'re processing all of your content to speed it up! This may take a few minutes.</p><p>All your content is already indexed, there is no need to index it again.</p></div><button id="yoast-indexation-stop" type="button" class="button">Stop indexing</button></div>';
+		$expected = '<div id="yoast-indexation-wrapper" class="hidden"><div><p>We\'re processing all of your content to speed it up! This may take a few minutes.</p><p>All your content is already indexed, there is no need to index it again.</p></div><button id="yoast-indexation-stop" type="button" class="yoast-button yoast-button--secondary">Stop indexing</button></div>';
 
 		$this->assertSame( $expected, $instance->present() );
 	}

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -15,7 +15,7 @@ if ( ! function_exists( 'add_filter' ) ) {
  * {@internal Nobody should be able to overrule the real version number as this can cause
  *            serious issues with the options, so no if ( ! defined() ).}}
  */
-define( 'WPSEO_VERSION', '14.4' );
+define( 'WPSEO_VERSION', '14.5-RC1' );
 
 
 if ( ! defined( 'WPSEO_PATH' ) ) {

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -8,7 +8,7 @@
  *
  * @wordpress-plugin
  * Plugin Name: Yoast SEO
- * Version:     14.4
+ * Version:     14.5-RC1
  * Plugin URI:  https://yoa.st/1uj
  * Description: The first true all-in-one SEO solution for WordPress, including on-page content analysis, XML sitemaps and much more.
  * Author:      Team Yoast

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,10 +165,22 @@
   dependencies:
     "@emotion/memoize" "0.7.1"
 
+"@emotion/is-prop-valid@^0.8.1":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
 "@emotion/memoize@0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
   integrity sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
 "@emotion/memoize@^0.6.1", "@emotion/memoize@^0.6.6":
   version "0.6.6"
@@ -648,15 +660,35 @@
     styled-components "^2.4.1"
     whatwg-fetch "1.1.1"
 
-"@yoast/search-metadata-previews@^2.7.0-rc.3":
-  version "2.7.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@yoast/search-metadata-previews/-/search-metadata-previews-2.7.0-rc.3.tgz#828798f85a73f6f4bc7ec1fc3947332af15607b1"
-  integrity sha512-o8+v4al+xheFXjzYBkV0qS430hDOJ776ZtZ3FU/gPpxUXdtXGEZLIQ+hbRg+F8cL+wxWJbWnyHPZQ4nrENxrkw==
+"@yoast/replacement-variable-editor@1.0.0-rc.3", "@yoast/replacement-variable-editor@^1.0.0-rc.3":
+  version "1.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@yoast/replacement-variable-editor/-/replacement-variable-editor-1.0.0-rc.3.tgz#13395bb31c91b8292b16153ffa071fd9991861da"
+  integrity sha512-yB8IV4GvDWDVBU4olclJL3dIWgkDzoSE0lJ1xBFydpYI6PKfdQCuMvzKfEjYRyoAgL4Mr6Y5ry0+BrAZmch/nw==
+  dependencies:
+    "@wordpress/a11y" "^1.1.3"
+    "@wordpress/i18n" "^1.2.3"
+    "@yoast/components" "^2.5.0-rc.3"
+    "@yoast/helpers" "^0.13.0-rc.3"
+    "@yoast/style-guide" "^0.12.0-rc.3"
+    draft-js "^0.11.4"
+    draft-js-mention-plugin "^3.0.4"
+    draft-js-plugins-editor "^2.0.4"
+    draft-js-single-line-plugin "^2.0.1"
+    lodash "^4.17.11"
+    prop-types "^15.7.2"
+    styled-components "^4.4.1"
+    yoastseo "^1.78.0-rc.3"
+
+"@yoast/search-metadata-previews@^2.7.0-rc.4":
+  version "2.7.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@yoast/search-metadata-previews/-/search-metadata-previews-2.7.0-rc.4.tgz#a9e1a37e8b1a9b03be963ea45b4eb14c77ba5352"
+  integrity sha512-dRKD+5mfqgsmQzJDbDwDlXdtYqv4EglxrSj3a6zEmMgoYXNYs30b5KJq80Sgnz4JfnIzKnwe0GcW+rooexvsmg==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
     "@yoast/components" "^2.5.0-rc.3"
     "@yoast/helpers" "^0.13.0-rc.3"
+    "@yoast/replacement-variable-editor" "1.0.0-rc.3"
     "@yoast/style-guide" "^0.12.0-rc.3"
     draft-js "^0.10.5"
     draft-js-mention-plugin "^3.0.4"
@@ -668,6 +700,21 @@
     react-transition-group "^2.7.1"
     styled-components "^4.2.0"
     yoastseo "^1.78.0-rc.3"
+
+"@yoast/social-metadata-forms@^1.0.0-rc.6":
+  version "1.0.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@yoast/social-metadata-forms/-/social-metadata-forms-1.0.0-rc.6.tgz#10a1584cf316d3eb118f8bbab99e418013de0d34"
+  integrity sha512-EVsirAOjy2tA8U6gjogwgzYwLcwIT9rlheXDiDqEFa9FRFPqR98e5KFXSXud+5JL/6GM3zQ8G3ok9a5eo2RKwg==
+  dependencies:
+    "@wordpress/i18n" "^1.1.0"
+    "@yoast/components" "^2.5.0-rc.3"
+    "@yoast/helpers" "^0.13.0-rc.3"
+    "@yoast/replacement-variable-editor" "^1.0.0-rc.3"
+    "@yoast/style-guide" "^0.12.0-rc.3"
+    lodash "^4.17.11"
+    prop-types "^15.6.0"
+    redux "^3.7.2"
+    styled-components "^4.2.0"
 
 "@yoast/style-guide@^0.12.0-rc.3":
   version "0.12.0-rc.3"
@@ -7098,6 +7145,11 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
+is-what@^3.3.1:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.8.0.tgz#610bc46a524355f2424eb85eedc6ebbbf7e1ff8c"
+  integrity sha512-UKeBoQfV8bjlM4pmx1FLDHdxslW/1mTksEs8ReVsilPmUv5cORd4+2/wFcviI3cUjrLybxCjzc8DnodAzJ/Wrg==
+
 is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
@@ -8232,6 +8284,13 @@ meow@^3.3.0, meow@^3.7.0:
     read-pkg-up "^1.0.1"
     redent "^1.0.0"
     trim-newlines "^1.0.0"
+
+merge-anything@^2.2.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/merge-anything/-/merge-anything-2.4.4.tgz#6226b2ac3d3d3fc5fb9e8d23aa400df25f98fdf0"
+  integrity sha512-l5XlriUDJKQT12bH+rVhAHjwIuXWdAIecGwsYjv2LJo+dA1AeRTmeQS+3QBpO6lEthBMDi2IUMpLC1yyRvGlwQ==
+  dependencies:
+    is-what "^3.3.1"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -11926,6 +11985,25 @@ styled-components@^4.2.0:
     stylis-rule-sheet "^0.0.10"
     supports-color "^5.5.0"
 
+styled-components@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.1.tgz#e0631e889f01db67df4de576fedaca463f05c2f2"
+  integrity sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@emotion/is-prop-valid" "^0.8.1"
+    "@emotion/unitless" "^0.7.0"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^5.0.0"
+    merge-anything "^2.2.4"
+    prop-types "^15.5.4"
+    react-is "^16.6.0"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^5.5.0"
+
 stylehacks@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.3.tgz#6718fcaf4d1e07d8a1318690881e8d96726a71d5"
@@ -13174,10 +13252,10 @@ yauzl@^2.4.2:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-yoast-components@^5.7.0-rc.3:
-  version "5.7.0-rc.3"
-  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-5.7.0-rc.3.tgz#4429350f9fb5b7c1c682254550853e88dfdfc8b9"
-  integrity sha512-wLWlqz0wZl9fq27QRr440FCfbE25Jcznf86LL5FTl+nvxaUQnMe9jKk71GeCWm+0+QdGQNevj53ELTukldtyfg==
+yoast-components@^5.7.0-rc.6:
+  version "5.7.0-rc.6"
+  resolved "https://registry.yarnpkg.com/yoast-components/-/yoast-components-5.7.0-rc.6.tgz#a0d70318896040f376cd46701346e840d0410a8a"
+  integrity sha512-tczlp84MENVuoeeY2qcmdg69dcvQupp4fr0dbXRZhuLFby6H1C1h50wY0HczdiND6Ovi+tFvaqvXHzVRjldXng==
   dependencies:
     "@wordpress/a11y" "^1.0.7"
     "@wordpress/i18n" "^1.1.0"
@@ -13185,7 +13263,8 @@ yoast-components@^5.7.0-rc.3:
     "@yoast/components" "^2.5.0-rc.3"
     "@yoast/configuration-wizard" "^2.7.0-rc.3"
     "@yoast/helpers" "^0.13.0-rc.3"
-    "@yoast/search-metadata-previews" "^2.7.0-rc.3"
+    "@yoast/replacement-variable-editor" "1.0.0-rc.3"
+    "@yoast/search-metadata-previews" "^2.7.0-rc.4"
     "@yoast/style-guide" "^0.12.0-rc.3"
     clipboard "^1.5.15"
     draft-js "^0.11.4"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* See #15535: 

> Currently we have a mix of react imports and @wordpress/element imports. In documentation we refer to React elements as wp.Element, React.Element, ReactElement, React.Component etc. This PR makes sure we consistently use @wordpress/element and every component is documented with either wp.Element or wp.Component for component functions.


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor: removes all React references in SEMrush components in favor of @wordpress/element

## Relevant technical choices:

* see summary

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* build the JS with `grunt build:js`
* Edit a post
* Enter some focus keyphrase in the Yoast sidebar or in the Yoast metabox
* Click the button to open the modal dialog
* Observe all of the components are present, except the "max related keyphrases" alert
* edit `js/src/components/RelatedKeyPhrasesModal.js` 
* at line 139, change the default value of `maxRelatedKeyphrasesEntered` from `false` to `true`  
* build the JS with `grunt build:js`
* Edit a post
* Enter some focus keyphrase in the Yoast sidebar or in the Yoast metabox
* Click the button to open the modal dialog
* Observe the "max related keyphrases" alert is now present

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-55]
