### PR TITLE
Redirect attachment toggle fix

### DIFF
--- a/admin/views/tabs/metas/paper-content/media-content.php
+++ b/admin/views/tabs/metas/paper-content/media-content.php
@@ -25,15 +25,14 @@ $media_attachment_help = new WPSEO_Admin_Help_Button(
 	<?php
 
 	$yoast_free_disable_attachments_texts = [
-		__( 'Yes', 'wordpress-seo' ),
 		__( 'No', 'wordpress-seo' ),
+		__( 'Yes', 'wordpress-seo' ),
 	];
 	$yform->light_switch(
 		'disable-attachment',
 		__( 'Redirect attachment URLs to the attachment itself?', 'wordpress-seo' ),
 		$yoast_free_disable_attachments_texts,
-		false,
-		true
+		false
 	);
 
 	?>

--- a/js/src/initializers/admin.js
+++ b/js/src/initializers/admin.js
@@ -260,7 +260,7 @@ export default function initAdmin( jQuery ) {
 
 		// Toggle the Media section.
 		jQuery( "#disable-attachment" ).change( function() {
-			jQuery( "#media_settings" ).toggle( jQuery( this ).is( ":checked" ) );
+			jQuery( "#media_settings" ).toggle( jQuery( this ).is( ":not(:checked)" ) );
 		} ).change();
 
 		// Toggle the Format-based archives section.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Inverses the functionality of the Disable Attachment toggle, this is a "disabled"-option which needed to be flipped visually.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A (regression)

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Settings: Yoast -> Search Appearance -> Media
* Toggle the "Redirect attachment to itself" and have the other options show when it is set to "No"
* This should match the "disable-attachment" setting (you can search in the source and see its value) - "true" = redirect to itself

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes FRO-172
