### PR TITLE
Remove paper style breadcrumbs and add extra header

### DIFF
--- a/admin/views/tabs/metas/breadcrumbs.php
+++ b/admin/views/tabs/metas/breadcrumbs.php
@@ -11,7 +11,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-$wpseo_breadcrumbs_presenter = new WPSEO_Paper_Presenter(
+$wpseo_breadcrumbs_presenter = new WPSEO_Collapsible_Presenter(
 	esc_html__( 'Breadcrumbs settings', 'wordpress-seo' ),
 	__DIR__ . '/paper-content/breadcrumbs-content.php',
 	[

--- a/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
+++ b/admin/views/tabs/metas/paper-content/breadcrumbs-content.php
@@ -12,7 +12,7 @@ if ( ! current_theme_supports( 'yoast-seo-breadcrumbs' ) ) {
 	echo '<br/>';
 }
 echo '<div id="breadcrumbsinfo">';
-
+echo '<h2>' . esc_html__( 'General breadcrumb settings', 'wordpress-seo' ) . '</h2>';
 $yform->textinput( 'breadcrumbs-sep', __( 'Separator between breadcrumbs', 'wordpress-seo' ) );
 $yform->textinput( 'breadcrumbs-home', __( 'Anchor text for the Homepage', 'wordpress-seo' ) );
 $yform->textinput( 'breadcrumbs-prefix', __( 'Prefix for the breadcrumb path', 'wordpress-seo' ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Removes the breadcrumbs paper styling and adds extra header.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the breadcrumbs paper styling and adds extra header.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Pull this branch
* Pull the release/14.5 branch from the wordpress-seo repo
* Link the monorepo and build the plugin
* Check if the paper is remove in `SEO` -> `Search Appearance` -> `Breadcrumbs` and check if there is an extra heading

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/FRO-170
