### PR TITLE
Restore button functionality in notifications

### DIFF
--- a/admin/views/partial-notifications-template.php
+++ b/admin/views/partial-notifications-template.php
@@ -42,7 +42,7 @@ if ( ! function_exists( '_yoast_display_notifications' ) ) {
 				case 'dismissed':
 					$button = sprintf(
 						'<button type="button" class="yoast-restore">%1$s</button>',
-						esc_html__( 'Restore', 'wordpress-seo' )
+						esc_html__( 'Show', 'wordpress-seo' )
 					);
 					break;
 			}

--- a/admin/views/partial-notifications-template.php
+++ b/admin/views/partial-notifications-template.php
@@ -73,14 +73,10 @@ if ( ! $active ) {
 }
 
 ?>
-<h2>
-	<?php echo esc_html( $i18n_title ); ?> (<?php echo (int) $active_total; ?>)
-</h2>
+<h2><?php echo esc_html( $i18n_title ); ?> (<?php echo (int) $active_total; ?>)</h2>
 
 <div>
-
 	<?php if ( $total ) : ?>
-
 		<div class="yoast-paper__content">
 			<?php
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: _yoast_display_notifications is considered a safe function.
@@ -90,7 +86,7 @@ if ( ! $active ) {
 
 		<?php
 		if ( $dismissed ) {
-			$dismissed_paper = new WPSEO_Paper_Presenter(
+			$dismissed_paper = new WPSEO_Collapsible_Presenter(
 				esc_html( $i18n_muted_issues_title ),
 				null,
 				[

--- a/admin/views/partial-notifications-template.php
+++ b/admin/views/partial-notifications-template.php
@@ -41,14 +41,14 @@ if ( ! function_exists( '_yoast_display_notifications' ) ) {
 
 				case 'dismissed':
 					$button = sprintf(
-						'<button type="button" class="button restore"><span class="screen-reader-text">%1$s</span><span class="dashicons yoast-svg-icon-eye"></span></button>',
-						esc_html__( 'Show this item.', 'wordpress-seo' )
+						'<button type="button" class="yoast-restore">%1$s</button>',
+						esc_html__( 'Restore', 'wordpress-seo' )
 					);
 					break;
 			}
 
 			$notifications .= sprintf(
-				'<div class="yoast-paper__item" id="%1$s" data-nonce="%2$s" data-json="%3$s">%4$s%5$s</div>',
+				'<div class="yoast-notification-holder yoast-paper__item" id="%1$s" data-nonce="%2$s" data-json="%3$s">%4$s%5$s</div>',
 				esc_attr( $notification->get_id() ),
 				esc_attr( $notification->get_nonce() ),
 				esc_attr( $notification->get_json() ),

--- a/css/src/components/buttons.css
+++ b/css/src/components/buttons.css
@@ -89,7 +89,7 @@
 	height: 8px;
 }
 
-.yoast-remove, .yoast-hide {
+.yoast-remove, .yoast-hide, .yoast-restore {
 	color: #dc3232;
 	background-color: transparent;
 	border: none;
@@ -98,7 +98,7 @@
 	padding: 0;
 }
 
-.yoast-hide {
+.yoast-hide, .yoast-restore {
 	color: var(--yoast-color-link);
 }
 

--- a/css/src/components/paper.css
+++ b/css/src/components/paper.css
@@ -9,26 +9,57 @@
 	box-sizing: border-box;
 }
 
-.yoast-paper .toggleable-container-trigger {
-	background: none;
-	border: 0px;
-	width: 100%;
-	text-align: left;
-	color: var(--yoast-color-primary);
-}
-
 .yoast-paper--small {
 	padding: 16px;
+}
+
+.yoast-paper__content:not(:only-child) {
+	padding: 0 24px 8px;
+	border-bottom: var(--yoast-border-default);
+	margin: 0 -24px 24px;
+}
+
+.yoast-paper .yoast-notifications-dismissed {
+	width: calc(600px - 48px);
+	margin-bottom: 0;
 }
 
 .yoast-paper__item {
 	display: flex;
 }
 
+.yoast-paper #yoast-warnings-dismissed .collapsible-header {
+	font-size: 16px;
+	padding-bottom: 0;
+	border: 0;
+	margin-bottom: 0;
+}
+
+.yoast-paper .toggleable-container-trigger {
+	background: none;
+	border: 0px;
+	width: 100%;
+	text-align: left;
+	color: var(--yoast-color-primary);
+	padding: 0;
+}
+
+.yoast-paper .toggleable-container-trigger[aria-expanded="true"] {
+	padding-bottom: 24px;
+	border-bottom: var(--yoast-border-default);
+	margin-bottom: 24px;
+}
+
+
 .yoast-paper__item .yoast-notification {
 	position: relative;
 	margin-left: 22px;
 }
+
+.yoast-paper__item .yoast-notification p {
+	margin-bottom: 24px;
+}
+
 
 .yoast-paper__item .yoast-notification::before {
 	content: '';
@@ -40,11 +71,13 @@
 	left: -22px;
 }
 
-.yoast-paper__item .yoast-hide {
+.yoast-paper__item .yoast-hide,
+.yoast-paper__item .yoast-restore {
 	margin-left: 32px;
+	margin-bottom: 24px;
 }
 
 .yoast-paper__item:not(:first-of-type) {
 	border-top: 1px solid var(--yoast-color-border);
-	padding-top: 16px;
+	padding-top: 24px;
 }

--- a/js/src/admin-global.js
+++ b/js/src/admin-global.js
@@ -146,7 +146,7 @@
 	}
 
 	/**
-	 * Handles dismiss and restore AJAX responses.
+	 * Handles notification dismiss and restore AJAX responses.
 	 *
 	 * @param {Object} $source Object that triggered the request.
 	 * @param {Object} response AJAX response.
@@ -154,7 +154,9 @@
 	 * @returns {void}
 	 */
 	function handleDismissRestoreResponse( $source, response ) {
-		$( ".yoast-notification-holder" ).off( "click", ".restore" ).off( "click", ".dismiss" );
+		$( ".yoast-notification-holder" )
+			.off( "click", ".yoast-restore" )
+			.off( "click", ".yoast-hide" );
 
 		if ( typeof response.html === "undefined" ) {
 			return;
@@ -196,7 +198,7 @@
 	function hookDismissRestoreButtons() {
 		var $dismissible = $( ".yoast-notification-holder" );
 
-		$dismissible.on( "click", ".dismiss", function() {
+		$dismissible.on( "click", ".yoast-hide", function() {
 			var $this = $( this );
 			var $source = $this.closest( ".yoast-notification-holder" );
 
@@ -216,7 +218,7 @@
 			);
 		} );
 
-		$dismissible.on( "click", ".restore", function() {
+		$dismissible.on( "click", ".yoast-restore", function() {
 			var $this = $( this );
 			var $source = $this.closest( ".yoast-notification-holder" );
 


### PR DESCRIPTION
Not fixed:
- Restore button styling
- Using "restore" has unwanted nesting of papers

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes FRO-131
