### PR TITLE
Add the ALLOW_KEY_PREFIX back to the toggles

### DIFF
--- a/admin/views/tabs/network/features.php
+++ b/admin/views/tabs/network/features.php
@@ -34,7 +34,7 @@ $yoast_features = new WPSEO_Features();
 	foreach ( $feature_toggles as $feature ) {
 		if ( $feature->premium && ! $yoast_features->is_premium() ) {
 			$yform->light_switch_disabled(
-				$feature->setting,
+				WPSEO_Option::ALLOW_KEY_PREFIX . $feature->setting,
 				$feature->name,
 				[
 					__( 'Off', 'wordpress-seo' ),
@@ -48,7 +48,7 @@ $yoast_features = new WPSEO_Features();
 		else {
 
 			$yform->light_switch(
-				$feature->setting,
+				WPSEO_Option::ALLOW_KEY_PREFIX . $feature->setting,
 				$feature->name,
 				[
 					__( 'Off', 'wordpress-seo' ),


### PR DESCRIPTION
This was breaking all the toggles in the feature tab of the network admin since relies on the toggles having as allow_enable_admin_bar_menu.

The prefix was probably removed by accident by Team Frontend during the redesign of the network pages

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* Make sure that the feature toggles work on the network tab.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Fixes a bug where saving features in the network admin would disable all features for all sites.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Set-up a multisite (does not need to be a fresh install)
* Go to the General->Features tab in the network admin
* Toggle some features and save
* Reload the page
* See that the values are persisted

## Quality assurance

* [x] I have tested this code to the best of my abilities
