### PR TITLE
Restore Related keyphrases modal basic styling.

### DIFF
--- a/css/src/editor/metabox.css
+++ b/css/src/editor/metabox.css
@@ -725,4 +725,13 @@ div.interface-pinned-items button.components-button.is-pressed[aria-label="Yoast
 div.interface-pinned-items button.components-button.is-pressed[aria-label="Yoast SEO Premium"] > svg path {
 	fill: #ffffff;
 }
+
+/* Related keyphrases modal: Needs high specificity. */
+.yoast-related-keyphrases-modal__button.yoast-related-keyphrases-modal__button {
+	margin-top: 8px;
+}
+
+.yoast-gutenberg-modal .yoast-related-keyphrases-modal__content {
+	min-height: 66vh;
+}
 /*# sourceMappingURL=metabox.css.map */

--- a/css/src/gutenberg-modal.css
+++ b/css/src/gutenberg-modal.css
@@ -1,8 +1,0 @@
-/* Needs high specificity. */
-.yoast-related-keyphrases-modal__button.yoast-related-keyphrases-modal__button {
-	margin-top: 8px;
-}
-
-.yoast-gutenberg-modal .yoast-related-keyphrases-modal__content {
-	min-height: 66vh;
-}

--- a/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -303,6 +303,7 @@ class SeoAnalysis extends Component {
 								<SynonymSlot location={ location } />
 								{ this.props.shouldUpsell && <Fragment>
 									{ this.renderSynonymsUpsell( location ) }
+									<br />
 									{ this.renderMultipleKeywordsUpsell( location ) }
 								</Fragment> }
 								{ this.props.shouldUpsellWordFormRecognition && this.renderWordFormsUpsell( location ) }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Restores basic styling for the Related keyphrases modal dialog after trunk merge.

## Relevant technical choices:

* deleted `gutenberg-modal.css` and moved its _two CSS rules_ to `metabox.css`: I'd think this is fine because it's just a very few lines of CSS cc @JoseeWouters 
* Also restores a line break that was introduced in https://github.com/Yoast/wordpress-seo/pull/15368 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- go to the Meta box > open SEO analysis 
- verify the two links `+ Add synonyms` and `+ Add related keyphrase` are on separate lines 
- observe the "Get related keyphrases" button in both the meta box and the sidebar 
- verify there's some spacing between the input field and the button e.g.:



- enter a focus keyphrase 
- click "Get related keyphrases" to open the modal dialog
- verify the element with CSS class `yoast-related-keyphrases-modal__content` has a `min-height: 66vh;` property


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-56]
