### PR TITLE
FRO-178 upsell-button metabox

### DIFF
--- a/js/src/components/UpsellBox.js
+++ b/js/src/components/UpsellBox.js
@@ -92,7 +92,7 @@ class UpsellBox extends Component {
 	 */
 	render() {
 		return (
-			<div>
+			<div class="yoast">
 				{ this.createInfoParagraphs( this.props.infoParagraphs ) }
 				{ this.createBenefitsList( this.props.benefits ) }
 				<UpsellButton

--- a/js/src/components/UpsellBox.js
+++ b/js/src/components/UpsellBox.js
@@ -92,7 +92,7 @@ class UpsellBox extends Component {
 	 */
 	render() {
 		return (
-			<div class="yoast">
+			<div className="yoast">
 				{ this.createInfoParagraphs( this.props.infoParagraphs ) }
 				{ this.createBenefitsList( this.props.benefits ) }
 				<UpsellButton

--- a/js/src/components/modals/KeywordSynonyms.js
+++ b/js/src/components/modals/KeywordSynonyms.js
@@ -64,7 +64,7 @@ const KeywordSynonyms = ( props ) => {
 			}
 			upsellButton={ {
 				href: props.buyLink,
-				className: "yoast-button-upsell",
+				className: "yoast-button yoast-button--buy",
 				rel: null,
 			} }
 			upsellButtonLabel={ __( "1 year free support and updates included!", "wordpress-seo" ) }

--- a/js/src/components/modals/MultipleKeywords.js
+++ b/js/src/components/modals/MultipleKeywords.js
@@ -63,7 +63,7 @@ const MultipleKeywords = ( props ) => {
 			}
 			upsellButton={ {
 				href: props.buyLink,
-				className: "yoast-button-upsell",
+				className: "yoast-button yoast-button--buy",
 				rel: null,
 			} }
 			upsellButtonLabel={ __( "1 year free support and updates included!", "wordpress-seo" ) }

--- a/js/tests/components/__snapshots__/UpsellBox.test.js.snap
+++ b/js/tests/components/__snapshots__/UpsellBox.test.js.snap
@@ -56,7 +56,7 @@ exports[`UpsellBox renders the snippet editor inside of it 1`] = `
   upsellButtonText="A button"
 >
   <div
-    class="yoast"
+    className="yoast"
   >
     <p
       key="0"

--- a/js/tests/components/__snapshots__/UpsellBox.test.js.snap
+++ b/js/tests/components/__snapshots__/UpsellBox.test.js.snap
@@ -55,7 +55,9 @@ exports[`UpsellBox renders the snippet editor inside of it 1`] = `
   upsellButtonLabel=""
   upsellButtonText="A button"
 >
-  <div>
+  <div
+    class="yoast"
+  >
     <p
       key="0"
     >


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add right classes to upsell buttons in the metabox.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check if the upsell buttons on the edit post/page has the correct styling.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/FRO-178, https://yoast.atlassian.net/browse/FRO-179
