### PR TITLE
P3-62 Fix SEMrush limit-reached upsell button css

### DIFF
--- a/js/src/components/RelatedKeyPhrasesModal.js
+++ b/js/src/components/RelatedKeyPhrasesModal.js
@@ -103,7 +103,7 @@ class RelatedKeyPhrasesModal extends Component {
 						icon={ <YoastIcon /> }
 					>
 						<ModalContainer
-							className="yoast-gutenberg-modal__content yoast-related-keyphrases-modal__content"
+							className="yoast-gutenberg-modal__content yoast-related-keyphrases-modal__content yoast"
 						>
 							{ this.state.isLoading && <SemRushLoading /> }
 							{ maxRelatedKeyphrasesEntered && (

--- a/js/src/components/modals/SemRushLimitReached.js
+++ b/js/src/components/modals/SemRushLimitReached.js
@@ -26,7 +26,7 @@ const SemRushLimitReached = () => {
 			</p>
 			<UpdateSemRushPlanLink
 				href="https://yoa.st/semrush-prices"
-				className="yoast-button-upsell"
+				className="yoast-button yoast-button--buy"
 			>
 				{
 					sprintf(
@@ -35,7 +35,7 @@ const SemRushLimitReached = () => {
 						"SEMrush"
 					)
 				}
-				<span aria-hidden="true" className="yoast-button-upsell__caret" />
+				<span aria-hidden="true" className="yoast-button--buy__caret" />
 			</UpdateSemRushPlanLink>
 		</Fragment>
 	);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The limit-reached content of the SEMrush related keyphrases modal (created in #15369) used a `yoast-upsell-button`, which is not used anymore due to (admin) redesign changes. 

This caused the limit-reached content to look like this:
![Screenshot 2020-06-30 at 12 01 41](https://user-images.githubusercontent.com/43582255/86113755-f3d16280-bac9-11ea-9219-0357b3d9fce6.png)


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the wrong css class was used for the SEMrush limit-reached upsell button. 

## Relevant technical choices:

* As suggested by Rolf: the button now uses the `yoast-button yoast-button--buy class`, and the `yoast-button-upsell__caret` is replaced with `yoast-button--buy__caret`. 
* The `yoast` class is added to the `ModalContainer` in the `RelatedKeyphrasesModal` to enable it to work 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this branch and build
* In the backend, go to Posts and edit a post
* In the Yoast sidebar or metabox, click "Get related keyphrases"
* Verify the content follows the design as shown below (when you comment out all in `ModalContainer` except `SemRushLimitReached`):

![Screenshot 2020-06-30 at 11 19 09](https://user-images.githubusercontent.com/43582255/86114615-12842900-bacb-11ea-89a4-bb9b8c591913.png)


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
