### PR TITLE
XMLRPC noindexing

### DIFF
--- a/src/conditionals/xmlrpc-conditional.php
+++ b/src/conditionals/xmlrpc-conditional.php
@@ -8,16 +8,16 @@
 namespace Yoast\WP\SEO\Conditionals;
 
 /**
- * Class XMLRPC_Conditional
+ * Conditional that is met when the current request is an XML-RPC request.
  *
  * @package Yoast\WP\SEO\Conditionals
  */
 class XMLRPC_Conditional implements Conditional {
 
 	/**
-	 * Returns whether or not this conditional is met.
+	 * Returns whether the current request is an XML-RPC request.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return boolean `true` when the current request is an XML-RPC request, `false` if not.
 	 */
 	public function is_met() {
 		return ( \defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST );

--- a/src/conditionals/xmlrpc-conditional.php
+++ b/src/conditionals/xmlrpc-conditional.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package Yoast\YoastSEO\Conditionals
+ */
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Class XMLRPC_Conditional
+ *
+ * @package Yoast\WP\SEO\Conditionals
+ */
+class XMLRPC_Conditional implements Conditional {
+
+	/**
+	 * Returns whether or not this conditional is met.
+	 *
+	 * @return boolean Whether or not the conditional is met.
+	 */
+	public function is_met() {
+		return ( \defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST );
+	}
+}
+

--- a/src/integrations/xmlrpc.php
+++ b/src/integrations/xmlrpc.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Frontend
+ */
+
+namespace Yoast\WP\SEO\Integrations;
+
+use Yoast\WP\SEO\Conditionals\XMLRPC_Conditional;
+
+/**
+ * Disables the WP core sitemaps.
+ */
+class XMLRPC implements Integration_Interface {
+
+	/**
+	 * @codeCoverageIgnore
+	 * @inheritDoc
+	 */
+	public static function get_conditionals() {
+		return [ XMLRPC_Conditional::class ];
+	}
+
+	/**
+	 * Disable the WP core XML sitemaps.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'xmlrpc_methods', [ $this, 'robots_header' ] );
+	}
+
+	/**
+	 * Sets a noindex, follow x-robots-tag header on all XMLRPC requests.
+	 *
+	 * @codeCoverageIgnore Basically impossible to test from the command line.
+	 *
+	 * @return void
+	 */
+	public function robots_header() {
+		if ( \headers_sent() === false ) {
+			\header( 'X-Robots-Tag: noindex, follow', true );
+		}
+	}
+}
+

--- a/src/integrations/xmlrpc.php
+++ b/src/integrations/xmlrpc.php
@@ -10,7 +10,7 @@ namespace Yoast\WP\SEO\Integrations;
 use Yoast\WP\SEO\Conditionals\XMLRPC_Conditional;
 
 /**
- * Disables the WP core sitemaps.
+ * Noindexes the xmlrpc.php file and all ways to request it.
  */
 class XMLRPC implements Integration_Interface {
 
@@ -23,7 +23,7 @@ class XMLRPC implements Integration_Interface {
 	}
 
 	/**
-	 * Disable the WP core XML sitemaps.
+	 * Initializes the integration.
 	 *
 	 * @return void
 	 */

--- a/tests/integrations/xmlrpc-test.php
+++ b/tests/integrations/xmlrpc-test.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package Yoast\YoastSEO\Integrations
+ */
+
+namespace Yoast\WP\SEO\Tests\Integrations;
+
+use Yoast\WP\SEO\Integrations\XMLRPC;
+use Yoast\WP\SEO\Tests\TestCase;
+use Brain\Monkey;
+
+
+/**
+ * Unit Test Class.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\XMLRPC
+ *
+ * @group integrations
+ */
+class XMLRPC_Test extends TestCase {
+	/**
+	 * Represents the instance we are testing.
+	 *
+	 * @var XMLRPC
+	 */
+	private $instance;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = new XMLRPC();
+	}
+
+	/**
+	 * Tests whether we hook the noindex header as expected.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertTrue( \has_action( 'xmlrpc_methods', [ $this->instance, 'robots_header' ] ), 'Has expected noindex action' );
+	}
+
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* The `xmlrpc.php` file and all possible ways to request it are now automatically `noindex`'d, removing them from Google's search results.

## Relevant technical choices:

* Didn't unittest the header output as that's proving impossible.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Open example.com/xmlrpc.php, see the HTTP header output contains an `X-Robots-Tag: noindex, follow` header.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes PROD-191
