### PR TITLE
Add port to indeaxble permalink when available

### DIFF
--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -193,6 +193,9 @@ class Indexable extends Model {
 		if ( isset( $permalink_parts['host'] ) ) {
 			$permalink .= $permalink_parts['host'];
 		}
+		if ( isset( $permalink_parts['port'] ) ) {
+			$permalink .= ':' . $permalink_parts['port'];
+		}
 		if ( isset( $permalink_parts['path'] ) ) {
 			$permalink .= $permalink_parts['path'];
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Port numbers can be part of a URL and should therefore be taken into account when building permalinks

## Summary

This PR can be summarized in the following changelog entry:

* Fixes missing port numbers in the indexables (when applicable)

## Relevant technical choices:

*

## Test instructions
This PR can be tested by following these steps:

1. Run a WordPress site on a server that uses a different port than 80 or 443
1. Install Yoast SEO without this patch
1. Visit a post and check the source of the page. See that the canonical metadata does not contain the port number.
1. Install this patch and reset the indexables
1. Re-visit the post and see the port included in the canonical URL

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/15397
