### PR TITLE
Add contentImage and snippetPreviewImageUrl variables to nonReplaceVars

### DIFF
--- a/js/src/helpers/replacementVariableHelpers.js
+++ b/js/src/helpers/replacementVariableHelpers.js
@@ -15,7 +15,7 @@ import { firstToUpperCase } from "./stringHelpers";
 import analysis from "yoastseo";
 const { stripHTMLTags: stripFullTags } = analysis.string;
 
-export const nonReplaceVars = [ "slug", "content" ];
+export const nonReplaceVars = [ "slug", "content", "contentImage", "snippetPreviewImageUrl" ];
 
 /**
  * Fills the redux store with the newly acquired data.

--- a/js/src/helpers/replacementVariableHelpers.js
+++ b/js/src/helpers/replacementVariableHelpers.js
@@ -15,7 +15,7 @@ import { firstToUpperCase } from "./stringHelpers";
 import analysis from "yoastseo";
 const { stripHTMLTags: stripFullTags } = analysis.string;
 
-export const nonReplaceVars = [ "slug", "content", "contentImage", "snippetPreviewImageUrl" ];
+export const nonReplaceVars = [ "slug", "content", "contentImage", "snippetPreviewImageURL" ];
 
 /**
  * Fills the redux store with the newly acquired data.


### PR DESCRIPTION
This ensures that they do not show up as a replacement variable in the replacement variable editor

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* `contentImage` and `snippetPreviewImageUrl` are not sensible variables, they also do not have any value when they are used.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Add contentImage and snippetPreviewImageUrl to the list of nonReplaceVars.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
1. Verify the bug on trunk
	1. Go to a replacement variable editor
	2. Enter `%co`
	3. See that `contentImage` show up as a replacement variable
	7. Enter `%snippet`
	8. See that `snippetPreviewImageUrl` is a suggestion
2. Checkout this branch
3. Build the JS
4. Go to a replacement variable editor
5. Enter `%co`
6. See that `contentImage` is no longer a suggestion
7. Enter `%snippet`
8. See that `snippetPreviewImageUrl` is no longer a suggestion

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-44
