### PR TITLE
Update checkbox to new styling

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -249,13 +249,10 @@ class Yoast_Form {
 			$class = '';
 		}
 
+		echo '<div class="yoast-field-group__checkbox">';
 		echo '<input class="checkbox ', esc_attr( $class ), '" type="checkbox" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="on"', checked( $val, 'on', false ), disabled( $this->is_control_disabled( $var ), true, false ), '/>';
-
-		if ( ! empty( $label ) ) {
-			$this->label( $label, [ 'for' => $var ] );
-		}
-
-		echo '<br class="clear" />';
+		echo '<label for="' . $var . '" class="yoast-field-group__checkbox">' . $label . "</label>";
+		echo '</div>';
 	}
 
 	/**

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -251,7 +251,7 @@ class Yoast_Form {
 
 		echo '<div class="yoast-field-group__checkbox">';
 		echo '<input class="checkbox ', esc_attr( $class ), '" type="checkbox" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="on"', checked( $val, 'on', false ), disabled( $this->is_control_disabled( $var ), true, false ), '/>';
-		echo '<label for="' . $var . '" class="yoast-field-group__checkbox">' . $label . "</label>";
+		echo '<label for="' . $var . '" class="yoast-field-group__checkbox">' . $label . '</label>';
 		echo '</div>';
 	}
 

--- a/js/tests/__snapshots__/advancedSettings.test.js.snap
+++ b/js/tests/__snapshots__/advancedSettings.test.js.snap
@@ -48,7 +48,7 @@ Array [
 }
 
 <div
-    className="Collapsible__StyledContainer-sc-1ahsa22-1 Collapsible__StyledContainerTopLevel-sc-1ahsa22-2 jZWaqb c0"
+    className="Collapsible__StyledContainer-sc-1ahsa22-1 Collapsible__StyledContainerTopLevel-sc-1ahsa22-2 laIFMe c0"
   >
     <h2
       className="Collapsible__StyledHeadingLevel-sc-1ahsa22-4 fytkxp"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Updates the checkboxes to the new Yoast styling in the plugin.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the checkboxes to the new Yoast styling in the plugin.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Build the plugin and get the `https://github.com/Yoast/wpseo-woocommerce/tree/FRO-211-woocommerse-styling-update branch` from the wpseo-woocommerce repo.
* Install and activate Woocommerce
* Go the the Woocommerce page under SEO
* Check if the checkboxes uses the new styling

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/FRO-211
