### PR TITLE
Siblings and subpages block fixes

### DIFF
--- a/src/config/migrations/20200702141921_CreateIndexableSubpagesIndex.php
+++ b/src/config/migrations/20200702141921_CreateIndexableSubpagesIndex.php
@@ -8,6 +8,7 @@
 namespace Yoast\WP\SEO\Config\Migrations;
 
 use Yoast\WP\Lib\Migrations\Migration;
+use Yoast\WP\Lib\Model;
 
 /**
  * CreateIndexableSubpagesIndex class.

--- a/src/config/migrations/20200702141921_CreateIndexableSubpagesIndex.php
+++ b/src/config/migrations/20200702141921_CreateIndexableSubpagesIndex.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package Yoast\WP\SEO\Config\Migrations
+ */
+
+namespace Yoast\WP\SEO\Config\Migrations;
+
+use Yoast\WP\Lib\Migrations\Migration;
+
+/**
+ * CreateIndexableSubpagesIndex class.
+ */
+class CreateIndexableSubpagesIndex extends Migration {
+
+	/**
+	 * The plugin this migration belongs to.
+	 *
+	 * @var string
+	 */
+	public static $plugin = 'free';
+
+	/**
+	 * Migration up.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		$this->change_column( $this->get_table_name(), 'post_status', 'string', [ 'null' => true, 'limit' => 20 ] );
+		$this->add_index(
+			$this->get_table_name(),
+			[ 'post_parent', 'object_type', 'post_status', 'object_id' ],
+			[ 'name' => 'subpages' ]
+		);
+	}
+
+	/**
+	 * Migration down.
+	 *
+	 * @return void
+	 */
+	public function down() {
+		$this->change_column( $this->get_table_name(), 'post_status', 'string', [ 'null' => true, 'limit' => 191 ] );
+		$this->remove_index(
+			$this->get_table_name(),
+			[ 'post_parent', 'object_type', 'post_status', 'object_id' ],
+			[ 'name' => 'subpages' ]
+		);
+	}
+
+	/**
+	 * Retrieves the table name to use for storing indexables.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Model::get_table_name( 'Indexable' );
+	}
+}

--- a/src/integrations/blocks/abstract-dynamic-block.php
+++ b/src/integrations/blocks/abstract-dynamic-block.php
@@ -57,7 +57,9 @@ abstract class Dynamic_Block implements Integration_Interface {
 	 * Presents the block output. This is abstract because in the loop we need to be able to build the data for the
 	 * presenter in the last moment.
 	 *
+	 * @param array $attributes The block attributes.
+	 *
 	 * @return string The block output.
 	 */
-	abstract public function present();
+	abstract public function present( $attributes );
 }

--- a/src/integrations/blocks/abstract-dynamic-block.php
+++ b/src/integrations/blocks/abstract-dynamic-block.php
@@ -42,8 +42,14 @@ abstract class Dynamic_Block implements Integration_Interface {
 	 */
 	public function register_block() {
 		\register_block_type( 'yoast-seo/' . $this->block_name, [
-			'editor_script' => $this->script,
+			'editor_script'   => $this->script,
 			'render_callback' => [ $this, 'present' ],
+			'attributes' => [
+				'className' => [
+					'default' => '',
+					'type'    => 'string',
+				],
+			],
 		] );
 	}
 

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -393,7 +393,7 @@ class Indexable_Repository {
 		$query = $this->query()
 			->where( 'post_parent', $post_parent )
 			->where( 'object_type', 'post' )
-			->where( 'post_status' ,'publish' )
+			->where( 'post_status' ,'publish' );
 
 		if ( ! empty( $exclude_ids ) ) {
 			$query->where_not_in( 'object_id', $exclude_ids );

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -392,7 +392,8 @@ class Indexable_Repository {
 	public function get_subpages_by_post_parent( $post_parent, $exclude_ids = [] ) {
 		$query = $this->query()
 			->where( 'post_parent', $post_parent )
-			->where( 'object_type', 'post' );
+			->where( 'object_type', 'post' )
+			->where( 'post_status' ,'publish' )
 
 		if ( ! empty( $exclude_ids ) ) {
 			$query->where_not_in( 'object_id', $exclude_ids );


### PR DESCRIPTION
This PR does the following:
- Adds an index for the queries made by siblings and child blocks
- Ensures siblings and child blocks don't crash when a custom class name is entered.
- Ensures siblings and child blocks only display published posts.

To test:
- Checkout the branch in premium with the same name.
- Create a page that has two children, one of which isn't published.
- Add a subpages block to this page.
- It should only display the published subpage.
- Add a custom class name to this block in the sidebar under advanced.
- The block shouldn't crash.