### PR TITLE
Fixes a bug where core/link format isn't available anymore

### DIFF
--- a/js/src/inline-links/edit-link.js
+++ b/js/src/inline-links/edit-link.js
@@ -23,7 +23,8 @@ import { decodeEntities } from "@wordpress/html-entities";
  */
 import InlineLinkUI from "./inline";
 
-const name = "yoast-seo/link";
+// Other blocks might restrict their richtext to core/link. That's why we need to replace core/link instead of registering our yoast-seo/link.
+const name = "core/link";
 const title = __( "Link", "wordpress-seo" );
 
 export const link = {

--- a/js/src/inline-links/utils.js
+++ b/js/src/inline-links/utils.js
@@ -88,7 +88,7 @@ export function isValidHref( href ) {
  */
 export function createLinkFormat( { url, opensInNewWindow, noFollow, sponsored, text } ) {
 	const format = {
-		type: "yoast-seo/link",
+		type: "core/link",
 		attributes: {
 			url,
 		},


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* As we added our own inline link format `yoast-seo/link` we remove the `core/link` format. This can cause problems with Richtext implementations which rely on the presence of the `core/link` format. This PR changes our own format from `yoast-seo/link` to `core/link` which means we now officially take ownership of `core/link` when Yoast SEO is active.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where inline link functionality in custom blocks could be missing.

## Relevant technical choices:

* As we added our own inline link format `yoast-seo/link` we remove the `core/link` format. This can cause problems with Richtext implementations which rely on the presence of the `core/link` format. This PR changes our own format from `yoast-seo/link` to `core/link` which means we now officially take ownership of `core/link` when Yoast SEO is active. Given future plans we have for this component, this seems like a good path forward.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* First of all, notice everything works as expected.
* Confirm the bug is solved.
* Confirm upgrade routine from 14.4 works.
* Confirm upgrade routine from without Yoast SEO to with Yoast SEO works

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #15568
