### PR TITLE
P3-73 Create an "Integrations" tab in the General settings of Yoast SEO

### DIFF
--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -50,6 +50,12 @@ $tabs->add_tab(
 );
 $tabs->add_tab(
 	new WPSEO_Option_Tab(
+		'integrations',
+		__( 'Integrations', 'wordpress-seo' )
+	)
+);
+$tabs->add_tab(
+	new WPSEO_Option_Tab(
 		'webmaster-tools',
 		__( 'Webmaster Tools', 'wordpress-seo' )
 	)

--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -46,7 +46,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'youtube_url',
 		'wikipedia_url',
 		'fbadminapp',
-		'semrush_enable',
+		'semrush_integration_active',
 	];
 
 	/**
@@ -160,7 +160,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'wikipedia_url',
 		'fbadminapp',
 		'indexables_indexation_completed',
-		'semrush_enable',
+		'semrush_integration_active',
 	];
 
 	/**

--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -46,6 +46,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'youtube_url',
 		'wikipedia_url',
 		'fbadminapp',
+		'semrush_enable'
 	];
 
 	/**
@@ -159,6 +160,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'wikipedia_url',
 		'fbadminapp',
 		'indexables_indexation_completed',
+		'semrush_enable'
 	];
 
 	/**

--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -46,7 +46,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'youtube_url',
 		'wikipedia_url',
 		'fbadminapp',
-		'semrush_enable'
+		'semrush_enable',
 	];
 
 	/**
@@ -160,7 +160,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'wikipedia_url',
 		'fbadminapp',
 		'indexables_indexation_completed',
-		'semrush_enable'
+		'semrush_enable',
 	];
 
 	/**

--- a/admin/views/class-yoast-integration-toggles.php
+++ b/admin/views/class-yoast-integration-toggles.php
@@ -64,7 +64,7 @@ class Yoast_Integration_Toggles {
 		$integration_toggles = [
 			(object) [
 				'name'            => __( 'SEMrush integration', 'wordpress-seo' ),
-				'setting'         => 'enable_semrush',
+				'setting'         => 'semrush_enable',
 				'label'           => __( 'The SEMrush integrations offers suggestions for related keywords.', 'wordpress-seo' ),
 				'order'           => 10,
 			],

--- a/admin/views/class-yoast-integration-toggles.php
+++ b/admin/views/class-yoast-integration-toggles.php
@@ -64,7 +64,7 @@ class Yoast_Integration_Toggles {
 		$integration_toggles = [
 			(object) [
 				'name'            => __( 'SEMrush integration', 'wordpress-seo' ),
-				'setting'         => 'semrush_enable',
+				'setting'         => 'semrush_integration_active',
 				'label'           => __( 'The SEMrush integrations offers suggestions for related keywords.', 'wordpress-seo' ),
 				'order'           => 10,
 			],

--- a/admin/views/class-yoast-integration-toggles.php
+++ b/admin/views/class-yoast-integration-toggles.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin
+ */
+
+/**
+ * Class for managing integration toggles.
+ */
+class Yoast_Integration_Toggles {
+
+	/**
+	 * Available integration toggles.
+	 *
+	 * @var array
+	 */
+	protected $toggles;
+
+	/**
+	 * Instance holder.
+	 *
+	 * @var self|null
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Gets the main integration toggles manager instance used.
+	 *
+	 * This essentially works like a Singleton, but for its drawbacks does not restrict
+	 * instantiation otherwise.
+	 *
+	 * @return self Main instance.
+	 */
+	public static function instance() {
+		if ( self::$instance === null ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Gets all available integration toggles.
+	 *
+	 * @return array List of sorted Yoast_Feature_Toggle instances.
+	 */
+	public function get_all() {
+		if ( $this->toggles === null ) {
+			$this->toggles = $this->load_toggles();
+		}
+
+		return $this->toggles;
+	}
+
+	/**
+	 * Loads the available integration toggles.
+	 *
+	 * Also ensures that the toggles are all Yoast_Feature_Toggle instances and sorted by their order value.
+	 *
+	 * @return array List of sorted Yoast_Feature_Toggle instances.
+	 */
+	protected function load_toggles() {
+		$integration_toggles = [
+			(object) [
+				'name'            => __( 'SEMrush integration', 'wordpress-seo' ),
+				'setting'         => 'enable_semrush',
+				'label'           => __( 'The SEMrush integrations offers suggestions for related keywords.', 'wordpress-seo' ),
+				'order'           => 10,
+			],
+		];
+
+		/**
+		 * Filter to add integration toggles from add-ons.
+		 *
+		 * @param array $integration_toggles Array with integration toggle objects where each object
+		 *                               should have a `name`, `setting` and `label` property.
+		 */
+		$integration_toggles = apply_filters( 'wpseo_integration_toggles', $integration_toggles );
+
+		$integration_toggles = array_map( [ $this, 'ensure_toggle' ], $integration_toggles );
+		usort( $integration_toggles, [ $this, 'sort_toggles_callback' ] );
+
+		return $integration_toggles;
+	}
+
+	/**
+	 * Ensures that the passed value is a Yoast_Feature_Toggle.
+	 *
+	 * @param Yoast_Feature_Toggle|object|array $toggle_data Feature toggle instance, or raw object or array
+	 *                                                       containing integration toggle data.
+	 * @return Yoast_Feature_Toggle Feature toggle instance based on $toggle_data.
+	 */
+	protected function ensure_toggle( $toggle_data ) {
+		if ( $toggle_data instanceof Yoast_Feature_Toggle ) {
+			return $toggle_data;
+		}
+
+		if ( is_object( $toggle_data ) ) {
+			$toggle_data = get_object_vars( $toggle_data );
+		}
+
+		return new Yoast_Feature_Toggle( $toggle_data );
+	}
+
+	/**
+	 * Callback for sorting integration toggles by their order.
+	 *
+	 * @param Yoast_Feature_Toggle $feature_a Feature A.
+	 * @param Yoast_Feature_Toggle $feature_b Feature B.
+	 *
+	 * @return bool Whether order for feature A is bigger than for feature B.
+	 */
+	protected function sort_toggles_callback( Yoast_Feature_Toggle $feature_a, Yoast_Feature_Toggle $feature_b ) {
+		return ( $feature_a->order > $feature_b->order );
+	}
+}

--- a/admin/views/class-yoast-integration-toggles.php
+++ b/admin/views/class-yoast-integration-toggles.php
@@ -63,9 +63,17 @@ class Yoast_Integration_Toggles {
 	protected function load_toggles() {
 		$integration_toggles = [
 			(object) [
-				'name'            => __( 'SEMrush integration', 'wordpress-seo' ),
+				/* translators: %s: 'SEMrush' */
+				'name'            => sprintf( __( '%s integration', 'wordpress-seo' ), 'SEMrush' ),
 				'setting'         => 'semrush_integration_active',
-				'label'           => __( 'The SEMrush integrations offers suggestions for related keywords.', 'wordpress-seo' ),
+				'label'           => sprintf(
+					__(
+						/* translators: %s: 'SEMrush' */
+						'The %s integration offers suggestions and insights for keywords related to the entered focus keyphrase.',
+						'wordpress-seo'
+					),
+				'SEMrush'
+				),
 				'order'           => 10,
 			],
 		];

--- a/admin/views/class-yoast-integration-toggles.php
+++ b/admin/views/class-yoast-integration-toggles.php
@@ -82,7 +82,7 @@ class Yoast_Integration_Toggles {
 		 * Filter to add integration toggles from add-ons.
 		 *
 		 * @param array $integration_toggles Array with integration toggle objects where each object
-		 *                               should have a `name`, `setting` and `label` property.
+		 *                                   should have a `name`, `setting` and `label` property.
 		 */
 		$integration_toggles = apply_filters( 'wpseo_integration_toggles', $integration_toggles );
 

--- a/admin/views/tabs/dashboard/integrations.php
+++ b/admin/views/tabs/dashboard/integrations.php
@@ -27,9 +27,11 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 
 		foreach ( $integration_toggles as $integration ) {
 			$help_text = esc_html( $integration->label );
+
 			if ( ! empty( $integration->extra ) ) {
 				$help_text .= ' ' . $integration->extra;
 			}
+
 			if ( ! empty( $integration->read_more_label ) ) {
 				$help_text .= ' ';
 				$help_text .= sprintf(

--- a/admin/views/tabs/dashboard/integrations.php
+++ b/admin/views/tabs/dashboard/integrations.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin\Views
+ *
+ * @uses Yoast_Form $yform Form object.
+ */
+
+if ( ! defined( 'WPSEO_VERSION' ) ) {
+	header( 'Status: 403 Forbidden' );
+	header( 'HTTP/1.1 403 Forbidden' );
+	exit();
+}
+
+$integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
+
+?>
+	<h2><?php esc_html_e( 'Integrations', 'wordpress-seo' ); ?></h2>
+	<div class="yoast-measure">
+		<?php
+		echo sprintf(
+		/* translators: %1$s expands to Yoast SEO */
+			esc_html__( '%1$s integrates with a couple of third parties. You can enable or disable these integrations below.', 'wordpress-seo' ),
+			'Yoast SEO'
+		);
+
+		foreach ( $integration_toggles as $integration ) {
+			$help_text = esc_html( $integration->label );
+			if ( ! empty( $integration->extra ) ) {
+				$help_text .= ' ' . $integration->extra;
+			}
+			if ( ! empty( $integration->read_more_label ) ) {
+				$help_text .= ' ';
+				$help_text .= sprintf(
+					'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
+					esc_url( WPSEO_Shortlinker::get( $integration->read_more_url ) ),
+					esc_html( $integration->read_more_label )
+				);
+			}
+
+			$feature_help = new WPSEO_Admin_Help_Panel(
+				$integration->setting,
+				/* translators: %s expands to a integration's name */
+				sprintf( esc_html__( 'Help on: %s', 'wordpress-seo' ), esc_html( $integration->name ) ),
+				$help_text
+			);
+
+			$yform->toggle_switch(
+				$integration->setting,
+				[
+					'on'  => __( 'On', 'wordpress-seo' ),
+					'off' => __( 'Off', 'wordpress-seo' ),
+				],
+				'<strong>' . $integration->name . '</strong>',
+				$feature_help->get_button_html() . $feature_help->get_panel_html()
+			);
+		}
+		?>
+	</div>
+<?php
+
+/*
+ * Required to prevent our settings framework from saving the default because the field isn't
+ * explicitly set when saving the Dashboard page.
+ */
+$yform->hidden( 'show_onboarding_notice', 'wpseo_show_onboarding_notice' );

--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -94,6 +94,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 			"{$allow_prefix}enable_xml_sitemap"             => true,
 			"{$allow_prefix}enable_text_link_counter"       => true,
 			"{$allow_prefix}enable_headless_rest_endpoints" => true,
+			"{$allow_prefix}semrush_integration_active"     => true,
 		];
 
 		if ( is_multisite() ) {

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -364,6 +364,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			'enable_xml_sitemap'             => false,
 			'enable_text_link_counter'       => false,
 			'enable_headless_rest_endpoints' => false,
+			'semrush_integration_active'     => false,
 		];
 
 		// We can reuse this logic from the base class with the above defaults to parse with the correct feature values.

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -62,7 +62,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			],
 			'access_tokens' => [],
 		],
-		'semrush_enable'                           => false,
+		'semrush_integration_active'               => false,
 	];
 
 	/**

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -62,7 +62,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			],
 			'access_tokens' => [],
 		],
-		'semrush_integration_active'               => false,
+		'semrush_integration_active'               => true,
 	];
 
 	/**

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -62,6 +62,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			],
 			'access_tokens' => [],
 		],
+		'semrush_enable'                           => false,
 	];
 
 	/**

--- a/integration-tests/inc/options/test-class-wpseo-option-wpseo.php
+++ b/integration-tests/inc/options/test-class-wpseo-option-wpseo.php
@@ -24,6 +24,7 @@ class WPSEO_Option_WPSEO_Test extends WPSEO_UnitTestCase {
 		'enable_cornerstone_content',
 		'enable_xml_sitemap',
 		'enable_text_link_counter',
+		'semrush_integration_active',
 	];
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to have an “Integrations” tab in the general settings of Yoast SEO, where people can disable the SEMrush integration in its totality.


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an "Integrations" tab in the Yoast SEO General Settings, showing the toggle to enable/disable SEMrush integration.

## Relevant technical choices:

* Added a `Yoast_Integration_Toggles` class which manages the array of integration toggles.
* Uses `Yoast_Feature_Toggle` class as it is generic enough to be used for integrations as well as features.
* ~Enabling/Disabling the toggle currently *does not set* the option (called `semrush_enable`). The option must probably be declared somewhere else in the tree.~
* Added an option called `semrush_integration_active` in the `wpseo[]` options array. It's also added to the options to be tracked.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Build to make sure the new class is autoloaded
* Visit SEO → General
* Observe new tab "Integrations"
* Select tab "Integrations"
* Observe text and toggle are present
* Click on the question mark icon to show the label
* click on the toggle to see it's working
* change the state of the toggle and save changes to see the option is saved in the database.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-73]
