### PR TITLE
Show a bottom border for the metabox container

### DIFF
--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -77,7 +77,6 @@ ul.wpseo-metabox-tabs li.active {
   height: auto;
   vertical-align: top;
   border: 1px solid rgba( 0,0,0,0.2 );
-  border-bottom: 0;
 }
 
 .wpseo-meta-section.active,

--- a/js/tests/__snapshots__/advancedSettings.test.js.snap
+++ b/js/tests/__snapshots__/advancedSettings.test.js.snap
@@ -27,15 +27,35 @@ Array [
     type="hidden"
     value="https://www.google.com"
   />,
-  <div
-    className="Collapsible__StyledContainer-sc-1ahsa22-1 Collapsible__StyledContainerTopLevel-sc-1ahsa22-2 jZWaqb"
+  .c0 h2 > button {
+  padding-left: 24px;
+  padding-top: 24px;
+}
+
+.c0 h2 > button span > span {
+  color: #A4286A;
+  line-height: 1.2em;
+}
+
+.c0 h2 > button:focus {
+  outline: none;
+}
+
+.c0 div[class^="Collapsible__Content"] {
+  padding: 24px 0;
+  margin: 0 24px;
+  border-top: 1px solid rgba(0,0,0,0.2);
+}
+
+<div
+    className="Collapsible__StyledContainer-sc-1ahsa22-1 Collapsible__StyledContainerTopLevel-sc-1ahsa22-2 laIFMe c0"
   >
     <h2
       className="Collapsible__StyledHeadingLevel-sc-1ahsa22-4 fytkxp"
     >
       <button
         aria-expanded={false}
-        className="Button__BaseButton-sc-32rbq-4 Button-sc-32rbq-3 Button-sc-32rbq-1 Button-sc-32rbq-2 Button-sc-32rbq-0 nHkJq Collapsible__StyledIconsButton-sc-1ahsa22-3 ixEIcM"
+        className="Button__BaseButton-sc-32rbq-4 Button-sc-32rbq-3 Button-sc-32rbq-1 Button-sc-32rbq-2 Button-sc-32rbq-0 cBBhpN Collapsible__StyledIconsButton-sc-1ahsa22-3 ixEIcM"
         id="collapsible-advanced-settings"
         onClick={[Function]}
         type="button"


### PR DESCRIPTION
This ensures that a border bottom will be displayed for the metabox container.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* No border on tabs without collapsibles. See:
![image](https://user-images.githubusercontent.com/8782235/86589487-1235d300-bf8e-11ea-8dd2-46a5df60a433.png)


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Fixes a bug where there is no border on the bottom of metabox tabs without any collapsible sections.

## Relevant technical choices:
* Because the border is added to the metabox container, it is no longer necessary to add a border on the collapsibles.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Test together with https://github.com/Yoast/javascript/pull/764
* Build everything :wrench: 
* Checkout the metabox
* See that the readability tab has a border bottom
* See that the SEO tab still looks good (ie. there is a border between the collapsed collapsibles).


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-54
