### PR TITLE
Turns disable core sitemaps into an initializer

### DIFF
--- a/src/initializers/disable-core-sitemaps.php
+++ b/src/initializers/disable-core-sitemaps.php
@@ -5,21 +5,21 @@
  * @package WPSEO\Frontend
  */
 
-namespace Yoast\WP\SEO\Integrations;
+namespace Yoast\WP\SEO\Initializers;
 
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 
 /**
  * Disables the WP core sitemaps.
  */
-class Disable_Core_Sitemaps implements Integration_Interface {
+class Disable_Core_Sitemaps implements Initializer_Interface {
 
 	use No_Conditionals;
 
 	/**
 	 * Disable the WP core XML sitemaps.
 	 */
-	public function register_hooks() {
+	public function initialize() {
 		\add_filter( 'wp_sitemaps_enabled', '__return_false' );
 	}
 }

--- a/tests/initializers/disable-core-sitemaps-test.php
+++ b/tests/initializers/disable-core-sitemaps-test.php
@@ -5,15 +5,15 @@
  * @package Yoast\YoastSEO\Integrations
  */
 
-namespace Yoast\WP\SEO\Tests\Integrations;
+namespace Yoast\WP\SEO\Tests\Initializers;
 
-use Yoast\WP\SEO\Integrations\Disable_Core_Sitemaps;
+use Yoast\WP\SEO\Initializers\Disable_Core_Sitemaps;
 use Yoast\WP\SEO\Tests\TestCase;
 
 /**
  * Unit Test Class.
  *
- * @coversDefaultClass \Yoast\WP\SEO\Integrations\Disable_Core_Sitemaps
+ * @coversDefaultClass \Yoast\WP\SEO\Initializers\Disable_Core_Sitemaps
  *
  * @group integrations
  */
@@ -39,8 +39,8 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 	 *
 	 * @covers ::register_hooks
 	 */
-	public function test_register_hooks() {
-		$this->instance->register_hooks();
+	public function test_initialize() {
+		$this->instance->initialize();
 
 		$this->assertTrue( \has_filter( 'wp_sitemaps_enabled', '__return_false' ), 'Does not have expected wp_sitemaps_is_enabled filter' );
 	}


### PR DESCRIPTION
Turns the disable core sitemaps integration into an initializer so it is loaded before WordPress redirects to the sitemap.

Fixes https://yoast.atlassian.net/browse/QAK-2011

Test instructions:
- run `./wp.sh core update --version=nightly` to update to WordPress 5.5
- Visit basic.wordpress.test/sitemap.xml
- You should be redirect to the Yoast sitemap and not see a 404.