### PR TITLE
Neutralize JavaScript snapshot tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/Yoast/wordpress-seo"
   },
   "scripts": {
-    "test": "jest",
+    "test": "jest -u",
     "build": "cross-env NODE_ENV=production webpack --config ./webpack/webpack.config.js --progress",
     "webpack-analyze-bundle": "cross-env BUNDLE_ANALYZER=1 NODE_ENV=production webpack --config ./webpack/webpack.config.js --progress",
     "i18n-wordpress-seo": "cross-env NODE_ENV=production babel js/src --plugins=@wordpress/babel-plugin-makepot | shusher",


### PR DESCRIPTION
This will prevent snapshot mismatches being the cause of builds not being triggered.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Solution:
* Makes jest update the snapshots, thus they will always pass.

Context:
* We currently have to make sure the snapshots are passing for all branches that are deployed to Yoast-dist (master, trunk, release/*, hotfix/*, feature/*)
* These snapshots are dependent on the JavaScript components and which branch/commit you are on in the JavaScript-repository.
* Because of these variations it's very easy to build the wrong snapshots; even when the code is correct.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [non-user-facing] This has no effect on functionality.

## Relevant technical choices:

* Applied in `yarn test` instead of in `travis` to also make people use it locally. Less thinking!

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `yarn test` and see `jest -u` is being executed. Your snapshots should be updated and never fail.
* The updated snapshots should not be committed, but it they are there is no big problem.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended