### PR TITLE
P2-84-yoast-didnt-recognize-my-keyphrase-not-shown

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -70,6 +70,7 @@ class WPSEO_Metabox_Formatter {
 			'cornerstoneActive'         => WPSEO_Options::get( 'enable_cornerstone_content', false ) ? 1 : 0,
 			'intl'                      => $this->get_content_analysis_component_translations(),
 			'isRtl'                     => is_rtl(),
+			'isPremium'                 => WPSEO_Utils::is_yoast_seo_premium(),
 			'addKeywordUpsell'          => $this->get_add_keyword_upsell_translations(),
 			'wordFormRecognitionActive' => YoastSEO()->helpers->language->is_word_form_recognition_active( WPSEO_Language_Utils::get_language( get_locale() ) ),
 			'siteIconUrl'               => get_site_icon_url(),


### PR DESCRIPTION
This change was made originally in https://github.com/Yoast/wordpress-seo-premium/pull/2868 - but I had to be done in wordpress-seo 

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The "Yoast didn't recognize my keyphrase" link had disappeared.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Restores the "Yoast didn't recognize my keyphrase" link.

## Relevant technical choices:

* `isPremium` was moved to `class-wpseo-utils` in this [commit](https://github.com/Yoast/wordpress-seo-premium/commit/6f7457b958f4dd65302a98b725d242180ff730cd). It seems that this broke the "Yoast didn't recognize my keyphrase" link functionality. @andizer and I created a quick fix by reintroducing `isPremium` in `class-wpseo-utils`, so that this is fixed before the 14.6 release.
* In the mean time, I will ask team components about a possible better solution.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See the steps in the [issue](https://yoast.atlassian.net/browse/P2-84).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #https://yoast.atlassian.net/browse/P2-84
