### PR TITLE
P1-56 Fix word form recognition check

### DIFF
--- a/js/src/analysis/isWordFormRecognitionActive.js
+++ b/js/src/analysis/isWordFormRecognitionActive.js
@@ -10,7 +10,7 @@ import { get } from "lodash-es";
 function isWordFormRecognitionActive() {
 	const l10nObject = getL10nObject();
 
-	return get( l10nObject, "wordFormRecognitionActive", 0 ) === 1;
+	return get( l10nObject, "wordFormRecognitionActive", false );
 }
 
 export default isWordFormRecognitionActive;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In the `window.wpseoScriptData` the `wordFormRecognitionActive` was changed to an actual boolean instead of a string `0` and `1`, which caused this bug.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the word form upsell would not be shown anymore.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Verify the upsell is back in the SEO analysis collapsible of the metabox and sidebar (see issue screenshot).
* Check this branch in premium, the upsells should not be there.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-56
