### PR TITLE
FRO-217 title scrollbar windows fix

### DIFF
--- a/js/src/components/MetaboxCollapsible.js
+++ b/js/src/components/MetaboxCollapsible.js
@@ -4,10 +4,9 @@ import styled from "styled-components";
 const MetaboxCollapsible = styled( SidebarCollapsible )`
 	h2 > button {
 		padding-left: 24px;
-		padding-top: 24px;
+		padding-top: 16px;
 		span > span {
 			color: #A4286A;
-			line-height: 1.2em;
 		}
 
 		:focus {
@@ -18,7 +17,7 @@ const MetaboxCollapsible = styled( SidebarCollapsible )`
 	div[class^="Collapsible__Content"] {
 		padding: 24px 0;
 		margin: 0 24px;
-		border-top: 1px solid rgba(0,0,0,0.2); 
+		border-top: 1px solid rgba(0,0,0,0.2);
 	}
 `;
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Remove scrollbar from overflow in metabox titles.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Remove scrollbar from overflow in metabox titles.

## Relevant technical choices:

* Also checkout the same branch from javascript.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check in Windows in the metabox of a post/page if the title are fully visible and don't scroll.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/FRO-217
