### PR TITLE
Optimize script and style loading

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -346,7 +346,6 @@ class WPSEO_Admin_Asset_Manager {
 					self::PREFIX . 'select2',
 				],
 				'version' => '4.0.3',
-				'suffix'  => '',
 			],
 			[
 				'name' => 'configuration-wizard',

--- a/admin/class-asset.php
+++ b/admin/class-asset.php
@@ -145,6 +145,8 @@ class WPSEO_Admin_Asset {
 		'in_footer' => true,
 		'rtl'       => true,
 		'media'     => 'all',
+		'version'   => '',
+		'suffix'    => '',
 	];
 
 	/**
@@ -168,11 +170,11 @@ class WPSEO_Admin_Asset {
 		$this->name      = $args['name'];
 		$this->src       = $args['src'];
 		$this->deps      = $args['deps'];
-		$this->version   = isset( $args['version'] ) ? $args['version'] : '';
+		$this->version   = $args['version'];
 		$this->media     = $args['media'];
 		$this->in_footer = $args['in_footer'];
 		$this->rtl       = $args['rtl'];
-		$this->suffix    = isset( $args['suffix'] ) ? $args['suffix'] : '';
+		$this->suffix    = $args['suffix'];
 	}
 
 	/**

--- a/admin/class-asset.php
+++ b/admin/class-asset.php
@@ -168,7 +168,7 @@ class WPSEO_Admin_Asset {
 		$this->name      = $args['name'];
 		$this->src       = $args['src'];
 		$this->deps      = $args['deps'];
-		$this->version   = $args['version'];
+		$this->version   = isset( $args['version'] ) ? $args['version'] : '';
 		$this->media     = $args['media'];
 		$this->in_footer = $args['in_footer'];
 		$this->rtl       = $args['rtl'];

--- a/admin/class-asset.php
+++ b/admin/class-asset.php
@@ -209,7 +209,11 @@ class WPSEO_Admin_Asset {
 	 * @return string
 	 */
 	public function get_version() {
-		return $this->version;
+		if ( ! empty( $this->version ) ) {
+			return $this->version;
+		}
+
+		return null;
 	}
 
 	/**

--- a/admin/class-asset.php
+++ b/admin/class-asset.php
@@ -142,7 +142,6 @@ class WPSEO_Admin_Asset {
 	 */
 	private $defaults = [
 		'deps'      => [],
-		'version'   => WPSEO_VERSION,
 		'in_footer' => true,
 		'rtl'       => true,
 		'media'     => 'all',

--- a/integration-tests/test-class-admin-asset.php
+++ b/integration-tests/test-class-admin-asset.php
@@ -57,7 +57,7 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 		$this->assertEquals( 'name', $asset->get_name() );
 		$this->assertEquals( 'src', $asset->get_src() );
 		$this->assertEquals( [], $asset->get_deps() );
-		$this->assertEquals( WPSEO_VERSION, $asset->get_version() );
+		$this->assertEquals( '', $asset->get_version() );
 		$this->assertEquals( 'all', $asset->get_media() );
 		$this->assertEquals( true, $asset->is_in_footer() );
 		$this->assertEquals( true, $asset->has_rtl() );

--- a/integration-tests/test-class-admin-asset.php
+++ b/integration-tests/test-class-admin-asset.php
@@ -44,7 +44,6 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Admin_Asset::get_version
 	 * @covers WPSEO_Admin_Asset::get_media
 	 * @covers WPSEO_Admin_Asset::is_in_footer
-	 * @covers WPSEO_Admin_Asset::get_suffix
 	 * @covers WPSEO_Admin_Asset::has_rtl
 	 */
 	public function test_constructor_default_values() {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Optimize script loading by removing `ver` parameters from scripts and styles when they're not needed.

## Relevant technical choices:

* We use the `$flat_version` in filenames everywhere when registering our assets, so we don't need the `?ver` parameter for cache busting. Removing this makes sure the web worker uses the same scripts as the browser.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Everything should basically keep working, this impacts the script that runs the analysis. If that works, this should be OK.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes QAK-2035
