### PR TITLE
Convert person selection warning to Alert

### DIFF
--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -44,6 +44,7 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 	$yform->select( 'company_or_person', __( 'Organization or person', 'wordpress-seo' ), $yoast_free_kg_select_options, 'styled', false );
 	?>
 	<div id="knowledge-graph-company">
+		<h3><?php esc_html_e( 'Organization', 'wordpress-seo' ); ?></h3>
 		<?php
 
 		/*
@@ -54,11 +55,9 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 		$yoast_seo_company_logo = WPSEO_Options::get( 'company_logo', '' );
 		if ( empty( $yoast_seo_company_name ) || empty( $yoast_seo_company_logo ) ) :
 			?>
-		<div id="knowledge-graph-company-warning"></div>
-		<?php endif; ?>
+			<div id="knowledge-graph-company-warning"></div>
+		<?php endif;
 
-		<h3><?php esc_html_e( 'Organization', 'wordpress-seo' ); ?></h3>
-		<?php
 		$yform->textinput( 'company_name', __( 'Organization name', 'wordpress-seo' ), [ 'autocomplete' => 'organization' ] );
 		$yform->media_input( 'company_logo', __( 'Organization logo', 'wordpress-seo' ) );
 		?>

--- a/js/src/components/WordPressUserSelectorSearchAppearance.js
+++ b/js/src/components/WordPressUserSelectorSearchAppearance.js
@@ -3,6 +3,7 @@
 /* External dependencies */
 import { Component, Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
+import { Alert } from "@yoast/components";
 import interpolateComponents from "interpolate-components";
 
 /* Internal dependencies */
@@ -64,11 +65,9 @@ class WordPressUserSelectorSearchAppearance extends Component {
 			return null;
 		}
 
-		return (
-			<p className="error-message">
-				{ __( "Error: Please select a user below to make your site's meta data complete.", "wordpress-seo" ) }
-			</p>
-		);
+		return <Alert type={"warning"}>
+			{ __( "Please select a user below to make your site's meta data complete.", "wordpress-seo" ) }
+			</Alert>;
 	}
 
 	/**
@@ -114,7 +113,7 @@ class WordPressUserSelectorSearchAppearance extends Component {
 				<label
 					htmlFor="wpseo-person-selector-name"
 				>
-					{ __( "Name:", "wordpress-seo" ) }
+					{ __( "Name", "wordpress-seo" ) }
 				</label>
 				<WordPressUserSelector
 					hasLabel={ false }

--- a/js/src/components/WordPressUserSelectorSearchAppearance.js
+++ b/js/src/components/WordPressUserSelectorSearchAppearance.js
@@ -65,9 +65,9 @@ class WordPressUserSelectorSearchAppearance extends Component {
 			return null;
 		}
 
-		return <Alert type={"warning"}>
+		return <Alert type={ "warning" }>
 			{ __( "Please select a user below to make your site's meta data complete.", "wordpress-seo" ) }
-			</Alert>;
+		</Alert>;
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The message that we show when no user is selected is ugly and does not match the style for when a company is not selected.
* Also moves the "company" header slightly higher, to have this placed the same way when switching between person and company.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the styling of the warning when no person is selected in the Person/Company schema selector.

## Relevant technical choices:

* Used the Alert from Yoast-components

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Toggle between company/person on the Yoast SEO -> Search Appearance settings page
* See the alert being much more pretty

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended


**Before**
<img width="642" alt="Screen Shot 2020-07-10 at 11 16 24" src="https://user-images.githubusercontent.com/2005352/87138743-2be15e00-c29f-11ea-8518-15917b39b614.png">

**After**
<img width="639" alt="Screen Shot 2020-07-10 at 11 16 39" src="https://user-images.githubusercontent.com/2005352/87138739-2a179a80-c29f-11ea-9aea-08dbb4707e43.png">
