### PR TITLE
Add a filter for the graph piece's type

### DIFF
--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -137,14 +137,14 @@ class Schema_Generator implements Generator_Interface {
 	 * Allow filtering the graph piece by its schema type.
 	 *
 	 * @param array             $graph_piece The graph piece we're filtering.
-	 * @param string            $identifier
+	 * @param string            $identifier  The identifier of the graph piece that is being filtered.
 	 * @param Meta_Tags_Context $context     The meta tags context.
 	 *
 	 * @return array The filtered graph piece.
 	 */
 	private function type_filter( $graph_piece, $identifier, Meta_Tags_Context $context ) {
 		$types = $this->get_type_from_piece( $graph_piece );
-		foreach( $types as $type ) {
+		foreach ( $types as $type ) {
 			$type = strtolower( $type );
 
 			// Prevent running the same filter twice. This makes sure we run f/i. for 'author' and for 'person'.
@@ -168,7 +168,7 @@ class Schema_Generator implements Generator_Interface {
 	 *
 	 * @param array $piece The graph piece.
 	 *
-	 * @return false|array False on failure, an array of the piece's types on success.
+	 * @return array An array of the piece's types.
 	 */
 	private function get_type_from_piece( $piece ) {
 		if ( isset( $piece['@type'] ) ) {
@@ -177,7 +177,7 @@ class Schema_Generator implements Generator_Interface {
 			}
 			return [ $piece['@type'] ];
 		}
-		return false;
+		return [];
 	}
 
 	/**

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -104,6 +104,20 @@ class Schema_Generator implements Generator_Interface {
 				 * @param Meta_Tags_Context $context     A value object with context variables.
 				 */
 				$graph_piece = \apply_filters( 'wpseo_schema_' . $identifier, $graph_piece, $context );
+
+				$type = strtolower( $this->get_type_from_piece( $graph_piece ) );
+				// Prevent running the same filter twice. This makes sure we run f/i. for 'author' and for 'person'.
+				if ( $type && $type !== $identifier ) {
+					/**
+					 * Filter: 'wpseo_schema_<type>' - Allows changing graph piece output by @type.
+					 *
+					 * @api array $graph_piece The graph piece to filter.
+					 *
+					 * @param Meta_Tags_Context $context A value object with context variables.
+					 */
+					$graph_piece = \apply_filters( 'wpseo_schema_' . $type, $graph_piece, $context );
+				}
+
 				if ( \is_array( $graph_piece ) ) {
 					$graph[] = $graph_piece;
 				}
@@ -129,6 +143,23 @@ class Schema_Generator implements Generator_Interface {
 			'@context' => 'https://schema.org',
 			'@graph'   => $graph,
 		];
+	}
+
+	/**
+	 * Retrieves the type from a graph piece.
+	 *
+	 * @param array $piece The graph piece.
+	 *
+	 * @return false|string False on failure, the piece's type on success.
+	 */
+	private function get_type_from_piece( $piece ) {
+		if ( isset( $piece['@type'] ) ) {
+			if ( is_array( $piece['@type'] ) ) {
+				return $piece['@type'][0];
+			}
+			return $piece['@type'];
+		}
+		return false;
 	}
 
 	/**

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -101,22 +101,10 @@ class Schema_Generator implements Generator_Interface {
 				 *
 				 * @api array $graph_piece The graph piece to filter.
 				 *
-				 * @param Meta_Tags_Context $context     A value object with context variables.
+				 * @param Meta_Tags_Context $context A value object with context variables.
 				 */
 				$graph_piece = \apply_filters( 'wpseo_schema_' . $identifier, $graph_piece, $context );
-
-				$type = strtolower( $this->get_type_from_piece( $graph_piece ) );
-				// Prevent running the same filter twice. This makes sure we run f/i. for 'author' and for 'person'.
-				if ( $type && $type !== $identifier ) {
-					/**
-					 * Filter: 'wpseo_schema_<type>' - Allows changing graph piece output by @type.
-					 *
-					 * @api array $graph_piece The graph piece to filter.
-					 *
-					 * @param Meta_Tags_Context $context A value object with context variables.
-					 */
-					$graph_piece = \apply_filters( 'wpseo_schema_' . $type, $graph_piece, $context );
-				}
+				$graph_piece = $this->type_filter( $graph_piece, $identifier, $context );
 
 				if ( \is_array( $graph_piece ) ) {
 					$graph[] = $graph_piece;
@@ -146,18 +134,48 @@ class Schema_Generator implements Generator_Interface {
 	}
 
 	/**
+	 * Allow filtering the graph piece by its schema type.
+	 *
+	 * @param array             $graph_piece The graph piece we're filtering.
+	 * @param string            $identifier
+	 * @param Meta_Tags_Context $context     The meta tags context.
+	 *
+	 * @return array The filtered graph piece.
+	 */
+	private function type_filter( $graph_piece, $identifier, Meta_Tags_Context $context ) {
+		$types = $this->get_type_from_piece( $graph_piece );
+		foreach( $types as $type ) {
+			$type = strtolower( $type );
+
+			// Prevent running the same filter twice. This makes sure we run f/i. for 'author' and for 'person'.
+			if ( $type && $type !== $identifier ) {
+				/**
+				 * Filter: 'wpseo_schema_<type>' - Allows changing graph piece output by @type.
+				 *
+				 * @api array $graph_piece The graph piece to filter.
+				 *
+				 * @param Meta_Tags_Context $context A value object with context variables.
+				 */
+				$graph_piece = \apply_filters( 'wpseo_schema_' . $type, $graph_piece, $context );
+			}
+		}
+
+		return $graph_piece;
+	}
+
+	/**
 	 * Retrieves the type from a graph piece.
 	 *
 	 * @param array $piece The graph piece.
 	 *
-	 * @return false|string False on failure, the piece's type on success.
+	 * @return false|array False on failure, an array of the piece's types on success.
 	 */
 	private function get_type_from_piece( $piece ) {
 		if ( isset( $piece['@type'] ) ) {
 			if ( is_array( $piece['@type'] ) ) {
-				return $piece['@type'][0];
+				return $piece['@type'];
 			}
-			return $piece['@type'];
+			return [ $piece['@type'] ];
 		}
 		return false;
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When we output an `Author`, we output a Schema piece of `@type` `Person`, if you want to filter _all_ instances of `Person`, we didn't have a filter for that. Now we do.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the option to filter our Schema by `@type`.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
