### PR TITLE
Add tracking opt-in

### DIFF
--- a/admin/config-ui/class-configuration-storage.php
+++ b/admin/config-ui/class-configuration-storage.php
@@ -51,6 +51,8 @@ class WPSEO_Configuration_Storage {
 			new WPSEO_Config_Field_Company_Logo(),
 			new WPSEO_Config_Field_Person(),
 			new WPSEO_Config_Field_Post_Type_Visibility(),
+			new WPSEO_Config_Field_Tracking_Intro(),
+			new WPSEO_Config_Field_Tracking(),
 		];
 
 		$post_type_factory = new WPSEO_Config_Factory_Post_Type();

--- a/admin/config-ui/class-configuration-structure.php
+++ b/admin/config-ui/class-configuration-structure.php
@@ -50,6 +50,10 @@ class WPSEO_Configuration_Structure {
 			'siteName',
 			'separator',
 		],
+		'tracking'         => [
+			'trackingIntro',
+			'tracking',
+		],
 		'newsletter'       => [
 			'mailchimpSignup',
 			'suggestions',
@@ -84,6 +88,7 @@ class WPSEO_Configuration_Structure {
 		);
 
 		$this->add_step( 'title-template', __( 'Title settings', 'wordpress-seo' ), $this->fields['titleTemplate'] );
+		$this->add_step( 'tracking', sprintf( __( 'Help us improve %s', 'wordpress-seo' ), 'Yoast SEO' ), $this->fields['tracking'] );
 		$this->add_step( 'newsletter', __( 'Continue learning', 'wordpress-seo' ), $this->fields['newsletter'], true, true );
 		$this->add_step( 'success', __( 'Success!', 'wordpress-seo' ), $this->fields['success'], true, true );
 	}

--- a/admin/config-ui/fields/class-field-tracking-intro.php
+++ b/admin/config-ui/fields/class-field-tracking-intro.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin\ConfigurationUI
+ */
+
+/**
+ * Class WPSEO_Config_Field_Tracking_Intro.
+ */
+class WPSEO_Config_Field_Tracking_Intro extends WPSEO_Config_Field {
+
+	/**
+	 * WPSEO_Config_Field_Tracking_Intro constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'trackingIntro', 'HTML' );
+
+		$html = '<p>' . esc_html__( 'At Yoast, we are always keen on providing the very best experience for you. To do so, we\'d like to collect some data about which other plugins and themes you have installed, and which features you use and don\'t use. Be assured that we\'ll never resell that data. And of course, as always, we won\'t collect any personal data about you or your visitors!', 'wordpress-seo' ) . '</p>';
+
+		$html .= '<p><a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/usage-tracking' ) . '">' . esc_html__( 'Read more about our usage tracking.', 'wordpress-seo' ) . '</a></p>';
+
+		$this->set_property( 'html', $html );
+	}
+}

--- a/admin/config-ui/fields/class-field-tracking.php
+++ b/admin/config-ui/fields/class-field-tracking.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin\ConfigurationUI
+ */
+
+/**
+ * Class WPSEO_Config_Field_Tracking.
+ */
+class WPSEO_Config_Field_Tracking extends WPSEO_Config_Field_Choice {
+
+	/**
+	 * WPSEO_Config_Field_Tracking constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'tracking' );
+
+		$this->set_property( 'label', __( 'Can we collect anonymous information about your website and its usage?', 'wordpress-seo' ) );
+
+		$this->add_choice( '0', __( 'No, I don\'t want to allow you to track my site data.', 'wordpress-seo' ) );
+		$this->add_choice( '1', __( 'Yes, you can track my site\'s data!', 'wordpress-seo' ) );
+	}
+
+	/**
+	 * Set adapter.
+	 *
+	 * @param WPSEO_Configuration_Options_Adapter $adapter Adapter to register lookup on.
+	 */
+	public function set_adapter( WPSEO_Configuration_Options_Adapter $adapter ) {
+		$adapter->add_custom_lookup(
+			$this->get_identifier(),
+			[ $this, 'get_data' ],
+			[ $this, 'set_data' ]
+		);
+	}
+
+	/**
+	 * Gets the option that is set for this field.
+	 *
+	 * @return string The value for the environment_type wpseo option.
+	 */
+	public function get_data() {
+		$tracking = WPSEO_Options::get( 'tracking' );
+		if ( $tracking ) {
+			return '1';
+		}
+		return '0';
+	}
+
+	/**
+	 * Set new data.
+	 *
+	 * @param string $tracking The site's environment type.
+	 *
+	 * @return bool Returns whether the value is successfully set.
+	 */
+	public function set_data( $tracking ) {
+		$return = true;
+		if ( $this->get_data() !== $tracking ) {
+			$return = WPSEO_Options::set( 'tracking', $tracking );
+		}
+
+		return $return;
+	}
+}

--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -45,23 +45,7 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 	 * @param int    $threshold The limit for the option.
 	 */
 	public function __construct( $endpoint, $threshold ) {
-		// Check if we're allowing tracking.
-		$tracking = WPSEO_Options::get( 'tracking' );
-
-		if ( $tracking === false ) {
-			return;
-		}
-
-		// Check if tracking is enabled because we're in premium or running an add-on.
-		$filter = apply_filters( 'wpseo_enable_tracking', false );
-
-		// Save this state.
-		if ( $tracking === null ) {
-			$tracking = $filter;
-			WPSEO_Options::set( 'tracking', $filter );
-		}
-
-		if ( $tracking === false ) {
+		if ( ! $this->tracking_enabled() ) {
 			return;
 		}
 
@@ -74,6 +58,10 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 	 * Registers all hooks to WordPress.
 	 */
 	public function register_hooks() {
+		if ( ! $this->tracking_enabled() ) {
+			return;
+		}
+
 		// Send tracking data on `admin_init`.
 		add_action( 'admin_init', [ $this, 'send' ], 1 );
 
@@ -157,20 +145,6 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 	protected function should_send_tracking( $ignore_time_treshhold = false ) {
 		global $pagenow;
 
-		// Don't send tracking if the user has opted out.
-		if ( WPSEO_Options::get( 'tracking' ) === false ) {
-			return false;
-		}
-
-		/**
-		 * Filter: 'wpseo_enable_tracking' - Enables the data tracking of Yoast SEO Premium.
-		 *
-		 * @api string $is_enabled The enabled state. Default is false.
-		 */
-		if ( apply_filters( 'wpseo_enable_tracking', false ) === false ) {
-			return false;
-		}
-
 		// Only send tracking on the main site of a multi-site instance. This returns true on non-multisite installs.
 		if ( ! is_main_site() ) {
 			return false;
@@ -216,5 +190,34 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 		$collector->add_collection( new WPSEO_Tracking_Settings_Data() );
 
 		return $collector;
+	}
+
+	/**
+	 * See if we should run tracking at all.
+	 */
+	private function tracking_enabled() {
+		// Check if we're allowing tracking.
+		$tracking = WPSEO_Options::get( 'tracking' );
+
+		if ( $tracking === false ) {
+			return;
+		}
+
+		/**
+		 * Filter: 'wpseo_enable_tracking' - Enables the data tracking of Yoast SEO Premium and add-ons.
+		 *
+		 * @api string $is_enabled The enabled state. Default is false.
+		 */
+		$filter = apply_filters( 'wpseo_enable_tracking', false );
+
+		// Save this state.
+		if ( $tracking === null ) {
+			$tracking = $filter;
+			WPSEO_Options::set( 'tracking', $filter );
+		}
+
+		if ( $tracking === false ) {
+			return;
+		}
 	}
 }

--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -45,6 +45,26 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 	 * @param int    $threshold The limit for the option.
 	 */
 	public function __construct( $endpoint, $threshold ) {
+		// Check if we're allowing tracking.
+		$tracking = WPSEO_Options::get( 'tracking' );
+
+		if ( $tracking === false ) {
+			return;
+		}
+
+		// Check if tracking is enabled because we're in premium or running an add-on.
+		$filter = apply_filters( 'wpseo_enable_tracking', false );
+
+		// Save this state.
+		if ( $tracking === null ) {
+			$tracking = $filter;
+			WPSEO_Options::set( 'tracking', $filter );
+		}
+
+		if ( $tracking === false ) {
+			return;
+		}
+
 		$this->endpoint     = $endpoint;
 		$this->threshold    = $threshold;
 		$this->current_time = time();
@@ -137,17 +157,17 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 	protected function should_send_tracking( $ignore_time_treshhold = false ) {
 		global $pagenow;
 
+		// Don't send tracking if the user has opted out.
+		if ( WPSEO_Options::get( 'tracking' ) === false ) {
+			return false;
+		}
+
 		/**
 		 * Filter: 'wpseo_enable_tracking' - Enables the data tracking of Yoast SEO Premium.
 		 *
 		 * @api string $is_enabled The enabled state. Default is false.
 		 */
 		if ( apply_filters( 'wpseo_enable_tracking', false ) === false ) {
-			return false;
-		}
-
-		// Don't send tracking if the user has opted out.
-		if ( WPSEO_Options::get( 'tracking' ) === false ) {
 			return false;
 		}
 

--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -194,30 +194,33 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 
 	/**
 	 * See if we should run tracking at all.
+	 *
+	 * @return bool True when we can track, false when we can't.
 	 */
 	private function tracking_enabled() {
 		// Check if we're allowing tracking.
 		$tracking = WPSEO_Options::get( 'tracking' );
 
 		if ( $tracking === false ) {
-			return;
+			return false;
 		}
-
-		/**
-		 * Filter: 'wpseo_enable_tracking' - Enables the data tracking of Yoast SEO Premium and add-ons.
-		 *
-		 * @api string $is_enabled The enabled state. Default is false.
-		 */
-		$filter = apply_filters( 'wpseo_enable_tracking', false );
 
 		// Save this state.
 		if ( $tracking === null ) {
-			$tracking = $filter;
-			WPSEO_Options::set( 'tracking', $filter );
+			/**
+			 * Filter: 'wpseo_enable_tracking' - Enables the data tracking of Yoast SEO Premium and add-ons.
+			 *
+			 * @api string $is_enabled The enabled state. Default is false.
+			 */
+			$tracking = apply_filters( 'wpseo_enable_tracking', false );
+
+			WPSEO_Options::set( 'tracking', $tracking );
 		}
 
 		if ( $tracking === false ) {
-			return;
+			return false;
 		}
+
+		return true;
 	}
 }

--- a/admin/tracking/class-tracking.php
+++ b/admin/tracking/class-tracking.php
@@ -146,6 +146,11 @@ class WPSEO_Tracking implements WPSEO_WordPress_Integration {
 			return false;
 		}
 
+		// Don't send tracking if the user has opted out.
+		if ( WPSEO_Options::get( 'tracking' ) === false ) {
+			return false;
+		}
+
 		// Only send tracking on the main site of a multi-site instance. This returns true on non-multisite installs.
 		if ( ! is_main_site() ) {
 			return false;

--- a/admin/views/class-yoast-feature-toggles.php
+++ b/admin/views/class-yoast-feature-toggles.php
@@ -144,6 +144,18 @@ class Yoast_Feature_Toggles {
 				'order'   => 90,
 			],
 			(object) [
+				'name'    => __( 'Usage tracking', 'wordpress-seo' ),
+				'label'   => __( 'Usage tracking', 'wordpress-seo' ),
+				'setting' => 'tracking',
+				'read_more_label' => sprintf(
+				/* translators: 1: Yoast SEO */
+					__( 'Allow us to track some data about your site to improve our plugin.', 'wordpress-seo' ),
+					'Yoast SEO'
+				),
+				'read_more_url'   => 'https://yoa.st/usage-tracking',
+				'order'   => 95,
+			],
+			(object) [
 				'name'    => __( 'REST API: Head endpoint', 'wordpress-seo' ),
 				'setting' => 'enable_headless_rest_endpoints',
 				'label'   => sprintf(

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -323,6 +323,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				case 'tracking':
 					$clean[ $key ] = ( isset( $dirty[ $key ] ) ? WPSEO_Utils::validate_bool( $dirty[ $key ] ) : null );
 					break;
+
 				/*
 				 * Boolean (checkbox) fields.
 				 */

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -26,6 +26,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	 */
 	protected $defaults = [
 		// Non-form fields, set via (ajax) function.
+		'tracking'                                 => null,
 		'ms_defaults_set'                          => false,
 		'ignore_search_engines_discouraged_notice' => false,
 		'ignore_indexation_warning'                => false,
@@ -319,6 +320,9 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 
 					break;
 
+				case 'tracking':
+					$clean[ $key ] = ( isset( $dirty[ $key ] ) ? WPSEO_Utils::validate_bool( $dirty[ $key ] ) : null );
+					break;
 				/*
 				 * Boolean (checkbox) fields.
 				 */
@@ -329,7 +333,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				 *  'enable_headless_rest_endpoints'
 				 *  'yoast_tracking'
 				 */
-				case 'tracking':
 				default:
 					$clean[ $key ] = ( isset( $dirty[ $key ] ) ? WPSEO_Utils::validate_bool( $dirty[ $key ] ) : false );
 					break;

--- a/integration-tests/config-ui/test-class-configuration-structure.php
+++ b/integration-tests/config-ui/test-class-configuration-structure.php
@@ -43,6 +43,7 @@ class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
 			'post-type-visibility',
 			'multiple-authors',
 			'title-template',
+			'tracking',
 			'newsletter',
 			'success',
 		];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Allow people to opt in to or out of tracking.

The following use cases:

- Only Yoast SEO free:
	- tracking off by default
- Only premium:	
	- tracking on by default
- Free + add-on:
	- tracking on by default

The feature toggle and the config wizard option will always default to off when they've not been specifically set to on.

## Summary

![Screenshot 2020-06-26 at 11 52 12](https://user-images.githubusercontent.com/487629/85846886-d1c4a100-b7a6-11ea-9d6b-8b1622374f13.png)

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* We've added the option for users to opt-in to allow Yoast to track some data about their site.
* [wordpress-seo-premium] We've added the option to opt-out of our usage tracking.

## Relevant technical choices:

* The `tracking` option defaults to `null`, which means that it can be overridden by the filter in premium and add-ons.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Two spots:
* See step 7 of the config wizard. Note that this step will default to "Yes" when Premium or any add-on is installed, and "No" otherwise.
* See the new feature toggle under SEO -> Features.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes UX-98
