### PR TITLE
Add cornerstone toggle to terms

### DIFF
--- a/admin/taxonomy/class-taxonomy-content-fields.php
+++ b/admin/taxonomy/class-taxonomy-content-fields.php
@@ -52,7 +52,7 @@ class WPSEO_Taxonomy_Content_Fields extends WPSEO_Taxonomy_Fields {
 				'',
 				'hidden',
 				''
-			)
+			),
 		];
 		/**
 		 * Filter: 'wpseo_taxonomy_content_fields' - Adds the possibility to register additional content fields.

--- a/admin/taxonomy/class-taxonomy-content-fields.php
+++ b/admin/taxonomy/class-taxonomy-content-fields.php
@@ -47,6 +47,12 @@ class WPSEO_Taxonomy_Content_Fields extends WPSEO_Taxonomy_Fields {
 				'hidden',
 				''
 			),
+			'is_cornerstone' => $this->get_field_config(
+				'',
+				'',
+				'hidden',
+				''
+			)
 		];
 		/**
 		 * Filter: 'wpseo_taxonomy_content_fields' - Adds the possibility to register additional content fields.

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -61,6 +61,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 		'wpseo_content_score'         => '',
 		'wpseo_focuskeywords'         => '[]',
 		'wpseo_keywordsynonyms'       => '[]',
+		'wpseo_is_cornerstone'        => '0',
 
 		// Social fields.
 		'wpseo_opengraph-title'       => '',

--- a/js/src/containers/MetaboxFill.js
+++ b/js/src/containers/MetaboxFill.js
@@ -1,6 +1,5 @@
 import MetaboxFill from "../components/fills/MetaboxFill";
 import { connect } from "react-redux";
-import { get } from "lodash-es";
 
 /**
  * Maps the state to props.
@@ -14,7 +13,7 @@ function mapStateToProps( state, ownProps ) {
 	const settings = {
 		...state.preferences,
 		// Because cornerstone is only applicable to posts, not terms. Despite the general setting.
-		isCornerstoneActive: get( window, "wpseoScriptData.isPost", false ) && state.preferences.isCornerstoneActive,
+		isCornerstoneActive: state.preferences.isCornerstoneActive,
 		// Because this value is initiated as an empty string.
 		displayAdvancedTab: !! window.wpseoAdminL10n.displayAdvancedTab,
 	};

--- a/js/src/initializers/term-scraper.js
+++ b/js/src/initializers/term-scraper.js
@@ -224,6 +224,38 @@ export default function initTermScraper( $ ) {
 	}
 
 	/**
+	 * Initializes cornerstone content analysis.
+	 *
+	 * @param {Object} store The redux store.
+	 * @param {Object} yoastSeoApp YoastSEO.js app.
+	 *
+	 * @returns {void}
+	 */
+	function initializeCornerstoneContentAnalysis( store, yoastSeoApp ) {
+		const cornerstoneField = document.getElementById( "hidden_wpseo_is_cornerstone" );
+
+		// This used to be a checkbox, then became a hidden input. For consistency, we set the value to '1'.
+		let isCornerstone = cornerstoneField.value === "1";
+		store.dispatch( setCornerstoneContent( isCornerstone ) );
+		yoastSeoApp.changeAssessorOptions( {
+			useCornerstone: isCornerstone,
+		} );
+
+		store.subscribe( () => {
+			const state = store.getState();
+
+			if ( state.isCornerstone !== isCornerstone ) {
+				isCornerstone = state.isCornerstone;
+				cornerstoneField.value = isCornerstone ? "1" : "0";
+
+				yoastSeoApp.changeAssessorOptions( {
+					useCornerstone: isCornerstone,
+				} );
+			}
+		} );
+	}
+
+	/**
 	 * Initializes analysis for the term edit screen.
 	 *
 	 * @returns {void}
@@ -378,9 +410,8 @@ export default function initTermScraper( $ ) {
 
 		// Initialize the snippet editor data.
 		let snippetEditorData = snippetEditorHelpers.getDataFromCollector( termScraper );
-		// This used to be a checkbox, then became a hidden input. For consistency, we set the value to '1'.
-		let isCornerstone = document.getElementById( "hidden_wpseo_is_cornerstone" ).value === "1";
-		store.dispatch( setCornerstoneContent( isCornerstone ) );
+
+		initializeCornerstoneContentAnalysis( store, app );
 
 		const snippetEditorTemplates = snippetEditorHelpers.getTemplatesFromL10n( wpseoScriptData.metabox );
 		snippetEditorData = snippetEditorHelpers.getDataWithTemplates( snippetEditorData, snippetEditorTemplates );
@@ -407,12 +438,6 @@ export default function initTermScraper( $ ) {
 
 				document.getElementById( "hidden_wpseo_focuskw" ).value = focusKeyword;
 				refreshAfterFocusKeywordChange();
-			}
-
-			if ( store.getState().isCornerstone !== isCornerstone ) {
-				isCornerstone = store.getState().isCornerstone;
-
-				document.getElementById( "hidden_wpseo_is_cornerstone" ).value = isCornerstone ? "1" : "0";
 			}
 
 			const data = snippetEditorHelpers.getDataFromStore( store );

--- a/js/src/initializers/term-scraper.js
+++ b/js/src/initializers/term-scraper.js
@@ -43,6 +43,7 @@ import { refreshSnippetEditor, updateData } from "../redux/actions/snippetEditor
 import { setWordPressSeoL10n, setYoastComponentsL10n } from "../helpers/i18n";
 import { setFocusKeyword } from "../redux/actions/focusKeyword";
 import { setMarkerStatus } from "../redux/actions/markerButtons";
+import { setCornerstoneContent } from "../redux/actions/cornerstoneContent";
 
 // Helper dependencies.
 import isGutenbergDataAvailable from "../helpers/isGutenbergDataAvailable";
@@ -377,6 +378,10 @@ export default function initTermScraper( $ ) {
 
 		// Initialize the snippet editor data.
 		let snippetEditorData = snippetEditorHelpers.getDataFromCollector( termScraper );
+		// This used to be a checkbox, then became a hidden input. For consistency, we set the value to '1'.
+		let isCornerstone = document.getElementById( "hidden_wpseo_is_cornerstone" ).value === "1";
+		store.dispatch( setCornerstoneContent( isCornerstone ) );
+
 		const snippetEditorTemplates = snippetEditorHelpers.getTemplatesFromL10n( wpseoScriptData.metabox );
 		snippetEditorData = snippetEditorHelpers.getDataWithTemplates( snippetEditorData, snippetEditorTemplates );
 
@@ -402,6 +407,12 @@ export default function initTermScraper( $ ) {
 
 				document.getElementById( "hidden_wpseo_focuskw" ).value = focusKeyword;
 				refreshAfterFocusKeywordChange();
+			}
+
+			if ( store.getState().isCornerstone !== isCornerstone ) {
+				isCornerstone = store.getState().isCornerstone;
+
+				document.getElementById( "hidden_wpseo_is_cornerstone" ).value = isCornerstone ? "1" : "0";
 			}
 
 			const data = snippetEditorHelpers.getDataFromStore( store );

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -81,8 +81,9 @@ class Indexable_Term_Builder {
 
 		$this->handle_social_images( $indexable );
 
+		$indexable->is_cornerstone = $this->get_meta_value( 'wpseo_is_cornerstone', $term_meta );
+
 		// Not implemented yet.
-		$indexable->is_cornerstone         = false;
 		$indexable->is_robots_nofollow     = null;
 		$indexable->is_robots_noarchive    = null;
 		$indexable->is_robots_noimageindex = null;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enables the cornerstone content toggle for taxonomies.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new category, save it, look it up in the indexables table and make sure `is_cornerstone` is `0`.
* Set the Is cornerstone content toggle to true and save it again, and make sure the toggle is set to true.
* Look it up in the indexables table and make sure `is_cornerstone` is `1`.
* Redo these steps for a custom taxonomy as well.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
