### PR TITLE
Fallback to the breadcrumb title for the og:title only if breadcrumbs…

### DIFF
--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -371,7 +371,7 @@ class Indexable_Presentation extends Abstract_Presentation {
 			return $this->model->open_graph_title;
 		}
 
-		if ( $this->model->breadcrumb_title ) {
+		if ( $this->model->breadcrumb_title && $this->options->get( 'breadcrumbs-enable' ) ) {
 			return $this->model->breadcrumb_title;
 		}
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Only use the breadcrumb title as a fallback for the open graph title if breadcrumbs are enabled.

## Relevant technical choices:

* This is pending an addition of a new `object_title` field for indexables, however as this field hasn't yet been added and adding it would take more work than we can properly do before 14.6 this fix will prevent the reported issue.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See https://yoast.atlassian.net/browse/QAK-2042

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/QAK-2042
