### PR TITLE
Inline link aria-label fix

### DIFF
--- a/js/src/inline-links/utils.js
+++ b/js/src/inline-links/utils.js
@@ -97,11 +97,7 @@ export function createLinkFormat( { url, opensInNewWindow, noFollow, sponsored, 
 	let relAttributes = [];
 
 	if ( opensInNewWindow ) {
-		// translators: accessibility label for external links, where the argument is the link text
-		const label = sprintf( __( "%s (opens in a new tab)", "wordpress-seo" ), text );
-
 		format.attributes.target = "_blank";
-		format.attributes[ "aria-label" ] = label;
 
 		relAttributes.push( "noreferrer noopener" );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes a bug where an inline link that opens in a new window would render `undefined` in the aria-label

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an inline link that opens in a new window would render `undefined` in the aria-label.

## Relevant technical choices:

* Omit the aria-label entirely until Gutenberg comes up with a better solution.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- create a post 
- add a paragraph
- select some text in the paragraph and add an external link
- check "Open in new tab" in the add link UI
- save the post
- see the post preview
- inspect the link source and confirm there is no longer an aria label value.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes https://yoast.atlassian.net/browse/P1-71
