### PR TITLE
Fix indexation alerts

### DIFF
--- a/js/src/indexation.js
+++ b/js/src/indexation.js
@@ -107,6 +107,9 @@ import ProgressBar from "./ui/progressBar";
 				a11ySpeak( settings.l10n.calculationInProgress, "polite" );
 				const progressBar = new ProgressBar( settings.amount, settings.ids.count, settings.ids.progress );
 
+				// Insert the warning, so that a success/error alert can be shown.
+				jQuery( '<div id="yoast-indexation-warning" class="notice"</div>' ).insertAfter( "#wpseo-title" );
+				
 				startIndexation( settings, progressBar ).then( () => {
 					if ( stoppedIndexation ) {
 						return;

--- a/js/src/indexation.js
+++ b/js/src/indexation.js
@@ -107,9 +107,11 @@ import ProgressBar from "./ui/progressBar";
 				a11ySpeak( settings.l10n.calculationInProgress, "polite" );
 				const progressBar = new ProgressBar( settings.amount, settings.ids.count, settings.ids.progress );
 
-				// Insert the warning, so that a success/error alert can be shown.
-				jQuery( '<div id="yoast-indexation-warning" class="notice"</div>' ).insertAfter( "#wpseo-title" );
-				
+				// If the div with the warning was removed, insert it again, so that a success/error alert can be shown.
+				if ( ! $( "#yoast-indexation-warning" ).length ) {
+					jQuery( '<div id="yoast-indexation-warning" class="notice"</div>' ).insertAfter( "#wpseo-title" ).hide();
+				}
+
 				startIndexation( settings, progressBar ).then( () => {
 					if ( stoppedIndexation ) {
 						return;
@@ -119,6 +121,7 @@ import ProgressBar from "./ui/progressBar";
 					a11ySpeak( settings.l10n.calculationCompleted );
 					$( "#yoast-indexation-warning" )
 						.html( "<p>" + settings.message.indexingCompleted + "</p>" )
+						.show()
 						.addClass( "notice-success" )
 						.removeClass( "notice-warning" );
 					$( settings.ids.message ).html( settings.message.indexingCompleted );

--- a/js/src/indexation.js
+++ b/js/src/indexation.js
@@ -136,6 +136,7 @@ import ProgressBar from "./ui/progressBar";
 					a11ySpeak( settings.l10n.calculationFailed );
 					$( "#yoast-indexation-warning" )
 						.html( "<p>" + settings.message.indexingFailed + "</p>" )
+						.show()
 						.addClass( "notice-error" )
 						.removeClass( "notice-warning" );
 					$( settings.ids.message ).html( settings.message.indexingFailed );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* At the moment, when an indexation process finishes (either with success or with a fail), feedback is shown to the user as plain text. This isn't very eye-catching. Therefore, these messages should be shown as an alert in the top of the screen.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an alert to signal whether an indexation process succeeded / failed.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check out `feature/internal-linking-phase-2` in Premium and merge this branch into it. Build.
* Use the Yoast Test Helper to reset the indexables and the prominent words.
* Go to the Yoast Tools page.

_Test indexable indexation success when the notice wasn't hidden_
* In the top of the screen, you should see a green alert that signals that you should run the indexable indexation.
* Click `Start processing and speed up your site now.`.
* When it finishes successfully, you should see a green alert in the top of the screen saying "Good job! You've sped up your site.".

_Test indexable indexation success when the notice was hidden_
* Use the Yoast Test Helper to reset the indexables.
* Refresh the Tools page.
* This time, click `Hide this notice`.
* Then, run the indexable indexation.
* When it finishes successfully, you should see a green alert in the top of the screen saying "Good job! You've sped up your site.".

_Test prominent words indexation success_
* Now run the internal linking indexation (you might have to reset the prominent words in the Test Helper again to get the `Analyze your content` button).
* When it finishes successfully, you should see a green alert in the top of the screen saying "Good job! All your internal linking suggestions are up to date. These suggestions appear alongside your content when you are writing or editing a post. We will notify you the next time you need to update your internal linking suggestions.".

_Test indexation failure when the notice wasn't hidden_
* Add the following code to the `index` method in `Indexable_Post_Indexation_Action`: `throw new \Exception( 'Test' );`
* Reset the indexables in the Test Helper.
* Refresh the Tools page to get the indexation button back.
* In the top of the screen, you should see a green alert that signals that you should run the indexable indexation.
* Click `Start processing and speed up your site now.`.
* When it crashes, you should see a red alert in the top of the screen saying "Something went wrong while optimizing the SEO data of your site. Please try again later.".

_Test indexation failure when the notice was hidden_
* Reset the indexables in the Test Helper.
* Refresh the Tools page to get the indexation button back.
* This time, click `Hide this notice`.
* Then, run the indexable indexation.
* When it crashes, you should see a red alert in the top of the screen saying "Something went wrong while optimizing the SEO data of your site. Please try again later.".

_Test prominent words indexation failure_
* Cut the code you have added from `Indexable_Post_Indexation_Action`.
* Paste it to the `run_indexation_action` method in `Prominent_Words_Route`.
* Run the indexable indexation (it should succeed).
* Now run the internal linking indexation (you might have to reset the prominent words in the Test Helper again to get the `Analyze your content` button).
* When it crashes, you should see a red alert in the top of the screen saying "".

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [#P2-112](https://yoast.atlassian.net/browse/P2-112)
