### PR TITLE
Use title as facebook title fallback

### DIFF
--- a/js/src/redux/selectors/fallbacks.js
+++ b/js/src/redux/selectors/fallbacks.js
@@ -1,13 +1,25 @@
-import { get } from "lodash";
+import { get, find } from "lodash";
 
 /**
- * Gets the fallback title from: state.analysisData.snippet.title.
+ * Gets the fallback title that is equal to the site title.
+ *
+ * This is stored in:
+ * state.snippetEditor.replacementVariables's value where the name is title.
  *
  * @param {Object} state The state object.
  *
  * @returns {string} The fallback title.
  */
-export const getTitleFallback = state => get( state, "analysisData.snippet.title", "" );
+export const getTitleFallback = state => {
+	const replacementVariables = get( state, "snippetEditor.replacementVariables", {} );
+	const titleReplacementVariable = find( replacementVariables, [ "name", "title" ] );
+
+	if ( titleReplacementVariable ) {
+		return titleReplacementVariable.value;
+	}
+
+	return "";
+}
 
 /**
  * Gets the fallback description from: state.analysisData.snippet.description.

--- a/js/tests/redux/selectors/fallbackSelectors.test.js
+++ b/js/tests/redux/selectors/fallbackSelectors.test.js
@@ -17,14 +17,20 @@ const testState = {
 		data: {
 			snippetPreviewImageURL: "featured.png",
 		},
+		replacementVariables: [
+			{
+				name: "title",
+				value: "Not Hello World!",
+			},
+		],
 	},
 };
 
 describe( getTitleFallback, () => {
-	it( "returns the snippit title as a fallback", () => {
+	it( "returns the indexable title as a fallback", () => {
 		const actual = getTitleFallback( testState );
 
-		const expected = "Hello World!";
+		const expected = "Not Hello World!";
 
 		expect( actual ).toEqual( expected );
 	} );

--- a/readme.txt
+++ b/readme.txt
@@ -215,24 +215,25 @@ Release Date: July 21st, 2020
 Enhancements:
 
 * Improves the editing experience in the Social tab, and gives it a dab of fresh paint.
-* `Noindex`es the `xmlrpc.php` file and all possible ways to request it, removing them from Google’s search results. [#15597](https://github.com/Yoast/wordpress-seo/pull/15597)
-* In the sharing metadata used for Facebook, Twitter, Pinterest, LinkedIn and many other sites, we now output the post title instead of the SEO title. This prevents the brand name from being added in most cases, which is better on those platforms. You can still set a specific sharing title on the Social tab of the Yoast SEO post settings. [#15622](https://github.com/Yoast/wordpress-seo/pull/15622)
-* Improves keyphrase counting in Indonesian by not counting - as a word boundary. [#696](https://github.com/Yoast/javascript/pull/696)
-* Improves the feedback text for the _keyphrase in title_ assessment to make clear that an exact keyphrase match is necessary. [#744](https://github.com/Yoast/javascript/pull/744)
-* Improves recognition of keywords that contain a hyphen in slug (for example: re-duplicated, on-the-go). [#740](https://github.com/Yoast/javascript/pull/740)
-* Improves transition words analysis for Russian. [#714](https://github.com/Yoast/javascript/pull/714)
+* `Noindex`es the `xmlrpc.php` file and all possible ways to request it, removing them from Google’s search results.
+* In the sharing metadata used for Facebook, Twitter, Pinterest, LinkedIn and many other sites, we now output the post title instead of the SEO title. This prevents the brand name from being added in most cases, which is better on those platforms. You can still set a specific sharing title on the Social tab of the Yoast SEO post settings.
+* Improves keyphrase counting in Indonesian by not counting - as a word boundary.
+* Improves the feedback text for the _keyphrase in title_ assessment to make clear that an exact keyphrase match is necessary.
+* Improves recognition of keywords that contain a hyphen in slug (for example: re-duplicated, on-the-go).
+* Improves transition words analysis for Russian.
+* Makes the plugin icon in the editor reflect the SEO and Readability score.
 
 Bugfixes:
 
-* Fixes a bug where there is no border on the bottom of metabox tabs without any collapsible sections. [#15624](https://github.com/Yoast/wordpress-seo/pull/15624)
-* Fixes a bug where the comment count would be output for Articles that did not accept comments. Props to [gr8shivam](https://github.com/gr8shivam). [#15540](https://github.com/Yoast/wordpress-seo/pull/15540)
-* Fixes a bug where the social previews did not reflect the `og:image` tag correctly in situations where the first image in the content was used as a fallback. [#15399](https://github.com/Yoast/wordpress-seo/pull/15399)
-* Fixes a bug where slashes in titles were removed before they were used as a replacement variable. Props [Jon Christopher](https://github.com/jchristopher). [#14498](https://github.com/Yoast/wordpress-seo/pull/14498)
-* Fixes `get_plugins()` undefined error if there is already `plugin.php` loaded via `init` hook by another plugin. Props [Krishna Kant](https://github.com/lushkant) [#14239](https://github.com/Yoast/wordpress-seo/pull/14239)
+* Fixes a bug where there is no border on the bottom of metabox tabs without any collapsible sections.
+* Fixes a bug where the comment count would be output for Articles that did not accept comments. Props to [gr8shivam](https://github.com/gr8shivam).
+* Fixes a bug where the social previews did not reflect the `og:image` tag correctly in situations where the first image in the content was used as a fallback.
+* Fixes a bug where slashes in titles were removed before they were used as a replacement variable. Props [Jon Christopher](https://github.com/jchristopher).
+* Fixes `get_plugins()` undefined error if there is already `plugin.php` loaded via `init` hook by another plugin. Props [Krishna Kant](https://github.com/lushkant).
 
 Other:
 
-* Removes functions, class variables and classes that were deprecated prior to version 11.5. [#15509](https://github.com/Yoast/wordpress-seo/pull/15509)
+* Removes functions, class variables and classes that were deprecated prior to version 11.5.
 
 = 14.5 =
 Release Date: July 8th, 2020


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* See https://github.com/Yoast/wordpress-seo/pull/15622 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the Facebook preview title fallback to be the indexable title instead of the SEO title.

## Relevant technical choices:

* Used the title replacement variable in the store instead of adding it again to a value that might make more sense.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Build this branch in premium.
* Create a post, edit the title.
* Check the facebook preview, it should have the post title.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-69
