### PR TITLE
Metabox styling reverts and fixes

### DIFF
--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -155,7 +155,7 @@ ul.wpseo-metabox-tabs li.active {
 }
 
 .wpseo-metabox-menu ul li a {
-  color: var( --yoast-color-label );
+  color:  #0073aa;
   display: flex;
   align-items: center;
   border: 1px solid rgba( 0,0,0,0.2 );
@@ -199,7 +199,7 @@ ul.wpseo-metabox-tabs li.active {
 
 .wpseo-metabox-menu ul li.active a {
   height: 36px;
-  color: #a4286a;
+  color: #444;
 }
 
 .wpseo-metabox-menu ul li.active span.wpseo-buy-premium {

--- a/js/src/components/MetaboxCollapsible.js
+++ b/js/src/components/MetaboxCollapsible.js
@@ -5,16 +5,9 @@ const MetaboxCollapsible = styled( SidebarCollapsible )`
 	h2 > button {
 		padding-left: 24px;
 		padding-top: 16px;
-		span > span {
-			color: #A4286A;
-		}
-
-		:focus {
-			outline: none;
-		}
 	}
 
-	div[class^="Collapsible__Content"] {
+	div[class^="collapsible_content"] {
 		padding: 24px 0;
 		margin: 0 24px;
 		border-top: 1px solid rgba(0,0,0,0.2);

--- a/js/src/components/social/SocialMetadata.js
+++ b/js/src/components/social/SocialMetadata.js
@@ -19,8 +19,8 @@ const SocialMetadata = ( { isFacebookEnabled, isTwitterEnabled } ) => {
 	return (
 		<Fragment>
 			{ isFacebookEnabled && <MetaboxCollapsible
-				/* Translators: %s expands to Facebook. */
 				hasSeparator={ false }
+				/* Translators: %s expands to Facebook. */
 				title={ sprintf( __( "%s preview", "wordpress-seo" ), "Facebook" ) }
 				initialIsOpen={ true }
 			>

--- a/js/src/components/social/SocialMetadata.js
+++ b/js/src/components/social/SocialMetadata.js
@@ -19,17 +19,14 @@ const SocialMetadata = ( { isFacebookEnabled, isTwitterEnabled } ) => {
 	return (
 		<Fragment>
 			{ isFacebookEnabled && <MetaboxCollapsible
-				hasPadding={ true }
-				hasSeparator={ true }
 				/* Translators: %s expands to Facebook. */
+				hasSeparator={ false }
 				title={ sprintf( __( "%s preview", "wordpress-seo" ), "Facebook" ) }
 				initialIsOpen={ true }
 			>
 				<FacebookContainer />
 			</MetaboxCollapsible> }
 			{ isTwitterEnabled && <MetaboxCollapsible
-				hasPadding={ true }
-				hasSeparator={ true }
 				/* Translators: %s expands to Twitter. */
 				title={ sprintf( __( "%s preview", "wordpress-seo" ), "Twitter" ) }
 				initialIsOpen={ true }

--- a/js/src/components/social/SocialUpsell.js
+++ b/js/src/components/social/SocialUpsell.js
@@ -7,7 +7,6 @@ import { Alert } from "@yoast/components";
 import { makeOutboundLink } from "@yoast/helpers";
 
 const PremiumInfoText = styled( Alert )`
-	margin-top: 16px;
 	p {
 		margin: 0;
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Because the admin redesign was reverted, we also have to revert part of the styling updates we have made in the metabox.
* There was a bug which caused the "separator" (border top on collapsible_content) to not appear, now fixed. Thijs signed off on the separator being ok to ship.
* The `FacebookPreview` had `hasSeparator={ true }`, which it should not have, because it is the top component. Fixed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [non-user-facing] Metabox collapsible colouring has been reverted from purple to its original colour, to fall in line with delays in new designs elsewhere in the plugin.
* [non-user-facing] There was an unreleased bug causing a border to appear at the top of the social tab where there should be none.
* There is now a small separator between the collapsible and the collapsible content, for easier visual scanning.

## Relevant technical choices:

* Link monorepo on `release/14.6`
* Build everything (in monorepo and wordpress-seo)
* Verify that everything looks spiffy:
- no purple!
- separators!
![image](https://user-images.githubusercontent.com/26220788/87435959-ae925200-c5ec-11ea-851e-92bf97c3f8a4.png)
- no odd line on facebook preview collapsible (compare `release/14.6`)
![image](https://user-images.githubusercontent.com/26220788/87436041-ccf84d80-c5ec-11ea-9b64-d455276a8d11.png)

Also verify that replacement variables still look good. If they don't, you probably have to run a `yarn install` in the monorepo.
![image](https://user-images.githubusercontent.com/26220788/87436086-db466980-c5ec-11ea-978a-7e77bc2bf0fc.png)


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes
P1-58
P1-57

Note that P1-46 will be fixed if you run a `yarn install` in the monorepo