### PR TITLE
Fix `grunt watch`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,7 @@ module.exports = function( grunt ) {
 		},
 		files: {
 			css: [
-				"css/dist/*.css",
+				"css/src/*.css",
 			],
 			cssMap: [
 				"css/dist/*.css.map",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,7 @@ module.exports = function( grunt ) {
 				"frontend/**/*.php",
 				"inc/**/*.php",
 				"src/**/*.php",
+				"config/**/*.php",
 			],
 			versionFiles: [
 				"package.json",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,6 +58,7 @@ module.exports = function( grunt ) {
 				"admin/**/*.php",
 				"frontend/**/*.php",
 				"inc/**/*.php",
+				"src/**/*.php",
 			],
 			versionFiles: [
 				"package.json",

--- a/composer.json
+++ b/composer.json
@@ -71,12 +71,21 @@
 		"integration-test": [
 			"@php ./vendor/phpunit/phpunit/phpunit -c phpunit-integration.xml.dist"
 		],
-        "lint": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude vendor_prefixed --exclude node_modules --exclude .git"
-        ],
-        "premium-lint": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint ./wp-seo-premium.php ./tests/load/wp-seo-premium.php ./premium/ ./integration-tests/premium/ ./tests/premium/ -e php"
-        ],
+		"lint": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude vendor_prefixed --exclude node_modules --exclude .git"
+		],
+		"lint-files": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint"
+		],
+		"lint-branch": [
+			"Yoast\\WP\\SEO\\Composer\\Actions::lint_branch"
+		],
+		"lint-staged": [
+			"Yoast\\WP\\SEO\\Composer\\Actions::lint_staged"
+		],
+		"premium-lint": [
+			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint ./wp-seo-premium.php ./tests/load/wp-seo-premium.php ./premium/ ./integration-tests/premium/ ./tests/premium/ -e php"
+		],
 		"config-yoastcs": [
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/yoast/yoastcs,../../../vendor/phpcompatibility/php-compatibility,../../../vendor/phpcompatibility/phpcompatibility-paragonie,../../../vendor/phpcompatibility/phpcompatibility-wp",
 			"@php ./vendor/squizlabs/php_codesniffer/scripts/phpcs --config-set default_standard Yoast"

--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -185,6 +185,7 @@ class Actions {
 		self::check_cs_for_changed_files( $args[0] );
 	}
 
+
 	/**
 	 * Runs PHPCS on changed files compared to some git reference.
 	 *
@@ -196,20 +197,15 @@ class Actions {
 	 */
 	private static function check_cs_for_changed_files( $compare ) {
 		\exec( 'git diff --name-only --diff-filter=d ' . \escapeshellarg( $compare ), $files );
-		$files = \array_filter(
-			$files,
-			function( $file ) {
-				return \substr( $file, -4 ) === '.php';
-			}
-		);
 
-		if ( empty( $files ) ) {
+		$php_files = self::filter_files( $files, '.php' );
+		if ( empty( $php_files ) ) {
 			echo 'No files to compare! Exiting.' . PHP_EOL;
 
 			return;
 		}
 
-		\system( 'composer check-cs -- ' . \implode( ' ', \array_map( 'escapeshellarg', $files ) ) );
+		\system( 'composer check-cs -- ' . \implode( ' ', \array_map( 'escapeshellarg', $php_files ) ) );
 	}
 	/**
 	 * Runs lint on changed files compared to some git reference.
@@ -222,20 +218,32 @@ class Actions {
 	 */
 	private static function lint_changed_files( $compare ) {
 		\exec( 'git diff --name-only --diff-filter=d ' . \escapeshellarg( $compare ), $files );
-		$files = \array_filter(
-			$files,
-			function( $file ) {
-				return \substr( $file, -4 ) === '.php';
-			}
-		);
 
-		if ( empty( $files ) ) {
+		$php_files = self::filter_files( $files, '.php' );
+		if ( empty( $php_files ) ) {
 			echo 'No files to compare! Exiting.' . PHP_EOL;
 
 			return;
 		}
 
-		\system( 'composer lint-files -- ' . \implode( ' ', \array_map( 'escapeshellarg', $files ) ) );
+		\system( 'composer lint-files -- ' . \implode( ' ', \array_map( 'escapeshellarg', $php_files ) ) );
+	}
+
+	/**
+	 * Filter files on extension.
+	 *
+	 * @param array  $files		List of files.
+	 * @param string $extension Extension to filter on.
+	 *
+	 * @return array Filtered list of files.
+	 */
+	private static function filter_files( $files, $extension ) {
+		return \array_filter(
+			$files,
+			function( $file ) use ( $extension ) {
+				return \substr( $file, ( 0 - strlen( $extension ) ) ) === $extension;
+			}
+		);
 	}
 
 	/**

--- a/grunt/config/aliases.yaml
+++ b/grunt/config/aliases.yaml
@@ -6,6 +6,12 @@
   - 'build:images'
   - 'build:i18n'
 
+'build-watch':
+  - 'shell:composer-install'
+  - 'build:js'
+  - 'build:css'
+  - 'watch'
+
 # Grunt command to only build CSS and JS
 'build:dev':
   - 'build:js'

--- a/grunt/config/clean.js
+++ b/grunt/config/clean.js
@@ -20,7 +20,7 @@ module.exports = {
 		"<%= paths.js %>/select2",
 	],
 	"build-assets-css": [
-		"<%= files.css %>",
+		"css/dist/*.css",
 		"!<%= paths.css %>monorepo*.css",
 		"<%= files.cssMap %>",
 		"<%= paths.css %>/select2",

--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -9,7 +9,7 @@ module.exports = {
 	tests: {
 		src: [ "<%= files.jsTests %>" ],
 		options: {
-			maxWarnings: 3,
+			maxWarnings: 0,
 		},
 	},
 	grunt: {

--- a/grunt/config/postcss.js
+++ b/grunt/config/postcss.js
@@ -14,7 +14,7 @@ module.exports = {
 				postCSSImport(),
 			],
 		},
-		src: "<%= files.css %>",
+		src: "css/dist/*.css",
 	},
 	release: {
 		options: {
@@ -25,6 +25,6 @@ module.exports = {
 				cssNano(),
 			],
 		},
-		src: "<%= files.css %>",
+		src: "css/dist/*.css",
 	},
 };

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -187,11 +187,11 @@ module.exports = function( grunt ) {
 		},
 
 		"php-lint": {
-			command: "composer lint",
+			command: "composer lint-branch",
 		},
 
 		phpcs: {
-			command: "composer cs 2",
+			command: "composer check-branch-cs",
 		},
 
 		"unlink-monorepo": {

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -187,12 +187,7 @@ module.exports = function( grunt ) {
 		},
 
 		"php-lint": {
-			command: "find -L . " +
-				"-path ./vendor -prune -o " +
-				"-path ./vendor_prefixed -prune -o " +
-				"-path ./node_modules -prune -o " +
-				"-path ./artifact -prune -o " +
-				"-name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
+			command: "composer lint",
 		},
 
 		phpcs: {

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -196,7 +196,7 @@ module.exports = function( grunt ) {
 		},
 
 		phpcs: {
-			command: "php ./vendor/squizlabs/php_codesniffer/scripts/phpcs",
+			command: "composer cs 2",
 		},
 
 		"unlink-monorepo": {

--- a/grunt/config/watch.js
+++ b/grunt/config/watch.js
@@ -35,4 +35,12 @@ module.exports = {
 			"eslint:plugin",
 		],
 	},
+	css: {
+		files: [
+			"<%= files.css %>",
+		],
+		tasks: [
+			"build:css",
+		],
+	},
 };

--- a/grunt/config/watch.js
+++ b/grunt/config/watch.js
@@ -20,9 +20,8 @@ module.exports = {
 			"<%= files.php %>",
 		],
 		tasks: [
-			"phplint",
-			"phpcs",
-			"checktextdomain",
+			"check:php",
+			"check:i18n",
 		],
 	},
 	js: {

--- a/grunt/config/watch.js
+++ b/grunt/config/watch.js
@@ -33,6 +33,14 @@ module.exports = {
 			"eslint:plugin",
 		],
 	},
+	jsTests: {
+		files: [
+			"<%= files.jsTests %>",
+		],
+		tasks: [
+			"eslint:tests",
+		],
+	},
 	css: {
 		files: [
 			"<%= files.css %>",

--- a/grunt/config/watch.js
+++ b/grunt/config/watch.js
@@ -21,7 +21,6 @@ module.exports = {
 		],
 		tasks: [
 			"check:php",
-			"check:i18n",
 		],
 	},
 	js: {

--- a/js/tests/data.test.js
+++ b/js/tests/data.test.js
@@ -4,6 +4,7 @@ global.jQuery = {};
 import Data from "../src/analysis/data.js";
 
 const wpData = {};
+// eslint-disable-next-line require-jsdoc
 const refresh = () => {
 	return true;
 };
@@ -32,6 +33,7 @@ data._wpData.select = mockSelect;
 
 describe( "setRefresh", () => {
 	it( "sets the refresh function", () => {
+		// eslint-disable-next-line require-jsdoc
 		const expected = () => {
 			return "refresh";
 		};

--- a/js/tests/edit.test.js
+++ b/js/tests/edit.test.js
@@ -11,6 +11,7 @@ jest.mock( "../src/analysis/classicEditorData.js", () => {
 		};
 	} );
 } );
+
 jest.mock( "../src/analysis/data.js", () => {
 	return jest.fn().mockImplementation( () => {
 		return {
@@ -18,6 +19,7 @@ jest.mock( "../src/analysis/data.js", () => {
 		};
 	} );
 } );
+
 jest.mock( "../src/helpers/isGutenbergDataAvailable", () => {
 	return jest.fn();
 } );

--- a/js/tests/helpers/factory.js
+++ b/js/tests/helpers/factory.js
@@ -1,6 +1,7 @@
 // Make sure the Jed object is globally available
 const Jed = require( "jed" );
 
+// eslint-disable-next-line require-jsdoc
 const FactoryProto = function() {};
 
 FactoryProto.prototype.buildJed = function() {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Current situation: because the plugin-grunt-tasks has a "CSS" section which tries to load a "sass" configuration which does not exist; the `grunt watch` command fails to do anything.

- Defining a `watch:css` config specifically combats this problem.
- Optimized PHPCS to only check for branch-changed files
- Optimized Lint to only check for branch-changed files
- Added the `src` directory to PHP checks
- Added the `JavaScript tests` to the checks (linting)

### Gains
- Reduced the execution time significantly
  - Parallel linting
  - Only lint & check CS for changed files
- Added new directories and files to the scope (`src`-folder, `JavaScript tests`)
- Not having to have a `make it work` / `build assets` command in your bash aliases anymore - `grunt build-watch` will do the work for you
- Having a tool that checks for the problems that Travis will fail on; running directly and giving direct feedback; this should result in cleaner PRs

### Introduced `build-watch`
This will run:
-  `composer install` 
- `grunt build:js`
- `grunt build:css`

It will **not** run `yarn link-monorepo` because that takes a long time and should already be done.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Only for dev-purposes

## Relevant technical choices:

* Repurposed the `files.css` configuration to point to the source directory instead of the dist directory.
* Could not touch `paths.css` because this is used in the `rtlcss`-config in the plugin-grunt-tasks. This can (and should) be improved.

### Watching for JavaScript files
I have decided to keep the JavaScript files-watching active.
When `yarn start` is used, this will cause double builds for the JavaScript files.
Though, otherwise we need to have two watch-commands which increase complexity greatly.

In my experience working on the components mostly does not touch the CSS or PHP files.
So stopping `yarn start` and running `grunt check` or `grunt watch` after to work on those files is an option.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `grunt watch`; modify a `php`, `js` or `css` file and see the appropriate steps being taken.
* Run `grunt build-watch`; to have all your assets being build and watched afterwards.

Grunt watch should do linting and CS checks on PHP files. Linting on JavaScript files.
The PHP linting and CS checks should only be done on the files changed on this branch (compared to trunk).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
