### PR TITLE
Use term_title as fallback for terms rather than empty replacevar title

### DIFF
--- a/js/src/redux/selectors/fallbacks.js
+++ b/js/src/redux/selectors/fallbacks.js
@@ -12,7 +12,12 @@ import { get, find } from "lodash";
  */
 export const getTitleFallback = state => {
 	const replacementVariables = get( state, "snippetEditor.replacementVariables", {} );
-	const titleReplacementVariable = find( replacementVariables, [ "name", "title" ] );
+
+	// The replacement variable for the term title is called term_title, rather than title.
+	const isTerm = get( window, "wpseoScriptData.isTerm", false );
+	const searchTitle = isTerm ? "term_title" : "title";
+
+	const titleReplacementVariable = find( replacementVariables, [ "name", searchTitle ] );
 
 	if ( titleReplacementVariable ) {
 		return titleReplacementVariable.value;

--- a/js/tests/redux/selectors/fallbackSelectors.test.js
+++ b/js/tests/redux/selectors/fallbackSelectors.test.js
@@ -22,6 +22,10 @@ const testState = {
 				name: "title",
 				value: "Not Hello World!",
 			},
+			{
+				name: "term_title",
+				value: "A term title",
+			},
 		],
 	},
 };
@@ -41,10 +45,27 @@ afterEach(
 );
 
 describe( getTitleFallback, () => {
-	it( "returns the indexable title as a fallback", () => {
+	it( "returns the indexable title as a fallback for posts", () => {
 		const actual = getTitleFallback( testState );
 
 		const expected = "Not Hello World!";
+
+		expect( actual ).toEqual( expected );
+	} );
+
+	it( "returns the indexable title as a fallback for terms", () => {
+		windowSpy.mockImplementation(
+			() => (
+				{
+					wpseoScriptData: {
+						isTerm: "1",
+					},
+				}
+			)
+		);
+		const actual = getTitleFallback( testState );
+
+		const expected = "A term title";
 
 		expect( actual ).toEqual( expected );
 	} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Show term title as fallback for Social Previews. An oversight in https://github.com/Yoast/wordpress-seo/pull/15664/files was that "title" is only filled out in posts. For terms the relevant replacevar is "term_title"

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Fixes an unreleased bug where social previews did not correctly fall back to the title of a term if the social title fields were empty.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new term, have empty social fields. Enter a title for the term. Preview fields should fall back to that title.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes QAK-2062
