### PR TITLE
Show post/term title instead of SEO title as twitter:title

### DIFF
--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -352,6 +352,31 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	}
 
 	/**
+	 * Generates the twitter title.
+	 *
+	 * @return string The twitter title.
+	 */
+	public function generate_twitter_title() {
+		if ( $this->model->twitter_title ) {
+			return $this->model->twitter_title;
+		}
+
+		if ( $this->open_graph_title && $this->context->open_graph_enabled === true ) {
+			return '';
+		}
+
+		if ( $this->model->breadcrumb_title ) {
+			return $this->model->breadcrumb_title;
+		}
+
+		if ( $this->title ) {
+			return $this->title;
+		}
+
+		return '';
+	}
+
+	/**
 	 * @inheritDoc
 	 */
 	public function generate_twitter_creator() {

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -139,6 +139,29 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	/**
 	 * @inheritDoc
 	 */
+	public function generate_twitter_title() {
+		if ( $this->model->twitter_title ) {
+			return $this->model->twitter_title;
+		}
+
+		if ( $this->open_graph_title && $this->context->open_graph_enabled === true ) {
+			return '';
+		}
+
+		if ( $this->model->breadcrumb_title ) {
+			return $this->model->breadcrumb_title;
+		}
+
+		if ( $this->title ) {
+			return $this->title;
+		}
+
+		return '';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
 	public function generate_robots() {
 		$robots = $this->get_base_robots();
 

--- a/tests/presentations/indexable-term-archive-presentation/twitter-title-test.php
+++ b/tests/presentations/indexable-term-archive-presentation/twitter-title-test.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Presentations\Indexable_Term_Archive_Presentation;
+
+use Yoast\WP\SEO\Tests\TestCase;
+
+/**
+ * Class Twitter_Title_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Presentations\Indexable_Term_Archive_Presentation
+ *
+ * @group presentations
+ * @group twitter-title
+ */
+class Twitter_Title_Test extends TestCase {
+	use Presentation_Instance_Builder;
+
+	/**
+	 * Does the setup for testing.
+	 */
+	public function setUp() {
+		$this->set_instance();
+
+		parent::setUp();
+	}
+
+	/**
+	 * Tests the situation where the twitter title is set.
+	 *
+	 * @covers ::generate_twitter_title
+	 */
+	public function test_with_twitter_title() {
+		$this->indexable->twitter_title = 'Twitter title';
+
+		$this->assertEquals( 'Twitter title', $this->instance->generate_twitter_title() );
+	}
+
+
+	/**
+	 * Tests the situation where the twitter title isn't set, but the breadcrumb title is.
+	 *
+	 * @covers ::generate_twitter_title
+	 */
+	public function test_with_breadcrumb_title() {
+		$this->indexable->twitter_title = '';
+		$this->context->open_graph_enabled    = false;
+
+		$this->indexable->breadcrumb_title = 'Breadcrumb title';
+
+		$this->assertEquals( 'Breadcrumb title', $this->instance->generate_twitter_title() );
+	}
+
+	/**
+	 * Tests the situation where the twitter title and breadcrumb title aren't set, but the title is.
+	 *
+	 * @covers ::generate_twitter_title
+	 */
+	public function test_with_post_title() {
+		$this->indexable->twitter_title = '';
+		$this->indexable->breadcrumb_title = '';
+		$this->title = 'Title';
+
+		$this->instance
+			->expects( 'generate_source' )
+			->once()
+			->andReturn( 'term' );
+
+		$this->assertEquals( 'Title', $this->instance->generate_twitter_title() );
+	}
+
+	/**
+	 * Tests the situation where the twitter title and breadcrumb title aren't set, but the title is.
+	 *
+	 * @covers ::generate_twitter_title
+	 */
+	public function test_with_open_graph_enabled() {
+		$this->indexable->twitter_title = '';
+		$this->context->open_graph_enabled    = true;
+		$this->indexable->breadcrumb_title = 'Breadcrumb title';
+		$this->title = 'Title';
+
+		$this->instance
+			->expects( 'generate_open_graph_title' )
+			->once()
+			->andReturn( 'Open Graph Title' );
+
+		$this->assertEquals( '', $this->instance->generate_twitter_title() );
+	}
+
+	/**
+	 * Tests the situation where the twitter title and breadcrumb title aren't set, but the title is.
+	 *
+	 * @covers ::generate_twitter_title
+	 */
+	public function test_with_open_graph_enabled_but_no_open_graph_title_set() {
+		$this->indexable->twitter_title = '';
+		$this->context->open_graph_enabled    = true;
+		$this->indexable->breadcrumb_title = 'Breadcrumb title';
+		$this->title = 'Title';
+
+		$this->instance
+			->expects( 'generate_open_graph_title' )
+			->once()
+			->andReturn( '' );
+
+		$this->assertEquals( 'Breadcrumb title', $this->instance->generate_twitter_title() );
+	}
+
+
+
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* The user changelog item is already covered in the item from https://github.com/Yoast/wordpress-seo/pull/15622.
* Internal changelog item: Fixes a bug where the SEO title instead of the post/term title would still be shown as twitter:title.

## Relevant technical choices:

* Like [the changes before](https://github.com/Yoast/wordpress-seo/pull/15662), I’ve limited the changes to single posts and single terms.
* Tests are still WIP.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/QAK-2067
