### PR TITLE
P3-81 Add REST endpoint to set country code option for SEMrush

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -48,6 +48,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'fbadminapp',
 		'semrush_integration_active',
 		'semrush_tokens',
+		'semrush_country_code',
 	];
 
 	/**

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -62,7 +62,8 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			'access_tokens' => [],
 		],
 		'semrush_integration_active'               => true,
-		'semrush_tokens' => [],
+		'semrush_tokens' 						   => [],
+		'semrush_country_code' 					   => 'us',
 	];
 
 	/**
@@ -335,6 +336,12 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 						}
 					}
 
+					break;
+
+				case 'semrush_country_code':
+					if ( isset( $dirty[ $key ] ) ) {
+						$clean[ $key ] = $dirty[ $key ];
+					}
 					break;
 
 				/*

--- a/src/actions/semrush/semrush-options-action.php
+++ b/src/actions/semrush/semrush-options-action.php
@@ -37,11 +37,20 @@ class SEMrush_Options_Action {
 	 */
 	public function set_country_code( $country_code ) {
 		// Code has already been validated at this point. No need to do that again.
-		$this->options_helper->set( 'semrush_country_code', $country_code );
+		$success = $this->options_helper->set( 'semrush_country_code', $country_code );
 
-		return (object) [
-			'status' => 200,
-		];
+		if ( $success ) {
+			return (object) [
+				'success' => true,
+				'status'  => 200,
+			];
+		}
+		else {
+			return (object) [
+				'success' => false,
+				'status'  => 500,
+			];
+		}
 	}
 
 }

--- a/src/actions/semrush/semrush-options-action.php
+++ b/src/actions/semrush/semrush-options-action.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Country code option action for SEMrush.
+ *
+ * @package Yoast\WP\SEO\Actions\SEMrush
+ */
+
+namespace Yoast\WP\SEO\Actions\SEMrush;
+
+use \Yoast\WP\SEO\Helpers\Options_Helper;
+
+/**
+ * Class SEMrush_Options_Action
+ */
+class SEMrush_Options_Action {
+
+	/**
+	 * @var Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
+	 * SEMrush_Options_Action constructor.
+	 *
+	 * @param \Yoast\WP\SEO\Helpers\Options_Helper $options_helper The WPSEO options helper
+	 */
+	public function __construct( Options_Helper $options_helper ) {
+		$this->options_helper = $options_helper;
+	}
+
+	/**
+	 * Stores SEMrush country code in the WPSEO options
+	 *
+	 * @param string $country_code The country code to store.
+	 *
+	 * @return object The response object.
+	 */
+	public function set_country_code( $country_code ) {
+		// Code has already been validated at this point. No need to do that again.
+		$this->options_helper->set( 'semrush_country_code', $country_code );
+
+		return (object) [
+			'status' => 200,
+		];
+	}
+
+}
+

--- a/src/actions/semrush/semrush-options-action.php
+++ b/src/actions/semrush/semrush-options-action.php
@@ -45,12 +45,12 @@ class SEMrush_Options_Action {
 				'status'  => 200,
 			];
 		}
-		else {
-			return (object) [
-				'success' => false,
-				'status'  => 500,
-			];
-		}
+		return (object) [
+			'success' => false,
+			'status'  => 500,
+			'error'   => 'Could not save option in the database',
+		];
+
 	}
 
 }

--- a/src/actions/semrush/semrush-options-action.php
+++ b/src/actions/semrush/semrush-options-action.php
@@ -22,7 +22,7 @@ class SEMrush_Options_Action {
 	/**
 	 * SEMrush_Options_Action constructor.
 	 *
-	 * @param \Yoast\WP\SEO\Helpers\Options_Helper $options_helper The WPSEO options helper
+	 * @param \Yoast\WP\SEO\Helpers\Options_Helper $options_helper The WPSEO options helper.
 	 */
 	public function __construct( Options_Helper $options_helper ) {
 		$this->options_helper = $options_helper;

--- a/src/actions/semrush/semrush-options-action.php
+++ b/src/actions/semrush/semrush-options-action.php
@@ -29,14 +29,14 @@ class SEMrush_Options_Action {
 	}
 
 	/**
-	 * Stores SEMrush country code in the WPSEO options
+	 * Stores SEMrush country code in the WPSEO options.
 	 *
 	 * @param string $country_code The country code to store.
 	 *
 	 * @return object The response object.
 	 */
 	public function set_country_code( $country_code ) {
-		// Code has already been validated at this point. No need to do that again.
+		// The country code has already been validated at this point. No need to do that again.
 		$success = $this->options_helper->set( 'semrush_country_code', $country_code );
 
 		if ( $success ) {
@@ -54,4 +54,3 @@ class SEMrush_Options_Action {
 	}
 
 }
-

--- a/src/routes/semrush-route.php
+++ b/src/routes/semrush-route.php
@@ -156,7 +156,7 @@ class SEMrush_Route implements Route_Interface {
 	 *
 	 * @param string $country_code The country code to check.
 	 *
-	 * @return boolean Whether or not the country code is valid.
+	 * @return bool Whether or not the country code is valid.
 	 */
 	public function has_valid_country_code( $country_code ) {
 		return ( $country_code !== '' && preg_match( '/^[a-z]{2}$/', $country_code ) === 1 );
@@ -165,7 +165,7 @@ class SEMrush_Route implements Route_Interface {
 	/**
 	 * Whether or not the current user is allowed to edit post and thus access the SEMrush modal.
 	 *
-	 * @return boolean Whether or not the current user is allowed to edit posts.
+	 * @return bool Whether or not the current user is allowed to edit posts.
 	 */
 	public function can_edit() {
 		return \current_user_can( 'edit_posts' );

--- a/src/routes/semrush-route.php
+++ b/src/routes/semrush-route.php
@@ -68,14 +68,14 @@ class SEMrush_Route implements Route_Interface {
 	/**
 	 * Semrush_Route constructor.
 	 *
-	 * @param Semrush_Login_Action   $login_action The login action.
+	 * @param Semrush_Login_Action   $login_action   The login action.
 	 * @param Semrush_Options_Action $options_action The options action.
 	 */
 	public function __construct(
 		Semrush_Login_Action $login_action,
 		Semrush_Options_Action $options_action
 	) {
-		$this->login_action = $login_action;
+		$this->login_action   = $login_action;
 		$this->options_action = $options_action;
 	}
 
@@ -126,7 +126,7 @@ class SEMrush_Route implements Route_Interface {
 		return new WP_REST_Response( $data, $data->status );
 	}
 	/**
-	 * Sets SEMrush country code option.
+	 * Sets the SEMrush country code option.
 	 *
 	 * @param WP_REST_Request $request The request. This request should have a country code param set.
 	 *

--- a/src/routes/semrush-route.php
+++ b/src/routes/semrush-route.php
@@ -10,6 +10,7 @@ namespace Yoast\WP\SEO\Routes;
 use WP_REST_Request;
 use WP_REST_Response;
 use Yoast\WP\SEO\Actions\Semrush\Semrush_Login_Action;
+use Yoast\WP\SEO\Actions\Semrush\SEMrush_Options_Action;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Main;
 
@@ -30,11 +31,25 @@ class SEMrush_Route implements Route_Interface {
 	const AUTHENTICATION_ROUTE = self::ROUTE_PREFIX . '/authenticate';
 
 	/**
+	 * The country code option route constant.
+	 *
+	 * @var string
+	 */
+	const COUNTRY_CODE_OPTION_ROUTE = self::ROUTE_PREFIX . '/country_code';
+
+	/**
 	 * The full login route constant.
 	 *
 	 * @var string
 	 */
 	const FULL_AUTHENTICATION_ROUTE = Main::API_V1_NAMESPACE . '/' . self::AUTHENTICATION_ROUTE;
+
+	/**
+	 * The full country code option route constant.
+	 *
+	 * @var string
+	 */
+	const FULL_COUNTRY_CODE_OPTION_ROUTE = Main::API_V1_NAMESPACE . '/' . self::COUNTRY_CODE_OPTION_ROUTE;
 
 	/**
 	 * The login action.
@@ -44,19 +59,31 @@ class SEMrush_Route implements Route_Interface {
 	private $login_action;
 
 	/**
+	 * The options action.
+	 *
+	 * @var SEMrush_Options_Action
+	 */
+	private $options_action;
+
+	/**
 	 * Semrush_Route constructor.
 	 *
-	 * @param Semrush_Login_Action $login_action The login action.
+	 * @param Semrush_Login_Action   $login_action The login action.
+	 * @param Semrush_Options_Action $options_action The options action.
 	 */
-	public function __construct( Semrush_Login_Action $login_action ) {
+	public function __construct(
+		Semrush_Login_Action $login_action,
+		Semrush_Options_Action $options_action
+	) {
 		$this->login_action = $login_action;
+		$this->options_action = $options_action;
 	}
 
 	/**
 	 * @inheritDoc
 	 */
 	public function register_routes() {
-		$route_args = [
+		$authentication_route_args = [
 			'methods'  => 'POST',
 			'callback' => [ $this, 'authenticate' ],
 			'args'     => [
@@ -67,7 +94,21 @@ class SEMrush_Route implements Route_Interface {
 			],
 		];
 
-		\register_rest_route( Main::API_V1_NAMESPACE, self::AUTHENTICATION_ROUTE, $route_args );
+		\register_rest_route( Main::API_V1_NAMESPACE, self::AUTHENTICATION_ROUTE, $authentication_route_args );
+
+		$set_country_code_option_route_args = [
+			'methods'  => 'POST',
+			'callback' => [ $this, 'set_country_code_option' ],
+			'permission_callback' => [ $this, 'can_edit' ],
+			'args'     => [
+				'country_code' => [
+					'validate_callback' => [ $this, 'has_valid_country_code' ],
+					'required'          => true,
+				],
+			],
+		];
+
+		\register_rest_route( Main::API_V1_NAMESPACE, self::COUNTRY_CODE_OPTION_ROUTE, $set_country_code_option_route_args );
 	}
 
 	/**
@@ -84,6 +125,20 @@ class SEMrush_Route implements Route_Interface {
 
 		return new WP_REST_Response( $data, $data->status );
 	}
+	/**
+	 * Sets SEMrush country code option.
+	 *
+	 * @param WP_REST_Request $request The request. This request should have a country code param set.
+	 *
+	 * @return WP_REST_Response The response.
+	 */
+	public function set_country_code_option( WP_REST_Request $request ) {
+		$data = $this
+			->options_action
+			->set_country_code( $request['country_code'] );
+
+		return new WP_REST_Response( $data, $data->status );
+	}
 
 	/**
 	 * Checks if a valid code was returned.
@@ -94,5 +149,25 @@ class SEMrush_Route implements Route_Interface {
 	 */
 	public function has_valid_code( $code ) {
 		return $code !== '';
+	}
+
+	/**
+	 * Checks if a valid country code was submitted.
+	 *
+	 * @param string $country_code The country code to check.
+	 *
+	 * @return boolean Whether or not the country code is valid.
+	 */
+	public function has_valid_country_code( $country_code ) {
+		return ( $country_code !== '' && preg_match('/^[a-z]{2}$/', $country_code ) === 1 );
+	}
+
+	/**
+	 * Whether or not the current user is allowed to edit post and thus access the SEMrush modal.
+	 *
+	 * @return boolean Whether or not the current user is allowed to edit posts.
+	 */
+	public function can_edit() {
+		return \current_user_can( 'edit_posts' );
 	}
 }

--- a/src/routes/semrush-route.php
+++ b/src/routes/semrush-route.php
@@ -159,7 +159,7 @@ class SEMrush_Route implements Route_Interface {
 	 * @return boolean Whether or not the country code is valid.
 	 */
 	public function has_valid_country_code( $country_code ) {
-		return ( $country_code !== '' && preg_match('/^[a-z]{2}$/', $country_code ) === 1 );
+		return ( $country_code !== '' && preg_match( '/^[a-z]{2}$/', $country_code ) === 1 );
 	}
 
 	/**

--- a/tests/routes/semrush-route-test.php
+++ b/tests/routes/semrush-route-test.php
@@ -10,6 +10,7 @@ namespace Yoast\WP\SEO\Tests\Routes;
 use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Actions\Semrush\SEMrush_Login_Action;
+use Yoast\WP\SEO\Actions\Semrush\SEMrush_Options_Action;
 use Yoast\WP\SEO\Routes\SEMrush_Route;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -31,6 +32,13 @@ class SEMrush_Route_Test extends TestCase {
 	protected $login_action;
 
 	/**
+	 * Represents the options action.
+	 *
+	 * @var Mockery\MockInterface|SEMrush_Options_Action
+	 */
+	protected $options_action;
+
+	/**
 	 * Represents the instance to test.
 	 *
 	 * @var SEMrush_Route
@@ -44,7 +52,8 @@ class SEMrush_Route_Test extends TestCase {
 		parent::setUp();
 
 		$this->login_action = Mockery::mock( SEMrush_Login_Action::class );
-		$this->instance     = new SEMrush_Route( $this->login_action );
+		$this->options_action = Mockery::mock( SEMrush_Options_Action::class );
+		$this->instance     = new SEMrush_Route( $this->login_action, $this->options_action );
 	}
 
 	/**
@@ -54,6 +63,7 @@ class SEMrush_Route_Test extends TestCase {
 	 */
 	public function test_construct() {
 		$this->assertAttributeInstanceOf( SEMrush_Login_Action::class, 'login_action', $this->instance );
+		$this->assertAttributeInstanceOf( SEMrush_Options_Action::class, 'options_action', $this->instance );
 	}
 
 	/**
@@ -87,6 +97,23 @@ class SEMrush_Route_Test extends TestCase {
 				]
 			);
 
+		Monkey\Functions\expect( 'register_rest_route' )
+			->with(
+				'yoast/v1',
+				'semrush/country_code',
+				[
+					'methods'  => 'POST',
+					'callback' => [ $this->instance, 'set_country_code_option' ],
+					'permission_callback' => [ $this->instance, 'can_edit' ],
+					'args'     => [
+						'country_code' => [
+							'validate_callback' => [ $this->instance, 'has_valid_country_code' ],
+							'required'          => true,
+						],
+					],
+				]
+			);
+
 		$this->instance->register_routes();
 	}
 
@@ -109,6 +136,26 @@ class SEMrush_Route_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the country code is valid, with invalid country code given as input.
+	 *
+	 * @covers ::has_valid_country_code
+	 */
+	public function test_is_valid_country_code_with_invalid_code_given() {
+		$this->assertFalse( $this->instance->has_valid_country_code( '' ) );
+		$this->assertFalse( $this->instance->has_valid_country_code( 'abc' ) );
+		$this->assertFalse( $this->instance->has_valid_country_code( '12' ) );
+	}
+
+	/**
+	 * Tests the country code is valid, with valid country code given as input.
+	 *
+	 * @covers ::has_valid_code
+	 */
+	public function test_is_valid_country_code_with_valid_code_given() {
+		$this->assertTrue( $this->instance->has_valid_country_code( 'nl' ) );
+	}
+
+	/**
 	 * Tests the authentication route.
 	 *
 	 * @covers ::authenticate
@@ -128,5 +175,27 @@ class SEMrush_Route_Test extends TestCase {
 		Mockery::mock( 'overload:WP_REST_Response' );
 
 		$this->assertInstanceOf( 'WP_REST_Response', $this->instance->authenticate( $request ) );
+	}
+
+	/**
+	 * Tests the authentication route.
+	 *
+	 * @covers ::authenticate
+	 */
+	public function test_country_code() {
+		$request = Mockery::mock( 'WP_REST_Request', 'ArrayAccess' );
+		$request
+			->expects( 'offsetGet' )
+			->with( 'country_code' )
+			->andReturn( 'nl' );
+
+		$this->options_action
+			->expects( 'set_country_code' )
+			->with( 'nl' )
+			->andReturn( (object) [ 'status' => '200' ] );
+
+		Mockery::mock( 'overload:WP_REST_Response' );
+
+		$this->assertInstanceOf( 'WP_REST_Response', $this->instance->set_country_code_option( $request ) );
 	}
 }

--- a/tests/routes/semrush-route-test.php
+++ b/tests/routes/semrush-route-test.php
@@ -51,9 +51,9 @@ class SEMrush_Route_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->login_action = Mockery::mock( SEMrush_Login_Action::class );
+		$this->login_action   = Mockery::mock( SEMrush_Login_Action::class );
 		$this->options_action = Mockery::mock( SEMrush_Options_Action::class );
-		$this->instance     = new SEMrush_Route( $this->login_action, $this->options_action );
+		$this->instance       = new SEMrush_Route( $this->login_action, $this->options_action );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The SEMrush modal has a country selector to choose the country database against which the request for related keyphrases must be performed. We want to store in an option the last country code that's been used, so we need a REST API endpoint to access with a POST request.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Added a `/semrush/country_code` REST endpoint to store the last country database queried by the SEMrush integration.

## Relevant technical choices:

* Multisite is not supported at the moment since the `semrush_tokens` options do not currently support it (to be discussed).
* The endpoint has currently been created only to store the value via POST: querying via GET hasn't been implemented since the country selector will probably read the value when the Edit page is accessed to avoid problems with concurrence.
* We check for the `edit_posts` to make sure the endpoint is accessed only by authorized users and that they are able to edit a post (and thus access the SEMrush modal).
* This means that the POST request must contain some sort of authentication. Read more about that in the [REST API documentation](https://developer.wordpress.org/rest-api/using-the-rest-api/authentication/). In the test instruction we provide a workaround using a plugin.
* The value is checked only to be sure it's a two-letter, lowercase string like ISO 3166-1 alpha-2 country codes. No check against the actual list of country codes is performed at the moment.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* run `composer install` to make sure the autoload files are generated
* run `composer test` to see the test are passed
* **to authenticate the request**, install and setup a plugin like [JWT Auth](https://wordpress.org/plugins/jwt-auth/).
* With a REST API tool like Insomnia or Postman, after setting up authentication using the plugin above, send a POST request to `http://basic.wordpress.test/wp-json/yoast/v1/semrush/country_code` submitting the parameter `country_code`.
* Test the response with different codes to see that only two-letter lowercase codes are accepted
* When the response is successful (code 200), check the database for the `wpseo` option to oserve that the `semrush_country_code` has been correctly set to the desired value.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-81]
