### PR TITLE
P1-67 Prefix block names with Yoast

### DIFF
--- a/js/src/structured-data-blocks/faq/block.js
+++ b/js/src/structured-data-blocks/faq/block.js
@@ -18,7 +18,7 @@ const attributes = {
 
 export default () => {
 	registerBlockType( "yoast/faq-block", {
-		title: __( "FAQ", "wordpress-seo" ),
+		title: __( "Yoast FAQ", "wordpress-seo" ),
 		description: __( "List your Frequently Asked Questions in an SEO-friendly way. You can only use one FAQ block per post.", "wordpress-seo" ),
 		icon: "editor-ul",
 		category: "yoast-structured-data-blocks",

--- a/js/src/structured-data-blocks/how-to/block.js
+++ b/js/src/structured-data-blocks/how-to/block.js
@@ -46,7 +46,7 @@ const attributes = {
 
 export default () => {
 	registerBlockType( "yoast/how-to-block", {
-		title: __( "How-to", "wordpress-seo" ),
+		title: __( "Yoast How-to", "wordpress-seo" ),
 		description: __( "Create a How-to guide in an SEO-friendly way. You can only use one How-to block per post.", "wordpress-seo" ),
 		icon: "editor-ol",
 		category: "yoast-structured-data-blocks",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* For WP 5.5 and the block directory, we need to add “Yoast” to our block names, because if people have the “most used blocks” option enabled, they’ll lose the context that the blocks are ours.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prefixed the FAQ and HowTo block names with Yoast.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use the `Add block` functionality.
* See FAQ and HowTo being prefixed by Yoast.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-67
