### PR TITLE
Adds writable check to robots.txt file editor to comply with WordPress.com

### DIFF
--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -12,8 +12,9 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 }
 
 $yform          = Yoast_Form::get_instance();
-$robots_file    = get_home_path() . 'robots.txt';
-$ht_access_file = get_home_path() . '.htaccess';
+$home_path 		= is_writable( get_home_path() ) ? get_home_path() : $_SERVER['DOCUMENT_ROOT'] . '/';
+$robots_file    = $home_path . 'robots.txt';
+$ht_access_file = $home_path . '.htaccess';
 
 if ( isset( $_POST['create_robots'] ) ) {
 	if ( ! current_user_can( 'edit_files' ) ) {
@@ -102,7 +103,7 @@ if ( isset( $msg ) && ! empty( $msg ) ) {
 echo '<h2>robots.txt</h2>';
 
 if ( ! file_exists( $robots_file ) ) {
-	if ( is_writable( get_home_path() ) ) {
+	if ( is_writable( $home_path ) ) {
 		echo '<form action="', esc_url( $action_url ), '" method="post" id="robotstxtcreateform">';
 		wp_nonce_field( 'wpseo_create_robots', '_wpnonce', true, true );
 		echo '<p>';


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* To add checks if the path to home is writable, so that the robots.txt file can be edited on WordPress.com Business sites

## Summary

On Business Plan sites hosted on WordPress.com, it is not possible to edit the robots.txt file in Tools > File Editor.

When I access this tool, I see the message "If you had a robots.txt file and it was editable, you could edit it from here."

This is due to the fact that `get_home_path()` points to a non-writable folder in WordPress.com where the core WordPress files are located.

`/wordpress/core/5.4.2/`

This PR adds checks on whether `get_home_path()` is writable.  If so, it sticks to `get_home_path()`, if not, it goes to `$_SERVER['DOCUMENT_ROOT']`.

#15675 

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `robots.txt` and `.htaccess` file editor would not work due to `get_home_path()` not being a writable path. Props to [Andrew dela Serna](https://github.com/druesome).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* On a site hosted on WordPress.com with a Business Plan, go to wp-admin
* Install Yoast Plugin
* Click SEO > Tools > File Editor and notice the error "If you had a robots.txt file and it was editable, you could edit it from here."
* To test this PR, create a production version with the branch issue_15675 and install on the WordPress.com site.
* Notice that the robots.txt file editor works as expected

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #15675 