### PR TITLE
P1-65 Add example and extra keywords to structured data blocks

### DIFF
--- a/js/src/structured-data-blocks/faq/block.js
+++ b/js/src/structured-data-blocks/faq/block.js
@@ -26,7 +26,18 @@ export default () => {
 			__( "FAQ", "wordpress-seo" ),
 			__( "Frequently Asked Questions", "wordpress-seo" ),
 			__( "Schema", "wordpress-seo" ),
+			__( "SEO", "wordpress-seo" ),
+			__( "Structured Data", "wordpress-seo-premium" ),
 		],
+		example: {
+			attributes: {
+				questions: [
+					{ id: Faq.generateId( "faq-question" ), question: [], answer: [] },
+					{ id: Faq.generateId( "faq-question" ), question: [], answer: [] },
+					{ id: Faq.generateId( "faq-question" ), question: [], answer: [] },
+				],
+			},
+		},
 		// Allow only one FAQ block per post.
 		supports: {
 			multiple: false,

--- a/js/src/structured-data-blocks/how-to/block.js
+++ b/js/src/structured-data-blocks/how-to/block.js
@@ -54,7 +54,17 @@ export default () => {
 			__( "How-to", "wordpress-seo" ),
 			__( "How to", "wordpress-seo" ),
 			__( "Schema", "wordpress-seo" ),
+			__( "SEO", "wordpress-seo" ),
+			__( "Structured Data", "wordpress-seo-premium" ),
 		],
+		example: {
+			attributes: {
+				steps: [
+					{ id: HowTo.generateId( "how-to-step" ), name: [], text: [] },
+					{ id: HowTo.generateId( "how-to-step" ), name: [], text: [] },
+				],
+			},
+		},
 		// Allow only one How-To block per post.
 		supports: {
 			multiple: false,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Compatibility with WordPress 5.5: makes sure Yoast structured data blocks are found on more keywords and have examples in the block inserter.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Compatibility with WordPress 5.5: makes sure Yoast structured data blocks are found on more keywords and have examples in the block inserter.

## Relevant technical choices:

* Nothing special, just a few extra attributes.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Confirm this works as expected. 

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Part of https://yoast.atlassian.net/browse/P1-66 and https://yoast.atlassian.net/browse/P1-65
