### PR TITLE
P1-63 Add logo to our block categories

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -278,6 +278,7 @@ class WPSEO_Admin_Asset_Manager {
 					'wp-annotations',
 					'wp-api',
 					'wp-api-fetch',
+					'wp-blocks',
 					'wp-components',
 					'wp-compose',
 					'wp-data',

--- a/js/src/components/PluginIcon.js
+++ b/js/src/components/PluginIcon.js
@@ -2,6 +2,11 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 
 const PluginIconSVG = styled.svg`
+	width: ${ props => props.size }px;
+	height: ${ props => props.size }px;
+	&&& path {
+		fill: ${ props => props.color };
+	}
 	&&& circle.yoast-icon-readability-score {
 		fill: ${ props => props.readabilityScoreColor };
 		display: ${ props => props.isContentAnalysisActive ? "inline" : "none" };
@@ -54,10 +59,21 @@ const PluginIcon = function( props ) {
 };
 
 PluginIcon.propTypes = {
-	readabilityScoreColor: PropTypes.string.isRequired,
-	isContentAnalysisActive: PropTypes.bool.isRequired,
-	seoScoreColor: PropTypes.string.isRequired,
-	isKeywordAnalysisActive: PropTypes.bool.isRequired,
+	readabilityScoreColor: PropTypes.string,
+	isContentAnalysisActive: PropTypes.bool,
+	seoScoreColor: PropTypes.string,
+	isKeywordAnalysisActive: PropTypes.bool,
+	size: PropTypes.number,
+	color: PropTypes.string,
+};
+
+PluginIcon.defaultProps = {
+	readabilityScoreColor: "#000000",
+	isContentAnalysisActive: false,
+	seoScoreColor: "#000000",
+	isKeywordAnalysisActive: false,
+	size: 20,
+	color: "#000001",
 };
 
 export default PluginIcon;

--- a/js/src/initializers/edit.js
+++ b/js/src/initializers/edit.js
@@ -1,6 +1,5 @@
 /* global window wp */
 /* External dependencies */
-import styled from "styled-components";
 import { Fragment } from "@wordpress/element";
 import { updateCategory } from "@wordpress/blocks";
 import { combineReducers, registerStore, select, dispatch } from "@wordpress/data";

--- a/js/src/initializers/edit.js
+++ b/js/src/initializers/edit.js
@@ -2,6 +2,7 @@
 /* External dependencies */
 import styled from "styled-components";
 import { Fragment } from "@wordpress/element";
+import { updateCategory } from "@wordpress/blocks";
 import { combineReducers, registerStore, select, dispatch } from "@wordpress/data";
 import { __, sprintf } from "@wordpress/i18n";
 import { registerFormatType } from "@wordpress/rich-text";
@@ -14,6 +15,7 @@ import {
 import Data from "../analysis/data.js";
 import reducers from "../redux/reducers";
 import PluginIcon from "../containers/PluginIcon";
+import YoastIcon from "../components/PluginIcon";
 import ClassicEditorData from "../analysis/classicEditorData.js";
 import isGutenbergDataAvailable from "../helpers/isGutenbergDataAvailable";
 import SidebarFill from "../containers/SidebarFill";
@@ -31,11 +33,6 @@ import DocumentSidebar from "../containers/DocumentSidebar";
 import PostPublish from "../containers/PostPublish";
 
 const PLUGIN_NAMESPACE = "yoast-seo";
-
-const PinnedPluginIcon = styled( PluginIcon )`
-	width: 20px;
-	height: 20px;
-`;
 
 /**
  * Contains the Yoast SEO block editor integration.
@@ -152,6 +149,9 @@ class Edit {
 		if ( ! isGutenbergDataAvailable() ) {
 			return;
 		}
+		const icon = <YoastIcon color="#a4286a" />;
+		updateCategory( "yoast-structured-data-blocks", { icon } );
+		updateCategory( "yoast-internal-linking-blocks", { icon } );
 
 		const {
 			PluginPrePublishPanel,
@@ -174,8 +174,8 @@ class Edit {
 		/**
 		 * Renders the yoast sidebar
 		 *
-	 	 * @returns {Component} The yoast sidebar component.
-	 	 */
+		 * @returns {Component} The yoast sidebar component.
+		 */
 		const YoastSidebar = () => (
 			<Fragment>
 				<PluginSidebarMoreMenuItem
@@ -223,7 +223,7 @@ class Edit {
 
 		registerPlugin( PLUGIN_NAMESPACE, {
 			render: YoastSidebar,
-			icon: <PinnedPluginIcon />,
+			icon: <PluginIcon />,
 		} );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds the Yoast logo to the Yoast block categories.

<img width="697" alt="Screenshot 2020-07-22 at 12 35 33" src="https://user-images.githubusercontent.com/1488816/88166655-e1090400-cc17-11ea-979a-2ebe10835443.png">


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the Yoast logo to the Yoast block categories.

## Relevant technical choices:

* Reused the plugin icon and made it useful for multiple usecases.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Notice the Yoast logo in the block inserter next to our block categories.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes https://yoast.atlassian.net/browse/P1-63
