### PR TITLE
Remove the color of the block category icon.

### DIFF
--- a/js/src/initializers/edit.js
+++ b/js/src/initializers/edit.js
@@ -148,7 +148,7 @@ class Edit {
 		if ( ! isGutenbergDataAvailable() ) {
 			return;
 		}
-		const icon = <YoastIcon color="#a4286a" />;
+		const icon = <YoastIcon />;
 		updateCategory( "yoast-structured-data-blocks", { icon } );
 		updateCategory( "yoast-internal-linking-blocks", { icon } );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Removes the color from the yoast icon next to block categories.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the color from the yoast icon next to block categories.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Confirm the color has in fact been removed.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
