### PR TITLE
Revert "Changed readfile to get_contents from wp_filesystem"

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -436,8 +436,7 @@ class WPSEO_Sitemaps {
 		header( 'Expires: ' . $this->date->format_timestamp( ( time() + $expires ), 'D, d M Y H:i:s' ) . ' GMT' );
 
 		// Don't use WP_Filesystem() here because that's not initialized yet. See https://yoast.atlassian.net/browse/QAK-2043.
-		global $wp_filesystem;
-		$wp_filesystem->get_contents( WPSEO_PATH . 'css/main-sitemap.xsl' );
+		readfile( WPSEO_PATH . 'css/main-sitemap.xsl' );
 	}
 
 	/**


### PR DESCRIPTION
This reverts commit c2a9a9d43e7bb806416199d478d82b8f38965000.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* For some reason, only a part of https://github.com/Yoast/wordpress-seo/pull/15549/ was reverted, which means https://yoast.atlassian.net/browse/QAK-2043 was not fixed at all. This PR reverts the part of https://github.com/Yoast/wordpress-seo/pull/15549/ which was not reverted before 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error would occur in sitemaps on sites where the home URL and site URL were different. Because the cause of this was a missing style sheet, the content of the sitemaps was still there, which means Google and other search engines could still reach the sitemaps and no SEO harm was done.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See Jannes' comment below.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
