### PR TITLE
Make sure to copy the translator comments

### DIFF
--- a/grunt/custom/convert-pot-to-wp.js
+++ b/grunt/custom/convert-pot-to-wp.js
@@ -59,6 +59,10 @@ function convertTranslationToPHP( translation, textdomain ) {
 
 			php += TAB + `/* ${extracted} */${NEWLINE}`;
 		}
+
+		if ( ! _isEmpty( comments.translator ) ) {
+			php += TAB + `/* translators: ${comments.translator} */${NEWLINE}`
+		}
 	}
 
 	if ( "" !== original ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to copy the translator comments from JS.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Improved the script to copy the translator comments as well.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout trunk
* Run `grunt build:i18n`
* Open the file `languages/wordpress-seojs.php`
* For strings containing `%s` there is no translator comment
* Checkout this branch do the build step
* Now the file should contain translator comments

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/QAK-2083
