### PR TITLE
Ignore the sniffs that require WP_Filesystem

### DIFF
--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -32,7 +32,9 @@ if ( isset( $_POST['create_robots'] ) ) {
 	do_robots();
 	$robots_content = ob_get_clean();
 
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen We think WP_Filesystem is not always predictable.
 	$f = fopen( $robots_file, 'x' );
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fwrite We think WP_Filesystem is not always predictable.
 	fwrite( $f, $robots_content );
 }
 
@@ -51,8 +53,11 @@ if ( isset( $_POST['submitrobots'] ) ) {
 	if ( isset( $_POST['robotsnew'] ) && file_exists( $robots_file ) ) {
 		$robotsnew = sanitize_textarea_field( wp_unslash( $_POST['robotsnew'] ) );
 		if ( is_writable( $robots_file ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen We think WP_Filesystem is not always predictable.
 			$f = fopen( $robots_file, 'w+' );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fwrite We think WP_Filesystem is not always predictable.
 			fwrite( $f, $robotsnew );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose We think WP_Filesystem is not always predictable.
 			fclose( $f );
 			$msg = sprintf(
 				/* translators: %s expands to robots.txt. */
@@ -79,8 +84,11 @@ if ( isset( $_POST['submithtaccess'] ) ) {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Writing to .htaccess file and escaping for HTML will break functionality.
 		$ht_access_new = wp_unslash( $_POST['htaccessnew'] );
 		if ( is_writable( $ht_access_file ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen We think WP_Filesystem is not always predictable.
 			$f = fopen( $ht_access_file, 'w+' );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fwrite We think WP_Filesystem is not always predictable.
 			fwrite( $f, $ht_access_new );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fcose We think WP_Filesystem is not always predictable.
 			fclose( $f );
 		}
 	}
@@ -134,10 +142,12 @@ if ( ! file_exists( $robots_file ) ) {
 	}
 }
 else {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen We think WP_Filesystem is not always predictable.
 	$f = fopen( $robots_file, 'r' );
 
 	$content = '';
 	if ( filesize( $robots_file ) > 0 ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fread We think WP_Filesystem is not always predictable.
 		$content = fread( $f, filesize( $robots_file ) );
 	}
 
@@ -184,10 +194,12 @@ if ( ! WPSEO_Utils::is_nginx() ) {
 	echo '</h2>';
 
 	if ( file_exists( $ht_access_file ) ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen We think WP_Filesystem is not always predictable.
 		$f = fopen( $ht_access_file, 'r' );
 
 		$contentht = '';
 		if ( filesize( $ht_access_file ) > 0 ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fread We think WP_Filesystem is not always predictable.
 			$contentht = fread( $f, filesize( $ht_access_file ) );
 		}
 

--- a/integration-tests/formatter/test-metabox-formatter.php
+++ b/integration-tests/formatter/test-metabox-formatter.php
@@ -48,6 +48,8 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 
 		// Make sure the folder exists.
 		wp_mkdir_p( plugin_dir_path( WPSEO_FILE ) . 'languages' );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents We think WP_Filesystem is not always predictable.
 		file_put_contents(
 			$file_name,
 			WPSEO_Utils::format_json_encode( [ 'key' => 'value' ] )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* `WP_Filesystem` is not always predictable and can lead to unexpected behaviour.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It just ignores a couple of sniffs that require WP_Filesystem.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
