### PR TITLE
Fixes a bug where wpseoShortcodePluginL10n was not defined.

### DIFF
--- a/js/src/post-edit.js
+++ b/js/src/post-edit.js
@@ -7,6 +7,7 @@ import initAdmin from "./initializers/admin";
 
 // Backwards compatibility globals.
 window.wpseoPostScraperL10n = window.wpseoScriptData.metabox;
+window.wpseoShortcodePluginL10n = window.wpseoScriptData.analysis.plugins.shortcodes;
 
 initTabs( jQuery );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes a bug where wpseoShortcodePluginL10n was not defined. See: https://wordpress.org/support/topic/conflict-with-yoast-seo-14-6-1/

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where wpseoShortcodePluginL10n was not defined.

## Relevant technical choices:

* Add the global back for backwards compatibility

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Try to reproduce the bug in the forums and notice it's fixed.

## Quality assurance

* [x] I have tested this code to the best of my abilities
