### PR TITLE
Exit after a successful safe redirect from the core sitemaps

### DIFF
--- a/src/initializers/disable-core-sitemaps.php
+++ b/src/initializers/disable-core-sitemaps.php
@@ -69,7 +69,7 @@ class Disable_Core_Sitemaps implements Initializer_Interface {
 			return;
 		}
 
-		if ( \wp_safe_redirect( \home_url( $redirect ), 301, 'Yoast SEO' ) ) {;
+		if ( \wp_safe_redirect( \home_url( $redirect ), 301, 'Yoast SEO' ) ) {
 			// If we can safely redirect, we should exit here.
 			exit;
 		}

--- a/src/initializers/disable-core-sitemaps.php
+++ b/src/initializers/disable-core-sitemaps.php
@@ -69,7 +69,10 @@ class Disable_Core_Sitemaps implements Initializer_Interface {
 			return;
 		}
 
-		\wp_safe_redirect( \home_url( $redirect ), 301, 'Yoast SEO' );
+		if ( \wp_safe_redirect( \home_url( $redirect ), 301, 'Yoast SEO' ) ) {;
+			// If we can safely redirect, we should exit here.
+			exit;
+		}
 	}
 
 	/**


### PR DESCRIPTION
⚠️ 
Please double check that this is the wanted / needed solution. We also may need to think about a follow-up if `wp_safe_redirect()` returns false. 
⚠️ 

## Context

* We redirect core sitemaps (WP 5.5+) to our own with `wp_safe_redirect()` but we need to exit the loop after this call.

## Summary

This PR can be summarized in the following changelog entry:

* N/A - expands upon [a PR](https://github.com/Yoast/wordpress-seo/pull/15669) in 14.7-RC2

## Relevant technical choices:

* https://developer.wordpress.org/reference/functions/wp_safe_redirect/ calls for a `exit()` after a `wp_safe_redirect()`

## Test instructions

This PR can be tested by following these steps:

1. See that visiting `domain/wp-sitemap-users-1.xml` successfully redirects instead of generating a 404.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes QAK-2092