### PR TITLE
Reset the indexation process when it fails so that it can be start again.

### DIFF
--- a/js/src/indexation.js
+++ b/js/src/indexation.js
@@ -123,6 +123,7 @@ import ProgressBar from "./ui/progressBar";
 						.html( "<p>" + settings.message.indexingCompleted + "</p>" )
 						.show()
 						.addClass( "notice-success" )
+						.removeClass( "notice-error" )
 						.removeClass( "notice-warning" );
 					$( settings.ids.message ).html( settings.message.indexingCompleted );
 

--- a/js/src/indexation.js
+++ b/js/src/indexation.js
@@ -142,6 +142,7 @@ import ProgressBar from "./ui/progressBar";
 					$( settings.ids.message ).html( settings.message.indexingFailed );
 
 					tb_remove();
+					indexationInProgress = false;
 				} );
 			}
 		} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When the indexables process is run on the tools page and fails for some reason, the process cannot be started again without a page reload. This PR fixes this by resetting a flag when an error is encountered.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the indexable indexation process could not be started again on the tools page if it failed without a page reload.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

**Note**: It is best to test this in Premium, where we also have an indexation process for internal linking suggestions. The testing instructions below are for Premium.

### Reproducing the bug.
* Checkout `release/14.7`.
* Let the indexable indexation process deliberately fail.
  * For example by throwing an exception in the `index` method of the `Indexable_Post_Indexation_Action`.
* Open the Yoast SEO tools page.
* Start the indexable indexation process by clicking on the button labeled _Start processing and speed up your site now_.
  * It should fail because of the introduced error.
* Try the internal linking indexation button.
  * It should open the indexation modal for internal linking, but nothing should happen.

### Checking if the bug has been fixed.
* Checkout this branch.
* Follow the same steps as above.
* However, this time the indexation for internal linking should run.
* Make sure that the success notice is all green (not [like this](https://user-images.githubusercontent.com/20280513/88402252-24f03a80-cdcb-11ea-83e0-06649aeb2ad5.png)).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
