### PR TITLE
If we are not premium; disable tracking on plugin activation

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -182,6 +182,11 @@ function _wpseo_activate() {
 		$wpseo_rewrite->schedule_flush();
 	}
 
+	// Reset tracking to be disabled by default.
+	if ( ! WPSEO_Utils::is_yoast_seo_premium() ) {
+		WPSEO_Options::set( 'tracking', false );
+	}
+
 	do_action( 'wpseo_register_roles' );
 	WPSEO_Role_Manager_Factory::get()->add();
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When a user has used Premium and goes back to Free, we want to have tracking disabled by default.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Only set this if we are not in premium
* Only set this on plugin activation

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Scenario 1:
* Activate Premium
* See tracking being enabled
  * You can check this by looking at the `wpseo` option in the `wp_options` table in your DB. The serialized object should have a `tracking` parameter which is set to 1 / `true`.
* Deactivate Premium
* Activate Free
* See tracking being disabled

Scenario 2:
* Activate Free
* Go to the configuration wizard - enable tracking
* Deactivate Free
* Activate Free
* See tracking being disabled

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P2-166