### PR TITLE
Exit after a successful safe redirect from the core sitemaps

### DIFF
--- a/src/initializers/disable-core-sitemaps.php
+++ b/src/initializers/disable-core-sitemaps.php
@@ -69,7 +69,7 @@ class Disable_Core_Sitemaps implements Initializer_Interface {
 			return;
 		}
 
-		if ( \wp_safe_redirect( \home_url( $redirect ), 301, 'Yoast SEO' ) ) {;
+		if ( \wp_safe_redirect( \home_url( $redirect ), 301, 'Yoast SEO' ) ) {
 			// If we can safely redirect, we should exit here.
 			exit;
 		}

--- a/src/initializers/disable-core-sitemaps.php
+++ b/src/initializers/disable-core-sitemaps.php
@@ -9,6 +9,7 @@ namespace Yoast\WP\SEO\Initializers;
 
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Redirect_Helper;
 
 /**
  * Disables the WP core sitemaps.
@@ -25,14 +26,23 @@ class Disable_Core_Sitemaps implements Initializer_Interface {
 	private $options;
 
 	/**
+	 * The redirect helper.
+	 *
+	 * @var Redirect_Helper
+	 */
+	private $redirect;
+
+	/**
 	 * Sitemaps_Enabled_Conditional constructor.
 	 *
-	 * @param Options_Helper $options The options helper.
+	 * @param Options_Helper  $options  The options helper.
+	 * @param Redirect_Helper $redirect The redirect helper.
 	 *
 	 * @codeCoverageIgnore
 	 */
-	public function __construct( Options_Helper $options ) {
-		$this->options = $options;
+	public function __construct( Options_Helper $options, Redirect_Helper $redirect ) {
+		$this->options  = $options;
+		$this->redirect = $redirect;
 	}
 
 	/**
@@ -69,10 +79,7 @@ class Disable_Core_Sitemaps implements Initializer_Interface {
 			return;
 		}
 
-		if ( \wp_safe_redirect( \home_url( $redirect ), 301, 'Yoast SEO' ) ) {
-			// If we can safely redirect, we should exit here.
-			exit;
-		}
+		$this->redirect->do_safe_redirect( \home_url( $redirect ), 301 );
 	}
 
 	/**

--- a/src/initializers/disable-core-sitemaps.php
+++ b/src/initializers/disable-core-sitemaps.php
@@ -69,7 +69,10 @@ class Disable_Core_Sitemaps implements Initializer_Interface {
 			return;
 		}
 
-		\wp_safe_redirect( \home_url( $redirect ), 301, 'Yoast SEO' );
+		if ( \wp_safe_redirect( \home_url( $redirect ), 301, 'Yoast SEO' ) ) {;
+			// If we can safely redirect, we should exit here.
+			exit;
+		}
 	}
 
 	/**

--- a/tests/initializers/disable-core-sitemaps-test.php
+++ b/tests/initializers/disable-core-sitemaps-test.php
@@ -10,6 +10,7 @@ namespace Yoast\WP\SEO\Tests\Initializers;
 use Brain\Monkey\Functions;
 use Mockery;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Redirect_Helper;
 use Yoast\WP\SEO\Initializers\Disable_Core_Sitemaps;
 use Yoast\WP\SEO\Tests\TestCase;
 
@@ -35,6 +36,13 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 	 */
 	private $options;
 
+	/**
+	 * The redirect helper.
+	 *
+	 * @var Redirect_Helper
+	 */
+	private $redirect;
+
 
 	/**
 	 * @inheritDoc
@@ -43,7 +51,8 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 		parent::setUp();
 
 		$this->options  = Mockery::mock( Options_Helper::class );
-		$this->instance = new Disable_Core_Sitemaps( $this->options );
+		$this->redirect = Mockery::mock( Redirect_Helper::class );
+		$this->instance = new Disable_Core_Sitemaps( $this->options, $this->redirect );
 	}
 
 	/**
@@ -93,11 +102,11 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 
 		if ( $redirect ) {
 			Functions\expect( 'home_url' )->once()->with( $redirect )->andReturnFirstArg();
-			Functions\expect( 'wp_safe_redirect' )->once()->with( $redirect, 301, 'Yoast SEO' );
+			$this->redirect->expects( 'do_safe_redirect' )->once()->with( $redirect, 301 );
 		}
 		else {
 			Functions\expect( 'home_url' )->never();
-			Functions\expect( 'wp_safe_redirect' )->never();
+			$this->redirect->expects( 'do_safe_redirect' )->never();
 		}
 
 		$this->instance->template_redirect();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR is [a copy of this one](https://github.com/Yoast/wordpress-seo/pull/15718), but based on the release branch, rather than `trunk`.
  * I did replace the code with the appropriate `do_safe_redirect` method on the `Redirect_Helper`, which does the same.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a (not yet released) bug where visiting the WordPress users sitemap would trigger a 404 error, instead of redirecting to its respective Yoast SEO sitemap.

## Relevant technical choices:

* https://developer.wordpress.org/reference/functions/wp_safe_redirect calls for an `exit()` after a `wp_safe_redirect()`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See that visiting `domain/wp-sitemap-users-1.xml` successfully redirects instead of generating a 404.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
