### PR TITLE
P3-63 Add error message when attempting to open the SEMrush modal with an empty keyphrase

### DIFF
--- a/js/src/components/RelatedKeyphrasesModal.js
+++ b/js/src/components/RelatedKeyphrasesModal.js
@@ -36,9 +36,7 @@ class RelatedKeyphrasesModal extends Component {
 	 * @returns {void}
 	 */
 	onModalOpen() {
-		if ( ! this.props.isLoggedInToSEMrush ) {
-			// Add not-logged in logic here.
-		}
+		// Add not-logged in logic here.
 
 		if ( ! this.props.keyphrase ) {
 			this.props.onOpenWithNoKeyphrase();
@@ -118,7 +116,6 @@ RelatedKeyphrasesModal.propTypes = {
 	onOpen: PropTypes.func.isRequired,
 	onOpenWithNoKeyphrase: PropTypes.func.isRequired,
 	onClose: PropTypes.func.isRequired,
-	isLoggedInToSEMrush: PropTypes.string,
 };
 
 RelatedKeyphrasesModal.defaultProps = {
@@ -127,7 +124,6 @@ RelatedKeyphrasesModal.defaultProps = {
 	maxRelatedKeyphrasesEntered: false,
 	whichModalOpen: "none",
 	currentDatabase: "us",
-	isLoggedInToSEMrush: "",
 };
 
 export default RelatedKeyphrasesModal;

--- a/js/src/components/RelatedKeyphrasesModal.js
+++ b/js/src/components/RelatedKeyphrasesModal.js
@@ -36,10 +36,12 @@ class RelatedKeyphrasesModal extends Component {
 	 * @returns {void}
 	 */
 	onModalOpen() {
-		// Add not-logged in logic here.
+		if ( ! this.props.isLoggedInToSEMrush ) {
+			// Add not-logged in logic here.
+		}
 
 		if ( ! this.props.keyphrase ) {
-			// Add logic to display the empty keyphrase message here.
+			this.props.onOpenWitnNoKeyphrase();
 			return;
 		}
 
@@ -114,7 +116,9 @@ RelatedKeyphrasesModal.propTypes = {
 	] ),
 	currentDatabase: PropTypes.string,
 	onOpen: PropTypes.func.isRequired,
+	onOpenWitnNoKeyphrase: PropTypes.func.isRequired,
 	onClose: PropTypes.func.isRequired,
+	isLoggedInToSEMrush: PropTypes.string,
 };
 
 RelatedKeyphrasesModal.defaultProps = {
@@ -123,6 +127,7 @@ RelatedKeyphrasesModal.defaultProps = {
 	maxRelatedKeyphrasesEntered: false,
 	whichModalOpen: "none",
 	currentDatabase: "us",
+	isLoggedInToSEMrush: "",
 };
 
 export default RelatedKeyphrasesModal;

--- a/js/src/components/RelatedKeyphrasesModal.js
+++ b/js/src/components/RelatedKeyphrasesModal.js
@@ -41,7 +41,7 @@ class RelatedKeyphrasesModal extends Component {
 		}
 
 		if ( ! this.props.keyphrase ) {
-			this.props.onOpenWitnNoKeyphrase();
+			this.props.onOpenWithNoKeyphrase();
 			return;
 		}
 
@@ -116,7 +116,7 @@ RelatedKeyphrasesModal.propTypes = {
 	] ),
 	currentDatabase: PropTypes.string,
 	onOpen: PropTypes.func.isRequired,
-	onOpenWitnNoKeyphrase: PropTypes.func.isRequired,
+	onOpenWithNoKeyphrase: PropTypes.func.isRequired,
 	onClose: PropTypes.func.isRequired,
 	isLoggedInToSEMrush: PropTypes.string,
 };

--- a/js/src/components/contentAnalysis/KeywordInput.js
+++ b/js/src/components/contentAnalysis/KeywordInput.js
@@ -111,6 +111,7 @@ KeywordInput.defaultProps = {
 function mapStateToProps( state ) {
 	return {
 		keyword: state.focusKeyword,
+		isLoggedInToSEMrush: state.SEMrushRequest.OAuthToken,
 	};
 }
 

--- a/js/src/components/contentAnalysis/KeywordInput.js
+++ b/js/src/components/contentAnalysis/KeywordInput.js
@@ -69,6 +69,7 @@ class KeywordInput extends Component {
 							helpLink={ KeywordInput.renderHelpLink() }
 							onBlurKeyword={ this.props.onBlurKeyword }
 							onFocusKeyword={ this.props.onFocusKeyword }
+							hasError={ this.props.displayNoKeyphraseMessage }
 						/>
 						{
 							this.props.keyword.length > 191 &&

--- a/js/src/components/contentAnalysis/KeywordInput.js
+++ b/js/src/components/contentAnalysis/KeywordInput.js
@@ -55,6 +55,12 @@ class KeywordInput extends Component {
 			<LocationConsumer>
 				{ location => (
 					<KeywordInputContainer>
+						{
+							this.props.displayNoKeyphraseMessage &&
+							<p role="alert">
+								{ __( "Please enter a focus keyphrase first to get related keyphrases", "wordpress-seo" ) }
+							</p>
+						}
 						<KeywordInputComponent
 							id={ `focus-keyword-input-${ location }` }
 							onChange={ this.props.onFocusKeywordChange }
@@ -94,11 +100,13 @@ KeywordInput.propTypes = {
 	onFocusKeyword: PropTypes.func.isRequired,
 	onBlurKeyword: PropTypes.func.isRequired,
 	isSEMrushIntegrationActive: PropTypes.bool,
+	displayNoKeyphraseMessage: PropTypes.bool,
 };
 
 KeywordInput.defaultProps = {
 	keyword: "",
 	isSEMrushIntegrationActive: false,
+	displayNoKeyphraseMessage: false,
 };
 
 /**
@@ -111,7 +119,7 @@ KeywordInput.defaultProps = {
 function mapStateToProps( state ) {
 	return {
 		keyword: state.focusKeyword,
-		isLoggedInToSEMrush: state.SEMrushRequest.OAuthToken,
+		displayNoKeyphraseMessage: state.SEMrushModal.displayNoKeyphraseMessage,
 	};
 }
 

--- a/js/src/containers/SEMrush.js
+++ b/js/src/containers/SEMrush.js
@@ -16,16 +16,29 @@ export default compose( [
 			isPending: select( "yoast-seo/editor" ).getSEMrushIsRequestPending(),
 			relatedKeyphrases: select( "yoast-seo/editor" ).getSEMrushKeyphrases(),
 			keyphraseLimitReached: select( "yoast-seo/editor" ).getSEMrushLimitReached(),
+			displayNoKeyphraseMessage: select( "yoast-seo/editor" ).getSEMrushNoKeyphraseMessage(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { setSEMrushOpenModal, setSEMrushDismissModal, setSEMrushChangeDatabase,
-			setSEMrushNewRequest, setSEMrushRequestSucceeded, setSEMrushRequestFailed,
-			setSEMrushSetRequestLimitReached, addSEMrushKeyphrase, removeSEMrushKeyphrase,
-			setSEMrushKeyphraseLimitReached } = dispatch(
+		const {
+			setSEMrushNoKeyphraseMessage,
+			setSEMrushOpenModal,
+			setSEMrushDismissModal,
+			setSEMrushChangeDatabase,
+			setSEMrushNewRequest,
+			setSEMrushRequestSucceeded,
+			setSEMrushRequestFailed,
+			setSEMrushSetRequestLimitReached,
+			addSEMrushKeyphrase,
+			removeSEMrushKeyphrase,
+			setSEMrushKeyphraseLimitReached,
+		} = dispatch(
 			"yoast-seo/editor"
 		);
 		return {
+			onOpenWitnNoKeyphrase: () => {
+				setSEMrushNoKeyphraseMessage();
+			},
 			onOpen: ( location ) => {
 				setSEMrushOpenModal( location );
 			},

--- a/js/src/containers/SEMrush.js
+++ b/js/src/containers/SEMrush.js
@@ -16,7 +16,6 @@ export default compose( [
 			isPending: select( "yoast-seo/editor" ).getSEMrushIsRequestPending(),
 			relatedKeyphrases: select( "yoast-seo/editor" ).getSEMrushKeyphrases(),
 			keyphraseLimitReached: select( "yoast-seo/editor" ).getSEMrushLimitReached(),
-			displayNoKeyphraseMessage: select( "yoast-seo/editor" ).getSEMrushNoKeyphraseMessage(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/js/src/containers/SEMrush.js
+++ b/js/src/containers/SEMrush.js
@@ -35,7 +35,7 @@ export default compose( [
 			"yoast-seo/editor"
 		);
 		return {
-			onOpenWitnNoKeyphrase: () => {
+			onOpenWithNoKeyphrase: () => {
 				setSEMrushNoKeyphraseMessage();
 			},
 			onOpen: ( location ) => {

--- a/js/src/redux/actions/SEMrushModal.js
+++ b/js/src/redux/actions/SEMrushModal.js
@@ -1,6 +1,7 @@
 export const MODAL_DISMISS = "MODAL_DISMISS";
 export const MODAL_OPEN = "MODAL_OPEN";
 export const MODAL_CHANGE_DATABASE = "MODAL_CHANGE_DATABASE";
+export const MODAL_OPEN_NO_KEYPHRASE = "MODAL_OPEN_NO_KEYPHRASE";
 
 /**
  * Dismisses the SEMrush modal.
@@ -24,6 +25,17 @@ export function setSEMrushOpenModal( location ) {
 	return {
 		type: MODAL_OPEN,
 		location,
+	};
+}
+
+/**
+ * Displayes the empty keyphrase message when attempting to open the SEMrush modal.
+ *
+ * @returns {Object} Action object.
+ */
+export function setSEMrushNoKeyphraseMessage() {
+	return {
+		type: MODAL_OPEN_NO_KEYPHRASE,
 	};
 }
 

--- a/js/src/redux/reducers/SEMrushModal.js
+++ b/js/src/redux/reducers/SEMrushModal.js
@@ -1,8 +1,9 @@
-import { MODAL_CHANGE_DATABASE, MODAL_DISMISS, MODAL_OPEN } from "../actions";
+import { MODAL_CHANGE_DATABASE, MODAL_DISMISS, MODAL_OPEN, MODAL_OPEN_NO_KEYPHRASE } from "../actions";
 
 const INITIAL_STATE = {
 	whichModalOpen: "none",
 	currentDatabase: "us",
+	displayNoKeyphraseMessage: false,
 };
 /**
  * A reducer for the SEMrush modal.
@@ -14,20 +15,29 @@ const INITIAL_STATE = {
  */
 function SEMrushModalReducer( state = INITIAL_STATE, action ) {
 	switch ( action.type ) {
-		case MODAL_DISMISS:
+		case MODAL_OPEN_NO_KEYPHRASE:
 			return {
 				whichModalOpen: "none",
 				currentDatabase: state.currentDatabase,
+				displayNoKeyphraseMessage: true,
 			};
 		case MODAL_OPEN:
 			return {
 				whichModalOpen: action.location,
 				currentDatabase: state.currentDatabase,
+				displayNoKeyphraseMessage: false,
 			};
 		case MODAL_CHANGE_DATABASE:
 			return {
 				whichModalOpen: state.whichModalOpen,
 				currentDatabase: action.country,
+				displayNoKeyphraseMessage: false,
+			};
+		case MODAL_DISMISS:
+			return {
+				whichModalOpen: "none",
+				currentDatabase: state.currentDatabase,
+				displayNoKeyphraseMessage: false,
 			};
 	}
 	return state;

--- a/js/src/redux/reducers/SEMrushRequest.js
+++ b/js/src/redux/reducers/SEMrushRequest.js
@@ -7,7 +7,7 @@ import {
 
 const INITIAL_STATE = {
 	isRequestPending: false,
-	OAuthToken: null,
+	OAuthToken: "",
 	keyphrase: "",
 	country: "us",
 	isSuccess: false,

--- a/js/src/redux/selectors/SEMrushModal.js
+++ b/js/src/redux/selectors/SEMrushModal.js
@@ -1,7 +1,7 @@
 /**
  * Gets the current modal status - open or closed.
  *
- * @param {Object} state    The state.
+ * @param {Object} state The state.
  *
  * @returns {string} Current modal status.
  */
@@ -12,10 +12,21 @@ export function getSEMrushModalOpen( state ) {
 /**
  * Gets the currently selected country.
  *
- * @param {Object} state    The state.
+ * @param {Object} state The state.
  *
  * @returns {string} Current country.
  */
 export function getSEMrushSelectedCountry( state ) {
 	return state.SEMrushModal.currentDatabase;
+}
+
+/**
+ * Gets the current display status of empty keyphrase message.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {string} Current empty keyphrase message state.
+ */
+export function getSEMrushNoKeyphraseMessage( state ) {
+	return state.SEMrushModal.displayNoKeyphraseMessage;
 }

--- a/js/src/redux/selectors/SEMrushRequest.js
+++ b/js/src/redux/selectors/SEMrushRequest.js
@@ -1,7 +1,7 @@
 /**
  * Gets the current request status - pending or done.
  *
- * @param {Object} state    The state.
+ * @param {Object} state The state.
  *
  * @returns {boolean} Current request status.
  */
@@ -12,7 +12,7 @@ export function getSEMrushIsRequestPending( state ) {
 /**
  * Gets the country of the current request.
  *
- * @param {Object} state    The state.
+ * @param {Object} state The state.
  *
  * @returns {string} Current request country.
  */
@@ -23,7 +23,7 @@ export function getSEMrushRequestCountry( state ) {
 /**
  * Gets the request return state (success or failed).
  *
- * @param {Object} state    The state.
+ * @param {Object} state The state.
  *
  * @returns {boolean} Current request return state.
  */
@@ -34,7 +34,7 @@ export function getSEMrushRequestIsSuccess( state ) {
 /**
  * Gets the request response.
  *
- * @param {Object} state    The state.
+ * @param {Object} state The state.
  *
  * @returns {Object} Current request response.
  */
@@ -45,7 +45,7 @@ export function getSEMrushRequestResponse( state ) {
 /**
  * Gets the request limit reached boolean.
  *
- * @param {Object} state    The state.
+ * @param {Object} state The state.
  *
  * @returns {boolean} Current request limit reached boolean.
  */
@@ -56,7 +56,7 @@ export function getSEMrushRequestLimitReached( state ) {
 /**
  * Gets the current keyphrase of the request.
  *
- * @param {Object} state    The state.
+ * @param {Object} state The state.
  *
  * @returns {string} Current request keyphrase.
  */
@@ -67,7 +67,7 @@ export function getSEMrushRequestKeyphrase( state ) {
 /**
  * Gets the current OAuth token of the request.
  *
- * @param {Object} state    The state.
+ * @param {Object} state The state.
  *
  * @returns {string} Current request OAuth token.
  */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Displays an error message when attempting to open the SEMrush modal with an empty keyphrase.

## Relevant technical choices:

- adds a new `displayNoKeyphraseMessage` property to the redux state
- adjusts actions, reducers, selectors accordingly

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- this PR needs to be tested together with the related JS repo PR https://github.com/Yoast/javascript/pull/805
- switch the JS repo to the branch `P3-63-error-message-empty-keyphrase`
- of course, switch Yoast SEO to this branch `P3-63-error-message-empty-keyphrase`
- run `yarn link-monorepo` and then build the plugin
- edit a post
- test both in the metabox and in the sidebar 
- empty the Focus keyphrase field
- click "Get related keyphrases"
- observe the SEMrush modal doesn't open
- observe a message is displayed _above_ the keyphrase input field
- the message is "Please enter a focus keyphrase first to get related keyphrases"
- for now, the message is unstyled: **will create a new issue for the Frontend team**
- the keyphrase input field will need CSS adjustments as well to match the design: most notably, there should be a big "X" to indicate there's an error (note: this "X" is the one we usually use for errors related to input validation) and the background should be a light red
- check that other errors still work, for example:
  - enter two words separated by a comma in the keyphrase input
  - observe a message "Are you trying to use multiple keyphrase...." appears _below_ the input
  - enter a keyphrase longer than 191 characters 
  - observe a yellow alert appears _below_ the input


Screenshot: for now, the message is unstyled:

<img width="1281" alt="Screenshot 2020-07-27 at 10 56 56" src="https://user-images.githubusercontent.com/1682452/88526672-82b79900-cffc-11ea-95e8-07ab8a98b5aa.png">

Design:

<img width="430" alt="Screenshot 2020-07-27 at 10 43 47" src="https://user-images.githubusercontent.com/1682452/88526702-8ba86a80-cffc-11ea-884d-0b0641f857c9.png">



## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-63]

