### PR TITLE
Fixes scores in classic editor publish box.

### DIFF
--- a/js/src/ui/publishBox.js
+++ b/js/src/ui/publishBox.js
@@ -112,11 +112,11 @@ function scrollToCollapsible( id ) {
 export function initialize() {
 	var notAvailableStatus = "na";
 
-	if ( wpseoScriptData.metabox.contentAnalysisActive === "1" ) {
+	if ( wpseoScriptData.metabox.contentAnalysisActive ) {
 		createScoresInPublishBox( "content", notAvailableStatus );
 	}
 
-	if ( wpseoScriptData.metabox.keywordAnalysisActive === "1" ) {
+	if ( wpseoScriptData.metabox.keywordAnalysisActive ) {
 		createScoresInPublishBox( "keyword", notAvailableStatus );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes a bug where the SEO and Readability scores were no longer shown in the publishbox.

<img width="302" alt="Screenshot 2020-07-28 at 10 15 43" src="https://user-images.githubusercontent.com/1488816/88638432-c6bda300-d0bb-11ea-914a-eaf36c9f35c8.png">


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the SEO and Readability scores were no longer shown in the publishbox.

## Relevant technical choices:

* Nothing specific.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Notice the publishbox scores are back in the classic editor.

## Quality assurance

* [ ] I have tested this code to the best of my abilities

Fixes https://github.com/Yoast/wordpress-seo/issues/15711
