### PR TITLE
Improved sql performance

### DIFF
--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -145,12 +145,11 @@ class Post_Helper {
 			->where( 'post_parent', $post_parent );
 
 		if ( $has_public_posts !== null ) {
-			$query->where_not_equal( 'has_public_posts', $has_public_posts );
+			$query->where_raw( '( has_public_posts IS NULL OR has_public_posts <> %s )', [ $has_public_posts ] );
 		}
 		else {
 			$query->where_not_null( 'has_public_posts' );
 		}
-
 		$results = $query->find_array();
 
 		if ( empty( $results ) ) {

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -37,10 +37,8 @@ class Post_Helper {
 	 *
 	 * @codeCoverageIgnore It only sets dependencies.
 	 */
-	public function __construct(
-		String_Helper $string
-	) {
-		$this->string     = $string;
+	public function __construct( String_Helper $string ) {
+		$this->string = $string;
 	}
 
 	/**

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -28,7 +28,7 @@ class Post_Helper {
 	 *
 	 * @var Indexable_Repository
 	 */
-	protected $indexable_repository;
+	private $repository;
 
 	/**
 	 * Post_Helper constructor.
@@ -37,19 +37,21 @@ class Post_Helper {
 	 *
 	 * @codeCoverageIgnore It only sets dependencies.
 	 */
-	public function __construct( String_Helper $string ) {
-		$this->string = $string;
+	public function __construct(
+		String_Helper $string
+	) {
+		$this->string     = $string;
 	}
 
 	/**
 	 * Sets the indexable repository. Done to avoid circular dependencies.
 	 *
-	 * @param Indexable_Repository $indexable_repository The indexable repository.
+	 * @param Indexable_Repository $repository The indexable repository.
 	 *
 	 * @required
 	 */
-	public function set_indexable_repository( Indexable_Repository $indexable_repository ) {
-		$this->indexable_repository = $indexable_repository;
+	public function set_indexable_repository( Indexable_Repository $repository ) {
+		$this->repository = $repository;
 	}
 
 	/**
@@ -135,12 +137,31 @@ class Post_Helper {
 	 * @return bool Whether the update was successful.
 	 */
 	public function update_has_public_posts_on_attachments( $post_parent, $has_public_posts ) {
-		return $this->indexable_repository->query()
-			->set( 'has_public_posts', $has_public_posts )
+		$query = $this->repository->query()
+			->select( 'id' )
 			->where( 'object_type', 'post' )
 			->where( 'object_sub_type', 'attachment' )
 			->where( 'post_status', 'inherit' )
-			->where( 'post_parent', $post_parent )
+			->where( 'post_parent', $post_parent );
+
+		if ( $has_public_posts !== null ) {
+			$query->where_not_equal( 'has_public_posts', $has_public_posts );
+		}
+		else {
+			$query->where_not_null( 'has_public_posts' );
+		}
+
+		$results = $query->find_array();
+
+		if ( empty( $results ) ) {
+			return true;
+		}
+
+		$updated = $this->repository->query()
+			->set( 'has_public_posts', $has_public_posts )
+			->where_id_in( \wp_list_pluck( $results, 'id' ) )
 			->update_many();
+
+		return $updated !== false;
 	}
 }

--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -187,7 +187,6 @@ class Meta_Surface {
 			return false;
 		}
 
-
 		return $this->build_meta( $this->context_memoizer->get( $indexable, 'Post_Type' ) );
 	}
 


### PR DESCRIPTION
## Warning 🚧 

Should be merged and rebased to trunk, after https://github.com/Yoast/wordpress-seo/pull/15609 has been merged.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves SQL performance by not performing unnecessary update queries when updating a post's public status.

## Relevant technical choices:

* A bug that was present before is still there. https://yoast.atlassian.net/jira/software/c/projects/P2/issues/P2-227

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new post, add a new attachment (*so upload a new attachment*) and publish it.
* Search for the attachment in the `wp_yoast_indexables` table and make sure `has_public_posts` is set to `NULL`.
* Now set the post status to private and update it.
* Search for the attachment in the `wp_yoast_indexables` table and make sure `has_public_posts` is set to `0` (false).

#### Testing performance
* For testing performance, I created a small plugin:
[logger.zip](https://github.com/Yoast/wordpress-seo/files/5027809/logger.zip)
* Unpack the contents of this zip in a folder called `logger` in your plugins folder.
* Now you can add the following code around the `update_has_public_posts_on_attachments` call in `indexable-post-watcher.php`.
```
$time = microtime( true ) * 1000;

$this->post->update_has_public_posts_on_attachments( $indexable->object_id, $indexable->is_public );

logger_log( ( microtime( true ) * 1000 - $time ) . ' ms' );
```
* Now you can see the time it takes to execute this function in `logger/log.txt`.
* If you update a post, without changing whether it's private, the function should now take considerably less time, than when you change the private status of the post.
** Note: ** due to the fact that gutenberg saves a post twice, because of backward compatibility, this function will be called twice per update.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/15380
