### PR TITLE
Differentiate between sidebar and metabox for language feedback

### DIFF
--- a/js/src/components/contentAnalysis/KeywordInput.js
+++ b/js/src/components/contentAnalysis/KeywordInput.js
@@ -50,9 +50,9 @@ class KeywordInput extends Component {
 	 * @returns {wp.Element} The component.
 	 */
 	render() {
-		return <Fragment>
-			<LocationConsumer>
-				{ context => (
+		return <LocationConsumer>
+			{ context => (
+				<Fragment>
 					<KeywordInputContainer>
 						<KeywordInputComponent
 							id={ `focus-keyword-input-${ context }` }
@@ -73,10 +73,10 @@ class KeywordInput extends Component {
 							</Alert>
 						}
 					</KeywordInputContainer>
-				) }
-			</LocationConsumer>
-			<Slot name="YoastAfterKeyphraseInput" />
-		</Fragment>;
+					<Slot name={ `YoastAfterKeywordInput${ context.charAt( 0 ).toUpperCase() + context.slice( 1 ) }` } />
+				</Fragment>
+			) }
+		</LocationConsumer>;
 	}
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Needed for https://github.com/Yoast/wordpress-seo-premium/pull/2921

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [non-user-facing] Puts different slot names after the KeywordInput in the metabox and the sidebar.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
