### PR TITLE
Added migration to add indexes for prominent words to the indexables table.

### DIFF
--- a/src/config/migrations/20200728095334_AddIndexesForProminentWordsOnIndexables.php
+++ b/src/config/migrations/20200728095334_AddIndexesForProminentWordsOnIndexables.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package Yoast\WP\SEO\Config\Migrations
+ */
+
+namespace Yoast\WP\SEO\Config\Migrations;
+
+use Yoast\WP\Lib\Migrations\Migration;
+use Yoast\WP\Lib\Model;
+
+/**
+ * AddIndexesForProminentWordsOnIndexables class.
+ */
+class AddIndexesForProminentWordsOnIndexables extends Migration {
+
+	/**
+	 * The plugin this migration belongs to.
+	 *
+	 * @var string
+	 */
+	public static $plugin = 'premium';
+
+	/**
+	 * The columns on which an index should be added.
+	 *
+	 * @var string[]
+	 */
+	private $columns_with_index = [
+		'prominent_words_version',
+		'object_type',
+		'object_sub_type',
+		'post_status',
+	];
+
+	/**
+	 * Migration up.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		$table_name = $this->get_table_name();
+		$adapter    = $this->get_adapter();
+
+		if ( ! $adapter->has_index( $table_name, $this->columns_with_index, [ 'name' => 'prominent_words' ] ) ) {
+			$this->add_index(
+				$table_name,
+				$this->columns_with_index,
+				[
+					'name' => 'prominent_words',
+				]
+			);
+		}
+	}
+
+	/**
+	 * Migration down.
+	 *
+	 * @return void
+	 */
+	public function down() {
+
+	}
+
+	/**
+	 * Retrieves the table name to use.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Model::get_table_name( 'Indexable' );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to be able to quickly identify how many indexables need to be indexed for prominent words / internal linking suggestions.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds indexes to the indexables table in the database, such that it is quicker and more efficient to retrieve the number of unindexed indexables for prominent words.

## Relevant technical choices:

* Decided to add this in Free on advice from Herre. Since it is best to keep all migrations for one table in one plugin.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Visit a Yoast page in the admin of your WordPress site to trigger the database migrations.
* Check the structure of the `wp_yoast_indexable` table in your database. 
  * It should have a new index called `prominent_words`.
    * The index should be on four columns: 
       * `prominent_words_version`
       * `object_type`
       * `object_sub_type`
       * `post_status`

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
