### PR TITLE
Remove transients when permalinks are reset

### DIFF
--- a/src/integrations/watchers/indexable-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-permalink-watcher.php
@@ -8,6 +8,9 @@
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
 use Yoast\WP\Lib\Model;
+use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
+use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Type_Archive_Indexation_Action;
+use Yoast\WP\SEO\Actions\Indexation\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
@@ -139,6 +142,10 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 			$this->options_helper->set( 'indexables_indexation_reason', $reason );
 			$this->options_helper->set( 'ignore_indexation_warning', false );
 			$this->options_helper->set( 'indexation_warning_hide_until', false );
+
+			delete_transient( Indexable_Post_Indexation_Action::TRANSIENT_CACHE_KEY );
+			delete_transient( Indexable_Post_Type_Archive_Indexation_Action::TRANSIENT_CACHE_KEY );
+			delete_transient( Indexable_Term_Indexation_Action::TRANSIENT_CACHE_KEY );
 		}
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We use transients as cache to prevent count queries all the time. But when everything is calculated and permalinks are reset the transients should removed as well.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Not released yet. Fixes a bug where the transients keeps state also when that state has changed

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Reproducing the bug.
* On the release branch
* Have all indexables calculated
* Change the permalink structure (WordPress permalink settings) or reset the category base (under search appearence)
  * Make sure that the amount of indexables affected by the change is bigger than 25. Since 25 indexables are re-indexed on every request and you would not get the notice either way.
* Visit the tools page: no notice is given and there is no possibility to calculate them.
* Remove the transients in the database.

### Checking if the bug has been fixed.
* Checkout this branch.
* Recalculate the indexables again.
* Do the change, either permalink structure or category base.
  * Make sure, again, that the amount of indexables affected by the change is bigger than 25. Since 25 indexables are re-indexed on every request and you would not get the notice either way.
* Visit the tools page and see there is a notice (with specific reason) and you can calculate the indexables 🎉.  

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
