### PR TITLE
Add the tracking option to the network overrides

### DIFF
--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -94,6 +94,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 			"{$allow_prefix}enable_xml_sitemap"             => true,
 			"{$allow_prefix}enable_text_link_counter"       => true,
 			"{$allow_prefix}enable_headless_rest_endpoints" => true,
+			"{$allow_prefix}tracking"                       => true,
 		];
 
 		if ( is_multisite() ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds the tracking option to the network overrides so it can be disabled from the network tab.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes disabling tracking from the network tab not working.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the network SEO settings of a multisite WordPress.
  * E.g. _Yoast_ > _General_ > _Features_ tab off the network admin.
* Usage tracking should be on allow control by default.
* Disable tracking.
* Refresh the page, it should stay disabled.
* Go to the SEO settings of a specific site.
* The toggle should be disabled with a notice that it's been disabled in the network.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/QAK-2127
