### PR TITLE
Migration for indexes on prominent words version columns should be in free.

### DIFF
--- a/src/config/migrations/20200728095334_AddIndexesForProminentWordsOnIndexables.php
+++ b/src/config/migrations/20200728095334_AddIndexesForProminentWordsOnIndexables.php
@@ -20,7 +20,7 @@ class AddIndexesForProminentWordsOnIndexables extends Migration {
 	 *
 	 * @var string
 	 */
-	public static $plugin = 'premium';
+	public static $plugin = 'free';
 
 	/**
 	 * The columns on which an index should be added.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a (not yet released) bug where a specific database migration would be done only for premium, and not free.

## Relevant technical choices:

* I moved the migration from premium too free, but forgot to change the `plugin` parameter from `premium` to `free`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See the (adapted) test instructions of the original PR: #15745

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
