### PR TITLE
Make it possible to hide the indexable warning on all pages again

### DIFF
--- a/src/integrations/admin/indexation-integration.php
+++ b/src/integrations/admin/indexation-integration.php
@@ -197,10 +197,7 @@ class Indexation_Integration implements Integration_Interface {
 			$this->add_admin_notice();
 		}
 
-		// Only enqueue indexation assets when the action is a button.
-		if ( $this->is_on_yoast_tools_page ) {
-			$this->enqueue_indexation_assets();
-		}
+		$this->enqueue_indexation_assets();
 	}
 
 	/**

--- a/tests/integrations/admin/indexation-integration-test.php
+++ b/tests/integrations/admin/indexation-integration-test.php
@@ -332,45 +332,6 @@ class Indexation_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that the modal and indexation assets are not enqueued when not on the Yoast tools page.
-	 *
-	 * @covers ::enqueue_scripts
-	 */
-	public function test_enqueue_scripts_without_indexable_assets() {
-		// Mock that 40 indexables should be indexed.
-		$this->set_total_unindexed_expectations(
-			[
-				'post_type_archive' => 5,
-				'general'           => 10,
-				'post'              => 15,
-				'term'              => 10,
-			]
-		);
-
-		$this->yoast_tools_page_conditional->expects( 'is_met' )
-			->once()
-			->andReturnFalse();
-
-		$this->options
-			->expects( 'get' )
-			->with( 'ignore_indexation_warning', false )
-			->andReturnTrue();
-
-		// Expect that the script and style for the modal is not enqueued.
-		$this->asset_manager
-			->expects( 'enqueue_script' )
-			->never()
-			->with( 'indexation' );
-
-		$this->asset_manager
-			->expects( 'enqueue_style' )
-			->never()
-			->with( 'admin-css' );
-
-		$this->instance->enqueue_scripts();
-	}
-
-	/**
 	 * Returns whether or not the warning is ignored.
 	 *
 	 * @return array The possible values.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When you clicked on "Hide this notice" for the indexable indexation, it only worked if you were on the tools page.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the indexable indexation warning would not be hidden if you were on a page other than the Tools page.

## Relevant technical choices:

* https://github.com/Yoast/wordpress-seo/pull/15447 ensured that `indexation.js` would only be loaded on the Tools page. But the functionality to hide the warning is in `indexation.js`. I reloaded `indexation.js` on all other pages again. I would like to get feedback on this decision because it feels pretty big.
* It's not the case that I'm reverting all the code of https://github.com/Yoast/wordpress-seo/pull/15447, because the `indexation_action_type` from that PR still ensures that when clicking the indexable indexation button, the indexation will still be run from the Tools page and not other pages.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Reset the indexables in the Test Helper.
* Go to the Yoast dashboard.
* Click "Hide this notice", and see the notice disappear.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-189
