### PR TITLE
Change the background-image when the schema-tab is selected

### DIFF
--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -737,5 +737,8 @@ div.interface-pinned-items button.components-button.is-pressed[aria-label="Yoast
   background-image: var(--yoast-svg-icon-schema);
   background-size: cover;
 }
+.wpseo-metabox-menu ul li.active a .wpseo-schema-icon {
+  background-image: var(--yoast-svg-icon-schema-active);
+}
 
 /*# sourceMappingURL=metabox.css.map */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to display active tabs in black.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Change the schema-tab icon based on whether the tab is active.

## Relevant technical choices:
* I tried used the `fill` CSS property, this does not seem to have any effect on the icon (probably because it is set as `background-image`).
* I tried to inline the image directly in the metabox definition. This removes the icon (probably because we espace raw HTMl).
* I tried to set the image as `content` on the `::before` property. This removes the possibility to resize the image.

In the end, I decided to stick with this ugly, but working, solution.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Test with JS PR
* Open the metabox
* Go to the schema tab
* See that the color of the icon changes

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-99
