### PR TITLE
Hide notice from other pages than the tools page

### DIFF
--- a/src/integrations/admin/indexation-integration.php
+++ b/src/integrations/admin/indexation-integration.php
@@ -193,6 +193,7 @@ class Indexation_Integration implements Integration_Interface {
 		$this->is_on_yoast_tools_page = $this->yoast_tools_page_conditional->is_met();
 		$this->indexation_action_type = ( $this->is_on_yoast_tools_page ) ? Indexation_Warning_Presenter::ACTION_TYPE_RUN_HERE : Indexation_Warning_Presenter::ACTION_TYPE_LINK_TO;
 
+		$this->hide_notice_listener();
 		if ( $this->is_indexation_warning_hidden() === false ) {
 			$this->add_admin_notice();
 		}
@@ -356,5 +357,22 @@ class Indexation_Integration implements Integration_Interface {
 		];
 
 		\wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'indexation', 'yoastIndexationData', $data );
+	}
+
+	/**
+	 * Hides the notice when the url query contains an argument that hides the notice.
+	 */
+	protected function hide_notice_listener()	{
+		if ( ! isset( $_GET['yoast_seo_hide'] ) ) {
+			return;
+		}
+
+		if ( $_GET['yoast_seo_hide'] !== 'indexation_warning' ) {
+			return;
+		}
+
+		\check_admin_referer( 'wpseo-ignore' );
+
+		$this->options_helper->set( 'ignore_indexation_warning', true );
 	}
 }

--- a/src/integrations/admin/indexation-integration.php
+++ b/src/integrations/admin/indexation-integration.php
@@ -362,7 +362,7 @@ class Indexation_Integration implements Integration_Interface {
 	/**
 	 * Hides the notice when the url query contains an argument that hides the notice.
 	 */
-	protected function hide_notice_listener()	{
+	protected function hide_notice_listener() {
 		if ( ! isset( $_GET['yoast_seo_hide'] ) ) {
 			return;
 		}

--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -73,8 +73,7 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 
 		if ( $this->show_indexation_incomplete_alert() ) {
 			$output .= $this->get_incomplete_indexation_alert();
-		}
-		else {
+		} else {
 			$output .= $this->get_base_alert();
 		}
 
@@ -171,12 +170,12 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 	 */
 	protected function get_estimate() {
 		if ( $this->total_unindexed > 2500 ) {
-			$estimate  = '<p>';
+			$estimate = '<p>';
 			$estimate .= \esc_html__( 'We estimate this could take a long time, due to the size of your site. As an alternative to waiting, you could:', 'wordpress-seo' );
 			$estimate .= '<ul class="ul-disc">';
 			$estimate .= '<li>';
 			$estimate .= \sprintf(
-				/* translators: 1: Expands to Yoast SEO, 2: Button start tag for the reminder, 3: Button closing tag */
+			/* translators: 1: Expands to Yoast SEO, 2: Button start tag for the reminder, 3: Button closing tag */
 				\esc_html__( 'Wait for a week or so, until %1$s automatically processes most of your content in the background. %2$sRemind me in a week.%3$s', 'wordpress-seo' ),
 				'Yoast SEO',
 				\sprintf(
@@ -229,7 +228,7 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 	 */
 	public function get_dismiss_button() {
 		/* translators: 1: Button/anchor start tag to dismiss the warning, 2: Button/anchor closing tag. */
-		$dismiss_button = \esc_html__('%1$sHide this notice%2$s (everything will continue to function normally)', 'wordpress-seo' );
+		$dismiss_button = \esc_html__( '%1$sHide this notice%2$s (everything will continue to function normally)', 'wordpress-seo' );
 
 		if ( $this->action_type === static::ACTION_TYPE_LINK_TO ) {
 			return \sprintf(
@@ -246,7 +245,7 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 			$dismiss_button,
 			\sprintf(
 				'<button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="%s">',
-				\esc_js(\wp_create_nonce('wpseo-ignore'))
+				\esc_js( \wp_create_nonce( 'wpseo-ignore' ) )
 			),
 			'</button>'
 		);

--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -80,15 +80,7 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 
 		$output .= '<hr />';
 		$output .= '<p>';
-		$output .= \sprintf(
-			/* translators: 1: Button start tag to dismiss the warning, 2: Button closing tag. */
-			\esc_html__( '%1$sHide this notice%2$s (everything will continue to function normally)', 'wordpress-seo' ),
-			\sprintf(
-				'<button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="%s">',
-				\esc_js( \wp_create_nonce( 'wpseo-ignore' ) )
-			),
-			'</button>'
-		);
+		$output .= $this->get_dismiss_button();
 		$output .= '</p>';
 		$output .= '</div>';
 
@@ -228,5 +220,35 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 		}
 
 		return $indexation_started <= ( \time() - \MONTH_IN_SECONDS );
+	}
+
+	/**
+	 * Generates the button/link for dismissing the notice.
+	 *
+	 * @return string The action.
+	 */
+	public function get_dismiss_button() {
+		/* translators: 1: Button/anchor start tag to dismiss the warning, 2: Button/anchor closing tag. */
+		$dismiss_button = \esc_html__('%1$sHide this notice%2$s (everything will continue to function normally)', 'wordpress-seo' );
+
+		if ( $this->action_type === static::ACTION_TYPE_LINK_TO ) {
+			return \sprintf(
+				$dismiss_button,
+				\sprintf(
+					'<a href="%s" class="button-link">',
+					\esc_url( \wp_nonce_url( \add_query_arg( 'yoast_seo_hide', 'indexation_warning' ), 'wpseo-ignore' ) )
+				),
+				'</a>'
+			);
+		}
+
+		return \sprintf(
+			$dismiss_button,
+			\sprintf(
+				'<button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="%s">',
+				\esc_js(\wp_create_nonce('wpseo-ignore'))
+			),
+			'</button>'
+		);
 	}
 }

--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -73,7 +73,8 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 
 		if ( $this->show_indexation_incomplete_alert() ) {
 			$output .= $this->get_incomplete_indexation_alert();
-		} else {
+		}
+		else {
 			$output .= $this->get_base_alert();
 		}
 

--- a/tests/integrations/admin/indexation-integration-test.php
+++ b/tests/integrations/admin/indexation-integration-test.php
@@ -170,64 +170,7 @@ class Indexation_Integration_Test extends TestCase {
 			]
 		);
 
-		$this->yoast_tools_page_conditional->expects( 'is_met' )
-			->once()
-			->andReturn( true );
-
-		$this->options
-			->expects( 'get' )
-			->with( 'indexation_started', false )
-			->andReturn( 0 );
-
-		$this->options
-			->expects( 'get' )
-			->with( 'ignore_indexation_warning', false )
-			->andReturnFalse();
-
-		$this->options
-			->expects( 'get' )
-			->with( 'indexation_warning_hide_until' )
-			->andReturn( 0 );
-
-		$this->options
-			->expects( 'get' )
-			->once()
-			->with( 'indexables_indexation_reason', '' )
-			->andReturn( '' );
-
-		Monkey\Actions\expectAdded( 'admin_notices' );
-
-		// Expect that the script and style for the modal is enqueued.
-		$this->asset_manager
-			->expects( 'enqueue_script' )
-			->once()
-			->with( 'indexation' );
-
-		$this->asset_manager
-			->expects( 'enqueue_style' )
-			->once()
-			->with( 'admin-css' );
-
-		// We should hook into the admin footer and admin notices hook.
-		Monkey\Actions\expectAdded( 'admin_footer' );
-
-		// Mock retrieval of the REST URL.
-		Monkey\Functions\expect( 'rest_url' )
-			->once()
-			->andReturn( 'https://example.org/wp-ajax/' );
-
-		// Mock WP nonce.
-		Monkey\Functions\expect( 'wp_create_nonce' )
-			->once()
-			->andReturn( 'nonce' );
-
-		// The script should be localized with the right data.
-		Monkey\Functions\expect( 'wp_localize_script' )
-			->with(
-				WPSEO_Admin_Asset_Manager::PREFIX . 'indexation',
-				'yoastIndexationData',
-				$this->get_localized_data()
-			);
+		$this->set_enqueue_expections();
 
 		$this->instance->enqueue_scripts();
 	}
@@ -291,6 +234,68 @@ class Indexation_Integration_Test extends TestCase {
 			);
 
 		$this->instance->enqueue_scripts();
+	}
+
+	/**
+	 * Tests if the listener for the notice hiding return early.
+	 *
+	 * @covers ::hide_notice_listener
+	 */
+	public function test_enqueue_scripts_having_a_listener_that_does_not_contain_expected_value() {
+		$_GET['yoast_seo_hide'] = 'not_indexation_warning';
+
+		// Mock that 40 indexables should be indexed.
+		$this->set_total_unindexed_expectations(
+			[
+				'post_type_archive' => 5,
+				'general'           => 10,
+				'post'              => 15,
+				'term'              => 10,
+			]
+		);
+
+		$this->options
+			->expects('set')
+			->never()
+			->with( 'ignore_indexation_warning', true );
+
+		$this->set_enqueue_expections();
+
+		$this->instance->enqueue_scripts();
+	}
+
+	/**
+	 * Tests if the listener for the notice is hiding the warning.
+	 *
+	 * @covers ::hide_notice_listener
+	 */
+	public function test_enqueue_scripts_having_a_listener_that_hides_the_warning() {
+		$_GET['yoast_seo_hide'] = 'indexation_warning';
+
+		// Mock that 40 indexables should be indexed.
+		$this->set_total_unindexed_expectations(
+			[
+				'post_type_archive' => 5,
+				'general'           => 10,
+				'post'              => 15,
+				'term'              => 10,
+			]
+		);
+
+		$this->set_enqueue_expections();
+
+		Monkey\Functions\expect( 'check_admin_referer' )
+			->once()
+			->with( 'wpseo-ignore' );
+
+		$this->options
+			->expects('set')
+			->once()
+			->with( 'ignore_indexation_warning', true );
+
+		$this->instance->enqueue_scripts();
+
+		unset( $_GET['yoast_seo_hide'] );
 	}
 
 	/**
@@ -564,5 +569,69 @@ class Indexation_Integration_Test extends TestCase {
 			->expects( 'get_total_unindexed' )
 			->once()
 			->andReturn( $total_unindexed_per_action['general'] );
+	}
+
+	/**
+	 * Sets default enqueue expectations.
+	 */
+	private function set_enqueue_expections() {
+		$this->yoast_tools_page_conditional->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		$this->options
+			->expects( 'get' )
+			->with( 'indexation_started', false )
+			->andReturn( 0 );
+
+		$this->options
+			->expects( 'get' )
+			->with( 'ignore_indexation_warning', false )
+			->andReturnFalse();
+
+		$this->options
+			->expects( 'get' )
+			->with( 'indexation_warning_hide_until' )
+			->andReturn( 0 );
+
+		$this->options
+			->expects( 'get' )
+			->once()
+			->with( 'indexables_indexation_reason', '' )
+			->andReturn( '' );
+
+		Monkey\Actions\expectAdded( 'admin_notices' );
+
+		// Expect that the script and style for the modal is enqueued.
+		$this->asset_manager
+			->expects( 'enqueue_script' )
+			->once()
+			->with( 'indexation' );
+
+		$this->asset_manager
+			->expects( 'enqueue_style' )
+			->once()
+			->with( 'admin-css' );
+
+		// We should hook into the admin footer and admin notices hook.
+		Monkey\Actions\expectAdded( 'admin_footer' );
+
+		// Mock retrieval of the REST URL.
+		Monkey\Functions\expect( 'rest_url' )
+			->once()
+			->andReturn( 'https://example.org/wp-ajax/' );
+
+		// Mock WP nonce.
+		Monkey\Functions\expect( 'wp_create_nonce' )
+			->once()
+			->andReturn( 'nonce' );
+
+		// The script should be localized with the right data.
+		Monkey\Functions\expect( 'wp_localize_script' )
+			->with(
+				WPSEO_Admin_Asset_Manager::PREFIX . 'indexation',
+				'yoastIndexationData',
+				$this->get_localized_data()
+			);
 	}
 }

--- a/tests/presenters/admin/indexation-warning-presenter-test.php
+++ b/tests/presenters/admin/indexation-warning-presenter-test.php
@@ -75,6 +75,13 @@ class Indexation_Warning_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'admin_url' )
 			->andReturn( 'https://example.com/wp-admin/admin.php?page=wpseo_tools' );
 
+		Monkey\Functions\expect( 'wp_nonce_url' )
+			->with( '\'https://example.com/wp-admin/admin.php?page=wpseo_tools&yoast_seo_hide=indexation_warning\'' )
+			->andReturn( 'https://example.com/wp-admin/admin.php?page=wpseo_tools&yoast_seo_hide=indexation_warning&wp_nonce=123456' );
+		Monkey\Functions\expect( 'add_query_arg' )
+			->with( 'yoast_seo_hide', 'indexation_warning' )
+			->andReturn( 'https://example.com/wp-admin/admin.php?page=wpseo_tools&yoast_seo_hide=indexation_warning' );
+
 		$presenter = new Indexation_Warning_Presenter( 12, $this->options, Indexation_Warning_Presenter::ACTION_TYPE_LINK_TO );
 
 		$expected  = '<div id="yoast-indexation-warning" class="notice notice-success"><p>';
@@ -82,7 +89,7 @@ class Indexation_Warning_Presenter_Test extends TestCase {
 		$expected .= '<p>To build your index, Yoast SEO needs to process all of your content.</p>';
 		$expected .= '<p>We estimate this will take less than a minute.</p>';
 		$expected .= '<a class="button" href="https://example.com/wp-admin/admin.php?page=wpseo_tools">Start processing and speed up your site now</a>';
-		$expected .= '<hr /><p><button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="123456789">Hide this notice</button> ';
+		$expected .= '<hr /><p><a href="https://example.com/wp-admin/admin.php?page=wpseo_tools&yoast_seo_hide=indexation_warning&wp_nonce=123456" class="button-link">Hide this notice</a> ';
 		$expected .= '(everything will continue to function normally)</p></div>';
 
 		$this->assertEquals( $expected, $presenter->present() );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When you clicked on "Hide this notice" for the indexable indexation, it only worked if you were on the tools page.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the indexable indexation warning would not be hidden if you were on a page other than the Tools page.

## Relevant technical choices:

* We changed the `Hide this notice` button into a link on all pages other than the Tools page. The indexation integration now checks whether there is a `yoast_seo_hide` query parameter in the URL, and if so, it hides the notification.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Reset the indexables in the Test Helper.
* Go to the Yoast dashboard.
* Hoover over "Hide this notice", and see it is a URL.
* Click "Hide this notice", and see the notice disappear.

* Reset the indexables in the Test Helper.
* Go to the Yoast tools page.
* Hoover over "Hide this notice", and see nothing (meaning it is a button).
* Click "Hide this notice", and see the notice disappear.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-189
