### PR TITLE
Fix travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,10 +86,10 @@ jobs:
         - nvm install lts/*
         - curl -o- -L https://yarnpkg.com/install.sh | bash
         - export PATH=$HOME/.yarn/bin:$PATH
-        - openssl aes-256-cbc -K $encrypted_06a9c1b95cfa_key -iv $encrypted_06a9c1b95cfa_iv -in ./config/deploy_keys/travis_dist_id_rsa.enc -out ./config/deploy_keys/travis_dist_id_rsa -d
-        - chmod 600 ./config/deploy_keys/travis_dist_id_rsa
+        - openssl aes-256-cbc -K $encrypted_06a9c1b95cfa_key -iv $encrypted_06a9c1b95cfa_iv -in ./config/travis/deploy_keys/travis_dist_id_rsa.enc -out ./config/travis/deploy_keys/travis_dist_id_rsa -d
+        - chmod 600 ./config/travis/deploy_keys/travis_dist_id_rsa
         - eval $(ssh-agent -s)
-        - ssh-add ./config/deploy_keys/travis_dist_id_rsa
+        - ssh-add ./config/travis/deploy_keys/travis_dist_id_rsa
 
       # If the commit was tagged, create an artifact and push it to the distribution github
       deploy:


### PR DESCRIPTION
After https://github.com/Yoast/wordpress-seo/pull/15757 moved them to config

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* It looks like the moving of the Travis deploy keys in https://github.com/Yoast/wordpress-seo/pull/15757 didn't go as planned.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Travis deploy keys where moved to a location other than specified.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
