### PR TITLE
P2-205 Hide the permalink warning also when you're not on the tools page

### DIFF
--- a/src/presenters/admin/indexation-permalink-warning-presenter.php
+++ b/src/presenters/admin/indexation-permalink-warning-presenter.php
@@ -36,15 +36,7 @@ class Indexation_Permalink_Warning_Presenter extends Indexation_Warning_Presente
 		$output .= $this->get_action( \__( 'Start processing and speed up your site now', 'wordpress-seo' ) );
 		$output .= '<hr />';
 		$output .= '<p>';
-		$output .= \sprintf(
-			/* translators: 1: Button start tag to dismiss the warning, 2: Button closing tag. */
-			\esc_html__( '%1$sHide this notice%2$s (everything will continue to function normally)', 'wordpress-seo' ),
-			\sprintf(
-				'<button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="%s">',
-				\esc_js( \wp_create_nonce( 'wpseo-ignore' ) )
-			),
-			'</button>'
-		);
+		$output .= $this->get_dismiss_button();
 		$output .= '</p>';
 		$output .= '</div>';
 
@@ -79,5 +71,35 @@ class Indexation_Permalink_Warning_Presenter extends Indexation_Warning_Presente
 		 * @param string $reason The reason value.
 		 */
 		return (string) \apply_filters( 'wpseo_indexables_indexation_alert', $text, $reason );
+	}
+
+	/**
+	 * Generates the button/link for dismissing the notice.
+	 *
+	 * @return string The action.
+	 */
+	public function get_dismiss_button() {
+		/* translators: 1: Button/anchor start tag to dismiss the warning, 2: Button/anchor closing tag. */
+		$dismiss_button = \esc_html__( '%1$sHide this notice%2$s (everything will continue to function normally)', 'wordpress-seo' );
+
+		if ( $this->action_type === static::ACTION_TYPE_LINK_TO ) {
+			return \sprintf(
+				$dismiss_button,
+				\sprintf(
+					'<a href="%s" class="button-link">',
+					\esc_url( \wp_nonce_url( \add_query_arg( 'yoast_seo_hide', 'indexation_warning' ), 'wpseo-ignore' ) )
+				),
+				'</a>'
+			);
+		}
+
+		return \sprintf(
+			$dismiss_button,
+			\sprintf(
+				'<button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="%s">',
+				\esc_js( \wp_create_nonce( 'wpseo-ignore' ) )
+			),
+			'</button>'
+		);
 	}
 }

--- a/src/presenters/admin/indexation-permalink-warning-presenter.php
+++ b/src/presenters/admin/indexation-permalink-warning-presenter.php
@@ -72,34 +72,4 @@ class Indexation_Permalink_Warning_Presenter extends Indexation_Warning_Presente
 		 */
 		return (string) \apply_filters( 'wpseo_indexables_indexation_alert', $text, $reason );
 	}
-
-	/**
-	 * Generates the button/link for dismissing the notice.
-	 *
-	 * @return string The action.
-	 */
-	public function get_dismiss_button() {
-		/* translators: 1: Button/anchor start tag to dismiss the warning, 2: Button/anchor closing tag. */
-		$dismiss_button = \esc_html__( '%1$sHide this notice%2$s (everything will continue to function normally)', 'wordpress-seo' );
-
-		if ( $this->action_type === static::ACTION_TYPE_LINK_TO ) {
-			return \sprintf(
-				$dismiss_button,
-				\sprintf(
-					'<a href="%s" class="button-link">',
-					\esc_url( \wp_nonce_url( \add_query_arg( 'yoast_seo_hide', 'indexation_warning' ), 'wpseo-ignore' ) )
-				),
-				'</a>'
-			);
-		}
-
-		return \sprintf(
-			$dismiss_button,
-			\sprintf(
-				'<button type="button" id="yoast-indexation-dismiss-button" class="button-link hide-if-no-js" data-nonce="%s">',
-				\esc_js( \wp_create_nonce( 'wpseo-ignore' ) )
-			),
-			'</button>'
-		);
-	}
 }

--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -227,7 +227,7 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 	 *
 	 * @return string The action.
 	 */
-	public function get_dismiss_button() {
+	protected function get_dismiss_button() {
 		/* translators: 1: Button/anchor start tag to dismiss the warning, 2: Button/anchor closing tag. */
 		$dismiss_button = \esc_html__( '%1$sHide this notice%2$s (everything will continue to function normally)', 'wordpress-seo' );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR is a follow-up to https://github.com/Yoast/wordpress-seo/pull/15776. There, we only fixed the `indexation-warning-presenter`, while we should have fixed the `indexation-permalink-warning-presenter` as well.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the indexable permalink warning would not be hidden if you were on a page other than the Tools page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

_Test the Category URLs setting_
* Reset the indexables in the Test Helper.
* Run the indexable indexation.
* Go to Search appearance --> Taxonomies and click the Category URLs toggle.
* The warning should appear. 
* Hoover over "Hide this notice", and see it is a URL.
* Click "Hide this notice", and see the notice disappear.

_Test the Permalinks setting_
* Reset the indexables in the Test Helper.
* Run the indexable indexation.
* Go to Settings --> Permalinks and change the category base and/or the tag base.
* The warning should appear. 
* Hoover over "Hide this notice", and see it is a URL.
* Click "Hide this notice", and see the notice disappear.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-205
