### PR TITLE
Load TwitterCardType in store and update the selector

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -6,6 +6,7 @@
  */
 
 use Yoast\WP\SEO\Config\Schema_Types;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 
 /**
  * This class forces needed methods for the metabox localization.
@@ -49,6 +50,7 @@ class WPSEO_Metabox_Formatter {
 		$analysis_seo         = new WPSEO_Metabox_Analysis_SEO();
 		$analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 		$schema_types         = new Schema_Types();
+		$options              = new Options_Helper();
 
 		return [
 			'author_name'               => get_the_author_meta( 'display_name' ),
@@ -85,6 +87,7 @@ class WPSEO_Metabox_Formatter {
 				'pageTypeOptions'    => $schema_types->get_page_type_options(),
 				'articleTypeOptions' => $schema_types->get_article_type_options(),
 			],
+			'twitterCardType'           => $options->get( 'twitter_card_type' ),
 
 			/**
 			 * Filter to determine if the markers should be enabled or not.

--- a/js/src/initializers/edit.js
+++ b/js/src/initializers/edit.js
@@ -95,6 +95,7 @@ class Edit {
 				authorName: this._localizedData.author_name,
 				siteName: this._localizedData.site_name,
 				contentImage: this._localizedData.first_content_image,
+				twitterCardType: this._localizedData.twitterCardType,
 			},
 			snippetEditor: {
 				baseUrl: this._args.snippetEditorBaseUrl,

--- a/js/src/redux/selectors/twitterEditor.js
+++ b/js/src/redux/selectors/twitterEditor.js
@@ -34,7 +34,7 @@ export const getTwitterImageUrl = state => get( state, "twitterEditor.image.url"
  *
  * @returns {String} Twitter image type.
  */
-export const getTwitterImageType = state => get( state, "twitterEditor.image.type", true );
+export const getTwitterImageType = state => get( state, "settings.socialPreviews.twitterCardType", "summary" );
 
 /**
  * Gets the Twitter image src from the state.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* [This PR on premium](https://github.com/Yoast/wordpress-seo-premium/pull/2774) contains only changes in Free code. This gives some problems. Therefore, the code should also be merged into free. This PR does exactly that ^.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Passes the twitterCardType to the JavaScript and loads it in the store.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
1. Change the Default Twitter card type in the settings (see original issue)
1. See that this changes the Twitter Preview in the Social React tab.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
