### PR TITLE
P3-98 Add `yoast` class to SEMrush modal

### DIFF
--- a/js/src/components/RelatedKeyphrasesModal.js
+++ b/js/src/components/RelatedKeyphrasesModal.js
@@ -76,7 +76,7 @@ class RelatedKeyphrasesModal extends Component {
 					<Modal
 						title={ __( "Related keyphrases", "wordpress-seo" ) }
 						onRequestClose={ this.onModalClose }
-						className="yoast-gutenberg-modal yoast-related-keyphrases-modal"
+						className="yoast yoast-gutenberg-modal yoast-related-keyphrases-modal"
 						icon={ <YoastIcon /> }
 					>
 						<ModalContainer


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The SEMrush modal contains some components which need a parent container with a `yoast` class.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add `yoast` class to SEMrush modal

## Relevant technical choices:

* the name of the branch has a wrong Jira issue number

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* The PR can't be tested (one can just check that the class is present) since the components affected will be merged later or are visible just in the Premium plugin. The PR will be directly merged.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P3-98
