### PR TITLE
Add missing text domain in JS tests

### DIFF
--- a/js/tests/setupTests.js
+++ b/js/tests/setupTests.js
@@ -18,6 +18,17 @@ setLocaleData( {
 	},
 }, "wordpress-seo" );
 
+// For the yoast-components imports.
+setLocaleData( {
+	"": {
+		domain: "yoast-components",
+		lang: "en",
+		/* eslint-disable */
+		plural_forms: "nplurals=2; plural=(n != 1);",
+		/* eslint-enable */
+	},
+}, "yoast-components" );
+
 
 /* Setup react to be used like in WordPress. */
 global.React = React;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `yoast-components` text domain was missing in the JS tests.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* You should not longer get errors about the `yoast-components` text-domain when running the JS tests (`yarn test`).
* The error would look like:
```
  console.error node_modules/memize/index.js:74
    Jed localization error: 
    
    Error: Domain `yoast-components` was not found.
```

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
