### PR TITLE
Check if there is a language string before adding translator comment

### DIFF
--- a/grunt/custom/convert-pot-to-wp.js
+++ b/grunt/custom/convert-pot-to-wp.js
@@ -60,7 +60,7 @@ function convertTranslationToPHP( translation, textdomain ) {
 			php += TAB + `/* ${extracted} */${NEWLINE}`;
 		}
 
-		if ( ! _isEmpty( comments.translator ) ) {
+		if ( ! _isEmpty( comments.translator ) && "" !== original ) {
 			php += TAB + `/* translators: ${comments.translator} */${NEWLINE}`
 		}
 	}

--- a/grunt/custom/convert-pot-to-wp.js
+++ b/grunt/custom/convert-pot-to-wp.js
@@ -60,7 +60,7 @@ function convertTranslationToPHP( translation, textdomain ) {
 			php += TAB + `/* ${extracted} */${NEWLINE}`;
 		}
 
-		if ( ! _isEmpty( comments.translator ) && "" !== original ) {
+		if ( ! _isEmpty( comments.translator ) && original !== "" ) {
 			php += TAB + `/* translators: ${comments.translator} */${NEWLINE}`
 		}
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We can't push to WordPress trunk because of `,` without value.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Deployment code only.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `grunt build:i18n` and verify that the `.php` files in the languages directory doesn't contain any unexpected values.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
