### PR TITLE
Fix breadcrumb page numbers in paginated series

### DIFF
--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -10,6 +10,7 @@ namespace Yoast\WP\SEO\Generators;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -56,6 +57,13 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	private $url_helper;
 
 	/**
+	 * The pagination helper.
+	 *
+	 * @var Pagination_Helper;
+	 */
+	private $pagination_helper;
+
+	/**
 	 * Breadcrumbs_Generator constructor.
 	 *
 	 * @param Indexable_Repository $repository          The repository.
@@ -63,19 +71,22 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 * @param Current_Page_Helper  $current_page_helper The current page helper.
 	 * @param Post_Type_Helper     $post_type_helper    The post type helper.
 	 * @param Url_Helper           $url_helper          The URL helper.
+	 * @param Pagination_Helper    $pagination_helper   The pagination helper.
 	 */
 	public function __construct(
 		Indexable_Repository $repository,
 		Options_Helper $options,
 		Current_Page_Helper $current_page_helper,
 		Post_Type_Helper $post_type_helper,
-		Url_Helper $url_helper
+		Url_Helper $url_helper,
+		Pagination_Helper $pagination_helper
 	) {
 		$this->repository          = $repository;
 		$this->options             = $options;
 		$this->current_page_helper = $current_page_helper;
 		$this->post_type_helper    = $post_type_helper;
 		$this->url_helper          = $url_helper;
+		$this->pagination_helper   = $pagination_helper;
 	}
 
 	/**
@@ -165,8 +176,8 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			$crumbs[0]['text'] = $breadcrumbs_home;
 		}
 
-		if ( $this->current_page_helper->is_paged() ) {
-			$crumbs[]['text'] = $this->get_pagination_text();
+		if ( $this->current_page_helper->is_paged() || \end( $indexables )->number_of_pages > 1 ) {
+			$crumbs[]['text'] = $this->get_pagination_text( \end( $indexables ) );
 		}
 
 		/**
@@ -302,7 +313,8 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 * @return string The crumb.
 	 */
 	private function get_pagination_text() {
-		$page_number = \get_query_var( 'paged', 1 );
+		$page_number = $this->pagination_helper->get_current_page_number();
+
 		if ( $page_number <= 1 ) {
 			return '';
 		}
@@ -311,7 +323,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			/* translators: %s expands to the current page number */
 			__( 'Page %s', 'wordpress-seo' ),
 			$page_number
-			);
+		);
 	}
 
 	/**

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -293,12 +293,14 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			$crumb['url']  = $home_url . \get_the_date( 'Y/m/d' ) . '/';
 			$day           = \esc_html( \get_the_date() );
 			$crumb['text'] = $prefix . ' ' . $day;
-		} elseif ( \is_month() ) {
+		}
+		elseif ( \is_month() ) {
 			$crumb['url']  = $home_url . \get_the_date( 'Y/m' ) . '/';
 			$month         = \esc_html( \trim( \single_month_title( ' ', false ) ) );
 			$crumb['text'] = $prefix . ' ' . $month;
 
-		} elseif ( \is_year() ) {
+		}
+		elseif ( \is_year() ) {
 			$year          = \get_the_date( 'Y' );
 			$crumb['url']  = $home_url . $year . '/';
 			$crumb['text'] = $prefix . ' ' . $year;

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -8,7 +8,6 @@
 namespace Yoast\WP\SEO\Generators;
 
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
-use Yoast\WP\SEO\Generators\Generator_Interface;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -35,21 +35,21 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	private $options;
 
 	/**
-	 * The current page helper
+	 * The current page helper.
 	 *
 	 * @var Current_Page_Helper
 	 */
 	private $current_page_helper;
 
 	/**
-	 * The post type helper
+	 * The post type helper.
 	 *
 	 * @var Post_Type_Helper
 	 */
 	private $post_type_helper;
 
 	/**
-	 * The URL helper
+	 * The URL helper.
 	 *
 	 * @var Url_Helper;
 	 */
@@ -278,7 +278,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 		$home_url = $this->url_helper->home();
 		$prefix   = $this->options->get( 'breadcrumbs-archiveprefix' );
 
-		if ( \is_day() ) { # Doesn't work: outputs basic.wordpress.test/July 24th, 2020
+		if ( \is_day() ) {
 			$crumb['url']  = $home_url . \get_the_date( 'Y/m/d' ) . '/';
 			$day           = \esc_html( \get_the_date() );
 			$crumb['text'] = $prefix . ' ' . $day;

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -177,7 +177,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 		}
 
 		if ( $this->current_page_helper->is_paged() || \end( $indexables )->number_of_pages > 1 ) {
-			$crumbs[]['text'] = $this->get_pagination_text( \end( $indexables ) );
+			$crumbs[]['text'] = $this->get_pagination_text();
 		}
 
 		/**

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -154,6 +154,10 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			$crumbs[0]['text'] = $breadcrumbs_home;
 		}
 
+		if ( $this->current_page_helper->is_paged() ) {
+			$crumbs[]['text'] = $this->get_pagination_text();
+		}
+
 		/**
 		 * Filter: 'wpseo_breadcrumb_links' - Allow the developer to filter the Yoast SEO breadcrumb links, add to them, change order, etc.
 		 *
@@ -273,6 +277,24 @@ class Breadcrumbs_Generator implements Generator_Interface {
 		}
 
 		return $crumb;
+	}
+
+	/**
+	 * Returns the text for the pagination crumb.
+	 *
+	 * @return string The crumb.
+	 */
+	private function get_pagination_text() {
+		$page_number = \get_query_var( 'paged', 1 );
+		if ( $page_number <= 1 ) {
+			return '';
+		}
+
+		return sprintf(
+			/* translators: %s expands to the current page number */
+			__( 'Page %s', 'wordpress-seo' ),
+			$page_number
+			);
 	}
 
 	/**

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -143,7 +143,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 					$crumb = $this->get_user_crumb( $crumb, $ancestor );
 					break;
 				case 'date-archive':
-					$crumb = $this->get_date_archive_crumb( $crumb, $ancestor );
+					$crumb = $this->get_date_archive_crumb( $crumb );
 					break;
 			}
 			return $crumb;
@@ -255,12 +255,11 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	/**
 	 * Returns the modified date archive crumb.
 	 *
-	 * @param array     $crumb    The crumb.
-	 * @param Indexable $ancestor The indexable.
+	 * @param array $crumb The crumb.
 	 *
 	 * @return array The crumb.
 	 */
-	private function get_date_archive_crumb( $crumb, $ancestor ) {
+	private function get_date_archive_crumb( $crumb ) {
 		$prefix = $this->options->get( 'breadcrumbs-archiveprefix' );
 
 		if ( \is_day() ) {

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -176,7 +176,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			$crumbs[0]['text'] = $breadcrumbs_home;
 		}
 
-		$crumbs = $this->add_paged_crumb( $crumbs, \end( $indexables ) );
+		$crumbs = $this->add_paged_crumb( $crumbs, $context->indexable );
 
 		/**
 		 * Filter: 'wpseo_breadcrumb_links' - Allow the developer to filter the Yoast SEO breadcrumb links, add to them, change order, etc.
@@ -363,22 +363,19 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 * @returns array The breadcrumbs.
 	 */
 	protected function add_paged_crumb( array $crumbs, $current_indexable ) {
-		if ( ! $current_indexable ) {
-			return $crumbs;
-		}
+		$is_simple_page = $this->current_page_helper->is_simple_page();
 
 		// If we're not on a paged page do nothing.
-		if ( ! $this->current_page_helper->is_simple_page() && ! $this->current_page_helper->is_paged() ) {
+		if ( ! $is_simple_page && ! $this->current_page_helper->is_paged() ) {
 			return $crumbs;
 		}
 
 		// If we're not on a paginated post do nothing.
-		if ( $this->current_page_helper->is_simple_page() && $current_indexable->number_of_pages === null ) {
+		if ( $is_simple_page && $current_indexable->number_of_pages === null ) {
 			return $crumbs;
 		}
 
 		$current_page_number = $this->pagination_helper->get_current_page_number();
-
 		if ( $current_page_number <= 1 ) {
 			return $crumbs;
 		}

--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -47,7 +47,7 @@ class Breadcrumb extends Abstract_Schema_Piece {
 		$list_elements = [];
 
 		// In case of pagination, replace the last breadcrumb, because it only contains "Page [number]" and has no URL.
-		if ( $this->helpers->current_page->is_paged() ) {
+		if ( $this->helpers->current_page->is_paged() || ( $this->context->indexable->number_of_pages > 1 ) ) {
 			\array_pop( $breadcrumbs );
 
 			$breadcrumbs[] = [

--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -60,8 +60,6 @@ class Breadcrumb extends Abstract_Schema_Piece {
 				return false;
 			}
 		}
-
-
 		// Create the last breadcrumb.
 		$last_breadcrumb = \array_pop( $breadcrumbs );
 		$breadcrumbs[]   = $this->format_last_breadcrumb( $last_breadcrumb );

--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -46,6 +46,16 @@ class Breadcrumb extends Abstract_Schema_Piece {
 		$breadcrumbs   = $this->context->presentation->breadcrumbs;
 		$list_elements = [];
 
+		// In case of pagination, replace the last breadcrumb, because it only contains "Page [number]" and has no URL.
+		if ( $this->helpers->current_page->is_paged() ) {
+			\array_pop( $breadcrumbs );
+
+			$breadcrumbs[] = [
+				'url'  => $this->context->canonical,
+				'text' => $this->context->title,
+			];
+		}
+
 		// Only output breadcrumbs that are not hidden.
 		$breadcrumbs = \array_filter( $breadcrumbs, [ $this, 'not_hidden' ] );
 
@@ -63,14 +73,6 @@ class Breadcrumb extends Abstract_Schema_Piece {
 		// Create the last breadcrumb.
 		$last_breadcrumb = \array_pop( $breadcrumbs );
 		$breadcrumbs[]   = $this->format_last_breadcrumb( $last_breadcrumb );
-
-		// Add a paginated state if the current page is paged.
-		if ( $this->helpers->current_page->is_paged() ) {
-			$breadcrumbs[] = [
-				'url'  => $this->context->canonical,
-				'text' => $this->context->title,
-			];
-		}
 
 		// Create intermediate breadcrumbs.
 		foreach ( $breadcrumbs as $index => $breadcrumb ) {

--- a/src/helpers/pagination-helper.php
+++ b/src/helpers/pagination-helper.php
@@ -71,7 +71,11 @@ class Pagination_Helper {
 	 *
 	 * @return string The paginated URL.
 	 */
-	public function get_paginated_url( $url, $page, $add_pagination_base = true, $pagination_query_name = 'page' ) {
+	public function get_paginated_url( $url, $page = null, $add_pagination_base = true, $pagination_query_name = 'page' ) {
+		if ( $page === null ) {
+			$page = $this->get_current_page_number();
+		}
+
 		$wp_rewrite = $this->wp_rewrite_wrapper->get();
 
 		if ( $wp_rewrite->using_permalinks() ) {
@@ -117,5 +121,27 @@ class Pagination_Helper {
 		$wp_query = $this->wp_query_wrapper->get_main_query();
 
 		return (int) $wp_query->get( 'page' );
+	}
+
+	/**
+	 * Returns the current page number.
+	 *
+	 * @return int The current page number.
+	 */
+	public function get_current_page_number() {
+		// Get the page number for an archive page.
+		$page_number = \get_query_var( 'paged', 1 );
+
+		if ( $page_number <= 1 ) {
+
+			// Get the page number for a page in a paginated post.
+			$page_number = \get_query_var( 'page', 1 );
+
+			if ( $page_number <= 1 ) {
+				return '';
+			}
+		}
+
+		return $page_number;
 	}
 }

--- a/src/helpers/pagination-helper.php
+++ b/src/helpers/pagination-helper.php
@@ -36,8 +36,6 @@ class Pagination_Helper {
 	 *
 	 * @param WP_Rewrite_Wrapper $wp_rewrite_wrapper The rewrite wrapper.
 	 * @param WP_Query_Wrapper   $wp_query_wrapper   The query wrapper.
-	 *
-	 * @codeCoverageIgnore
 	 */
 	public function __construct(
 		WP_Rewrite_Wrapper $wp_rewrite_wrapper,

--- a/src/helpers/pagination-helper.php
+++ b/src/helpers/pagination-helper.php
@@ -129,7 +129,7 @@ class Pagination_Helper {
 			return $page_number;
 		}
 
-		// Get the page number for a page in a paginated post
+		// Get the page number for a page in a paginated post.
 		return \get_query_var( 'page', 1 );
 	}
 }

--- a/src/helpers/pagination-helper.php
+++ b/src/helpers/pagination-helper.php
@@ -71,11 +71,7 @@ class Pagination_Helper {
 	 *
 	 * @return string The paginated URL.
 	 */
-	public function get_paginated_url( $url, $page = null, $add_pagination_base = true, $pagination_query_name = 'page' ) {
-		if ( $page === null ) {
-			$page = $this->get_current_page_number();
-		}
-
+	public function get_paginated_url( $url, $page, $add_pagination_base = true, $pagination_query_name = 'page' ) {
 		$wp_rewrite = $this->wp_rewrite_wrapper->get();
 
 		if ( $wp_rewrite->using_permalinks() ) {
@@ -131,17 +127,11 @@ class Pagination_Helper {
 	public function get_current_page_number() {
 		// Get the page number for an archive page.
 		$page_number = \get_query_var( 'paged', 1 );
-
-		if ( $page_number <= 1 ) {
-
-			// Get the page number for a page in a paginated post.
-			$page_number = \get_query_var( 'page', 1 );
-
-			if ( $page_number <= 1 ) {
-				return '';
-			}
+		if ( $page_number > 1 ) {
+			return $page_number;
 		}
 
-		return $page_number;
+		// Get the page number for a page in a paginated post
+		return \get_query_var( 'page', 1 );
 	}
 }

--- a/tests/unit/generators/breadcrumbs-generator-test.php
+++ b/tests/unit/generators/breadcrumbs-generator-test.php
@@ -106,15 +106,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 		$this->url_helper        = Mockery::mock( Url_Helper::class );
 		$this->pagination_helper = Mockery::mock( Pagination_Helper::class );
 		$this->instance          = new Breadcrumbs_Generator( $this->repository, $this->options, $this->current_page, $this->post_type_helper, $this->url_helper, $this->pagination_helper );
-
-		$this->indexable                   = Mockery::mock( Indexable_Mock::class );
-		$this->indexable->object_id        = 1;
-		$this->indexable->object_type      = 'post';
-		$this->indexable->object_sub_type  = 'post';
-		$this->indexable->permalink        = 'https://example.com/post';
-		$this->indexable->breadcrumb_title = 'post';
-		$this->context                     = Mockery::mock( Meta_Tags_Context_Mock::class );
-		$this->context->indexable          = $this->indexable;
+		$this->context           = Mockery::mock( Meta_Tags_Context_Mock::class );
 	}
 
 	/**
@@ -123,7 +115,6 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	 * @covers ::__construct
 	 * @covers ::generate
 	 * @covers ::should_have_blog_crumb
-	 * @covers ::get_pagination_text
 	 *
 	 * @dataProvider generate_provider
 	 *
@@ -134,7 +125,17 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	 * @param string $message         Message to show when test fails.
 	 */
 	public function test_generate( $scenario, $page_for_posts, $breadcrumb_home, $front_page_id, $message ) {
+		$this->indexable                   = Mockery::mock( Indexable_Mock::class );
+		$this->indexable->object_id        = 1;
+		$this->indexable->object_type      = 'post';
+		$this->indexable->object_sub_type  = 'post';
+		$this->indexable->permalink        = 'https://example.com/post';
+		$this->indexable->breadcrumb_title = 'post';
+		$this->context->indexable          = $this->indexable;
+
 		$this->set_scenario( $scenario );
+
+		$is_simple_page = false;
 
 		Monkey\Functions\expect( 'get_option' )
 			->once()
@@ -162,6 +163,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 		}
 
 		if ( \strpos( $scenario, 'on-singular-post-page' ) === 0 ) {
+			$is_simple_page = true;
 			$this->repository
 				->expects( 'find_by_id_and_type' )
 				->once()
@@ -208,9 +210,15 @@ class Breadcrumbs_Generator_Test extends TestCase {
 			->andReturn( $page_type );
 
 		$this->current_page
-			->expects( 'is_paged' )
-			->once()
-			->andReturnFalse();
+			->expects( 'is_simple_page' )
+			->andReturn( $is_simple_page );
+
+		if ( ! $is_simple_page ) {
+			$this->current_page
+				->expects( 'is_paged' )
+				->once()
+				->andReturnFalse();
+		}
 
 		$expected = [
 			[
@@ -239,63 +247,63 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	 */
 	public function generate_provider() {
 		return [
-			[
+			'hide-blog-page' => [
 				'scenario'         => 'hide-blog-page',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
 				'front_page_id'    => 0,
 				'message'          => 'Tests with the display blog page option disabled.',
 			],
-			[
+			'show_posts_on_front' => [
 				'scenario'         => 'show_posts_on_front',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
 				'front_page_id'    => 0,
 				'message'          => 'Tests with the posts being shown on front',
 			],
-			[
+			'show_page_on_front' => [
 				'scenario'         => 'show_page_on_front',
 				'page_for_posts'   => 0,
 				'breadcrumb_home'  => 'home',
 				'front_page_id'    => 0,
 				'message'          => 'Tests with the page being shown on front, but no page being set',
 			],
-			[
+			'on-home-page' => [
 				'scenario'         => 'on-home-page',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
 				'front_page_id'    => 0,
 				'message'          => 'Tests with current request being the home page',
 			],
-			[
+			'on-search-page' => [
 				'scenario'         => 'on-search-page',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
 				'front_page_id'    => 0,
 				'message'          => 'Tests with current request being the search page',
 			],
-			[
+			'on-singular-post-page' => [
 				'scenario'         => 'on-singular-post-page',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
 				'front_page_id'    => 0,
 				'message'          => 'Tests with current request being a singular post page',
 			],
-			[
+			'not-on-home-search-or-singular-post-page' => [
 				'scenario'         => 'not-on-home-search-or-singular-post-page',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
 				'front_page_id'    => 0,
 				'message'          => 'Tests with current request being not the home, search or a singular post page',
 			],
-			[
+			'on-singular-post-page-with-front-page-id' =>[
 				'scenario'         => 'on-singular-post-page-with-front-page-id',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
 				'front_page_id'    => 2,
 				'message'          => 'Tests with current request being a singular post page and a front page being set',
 			],
-			[
+			'show-custom-post-type' => [
 				'scenario'         => 'show-custom-post-type',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
@@ -303,6 +311,252 @@ class Breadcrumbs_Generator_Test extends TestCase {
 				'message'          => 'Tests with current request being a singular custom post page',
 			],
 		];
+	}
+	/**
+	 * Tests the generation of the bread crumbs for a date archive.
+	 *
+	 * @param string $scenario     Scenario to test (day, month, year).
+	 * @param bool   $is_paged     Is the page being paged.
+	 * @param int    $current_page The current page number.
+	 * @param array  $expected     The expected output.
+	 *
+	 * @dataProvider date_archive_provider
+	 *
+	 * @covers ::generate
+	 * @covers ::get_date_archive_crumb
+	 * @covers ::add_paged_crumb
+	 */
+	public function test_with_date_archive( $scenario, $is_paged, $current_page, $expected ) {
+		$this->setup_expectations_for_date_archive( $scenario, $is_paged, $current_page );
+
+		$this->assertEquals(
+			$expected,
+			\array_slice( $this->instance->generate( $this->context ), -2 )
+		);
+	}
+
+	/**
+	 * Provides data to test_with_date_archive.
+	 *
+	 * @return array[] Test data to use.
+	 */
+	public function date_archive_provider() {
+		return [
+			'for_day' => [
+				'scenario'     => 'day',
+				'is_paged'     => true,
+				'current_page' => 5,
+				'expected'     => [
+					[
+						'url'  => 'https://example.com/2020/08/11/',
+						'text' => 'Archive August 11th, 2020',
+					],
+					[
+						'text' => 'Page 5',
+					],
+				],
+			],
+			'for_day_on_first_page' => [
+				'scenario'     => 'day',
+				'is_paged'     => true,
+				'current_page' => 1,
+				'expected'     => [
+					[
+						'url'  => 'https://example.com/2020/08/11/',
+						'text' => 'Archive August 11th, 2020',
+					],
+				],
+			],
+			'for_day_not_paged' => [
+				'scenario'     => 'day',
+				'is_paged'     => false,
+				'current_page' => 5,
+				'expected'     => [
+					[
+						'url'  => 'https://example.com/2020/08/11/',
+						'text' => 'Archive August 11th, 2020',
+					],
+				],
+			],
+			'for_month' => [
+				'scenario'     => 'month',
+				'is_paged'     => true,
+				'current_page' => 5,
+				'expected'     => [
+					[
+						'url'  => 'https://example.com/2020/08/',
+						'text' => 'Archive August',
+					],
+					[
+						'text' => 'Page 5',
+					],
+				],
+			],
+			'for_month_on_first_page' => [
+				'scenario'     => 'month',
+				'is_paged'     => true,
+				'current_page' => 1,
+				'expected'     => [
+					[
+						'url'  => 'https://example.com/2020/08/',
+						'text' => 'Archive August',
+					],
+				],
+			],
+			'for_month_not_paged' => [
+				'scenario'     => 'month',
+				'is_paged'     => false,
+				'current_page' => 5,
+				'expected'     => [
+					[
+						'url'  => 'https://example.com/2020/08/',
+						'text' => 'Archive August',
+					],
+				],
+			],
+			'for_year' => [
+				'scenario'     => 'year',
+				'is_paged'     => true,
+				'current_page' => 5,
+				'expected'     => [
+					[
+						'url'  => 'https://example.com/2020/',
+						'text' => 'Archive 2020',
+					],
+					[
+						'text' => 'Page 5',
+					],
+				],
+			],
+			'for_year_on_first_page' => [
+				'scenario'     => 'year',
+				'is_paged'     => true,
+				'current_page' => 1,
+				'expected'     => [
+					[
+						'url'  => 'https://example.com/2020/',
+						'text' => 'Archive 2020',
+					],
+				],
+			],
+			'for_year_not_paged' => [
+				'scenario'     => 'year',
+				'is_paged'     => false,
+				'current_page' => 5,
+				'expected'     => [
+					[
+						'url'  => 'https://example.com/2020/',
+						'text' => 'Archive 2020',
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Sets some expectations specific for the data archive tests.
+	 *
+	 * @param string $scenario   The scenario to set.
+	 * @param bool $is_paged     When the page is paged.
+	 * @param bool $current_page The current page number.
+	 */
+	protected function setup_expectations_for_date_archive( $scenario, $is_paged, $current_page ) {
+		$this->indexable                   = Mockery::mock( Indexable_Mock::class );
+		$this->indexable->object_id        = 1;
+		$this->indexable->object_type      = 'date-archive';
+		$this->indexable->object_sub_type  = null;
+		$this->indexable->permalink        = null;
+		$this->indexable->breadcrumb_title = null;
+		$this->context                     = Mockery::mock( Meta_Tags_Context_Mock::class );
+		$this->context->indexable          = $this->indexable;
+
+		$is_day   = false;
+		$is_month = false;
+		$is_year  = false;
+
+		switch( $scenario ) {
+			case 'day' :
+				$is_day = true;
+
+				Monkey\Functions\expect( 'get_the_date' )
+					->once()
+					->withNoArgs()
+					->andReturn( 'August 11th, 2020' );
+
+				Monkey\Functions\expect( 'get_the_date' )
+					->once()
+					->with( 'Y/m/d' )
+					->andReturn( '2020/08/11' );
+				break;
+			case 'month' :
+				$is_month = true;
+
+				Monkey\Functions\expect( 'single_month_title' )
+					->once()
+					->with( ' ', false )
+					->andReturn( 'August' );
+
+				Monkey\Functions\expect( 'get_the_date' )
+					->once()
+					->with( 'Y/m' )
+					->andReturn( '2020/08' );
+
+				break;
+
+			case 'year' :
+				$is_year = true;
+
+				Monkey\Functions\expect( 'get_the_date' )
+					->once()
+					->with( 'Y' )
+					->andReturn( 2020 );
+
+				break;
+		}
+
+		Monkey\Functions\expect( 'is_day' )->andReturn( $is_day );
+		Monkey\Functions\expect( 'is_month' )->andReturn( $is_month );
+		Monkey\Functions\expect( 'is_year' )->andReturn( $is_year );
+
+		$this->current_page
+			->expects( 'is_paged' )
+			->andReturn( $is_paged );
+
+		if ( $is_paged ) {
+			$this->pagination_helper
+				->expects( 'get_current_page_number' )
+				->andReturn( $current_page );
+		}
+
+		$this->options
+			->expects( 'get' )
+			->with( 'breadcrumbs-home' )
+			->andReturn( '' );
+
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'page_for_posts' )
+			->andReturn( false );
+
+		$this->repository
+			->expects( 'get_ancestors' )
+			->once()
+			->with( $this->indexable )
+			->andReturn( [] );
+
+		$this->url_helper
+			->expects( 'home' )
+			->andReturn( 'https://example.com/' );
+
+		$this->options
+			->expects( 'get' )
+			->with( 'breadcrumbs-archiveprefix' )
+			->andReturn( 'Archive' );
+
+		$this->current_page
+			->expects( 'is_simple_page' )
+			->once()
+			->andReturnFalse();
 	}
 
 	/**

--- a/tests/unit/generators/breadcrumbs-generator-test.php
+++ b/tests/unit/generators/breadcrumbs-generator-test.php
@@ -12,7 +12,9 @@ use Mockery;
 use Yoast\WP\SEO\Generators\Breadcrumbs_Generator;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
+use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
@@ -50,7 +52,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	private $current_page;
 
 	/**
-	 * The post type helper
+	 * The post type helper.
 	 *
 	 * @var Post_Type_Helper
 	 */
@@ -78,16 +80,32 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	private $indexable;
 
 	/**
+	 * The URL helper.
+	 *
+	 * @var Url_Helper
+	 */
+	private $url_helper;
+
+	/**
+	 * The pagination helper.
+	 *
+	 * @var Pagination_Helper
+	 */
+	private $pagination_helper;
+
+	/**
 	 * @inheritDoc
 	 */
 	public function setUp() {
 		parent::setUp();
 
-		$this->repository       = Mockery::mock( Indexable_Repository::class );
-		$this->options          = Mockery::mock( Options_Helper::class );
-		$this->current_page     = Mockery::mock( Current_Page_Helper::class );
-		$this->post_type_helper = Mockery::mock( Post_Type_Helper::class );
-		$this->instance         = new Breadcrumbs_Generator( $this->repository, $this->options, $this->current_page, $this->post_type_helper );
+		$this->repository        = Mockery::mock( Indexable_Repository::class );
+		$this->options           = Mockery::mock( Options_Helper::class );
+		$this->current_page      = Mockery::mock( Current_Page_Helper::class );
+		$this->post_type_helper  = Mockery::mock( Post_Type_Helper::class );
+		$this->url_helper        = Mockery::mock( Url_Helper::class );
+		$this->pagination_helper = Mockery::mock( Pagination_Helper::class );
+		$this->instance          = new Breadcrumbs_Generator( $this->repository, $this->options, $this->current_page, $this->post_type_helper, $this->url_helper, $this->pagination_helper );
 
 		$this->indexable                   = Mockery::mock( Indexable_Mock::class );
 		$this->indexable->object_id        = 1;
@@ -105,6 +123,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	 * @covers ::__construct
 	 * @covers ::generate
 	 * @covers ::should_have_blog_crumb
+	 * @covers ::get_pagination_text
 	 *
 	 * @dataProvider generate_provider
 	 *
@@ -188,6 +207,10 @@ class Breadcrumbs_Generator_Test extends TestCase {
 			->once()
 			->andReturn( $page_type );
 
+		$this->current_page
+			->expects( 'is_paged' )
+			->once()
+			->andReturnFalse();
 
 		$expected = [
 			[

--- a/tests/unit/generators/breadcrumbs-generator-test.php
+++ b/tests/unit/generators/breadcrumbs-generator-test.php
@@ -331,7 +331,6 @@ class Breadcrumbs_Generator_Test extends TestCase {
 				->andReturnTrue();
 		}
 
-
 		if ( $scenario === 'show-custom-post-type' ) {
 			$this->indexable->object_sub_type = 'custom';
 		}

--- a/tests/unit/generators/schema/breadcrumb-test.php
+++ b/tests/unit/generators/schema/breadcrumb-test.php
@@ -231,13 +231,18 @@ class Breadcrumb_Test extends TestCase {
 
 		$this->meta_tags_context->presentation->breadcrumbs = $breadcrumb_data;
 
+		$this->current_page
+			->expects( 'is_paged' )
+			->once()
+			->andReturnFalse();
+
 		$actual = $this->instance->generate();
 
 		$this->assertEquals( false, $actual );
 	}
 
 	/**
-	 * Generate method should break on broken breadcrumbs.
+	 * Tests the generate method when the page is paginated (as detected through 'is_paged').
 	 *
 	 * @covers ::generate
 	 * @covers ::not_hidden
@@ -245,7 +250,7 @@ class Breadcrumb_Test extends TestCase {
 	 * @covers ::create_breadcrumb
 	 * @covers ::format_last_breadcrumb
 	 */
-	public function test_generate_when_page_is_paginated() {
+	public function test_generate_when_page_is_paginated_through_is_paged() {
 		$breadcrumb_data = [
 			[
 				'url'  => 'https://wordpress.example.com/',
@@ -256,12 +261,106 @@ class Breadcrumb_Test extends TestCase {
 				'text' => 'Test post',
 				'id'   => '123',
 			],
+			[
+				'text' => 'Page 2',
+			],
 		];
 
 		$this->meta_tags_context->presentation->breadcrumbs = $breadcrumb_data;
 		$this->meta_tags_context->title                     = 'Page title';
 
 		$this->current_page->expects( 'is_paged' )->andReturnTrue();
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Home' )
+			->once()
+			->andReturnArg( 0 );
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Test post' )
+			->once()
+			->andReturnArg( 0 );
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Page title' )
+			->once()
+			->andReturnArg( 0 );
+
+		$expected = [
+			'@type'           => 'BreadcrumbList',
+			'@id'             => 'https://wordpress.example.com/canonical#breadcrumb',
+			'itemListElement' => [
+				[
+					'@type'    => 'ListItem',
+					'position' => 1,
+					'item'     => [
+						'@type' => 'WebPage',
+						'@id'   => 'https://wordpress.example.com/',
+						'url'   => 'https://wordpress.example.com/',
+						'name'  => 'Home',
+					],
+				],
+				[
+					'@type'    => 'ListItem',
+					'position' => 2,
+					'item'     => [
+						'@type' => 'WebPage',
+						'@id'   => 'https://wordpress.example.com/post-title',
+						'url'   => 'https://wordpress.example.com/post-title',
+						'name'  => 'Test post',
+					],
+				],
+				[
+					'@type'    => 'ListItem',
+					'position' => 3,
+					'item'     => [
+						'@type' => 'WebPage',
+						'@id'   => 'https://wordpress.example.com/canonical',
+						'url'   => 'https://wordpress.example.com/canonical',
+						'name'  => 'Page title',
+					],
+				],
+			],
+		];
+
+		$actual = $this->instance->generate();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests the generate method when the page is paginated (as detected through 'number_of_pages').
+	 *
+	 * @covers ::generate
+	 * @covers ::not_hidden
+	 * @covers ::is_broken
+	 * @covers ::create_breadcrumb
+	 * @covers ::format_last_breadcrumb
+	 */
+	public function test_generate_when_page_is_paginated_through_number_of_pages() {
+		$breadcrumb_data = [
+			[
+				'url'  => 'https://wordpress.example.com/',
+				'text' => 'Home',
+			],
+			[
+				'url'  => 'https://wordpress.example.com/post-title',
+				'text' => 'Test post',
+				'id'   => '123',
+			],
+			[
+				'text' => 'Page 2',
+			],
+		];
+
+		$this->meta_tags_context->presentation->breadcrumbs  = $breadcrumb_data;
+		$this->meta_tags_context->title                      = 'Page title';
+		$this->meta_tags_context->indexable->number_of_pages = 3;
+
+		$this->current_page->expects( 'is_paged' )->andReturnFalse();
 
 		$this->html
 			->expects( 'smart_strip_tags' )

--- a/tests/unit/generators/schema/breadcrumb-test.php
+++ b/tests/unit/generators/schema/breadcrumb-test.php
@@ -16,6 +16,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * Class Breadcrumb_Test
  *
  * @group generators
+ * @group breadcrumbs
  * @group schema
  *
  * @coversDefaultClass \Yoast\WP\SEO\Generators\Schema\Breadcrumb

--- a/tests/unit/helpers/pagination-helper-test.php
+++ b/tests/unit/helpers/pagination-helper-test.php
@@ -48,6 +48,15 @@ class Pagination_Helper_Test extends TestCase {
 	}
 
 	/**
+	 * Tests if given dependencies are set as expected.
+	 *
+	 * @covers ::__construct()
+	 */
+	public function test_constructor() {
+		$this->assertAttributeInstanceOf( WP_Rewrite_Wrapper::class, 'wp_rewrite_wrapper', $this->instance  );
+		$this->assertAttributeInstanceOf( WP_Query_Wrapper::class, 'wp_query_wrapper', $this->instance  );
+	}
+	/**
 	 * Tests that `is_disabled` returns false by default.
 	 *
 	 * @covers ::is_rel_adjacent_disabled
@@ -191,6 +200,38 @@ class Pagination_Helper_Test extends TestCase {
 			->andReturn( $wp_query );
 
 		$this->assertEquals( 2, $this->instance->get_current_post_page_number() );
+	}
+
+	/**
+	 * Tests the retrieval of the current page number.
+	 *
+	 * @covers ::get_current_page_number
+	 */
+	public function test_get_current_page_number() {
+		Monkey\Functions\expect( 'get_query_var' )
+			->with( 'paged', 1 )
+			->andReturn( 100 );
+
+		$this->assertSame( 100, $this->instance->get_current_page_number() );
+	}
+
+	/**
+	 * Tests the retrieval of the current page number.
+	 *
+	 * @covers ::get_current_page_number
+	 */
+	public function test_get_current_page_number_fallback_to_page() {
+		Monkey\Functions\expect( 'get_query_var' )
+			->twice()
+			->andReturnUsing( function( $query_var, $default ) {
+				if ( $query_var === 'page' ) {
+					$default = 2;
+				}
+
+				return $default;
+			} );
+
+		$this->assertSame( 2, $this->instance->get_current_page_number() );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Page numbers in the breadcrumbs are useful, as they let users know where they are on the site.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the page number was not shown in the breadcrumb for paginated series.

## Relevant technical choices:

* Because date archives don't have an indexable permalink, only for this archive type we constructed the URL's from scratch. Since a "Page ..." breadcrumb was added, these URL's are now needed to turn the breadcrumb before the Page breadcrumb into a URL.
* The `is_paged` method doesn't detect pagination in the case of a paginated post. Therefore, we now also look at the `number_of_pages` in the indexables table. We do this for the last indexable in the `$indexables` array, because that is the indexable of the current page (the first indexable in that array, for example, would be the home page indexable).
* We created a helper function `get_current_page_number`. This function not only checks `\get_query_var( 'paged', 1 )` to find the pagination page number (this was already in the code before we started), but also checks `\get_query_var( 'page', 1 )`. Only the latter finds the page number on paginated posts.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Read the instructions until the end before you start testing :) You need to test multiple things on each page.
* Make sure you have breadcrumbs enabled (see the issue).
* In paginated series (for example, on the home page, term archive pages or author archive pages), check that all pages except the first one have a Page breadcrumb. See the issue for an example. All the crumbs before the Page crumb should be URLs. The Page crumb should only be text.
* Check that the first page does NOT have a Page breadcrumb.
* On all the pages where you check the breadcrumbs, also check the Schema output. There should be a Schema graph piece called `BreadcrumbList`. The last breadcrumb ("Page ...") should NOT be output in the Schema.
    * Note that the homepage doesn't have a `BreadcrumbList` Schema piece.
* Pay extra attention to a date archive page. Check whether the URLs are working correctly for year, month and day archives.
* Pay extra attention to a paginated post. Create a new post that contains at least two Page break blocks to test this, and test both on pages 2 and 3 of that post.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-2
