### PR TITLE
Make addon display titles translatable

### DIFF
--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -35,7 +35,7 @@ $extensions = [
 			'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zt' ),
 			'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zs' ),
 			'title'         => 'Local SEO',
-			'display_title' => 'Stop losing customers to other local businesses',
+			'display_title' => __( 'Stop losing customers to other local businesses', 'wordpress-seo' ),
 			'desc'          => __( 'Rank better locally and in Google Maps, without breaking a sweat!', 'wordpress-seo' ),
 			'image'         => plugins_url( 'images/local_plugin_assistant.svg?v=' . WPSEO_VERSION, WPSEO_FILE ),
 			'benefits'      => [
@@ -51,7 +51,7 @@ $extensions = [
 			'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zx/' ),
 			'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zw/' ),
 			'title'         => 'Video SEO',
-			'display_title' => 'Start ranking better for your videos',
+			'display_title' => __( 'Start ranking better for your videos', 'wordpress-seo' ),
 			'desc'          => __( 'Optimize your videos to show them off in search results and get more clicks!', 'wordpress-seo' ),
 			'image'         => plugins_url( 'images/video_plugin_assistant.svg?v=' . WPSEO_VERSION, WPSEO_FILE ),
 			'benefits'      => [
@@ -66,7 +66,7 @@ $extensions = [
 			'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zv/' ),
 			'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zu/' ),
 			'title'         => 'News SEO',
-			'display_title' => 'Everything you need for Google News',
+			'display_title' => __( 'Everything you need for Google News', 'wordpress-seo' ),
 			'desc'          => __( 'Are you in Google News? Increase your traffic from Google News by optimizing for it!', 'wordpress-seo' ),
 			'image'         => plugins_url( 'images/news_plugin_assistant.svg?v=' . WPSEO_VERSION, WPSEO_FILE ),
 			'benefits'      => [
@@ -85,7 +85,7 @@ if ( WPSEO_Utils::is_woocommerce_active() ) {
 			'buyUrl'        => WPSEO_Shortlinker::get( 'https://yoa.st/zr' ),
 			'infoUrl'       => WPSEO_Shortlinker::get( 'https://yoa.st/zq' ),
 			'title'         => 'Yoast WooCommerce SEO',
-			'display_title' => 'Make your products stand out in Google',
+			'display_title' => __( 'Make your products stand out in Google', 'wordpress-seo' ),
 			/* translators: %1$s expands to Yoast SEO */
 			'desc'          => sprintf( __( 'Seamlessly integrate WooCommerce with %1$s and get extra features!', 'wordpress-seo' ), 'Yoast SEO' ),
 			'image'         => plugins_url( 'images/woo_plugin_assistant.svg?v=' . WPSEO_VERSION, WPSEO_FILE ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Make the titles of the addon upsell cards on the Premium page translatable.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* As long as there are no translations, you'll keep seeing the English string. I visited the Premium page to double-check I didn't completely break the title.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #