### PR TITLE
Fix premium button styling in keyphrases table

### DIFF
--- a/js/src/components/modals/KeyphrasesTable.js
+++ b/js/src/components/modals/KeyphrasesTable.js
@@ -157,7 +157,7 @@ class KeyphrasesTable extends Component {
 										/>
 									</td>
 									{
-										renderAction && <td>
+										renderAction && <td className="yoast-table--nobreak">
 											{ renderAction( relatedKeyphrase, relatedKeyphrases ) }
 										</td>
 									}

--- a/js/src/components/modals/KeyphrasesTable.js
+++ b/js/src/components/modals/KeyphrasesTable.js
@@ -90,7 +90,7 @@ class KeyphrasesTable extends Component {
 
 		return (
 			data && ! isEmpty( data ) && <Fragment>
-				<table className="yoast-table">
+				<table className="yoast yoast-table">
 					<thead>
 						<tr>
 							<th
@@ -127,7 +127,7 @@ class KeyphrasesTable extends Component {
 									</span>
 								</HelpLink>
 							</th>
-							{ renderAction && <td /> }
+							{ renderAction && <td className="yoast-table--nobreak" /> }
 						</tr>
 					</thead>
 					<tbody>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Correct styling: 
<img width="620" alt="Screenshot 2020-08-10 at 14 49 07" src="https://user-images.githubusercontent.com/43582255/89790568-69493d80-db22-11ea-9a5f-fc96ea6e4136.png">


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the button styling in the KeyphrasesTable.

## Relevant technical choices:

* As discussed with Rolf, a parent `yoast` class was missing and the `td` containing the buttons needed the `yoast-table--nobreak` class.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

**Testing on Free:**
- Switch to this branch and build
- Edit a post, add a keyphrase and open the SEMrush modal
- Check there are no errors
- Check the column with the buttons is _not_ displayed

**Testing on Premium**
* on Premium, make a new branch, branching out from `feature/semrush` and switch to that branch
* Add the Free repo as additional remote on the Premium repo, if you didn't add it already
* Run `git fetch --all` and `git pull free P3-106-fix-premium-button-styling`
* Build in the premium directory and in the root

_In the backend_
* Edit a post, add a keyphrase and open the SEMrush modal
* See the correct styling of the buttons (ah shown in the screenshot above)
* Clear your dev tools console, as currently there are many unrelated warnings and errors
* Click one of the buttons in the Related keyphrases table
* Check there are no errors in the console
* Check the Related keyphrase has been added in the Sidebar
* Remove the Related keyphrase you just added by clicking the associated "Remove" button
* Check there are no errors in the console
* Check the Related keyphrase has been removed from the Sidebar
* Add up to 4 Related keyphrases
* Check the other buttons get disabled and there are no errors


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-106]
