### PR TITLE
P3 84 update notifications

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -174,15 +174,24 @@ class WPSEO_Admin_Init {
 	private function get_yoast_seo_update_notification( $release_info ) {
 		$info_message = '<strong>' .
 				sprintf(
-				/* translators: %1$s expands to Yoast SEO, %2$s expands to the plugin version, */
+				/* translators: %1$s expands to Yoast SEO, %2$s expands to the plugin version. */
 					__( 'New in %1$s %2$s: ', 'wordpress-seo' ),
 					'Yoast SEO',
 					$release_info->version
 				) .
 				'</strong>' .
 				$release_info->release_description;
+		if ( ! empty( $release_info->shortlink ) ) {
+			$link = esc_url( WPSEO_Shortlinker::get( $release_info->shortlink ) );
+			$info_message .= ' <a href="' . esc_url( $link ) . '" target="_blank">' .
+							 sprintf(
+							 	/* translators: %s expands to the plugin version. */
+							 	__( 'Read all about version %s here', 'wordpress-seo' ),
+								$release_info->version
+							 ) .
+							 '</a>';
+		}
 		$data         = (object) [ 'dismiss_value' => $release_info->version ];
-
 
 		return new Yoast_Notification(
 			$info_message,

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -139,8 +139,14 @@ class WPSEO_Admin_Init {
 	public function yoast_plugin_update_notification() {
 		$notification_center   = Yoast_Notification_Center::get();
 		$current_minor_version = $this->get_major_minor_version( WPSEO_Options::get( 'version', WPSEO_VERSION ) );
-
 		$file = plugin_dir_path( WPSEO_FILE ) . 'release-info.json';
+
+		// Remove if file is not present.
+		if ( ! file_exists( $file ) ) {
+			$notification_center->remove_notification_by_id( 'wpseo-plugin-updated' );
+			return;
+		}
+
 		$release_json = file_get_contents( $file );
 		/**
 		 * Filter: 'wpseo_update_notice_content' - Allow filtering of the content
@@ -150,7 +156,7 @@ class WPSEO_Admin_Init {
 		 */
 		$release_info = apply_filters( 'wpseo_update_notice_content', json_decode( $release_json ) );
 
-		// Remove if file is not present, malformed or for a different version.
+		// Remove if file is malformed or for a different version.
 		if ( is_null( $release_info )
 			|| empty( $release_info->version )
 			|| version_compare( $this->get_major_minor_version( $release_info->version ), $current_minor_version, '!=' )

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -141,7 +141,13 @@ class WPSEO_Admin_Init {
 
 		$file = plugin_dir_path( WPSEO_FILE ) . 'release-info.json';
 		$release_json = file_get_contents( $file );
-		$release_info = json_decode( $release_json );
+		/**
+		 * Filter: 'wpseo_update_notice_content' - Allow filtering of the content
+		 * of the update notice read from the release-info.json file.
+		 *
+		 * @api object The object from the release-info.json file.
+		 */
+		$release_info = apply_filters( 'wpseo_update_notice_content', json_decode( $release_json ) );
 
 		// Remove if file is not present, malformed or for a different version.
 		if ( is_null( $release_info )

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -137,8 +137,8 @@ class WPSEO_Admin_Init {
 	 * @return void
 	 */
 	public function yoast_plugin_update_notification() {
-		$notification_center = Yoast_Notification_Center::get();
-		$current_version     = WPSEO_Options::get( 'version', WPSEO_VERSION );
+		$notification_center   = Yoast_Notification_Center::get();
+		$current_minor_version = $this->get_major_minor_version( WPSEO_Options::get( 'version', WPSEO_VERSION ) );
 
 		$file = plugin_dir_path( WPSEO_FILE ) . 'release-info.json';
 		$release_json = file_get_contents( $file );
@@ -153,21 +153,34 @@ class WPSEO_Admin_Init {
 		// Remove if file is not present, malformed or for a different version.
 		if ( is_null( $release_info )
 			|| empty( $release_info->version )
-			|| (float) $release_info->version !== (float) $current_version
+			|| version_compare( $this->get_major_minor_version( $release_info->version ), $current_minor_version, '!=' )
 		 	|| empty( $release_info->release_description )
 		) {
 			$notification_center->remove_notification_by_id( 'wpseo-plugin-updated' );
 			return;
 		}
 
-		$notification  = $this->get_yoast_seo_update_notification( $release_info );
+		$notification = $this->get_yoast_seo_update_notification( $release_info );
 
 		// Restore notification if it was dismissed in a previous minor version.
 		$last_dismissed_version = get_user_option( $notification->get_dismissal_key() );
-		if ( ! $last_dismissed_version || (float) $last_dismissed_version < (float) $current_version ) {
+		if ( ! $last_dismissed_version
+			 || version_compare( $this->get_major_minor_version( $last_dismissed_version ), $current_minor_version, '<' )
+		) {
 			Yoast_Notification_Center::restore_notification( $notification );
 		}
 		$notification_center->add_notification( $notification );
+	}
+
+	/**
+	 * Helper to truncate the version string up to the minor number
+	 *
+	 * @param string $version The version string to extract the major.minor number from.
+	 * @return string The version string up to the minor number.
+	 */
+	private function get_major_minor_version( $version ) {
+		$version_parts = preg_split( '/[^0-9]+/', $version, 3 );
+		return join( '.', array_slice( $version_parts, 0, 2 ) );
 	}
 
 	/**

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -198,7 +198,7 @@ class WPSEO_Admin_Init {
 							 ) .
 							 '</a>';
 		}
-		$data         = (object) [ 'dismiss_value' => $release_info->version ];
+		$data         = (object) [ 'dismiss_value' => WPSEO_Options::get( 'version', WPSEO_VERSION ) ];
 
 		return new Yoast_Notification(
 			$info_message,

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -161,10 +161,9 @@ class WPSEO_Admin_Init {
 		}
 
 		$notification  = $this->get_yoast_seo_update_notification( $release_info );
-		$dismissal_key = $notification->get_dismissal_key();
 
 		// Restore notification if it was dismissed in a previous minor version.
-		$last_dismissed_version = get_user_option( $dismissal_key );
+		$last_dismissed_version = get_user_option( $notification->get_dismissal_key() );
 		if ( ! $last_dismissed_version || (float) $last_dismissed_version < (float) $current_version ) {
 			Yoast_Notification_Center::restore_notification( $notification );
 		}
@@ -172,7 +171,7 @@ class WPSEO_Admin_Init {
 	}
 
 	/**
-	 * Build Yoast SEO update notification.
+	 * Builds Yoast SEO update notification.
 	 *
 	 * @param object $release_info The release information.
 	 *
@@ -188,6 +187,7 @@ class WPSEO_Admin_Init {
 				) .
 				'</strong>' .
 				$release_info->release_description;
+
 		if ( ! empty( $release_info->shortlink ) ) {
 			$link = esc_url( WPSEO_Shortlinker::get( $release_info->shortlink ) );
 			$info_message .= ' <a href="' . esc_url( $link ) . '" target="_blank">' .
@@ -198,14 +198,13 @@ class WPSEO_Admin_Init {
 							 ) .
 							 '</a>';
 		}
-		$data         = (object) [ 'dismiss_value' => WPSEO_Options::get( 'version', WPSEO_VERSION ) ];
 
 		return new Yoast_Notification(
 			$info_message,
 			[
 				'id'            => 'wpseo-plugin-updated',
 				'type'          => Yoast_Notification::UPDATED,
-				'data_json'     => $data,
+				'data_json'     => [ 'dismiss_value' => WPSEO_Options::get( 'version', WPSEO_VERSION ) ],
 				'dismissal_key' => 'wpseo-plugin-updated',
 			]
 		);

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -132,25 +132,26 @@ class WPSEO_Admin_Init {
 	}
 
 	/**
-	 * Determines whether a suggested plugins notification needs to be displayed.
+	 * Determines whether a update notification needs to be displayed.
 	 *
 	 * @return void
 	 */
 	public function yoast_plugin_update_notification() {
 		$notification_center = Yoast_Notification_Center::get();
-		$notification     = $this->get_yoast_seo_update_notification();
+		$notification        = $this->get_yoast_seo_update_notification();
+		$dismissal_key 	     = $notification->get_dismissal_key();
 
+		$last_dismissed_version = get_user_option( $dismissal_key );
+		if ( ! $last_dismissed_version || (float) $last_dismissed_version < (float) WPSEO_VERSION ) {
+			Yoast_Notification_Center::restore_notification( $notification );
+		}
 		$notification_center->add_notification( $notification );
 	}
 
 	/**
-	 * Build Yoast SEO suggested plugins notification.
+	 * Build Yoast SEO update notification.
 	 *
-	 * @param string $name            The plugin name to use for the unique ID.
-	 * @param array  $plugin          The plugin to retrieve the data from.
-	 * @param string $dependency_name The name of the dependency.
-	 *
-	 * @return Yoast_Notification The notification containing the suggested plugin.
+	 * @return Yoast_Notification The notification for the present version
 	 */
 	private function get_yoast_seo_update_notification() {
 		$file = plugin_dir_path( WPSEO_FILE ) . 'release-info.json';
@@ -165,7 +166,7 @@ class WPSEO_Admin_Init {
 						) .
 						'</strong>' .
 						$release_info->release_description;
-		$data = (object)[ 'version' => $release_info->version ];
+		$data = (object) [ 'dismiss_value' => $release_info->version ];
 
 		return new Yoast_Notification(
 			$info_message,
@@ -173,7 +174,7 @@ class WPSEO_Admin_Init {
 				'id'            => 'wpseo-plugin-updated',
 				'type'          => Yoast_Notification::UPDATED,
 				'data_json'		=> $data,
-				'dismissal_key' => 'wpseo-plugin-updated-' . $release_info->version,
+				'dismissal_key' => 'wpseo-plugin-updated',
 			]
 		);
 	}

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -138,42 +138,62 @@ class WPSEO_Admin_Init {
 	 */
 	public function yoast_plugin_update_notification() {
 		$notification_center = Yoast_Notification_Center::get();
-		$notification        = $this->get_yoast_seo_update_notification();
-		$dismissal_key 	     = $notification->get_dismissal_key();
 
-		$last_dismissed_version = get_user_option( $dismissal_key );
-		if ( ! $last_dismissed_version || (float) $last_dismissed_version < (float) WPSEO_VERSION ) {
-			Yoast_Notification_Center::restore_notification( $notification );
+		$file = plugin_dir_path( WPSEO_FILE ) . 'release-info.json';
+		$release_json = file_get_contents( $file );
+		$release_info = json_decode( $release_json );
+
+		if ( is_null( $release_info ) ) {
+			return;
 		}
-		$notification_center->add_notification( $notification );
+
+		if (
+			! empty( $release_info->version )
+			&& (float) $release_info->version === (float) WPSEO_VERSION
+		 	&& ! empty( $release_info->release_description )
+		) {
+			$notification  = $this->get_yoast_seo_update_notification( $release_info );
+			$dismissal_key = $notification->get_dismissal_key();
+
+			$last_dismissed_version = get_user_option( $dismissal_key );
+			if ( ! $last_dismissed_version || (float) $last_dismissed_version < (float) WPSEO_VERSION ) {
+				Yoast_Notification_Center::restore_notification( $notification );
+			}
+			$notification_center->add_notification( $notification );
+			return;
+		}
+
 	}
 
 	/**
 	 * Build Yoast SEO update notification.
 	 *
+	 * @param object $release_info The release info object.
+	 *
 	 * @return Yoast_Notification The notification for the present version
 	 */
-	private function get_yoast_seo_update_notification() {
-		$file = plugin_dir_path( WPSEO_FILE ) . 'release-info.json';
-		$release_info = json_decode( file_get_contents( $file ) );
+	private function get_yoast_seo_update_notification( $release_info ) {
+		$version     = $release_info->version;
+		$description = $release_info->release_description;
+		$link		 = isset( $release_info->shortlink ) ? $release_info->shortlink : null;
 
 		$info_message = '<strong>' .
 						sprintf(
-							/* translators: %1$s expands to Yoast SEO, %2$s expands to the plugin version, */
+						/* translators: %1$s expands to Yoast SEO, %2$s expands to the plugin version, */
 							__( 'New in %1$s %2$s: ', 'wordpress-seo' ),
 							'Yoast SEO',
-							$release_info->version
+							$version
 						) .
 						'</strong>' .
-						$release_info->release_description;
-		$data = (object) [ 'dismiss_value' => $release_info->version ];
+						$description;
+		$data         = (object) [ 'dismiss_value' => $version ];
 
 		return new Yoast_Notification(
 			$info_message,
 			[
 				'id'            => 'wpseo-plugin-updated',
 				'type'          => Yoast_Notification::UPDATED,
-				'data_json'		=> $data,
+				'data_json'     => $data,
 				'dismissal_key' => 'wpseo-plugin-updated',
 			]
 		);

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -138,6 +138,7 @@ class WPSEO_Admin_Init {
 	 */
 	public function yoast_plugin_update_notification() {
 		$notification_center = Yoast_Notification_Center::get();
+		$current_version     = WPSEO_Options::get( 'version', WPSEO_VERSION );
 
 		$file = plugin_dir_path( WPSEO_FILE ) . 'release-info.json';
 		$release_json = file_get_contents( $file );
@@ -152,7 +153,7 @@ class WPSEO_Admin_Init {
 		// Remove if file is not present, malformed or for a different version.
 		if ( is_null( $release_info )
 			|| empty( $release_info->version )
-			|| (float) $release_info->version !== (float) WPSEO_VERSION
+			|| (float) $release_info->version !== (float) $current_version
 		 	|| empty( $release_info->release_description )
 		) {
 			$notification_center->remove_notification_by_id( 'wpseo-plugin-updated' );
@@ -164,7 +165,7 @@ class WPSEO_Admin_Init {
 
 		// Restore notification if it was dismissed in a previous minor version.
 		$last_dismissed_version = get_user_option( $dismissal_key );
-		if ( ! $last_dismissed_version || (float) $last_dismissed_version < (float) WPSEO_VERSION ) {
+		if ( ! $last_dismissed_version || (float) $last_dismissed_version < (float) $current_version ) {
 			Yoast_Notification_Center::restore_notification( $notification );
 		}
 		$notification_center->add_notification( $notification );

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -164,8 +164,9 @@ class Yoast_Notification_Center {
 			return true;
 		}
 
-		$dismissal_key   = $notification->get_dismissal_key();
-		$notification_id = $notification->get_id();
+		$dismissal_key      = $notification->get_dismissal_key();
+		$notification_id    = $notification->get_id();
+		$notification_json  = $notification->get_json();
 
 		$is_dismissing = ( $dismissal_key === self::get_user_input( 'notification' ) );
 		if ( ! $is_dismissing ) {
@@ -184,6 +185,13 @@ class Yoast_Notification_Center {
 		$user_nonce = self::get_user_input( 'nonce' );
 		if ( wp_verify_nonce( $user_nonce, $notification_id ) === false ) {
 			return false;
+		}
+
+		if ( ! empty( $notification_json ) ) {
+			$notification_data = json_decode( $notification_json );
+			if ( ! is_null( $notification_data ) && isset( $notification_data->dismiss_value ) ) {
+				$meta_value = $notification_data->dismiss_value;
+			}
 		}
 
 		return self::dismiss_notification( $notification, $meta_value );

--- a/release-info.json
+++ b/release-info.json
@@ -1,5 +1,5 @@
 {
-  "version": "14.7",
+  "version": "14.8",
   "release_description": "This is <b>the description</b>.",
   "shortlink": "yoa.st/test"
 }

--- a/release-info.json
+++ b/release-info.json
@@ -1,0 +1,5 @@
+{
+  "version": "14.7",
+  "release_description": "This is <b>the description</b>.",
+  "shortlink": "yoa.st/test"
+}


### PR DESCRIPTION
## Context

<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to show notifications in WordPress after a user has manually or automatically updated Yoast SEO (Premium) or one of the add-ons. This should happen for all users, and not just the ones that have automatic updates enabled. The reason for that is that not all of our users are subscribed to our newsletter or follow us on social media. This way they can still find some more detailed information on the version they’ve just upgraded to.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an update notification for major and minor releases.

## Relevant technical choices:

* The last version in which the user has dismissed the notification is stored in the usual user option. Normally this is set to `seen` in the database, but the functions have a parameter for that which was unused. The Notification Center class has been modified to get the value from the `data-json` object, which is an option set when the Notification object is created. This is not restricted to the described usage (the update notification) but could be used in the future for other purposes.
* On `admin_init` the `release-info.json` file is read, if present, and decoded to a JSON object. The new filter `wpseo_update_notice_content` is added to allow editing of the object: it is meant to be used in Premium to substitute (or add?) the content with the one from `/premium/release-info.json`.
* The notification is removed:
  * if there is no file
  * if it's malformed (can't be decoded to an object)
  * if `version` or `release_description` in the file are missing
  * if `version` from the file doesn't match the plugin version, up to the minor number.
* A dismissed notification is restored if the version when it was dismissed is lower, up the minor version number (ignoring the patch number), than the current plugin version.
* The notification 
* Even though the `release_description` comes from the JSON file so it's not actually translatable, the text for the opening ("New in Yoast SEO 14.8") and the link ("Read all about version 14.8 here") has been already made translatable.


## Test instructions

<!--
Please follow these guidelines when creating test instructions:

- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
  -->
  This PR can be tested by following these steps:

### Preparation

* checkout the branch and perform the usual build steps
* make sure you have at least two different users with different roles who can access the Yoast SEO Dashboard (e.g. an Admin and a SEO Manager) and thus display the notifications. Take note of their IDs to make it easier to inspect the database
* make sure you have MySQL Workbench, or Adminer, or any other mean to inspect your database
* make sure you have the Yoast Test Helper plugin installed and active

### Tests

#### Test that the notification is visible and is working.

* Open the WordPress Dashboard and observe that the Yoast menu in the toolbar shows a new notification
* Visit SEO → General, and observe the update notification matching the design
  ![New release notification](https://user-images.githubusercontent.com/15989132/89799286-8fc0a600-db2d-11ea-9838-cfa70cdd3ec7.jpg)
* Dismiss the notification with the button on the right of it
* Navigate the backend to see that the notification counter shows the right number of undismissed notifications
* Visit SEO → General, and observe the update notification is still dismissed.
* With your MySQL inspection tool, check the `wp_usermeta` table to see that for the current user there is an option called `wp_wpseo-plugin-updated` with value set to the current plugin version (it should be `14.8-RC1`, unless the branch has been rebased to later commits of `trunk`)
* switch to the other user, and see that the notification is visibile and not dismissed. 
* With your MySQL inspection tool, check the `wp_usermeta` table to see that for the current user there is no option called `wp_wpseo-plugin-updated`

#### Test that the dismissed notification is restored on upgrade

* Make sure the notification is present but dismissed.
* With your MySQL inspection tool, in the `wp_usermeta` table change the `wp_wpseo-plugin-updated` option to an earlier version number (e.g. `14.7.3`).
* Visit the Dashboard and observe that the Yoast menu in the toolbar shows a new notification is present
* Visit SEO → General, and observe the update notification is not dismissed anymore.
* Dismiss the notification.
* Visit Tools → Yoast Test and take not of the current version. Do not move away from this page.
* Change `version` in `release-info.json` to a later minor version (e.g. `14.9`)
* Back in Yoast Test, set the same version number in Yoast SEO DB Version and save.
* Observe that the Yoast menu in the toolbar shows a new notification is present
* Visit SEO → General, and observe that the update notification shows the new version and is not dismissed.
* Visit Tools → Yoast Test again to reset the plugin version in the DB to the right one (should happen automatically on visit), and change back the `version` in `release-info.json` to the original one.

#### Test that the notification is removed on certain cases

* Make sure the notification is present (whether dismissed or not).
* Change `version` in `release-info.json` to a different minor or major version, which is not matching the current plugin version.
* Visit SEO → General, and observe the update notification is not present anymore.
* With your MySQL inspection tool, check the `wp_usermeta` table to see that for the current user there is not option called `wp_wpseo-plugin-updated` anymore.
* Change back the `version` in `release-info.json` to the original one.
* Visit SEO → General, and observe the update notification is present and not dismissed
* Dismiss the notification
* Edit `release-info.json` to remove the `version`, or the `release_description`, or introduce an error like removing a comma or a quote.
* Visit SEO → General, and observe the update notification is not present anymore.
* With your MySQL inspection tool, check the `wp_usermeta` table to see that for the current user there is no option called `wp_wpseo-plugin-updated` anymore.
* restore `release-info.json` to the original form
* Visit SEO → General, and observe the update notification is present and not dismissed
* Dismiss the notification
* delete `release-info.json` or move it away from the directory
* Visit SEO → General, and observe the update notification is not present anymore.
* With your MySQL inspection tool, check the `wp_usermeta` table to see that for the current user there is no option called `wp_wpseo-plugin-updated` anymore.


## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-84]