### PR TITLE
P1-121 Add safety check to the tool file editor

### DIFF
--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -11,8 +11,13 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-$yform          = Yoast_Form::get_instance();
-$home_path 		= is_writable( get_home_path() ) ? get_home_path() : $_SERVER['DOCUMENT_ROOT'] . '/';
+$yform     = Yoast_Form::get_instance();
+$home_path = get_home_path();
+
+if ( ! is_writable( $home_path ) && ! empty( $_SERVER['DOCUMENT_ROOT'] ) ) {
+	$home_path = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR;
+}
+
 $robots_file    = $home_path . 'robots.txt';
 $ht_access_file = $home_path . '.htaccess';
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Follow-up on community patch https://github.com/Yoast/wordpress-seo/pull/15697 I reviewed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where `DOCUMENT_ROOT` could be used even when empty.
* Fixes a bug where `DIRECTORY_SEPARATOR` would not be used when it should.

## Relevant technical choices:

* The PHP global `DOCUMENT_ROOT` can be empty. This is now checked.
* The `/` can be `\` on Windows, using the constant.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the SEO -> Tools -> File editor page.
* Verify you can view/edit robots.txt and .htaccess (if on apache) as usual.
* To fake the `is_writable` check to return false, edit the code to:
  * `if ( ! false && ! empty( $_SERVER['DOCUMENT_ROOT'] ) ) {` -- this will make it use the `DOCUMENT_ROOT`.
  * Verify viewing/editing again.
* To fake the `DOCUMENT_ROOT` being empty too, edit the code to:
  * `if ( ! false && ! true ) {` -- this will make it not switch to the `DOCUMENT_ROOT` after all.
  * It should use the `get_home_path` version still. Since we are on an environment that that works for, you can still view and edit. This is a non-fixable situation for environments that don't have a writable `get_home_path` nor a set `DOCUMENT_ROOT`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-121
