### PR TITLE
Added validation for the keyphrase input

### DIFF
--- a/js/src/components/contentAnalysis/KeywordInput.js
+++ b/js/src/components/contentAnalysis/KeywordInput.js
@@ -28,6 +28,17 @@ const KeywordInputContainer = styled.div`
  */
 class KeywordInput extends Component {
 	/**
+	 * The constructor.
+	 *
+	 * @param {Object} props The props to use in the component.
+	 */
+	constructor( props ) {
+		super( props );
+
+		this.validate = this.validate.bind( this );
+	}
+
+	/**
 	 * Renders a help link.
 	 *
 	 * @returns {wp.Element} The help link component.
@@ -46,21 +57,32 @@ class KeywordInput extends Component {
 	}
 
 	/**
+	 * Validates the keyword input.
+	 *
+	 * @returns {array} The detected errors.
+	 */
+	validate() {
+		const errors = [];
+
+		if ( this.props.keyword.length === 0 && this.props.displayNoKeyphraseMessage ) {
+			errors.push( __( "Please enter a focus keyphrase first to get related keyphrases", "wordpress-seo" ) );
+		}
+
+		return errors;
+	}
+
+	/**
 	 * Renders the component.
 	 *
 	 * @returns {wp.Element} The component.
 	 */
 	render() {
+		const errors = this.validate();
+
 		return <LocationConsumer>
 			{ context => (
 				<Fragment>
 					<KeywordInputContainer>
-						{
-							this.props.displayNoKeyphraseMessage &&
-							<p role="alert">
-								{ __( "Please enter a focus keyphrase first to get related keyphrases", "wordpress-seo" ) }
-							</p>
-						}
 						<KeywordInputComponent
 							id={ `focus-keyword-input-${ context }` }
 							onChange={ this.props.onFocusKeywordChange }
@@ -69,7 +91,8 @@ class KeywordInput extends Component {
 							helpLink={ KeywordInput.renderHelpLink() }
 							onBlurKeyword={ this.props.onBlurKeyword }
 							onFocusKeyword={ this.props.onFocusKeyword }
-							hasError={ this.props.displayNoKeyphraseMessage }
+							hasError={ errors.length > 0 }
+							errorMessages={ errors }
 						/>
 						{
 							this.props.keyword.length > 191 &&


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds centralized keyphrase validation to the `KeywordInput` component which utilizes the unordered list introduced in P3-90.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds centralized keyphrase validation to the `KeywordInput` component.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check out this PR, make sure you have the `feature/semrush` branch checked out for the Javascript monorepo and have it linked.
* Make sure you've run `composer install`, `yarn` and `grunt build`.
* Edit a post or create a new one
* Hit the 'Get related keyphrases' button without filling in a keyphrase. Note the error pops up above the input field. No modal pops up.
* Start typing a keyphrase and note that the error disappears.
* Hit the 'Get related keyphrases' button again. Note that the modal pops up.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
