### PR TITLE
Show Country Selector with request failed message

### DIFF
--- a/js/src/components/RelatedKeyphrasesModalContent.js
+++ b/js/src/components/RelatedKeyphrasesModalContent.js
@@ -57,19 +57,6 @@ function getUserMessage( props ) {
 }
 
 /**
- * Determines whether the request limit is reached or the request has failed.
- *
- * @param {Object} props The props to use.
- *
- * @returns {boolean} Whether the request limit is reached or the request has failed.
- */
-function isLimitReachedOrRequestFailed( props ) {
-	const { requestLimitReached, isSuccess, response } = props;
-
-	return requestLimitReached || ! isSuccess && hasError( response );
-}
-
-/**
  * Renders the SEMrush related keyphrases modal content.
  *
  * @param {Object} props The props to use within the content.
@@ -84,6 +71,7 @@ export default function RelatedKeyphraseModalContent( props ) {
 		setCountry,
 		renderAction,
 		countryCode,
+		requestLimitReached,
 		setRequestFailed,
 		setNoResultsFound,
 		relatedKeyphrases,
@@ -93,7 +81,7 @@ export default function RelatedKeyphraseModalContent( props ) {
 
 	return (
 		<Fragment>
-			{ ! isLimitReachedOrRequestFailed( props ) && (
+			{ ! requestLimitReached && (
 				<Fragment>
 					<SemRushUpsellAlert />
 					<SEMrushCountrySelector
@@ -126,6 +114,7 @@ RelatedKeyphraseModalContent.propTypes = {
 	keyphrase: PropTypes.string,
 	relatedKeyphrases: PropTypes.array,
 	renderAction: PropTypes.func,
+	requestLimitReached: PropTypes.bool,
 	countryCode: PropTypes.string.isRequired,
 	setCountry: PropTypes.func.isRequired,
 	newRequest: PropTypes.func.isRequired,
@@ -140,5 +129,6 @@ RelatedKeyphraseModalContent.defaultProps = {
 	keyphrase: "",
 	relatedKeyphrases: [],
 	renderAction: null,
+	requestLimitReached: false,
 	response: {},
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
After decision from product, the request-failed design was updated (from - to)
<img width="400" alt="request-failed-old" src="https://user-images.githubusercontent.com/43582255/89881936-6acc4180-dbc6-11ea-9b4a-1b63bc6785aa.png"> <img width="400" alt="request-failed" src="https://user-images.githubusercontent.com/43582255/89881873-58520800-dbc6-11ea-8e38-4b2db9fc2298.png">

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates request-failed content.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Ensure you have a valid SEMrush token present in your database before testing (see https://github.com/Yoast/wordpress-seo/pull/15607 for more information on how to do this).
* Ensure you've run `composer install`, `yarn` and `grunt build`.
* Navigate to a new or pre-existing post in the admin.
* Add a keyphrase (suggestion: `yoast`) and click the 'Get related keyphrases' button.
* See that the modal pops up and contains the upsell message, country selector with button and debug information.
* Select a country code, hit the 'Change Country' button.
* See that the keyphrases table appears with information regarding the keyphrase.
* Change the country to Hungary and click 'Change Country'. See that a 'no results found' message is displayed.
* In `js/src/components/RelatedKeyphrasesModalContent.js` replace `! isSuccess && hasError( response )` with `true` and run `grunt build:dev`
<img width="300" alt="Screenshot 2020-08-11 at 11 37 14" src="https://user-images.githubusercontent.com/43582255/89882365-03fb5800-dbc7-11ea-9ff8-9be25acf972e.png">

* Reload the post edit page, open the SEMrush modal and see the design matches the one as shown in the screenshot above.
* Switch an additional 8 - 9 times between the various countries and confirm every time until you hit your daily limit (10) of API calls.
* See that a message regarding the limit being reached is displayed as shown below.
<img width="400" alt="limit-reached" src="https://user-images.githubusercontent.com/43582255/89882583-50469800-dbc7-11ea-9f41-9db459d3a369.png">

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
