### PR TITLE
P1-123 Add schema type validation

### DIFF
--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -202,7 +202,7 @@ class Schema_Generator implements Generator_Interface {
 		if ( ! \is_array( $piece['@type'] ) ) {
 			return $piece;
 		}
-		
+
 		/*
 		 * Ensure the types are unique.
 		 * Use array_values to reset the indices (e.g. no 0, 2 because 1 was a duplicate).
@@ -213,7 +213,7 @@ class Schema_Generator implements Generator_Interface {
 		if ( \count( $piece['@type'] ) === 1 ) {
 			$piece['@type'] = \reset( $piece['@type'] );
 		}
-		
+
 		return $piece;
 	}
 

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -105,6 +105,7 @@ class Schema_Generator implements Generator_Interface {
 				 */
 				$graph_piece = \apply_filters( 'wpseo_schema_' . $identifier, $graph_piece, $context );
 				$graph_piece = $this->type_filter( $graph_piece, $identifier, $context );
+				$graph_piece = $this->validate_type( $graph_piece );
 
 				if ( \is_array( $graph_piece ) ) {
 					$graph[] = $graph_piece;
@@ -178,6 +179,39 @@ class Schema_Generator implements Generator_Interface {
 			return [ $piece['@type'] ];
 		}
 		return [];
+	}
+
+	/**
+	 * Validates a graph piece's type.
+	 *
+	 * When the type is an array:
+	 *   - Ensure the values are unique.
+	 *   - Only 1 value? Use that value without the array wrapping.
+	 *
+	 * @param array $piece The graph piece.
+	 *
+	 * @return array The graph piece.
+	 */
+	private function validate_type( $piece ) {
+		if ( ! isset( $piece['@type'] ) ) {
+			// No type to validate.
+			return $piece;
+		}
+
+		if ( \is_array( $piece['@type'] ) ) {
+			/*
+			 * Ensure the types are unique.
+			 * Use array_values to reset the indices (e.g. no 0, 2 because 1 was a duplicate).
+			 */
+			$piece['@type'] = \array_values( \array_unique( $piece['@type'] ) );
+
+			// Use the first value if there is only 1 type.
+			if ( \count( $piece['@type'] ) === 1 ) {
+				$piece['@type'] = \reset( $piece['@type'] );
+			}
+		}
+
+		return $piece;
 	}
 
 	/**

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -198,19 +198,22 @@ class Schema_Generator implements Generator_Interface {
 			return $piece;
 		}
 
-		if ( \is_array( $piece['@type'] ) ) {
-			/*
-			 * Ensure the types are unique.
-			 * Use array_values to reset the indices (e.g. no 0, 2 because 1 was a duplicate).
-			 */
-			$piece['@type'] = \array_values( \array_unique( $piece['@type'] ) );
-
-			// Use the first value if there is only 1 type.
-			if ( \count( $piece['@type'] ) === 1 ) {
-				$piece['@type'] = \reset( $piece['@type'] );
-			}
+		// If it is not an array, we can return immediately.
+		if ( ! \is_array( $piece['@type'] ) ) {
+			return $piece;
 		}
+		
+		/*
+		 * Ensure the types are unique.
+		 * Use array_values to reset the indices (e.g. no 0, 2 because 1 was a duplicate).
+		 */
+		$piece['@type'] = \array_values( \array_unique( $piece['@type'] ) );
 
+		// Use the first value if there is only 1 type.
+		if ( \count( $piece['@type'] ) === 1 ) {
+			$piece['@type'] = \reset( $piece['@type'] );
+		}
+		
 		return $piece;
 	}
 

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -364,6 +364,122 @@ class Schema_Generator_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that a type array with 1 entry gets put without the array.
+	 *
+	 * @covers ::__construct
+	 * @covers ::generate
+	 * @covers ::get_graph_pieces
+	 * @covers ::validate_type
+	 */
+	public function test_validate_type_singular_array() {
+		$this->context->blocks = [];
+
+		$this->current_page
+			->expects( 'is_home_static_page' )
+			->twice()
+			->andReturnTrue();
+
+		$this->current_page
+			->expects( 'is_front_page' )
+			->andReturnTrue();
+
+		Monkey\Filters\expectApplied( 'wpseo_schema_website' )
+			->once()
+			->andReturn( [
+				'@type'           => [ 'WebSite' ] ,
+				'@id'             => '#website',
+				'url'             => null,
+				'name'            => '',
+				'description'     => 'description',
+				'potentialAction' => [
+					[
+						'@type'       => 'SearchAction',
+						'target'      => '?s={search_term_string}',
+						'query-input' => 'required name=search_term_string',
+					],
+				],
+				'inLanguage'      => 'English',
+			] );
+
+		$this->assertEquals(
+			[
+				'@type'           => 'WebSite',
+				'@id'             => '#website',
+				'url'             => null,
+				'name'            => '',
+				'description'     => 'description',
+				'potentialAction' => [
+					[
+						'@type'       => 'SearchAction',
+						'target'      => '?s={search_term_string}',
+						'query-input' => 'required name=search_term_string',
+					],
+				],
+				'inLanguage'      => 'English',
+			],
+			$this->instance->generate( $this->context )['@graph'][0]
+		);
+	}
+
+	/**
+	 * Tests that a type array duplicates get squashed.
+	 *
+	 * @covers ::__construct
+	 * @covers ::generate
+	 * @covers ::get_graph_pieces
+	 * @covers ::validate_type
+	 */
+	public function test_validate_type_unique_array() {
+		$this->context->blocks = [];
+
+		$this->current_page
+			->expects( 'is_home_static_page' )
+			->twice()
+			->andReturnTrue();
+
+		$this->current_page
+			->expects( 'is_front_page' )
+			->andReturnTrue();
+
+		Monkey\Filters\expectApplied( 'wpseo_schema_website' )
+			->once()
+			->andReturn( [
+				'@type'           => [ 'WebSite', 'WebSite', 'Something', 'Something', 'Something' ] ,
+				'@id'             => '#website',
+				'url'             => null,
+				'name'            => '',
+				'description'     => 'description',
+				'potentialAction' => [
+					[
+						'@type'       => 'SearchAction',
+						'target'      => '?s={search_term_string}',
+						'query-input' => 'required name=search_term_string',
+					],
+				],
+				'inLanguage'      => 'English',
+			] );
+
+		$this->assertEquals(
+			[
+				'@type'           => [ 'WebSite', 'Something' ],
+				'@id'             => '#website',
+				'url'             => null,
+				'name'            => '',
+				'description'     => 'description',
+				'potentialAction' => [
+					[
+						'@type'       => 'SearchAction',
+						'target'      => '?s={search_term_string}',
+						'query-input' => 'required name=search_term_string',
+					],
+				],
+				'inLanguage'      => 'English',
+			],
+			$this->instance->generate( $this->context )['@graph'][0]
+		);
+	}
+
+	/**
 	 * The generated schema that is applicable for almost every test scenario in this file.
 	 *
 	 * @return array The schema.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In https://yoast.atlassian.net/browse/P1-110 I noticed adding the same page type to what is added already added in SEO Woo would result into duplicate output. Instead of fixing that in the filter everywhere this adds a check after the filter.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds validation for schema type array: unique values only and single value inside an array removes the array wrapping.

## Relevant technical choices:

* When the type is an array:
  - Ensure the values are unique.
  - Only 1 value? Use that value without the array wrapping.
* What do you think of the changelog entry? Too technical? Suggestion welcome 😉 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the frontend of a post (default post, create a new one if you changed the schema settings).
* Check the schema output, the `@type` of the `#webpage` should be `WebPage`. This is unchanged in this PR.
* Edit the post's schema settings to `WebPage` (not the default kind).
* Verify the schema output is still `WebPage`. Changed from `[ 'WebPage' ]` in this PR.
* The duplication you could check with:
  * SEO Woo and a product: then set the schema page type to `ItemPage`.
    * Before this PR it would have `[ 'WebPage', 'ItemPage', 'ItemPage' ]` and with this PR the duplicate is no more.
  * Alternatively, you can add a filter: `add_filter('wpseo_schema_webpage_type', function() { return ['WebPage', 'WebPage', 'CollectionPage', 'CollectionPage']; } );`
    * This PR would squash those duplicates down to `[ 'WebPage', 'CollectionPage' ]`.

### Note to testers
This touches all the `@type` output. For the Person graph piece we currently output `[ 'Person' ]`, with this PR that changes to `Person`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-123
