### PR TITLE
P3-103 disable SEMrush on terms edit pages and edit attachment page

### DIFF
--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -53,14 +53,15 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 		// Todo: a column needs to be added on the termpages to add a filter for the keyword, so this can be used in the focus keyphrase doubles.
 		if ( is_object( $this->term ) && property_exists( $this->term, 'taxonomy' ) ) {
 			$values = [
-				'search_url'          => $this->search_url(),
-				'post_edit_url'       => $this->edit_url(),
-				'base_url'            => $this->base_url_for_js(),
-				'taxonomy'            => $this->term->taxonomy,
-				'keyword_usage'       => $this->get_focus_keyword_usage(),
-				'title_template'      => $this->get_title_template(),
-				'metadesc_template'   => $this->get_metadesc_template(),
-				'first_content_image' => $this->get_image_url(),
+				'search_url'               => $this->search_url(),
+				'post_edit_url'            => $this->edit_url(),
+				'base_url'                 => $this->base_url_for_js(),
+				'taxonomy'                 => $this->term->taxonomy,
+				'keyword_usage'            => $this->get_focus_keyword_usage(),
+				'title_template'           => $this->get_title_template(),
+				'metadesc_template'        => $this->get_metadesc_template(),
+				'first_content_image'      => $this->get_image_url(),
+				'semrushIntegrationActive' => 0,
 			];
 		}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -263,6 +263,10 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$values['cornerstoneActive'] = false;
 		}
 
+		if ( $values['semrushIntegrationActive'] && $post->post_type === 'attachment' ) {
+			$values['semrushIntegrationActive'] = 0;
+		}
+
 		return $values;
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the SEMrush integration on the edit terms and edit attachment pages.

## Relevant technical choices:

* Uses the existing `semrushIntegrationActive` value and sets it to `0` to disable SEMrush. I think this is the simplest way to do it. Do let me know if a separate value is preferred.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- make sure the SEMrush integration is enabled under SEO > General > Integrations
- edit a category
- observe there's no "Get related keyphrases" button in the metabox and there are no errors
- edit a tag
- observe there's no "Get related keyphrases" button in the metabox and there are no errors
- install and activate a plugin that adds custom taxonomies e.g.:
  - activate the Yoast Test Helper plugin (it should already be installed on the Docker environment)
  - go to Tools > Yoast test, and check Enable post types & taxonomies.
  - edit a Book category and genre and verify SEMrush is disabled there
  - edit a Movie category and genre and verify SEMrush is disabled there
- go to the WordPress Media Library
- make sure you're in the legacy "list mode", that is: the list of attachments displayed within a table
- edit an attachment
- observe there's no "Get related keyphrases" button in the metabox and there are no errors

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-103]
