### PR TITLE
Move license_server_version to Options framework

### DIFF
--- a/admin/class-license-page-manager.php
+++ b/admin/class-license-page-manager.php
@@ -15,13 +15,6 @@ class WPSEO_License_Page_Manager implements WPSEO_WordPress_Integration {
 	 *
 	 * @var string
 	 */
-	const VERSION_LEGACY = '1';
-
-	/**
-	 * Version number for License Page Manager.
-	 *
-	 * @var string
-	 */
 	const VERSION_BACKWARDS_COMPATIBILITY = '2';
 
 	/**
@@ -124,7 +117,7 @@ class WPSEO_License_Page_Manager implements WPSEO_WordPress_Integration {
 	 * @return int The version number
 	 */
 	protected function get_version() {
-		return get_option( $this->get_option_name(), self::VERSION_BACKWARDS_COMPATIBILITY );
+		return WPSEO_Options::get( $this->get_option_name(), self::VERSION_BACKWARDS_COMPATIBILITY );
 	}
 
 	/**
@@ -133,7 +126,7 @@ class WPSEO_License_Page_Manager implements WPSEO_WordPress_Integration {
 	 * @return string The option name.
 	 */
 	protected function get_option_name() {
-		return 'wpseo_license_server_version';
+		return 'license_server_version';
 	}
 
 	/**
@@ -153,7 +146,7 @@ class WPSEO_License_Page_Manager implements WPSEO_WordPress_Integration {
 	 * @param string $server_version The version number to save.
 	 */
 	protected function set_version( $server_version ) {
-		update_option( $this->get_option_name(), $server_version );
+		WPSEO_Options::set( $this->get_option_name(), $server_version );
 	}
 
 	/**
@@ -200,7 +193,7 @@ class WPSEO_License_Page_Manager implements WPSEO_WordPress_Integration {
 			'capabilities' => 'wpseo_manage_options',
 		];
 
-		$notification = new Yoast_Notification(
+		return new Yoast_Notification(
 			sprintf(
 				/* translators: %1$s expands to the product name. %2$s expands to a link to My Yoast  */
 				__( 'You are not receiving updates or support! Fix this problem by adding this site and enabling %1$s for it in %2$s.', 'wordpress-seo' ),
@@ -209,7 +202,5 @@ class WPSEO_License_Page_Manager implements WPSEO_WordPress_Integration {
 			),
 			$notification_options
 		);
-
-		return $notification;
 	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -36,7 +36,6 @@ class WPSEO_Upgrade {
 			'4.9'        => 'upgrade_49',
 			'5.0'        => 'upgrade_50',
 			'5.5'        => 'upgrade_55',
-			'5.6'        => 'upgrade_56',
 			'6.3'        => 'upgrade_63',
 			'7.0-RC0'    => 'upgrade_70',
 			'7.1-RC0'    => 'upgrade_71',
@@ -58,6 +57,7 @@ class WPSEO_Upgrade {
 			'14.1-RC0'   => 'upgrade_141',
 			'14.2-RC0'   => 'upgrade_142',
 			'14.5-RC0'   => 'upgrade_145',
+			'14.9-RC0'   => 'upgrade_149',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -380,16 +380,6 @@ class WPSEO_Upgrade {
 		// Register capabilities.
 		do_action( 'wpseo_register_capabilities' );
 		WPSEO_Capability_Manager_Factory::get()->add();
-	}
-
-	/**
-	 * Updates legacy license page options to the latest version.
-	 */
-	private function upgrade_56() {
-		global $wpdb;
-
-		// Make sure License Server checks are on the latest server version by default.
-		update_option( 'wpseo_license_server_version', WPSEO_License_Page_Manager::VERSION_BACKWARDS_COMPATIBILITY );
 	}
 
 	/**
@@ -729,6 +719,15 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_145() {
 		add_action( 'init', [ $this, 'set_indexation_completed_option_for_145' ] );
+	}
+
+	/**
+	 * Performs the 14.9 upgrade.
+	 */
+	private function upgrade_149() {
+		$version = get_option( 'wpseo_license_server_version', WPSEO_License_Page_Manager::VERSION_BACKWARDS_COMPATIBILITY );
+		WPSEO_Options::set( 'license_server_version', $version );
+		delete_option( 'wpseo_license_server_version' );
 	}
 
 	/**

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -132,7 +132,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	 * @todo [JRF => testers] Check if the extra actions below would run into problems if an option
 	 *       is updated early on and if so, change the call to schedule these for a later action on add/update
 	 *       instead of running them straight away.
-	 *
 	 */
 	protected function __construct() {
 		parent::__construct();
@@ -273,7 +272,8 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				case 'ms_defaults_set':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = WPSEO_Utils::validate_bool( $dirty[ $key ] );
-					} elseif ( isset( $old[ $key ] ) ) {
+					}
+					elseif ( isset( $old[ $key ] ) ) {
 						$clean[ $key ] = WPSEO_Utils::validate_bool( $old[ $key ] );
 					}
 					break;

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -27,6 +27,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	protected $defaults = [
 		// Non-form fields, set via (ajax) function.
 		'tracking'                                 => null,
+		'license_server_version'                   => false,
 		'ms_defaults_set'                          => false,
 		'ignore_search_engines_discouraged_notice' => false,
 		'ignore_indexation_warning'                => false,
@@ -127,11 +128,11 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	/**
 	 * Add the actions and filters for the option.
 	 *
-	 * @todo [JRF => testers] Check if the extra actions below would run into problems if an option
-	 * is updated early on and if so, change the call to schedule these for a later action on add/update
-	 * instead of running them straight away.
-	 *
 	 * @return \WPSEO_Option_Wpseo
+	 * @todo [JRF => testers] Check if the extra actions below would run into problems if an option
+	 *       is updated early on and if so, change the call to schedule these for a later action on add/update
+	 *       instead of running them straight away.
+	 *
 	 */
 	protected function __construct() {
 		parent::__construct();
@@ -245,6 +246,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 					$clean[ $key ] = WPSEO_VERSION;
 					break;
 				case 'previous_version':
+				case 'license_server_version':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = $dirty[ $key ];
 					}
@@ -271,8 +273,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				case 'ms_defaults_set':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = WPSEO_Utils::validate_bool( $dirty[ $key ] );
-					}
-					elseif ( isset( $old[ $key ] ) ) {
+					} elseif ( isset( $old[ $key ] ) ) {
 						$clean[ $key ] = WPSEO_Utils::validate_bool( $old[ $key ] );
 					}
 					break;
@@ -434,7 +435,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 
 		foreach ( $value_change as $key ) {
 			if ( isset( $option_value[ $key ] )
-				&& in_array( $option_value[ $key ], $target_values, true )
+				 && in_array( $option_value[ $key ], $target_values, true )
 			) {
 				$option_value[ $key ] = true;
 			}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Performance optimization: move the `wpseo_license_server_version` option to the options framework. Prevents regular DB queries.

## Test instructions
Not sure how to test this... @herregroen / @andizer do you know?

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

