### PR TITLE
Add wpseo_sitemap_index_links filter

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -395,6 +395,13 @@ class WPSEO_Sitemaps {
 			$links = array_merge( $links, $provider->get_index_links( $entries_per_page ) );
 		}
 
+		/**
+		 * Filter the sitemap links array before the index sitemap is built.
+		 *
+		 * @param array  $links Array of sitemap links
+		 */
+		$links = apply_filters( 'sitemap_index_links', $links );
+
 		if ( empty( $links ) ) {
 			$this->bad_sitemap = true;
 			$this->sitemap     = '';

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -400,7 +400,7 @@ class WPSEO_Sitemaps {
 		 *
 		 * @param array  $links Array of sitemap links
 		 */
-		$links = apply_filters( 'sitemap_index_links', $links );
+		$links = apply_filters( 'wpseo_sitemap_index_links', $links );
 
 		if ( empty( $links ) ) {
 			$this->bad_sitemap = true;


### PR DESCRIPTION
## Context
We want to allow users of the plugin to dynamically add/remove/change links to the individual sitemaps in the sitemaps index.

## Summary
* Add sitemap_index_links filter

## Relevant technical choices:
* Naming of the filter: `wpseo_sitemap_index_links`
* Argument to the filter: I chose to pass the entire `$links` array because it solves the most use cases with just one filter.

## Test instructions
* Register a handler for the `wpseo_sitemap_index_links`
* Check the value of the passed argument
* Modify and return the array
* Check `sitemap_index.xml` to see if it reflects the changes to the array 

## UI changes
* None

## Documentation
* None besides docblock

## Quality assurance
* [x] I have tested this code to the best of my abilities
* [ ] I have not added any unittests, as i couldn't find any tests for the sitemap classes anyway

Fixes #15796, fixes #14240