### PR TITLE
P1-119 Apply advanced section capability and option to the schema tab

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -84,6 +84,7 @@ class WPSEO_Metabox_Formatter {
 				'twitter'  => WPSEO_Options::get( 'twitter', false ),
 			],
 			'schema'                    => [
+				'displayFooter'      => WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ),
 				'pageTypeOptions'    => $schema_types->get_page_type_options(),
 				'articleTypeOptions' => $schema_types->get_article_type_options(),
 			],

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -41,6 +41,13 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	protected $editor;
 
 	/**
+	 * Whether or not the advanced metadata is enabled.
+	 *
+	 * @var bool
+	 */
+	protected $is_advanced_metadata_enabled;
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
@@ -59,7 +66,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$this->editor = new WPSEO_Metabox_Editor();
 		$this->editor->register_hooks();
 
-		$this->social_is_enabled = WPSEO_Options::get( 'opengraph', false ) || WPSEO_Options::get( 'twitter', false );
+		$this->social_is_enabled            = WPSEO_Options::get( 'opengraph', false ) || WPSEO_Options::get( 'twitter', false );
+		$this->is_advanced_metadata_enabled = WPSEO_Capability_Utils::current_user_can( 'wpseo_edit_advanced_metadata' ) || WPSEO_Options::get( 'disableadvanced_meta' ) === false;
 
 		$this->analysis_seo         = new WPSEO_Metabox_Analysis_SEO();
 		$this->analysis_readability = new WPSEO_Metabox_Analysis_Readability();
@@ -339,7 +347,9 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$content_sections[] = $this->get_readability_meta_section();
 		}
 
-		$content_sections[] = $this->get_schema_meta_section( $post_type );
+		if ( $this->is_advanced_metadata_enabled ) {
+			$content_sections[] = $this->get_schema_meta_section( $post_type );
+		}
 
 		// Whether social is enabled.
 		if ( $this->social_is_enabled ) {
@@ -390,7 +400,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		$html_after = '';
 
-		if ( WPSEO_Capability_Utils::current_user_can( 'wpseo_edit_advanced_metadata' ) || WPSEO_Options::get( 'disableadvanced_meta' ) === false ) {
+		if ( $this->is_advanced_metadata_enabled ) {
 			$html_after = $this->get_tab_content( 'advanced' );
 		}
 

--- a/admin/views/class-yoast-feature-toggles.php
+++ b/admin/views/class-yoast-feature-toggles.php
@@ -133,11 +133,11 @@ class Yoast_Feature_Toggles {
 				'order'   => 80,
 			],
 			(object) [
-				'name'    => __( 'Security: no advanced settings for authors', 'wordpress-seo' ),
+				'name'    => __( 'Security: no advanced or schema settings for authors', 'wordpress-seo' ),
 				'setting' => 'disableadvanced_meta',
 				'label'   => sprintf(
 					/* translators: 1: Yoast SEO, 2: translated version of "Off" */
-					__( 'The advanced section of the %1$s meta box allows a user to remove posts from the search results or change the canonical. These are things you might not want any author to do. That\'s why, by default, only editors and administrators can do this. Setting to "%2$s" allows all users to change these settings.', 'wordpress-seo' ),
+					__( 'The advanced section of the %1$s meta box allows a user to remove posts from the search results or change the canonical. The settings in the schema tab allows a user to change schema meta data for a post. These are things you might not want any author to do. That\'s why, by default, only editors and administrators can do this. Setting to "%2$s" allows all users to change these settings.', 'wordpress-seo' ),
 					'Yoast SEO',
 					__( 'Off', 'wordpress-seo' )
 				),

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -379,6 +379,10 @@ class WPSEO_Meta {
 				break;
 
 			case 'schema':
+				if ( ! WPSEO_Capability_Utils::current_user_can( 'wpseo_edit_advanced_metadata' ) && WPSEO_Options::get( 'disableadvanced_meta' ) ) {
+					return [];
+				}
+
 				$field_defs['schema_page_type']['default'] = WPSEO_Options::get( 'schema-page-type-' . $post_type );
 
 				$article_helper = new Article_Helper();

--- a/js/src/components/SchemaTab.js
+++ b/js/src/components/SchemaTab.js
@@ -75,7 +75,7 @@ const Content = ( props ) => (
 			onChange={ props.schemaArticleTypeChange }
 			selected={ props.schemaArticleTypeSelected }
 		/> }
-		<p>{ footerWithLink( props.postTypeName ) }</p>
+		{ props.displayFooter && <p>{ footerWithLink( props.postTypeName ) }</p> }
 	</Fragment>
 );
 
@@ -92,6 +92,7 @@ Content.propTypes = {
 	helpTextTitle: PropTypes.string.isRequired,
 	helpTextDescription: PropTypes.string.isRequired,
 	postTypeName: PropTypes.string.isRequired,
+	displayFooter: PropTypes.bool,
 };
 
 Content.defaultProps = {
@@ -100,6 +101,7 @@ Content.defaultProps = {
 	schemaArticleTypeChange: () => {},
 	schemaArticleTypeSelected: null,
 	schemaArticleTypeOptions: null,
+	displayFooter: false,
 };
 
 /**
@@ -138,12 +140,14 @@ SchemaTab.propTypes = {
 	helpTextDescription: PropTypes.string.isRequired,
 	isMetabox: PropTypes.bool.isRequired,
 	postTypeName: PropTypes.string.isRequired,
+	displayFooter: PropTypes.bool,
 };
 
 SchemaTab.defaultProps = {
 	showArticleTypeInput: false,
 	articleTypeLabel: "",
 	additionalHelpTextLink: "",
+	displayFooter: false,
 };
 
 export default SchemaTab;

--- a/js/src/components/fills/MetaboxFill.js
+++ b/js/src/components/fills/MetaboxFill.js
@@ -100,7 +100,7 @@ export default function MetaboxFill( { settings, store, theme } ) {
 					<AdvancedSettings />
 				</TopLevelProviders>
 			</SidebarItem> }
-			{ !! window.wpseoScriptData.isPost && <SidebarItem renderPriority={ 50 }>
+			{ settings.displaySchemaSettings && <SidebarItem renderPriority={ 50 }>
 				<TopLevelProviders
 					store={ store }
 					theme={ theme }

--- a/js/src/components/fills/SidebarFill.js
+++ b/js/src/components/fills/SidebarFill.js
@@ -86,7 +86,7 @@ export default function SidebarFill( { settings, store, theme } ) {
 						<CollapsibleCornerstone />
 					</TopLevelProviders>
 				</SidebarItem> }
-				{ !! window.wpseoScriptData.isPost && <SidebarItem renderPriority={ 40 }>
+				{ settings.displaySchemaSettings && <SidebarItem renderPriority={ 40 }>
 					<TopLevelProviders
 						store={ store }
 						theme={ theme }

--- a/js/src/containers/MetaboxFill.js
+++ b/js/src/containers/MetaboxFill.js
@@ -10,15 +10,8 @@ import { connect } from "react-redux";
  * @returns {Object} The props for the Metabox component.
  */
 function mapStateToProps( state, ownProps ) {
-	const settings = {
-		...state.preferences,
-		// Because cornerstone is only applicable to posts, not terms. Despite the general setting.
-		isCornerstoneActive: state.preferences.isCornerstoneActive,
-		// Because this value is initiated as an empty string.
-		displayAdvancedTab: !! window.wpseoAdminL10n.displayAdvancedTab,
-	};
 	return {
-		settings,
+		settings: state.preferences,
 		store: ownProps.store,
 	};
 }

--- a/js/src/containers/SchemaTab.js
+++ b/js/src/containers/SchemaTab.js
@@ -1,6 +1,8 @@
 import { __, sprintf } from "@wordpress/i18n";
 import { LocationConsumer } from "../components/contexts/location";
 import SchemaTab from "../components/SchemaTab";
+import { compose } from "@wordpress/compose";
+import { withSelect } from "@wordpress/data";
 
 const articleTypeInputId = "yoast_wpseo_schema_article_type";
 const pageTypeInputId = "yoast_wpseo_schema_page_type";
@@ -128,9 +130,11 @@ const getLocationBasedProps = ( location ) => {
 /**
  * Renders the SchemaComponent.
  *
+ * @param {Object} props The props.
+ *
  * @returns {React.Component} The SchemaTab.
  */
-const SchemaTabContainer = () => {
+const SchemaTabContainer = ( props ) => {
 	const isArticleAvailable = getArticleTypeInput() !== null;
 	const { pageTypeOptions } = window.wpseoScriptData.metabox.schema;
 
@@ -158,15 +162,22 @@ const SchemaTabContainer = () => {
 	return (
 		<LocationConsumer>
 			{ location => {
-				const props = {
+				const schemaTabProps = {
+					...props,
 					...baseProps,
 					...getLocationBasedProps( location ),
 				};
 
-				return <SchemaTab { ...props } />;
+				return <SchemaTab { ...schemaTabProps } />;
 			} }
 		</LocationConsumer>
 	);
 };
 
-export default SchemaTabContainer;
+export default compose( [
+	withSelect( ( select ) => {
+		const { getPreferences } = select( "yoast-seo/editor" );
+
+		return { displayFooter: getPreferences().displaySchemaSettingsFooter };
+	} ),
+] )( SchemaTabContainer );

--- a/js/src/redux/reducers/preferences.js
+++ b/js/src/redux/reducers/preferences.js
@@ -10,12 +10,16 @@ import isWordFormRecognitionActive from "../../analysis/isWordFormRecognitionAct
  * @returns {Object} The default state.
  */
 function getDefaultState() {
+	const displayAdvancedTab = !! window.wpseoAdminL10n.displayAdvancedTab;
+
 	return {
 		isContentAnalysisActive: isContentAnalysisActive(),
 		isKeywordAnalysisActive: isKeywordAnalysisActive(),
 		isWordFormRecognitionActive: isUndefined( window.wpseoPremiumMetaboxData ) && isWordFormRecognitionActive(),
 		isCornerstoneActive: isCornerstoneActive(),
 		shouldUpsell: isUndefined( window.wpseoPremiumMetaboxData ),
+		displayAdvancedTab: displayAdvancedTab,
+		displaySchemaSettings: displayAdvancedTab && !! window.wpseoScriptData.isPost,
 	};
 }
 

--- a/js/src/redux/reducers/preferences.js
+++ b/js/src/redux/reducers/preferences.js
@@ -1,4 +1,4 @@
-import { isUndefined } from "lodash-es";
+import { isUndefined, get } from "lodash-es";
 import isContentAnalysisActive from "../../analysis/isContentAnalysisActive";
 import isKeywordAnalysisActive from "../../analysis/isKeywordAnalysisActive";
 import isCornerstoneActive from "../../analysis/isCornerstoneContentActive";
@@ -20,6 +20,7 @@ function getDefaultState() {
 		shouldUpsell: isUndefined( window.wpseoPremiumMetaboxData ),
 		displayAdvancedTab: displayAdvancedTab,
 		displaySchemaSettings: displayAdvancedTab && !! window.wpseoScriptData.isPost,
+		displaySchemaSettingsFooter: get( window, "wpseoScriptData.metabox.schema.displayFooter", false ),
 	};
 }
 

--- a/tests/unit/admin/metabox/metabox-test.php
+++ b/tests/unit/admin/metabox/metabox-test.php
@@ -32,6 +32,11 @@ class Metabox_Test extends TestCase {
 		global $_SERVER;
 		$_SERVER['HTTP_USER_AGENT'] = 'User Agent';
 
+		Monkey\Functions\expect( 'current_user_can' )
+			->with( 'wpseo_manage_options' )
+			->once()
+			->andReturnTrue();
+
 		$this->instance = new Metabox_Double();
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We do not want every user to be presented with the schema settings of an indexable. Now coupled to the advanced section and adapted the help text for that option.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Apply the advanced section's capability and option checks to the schema settings.
* Fixes a bug where a user could be presented with a link without having access to that page.

## Relevant technical choices:

* The MetaboxFill container had some specific props (compared to the SidebarFill). I cleaned that up.
* I added the variables to the preferences reducer. This should probably have its own (schema) reducer in the end. But I know we have a cleanup coming and this is the quick version for the release branch.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to SEO -> General -> Features and set the option `Security: no advanced or schema settings for author` to `On`.
  * Also verify this now has the same text and help text as it should per https://yoast.atlassian.net/browse/P1-122
* Have a user with each of these roles: `Admin`, `SEO Manager`, `SEO Editor`, `Editor` and `Author` (hint: you can use the `User Switching` plugin to more easily switch your user between these roles).
* Create a post as the `Author`.
* As `Admin` and `SEO Manager` you should:
  * see the schema settings in the metabox tab as well as in the sidebar.
  * be able to change the schema settings.
  * see the footer with `You can change the default type for Posts in your Search Appearance Settings.` with a link that takes you to the search appearance settings.
* As an `SEO Editor` you should:
  * see the schema settings in the metabox tab, as well as in the sidebar.
  * be able to change the schema settings.
  * __not__ see the footer, because you do not have access to the search appearance settings.
* As an `Editor` and the `Author` (of that specific post) you should:
  * __not__ see the schema settings in the metabox tab, nor in the sidebar.
  * __not__ be able to change the schema settings.
    * Hack test: you could verify this by editing the form and adding the inputs to them that are on the page normally: `<input type="hidden" id="yoast_wpseo_schema_page_type" name="yoast_wpseo_schema_page_type" value="WebPage" data-default="WebPage">
<input type="hidden" id="yoast_wpseo_schema_article_type" name="yoast_wpseo_schema_article_type" value="Article" data-default="Article">`. When you save this it takes it along in the form submit. However, it should not actually update the values in the database. Note the `value=` part should be different than your current settings so you can verify this. You can then verify by switching back to the `Admin` user and refreshing the edit page.
* Switch the security setting in SEO -> General -> Features to `Off` (as `Admin` or `SEO Manager`).
* The values above should still be the same for an `Admin`, `SEO Manager` and `SEO Editor`.
* As an `Editor` and the `Author` (of the specific post) you should:
  * see the schema settings in the metabox tab, as well as in the sidebar.
  * be able to change the schema settings.
  * __not__ see the footer, because you do not have access to the search appearance settings.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-119 and https://yoast.atlassian.net/browse/P1-122
