### PR TITLE
P3-101 - P3-95 Refactor checks for comma in keyphrase and max keyphrase length

### DIFF
--- a/js/src/components/contentAnalysis/KeywordInput.js
+++ b/js/src/components/contentAnalysis/KeywordInput.js
@@ -8,7 +8,6 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { KeywordInput as KeywordInputComponent } from "yoast-components";
 import styled from "styled-components";
-import { Alert } from "@yoast/components";
 
 /* Internal dependencies */
 import { setFocusKeyword } from "../../redux/actions/focusKeyword";
@@ -68,6 +67,14 @@ class KeywordInput extends Component {
 			errors.push( __( "Please enter a focus keyphrase first to get related keyphrases", "wordpress-seo" ) );
 		}
 
+		if ( this.props.keyword.includes( "," ) ) {
+			errors.push(  __( "Are you trying to use multiple keyphrases? You should add them separately below.", "wordpress-seo" )  );
+		}
+
+		if ( this.props.keyword.length > 191 ) {
+			errors.push(  __( "Your keyphrase is too long. It can be a maximum of 191 characters.",	"wordpress-seo"	)  );
+		}
+
 		return errors;
 	}
 
@@ -94,15 +101,6 @@ class KeywordInput extends Component {
 							hasError={ errors.length > 0 }
 							errorMessages={ errors }
 						/>
-						{
-							this.props.keyword.length > 191 &&
-							<Alert type="warning">
-								{ __(
-									"Your keyphrase is too long. It can be a maximum of 191 characters.",
-									"wordpress-seo"
-								) }
-							</Alert>
-						}
 						{
 							this.props.isSEMrushIntegrationActive &&
 							<SEMrushModal


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The `KeywordInput` component from `yoast-components` has been recently refactored (see: https://github.com/Yoast/javascript/pull/814) to be a stateless component accepting error messages as props, instead of performing cheks internally (namely, the check for a comma in the keyphrase).
We are adding back the check for a comma (issue P3-101), and refactor the check for maximum length of the keyphrase to use the new component API (issue P3-95)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor checks for comma in keyphrase and max keyphrase length to adapt them to the new implementation of component

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* make sure you are on the `feature/semrush` branch of monorepo
* build as usual
* start writing a new post, see there are no errors above the focus keyphrase input
* insert a keyphrase longer than 191 characters, see that the error pops up as an element in a unordered list
* shorten the keyphrase below 191 chars, see the error goes away
* insert a keyphrase containing a comma, see that the error pops up as an element in a unordered list
* remove the comma, see the error goes away
* try inserting a keyphrase longer than 191 chars with a comma in it, see the two messages are displayed as different points in the list
* empty the keyphrase input, see the errors go away
* click on the "Get related keyphrases" button, see that the modal doesn't open and the error pops up as an element in a unordered list
* start writing a keyphrase, see the error goes away

### Note
Once you have clicked on the button, the Redux state contains `displayNoKeyphraseMessage` set as true until the modal opens.
This means that if you click the button with an empty keyphrase (error pops up), then you write a keyphrase (error disappears), then you delete the keyphrase, the error appears again even if you haven't clicked the button again.
We'll see if this is something we need to fix.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-101] and [P3-95]
