### PR TITLE
Show maximum related keyphrase warning

### DIFF
--- a/js/src/components/RelatedKeyphrasesModal.js
+++ b/js/src/components/RelatedKeyphrasesModal.js
@@ -10,7 +10,6 @@ import { BaseButton } from "@yoast/components";
 /* Internal dependencies */
 import { ModalContainer } from "./modals/Container";
 import YoastIcon from "../../../images/Yoast_icon_kader.svg";
-import SemRushMaxRelatedKeyphrases from "./modals/SemRushMaxRelatedKeyphrases";
 
 /**
  * Redux container for the RelatedKeyPhrasesModal modal.
@@ -61,7 +60,7 @@ class RelatedKeyphrasesModal extends Component {
 	 * @returns {React.Element} The RelatedKeyPhrasesModal modal component.
 	 */
 	render() {
-		const { keyphrase, location, maxRelatedKeyphrasesEntered, whichModalOpen } = this.props;
+		const { keyphrase, location, whichModalOpen } = this.props;
 
 		return (
 			<Fragment>
@@ -82,10 +81,6 @@ class RelatedKeyphrasesModal extends Component {
 						<ModalContainer
 							className="yoast-gutenberg-modal__content yoast-related-keyphrases-modal__content"
 						>
-							{ maxRelatedKeyphrasesEntered && (
-								<SemRushMaxRelatedKeyphrases />
-							) }
-
 							<Slot name="YoastRelatedKeyphrases" />
 
 						</ModalContainer>
@@ -99,7 +94,6 @@ class RelatedKeyphrasesModal extends Component {
 RelatedKeyphrasesModal.propTypes = {
 	keyphrase: PropTypes.string,
 	location: PropTypes.string,
-	maxRelatedKeyphrasesEntered: PropTypes.bool,
 	whichModalOpen: PropTypes.oneOf( [
 		"none",
 		"metabox",
@@ -113,7 +107,6 @@ RelatedKeyphrasesModal.propTypes = {
 RelatedKeyphrasesModal.defaultProps = {
 	keyphrase: "",
 	location: "",
-	maxRelatedKeyphrasesEntered: false,
 	whichModalOpen: "none",
 };
 

--- a/js/src/components/RelatedKeyphrasesModalContent.js
+++ b/js/src/components/RelatedKeyphrasesModalContent.js
@@ -11,9 +11,8 @@ import SEMrushCountrySelector from "./modals/SEMrushCountrySelector";
 import KeyphrasesTable from "./modals/KeyphrasesTable";
 import SemRushUpsellAlert from "./modals/SemRushUpsellAlert";
 import SemRushRequestFailed from "./modals/SemRushRequestFailed";
-
-import getL10nObject from "../analysis/getL10nObject";
 import SemRushMaxRelatedKeyphrases from "./modals/SemRushMaxRelatedKeyphrases";
+import getL10nObject from "../analysis/getL10nObject";
 
 /**
  * Determines whether the error property is present in the passed response object.

--- a/js/src/components/RelatedKeyphrasesModalContent.js
+++ b/js/src/components/RelatedKeyphrasesModalContent.js
@@ -12,6 +12,8 @@ import KeyphrasesTable from "./modals/KeyphrasesTable";
 import SemRushUpsellAlert from "./modals/SemRushUpsellAlert";
 import SemRushRequestFailed from "./modals/SemRushRequestFailed";
 
+import getL10nObject from "../analysis/getL10nObject";
+
 /**
  * Determines whether the error property is present in the passed response object.
  *
@@ -79,11 +81,13 @@ export default function RelatedKeyphraseModalContent( props ) {
 		setRequestLimitReached,
 	} = props;
 
+	const l10nObject = getL10nObject();
+
 	return (
 		<Fragment>
 			{ ! requestLimitReached && (
 				<Fragment>
-					<SemRushUpsellAlert />
+					{ ! l10nObject.isPremium && <SemRushUpsellAlert /> }
 					<SEMrushCountrySelector
 						countryCode={ countryCode }
 						setCountry={ setCountry }

--- a/js/src/components/RelatedKeyphrasesModalContent.js
+++ b/js/src/components/RelatedKeyphrasesModalContent.js
@@ -13,6 +13,7 @@ import SemRushUpsellAlert from "./modals/SemRushUpsellAlert";
 import SemRushRequestFailed from "./modals/SemRushRequestFailed";
 
 import getL10nObject from "../analysis/getL10nObject";
+import SemRushMaxRelatedKeyphrases from "./modals/SemRushMaxRelatedKeyphrases";
 
 /**
  * Determines whether the error property is present in the passed response object.
@@ -59,6 +60,17 @@ function getUserMessage( props ) {
 }
 
 /**
+ * Determines whether the maximum amount of related keyphrases has been reached.
+ *
+ * @param {array} relatedKeyphrases The related keyphrases. Can be empty.
+ *
+ * @returns {boolean} Whether or not the maximum limit has been reached.
+ */
+function hasMaximumRelatedKeyphrases( relatedKeyphrases ) {
+	return relatedKeyphrases && relatedKeyphrases.length >= 4;
+}
+
+/**
  * Renders the SEMrush related keyphrases modal content.
  *
  * @param {Object} props The props to use within the content.
@@ -81,13 +93,14 @@ export default function RelatedKeyphraseModalContent( props ) {
 		setRequestLimitReached,
 	} = props;
 
-	const l10nObject = getL10nObject();
+	const isPremium = getL10nObject().isPremium;
 
 	return (
 		<Fragment>
 			{ ! requestLimitReached && (
 				<Fragment>
-					{ ! l10nObject.isPremium && <SemRushUpsellAlert /> }
+					{ ! isPremium && <SemRushUpsellAlert /> }
+					{ isPremium && hasMaximumRelatedKeyphrases( relatedKeyphrases ) && <SemRushMaxRelatedKeyphrases /> }
 					<SEMrushCountrySelector
 						countryCode={ countryCode }
 						setCountry={ setCountry }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds the maximum related keyphrases warning to the modal, if applicable.
* Only shows the 'upsell to Premium' message, if the user is not using Premium.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the maximum related keyphrases warning to the modal (if applicable) and only shows the 'upsell to Premium' message if the user is not using Premium.

## Relevant technical choices:

* I've added the logic for displaying the maximum related keyphrases warning to Free, despite it being something we only show in Premium. The thought behind this is that we only have the one modal and based on the existence of related keyphrases, we can then show/hide the message. By default, `relatedKeyphrases` is an empty array in Free and thus will never trigger the message.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this branch and make sure you build everything properly.
* Navigate to a new or existing post.
* Enter a keyphrase and hit the 'Get related keyphrases' button.
* You should see the 'upgrade to Premium' message and should NOT see the maximum related keyphrases warning.

_Now for the trickier part_
* To test the behavior in Premium, make sure you have the Free repository set up as a 'git remote' within your Premium repository and then you've run `git fetch --all`.
* Ensure you're on the `feature/semrush` branch and create a new branch based off of this one _for testing purposes only_
* In the root folder of Yoast SEO Premium, run `git merge free P3-110-show-max-keyphrase`. This will merge the branch from Free, into the newly created branch.
* Build the files
* Navigate to a new or existing post.
* Enter a keyphrase and hit the 'Get related keyphrases' button.
* You should no longer see the 'upgrade to Premium' message.
* Send an API request to SEMrush to retrieve some data.
* Add related keyphrases until you hit the limit. 
* The buttons should be grayed out and the maximum related keyphrases message should be displayed in the modal.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
