### PR TITLE
Show SchemaSettings change alert before onBlur

### DIFF
--- a/js/src/components/SchemaSettings.js
+++ b/js/src/components/SchemaSettings.js
@@ -25,7 +25,7 @@ class SchemaSettings extends Component {
 
 		// Save the initial value for the alert check.
 		this.initialPageType = props.pageType.value;
-		this.initialArticleType = props.articleType ? props.articleType.value : "none";
+		this.initialArticleType = props.articleType ? props.articleType.value : "None";
 
 		/* eslint-disable camelcase */
 		this.state = {
@@ -58,14 +58,14 @@ class SchemaSettings extends Component {
 	 * Changes the state appropriately whenever an option is highlighted in a specific field.
 	 * This is needed because we need to show an alert when the select is "dirty", which is before the onBlur event sometimes.
 	 *
-	 * @param {string} fieldName      The name of the field to which this option belongs
-	 * @param {string} focussedOption The name of the focussed option.
+	 * @param {string} fieldName     The name of the field to which this option belongs
+	 * @param {string} focusedOption The name of the focused option.
 	 *
 	 * @returns {void}
 	 */
-	handleOptionFocus( fieldName, focussedOption ) {
+	handleOptionFocus( fieldName, focusedOption ) {
 		this.setState( {
-			[ fieldName ]: focussedOption,
+			[ fieldName ]: focusedOption,
 		} );
 	}
 

--- a/js/src/components/SchemaSettings.js
+++ b/js/src/components/SchemaSettings.js
@@ -27,12 +27,12 @@ class SchemaSettings extends Component {
 		this.initialPageType = props.pageType.value;
 		this.initialArticleType = props.articleType ? props.articleType.value : "none";
 
-		// eslint-disable camelcase
+		/* eslint-disable camelcase */
 		this.state = {
 			schema_page_type: this.initialPageType,
 			schema_article_type: this.initialArticleType,
 		};
-		// eslint-enable camelcase
+		/* eslint-enable camelcase */
 
 		this.handleOptionFocus = this.handleOptionFocus.bind( this );
 	}

--- a/js/src/components/SchemaSettings.js
+++ b/js/src/components/SchemaSettings.js
@@ -60,6 +60,8 @@ class SchemaSettings extends Component {
 	 *
 	 * @param {string} fieldName      The name of the field to which this option belongs
 	 * @param {string} focussedOption The name of the focussed option.
+	 *
+	 * @returns {void}
 	 */
 	handleOptionFocus( fieldName, focussedOption ) {
 		this.setState( {

--- a/js/src/components/SchemaSettings.js
+++ b/js/src/components/SchemaSettings.js
@@ -26,6 +26,15 @@ class SchemaSettings extends Component {
 		// Save the initial value for the alert check.
 		this.initialPageType = props.pageType.value;
 		this.initialArticleType = props.articleType ? props.articleType.value : "none";
+
+		// eslint-disable camelcase
+		this.state = {
+			schema_page_type: this.initialPageType,
+			schema_article_type: this.initialArticleType,
+		};
+		// eslint-enable camelcase
+
+		this.handleOptionFocus = this.handleOptionFocus.bind( this );
 	}
 
 	/**
@@ -34,15 +43,28 @@ class SchemaSettings extends Component {
 	 * @returns {boolean} True if a value differs from the initial value.
 	 */
 	shouldShowAlert() {
-		if ( this.props.pageType && this.props.pageType.value !== this.initialPageType ) {
+		if ( this.state.schema_page_type !== this.initialPageType ) {
 			return true;
 		}
 
-		if ( this.props.articleType && this.props.articleType.value !== this.initialArticleType ) {
+		if ( this.state.schema_article_type !== this.initialArticleType ) {
 			return true;
 		}
 
 		return false;
+	}
+
+	/**
+	 * Changes the state appropriately whenever an option is highlighted in a specific field.
+	 * This is needed because we need to show an alert when the select is "dirty", which is before the onBlur event sometimes.
+	 *
+	 * @param {string} fieldName      The name of the field to which this option belongs
+	 * @param {string} focussedOption The name of the focussed option.
+	 */
+	handleOptionFocus( fieldName, focussedOption ) {
+		this.setState( {
+			[ fieldName ]: focussedOption,
+		} );
 	}
 
 	/**
@@ -87,6 +109,7 @@ class SchemaSettings extends Component {
 					label={ __( "Default Page type", "wordpress-seo" ) }
 					onChange={ this.props.pageType.onChange }
 					selected={ this.props.pageType.value }
+					onOptionFocus={ this.handleOptionFocus }
 				/>
 				{ this.props.articleType && <Select
 					id={ `schema-article-type-${ this.props.postType }` }
@@ -94,6 +117,7 @@ class SchemaSettings extends Component {
 					options={ this.props.articleTypeOptions }
 					label={ __( "Default Article type", "wordpress-seo" ) }
 					onChange={ this.props.articleType.onChange }
+					onOptionFocus={ this.handleOptionFocus }
 					selected={ this.props.articleType.value }
 				/> }
 			</Fragment>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In order to alert users to what their Search Appearance Schema setting will do upon saving, we show an alert. We currently show this onBlur of the setting's input field. Sometimes users click the save button immediately after selecting an option, and thus the "onBlur" event coincides with saving, and thus the alert is too late. We now fix this by decoupling saving and showing the alert.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes unreleased suboptimal user experience whereby a cautionary alert (that should be shown before saving schema settings) could be shown on the exact moment a user clicked save.

## Relevant technical choices:

* Because of a11y concerns, developers should not introduce [context changes](https://www.w3.org/TR/WCAG21/#dfn-change-of-context) in functions listening to onInput or onChange events, because those could trigger before a user "confirms" their selection. This is disorienting to keyboard and screenreader users. See: https://core.trac.wordpress.org/ticket/40925
* To dissuade devs from passing such functions we have opted to set the onInput function via a more descriptive prop that's called `onOptionFocus`, and we have added documentation to the `onInputHandler` in the monorepo (see coupled PR: https://github.com/Yoast/javascript/pull/827).


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this branch and the [identically named branch on the monorepo](https://github.com/Yoast/javascript/pull/827), `yarn link-monorepo`.
* Go to search appearance -> content types, and verify that the alert appears when you change the inputs of the schema settings with keyboard, mouse etc... *BEFORE* clicking away from it.
* The alert should disappear when you select the initial values again... Also *BEFORE* clicking away from it.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-120
