### PR TITLE
Exclude the file_system specific sniffs

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -24,6 +24,13 @@
         <exclude name="WordPress.Functions.DontExtract" /><!-- TODO audit usage & replace -->
         <exclude name="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber" /><!-- TODO Remove this once we're on 0.5. See https://github.com/squizlabs/PHP_CodeSniffer/issues/650 for more info. -->
         <exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+
+        <!-- See https://github.com/Yoast/wordpress-seo/pull/15713 - We discovered that WP_Filesystem can lead to unexpected behaviour. -->
+   	 	<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fopen" />
+   	 	<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fwrite" />
+   	 	<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fclose" />
+   	 	<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fread" />
+   	 	<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents" />
     </rule>
 
     <!-- Demand short arrays. -->


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Apply an earlier CS fix for the sitemaps resulted in the need for a patch release because using `WP_Filesystem` broke websites. Therefore the decision (during the architecture meeting) has been made to disable the sniffs that are related to the `WP_Filesystem`. Just to prevent more broken websites.
* See https://github.com/Yoast/wordpress-seo/pull/15713

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Disables the sniffs.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* I hope I have disabled the sniffs the right way. 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
