### PR TITLE
P3 109 send request on open modal

### DIFF
--- a/js/src/components/RelatedKeyphrasesModalContent.js
+++ b/js/src/components/RelatedKeyphrasesModalContent.js
@@ -109,6 +109,7 @@ export default function RelatedKeyphraseModalContent( props ) {
 						setNoResultsFound={ setNoResultsFound }
 						setRequestSucceeded={ setRequestSucceeded }
 						setRequestLimitReached={ setRequestLimitReached }
+						response={ response }
 					/>
 				</Fragment>
 			) }

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -194,8 +194,7 @@ class SEMrushCountrySelector extends Component {
 		this.select2.on( "change.select2", this.onChangeHandler );
 
 		//	Fire a new request when the modal is first opened
-		if ( ! this.props.response )
-		{
+		if ( ! this.props.response ) {
 			this.relatedKeyphrasesRequest();
 		}
 	}

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -193,8 +193,8 @@ class SEMrushCountrySelector extends Component {
 		} );
 		this.select2.on( "change.select2", this.onChangeHandler );
 
-		//Fire a new request when the modal is first opened
-		if ( !this.props.response )
+		//	Fire a new request when the modal is first opened
+		if ( ! this.props.response )
 		{
 			this.relatedKeyphrasesRequest();
 		}

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -192,6 +192,12 @@ class SEMrushCountrySelector extends Component {
 			dropdownParent: jQuery( ".yoast-related-keyphrases-modal__content" ),
 		} );
 		this.select2.on( "change.select2", this.onChangeHandler );
+
+		//Fire a new request when the modal is first opened
+		if ( !this.props.response )
+		{
+			this.relatedKeyphrasesRequest();
+		}
 	}
 
 	/**
@@ -346,6 +352,7 @@ class SEMrushCountrySelector extends Component {
 SEMrushCountrySelector.propTypes = {
 	keyphrase: PropTypes.string,
 	countryCode: PropTypes.string,
+	response: PropTypes.object,
 	setCountry: PropTypes.func.isRequired,
 	newRequest: PropTypes.func.isRequired,
 	setNoResultsFound: PropTypes.func.isRequired,
@@ -357,6 +364,7 @@ SEMrushCountrySelector.propTypes = {
 SEMrushCountrySelector.defaultProps = {
 	keyphrase: "",
 	countryCode: "us",
+	response: "",
 };
 
 /**

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -180,7 +180,7 @@ class SEMrushCountrySelector extends Component {
 	}
 
 	/**
-	 * Creates a select2 component from the select and listen to the change action.
+	 * Creates a select2 component from the select, listens to the change action and fires the first SEMrush request.
 	 *
 	 * @returns {void}
 	 */

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -363,7 +363,7 @@ SEMrushCountrySelector.propTypes = {
 SEMrushCountrySelector.defaultProps = {
 	keyphrase: "",
 	countryCode: "us",
-	response: "",
+	response: {},
 };
 
 /**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In this PR we want to fire a request when the SEMrush modal is first opened, so the user immediately gets SEMrush related keyphrases.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* When the modal is first opened and rendered, `relatedKeyphrasesRequest()` is called which fetches data from semrush.

## Relevant technical choices:

* I have chosen to call `relatedKeyphrasesRequest()` within the `componentDidMount()` function since this was the safest place to call it since it only triggers when everything has rendered correctly. This allows for a clean SEMrush request which can be handled by the correctly rendered components.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this branch and build
* Make sure you have a (non expired) SEMrush token. If not, run the steps here #15607 
* Go to a post
* Enter a keyphrase
* Open the modal
* Notice that a request is fired when you opened the modal, and make sure the data is rendered correctly within the table.
* Close the modal
* Open the modal again
* Make sure the request is not fired again
* Make sure everything else within the modal still works as expected
* Make sure that when refreshing the page it does fire the request again upon opening the modal for the first time

## UI changes
* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [X] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

