### PR TITLE
Disable permalink generation on unpublished posts

### DIFF
--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -91,10 +91,9 @@ class Indexable_Post_Builder {
 			$indexable->permalink = \wp_get_attachment_url( $post_id );
 		}
 
-		$unpublished_status = ['draft', 'pending', 'auto-draft', 'future'];
-
-		if ( in_array( $post->post_status, $unpublished_status ) ) {
-			$indexable->permalink = null;
+		// Save the permalink as an empty string 
+		if ( in_array( $post->post_status, ['draft', 'pending', 'auto-draft', 'future'] ) ) {
+			$indexable->permalink = '';
 		}
 
 		$indexable->primary_focus_keyword_score = $this->get_keyword_score(

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -91,6 +91,11 @@ class Indexable_Post_Builder {
 			$indexable->permalink = \wp_get_attachment_url( $post_id );
 		}
 
+		$unpublished_status = ['draft', 'pending', 'auto-draft', 'future'];
+
+		if ( in_array( $post->post_status, $unpublished_status ) ) {
+			$indexable->permalink = null;
+		}
 
 		$indexable->primary_focus_keyword_score = $this->get_keyword_score(
 			$this->get_meta_value( $post_id, 'focuskw' ),

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -91,7 +91,6 @@ class Indexable_Post_Builder {
 			$indexable->permalink = \wp_get_attachment_url( $post_id );
 		}
 
-		// Save the permalink as an empty string 
 		if ( in_array( $post->post_status, ['draft', 'pending', 'auto-draft', 'future'] ) ) {
 			$indexable->permalink = '';
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to disable permalink generation when a post is not yet published. This aims to prevent caching issues ([see related issue](https://github.com/Yoast/wordpress-seo/issues/15246#issuecomment-651033479)).

## Summary

This PR can be summarized in the following changelog entry:

* Enhancement: prevents non-usable permalinks to make their way into our indexables data.

## Relevant technical choices:

⚠️  - Work in progress, will need a decision:
There are 2 places we generate permalinks: 
- indexable-post-builder.php
- indexable-repository.php

The latter will trigger on post visit or API call and only if the permalink is `null`. So: do we build the check for an unpublished post in both locations OR do we save the permalink as empty string instead of null, so that it isn't regenerated in indexable-repository? The API call will happen during post editing, so this does need a workaround. If we don't, the first change is useless.

Edit: decided with Herre that saving the permalink as an empty string is the way to go.

I also thought about making the `unpublished_status` array filterable, but decided against that because this might be too niche of a market.

## Test instructions
This PR can be tested by following these steps:

1. Create a new post, but do not publish or save it yet.
1. Check the database:
-- With this fix enabled, the last entry should be of the current post, but with no permalink and permalink_hash
-- Without this fix, the last entry will have a permalink which will contain something along the lines of `auto-draft`. 
1. After clicking "Save draft", the same logic as previously stated should apply.
1. After clicking publish, the database entry should have a valid permalink.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/15246
