### PR TITLE
Add SECURITY.md to the repository

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -17,10 +17,10 @@ Please do not discuss any vulnerabilities (even resolved ones) without express c
 ### Submit your report
 When you've found a security issue that abides by the rules and scope of this project, please submit the report to us via security@yoast.com. In your mail, make sure to include:
 
-- The calculation of the CVSS (using the CVSS calculator)
-- The impact of the issue
-- A detailed guide on how to reproduce the issue
-- Provide the email address you used to create a MyYoast-account (if applicable)
+- the calculation of the CVSS (using the [CVSS calculator](https://www.first.org/cvss/calculator/3.0));
+- the impact of the issue;
+- a detailed guide on how to reproduce the issue;
+- the email address you used to create a MyYoast-account (if applicable).
 
 ### After your submission
 We will make a best effort to meet the following response targets for security reports:

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+This is a short excerpt of our [security bounty program](https://yoast.com/security-program/):
+
+### The rules
+- Please provide detailed reports with reproducible steps. If the report is not detailed enough to reproduce the issue, the issue will not be eligible for a reward.
+- Submit one vulnerability per report, unless you need to chain vulnerabilities to provide impact.
+- For duplicates, we only award the first report that was received (provided that it can be fully reproduced).
+- Multiple vulnerabilities caused by one underlying issue will only be eligible for one reward.
+- When testing has an overlap with systems or services not owned by you, the tester, make a good faith effort to avoid privacy violations, destruction of data, and interruption or degradation of that service. Only interact with accounts you own or with the explicit permission of the account holder.
+
+### Disclosure Policy
+Please do not discuss any vulnerabilities (even resolved ones) without express consent.
+
+### Submit your report
+When you've found a security issue that abides by the rules and scope of this project, please submit the report to us via security@yoast.com. In your mail, make sure to include:
+
+- The calculation of the CVSS (using the CVSS calculator)
+- The impact of the issue
+- A detailed guide on how to reproduce the issue
+- Provide the email address you used to create a MyYoast-account (if applicable)
+
+### After your submission
+We will make a best effort to meet the following response targets for security reports:
+
+- Time to first response (from report submit) - 3 business days
+- Time to triage (from report submit) - 10 business days
+- Time to bounty (from triage) - 10 business days


### PR DESCRIPTION
Adding the security policy to the repo to let security researchers know about our security bug bounty program. As advised [here](https://docs.github.com/en/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository) and agreed upon in the security meetings. I added the file to the `.github` dir to keep the root as clean as possible.

This PR is not related to the plugins' code or workings, hence no test instructions are provided. 
Awaiting review from security team leads.