### PR TITLE
[P2-272] Don't do queries when there are no post IDs

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -98,6 +98,10 @@ class WPSEO_Meta_Columns {
 			$post_ids = array_keys( $posts );
 		}
 
+		if ( empty( $post_ids ) ) {
+			return;
+		}
+
 		if ( isset( $posts[0] ) && ! is_a( $posts[0], WP_Post::class ) ) {
 			// Prime the post caches as core would to avoid duplicate queries.
 			// This needs to be done as this executes before core does.

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -329,6 +329,10 @@ class Indexable_Repository {
 	 * @return Indexable[] An array of indexables.
 	 */
 	public function find_by_multiple_ids_and_type( $object_ids, $object_type, $auto_create = true ) {
+		if ( empty( $object_ids ) ) {
+			return [];
+		}
+
 		/**
 		 * Represents an array of indexable objects.
 		 *

--- a/tests/unit/admin/meta-columns-test.php
+++ b/tests/unit/admin/meta-columns-test.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Admin;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use stdClass;
+use WPSEO_Meta_Columns;
+use Yoast\WP\SEO\Surfaces\Meta_Surface;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Unit test class.
+ *
+ * @group Admin
+ *
+ * @coversDefaultClass WPSEO_Meta_Columns
+ */
+class Meta_Columns_Test extends TestCase {
+
+	/**
+	 * Tests the get_post_ids_and_set_meta_cache function.
+	 *
+	 * @covers ::__construct
+	 * @covers ::get_post_ids_and_set_meta_cache
+	 */
+	public function test_get_post_ids_and_set_meta_cache() {
+		global $wp_query;
+
+		$instance = new WPSEO_Meta_Columns();
+
+		$posts = [ Mockery::mock( 'WP_Post' ) ];
+
+		$wp_query = Mockery::mock( 'WP_Query' );
+		$wp_query->posts = [];
+		$wp_query->expects( 'get_posts' )->once()->andReturn( $posts );
+
+		Functions\expect( 'wp_list_pluck' )
+			->once()
+			->with( $posts, 'ID' )
+			->andReturn( [ 1 ] );
+
+		$results = [ (object) [ 'id' => 1 ] ];
+
+		$meta_surface = Mockery::mock( Meta_Surface::class );
+		$meta_surface->expects( 'for_posts' )
+			->once()
+			->with( [ 1 ] )
+			->andReturn( $results );
+
+		Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'meta' => $meta_surface ] );
+
+		$instance->get_post_ids_and_set_meta_cache( 'top' );
+	}
+
+	/**
+	 * Tests the get_post_ids_and_set_meta_cache function.
+	 *
+	 * @covers ::__construct
+	 * @covers ::get_post_ids_and_set_meta_cache
+	 */
+	public function test_get_post_ids_and_set_meta_cache_with_posts() {
+		global $wp_query;
+
+		$instance = new WPSEO_Meta_Columns();
+
+		$posts = [ Mockery::mock( 'WP_Post' ) ];
+
+		$wp_query = Mockery::mock( 'WP_Query' );
+		$wp_query->posts = $posts;
+
+		Functions\expect( 'wp_list_pluck' )
+			->once()
+			->with( $posts, 'ID' )
+			->andReturn( [ 1 ] );
+
+		$results = [ (object) [ 'id' => 1 ] ];
+
+		$meta_surface = Mockery::mock( Meta_Surface::class );
+		$meta_surface->expects( 'for_posts' )
+			->once()
+			->with( [ 1 ] )
+			->andReturn( $results );
+
+		Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'meta' => $meta_surface ] );
+
+		$instance->get_post_ids_and_set_meta_cache( 'top' );
+	}
+
+	/**
+	 * Tests the get_post_ids_and_set_meta_cache function.
+	 *
+	 * @covers ::__construct
+	 * @covers ::get_post_ids_and_set_meta_cache
+	 */
+	public function test_get_post_ids_and_set_meta_cache_with_non_post_query() {
+		global $wp_query;
+
+		$instance = new WPSEO_Meta_Columns();
+
+		$posts = [ new stdClass ];
+
+		$wp_query = Mockery::mock( 'WP_Query' );
+		$wp_query->posts = [];
+		$wp_query->expects( 'get_posts' )->once()->andReturn( $posts );
+
+		Functions\expect( 'wp_list_pluck' )
+			->once()
+			->with( $posts, 'ID' )
+			->andReturn( [ 1 ] );
+
+		Functions\expect( '_prime_post_caches' )->once()->with( [ 1 ] );
+
+		$results = [ (object) [ 'id' => 1 ] ];
+
+		$meta_surface = Mockery::mock( Meta_Surface::class );
+		$meta_surface->expects( 'for_posts' )
+			->once()
+			->with( [ 1 ] )
+			->andReturn( $results );
+
+		Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'meta' => $meta_surface ] );
+
+		$instance->get_post_ids_and_set_meta_cache( 'top' );
+	}
+
+	/**
+	 * Tests the get_post_ids_and_set_meta_cache function.
+	 *
+	 * @covers ::__construct
+	 * @covers ::get_post_ids_and_set_meta_cache
+	 */
+	public function test_get_post_ids_and_set_meta_cache_with_no_results() {
+		global $wp_query;
+
+		$instance = new WPSEO_Meta_Columns();
+
+		$posts = [];
+
+		$wp_query = Mockery::mock( 'WP_Query' );
+		$wp_query->posts = [];
+		$wp_query->expects( 'get_posts' )->once()->andReturn( $posts );
+
+		$instance->get_post_ids_and_set_meta_cache( 'top' );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to do any queries that result in invalid SQL.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an error that occurred when viewing the overview of posts, pages or custom post types while there were no entries.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See https://yoast.atlassian.net/browse/P2-272 for the original steps to reproduce.
* This issue should also occur on the overview of any custom post types that has no posts.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-272