### PR TITLE
WebPack RC build version fix - P2-256

### DIFF
--- a/config/grunt/task-config/webpack.js
+++ b/config/grunt/task-config/webpack.js
@@ -1,12 +1,8 @@
 /* global require */
 const webpackConfig = require( "../../webpack/webpack.config" );
-const get = require( "lodash" ).get;
-
 module.exports = ( grunt ) => {
-	const pluginVersion = get( grunt, "config.data.pluginVersion", null );
-
 	return {
-		buildDev: () => webpackConfig( { environment: "development", pluginVersion } ),
-		buildProd: () => webpackConfig( { environment: "production", pluginVersion } ),
+		buildDev: () => webpackConfig( { environment: "development", pluginVersion: "<%= pluginVersionSlug %>" } ),
+		buildProd: () => webpackConfig( { environment: "production", pluginVersion: "<%= pluginVersionSlug %>" } ),
 	};
 };

--- a/config/grunt/task-config/webpack.js
+++ b/config/grunt/task-config/webpack.js
@@ -1,6 +1,6 @@
 /* global require */
 const webpackConfig = require( "../../webpack/webpack.config" );
-module.exports = ( grunt ) => {
+module.exports = () => {
 	return {
 		buildDev: () => webpackConfig( { environment: "development", pluginVersion: "<%= pluginVersionSlug %>" } ),
 		buildProd: () => webpackConfig( { environment: "production", pluginVersion: "<%= pluginVersionSlug %>" } ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Using the `<%= %>` variable notation makes sure the variable is read on run-time instead of initialization. This prevents the problem of not having the correct version after doing a version bump in the same grunt-sequence (alias progression).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use the `create RC`-flow
* Bump the RC version
* See the JavaScript and CSS files having the correct (bumped) version in their filename after they have been build.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P2-256
