### PR TITLE
P3-118 Fix problem with country code not initialized with value from database

### DIFF
--- a/js/src/initializers/editor-store.js
+++ b/js/src/initializers/editor-store.js
@@ -33,7 +33,9 @@ export default function initEditorStore() {
 				recommendedReplacementVariables: window.wpseoScriptData.analysis.plugins.replaceVars.recommended_replace_vars,
 				siteIconUrl: window.wpseoScriptData.metabox.siteIconUrl,
 			},
-		} ),
+		} )
+	);
+	store.dispatch(
 		setSEMrushChangeCountry( window.wpseoScriptData.metabox.countryCode )
 	);
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* #15832 introduced a regression about the retrieval of the country code from the database.
When user edits a post and opens the SEMrush modal, the country database is set on `us` (the default value) regardless of the value stored in the database.
Changing the value in the country selector and sending a new request changes the value correctly in the database, but if you reload the page the selector will be reset to `us` again. 
Also, opening the modal for the first time sends a request immediately, so the value in the database is set to `us` after the modal has been opened.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fix problem with country code not initialized with value from database

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Build as usual
* Edit a post and input a focus keyphrase
* Open the SEMrush modal and take note of the country database that's been queried (should be `us` by default, but you may have changed it before)
* Select another country in the dropdown and click on the button to send another request
* reload the page and input a focus keyphrase
* Open the SEMrush modal and observe the dropdown is set on the last country you choose in the step above
* You can also perform the above tests checking for the `wpseo` options array in the database (`semrush_country_code` key) and `State > root > SEMrushRequest > countryCode` for `yoast-seo/editor` in the Redux DevTools.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-118]
