### PR TITLE
P1-134 Prevent modal from closing when the media library opens

### DIFF
--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -3,8 +3,9 @@ import { MultiSelect, Select } from "@yoast/components";
 import { RadioButtonGroup } from "@yoast/components";
 import { TextInput } from "@yoast/components";
 import { curryUpdateToHiddenInput, getValueFromHiddenInput } from "@yoast/helpers";
-import { Component, Fragment } from "@wordpress/element";
+import { Fragment } from "@wordpress/element";
 import { Alert } from "@yoast/components";
+import PropTypes from "prop-types";
 
 /**
  * Boolean that tells whether the current object refers to a post or a taxonomy.
@@ -12,6 +13,22 @@ import { Alert } from "@yoast/components";
  * @returns {Boolean} Whether this is a post or not.
  */
 const isPost = () => !! window.wpseoScriptData.isPost;
+
+/**
+ * If location is not empty, we append it to the id, to keep id's unique.
+ *
+ * @param {string} id       The id.
+ * @param {string} location The location.
+ *
+ * @returns {string} The hopefully unique id.
+ */
+const appendLocation = ( id, location ) => {
+	if ( location ) {
+		return `${ id }_${ location }`;
+	}
+
+	return id;
+};
 
 /**
  * The values that are used for the noIndex field differ for posts and taxonomies. This function returns an array of
@@ -54,16 +71,18 @@ const getNoIndexOptions = () => {
 	];
 };
 
-
 /**
  * Functional component for the Meta Robots No-Index option.
  *
+ * @param {Object} props The props object
+ *
  * @returns {Component} The Meta Robots No-Index component.
  */
-const MetaRobotsNoIndex = () => {
+const MetaRobotsNoIndex = ( { location } ) => {
 	const hiddenInputId = isPost() ? "#yoast_wpseo_meta-robots-noindex" : "#hidden_wpseo_noindex";
 	const metaRobotsNoIndexOptions = getNoIndexOptions();
 	const value = getValueFromHiddenInput( hiddenInputId );
+	const id = appendLocation( "yoast_wpseo_meta-robots-noindex-react", location );
 	return <Fragment>
 		{
 			window.wpseoAdminL10n.privateBlog &&
@@ -84,13 +103,21 @@ const MetaRobotsNoIndex = () => {
 				) }
 			onChange={ curryUpdateToHiddenInput( hiddenInputId ) }
 			name={ "yoast_wpseo_meta-robots-noindex-react" }
-			id={ "yoast_wpseo_meta-robots-noindex-react" }
+			id={ id }
 			options={ metaRobotsNoIndexOptions }
 			selected={ value }
 			linkTo={ "https://yoa.st/allow-search-engines" }
 			linkText={ __( "Learn more about the no-index setting on our help page.", "wordpress-seo" ) }
 		/>
 	</Fragment>;
+};
+
+MetaRobotsNoIndex.propTypes = {
+	location: PropTypes.string,
+};
+
+MetaRobotsNoIndex.defaultProps = {
+	location: "",
 };
 
 /**
@@ -120,17 +147,20 @@ const MetaRobotsNoFollow = () => {
 /**
  * Functional component for the Meta Robots Advanced field.
  *
+ * @param {Object} props The props object
+ *
  * @returns {Component} The Meta Robots advanced field component.
  */
-const MetaRobotsAdvanced = () => {
+const MetaRobotsAdvanced = ( { location } ) => {
 	const hiddenInputId = "#yoast_wpseo_meta-robots-adv";
 	const value = getValueFromHiddenInput( hiddenInputId );
+	const id = appendLocation( "yoast_wpseo_meta-robots-adv-react", location );
 
 	return <MultiSelect
 		label={ __( "Meta robots advanced", "wordpress-seo" ) }
 		onChange={ curryUpdateToHiddenInput( hiddenInputId ) }
 		name="yoast_wpseo_meta-robots-adv-react"
-		id="yoast_wpseo_meta-robots-adv-react"
+		id={ id }
 		options={ [
 			{ name: __( "No Image Index", "wordpress-seo" ), value: "noimageindex" },
 			{ name: __( "No Archive", "wordpress-seo" ), value: "noarchive" },
@@ -142,18 +172,29 @@ const MetaRobotsAdvanced = () => {
 	/>;
 };
 
+MetaRobotsAdvanced.propTypes = {
+	location: PropTypes.string,
+};
+
+MetaRobotsAdvanced.defaultProps = {
+	location: "",
+};
+
 /**
  * Functional component for the Breadcrumbs Title.
  *
+ * @param {Object} props The props object
+ *
  * @returns {Component} The Breadcrumbs title component.
  */
-const BreadCrumbsTitle = () => {
+const BreadCrumbsTitle = ( { location } ) => {
 	const hiddenInputId = isPost() ? "#yoast_wpseo_bctitle" : "#hidden_wpseo_bctitle";
 	const value = getValueFromHiddenInput( hiddenInputId );
+	const id = appendLocation( "yoast_wpseo_bctitle-react", location );
 
 	return <TextInput
 		label={ __( "Breadcrumbs Title", "wordpress-seo" ) }
-		id="yoast_wpseo_bctitle-react"
+		id={ id }
 		name="yoast_wpseo_bctitle-react"
 		onChange={ curryUpdateToHiddenInput( hiddenInputId ) }
 		value={ value }
@@ -162,18 +203,29 @@ const BreadCrumbsTitle = () => {
 	/>;
 };
 
+BreadCrumbsTitle.propTypes = {
+	location: PropTypes.string,
+};
+
+BreadCrumbsTitle.defaultProps = {
+	location: "",
+};
+
 /**
  * Functional component for the Canonical URL.
  *
+ * @param {Object} props The props object
+ *
  * @returns {Component} The canonical URL component.
  */
-const CanonicalURL = () => {
+const CanonicalURL = ( { location } ) => {
 	const hiddenInputId = isPost() ? "#yoast_wpseo_canonical" : "#hidden_wpseo_canonical";
 	const value = getValueFromHiddenInput( hiddenInputId );
+	const id = appendLocation( "yoast_wpseo_canonical-react", location );
 
 	return <TextInput
 		label={ __( "Canonical URL", "wordpress-seo" ) }
-		id="yoast_wpseo_canonical-react"
+		id={ id }
 		name="yoast_wpseo_canonical-react"
 		onChange={ curryUpdateToHiddenInput( hiddenInputId ) }
 		value={ value }
@@ -182,29 +234,41 @@ const CanonicalURL = () => {
 	/>;
 };
 
+CanonicalURL.propTypes = {
+	location: PropTypes.string,
+};
+
+CanonicalURL.defaultProps = {
+	location: "",
+};
 
 /**
- * Class that renders the Advanced Settings tab.
+ * The Advanced Settings component.
+ *
+ * @param {Object} props The props object
+ *
+ * @returns {wp.Element} The AdvancedSettings component.
  */
-class AdvancedSettings extends Component {
-	/**
-	 * Returns all the fields that should be in the Advanced Settings tab based on global settings.
-	 *
-	 * @returns {Component} The Advanced settings tab.
-	 */
-	render() {
-		return (
-			<Fragment>
-				<MetaRobotsNoIndex />
-				{ isPost() && <MetaRobotsNoFollow /> }
-				{ isPost() && <MetaRobotsAdvanced /> }
-				{
-					! window.wpseoAdminL10n.breadcrumbsDisabled && <BreadCrumbsTitle />
-				}
-				<CanonicalURL />
-			</Fragment>
-		);
-	}
-}
+const AdvancedSettings = ( { location } ) => {
+	return (
+		<Fragment>
+			<MetaRobotsNoIndex location={ location } />
+			{ isPost() && <MetaRobotsNoFollow /> }
+			{ isPost() && <MetaRobotsAdvanced location={ location } /> }
+			{
+				! window.wpseoAdminL10n.breadcrumbsDisabled && <BreadCrumbsTitle location={ location } />
+			}
+			<CanonicalURL location={ location } />
+		</Fragment>
+	);
+};
+
+AdvancedSettings.propTypes = {
+	location: PropTypes.string,
+};
+
+AdvancedSettings.defaultProps = {
+	location: "",
+};
 
 export default AdvancedSettings;

--- a/js/src/components/modals/PostSettingsModal.js
+++ b/js/src/components/modals/PostSettingsModal.js
@@ -40,7 +40,7 @@ const modalContent = ( preferences ) => [
 	},
 	{
 		title: __( "Advanced", "wordpress-seo" ),
-		content: <AdvancedSettings />,
+		content: <AdvancedSettings location="modal" />,
 		shouldRender: preferences.displayAdvancedTab,
 	},
 ];
@@ -81,6 +81,26 @@ DrawerContainer.propTypes = {
 };
 
 /**
+ * Returns false for events passed to onRequestClose, that should not lead to the modal closing.
+ * Returns true for events that indeed should lead to the modal closing.
+ *
+ * @param {Event} event The event that was passed to onRequestClose.
+ *
+ * @returns {boolean} False when this event should not lead to closing to modal. True otherwise.
+ */
+const isCloseEvent = ( event ) => {
+	if ( event.type === "blur" ) {
+		// The blur event type should only close the modal when the screen overlay is clicked.
+		if ( event.relatedTarget && event.relatedTarget.querySelector( ".components-modal__screen-overlay" ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	return true;
+};
+
+/**
  * Returns a button in a div that can be used to open the modal.
  *
  * Warning: contains styling that is specific for the Sidebar.
@@ -91,8 +111,8 @@ const PostSettingsModal = ( { preferences, postTypeName } ) => {
 	const [ isOpen, changeIsOpen ] = useState( false );
 
 	const closeModal = useCallback( ( event ) => {
-		// Prevent the modal from closing when the media library opens over the modal.
-		if ( event.type === "blur" && event.relatedTarget.className === "media-modal wp-core-ui" ) {
+		// Prevent the modal from closing when the event is a false positive.
+		if ( ! isCloseEvent( event ) ) {
 			return;
 		}
 

--- a/js/src/components/modals/PostSettingsModal.js
+++ b/js/src/components/modals/PostSettingsModal.js
@@ -90,7 +90,14 @@ DrawerContainer.propTypes = {
 const PostSettingsModal = ( { preferences, postTypeName } ) => {
 	const [ isOpen, changeIsOpen ] = useState( false );
 
-	const closeModal = useCallback( () => changeIsOpen( false ), [] );
+	const closeModal = useCallback( ( event ) => {
+		// Prevent the modal from closing when the media library opens over the modal.
+		if ( event.type === "blur" && event.relatedTarget.className === "media-modal wp-core-ui" ) {
+			return;
+		}
+
+		changeIsOpen( false );
+	}, [] );
 	const openModal = useCallback( () => changeIsOpen( true ), [] );
 
 	return (


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The modal currently closes after selecting an image in or closing the media library. This gives a very bad user experience since the user has to open the modal again. This PR prevents the modal from closing when the media library opens.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents the Metabox Modal from closing when the media library opens.

## Relevant technical choices:

* I check whether the media library opens by looking for the `blur` eventType and whether the related target (the media library) has a `className` of `media-modal wp-core-ui`. I think this covers all our current cases in the modal and might even cover future cases where the media library is needed.
* Note: the media library dialog does not have an ID. Therefore, I have decided to match based on the `className`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Facebook and Twitter image selection
* Open the post settings modal
* Do the steps below for Twitter and Facebook
* Open the Twitter preview settings
* Click the `Select Image` button
* Select an image in the media library
* After selection, the modal should still be open
* Click the `Replace Image` button
* Select an image in the media library
* After selection, the modal should still be open
* Click the `Replace Image` button
* Close the media library by clicking on the :x: in the top-right corner
* The modal should still be open
* Click the `Replace Image` button
* Close the media library by pressing the `ESC` key
* The modal should still be open
* Click the `Replace Image` button
* Close the media library by clicking outside its borders
* The modal should still be open

### Advanced Meta Robots dropdown
* Open the post settings modal
* Go to the Advanced: Meta robots advanced select
* Verify the styling is now the same as before (and in the metabox).
* Open the dropdown and click an option (or select it with the keyboard), the modal should still be open
* Open the dropdown and click outside of the modal, the modal should close
* Known thing: pressing escape when the select has focus will not close the modal, it is captured by select2
* Smoketest the metabox version

### Modal itself
* Open the post settings modal
* Press escape, the modal should close
* Open the modal
* Click the `Return to your post` button below, the modal should close
* Open the modal
* Click outside of the modal, the modal should close

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-134
