### PR TITLE
Check trimmed keyphrase before opening the modal

### DIFF
--- a/js/src/components/RelatedKeyphrasesModal.js
+++ b/js/src/components/RelatedKeyphrasesModal.js
@@ -38,7 +38,7 @@ class RelatedKeyphrasesModal extends Component {
 	onModalOpen() {
 		// Add not-logged in logic here.
 
-		if ( ! this.props.keyphrase ) {
+		if ( ! this.props.keyphrase.trim() ) {
 			this.props.onOpenWithNoKeyphrase();
 			return;
 		}

--- a/js/src/components/contentAnalysis/KeywordInput.js
+++ b/js/src/components/contentAnalysis/KeywordInput.js
@@ -10,8 +10,8 @@ import { KeywordInput as KeywordInputComponent } from "yoast-components";
 import styled from "styled-components";
 
 /* Internal dependencies */
-import { setFocusKeyword } from "../../redux/actions/focusKeyword";
-import { setMarkerPauseStatus } from "../../redux/actions/markerPauseStatus";
+import { setFocusKeyword } from "../../redux/actions";
+import { setMarkerPauseStatus } from "../../redux/actions";
 import HelpLink from "../HelpLink";
 import { LocationConsumer } from "../contexts/location";
 import SEMrushModal from "../../containers/RelatedKeyphrasesModal";
@@ -63,7 +63,7 @@ class KeywordInput extends Component {
 	validate() {
 		const errors = [];
 
-		if ( this.props.keyword.length === 0 && this.props.displayNoKeyphraseMessage ) {
+		if ( this.props.keyword.trim().length === 0 && this.props.displayNoKeyphraseMessage ) {
 			errors.push( __( "Please enter a focus keyphrase first to get related keyphrases", "wordpress-seo" ) );
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to allow the user to open the SEMrush modal only if the focus keyphrase is not completely blank.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Show error message when trying to get related keyphrases for a blank focus keyword

## Relevant technical choices:

* The original issue asked to prevent to fire the content analysis for blank keyphrase too, but it's a bit harder and out of the scope of the SEMrush integration. It will be the focus of another issue.
* The commit also fixes two warnings about import that could be shortened.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Build as usual
* Edit a new or an existing post
* insert a focus keyphrase of only spaces, or tabs
* Click the "Get related keyphrases" button
* See the error message "Please enter a focus keyphrase first to get related keyphrases" popping up, and the modal not opening
* Try the same with a keyphrase containing spaces, even at the start and at the end, and see the modal is working

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-86]
