### PR TITLE
Add postSettingsModal actions

### DIFF
--- a/js/src/components/SnippetPreviewModal.js
+++ b/js/src/components/SnippetPreviewModal.js
@@ -7,6 +7,7 @@ import styled, { createGlobalStyle } from "styled-components";
 /* Yoast dependencies */
 import { ButtonSection } from "yoast-components";
 import { colors, rgba } from "@yoast/style-guide";
+import { Alert } from "@yoast/components";
 
 /* Internal dependencies */
 import SnippetEditorWrapper from "../containers/SnippetEditor";
@@ -46,6 +47,11 @@ class SnippetPreviewModal extends Component {
 		this.setState( { isOpen: false } );
 	}
 
+	/**
+	 * Returns the SnippetPreviewModal.
+	 * 
+	 * @returns {Component} The SnippetPreviewModal.
+	 */
 	render() {
 		return (
 			<Fragment>
@@ -63,6 +69,9 @@ class SnippetPreviewModal extends Component {
 						onRequestClose={ this.closeModal }
 						overlayClassName="yoast-modal__screen-overlay"
 					>
+						<Alert type="info">
+							{ __( "This preview will be removed from here, and can already be found in the post settings.", "wordpress-seo" ) }
+						</Alert>
 						<ModalContentSpacer>
 							<SnippetEditorWrapper showCloseButton={ false } hasPaperStyle={ false } />
 						</ModalContentSpacer>

--- a/js/src/components/SnippetPreviewModal.js
+++ b/js/src/components/SnippetPreviewModal.js
@@ -49,7 +49,7 @@ class SnippetPreviewModal extends Component {
 
 	/**
 	 * Returns the SnippetPreviewModal.
-	 * 
+	 *
 	 * @returns {Component} The SnippetPreviewModal.
 	 */
 	render() {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to notify users that the SnippetPreviewModal will be removed in the future.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add an info alert to the SnippetPreviewModal that points to the new location.

## Relevant technical choices:

* Copy has been created by Thijs.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Open the `SnippetPreviewModal`
* See the Alert.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-136
