### PR TITLE
Route data via Redux for Advanced Tab

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1117,8 +1117,8 @@ SVG;
 			'postType'             => get_post_type(),
 			'postTypeNamePlural'   => ( $page_type === 'post' ) ? $label_object->label : $label_object->name,
 			'postTypeNameSingular' => ( $page_type === 'post' ) ? $label_object->labels->singular_name : $label_object->singular_name,
-			'breadcrumbsDisabled'  => WPSEO_Options::get( 'breadcrumbs-enable', false ) !== true && ! current_theme_supports( 'yoast-seo-breadcrumbs' ),
-			'privateBlog'          => ( (string) get_option( 'blog_public' ) ) === '0',
+			'isBreadcrumbsDisabled'  => WPSEO_Options::get( 'breadcrumbs-enable', false ) !== true && ! current_theme_supports( 'yoast-seo-breadcrumbs' ),
+			'isPrivateBlog'          => ( (string) get_option( 'blog_public' ) ) === '0',
 		];
 
 		$additional_entries = apply_filters( 'wpseo_admin_l10n', [] );

--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -125,7 +125,6 @@ MetaRobotsNoIndex.defaultProps = {
  * @returns {Component} The Meta Robots No-Follow option.
  */
 const MetaRobotsNoFollow = ( { noFollow, onNoFollowChange } ) => {
-	console.log( noFollow );
 	return <RadioButtonGroup
 		options={ [ { value: "0", label: "Yes" }, { value: "1", label: "No" } ] }
 		label={ sprintf(

--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -33,12 +33,14 @@ const appendLocation = ( id, location ) => {
  * The values that are used for the noIndex field differ for posts and taxonomies. This function returns an array of
  * options that can be used to populate a select field.
  *
+ * @param {Object} editorContext An object containing context about this editor.
+ *
  * @returns {void} Array Returns an array of options for the noIndex setting.
  */
-const getNoIndexOptions = () => {
+const getNoIndexOptions = ( editorContext ) => {
 	const translatedNo = __( "No", "wordpress-seo" );
 	const translatedYes = __( "Yes", "wordpress-seo" );
-	const noIndex = window.wpseoAdminL10n.noIndex ? translatedNo : translatedYes;
+	const noIndex = editorContext.noIndex ? translatedNo : translatedYes;
 
 	if ( isPost() ) {
 		return [
@@ -47,7 +49,7 @@ const getNoIndexOptions = () => {
 					/* Translators: %s translates to "yes" or "no", %s translates to the Post Label in plural form */
 					__( "%s (current default for %s)", "wordpress-seo" ),
 					noIndex,
-					window.wpseoAdminL10n.postTypeNamePlural,
+					editorContext.postTypeNamePlural,
 				),
 				value: "0",
 			},
@@ -61,7 +63,7 @@ const getNoIndexOptions = () => {
 				/* Translators: %s translates to the "yes" or "no" ,%s translates to the Post Label in plural form */
 				__( "%s (current default for %s)", "wordpress-seo" ),
 				noIndex,
-				window.wpseoAdminL10n.postTypeNamePlural,
+				editorContext.postTypeNamePlural,
 			),
 			value: "default",
 		},
@@ -77,8 +79,8 @@ const getNoIndexOptions = () => {
  *
  * @returns {Component} The Meta Robots No-Index component.
  */
-const MetaRobotsNoIndex = ( { noIndex, onNoIndexChange, postTypeName, isPrivateBlog, location } ) => {
-	const metaRobotsNoIndexOptions = getNoIndexOptions();
+const MetaRobotsNoIndex = ( { noIndex, onNoIndexChange, editorContext, isPrivateBlog, location } ) => {
+	const metaRobotsNoIndexOptions = getNoIndexOptions( editorContext );
 	const id = appendLocation( "yoast_wpseo_meta-robots-noindex-react", location );
 	return <Fragment>
 		{
@@ -96,7 +98,7 @@ const MetaRobotsNoIndex = ( { noIndex, onNoIndexChange, postTypeName, isPrivateB
 				sprintf(
 					/* Translators: %s translates to the Post Label in singular form */
 					__( "Allow search engines to show this %s in search results?", "wordpress-seo" ),
-					postTypeName,
+					editorContext.postTypeNameSingular,
 				) }
 			onChange={ onNoIndexChange }
 			name={ "yoast_wpseo_meta-robots-noindex-react" }
@@ -112,7 +114,7 @@ const MetaRobotsNoIndex = ( { noIndex, onNoIndexChange, postTypeName, isPrivateB
 MetaRobotsNoIndex.propTypes = {
 	noIndex: PropTypes.string.isRequired,
 	onNoIndexChange: PropTypes.func.isRequired,
-	postTypeName: PropTypes.string.isRequired,
+	editorContext: PropTypes.object.isRequired,
 	isPrivateBlog: PropTypes.bool,
 	location: PropTypes.string,
 };
@@ -286,7 +288,7 @@ const AdvancedSettings = ( props ) => {
 		noIndex,
 		onNoIndexChange,
 		location,
-		postTypeName: editorContext.postTypeNameSingular,
+		editorContext,
 		isPrivateBlog,
 	};
 

--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -187,7 +187,7 @@ MetaRobotsAdvanced.defaultProps = {
  *
  * @returns {Component} The Breadcrumbs title component.
  */
-const BreadCrumbsTitle = ( { location } ) => {
+const BreadcrumbsTitle = ( { location } ) => {
 	const hiddenInputId = isPost() ? "#yoast_wpseo_bctitle" : "#hidden_wpseo_bctitle";
 	const value = getValueFromHiddenInput( hiddenInputId );
 	const id = appendLocation( "yoast_wpseo_bctitle-react", location );
@@ -203,11 +203,11 @@ const BreadCrumbsTitle = ( { location } ) => {
 	/>;
 };
 
-BreadCrumbsTitle.propTypes = {
+BreadcrumbsTitle.propTypes = {
 	location: PropTypes.string,
 };
 
-BreadCrumbsTitle.defaultProps = {
+BreadcrumbsTitle.defaultProps = {
 	location: "",
 };
 
@@ -256,7 +256,7 @@ const AdvancedSettings = ( { location } ) => {
 			{ isPost() && <MetaRobotsNoFollow /> }
 			{ isPost() && <MetaRobotsAdvanced location={ location } /> }
 			{
-				! window.wpseoAdminL10n.breadcrumbsDisabled && <BreadCrumbsTitle location={ location } />
+				! window.wpseoAdminL10n.breadcrumbsDisabled && <BreadcrumbsTitle location={ location } />
 			}
 			<CanonicalURL location={ location } />
 		</Fragment>

--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -2,8 +2,7 @@ import { __, sprintf } from "@wordpress/i18n";
 import { MultiSelect, Select } from "@yoast/components";
 import { RadioButtonGroup } from "@yoast/components";
 import { TextInput } from "@yoast/components";
-import { curryUpdateToHiddenInput, getValueFromHiddenInput } from "@yoast/helpers";
-import { Fragment } from "@wordpress/element";
+import { Fragment, useEffect } from "@wordpress/element";
 import { Alert } from "@yoast/components";
 import PropTypes from "prop-types";
 
@@ -78,10 +77,8 @@ const getNoIndexOptions = () => {
  *
  * @returns {Component} The Meta Robots No-Index component.
  */
-const MetaRobotsNoIndex = ( { location } ) => {
-	const hiddenInputId = isPost() ? "#yoast_wpseo_meta-robots-noindex" : "#hidden_wpseo_noindex";
+const MetaRobotsNoIndex = ( { noIndex, onNoIndexChange, location } ) => {
 	const metaRobotsNoIndexOptions = getNoIndexOptions();
-	const value = getValueFromHiddenInput( hiddenInputId );
 	const id = appendLocation( "yoast_wpseo_meta-robots-noindex-react", location );
 	return <Fragment>
 		{
@@ -101,11 +98,11 @@ const MetaRobotsNoIndex = ( { location } ) => {
 					__( "Allow search engines to show this %s in search results?", "wordpress-seo" ),
 					window.wpseoAdminL10n.postTypeNameSingular,
 				) }
-			onChange={ curryUpdateToHiddenInput( hiddenInputId ) }
+			onChange={ onNoIndexChange }
 			name={ "yoast_wpseo_meta-robots-noindex-react" }
 			id={ id }
 			options={ metaRobotsNoIndexOptions }
-			selected={ value }
+			selected={ noIndex }
 			linkTo={ "https://yoa.st/allow-search-engines" }
 			linkText={ __( "Learn more about the no-index setting on our help page.", "wordpress-seo" ) }
 		/>
@@ -113,6 +110,8 @@ const MetaRobotsNoIndex = ( { location } ) => {
 };
 
 MetaRobotsNoIndex.propTypes = {
+	noIndex: PropTypes.string.isRequired,
+	onNoIndexChange: PropTypes.func.isRequired,
 	location: PropTypes.string,
 };
 
@@ -125,10 +124,8 @@ MetaRobotsNoIndex.defaultProps = {
  *
  * @returns {Component} The Meta Robots No-Follow option.
  */
-const MetaRobotsNoFollow = () => {
-	const hiddenInputId = "#yoast_wpseo_meta-robots-nofollow";
-	const value = getValueFromHiddenInput( hiddenInputId );
-
+const MetaRobotsNoFollow = ( { noFollow, onNoFollowChange } ) => {
+	console.log( noFollow );
 	return <RadioButtonGroup
 		options={ [ { value: "0", label: "Yes" }, { value: "1", label: "No" } ] }
 		label={ sprintf(
@@ -137,11 +134,16 @@ const MetaRobotsNoFollow = () => {
 			window.wpseoAdminL10n.postTypeNameSingular,
 		) }
 		groupName="yoast_wpseo_meta-robots-nofollow-react"
-		onChange={ curryUpdateToHiddenInput( hiddenInputId ) }
-		selected={ value }
+		onChange={ onNoFollowChange }
+		selected={ noFollow }
 		linkTo={ "https://yoa.st/follow-links" }
 		linkText={ __( "Learn more about the no-follow setting on our help page.", "wordpress-seo" ) }
 	/>;
+};
+
+MetaRobotsNoFollow.propTypes = {
+	noFollow: PropTypes.string.isRequired,
+	onNoFollowChange: PropTypes.func.isRequired,
 };
 
 /**
@@ -151,14 +153,12 @@ const MetaRobotsNoFollow = () => {
  *
  * @returns {Component} The Meta Robots advanced field component.
  */
-const MetaRobotsAdvanced = ( { location } ) => {
-	const hiddenInputId = "#yoast_wpseo_meta-robots-adv";
-	const value = getValueFromHiddenInput( hiddenInputId );
+const MetaRobotsAdvanced = ( { advanced, onAdvancedChange, location } ) => {
 	const id = appendLocation( "yoast_wpseo_meta-robots-adv-react", location );
 
 	return <MultiSelect
 		label={ __( "Meta robots advanced", "wordpress-seo" ) }
-		onChange={ curryUpdateToHiddenInput( hiddenInputId ) }
+		onChange={ onAdvancedChange }
 		name="yoast_wpseo_meta-robots-adv-react"
 		id={ id }
 		options={ [
@@ -166,13 +166,15 @@ const MetaRobotsAdvanced = ( { location } ) => {
 			{ name: __( "No Archive", "wordpress-seo" ), value: "noarchive" },
 			{ name: __( "No Snippet", "wordpress-seo" ), value: "nosnippet" },
 		] }
-		selected={ value.split( "," ) }
+		selected={ advanced }
 		linkTo={ "https://yoa.st/meta-robots-advanced" }
 		linkText={ __( "Learn more about advanced meta robots settings on our help page.", "wordpress-seo" ) }
 	/>;
 };
 
 MetaRobotsAdvanced.propTypes = {
+	advanced: PropTypes.array.isRequired,
+	onAdvancedChange: PropTypes.func.isRequired,
 	location: PropTypes.string,
 };
 
@@ -187,23 +189,23 @@ MetaRobotsAdvanced.defaultProps = {
  *
  * @returns {Component} The Breadcrumbs title component.
  */
-const BreadcrumbsTitle = ( { location } ) => {
-	const hiddenInputId = isPost() ? "#yoast_wpseo_bctitle" : "#hidden_wpseo_bctitle";
-	const value = getValueFromHiddenInput( hiddenInputId );
+const BreadcrumbsTitle = ( { breadcrumbsTitle, onBreadcrumbsTitleChange, location } ) => {
 	const id = appendLocation( "yoast_wpseo_bctitle-react", location );
 
 	return <TextInput
 		label={ __( "Breadcrumbs Title", "wordpress-seo" ) }
 		id={ id }
 		name="yoast_wpseo_bctitle-react"
-		onChange={ curryUpdateToHiddenInput( hiddenInputId ) }
-		value={ value }
+		onChange={ onBreadcrumbsTitleChange }
+		value={ breadcrumbsTitle }
 		linkTo={ "https://yoa.st/breadcrumbs-title" }
 		linkText={ __( "Learn more about the breadcrumbs title setting on our help page.", "wordpress-seo" ) }
 	/>;
 };
 
 BreadcrumbsTitle.propTypes = {
+	breadcrumbsTitle: PropTypes.string.isRequired,
+	onBreadcrumbsTitleChange: PropTypes.func.isRequired,
 	location: PropTypes.string,
 };
 
@@ -218,23 +220,23 @@ BreadcrumbsTitle.defaultProps = {
  *
  * @returns {Component} The canonical URL component.
  */
-const CanonicalURL = ( { location } ) => {
-	const hiddenInputId = isPost() ? "#yoast_wpseo_canonical" : "#hidden_wpseo_canonical";
-	const value = getValueFromHiddenInput( hiddenInputId );
+const CanonicalURL = ( { canonical, onCanonicalChange, location } ) => {
 	const id = appendLocation( "yoast_wpseo_canonical-react", location );
 
 	return <TextInput
 		label={ __( "Canonical URL", "wordpress-seo" ) }
 		id={ id }
 		name="yoast_wpseo_canonical-react"
-		onChange={ curryUpdateToHiddenInput( hiddenInputId ) }
-		value={ value }
+		onChange={ onCanonicalChange }
+		value={ canonical }
 		linkTo={ "https://yoa.st/canonical-url" }
 		linkText={ __( "Learn more about canonical URLs on our help page.", "wordpress-seo" ) }
 	/>;
 };
 
 CanonicalURL.propTypes = {
+	canonical: PropTypes.string.isRequired,
+	onCanonicalChange: PropTypes.func.isRequired,
 	location: PropTypes.string,
 };
 
@@ -249,26 +251,101 @@ CanonicalURL.defaultProps = {
  *
  * @returns {wp.Element} The AdvancedSettings component.
  */
-const AdvancedSettings = ( { location } ) => {
+const AdvancedSettings = ( props ) => {
+	const {
+		noIndex,
+		noFollow,
+		advanced,
+		breadcrumbsTitle,
+		canonical,
+		location,
+		onNoIndexChange,
+		onNoFollowChange,
+		onAdvancedChange,
+		onBreadcrumbsTitleChange,
+		onCanonicalChange,
+		onLoad,
+		isLoading,
+	} = props;
+
+	useEffect( () => {
+		setTimeout( () => {
+			if ( isLoading ) {
+				onLoad();
+			}
+		} );
+	} );
+
+	const noIndexProps = {
+		noIndex,
+		onNoIndexChange,
+		location,
+	};
+
+	const noFollowProps = {
+		noFollow,
+		onNoFollowChange,
+		location,
+	};
+
+	const advancedProps = {
+		advanced,
+		onAdvancedChange,
+		location,
+	};
+	const breadcrumbsTitleProps = {
+		breadcrumbsTitle,
+		onBreadcrumbsTitleChange,
+		location,
+	};
+
+	const canonicalProps = {
+		canonical,
+		onCanonicalChange,
+		location,
+	};
+
+	if ( isLoading ) {
+		return null;
+	}
+
 	return (
 		<Fragment>
-			<MetaRobotsNoIndex location={ location } />
-			{ isPost() && <MetaRobotsNoFollow /> }
-			{ isPost() && <MetaRobotsAdvanced location={ location } /> }
+			<MetaRobotsNoIndex { ...noIndexProps } />
+			{ isPost() && <MetaRobotsNoFollow { ...noFollowProps } /> }
+			{ isPost() && <MetaRobotsAdvanced { ...advancedProps } /> }
 			{
-				! window.wpseoAdminL10n.breadcrumbsDisabled && <BreadcrumbsTitle location={ location } />
+				! window.wpseoAdminL10n.breadcrumbsDisabled && <BreadcrumbsTitle { ...breadcrumbsTitleProps } />
 			}
-			<CanonicalURL location={ location } />
+			<CanonicalURL { ...canonicalProps } />
 		</Fragment>
 	);
 };
 
 AdvancedSettings.propTypes = {
+	noIndex: PropTypes.string.isRequired,
+	canonical: PropTypes.string.isRequired,
+	onNoIndexChange: PropTypes.func.isRequired,
+	onCanonicalChange: PropTypes.func.isRequired,
+	onLoad: PropTypes.func.isRequired,
+	isLoading: PropTypes.bool.isRequired,
+	advanced: PropTypes.array,
+	onAdvancedChange: PropTypes.func,
+	noFollow: PropTypes.string,
+	onNoFollowChange: PropTypes.func,
+	breadcrumbsTitle: PropTypes.string,
+	onBreadcrumbsTitleChange: PropTypes.func,
 	location: PropTypes.string,
 };
 
 AdvancedSettings.defaultProps = {
 	location: "",
+	advanced: [],
+	onAdvancedChange: () => {},
+	noFollow: "",
+	onNoFollowChange: () => {},
+	breadcrumbsTitle: "",
+	onBreadcrumbsTitleChange: () => {},
 };
 
 export default AdvancedSettings;

--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -77,12 +77,12 @@ const getNoIndexOptions = () => {
  *
  * @returns {Component} The Meta Robots No-Index component.
  */
-const MetaRobotsNoIndex = ( { noIndex, onNoIndexChange, location } ) => {
+const MetaRobotsNoIndex = ( { noIndex, onNoIndexChange, postTypeName, isPrivateBlog, location } ) => {
 	const metaRobotsNoIndexOptions = getNoIndexOptions();
 	const id = appendLocation( "yoast_wpseo_meta-robots-noindex-react", location );
 	return <Fragment>
 		{
-			window.wpseoAdminL10n.privateBlog &&
+			isPrivateBlog &&
 			<Alert type="warning">
 				{ __(
 					"Even though you can set the meta robots setting here, the entire site is set to noindex in the sitewide privacy settings, " +
@@ -96,7 +96,7 @@ const MetaRobotsNoIndex = ( { noIndex, onNoIndexChange, location } ) => {
 				sprintf(
 					/* Translators: %s translates to the Post Label in singular form */
 					__( "Allow search engines to show this %s in search results?", "wordpress-seo" ),
-					window.wpseoAdminL10n.postTypeNameSingular,
+					postTypeName,
 				) }
 			onChange={ onNoIndexChange }
 			name={ "yoast_wpseo_meta-robots-noindex-react" }
@@ -112,10 +112,13 @@ const MetaRobotsNoIndex = ( { noIndex, onNoIndexChange, location } ) => {
 MetaRobotsNoIndex.propTypes = {
 	noIndex: PropTypes.string.isRequired,
 	onNoIndexChange: PropTypes.func.isRequired,
+	postTypeName: PropTypes.string.isRequired,
+	isPrivateBlog: PropTypes.bool,
 	location: PropTypes.string,
 };
 
 MetaRobotsNoIndex.defaultProps = {
+	isPrivateBlog: false,
 	location: "",
 };
 
@@ -124,13 +127,13 @@ MetaRobotsNoIndex.defaultProps = {
  *
  * @returns {Component} The Meta Robots No-Follow option.
  */
-const MetaRobotsNoFollow = ( { noFollow, onNoFollowChange } ) => {
+const MetaRobotsNoFollow = ( { noFollow, onNoFollowChange, postTypeName } ) => {
 	return <RadioButtonGroup
 		options={ [ { value: "0", label: "Yes" }, { value: "1", label: "No" } ] }
 		label={ sprintf(
 			/* Translators: %s translates to the Post Label in singular form */
 			__( "Should search engines follow links on this %s", "wordpress-seo" ),
-			window.wpseoAdminL10n.postTypeNameSingular,
+			postTypeName,
 		) }
 		groupName="yoast_wpseo_meta-robots-nofollow-react"
 		onChange={ onNoFollowChange }
@@ -143,6 +146,7 @@ const MetaRobotsNoFollow = ( { noFollow, onNoFollowChange } ) => {
 MetaRobotsNoFollow.propTypes = {
 	noFollow: PropTypes.string.isRequired,
 	onNoFollowChange: PropTypes.func.isRequired,
+	postTypeName: PropTypes.string.isRequired,
 };
 
 /**
@@ -265,6 +269,9 @@ const AdvancedSettings = ( props ) => {
 		onCanonicalChange,
 		onLoad,
 		isLoading,
+		editorContext,
+		isBreadcrumbsDisabled,
+		isPrivateBlog,
 	} = props;
 
 	useEffect( () => {
@@ -279,12 +286,15 @@ const AdvancedSettings = ( props ) => {
 		noIndex,
 		onNoIndexChange,
 		location,
+		postTypeName: editorContext.postTypeNameSingular,
+		isPrivateBlog,
 	};
 
 	const noFollowProps = {
 		noFollow,
 		onNoFollowChange,
 		location,
+		postTypeName: editorContext.postTypeNameSingular,
 	};
 
 	const advancedProps = {
@@ -311,10 +321,10 @@ const AdvancedSettings = ( props ) => {
 	return (
 		<Fragment>
 			<MetaRobotsNoIndex { ...noIndexProps } />
-			{ isPost() && <MetaRobotsNoFollow { ...noFollowProps } /> }
-			{ isPost() && <MetaRobotsAdvanced { ...advancedProps } /> }
+			{ editorContext.isPost  && <MetaRobotsNoFollow { ...noFollowProps } /> }
+			{ editorContext.isPost && <MetaRobotsAdvanced { ...advancedProps } /> }
 			{
-				! window.wpseoAdminL10n.breadcrumbsDisabled && <BreadcrumbsTitle { ...breadcrumbsTitleProps } />
+				! isBreadcrumbsDisabled && <BreadcrumbsTitle { ...breadcrumbsTitleProps } />
 			}
 			<CanonicalURL { ...canonicalProps } />
 		</Fragment>
@@ -328,6 +338,9 @@ AdvancedSettings.propTypes = {
 	onCanonicalChange: PropTypes.func.isRequired,
 	onLoad: PropTypes.func.isRequired,
 	isLoading: PropTypes.bool.isRequired,
+	editorContext: PropTypes.object.isRequired,
+	isBreadcrumbsDisabled: PropTypes.bool.isRequired,
+	isPrivateBlog: PropTypes.bool,
 	advanced: PropTypes.array,
 	onAdvancedChange: PropTypes.func,
 	noFollow: PropTypes.string,
@@ -345,6 +358,7 @@ AdvancedSettings.defaultProps = {
 	onNoFollowChange: () => {},
 	breadcrumbsTitle: "",
 	onBreadcrumbsTitleChange: () => {},
+	isPrivateBlog: false,
 };
 
 export default AdvancedSettings;

--- a/js/src/components/fills/MetaboxFill.js
+++ b/js/src/components/fills/MetaboxFill.js
@@ -13,7 +13,7 @@ import SeoAnalysis from "../contentAnalysis/SeoAnalysis";
 import MetaboxCollapsible from "../MetaboxCollapsible";
 import SidebarItem from "../SidebarItem";
 import TopLevelProviders from "../TopLevelProviders";
-import AdvancedSettings from "../AdvancedSettings";
+import AdvancedSettings from "../../containers/AdvancedSettings";
 import SocialMetadataPortal from "../portals/SocialMetadataPortal";
 import SchemaTabContainer from "../../containers/SchemaTab";
 

--- a/js/src/components/modals/PostSettingsModal.js
+++ b/js/src/components/modals/PostSettingsModal.js
@@ -7,7 +7,7 @@ import SnippetEditor from "../../containers/SnippetEditor";
 import FacebookContainer from "../../containers/FacebookEditor";
 import TwitterContainer from "../../containers/TwitterEditor";
 import SchemaTabContainer from "../../containers/SchemaTab";
-import AdvancedSettings from "../AdvancedSettings";
+import AdvancedSettings from "../../containers/AdvancedSettings";
 import PropTypes from "prop-types";
 
 /**

--- a/js/src/containers/AdvancedSettings.js
+++ b/js/src/containers/AdvancedSettings.js
@@ -14,7 +14,12 @@ export default compose( [
 			getBreadcrumbsTitle,
 			getCanonical,
 			getIsLoading,
+			getEditorContext,
+			getPreferences,
 		} = select( "yoast-seo/editor" );
+
+		const { isBreadcrumbsDisabled, isPrivateBlog } = getPreferences();
+
 		return {
 			noIndex: getNoIndex(),
 			noFollow: getNoFollow(),
@@ -22,6 +27,9 @@ export default compose( [
 			breadcrumbsTitle: getBreadcrumbsTitle(),
 			canonical: getCanonical(),
 			isLoading: getIsLoading(),
+			editorContext: getEditorContext(),
+			isBreadcrumbsDisabled,
+			isPrivateBlog,
 			location: ownProps.location || "",
 		};
 	} ),

--- a/js/src/containers/AdvancedSettings.js
+++ b/js/src/containers/AdvancedSettings.js
@@ -1,0 +1,48 @@
+/* External dependencies */
+import { compose } from "@wordpress/compose";
+import { withDispatch, withSelect } from "@wordpress/data";
+
+/* Internal dependencies */
+import AdvancedSettings from "../components/AdvancedSettings";
+
+export default compose( [
+	withSelect( ( select, ownProps ) => {
+		const {
+			getNoIndex,
+			getNoFollow,
+			getAdvanced,
+			getBreadcrumbsTitle,
+			getCanonical,
+			getIsLoading,
+		} = select( "yoast-seo/editor" );
+		return {
+			noIndex: getNoIndex(),
+			noFollow: getNoFollow(),
+			advanced: getAdvanced(),
+			breadcrumbsTitle: getBreadcrumbsTitle(),
+			canonical: getCanonical(),
+			isLoading: getIsLoading(),
+			location: ownProps.location || "",
+		};
+	} ),
+
+	withDispatch( dispatch => {
+		const {
+			setNoIndex,
+			setNoFollow,
+			setAdvanced,
+			setBreadcrumbsTitle,
+			setCanonical,
+			loadAdvancedSettingsData,
+		} = dispatch( "yoast-seo/editor" );
+
+		return {
+			onNoIndexChange: setNoIndex,
+			onNoFollowChange:	setNoFollow,
+			onAdvancedChange: setAdvanced,
+			onBreadcrumbsTitleChange: setBreadcrumbsTitle,
+			onCanonicalChange: setCanonical,
+			onLoad: loadAdvancedSettingsData,
+		};
+	} ),
+] )( AdvancedSettings );

--- a/js/src/containers/AdvancedSettings.js
+++ b/js/src/containers/AdvancedSettings.js
@@ -38,7 +38,7 @@ export default compose( [
 
 		return {
 			onNoIndexChange: setNoIndex,
-			onNoFollowChange:	setNoFollow,
+			onNoFollowChange: setNoFollow,
 			onAdvancedChange: setAdvanced,
 			onBreadcrumbsTitleChange: setBreadcrumbsTitle,
 			onCanonicalChange: setCanonical,

--- a/js/src/containers/PostSettingsModal.js
+++ b/js/src/containers/PostSettingsModal.js
@@ -22,12 +22,13 @@ const getPostTypeName = ( postTypeNameSingular ) => {
 export default withSelect( select => {
 	const {
 		getPreferences,
+		getEditorContext,
 	} = select( "yoast-seo/editor" );
 
 	const preferences = getPreferences();
 
 	return {
 		preferences,
-		postTypeName: getPostTypeName( preferences.postTypeNameSingular ),
+		postTypeName: getPostTypeName( getEditorContext().postTypeNameSingular ),
 	};
 } )( PostSettingsModal );

--- a/js/src/helpers/fields/AdvancedFields.js
+++ b/js/src/helpers/fields/AdvancedFields.js
@@ -53,7 +53,7 @@ export default class AdvancedFields {
 	 * @returns {string} The No Index setting.
 	 */
 	static get noIndex() {
-		return AdvancedFields.noIndexElement.value  || "";
+		return AdvancedFields.noIndexElement && AdvancedFields.noIndexElement.value  || "";
 	}
 
 	/**
@@ -73,8 +73,7 @@ export default class AdvancedFields {
 	 * @returns {string} The No Follow setting.
 	 */
 	static get noFollow() {
-		const el = AdvancedFields.noFollowElement;
-		return el.value || null;
+		return AdvancedFields.noFollowElement && AdvancedFields.noFollowElement.value || "";
 	}
 
 	/**
@@ -94,7 +93,7 @@ export default class AdvancedFields {
 	 * @returns {string} The Advanced (metarobots) setting.
 	 */
 	static get advanced() {
-		return AdvancedFields.advancedElement.value || "";
+		return AdvancedFields.advancedElement && AdvancedFields.advancedElement.value || "";
 	}
 
 	/**
@@ -134,7 +133,7 @@ export default class AdvancedFields {
 	 * @returns {string} The Canonical URL setting.
 	 */
 	static get canonical() {
-		return AdvancedFields.canonicalElement.value  || "";
+		return AdvancedFields.canonicalElement && AdvancedFields.canonicalElement.value  || "";
 	}
 
 	/**

--- a/js/src/helpers/fields/AdvancedFields.js
+++ b/js/src/helpers/fields/AdvancedFields.js
@@ -1,0 +1,150 @@
+/**
+ * This class is responsible for handling the interaction with the hidden fields for Advanced Settings.
+ */
+export default class AdvancedFields {
+	/**
+	 * Getter for the noIndexElement.
+	 *
+	 * @returns {HTMLElement} The noIndexElement.
+	 */
+	static get noIndexElement() {
+		return document.getElementById( window.wpseoScriptData.isPost ? "yoast_wpseo_meta-robots-noindex" : "hidden_wpseo_noindex" );
+	}
+
+	/**
+	 * Getter for the noFollowElement.
+	 *
+	 * @returns {HTMLElement} The noFollowElement.
+	 */
+	static get noFollowElement() {
+		return document.getElementById( "yoast_wpseo_meta-robots-nofollow" );
+	}
+
+	/**
+	 * Getter for the advancedElement.
+	 *
+	 * @returns {HTMLElement} The advancedElement.
+	 */
+	static get advancedElement() {
+		return document.getElementById( "yoast_wpseo_meta-robots-adv" );
+	}
+
+	/**
+	 * Getter for the breadcrumbsTitleElement.
+	 *
+	 * @returns {HTMLElement} The breadcrumbsTitleElement.
+	 */
+	static get breadcrumbsTitleElement() {
+		return document.getElementById( window.wpseoScriptData.isPost ? "yoast_wpseo_bctitle" : "hidden_wpseo_bctitle" );
+	}
+
+	/**
+	 * Getter for the canonicalElement.
+	 *
+	 * @returns {HTMLElement} The canonicalElement.
+	 */
+	static get canonicalElement() {
+		return document.getElementById( window.wpseoScriptData.isPost ? "yoast_wpseo_canonical" : "hidden_wpseo_canonical" );
+	}
+
+	/**
+	 * Getter for the No Index setting.
+	 *
+	 * @returns {string} The No Index setting.
+	 */
+	static get noIndex() {
+		return AdvancedFields.noIndexElement.value  || "";
+	}
+
+	/**
+	 * Setter for the No Index setting.
+	 *
+	 * @param {string} value The value to set.
+	 *
+	 * @returns {void}
+	 */
+	static set noIndex( value ) {
+		AdvancedFields.noIndexElement.value = value;
+	}
+
+	/**
+	 * Getter for the No Follow setting.
+	 *
+	 * @returns {string} The No Follow setting.
+	 */
+	static get noFollow() {
+		const el = AdvancedFields.noFollowElement;
+		return el.value || null;
+	}
+
+	/**
+	 * Setter for the No Follow setting.
+	 *
+	 * @param {string} value The value to set.
+	 *
+	 * @returns {void}
+	 */
+	static set noFollow( value ) {
+		AdvancedFields.noFollowElement.value = value;
+	}
+
+	/**
+	 * Getter for the Advanced (metarobots) setting.
+	 *
+	 * @returns {string} The Advanced (metarobots) setting.
+	 */
+	static get advanced() {
+		return AdvancedFields.advancedElement.value || "";
+	}
+
+	/**
+	 * Setter for the Advanced (metarobots) setting.
+	 *
+	 * @param {string} value The value to set.
+	 *
+	 * @returns {void}
+	 */
+	static set advanced( value ) {
+		AdvancedFields.advancedElement.value = value;
+	}
+
+	/**
+	 * Getter for the BreadCrumbsTitle setting.
+	 *
+	 * @returns {string} The BreadCrumbsTitle setting.
+	 */
+	static get breadcrumbsTitle() {
+		return AdvancedFields.breadcrumbsTitleElement && AdvancedFields.breadcrumbsTitleElement.value || "";
+	}
+
+	/**
+	 * Setter for the BreadCrumbsTitle setting.
+	 *
+	 * @param {string} value The value to set.
+	 *
+	 * @returns {void}
+	 */
+	static set breadcrumbsTitle( value ) {
+		AdvancedFields.breadcrumbsTitleElement.value = value;
+	}
+
+	/**
+	 * Getter for the Canonical URL setting.
+	 *
+	 * @returns {string} The Canonical URL setting.
+	 */
+	static get canonical() {
+		return AdvancedFields.canonicalElement.value  || "";
+	}
+
+	/**
+	 * Setter for the Canonical URL setting.
+	 *
+	 * @param {string} value The value to set.
+	 *
+	 * @returns {void}
+	 */
+	static set canonical( value ) {
+		AdvancedFields.canonicalElement.value = value;
+	}
+}

--- a/js/src/redux/actions/advancedSettings.js
+++ b/js/src/redux/actions/advancedSettings.js
@@ -1,0 +1,87 @@
+import AdvancedFields from "../../helpers/fields/AdvancedFields";
+
+export const SET_NO_INDEX = "SET_NO_INDEX";
+export const SET_NO_FOLLOW = "SET_NO_FOLLOW";
+export const SET_ADVANCED = "SET_ADVANCED";
+export const SET_BREADCRUMBS_TITLE = "SET_BREADCRUMBS_TITLE";
+export const SET_CANONICAL_URL = "SET_CANONICAL_URL";
+export const LOAD_ADVANCED_SETTINGS = "LOAD_ADVANCED_SETTINGS";
+
+/**
+ * An action creator for setting the No Index value (Advanced Settings).
+ *
+ * @param {String} value The value.
+ *
+ * @returns {Object} The action object.
+ */
+export const setNoIndex = ( value ) => {
+	AdvancedFields.noIndex = value;
+	return { type: SET_NO_INDEX, value };
+};
+
+/**
+ * An action creator for setting the No Follow value (Advanced Settings).
+ *
+ * @param {String} value The value.
+ *
+ * @returns {Object} The action object.
+ */
+export const setNoFollow = ( value ) => {
+	AdvancedFields.noFollow = value;
+	return { type: SET_NO_FOLLOW, value };
+};
+
+/**
+ * An action creator for setting the Advanced Metarobots setting (Advanced Settings).
+ *
+ * @param {Array} value The value.
+ *
+ * @returns {Object} The action object.
+ */
+export const setAdvanced = ( value ) => {
+	AdvancedFields.advanced = value.join( "," );
+	return { type: SET_ADVANCED, value };
+};
+
+/**
+ * An action creator for setting the BreadcrumbsTitle setting (Advanced Settings).
+ *
+ * @param {String} value The value.
+ *
+ * @returns {Object} The action object.
+ */
+export const setBreadcrumbsTitle = ( value ) => {
+	AdvancedFields.breadcrumbsTitle = value;
+	return { type: SET_BREADCRUMBS_TITLE, value };
+};
+
+/**
+ * An action creator for setting the Canonical URL setting (Advanced Settings).
+ *
+ * @param {String} value The value.
+ *
+ * @returns {Object} The action object.
+ */
+export const setCanonical = ( value ) => {
+	AdvancedFields.canonical = value;
+	return { type: SET_CANONICAL_URL, value };
+};
+
+/**
+ * An action creator for loading all Advanced Settings data.
+ *
+ * @returns {object} The action object.
+ */
+export const loadAdvancedSettingsData = () => {
+	return {
+		type: LOAD_ADVANCED_SETTINGS,
+		settings: {
+			noIndex: AdvancedFields.noIndex,
+			noFollow: AdvancedFields.noFollow,
+			advanced: AdvancedFields.advanced.split( "," ),
+			breadcrumbsTitle: AdvancedFields.breadcrumbsTitle,
+			canonical: AdvancedFields.canonical,
+			isLoading: false,
+		},
+	};
+};

--- a/js/src/redux/actions/index.js
+++ b/js/src/redux/actions/index.js
@@ -7,3 +7,4 @@ export * from "./activeMarker";
 export * from "./markerPauseStatus";
 export * from "./twitterEditor";
 export * from "./facebookEditor";
+export * from "./advancedSettings";

--- a/js/src/redux/reducers/advancedSettings.js
+++ b/js/src/redux/reducers/advancedSettings.js
@@ -1,0 +1,54 @@
+/* eslint-disable complexity */
+import {
+	SET_NO_INDEX,
+	SET_NO_FOLLOW,
+	SET_ADVANCED,
+	SET_BREADCRUMBS_TITLE,
+	SET_CANONICAL_URL,
+	LOAD_ADVANCED_SETTINGS,
+} from "../actions/advancedSettings";
+
+/**
+ * Initial state
+ */
+const initialState = {
+	noIndex: "",
+	noFollow: "",
+	advanced: [],
+	breadcrumbsTitle: "",
+	canonical: "",
+	isLoading: true,
+};
+
+/**
+ * A reducer for the AdvancedSettings object.
+ *
+ * @param {Object} state The current state of the object.
+ * @param {Object} action The current action received.
+ *
+ * @returns {Object} The updated AdvancedSettings object.
+ */
+const advancedSettingsReducer = ( state = initialState, action ) => {
+	switch ( action.type ) {
+		case LOAD_ADVANCED_SETTINGS:
+			return {
+				...state,
+				...action.settings,
+			};
+		case SET_NO_INDEX:
+			return { ...state, noIndex: action.value };
+		case SET_NO_FOLLOW:
+			return { ...state, noFollow: action.value || initialState.noFollow };
+		case SET_ADVANCED:
+			return { ...state, advanced: action.value || initialState.advanced };
+		case SET_CANONICAL_URL:
+			return { ...state, canonical: action.value || initialState.canonical };
+		case SET_BREADCRUMBS_TITLE:
+			return { ...state, breadcrumbsTitle: action.value || initialState.breadcrumbsTitle };
+	  default:
+			return state;
+	}
+};
+
+export default advancedSettingsReducer;
+/* eslint-enable complexity */

--- a/js/src/redux/reducers/advancedSettings.js
+++ b/js/src/redux/reducers/advancedSettings.js
@@ -38,13 +38,13 @@ const advancedSettingsReducer = ( state = initialState, action ) => {
 		case SET_NO_INDEX:
 			return { ...state, noIndex: action.value };
 		case SET_NO_FOLLOW:
-			return { ...state, noFollow: action.value || initialState.noFollow };
+			return { ...state, noFollow: action.value };
 		case SET_ADVANCED:
-			return { ...state, advanced: action.value || initialState.advanced };
+			return { ...state, advanced: action.value };
 		case SET_CANONICAL_URL:
-			return { ...state, canonical: action.value || initialState.canonical };
+			return { ...state, canonical: action.value };
 		case SET_BREADCRUMBS_TITLE:
-			return { ...state, breadcrumbsTitle: action.value || initialState.breadcrumbsTitle };
+			return { ...state, breadcrumbsTitle: action.value };
 	  default:
 			return state;
 	}

--- a/js/src/redux/reducers/editorContext.js
+++ b/js/src/redux/reducers/editorContext.js
@@ -7,6 +7,7 @@ function getDefaultState() {
 	return {
 		isPost: window.wpseoScriptData.hasOwnProperty( "isPost" ),
 		isTerm: window.wpseoScriptData.hasOwnProperty( "isTerm" ),
+		noIndex: window.wpseoAdminL10n.noIndex === "1",
 		postTypeNameSingular: window.wpseoAdminL10n.postTypeNameSingular,
 		postTypeNamePlural: window.wpseoAdminL10n.postTypeNamePlural,
 	};

--- a/js/src/redux/reducers/editorContext.js
+++ b/js/src/redux/reducers/editorContext.js
@@ -1,0 +1,26 @@
+/**
+ * Gets the default state.
+ *
+ * @returns {Object} The default state.
+ */
+function getDefaultState() {
+	return {
+		isPost: window.wpseoScriptData.hasOwnProperty( "isPost" ),
+		isTerm: window.wpseoScriptData.hasOwnProperty( "isTerm" ),
+		postTypeNameSingular: window.wpseoAdminL10n.postTypeNameSingular,
+		postTypeNamePlural: window.wpseoAdminL10n.postTypeNamePlural,
+	};
+}
+
+/**
+ * A reducer for the preferences.
+ *
+ * @param {Object} state  The current state of the object.
+ *
+ * @returns {Object} The state.
+ */
+function editorContextReducer( state = getDefaultState() ) {
+	return state;
+}
+
+export default editorContextReducer;

--- a/js/src/redux/reducers/index.js
+++ b/js/src/redux/reducers/index.js
@@ -1,5 +1,6 @@
 import { analysis } from "yoast-components";
 import activeMarker from "./activeMarker";
+import advancedSettings from "./advancedSettings";
 import analysisData from "./analysisData";
 import isCornerstone from "./cornerstoneContent";
 import facebookEditor from "./facebookEditor";
@@ -15,6 +16,7 @@ import warning from "./warning";
 
 export default {
 	analysis,
+	advancedSettings,
 	activeMarker,
 	analysisData,
 	isCornerstone,

--- a/js/src/redux/reducers/index.js
+++ b/js/src/redux/reducers/index.js
@@ -2,6 +2,7 @@ import { analysis } from "yoast-components";
 import activeMarker from "./activeMarker";
 import advancedSettings from "./advancedSettings";
 import analysisData from "./analysisData";
+import editorContext from "./editorContext";
 import isCornerstone from "./cornerstoneContent";
 import facebookEditor from "./facebookEditor";
 import focusKeyword from "./focusKeyword";
@@ -19,6 +20,7 @@ export default {
 	advancedSettings,
 	activeMarker,
 	analysisData,
+	editorContext,
 	isCornerstone,
 	facebookEditor,
 	focusKeyword,

--- a/js/src/redux/reducers/preferences.js
+++ b/js/src/redux/reducers/preferences.js
@@ -17,6 +17,8 @@ function getDefaultState() {
 		isKeywordAnalysisActive: isKeywordAnalysisActive(),
 		isWordFormRecognitionActive: isUndefined( window.wpseoPremiumMetaboxData ) && isWordFormRecognitionActive(),
 		isCornerstoneActive: isCornerstoneActive(),
+		isBreadcrumbsDisabled: ! ! window.wpseoAdminL10n.isBreadcrumbsDisabled,
+		isPrivateBlog: ! ! window.wpseoAdminL10n.isPrivateBlog,
 		shouldUpsell: isUndefined( window.wpseoPremiumMetaboxData ),
 		displayAdvancedTab: displayAdvancedTab,
 		displaySchemaSettings: displayAdvancedTab && !! window.wpseoScriptData.isPost,

--- a/js/src/redux/reducers/preferences.js
+++ b/js/src/redux/reducers/preferences.js
@@ -25,7 +25,6 @@ function getDefaultState() {
 		displaySchemaSettingsFooter: window.wpseoScriptData.metabox.schema.displayFooter,
 		displayFacebook: window.wpseoScriptData.metabox.showSocial.facebook,
 		displayTwitter: window.wpseoScriptData.metabox.showSocial.twitter,
-		postTypeNameSingular: window.wpseoAdminL10n.postTypeNameSingular,
 	};
 }
 

--- a/js/src/redux/selectors/advancedSettings.js
+++ b/js/src/redux/selectors/advancedSettings.js
@@ -1,0 +1,54 @@
+import { get } from "lodash";
+
+/**
+ * Gets the twitter title from the state.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {String} Twitter title.
+ */
+export const getNoIndex = state => get( state, "advancedSettings.noIndex", "" );
+
+/**
+ * Gets the twitter description from the state.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {String} Twitter description.
+ */
+export const getNoFollow = state => get( state, "advancedSettings.noFollow", "" );
+
+/**
+ * Gets the twitter image URL from the state.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {String} Twitter image URL.
+ */
+export const getAdvanced = state => get( state, "advancedSettings.advanced", "" );
+
+/**
+ * Gets the twitter image type from the state.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {String} Twitter image type.
+ */
+export const getBreadcrumbsTitle = state => get( state, "advancedSettings.breadcrumbsTitle", "summary" );
+
+/**
+ * Gets the Twitter image src from the state.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {String} Twitter image src.
+ */
+export const getCanonical = state => get( state, "advancedSettings.canonical", "" );
+
+/** Gets the Twitter image src from the state.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {String} Twitter image src.
+ */
+export const getIsLoading = state => get( state, "advancedSettings.isLoading", true );

--- a/js/src/redux/selectors/editorContext.js
+++ b/js/src/redux/selectors/editorContext.js
@@ -1,0 +1,10 @@
+/**
+ * Gets the editor context.
+ *
+ * @param {Object} state    The state.
+ *
+ * @returns {string} the editor context.
+ */
+export function getEditorContext( state ) {
+	return state.editorContext;
+}

--- a/js/src/redux/selectors/index.js
+++ b/js/src/redux/selectors/index.js
@@ -10,3 +10,4 @@ export * from "./activeMarker";
 export * from "./markerPauseStatus";
 export * from "./preferences";
 export * from "./advancedSettings";
+export * from "./editorContext";

--- a/js/src/redux/selectors/index.js
+++ b/js/src/redux/selectors/index.js
@@ -9,3 +9,4 @@ export * from "./primaryTaxonomies";
 export * from "./activeMarker";
 export * from "./markerPauseStatus";
 export * from "./preferences";
+export * from "./advancedSettings";

--- a/js/tests/redux/actions/advancedSetings.test.js
+++ b/js/tests/redux/actions/advancedSetings.test.js
@@ -1,0 +1,105 @@
+import * as actions from "../../../src/redux/actions/advancedSettings";
+import AdvancedFields from "../../../src/helpers/fields/AdvancedFields.js";
+
+jest.mock( "../../../src/helpers/fields/AdvancedFields.js", () => {
+	return {};
+} );
+
+const populatedFields = {
+	noIndex: "testNoIndex",
+	noFollow: "testNoFollow",
+	advanced: "testAdvanced1,testAdvanced2",
+	breadcrumbsTitle: "testBcTitle",
+	canonical: "www.testCanonicalUrl.com",
+};
+
+describe( "setNoIndex", () => {
+	it( "Returns a setNoIndex action and populates the advanced hidden fields", () => {
+		const expected = {
+			type: "SET_NO_INDEX",
+			value: "testNoIndex",
+
+		};
+		const actual = actions.setNoIndex( "testNoIndex" );
+
+		expect( AdvancedFields.noIndex ).toEqual( "testNoIndex" );
+		expect( actual ).toEqual( expected );
+	} );
+} );
+describe( "setNoFollow", () => {
+	it( "Returns a setNoFollow action and populates the advanced hidden fields", () => {
+		const expected = {
+			type: "SET_NO_FOLLOW",
+			value: "testNoFollow",
+
+		};
+		const actual = actions.setNoFollow( "testNoFollow" );
+
+		expect( AdvancedFields.noFollow ).toEqual( "testNoFollow" );
+		expect( actual ).toEqual( expected );
+	} );
+} );
+describe( "setAdvanced", () => {
+	it( "Returns a setAdvanced action", () => {
+		const expected = {
+			type: "SET_ADVANCED",
+			value: [ "testAdvanced1", "testAdvanced2" ],
+
+		};
+		const actual = actions.setAdvanced( [ "testAdvanced1", "testAdvanced2" ] );
+
+		expect( actual ).toEqual( expected );
+	} );
+	it( "Joins the passed array into a comma separated string", () => {
+		actions.setAdvanced( [ "testAdvanced1", "testAdvanced2" ] );
+		expect( AdvancedFields.advanced ).toEqual( "testAdvanced1,testAdvanced2" );
+	} );
+} );
+describe( "setBreadcrumbsTitle", () => {
+	it( "Returns a setBreadcrumbsTitle action and populates the advanced hidden fields", () => {
+		const expected = {
+			type: "SET_BREADCRUMBS_TITLE",
+			value: "testBcTitle",
+
+		};
+
+		const actual = actions.setBreadcrumbsTitle( "testBcTitle" );
+		expect( AdvancedFields.breadcrumbsTitle ).toEqual( "testBcTitle" );
+		expect( actual ).toEqual( expected );
+	} );
+} );
+describe( "setCanonical", () => {
+	it( "Returns a setCanonical action and populates the advanced hidden fields", () => {
+		const expected = {
+			type: "SET_CANONICAL_URL",
+			value: "www.testCanonicalUrl.com",
+
+		};
+
+		const actual = actions.setCanonical( "www.testCanonicalUrl.com" );
+		expect( AdvancedFields.canonical ).toEqual( "www.testCanonicalUrl.com" );
+		expect( actual ).toEqual( expected );
+	} );
+} );
+describe( "loadAdvancedSettingsData", () => {
+	it( "Returns a loadAdvancedSettings action and populates the advanced hidden fields", () => {
+		const expected = {
+			type: "LOAD_ADVANCED_SETTINGS",
+			settings: {
+				...populatedFields,
+				isLoading: false,
+				advanced: populatedFields.advanced.split( "," ),
+			},
+
+		};
+
+		const actual = actions.loadAdvancedSettingsData();
+		expect( actual ).toEqual( expected );
+	} );
+	it( "Retrieves the advanced settings string, and splits it into an array", () => {
+		const actual = actions.loadAdvancedSettingsData().settings.advanced;
+		expect( typeof AdvancedFields.advanced ).toEqual( "string" );
+		expect( Array.isArray( actual ) ).toBeTruthy();
+	} );
+} );
+

--- a/js/tests/redux/reducers/advancedSettings.test.js
+++ b/js/tests/redux/reducers/advancedSettings.test.js
@@ -1,0 +1,59 @@
+import advancedSettingsReducer from "../../../src/redux/reducers/advancedSettings";
+import * as actions from "../../../src/redux/actions/advancedSettings";
+
+describe( "Analysis data reducer", () => {
+	const initialState = {
+		noIndex: "",
+		noFollow: "",
+		advanced: [],
+		breadcrumbsTitle: "",
+		canonical: "",
+		isLoading: true,
+	};
+
+	it( "has a default state", () => {
+		const result = advancedSettingsReducer( initialState, { type: "undefined" } );
+
+		expect( result ).toEqual( initialState );
+	} );
+
+	it( "handles setNoIndex actions", () => {
+		const result = advancedSettingsReducer( initialState, { type: actions.SET_NO_INDEX, value: "newValue" } );
+
+		expect( result ).toEqual( Object.assign( {}, initialState, {
+			noIndex: "newValue",
+		} ) );
+	} );
+
+	it( "handles setNoFollow actions", () => {
+		const result = advancedSettingsReducer( initialState, { type: actions.SET_NO_FOLLOW, value: "newValue" } );
+
+		expect( result ).toEqual( Object.assign( {}, initialState, {
+			noFollow: "newValue",
+		} ) );
+	} );
+
+	it( "handles setAdvanced actions", () => {
+		const result = advancedSettingsReducer( initialState, { type: actions.SET_ADVANCED, value: [ "newValue", "newValue2" ] } );
+
+		expect( result ).toEqual( Object.assign( {}, initialState, {
+			advanced: [ "newValue", "newValue2" ],
+		} ) );
+	} );
+
+	it( "handles setBreadcrumbsTitle actions", () => {
+		const result = advancedSettingsReducer( initialState, { type: actions.SET_BREADCRUMBS_TITLE, value: "newValue" } );
+
+		expect( result ).toEqual( Object.assign( {}, initialState, {
+			breadcrumbsTitle: "newValue",
+		} ) );
+	} );
+
+	it( "handles setCanonicalUrl actions", () => {
+		const result = advancedSettingsReducer( initialState, { type: actions.SET_CANONICAL_URL, value: "newValue" } );
+
+		expect( result ).toEqual( Object.assign( {}, initialState, {
+			canonical: "newValue",
+		} ) );
+	} );
+} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We need Redux to be the source of truth for the Advanced tab, because there will be a period of time where the Advanced Settings are both visible in the metabox and in the modal. It is not yet clear how long this period will be.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Data source of truth for Advanced Tab is now our Redux store. Persistence still flows via hidden fields.

## Relevant technical choices:

* NOTE that the select2 fix we have implemented will be undone in a follow-up PR that is coming soon. We will switch to `react-select` soon, but decided to split that out to a new issue to keep the scope small. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test together with sibling PR on javascript: https://github.com/Yoast/javascript/pull/838
* Verify that the Advanced Tabs settings are correctly retrieved and are represented in our redux store (use browser plugin).
* Upon changing values, verify that the hidden fields and the store are reflecting those changes.
* Verify that advanced settings in the modal and in the metabox are both updated and in sync.
 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-142
