### PR TITLE
Call the article helper to determine the Schema article type

### DIFF
--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -270,7 +270,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				$enriched_defaults[ 'display-metabox-pt-' . $pt->name ]      = true;
 				$enriched_defaults[ 'post_types-' . $pt->name . '-maintax' ] = 0; // Select box.
 				$enriched_defaults[ 'schema-page-type-' . $pt->name ]        = 'WebPage';
-				$enriched_defaults[ 'schema-article-type-' . $pt->name ]     = ( $pt->name === 'post' ) ? 'Article' : 'None';
+				$enriched_defaults[ 'schema-article-type-' . $pt->name ]     = ( YoastSEO()->helpers->schema->article->is_article_post_type( $pt->name ) ) ? 'Article' : 'None';
 
 				if ( ! $pt->_builtin && WPSEO_Post_Type::has_archive( $pt ) ) {
 					$enriched_defaults[ 'title-ptarchive-' . $pt->name ]    = $archive . ' %%page%% %%sep%% %%sitename%%'; // Text field.

--- a/src/helpers/schema/article-helper.php
+++ b/src/helpers/schema/article-helper.php
@@ -19,7 +19,7 @@ class Article_Helper {
 	 *
 	 * @param string $post_type Post type to check.
 	 *
-	 * @return bool True if it has article schema, false if not.
+	 * @return bool True if it has Article schema, false if not.
 	 */
 	public function is_article_post_type( $post_type = null ) {
 		if ( \is_null( $post_type ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* See https://github.com/Yoast/wordpress-seo/issues/15865 and https://yoast.atlassian.net/browse/P2-296.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes it possible to change the default Schema Article type for custom post types.

## Relevant technical choices:

* We already had a filter available to change the default Schema Article type (`wpseo_schema_article_post_types`), but it wasn't called anywhere. Now it is.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use the Test Helper to `Enable post types & taxonomies.` See that you have Books and Movies available as custom post types.
* In your database, in `wp_options` go to `wpseo_titles`.
* See that `schema-article-type-movie` is set to `None`. (If it isn't, manually change the value so that you can continue testing).
* Add the following filter to your code, for example in your theme's `functions.php`:
```
	add_filter( 'wpseo_schema_article_post_types', function () {
	    return [ 'post', 'movie' ];
    }
    );
```
* Under `Search Appearance`, `Content Types`, edit any field for Movies and save the changes.
* Refresh your database and see that `schema-article-type-movie` is set to `Article`.
* Edit any field for Posts and save the changes.
* Refresh your database and see that `schema-article-type-post` is (still) set to `Article`.
* Edit any field for Pages and save the changes.
* Refresh your database and see that `schema-article-type-post` is (still) set to `None`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/15865
