### PR TITLE
Add SEMrush login popup

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -6,6 +6,8 @@
  */
 
 use Yoast\WP\SEO\Config\Schema_Types;
+use Yoast\WP\SEO\Exceptions\OAuth\OAuth_Authentication_Failed_Exception;
+use Yoast\WP\SEO\Exceptions\SEMrush\SEMrush_Empty_Token_Exception;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Config\SEMrush_Client;
 use Yoast\WP\SEO\Exceptions\SEMrush\SEMrush_Empty_Token_Property_Exception;
@@ -298,6 +300,16 @@ class WPSEO_Metabox_Formatter {
 		try {
 			$semrush_client = new SEMrush_Client( $options_helper );
 		} catch ( SEMrush_Empty_Token_Property_Exception $e ) {
+			// return false if token is malformed (empty property).
+			return false;
+		}
+
+		// Get token (and refresh it if it's expired).
+		try {
+			$semrush_client->get_tokens();
+		} catch ( OAuth_Authentication_Failed_Exception $e ) {
+			return false;
+		} catch ( SEMrush_Empty_Token_Exception $e ) {
 			return false;
 		}
 

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -7,6 +7,8 @@
 
 use Yoast\WP\SEO\Config\Schema_Types;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Config\SEMrush_Client;
+use Yoast\WP\SEO\Exceptions\SEMrush\SEMrush_Empty_Token_Property_Exception;
 
 /**
  * This class forces needed methods for the metabox localization.
@@ -81,6 +83,7 @@ class WPSEO_Metabox_Formatter {
 			'wordFormRecognitionActive' => YoastSEO()->helpers->language->is_word_form_recognition_active( WPSEO_Language_Utils::get_language( get_locale() ) ),
 			'siteIconUrl'               => get_site_icon_url(),
 			'countryCode'	   			=> WPSEO_Options::get( 'semrush_country_code', false ),
+			'SEMrushLoginStatus'		=> $this->get_SEMrush_login_status( $options ),
 			'showSocial'                => [
 				'facebook' => WPSEO_Options::get( 'opengraph', false ),
 				'twitter'  => WPSEO_Options::get( 'twitter', false ),
@@ -282,5 +285,22 @@ class WPSEO_Metabox_Formatter {
 		 * @param array $is_markdown Is markdown support for Yoast SEO active.
 		 */
 		return apply_filters( 'wpseo_is_markdown_enabled', $is_markdown );
+	}
+
+	/**
+	 * Checks if the use is logged in to SEMrush.
+	 *
+	 * @param {Options_Helper} $options_helper The Options Helper object.
+	 *
+	 * @return boolean The SEMrush login status.
+	 */
+	private function get_SEMrush_login_status( $options_helper ) {
+		try {
+			$semrush_client = new SEMrush_Client( $options_helper );
+		} catch ( SEMrush_Empty_Token_Property_Exception $e ) {
+			return false;
+		}
+
+		return $semrush_client->has_valid_tokens();
 	}
 }

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -84,8 +84,8 @@ class WPSEO_Metabox_Formatter {
 			'addKeywordUpsell'          => $this->get_add_keyword_upsell_translations(),
 			'wordFormRecognitionActive' => YoastSEO()->helpers->language->is_word_form_recognition_active( WPSEO_Language_Utils::get_language( get_locale() ) ),
 			'siteIconUrl'               => get_site_icon_url(),
-			'countryCode'	   			=> WPSEO_Options::get( 'semrush_country_code', false ),
-			'SEMrushLoginStatus'		=> $this->get_semrush_login_status( $options ),
+			'countryCode'               => WPSEO_Options::get( 'semrush_country_code', false ),
+			'SEMrushLoginStatus'        => $this->get_semrush_login_status( $options ),
 			'showSocial'                => [
 				'facebook' => WPSEO_Options::get( 'opengraph', false ),
 				'twitter'  => WPSEO_Options::get( 'twitter', false ),
@@ -290,7 +290,7 @@ class WPSEO_Metabox_Formatter {
 	}
 
 	/**
-	 * Checks if the use is logged in to SEMrush.
+	 * Checks if the user is logged in to SEMrush.
 	 *
 	 * @param {Options_Helper} $options_helper The Options Helper object.
 	 *

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -85,7 +85,7 @@ class WPSEO_Metabox_Formatter {
 			'wordFormRecognitionActive' => YoastSEO()->helpers->language->is_word_form_recognition_active( WPSEO_Language_Utils::get_language( get_locale() ) ),
 			'siteIconUrl'               => get_site_icon_url(),
 			'countryCode'	   			=> WPSEO_Options::get( 'semrush_country_code', false ),
-			'SEMrushLoginStatus'		=> $this->get_SEMrush_login_status( $options ),
+			'SEMrushLoginStatus'		=> $this->get_semrush_login_status( $options ),
 			'showSocial'                => [
 				'facebook' => WPSEO_Options::get( 'opengraph', false ),
 				'twitter'  => WPSEO_Options::get( 'twitter', false ),
@@ -296,7 +296,7 @@ class WPSEO_Metabox_Formatter {
 	 *
 	 * @return boolean The SEMrush login status.
 	 */
-	private function get_SEMrush_login_status( $options_helper ) {
+	private function get_semrush_login_status( $options_helper ) {
 		try {
 			$semrush_client = new SEMrush_Client( $options_helper );
 		} catch ( SEMrush_Empty_Token_Property_Exception $e ) {

--- a/config/grunt/task-config/eslint.js
+++ b/config/grunt/task-config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 127,
+			maxWarnings: 125,
 		},
 	},
 	tests: {

--- a/css/src/modal.css
+++ b/css/src/modal.css
@@ -378,7 +378,8 @@
 	max-width: 712px;
 }
 
-.yoast-related-keyphrases-modal__button.yoast-related-keyphrases-modal__button {
+#yoast-get-related-keyphrases-sidebar,
+#yoast-get-related-keyphrases-metabox {
 	margin-top: 8px;
 }
 

--- a/js/src/components/SEMrushRelatedKeyphrasesModal.js
+++ b/js/src/components/SEMrushRelatedKeyphrasesModal.js
@@ -95,8 +95,7 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 
 		return (
 			<Fragment>
-				{ isLoggedIn &&
-				<div className={ "yoast" }>
+				{ isLoggedIn && <div className={ "yoast" }>
 					<Button
 						variant={ "secondary" }
 						id={ `yoast-get-related-keyphrases-${location}` }
@@ -106,19 +105,18 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 					</Button>
 				</div> }
 				{ keyphrase && whichModalOpen === location &&
-				<Modal
-					title={ __( "Related keyphrases", "wordpress-seo" ) }
-					onRequestClose={ this.onModalClose }
-					icon={ <YoastIcon /> }
-					additionalClassName="yoast-related-keyphrases-modal"
-				>
-					<ModalContainer
-						className="yoast-gutenberg-modal__content yoast-related-keyphrases-modal__content"
+					<Modal
+						title={ __( "Related keyphrases", "wordpress-seo" ) }
+						onRequestClose={ this.onModalClose }
+						icon={ <YoastIcon /> }
+						additionalClassName="yoast-related-keyphrases-modal"
 					>
-						<Slot name="YoastRelatedKeyphrases" />
-
-					</ModalContainer>
-				</Modal>
+						<ModalContainer
+							className="yoast-gutenberg-modal__content yoast-related-keyphrases-modal__content"
+						>
+							<Slot name="YoastRelatedKeyphrases" />
+						</ModalContainer>
+					</Modal>
 				}
 				{ ! isLoggedIn && <div className={ "yoast" }>
 					<ButtonStyledLink

--- a/js/src/components/SEMrushRelatedKeyphrasesModal.js
+++ b/js/src/components/SEMrushRelatedKeyphrasesModal.js
@@ -6,6 +6,7 @@ import PropTypes from "prop-types";
 
 /* Yoast dependencies */
 import { BaseButton } from "@yoast/components";
+import { ButtonStyledLink } from "@yoast/components";
 
 /* Internal dependencies */
 import { ModalContainer } from "./modals/Container";
@@ -56,37 +57,74 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 	}
 
 	/**
+	 * Opens the popup window.
+	 *
+	 * @param {event} e The click event.
+	 *
+	 * @returns {void}
+	 */
+	onLinkClick( e ) {
+		const url = "https://oauth.semrush.com/oauth2/authorize?" +
+			"ref=1513012826&client_id=yoast&redirect_uri=https%3A%2F%2Foauth.semrush.com%2Foauth2%2Fyoast%2Fsuccess&response_type=code&scope=user.id";
+		const height = "570";
+		const width  = "340";
+		const top = window.top.outerHeight / 2 + window.top.screenY - ( height / 2 );
+		const left = window.top.outerWidth / 2 + window.top.screenX - ( width / 2 );
+
+		const features = [
+			"top=" + top,
+			"left=" + left,
+			"width=" + width,
+			"height=" + height,
+			"resizable=1",
+			"scrollbars=1",
+			"status=0",
+		];
+
+		window.open( url, "SEMrush_login", features.join( "," ) );
+		e.preventDefault();
+	}
+
+	/**
 	 * Renders the RelatedKeyPhrasesModal modal component.
 	 *
 	 * @returns {React.Element} The RelatedKeyPhrasesModal modal component.
 	 */
 	render() {
-		const { keyphrase, location, whichModalOpen } = this.props;
+		const { keyphrase, location, whichModalOpen, isLoggedIn } = this.props;
 
 		return (
 			<Fragment>
-				<BaseButton
+				{ isLoggedIn && <BaseButton
 					id="yoast-get-related-keyphrases"
 					className="yoast-related-keyphrases-modal__button"
 					onClick={ this.onModalOpen }
 				>
 					{ __( "Get related keyphrases", "wordpress-seo" ) }
-				</BaseButton>
+				</BaseButton> }
 				{ keyphrase && whichModalOpen === location &&
-					<Modal
-						title={ __( "Related keyphrases", "wordpress-seo" ) }
-						onRequestClose={ this.onModalClose }
-						icon={ <YoastIcon /> }
-						additionalClassName="yoast-related-keyphrases-modal"
+				<Modal
+					title={ __( "Related keyphrases", "wordpress-seo" ) }
+					onRequestClose={ this.onModalClose }
+					icon={ <YoastIcon /> }
+					additionalClassName="yoast-related-keyphrases-modal"
+				>
+					<ModalContainer
+						className="yoast-gutenberg-modal__content yoast-related-keyphrases-modal__content"
 					>
-						<ModalContainer
-							className="yoast-gutenberg-modal__content yoast-related-keyphrases-modal__content"
-						>
-							<Slot name="YoastRelatedKeyphrases" />
+						<Slot name="YoastRelatedKeyphrases" />
 
-						</ModalContainer>
-					</Modal>
+					</ModalContainer>
+				</Modal>
 				}
+				{ ! isLoggedIn && <ButtonStyledLink
+					variant={ "secondary" }
+					small={ true }
+					href={ "https://oauth.semrush.com/auth/login" }
+					onClick={ this.onLinkClick }
+				>
+					{ __( "Get related keyphrases", "wordpress-seo" ) }
+				</ButtonStyledLink> }
 			</Fragment>
 		);
 	}
@@ -100,6 +138,7 @@ SEMrushRelatedKeyphrasesModal.propTypes = {
 		"metabox",
 		"sidebar",
 	] ),
+	isLoggedIn: PropTypes.bool,
 	onOpen: PropTypes.func.isRequired,
 	onOpenWithNoKeyphrase: PropTypes.func.isRequired,
 	onClose: PropTypes.func.isRequired,
@@ -109,6 +148,7 @@ SEMrushRelatedKeyphrasesModal.defaultProps = {
 	keyphrase: "",
 	location: "",
 	whichModalOpen: "none",
+	isLoggedIn: false,
 };
 
 export default SEMrushRelatedKeyphrasesModal;

--- a/js/src/components/SEMrushRelatedKeyphrasesModal.js
+++ b/js/src/components/SEMrushRelatedKeyphrasesModal.js
@@ -5,7 +5,7 @@ import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 
 /* Yoast dependencies */
-import { BaseButton } from "@yoast/components";
+import { Button } from "@yoast/components/src/button";
 import { ButtonStyledLink } from "@yoast/components";
 
 /* Internal dependencies */
@@ -95,13 +95,17 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 
 		return (
 			<Fragment>
-				{ isLoggedIn && <BaseButton
-					id="yoast-get-related-keyphrases"
-					className="yoast-related-keyphrases-modal__button"
-					onClick={ this.onModalOpen }
-				>
-					{ __( "Get related keyphrases", "wordpress-seo" ) }
-				</BaseButton> }
+				{ isLoggedIn &&
+				<div className={ "yoast" }>
+					<Button
+						variant={ "secondary" }
+						small={ true }
+						id={ `yoast-get-related-keyphrases-${location}` }
+						onClick={ this.onModalOpen }
+					>
+						{ __( "Get related keyphrases", "wordpress-seo" ) }
+					</Button>
+				</div> }
 				{ keyphrase && whichModalOpen === location &&
 				<Modal
 					title={ __( "Related keyphrases", "wordpress-seo" ) }
@@ -117,14 +121,17 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 					</ModalContainer>
 				</Modal>
 				}
-				{ ! isLoggedIn && <ButtonStyledLink
-					variant={ "secondary" }
-					small={ true }
-					href={ "https://oauth.semrush.com/auth/login" }
-					onClick={ this.onLinkClick }
-				>
-					{ __( "Get related keyphrases", "wordpress-seo" ) }
-				</ButtonStyledLink> }
+				{ ! isLoggedIn && <div className={ "yoast" }>
+					<ButtonStyledLink
+						variant={ "secondary" }
+						small={ true }
+						id={ `yoast-get-related-keyphrases-${location}` }
+						href={ "https://oauth.semrush.com/auth/login" }
+						onClick={ this.onLinkClick }
+					>
+						{ __( "Get related keyphrases", "wordpress-seo" ) }
+					</ButtonStyledLink>
+				</div> }
 			</Fragment>
 		);
 	}

--- a/js/src/components/SEMrushRelatedKeyphrasesModal.js
+++ b/js/src/components/SEMrushRelatedKeyphrasesModal.js
@@ -5,8 +5,7 @@ import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 
 /* Yoast dependencies */
-import { Button } from "@yoast/components/src/button";
-import { ButtonStyledLink } from "@yoast/components";
+import { Button, ButtonStyledLink } from "@yoast/components/src/button";
 
 /* Internal dependencies */
 import { ModalContainer } from "./modals/Container";
@@ -88,7 +87,7 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 	/**
 	 * Renders the RelatedKeyPhrasesModal modal component.
 	 *
-	 * @returns {React.Element} The RelatedKeyPhrasesModal modal component.
+	 * @returns {wp.Element} The RelatedKeyPhrasesModal modal component.
 	 */
 	render() {
 		const { keyphrase, location, whichModalOpen, isLoggedIn } = this.props;

--- a/js/src/components/SEMrushRelatedKeyphrasesModal.js
+++ b/js/src/components/SEMrushRelatedKeyphrasesModal.js
@@ -63,12 +63,11 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 	 * @returns {void}
 	 */
 	onLinkClick( e ) {
-		const url = "https://oauth.semrush.com/oauth2/authorize?" +
-			"ref=1513012826&client_id=yoast&redirect_uri=https%3A%2F%2Foauth.semrush.com%2Foauth2%2Fyoast%2Fsuccess&response_type=code&scope=user.id";
+		const url    = e.target.href;
 		const height = "570";
 		const width  = "340";
-		const top = window.top.outerHeight / 2 + window.top.screenY - ( height / 2 );
-		const left = window.top.outerWidth / 2 + window.top.screenX - ( width / 2 );
+		const top    = window.top.outerHeight / 2 + window.top.screenY - ( height / 2 );
+		const left   = window.top.outerWidth / 2 + window.top.screenX - ( width / 2 );
 
 		const features = [
 			"top=" + top,
@@ -121,10 +120,15 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 					<ButtonStyledLink
 						variant={ "secondary" }
 						id={ `yoast-get-related-keyphrases-${location}` }
-						href={ "https://oauth.semrush.com/auth/login" }
+						href={ "https://oauth.semrush.com/oauth2/authorize?" +
+							"ref=1513012826&client_id=yoast&redirect_uri=https%3A%2F%2Foauth.semrush.com%2Foauth2%2Fyoast%2Fsuccess&" +
+							"response_type=code&scope=user.id" }
 						onClick={ this.onLinkClick }
 					>
 						{ __( "Get related keyphrases", "wordpress-seo" ) }
+						<span className={ "screen-reader-text" }>
+							{ __( "(Opens in a new browser window)", "wordpress-seo" ) }
+						</span>
 					</ButtonStyledLink>
 				</div> }
 			</Fragment>

--- a/js/src/components/SEMrushRelatedKeyphrasesModal.js
+++ b/js/src/components/SEMrushRelatedKeyphrasesModal.js
@@ -99,7 +99,6 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 				<div className={ "yoast" }>
 					<Button
 						variant={ "secondary" }
-						small={ true }
 						id={ `yoast-get-related-keyphrases-${location}` }
 						onClick={ this.onModalOpen }
 					>
@@ -124,7 +123,6 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 				{ ! isLoggedIn && <div className={ "yoast" }>
 					<ButtonStyledLink
 						variant={ "secondary" }
-						small={ true }
 						id={ `yoast-get-related-keyphrases-${location}` }
 						href={ "https://oauth.semrush.com/auth/login" }
 						onClick={ this.onLinkClick }

--- a/js/src/containers/SEMrushRelatedKeyphrasesModal.js
+++ b/js/src/containers/SEMrushRelatedKeyphrasesModal.js
@@ -6,6 +6,7 @@ export default compose( [
 	withSelect( ( select ) => {
 		return {
 			whichModalOpen: select( "yoast-seo/editor" ).getSEMrushModalOpen(),
+			isLoggedIn: select( "yoast-seo/editor" ).getSEMrushLoginStatus(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/js/src/initializers/editor-store.js
+++ b/js/src/initializers/editor-store.js
@@ -5,6 +5,7 @@ import * as selectors from "../redux/selectors";
 import * as actions from "../redux/actions";
 import { setSettings } from "../redux/actions/settings";
 import { setSEMrushChangeCountry } from "../redux/actions";
+import { setSEMrushLoginStatus } from "../redux/actions";
 
 /**
  * Initializes the Yoast SEO editor store.
@@ -37,6 +38,9 @@ export default function initEditorStore() {
 	);
 	store.dispatch(
 		setSEMrushChangeCountry( window.wpseoScriptData.metabox.countryCode )
+	);
+	store.dispatch(
+		setSEMrushLoginStatus( window.wpseoScriptData.metabox.SEMrushLoginStatus )
 	);
 
 	return store;

--- a/js/src/redux/actions/SEMrushRequest.js
+++ b/js/src/redux/actions/SEMrushRequest.js
@@ -5,6 +5,7 @@ export const SET_REQUEST_FAILED = "SET_REQUEST_FAILED";
 export const SET_REQUEST_LIMIT_REACHED = "SET_LIMIT_REACHED";
 export const NEW_REQUEST = "NEW_REQUEST";
 export const NO_DATA_FOUND = "NO_DATA_FOUND";
+export const SET_LOGIN_STATUS = "SET_LOGIN_STATUS";
 
 /**
  * An action creator for starting a new request.
@@ -88,5 +89,19 @@ export function setSEMrushNoResultsFound( countryCode, keyphrase ) {
 		type: NO_DATA_FOUND,
 		countryCode,
 		keyphrase,
+	};
+}
+
+/**
+ * An action creator to check if the user is logged in to SEMrush.
+ *
+ * @param {boolean} loginStatus The login status.
+ *
+ * @returns {Object} Action object.
+ */
+export function setSEMrushLoginStatus( loginStatus ) {
+	return {
+		type: SET_LOGIN_STATUS,
+		loginStatus,
 	};
 }

--- a/js/src/redux/reducers/SEMrushRequest.js
+++ b/js/src/redux/reducers/SEMrushRequest.js
@@ -5,6 +5,7 @@ import {
 	NEW_REQUEST,
 	CHANGE_COUNTRY,
 	NO_DATA_FOUND,
+	SET_LOGIN_STATUS,
 } from "../actions/SEMrushRequest";
 
 const INITIAL_STATE = {
@@ -15,6 +16,7 @@ const INITIAL_STATE = {
 	response: null,
 	limitReached: false,
 	hasData: true,
+	isLoggedIn: false,
 };
 /**
  * A reducer for the SEMrush request.
@@ -72,6 +74,11 @@ function SEMrushRequestReducer( state = INITIAL_STATE, action ) {
 				isRequestPending: false,
 				hasData: false,
 				response: null,
+			};
+		case SET_LOGIN_STATUS:
+			return {
+				...state,
+				isLoggedIn: action.loginStatus,
 			};
 		default:
 			return state;

--- a/js/src/redux/selectors/SEMrushRequest.js
+++ b/js/src/redux/selectors/SEMrushRequest.js
@@ -74,3 +74,13 @@ export function getSEMrushSelectedCountry( state ) {
 export function getSEMrushRequestHasData( state ) {
 	return state.SEMrushRequest.hasData;
 }
+/**
+ * Checks whether the user is logged in to SEMrush.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {boolean} Whether or not the user is logged in to SEMrush.
+ */
+export function getEMrushLoginStatus( state ) {
+	return state.SEMrushRequest.isLoggedIn;
+}

--- a/js/src/redux/selectors/SEMrushRequest.js
+++ b/js/src/redux/selectors/SEMrushRequest.js
@@ -74,8 +74,9 @@ export function getSEMrushSelectedCountry( state ) {
 export function getSEMrushRequestHasData( state ) {
 	return state.SEMrushRequest.hasData;
 }
+
 /**
- * Checks whether the user is logged in to SEMrush.
+ * Gets the user logged in to SEMrush status.
  *
  * @param {Object} state The state.
  *

--- a/js/src/redux/selectors/SEMrushRequest.js
+++ b/js/src/redux/selectors/SEMrushRequest.js
@@ -81,6 +81,6 @@ export function getSEMrushRequestHasData( state ) {
  *
  * @returns {boolean} Whether or not the user is logged in to SEMrush.
  */
-export function getEMrushLoginStatus( state ) {
+export function getSEMrushLoginStatus( state ) {
 	return state.SEMrushRequest.isLoggedIn;
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When the user is not logged in in SEMrush, instead of the SEMrush modal we want to show a popup where the user can log in or register.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a link to the SEMrush login/register form in a popup window

## Relevant technical choices:

* This PR just shows conditionally a link opening a popup to login/register to SEMrush. **It does not** manage the steps after the authorization by SEMrush has been granted.
* The user is considered "logged out" when no token is stored in the DB, or if it's expired and cannot be refreshed. The check is performed "at runtime" on the server and the result is stored in the Redux store (where it could be updated following a successful login — not covered by this PR)
* The "button" to open the popup is actually a `<a>` tag as it should be, being a link. The `ButtonStyledLink` component has been used for this purpose.
* To ensure style consistency, the "Get related keyphrases" `BaseButton` opening the Modal has been replaced by a new `Button` component (the one used by the keyphrases table on Premium). To get the style right, the components need to have a parent container with a `yoast` class. It's easy (and it's actually happening already) for the metabox, but it's a bit more tricky for the sidebar, so the button and the link have been surrounded by a `<div>` with the `yoast` class.
* The PR also fixes a problem with the ID of the "Get related keyphrases" button, which had the same value for the one in the metabox and the one in the sidebar.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

**The order of the following steps depends on whether you have already valid tokens in the database or not**

If you already have valid tokens in the database:
* Edit a post
* See the "Get related keyphrases" button, and inspect with the React Tools to see it's using a `Button` component
* See the style is the same on both the metabox and the sidebar (_suggestion: take a screencap to make the comparison with the popup link easier later_)
* Insert a keyphrase and click on the button to open the modal
* Perform the above test (minus the parts related to the sidebar) with the Classic Editor activated

If you don't have valid tokens in the database:
* Edit a post
* See the "Get related keyphrases" button, and inspect with the React Tools to see it's using a `ButtonStyledLink` component containing an `<a>` (you can also see the destination URL in the browser status bar)
* See the style is the same on both the metabox and the sidebar, and the same as the style for the button when you have valid tokens in the DB 
* Click on the button to see the popup opening on the center of the current window, without any scrollbar (all the content is displayed, even if you switch to the "Register" tab)
* login into SEMrush and go on until you see the message 

> <h1>Authorization provided</h1>
> Access to service provided. This window should close soon and authorization information will be shown in application.

* Close the popup, in the future it will happen automatically, the tokens will be stored in the DB, and the modal will then open.
* Perform the above test (minus the parts related to the sidebar) with the Classic Editor activated

### If you have valid tokens and want to perform the second part of the test:
* With a DB inspector, search for the `wpseo` array of options in `wp_options` table
* make sure you copy the content of the option elsewhere for backup
* edit the serialized array so the part which looks like:
```
s:14:"semrush_tokens";a:5:{s:12:"access_token";s:40:"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";s:13:"refresh_token";s:40:"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";s:7:"expires";i:1598357188;s:11:"has_expired";b:0;s:10:"created_at";i:1597752388;}
```
becomes
```
s:14:"semrush_tokens";a:0:{}
```
* You can also set `b:1` in the above snippet to force a refresh of the token, or set the `expires` to a past UNIX time and see that the token is refreshed at load time, so the button opening the modal is shown instead of the link opening the popup.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-57]
