### PR TITLE
Strip extra robot values

### DIFF
--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -287,9 +287,9 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 		$robots = \array_merge(
 			$robots,
 			[
-				'noimageindex' => ( $this->model->is_robots_noimageindex === true ) ? 'noimageindex' : null,
-				'noarchive'    => ( $this->model->is_robots_noarchive === true ) ? 'noarchive' : null,
-				'nosnippet'    => ( $this->model->is_robots_nosnippet === true ) ? 'nosnippet' : null,
+				'imageindex' => ( $this->model->is_robots_noimageindex === true ) ? 'noimageindex' : null,
+				'archive'    => ( $this->model->is_robots_noarchive === true ) ? 'noarchive' : null,
+				'snippet'    => ( $this->model->is_robots_nosnippet === true ) ? 'nosnippet' : null,
 			]
 		);
 

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -264,15 +264,24 @@ class Indexable_Presentation extends Abstract_Presentation {
 		 */
 		$robots_filtered = \apply_filters( 'wpseo_robots', $robots_string, $this );
 
+		// Convert the robots string back to an array.
 		if ( \is_string( $robots_filtered ) ) {
 			$robots_values = \explode( ', ', $robots_filtered );
 			$robots_new    = [];
 
 			foreach ( $robots_values as $value ) {
 				$key = $value;
+
+				// Change `noindex` to `index.
 				if ( \strpos( $key, 'no' ) === 0 ) {
 					$key = \substr( $value, 2 );
 				}
+				// Change `max-snippet:-1` to `max-snippet`.
+				$colon_position = \strpos( $key, ':' );
+				if ( $colon_position !== false ) {
+					$key = \substr( $value, 0, $colon_position );
+				}
+
 				$robots_new[ $key ] = $value;
 			}
 

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -247,13 +247,17 @@ class Indexable_Presentation extends Abstract_Presentation {
 	 * @return array The filtered meta robots values.
 	 */
 	protected function filter_robots( $robots ) {
+		// Remove values that are only listened to when indexing.
 		if ( $robots['index'] === 'noindex' ) {
+			$robots['imageindex']        = null;
+			$robots['archive']           = null;
+			$robots['snippet']           = null;
 			$robots['max-snippet']       = null;
 			$robots['max-image-preview'] = null;
 			$robots['max-video-preview'] = null;
 		}
 
-		$robots_string = \implode( ', ', $robots );
+		$robots_string = \implode( ', ', \array_filter( $robots ) );
 
 		/**
 		 * Filter: 'wpseo_robots' - Allows filtering of the meta robots output of Yoast SEO.

--- a/tests/unit/presentations/indexable-author-archive-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/robots-test.php
@@ -100,11 +100,11 @@ class Robots_Test extends TestCase {
 
 		$actual   = $this->instance->generate_robots();
 		$expected = [
-			'index'                   => 'index',
-			'follow'                  => 'follow',
-			'max-snippet:-1'          => 'max-snippet:-1',
-			'max-image-preview:large' => 'max-image-preview:large',
-			'max-video-preview:-1'    => 'max-video-preview:-1',
+			'index'             => 'index',
+			'follow'            => 'follow',
+			'max-snippet'       => 'max-snippet:-1',
+			'max-image-preview' => 'max-image-preview:large',
+			'max-video-preview' => 'max-video-preview:-1',
 		];
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/unit/presentations/indexable-date-archive-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-date-archive-presentation/robots-test.php
@@ -36,11 +36,11 @@ class Robots_Test extends TestCase {
 
 		$actual   = $this->instance->generate_robots();
 		$expected = [
-			'index'                   => 'index',
-			'follow'                  => 'follow',
-			'max-snippet:-1'          => 'max-snippet:-1',
-			'max-image-preview:large' => 'max-image-preview:large',
-			'max-video-preview:-1'    => 'max-video-preview:-1',
+			'index'             => 'index',
+			'follow'            => 'follow',
+			'max-snippet'       => 'max-snippet:-1',
+			'max-image-preview' => 'max-image-preview:large',
+			'max-video-preview' => 'max-video-preview:-1',
 		];
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/unit/presentations/indexable-post-type-archive-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-post-type-archive-presentation/robots-test.php
@@ -63,11 +63,11 @@ class Robots_Test extends TestCase {
 
 		$actual   = $this->instance->generate_robots();
 		$expected = [
-			'index'                   => 'index',
-			'follow'                  => 'follow',
-			'max-snippet:-1'          => 'max-snippet:-1',
-			'max-image-preview:large' => 'max-image-preview:large',
-			'max-video-preview:-1'    => 'max-video-preview:-1',
+			'index'             => 'index',
+			'follow'            => 'follow',
+			'max-snippet'       => 'max-snippet:-1',
+			'max-image-preview' => 'max-image-preview:large',
+			'max-video-preview' => 'max-video-preview:-1',
 		];
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/unit/presentations/indexable-post-type-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/robots-test.php
@@ -49,12 +49,12 @@ class Robots_Test extends TestCase {
 
 		$actual   = $this->instance->generate_robots();
 		$expected = [
-			'index'                   => 'index',
-			'follow'                  => 'follow',
-			'snippet'                 => 'nosnippet',
-			'archive'                 => 'noarchive',
-			'imageindex'              => 'noimageindex',
-			'max-video-preview:-1'    => 'max-video-preview:-1',
+			'index'             => 'index',
+			'follow'            => 'follow',
+			'snippet'           => 'nosnippet',
+			'archive'           => 'noarchive',
+			'imageindex'        => 'noimageindex',
+			'max-video-preview' => 'max-video-preview:-1',
 		];
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/unit/presentations/indexable-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-presentation/robots-test.php
@@ -35,11 +35,11 @@ class Robots_Test extends TestCase {
 	public function test_generate_robots() {
 		$actual   = $this->instance->generate_robots();
 		$expected = [
-			'index'                   => 'index',
-			'follow'                  => 'follow',
-			'max-snippet:-1'          => 'max-snippet:-1',
-			'max-image-preview:large' => 'max-image-preview:large',
-			'max-video-preview:-1'    => 'max-video-preview:-1',
+			'index'             => 'index',
+			'follow'            => 'follow',
+			'max-snippet'       => 'max-snippet:-1',
+			'max-image-preview' => 'max-image-preview:large',
+			'max-video-preview' => 'max-video-preview:-1',
 		];
 
 		$this->assertEquals( $expected, $actual );
@@ -98,11 +98,11 @@ class Robots_Test extends TestCase {
 			->once()
 			->with(
 				[
-					'index'                   => 'index',
-					'follow'                  => 'follow',
-					'max-snippet:-1'          => 'max-snippet:-1',
-					'max-image-preview:large' => 'max-image-preview:large',
-					'max-video-preview:-1'    => 'max-video-preview:-1',
+					'index'             => 'index',
+					'follow'            => 'follow',
+					'max-snippet'       => 'max-snippet:-1',
+					'max-image-preview' => 'max-image-preview:large',
+					'max-video-preview' => 'max-video-preview:-1',
 				],
 				$this->instance
 			)

--- a/tests/unit/presentations/indexable-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-presentation/robots-test.php
@@ -121,4 +121,39 @@ class Robots_Test extends TestCase {
 			$this->instance->generate_robots()
 		);
 	}
+
+	/**
+	 * Tests whether filter robots removes values when noindex.
+	 *
+	 * @covers ::generate_robots
+	 * @covers ::get_base_robots
+	 * @covers ::filter_robots
+	 */
+	public function test_generate_robots_strip_values_when_noindex() {
+		$this->instance->model->is_robots_noindex      = true;
+		$this->instance->model->is_robots_nofollow     = true;
+		$this->instance->model->is_robots_nosnippet    = true;
+		$this->instance->model->is_robots_noimageindex = true;
+		$this->instance->model->is_robots_noarchive    = true;
+
+		$expected = [
+			'index'  => 'noindex',
+			'follow' => 'nofollow',
+		];
+
+		// Check the values are stripped before running the filter by comparing the input of the filter.
+		Monkey\Filters\expectApplied( 'wpseo_robots' )
+			->twice()
+			->with( 'noindex, nofollow', $this->instance )
+			->andReturn( 'noindex, nofollow' );
+
+		$this->assertEquals( $expected, $this->instance->generate_robots() );
+
+		// Check again with snippet, imageindex and archive to false. It should not matter.
+		$this->instance->model->is_robots_nosnippet    = false;
+		$this->instance->model->is_robots_noimageindex = false;
+		$this->instance->model->is_robots_noarchive    = false;
+
+		$this->assertEquals( $expected, $this->instance->generate_robots() );
+	}
 }

--- a/tests/unit/presentations/indexable-term-archive-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/robots-test.php
@@ -48,11 +48,11 @@ class Robots_Test extends TestCase {
 
 		$actual   = $this->instance->generate_robots();
 		$expected = [
-			'index'                   => 'index',
-			'follow'                  => 'follow',
-			'max-snippet:-1'          => 'max-snippet:-1',
-			'max-image-preview:large' => 'max-image-preview:large',
-			'max-video-preview:-1'    => 'max-video-preview:-1',
+			'index'             => 'index',
+			'follow'            => 'follow',
+			'max-snippet'       => 'max-snippet:-1',
+			'max-image-preview' => 'max-image-preview:large',
+			'max-video-preview' => 'max-video-preview:-1',
 		];
 
 		$this->assertEquals( $expected, $actual );
@@ -114,11 +114,11 @@ class Robots_Test extends TestCase {
 
 		$actual   = $this->instance->generate_robots();
 		$expected = [
-			'index'                   => 'index',
-			'follow'                  => 'follow',
-			'max-snippet:-1'          => 'max-snippet:-1',
-			'max-image-preview:large' => 'max-image-preview:large',
-			'max-video-preview:-1'    => 'max-video-preview:-1',
+			'index'             => 'index',
+			'follow'            => 'follow',
+			'max-snippet'       => 'max-snippet:-1',
+			'max-image-preview' => 'max-image-preview:large',
+			'max-video-preview' => 'max-video-preview:-1',
 		];
 
 		$this->assertEquals( $expected, $actual );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This was missed in https://github.com/Yoast/wordpress-seo/pull/15880

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `archive`, `imageindex` and `snippet` robot values where output when set to no index.

## Relevant technical choices:

* The removing is done before the filtering, just like the `max-` values. So when filtering, they can be still be forced to appear.
* Removed the `no` part from the keys for `noimageindex`, `noarchive` and `nosnippet` to make it consistent with `noindex` and `nofollow`. There was a mismatch with the robots array before the string filter and after. As the string to array removes the `no` part from the key.
* Fixed the robots string to array part by removing any `:value` parts from the key. E.g. `max-snippet:-1` in the string will convert to `max-snippet => max-snippet:-1` in the array. Making it the same as before the string conversion.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* For posts, pages and custom posts, check the robot output on the frontend.
* Enabling/disabling the index should change the robots value.
  * When `noindex` it should not output any of the extra values (except the follow/nofollow).
  * You can change the extra robot values by changing the `Meta robots advanced` setting:
    * Adding `No Image Index` should remove `max-image-preview:large` and add `noimageindex`.
    * Adding `No Archive` should add `noarchive`.
    * Adding `No Snippet` should remove `max-snippet:-1` and add `nosnippet`.
  * Test some of the above combinations.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-146
