### PR TITLE
Prevent ATtype of null to end up in our schema

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -402,8 +402,8 @@ class Meta_Tags_Context extends Abstract_Presentation {
 					$type[] = 'CollectionPage';
 				}
 
-				// Ensure we get only unique values, and remove the index.
-				$type = \array_values( \array_unique( $type ) );
+				// Ensure we get only unique values, and remove any null values and the index.
+				$type = \array_filter( \array_values( \array_unique( $type ) ) );
 		}
 
 		/**


### PR DESCRIPTION
## Context

* Prevent `null` to be part of `@ type` in our schema.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where `null` could be part of `@ type` in our schema.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install Yoast 14.8.1 and follow the steps in https://github.com/Yoast/wordpress-seo/issues/15936
* You will see that `null` is a part of the `@ type` in the schema.
* apply this patch and null will not be output anymore.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
