### PR TITLE
Documentation: remove file comments from namespaced classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,8 +82,8 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=625",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=546",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=657",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=278",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs-summary": [

--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Composer
- */
 
 namespace Yoast\WP\SEO\Composer;
 

--- a/config/dependency-injection/container-compiler.php
+++ b/config/dependency-injection/container-compiler.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Dependency_Injection
- */
 
 namespace Yoast\WP\SEO\Dependency_Injection;
 

--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Dependency_Injection
- */
 
 namespace Yoast\WP\SEO\Dependency_Injection;
 

--- a/config/dependency-injection/loader-pass.php
+++ b/config/dependency-injection/loader-pass.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Dependency_Injection
- */
 
 namespace Yoast\WP\SEO\Dependency_Injection;
 

--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Dependency_Injection
- */
 
 namespace Yoast\WP\SEO\Dependency_Injection;
 

--- a/config/php-codeshift/remove-vendor-prefixing-array-key-visitor.php
+++ b/config/php-codeshift/remove-vendor-prefixing-array-key-visitor.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\PHP_CodeShift
- */
 
 namespace Yoast\WP\SEO\PHP_CodeShift;
 
@@ -13,7 +8,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\NodeVisitorAbstract;
 
 /**
- * Class Vendor_Prefixing_Visitor
+ * Class Remove_Vendor_Prefixing_Array_Key_Visitor.
  */
 class Remove_Vendor_Prefixing_Array_Key_Visitor extends NodeVisitorAbstract {
 

--- a/config/php-codeshift/remove-vendor-prefixing-codemod.php
+++ b/config/php-codeshift/remove-vendor-prefixing-codemod.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\PHP_CodeShift
- */
 
 namespace Yoast\WP\SEO\PHP_CodeShift;
 
 use Codeshift\AbstractCodemod;
 
 /**
- * Class Vendor_Prefixing_Codemod
+ * Class Remove_Vendor_Prefixing_Codemod.
  */
 class Remove_Vendor_Prefixing_Codemod extends AbstractCodemod {
 

--- a/config/php-codeshift/remove-vendor-prefixing-comment-visitor.php
+++ b/config/php-codeshift/remove-vendor-prefixing-comment-visitor.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\PHP_CodeShift
- */
 
 namespace Yoast\WP\SEO\PHP_CodeShift;
 
@@ -12,7 +7,7 @@ use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 
 /**
- * Class Vendor_Prefixing_Visitor
+ * Class Remove_Vendor_Prefixing_Comment_Visitor.
  */
 class Remove_Vendor_Prefixing_Comment_Visitor extends NodeVisitorAbstract {
 

--- a/config/php-codeshift/remove-vendor-prefixing-visitor.php
+++ b/config/php-codeshift/remove-vendor-prefixing-visitor.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\PHP_CodeShift
- */
 
 namespace Yoast\WP\SEO\PHP_CodeShift;
 
@@ -12,7 +7,7 @@ use PhpParser\Node\Name;
 use PhpParser\NodeVisitorAbstract;
 
 /**
- * Class Vendor_Prefixing_Visitor
+ * Class Remove_Vendor_Prefixing_Visitor.
  */
 class Remove_Vendor_Prefixing_Visitor extends NodeVisitorAbstract {
 

--- a/lib/migrations/adapter.php
+++ b/lib/migrations/adapter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast migrations adapter class.
- *
- * @package Yoast\WP\Lib\Migrations
- */
 
 namespace Yoast\WP\Lib\Migrations;
 
@@ -11,7 +6,7 @@ use Exception;
 use Yoast\WP\Lib\Model;
 
 /**
- * Adapter class.
+ * Yoast migrations adapter class.
  */
 class Adapter {
 

--- a/lib/migrations/column.php
+++ b/lib/migrations/column.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Yoast migrations adapter class.
- *
- * @package Yoast\WP\Lib\Migrations
- */
 
 namespace Yoast\WP\Lib\Migrations;
 
 use Exception;
 
 /**
- * Column class
+ * Yoast migrations column class.
  */
 class Column {
 

--- a/lib/migrations/constants.php
+++ b/lib/migrations/constants.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * Yoast migrations constants class.
- *
- * @package Yoast\WP\Lib\Migrations
- */
 
 namespace Yoast\WP\Lib\Migrations;
 
 /**
- * Constants class
+ * Yoast migrations constants class.
  */
 class Constants {
 	// @codingStandardsIgnoreLine WordPress.DB.RestrictedFunctions.mysql

--- a/lib/migrations/migration.php
+++ b/lib/migrations/migration.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * Base migration class.
- *
- * @package Yoast\WP\Lib
- */
 
 namespace Yoast\WP\Lib\Migrations;
 
 /**
- * Migration class
+ * Base migration class.
  */
 abstract class Migration {
 

--- a/lib/migrations/table.php
+++ b/lib/migrations/table.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Yoast migrations adapter class.
- *
- * @package Yoast\WP\Lib\Migrations
- */
 
 namespace Yoast\WP\Lib\Migrations;
 
 use Exception;
 
 /**
- * Table class
+ * Yoast migrations table class.
  */
 class Table {
 

--- a/lib/model.php
+++ b/lib/model.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast model class.
- *
- * @package Yoast\WP\Lib
- */
 
 namespace Yoast\WP\Lib;
 

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast ORM class.
- *
- * @package Yoast\WP\Lib
- */
 
 namespace Yoast\WP\Lib;
 
@@ -11,7 +6,9 @@ use wpdb;
 use Yoast\WP\SEO\Config\Migration_Status;
 
 /**
- * Based on Idiorm.
+ * Yoast ORM class.
+ *
+ * Based on Idiorm
  *
  * URL: http://github.com/j4mie/idiorm/
  *

--- a/src/actions/indexables/indexable-head-action.php
+++ b/src/actions/indexables/indexable-head-action.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Get ehad action for indexables.
- *
- * @package Yoast\WP\SEO\Actions\Indexables
- */
 
 namespace Yoast\WP\SEO\Actions\Indexables;
 
 use Yoast\WP\SEO\Surfaces\Meta_Surface;
 
 /**
- * Indexable_Head_Action class
+ * Get head action for indexables.
  */
 class Indexable_Head_Action {
 

--- a/src/actions/indexation/abstract-link-indexing-action.php
+++ b/src/actions/indexation/abstract-link-indexing-action.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Reindexation action for indexables.
- *
- * @package Yoast\WP\SEO\Actions\Indexation
- */
 
 namespace Yoast\WP\SEO\Actions\Indexation;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Models\SEO_Links;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
- * Post_Link_Indexing_Action class.
+ * Reindexation action for link indexables.
  */
 abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interface {
 

--- a/src/actions/indexation/indexable-complete-indexation-action.php
+++ b/src/actions/indexation/indexable-complete-indexation-action.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Indexation action to call when the indexable indexation process is completed.
- *
- * @package Yoast\WP\SEO\Actions\Indexation
- */
 
 namespace Yoast\WP\SEO\Actions\Indexation;
 

--- a/src/actions/indexation/indexable-general-indexation-action.php
+++ b/src/actions/indexation/indexable-general-indexation-action.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Reindexation action for indexables.
- *
- * @package Yoast\WP\SEO\Actions\Indexation
- */
 
 namespace Yoast\WP\SEO\Actions\Indexation;
 
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
- * Indexable_Misc_Indexation_Action class.
+ * General reindexation action for indexables.
  */
 class Indexable_General_Indexation_Action implements Indexation_Action_Interface {
 

--- a/src/actions/indexation/indexable-post-indexation-action.php
+++ b/src/actions/indexation/indexable-post-indexation-action.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Reindexation action for indexables.
- *
- * @package Yoast\WP\SEO\Actions\Indexation
- */
 
 namespace Yoast\WP\SEO\Actions\Indexation;
 
@@ -14,7 +9,7 @@ use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
- * Indexable_Post_Indexation_Action class.
+ * Reindexation action for post indexables.
  */
 class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 

--- a/src/actions/indexation/indexable-post-type-archive-indexation-action.php
+++ b/src/actions/indexation/indexable-post-type-archive-indexation-action.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Reindexation action for post type archive indexables.
- *
- * @package Yoast\WP\SEO\Actions\Indexation
- */
 
 namespace Yoast\WP\SEO\Actions\Indexation;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
- * Indexation_Post_Type_Archive_Action class.
+ * Reindexation action for post type archive indexables.
  */
 class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action_Interface {
 

--- a/src/actions/indexation/indexable-prepare-indexation-action.php
+++ b/src/actions/indexation/indexable-prepare-indexation-action.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Action for preparing the indexable indexation routine.
- *
- * @package Yoast\WP\SEO\Actions\Indexation
- */
 
 namespace Yoast\WP\SEO\Actions\Indexation;
 

--- a/src/actions/indexation/indexable-term-indexation-action.php
+++ b/src/actions/indexation/indexable-term-indexation-action.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Reindexation action for indexables.
- *
- * @package Yoast\WP\SEO\Actions\Indexation
- */
 
 namespace Yoast\WP\SEO\Actions\Indexation;
 
@@ -14,7 +9,7 @@ use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
- * Indexable_Term_Indexation_Action class.
+ * Reindexation action for term indexables.
  */
 class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 

--- a/src/actions/indexation/indexation-action-interface.php
+++ b/src/actions/indexation/indexation-action-interface.php
@@ -1,12 +1,10 @@
 <?php
-/**
- * Reindexation action for indexables
- *
- * @package Yoast\WP\SEO\Actions\Indexation
- */
 
 namespace Yoast\WP\SEO\Actions\Indexation;
 
+/**
+ * Interface definition of reindexation action for indexables.
+ */
 interface Indexation_Action_Interface {
 
 	/**

--- a/src/actions/indexation/post-link-indexing-action.php
+++ b/src/actions/indexation/post-link-indexing-action.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Reindexation action for indexables.
- *
- * @package Yoast\WP\SEO\Actions\Indexation
- */
 
 namespace Yoast\WP\SEO\Actions\Indexation;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Lib\Model;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 
 /**
- * Post_Link_Indexing_Action class.
+ * Reindexation action for post link indexables.
  */
 class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 

--- a/src/actions/indexation/term-link-indexing-action.php
+++ b/src/actions/indexation/term-link-indexing-action.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Reindexation action for indexables.
- *
- * @package Yoast\WP\SEO\Actions\Indexation
- */
 
 namespace Yoast\WP\SEO\Actions\Indexation;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Lib\Model;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 
 /**
- * Term_Link_Indexing_Action class.
+ * Reindexation action for term link indexables.
  */
 class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Author Builder for the indexables.
- *
- * @package Yoast\YoastSEO\Builders
- */
 
 namespace Yoast\WP\SEO\Builders;
 
@@ -11,6 +6,8 @@ use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 
 /**
+ * Author Builder for the indexables.
+ *
  * Formats the author meta to indexable format.
  */
 class Indexable_Author_Builder {

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Builder for the indexables.
- *
- * @package Yoast\YoastSEO\Builders
- */
 
 namespace Yoast\WP\SEO\Builders;
 
@@ -11,6 +6,8 @@ use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
+ * Builder for the indexables.
+ *
  * Creates all the indexables.
  */
 class Indexable_Builder {

--- a/src/builders/indexable-date-archive-builder.php
+++ b/src/builders/indexable-date-archive-builder.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Date Archive Builder for the indexables.
- *
- * @package Yoast\YoastSEO\Builders
- */
 
 namespace Yoast\WP\SEO\Builders;
 
@@ -11,6 +6,8 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 
 /**
+ * Date Archive Builder for the indexables.
+ *
  * Formats the date archive meta to indexable format.
  */
 class Indexable_Date_Archive_Builder {

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Builder for the indexables hierarchy.
- *
- * @package Yoast\YoastSEO\Builders
- */
 
 namespace Yoast\WP\SEO\Builders;
 
@@ -18,6 +13,8 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 
 /**
+ * Builder for the indexables hierarchy.
+ *
  * Builds the indexable hierarchy for indexables.
  */
 class Indexable_Hierarchy_Builder {

--- a/src/builders/indexable-home-page-builder.php
+++ b/src/builders/indexable-home-page-builder.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Homepage Builder for the indexables.
- *
- * @package Yoast\YoastSEO\Builders
- */
 
 namespace Yoast\WP\SEO\Builders;
 
@@ -12,6 +7,8 @@ use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 
 /**
+ * Homepage Builder for the indexables.
+ *
  * Formats the homepage meta to indexable format.
  */
 class Indexable_Home_Page_Builder {

--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Post link builder.
- *
- * @package Yoast\WP\SEO\Builders
- */
 
 namespace Yoast\WP\SEO\Builders;
 
@@ -15,7 +10,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Repositories\SEO_Links_Repository;
 
 /**
- * Indexable_Link_Builder class
+ * Post link builder.
  */
 class Indexable_Link_Builder {
 

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Post Builder for the indexables.
- *
- * @package Yoast\YoastSEO\Builders
- */
 
 namespace Yoast\WP\SEO\Builders;
 
@@ -13,6 +8,8 @@ use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
+ * Post Builder for the indexables.
+ *
  * Formats the post meta to indexable format.
  */
 class Indexable_Post_Builder {

--- a/src/builders/indexable-post-type-archive-builder.php
+++ b/src/builders/indexable-post-type-archive-builder.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Post type archive builder for the indexables.
- *
- * @package Yoast\YoastSEO\Builders
- */
 
 namespace Yoast\WP\SEO\Builders;
 
@@ -11,6 +6,8 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 
 /**
+ * Post type archive builder for the indexables.
+ *
  * Formats the post type archive meta to indexable format.
  */
 class Indexable_Post_Type_Archive_Builder {

--- a/src/builders/indexable-rebuilder.php
+++ b/src/builders/indexable-rebuilder.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Rebuilder for the indexables.
- *
- * @package Yoast\YoastSEO\Builders
- */
 
 namespace Yoast\WP\SEO\Builders;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use YoastSEO_Vendor\Psr\Log\LogLevel;
 
 /**
- * Class Indexable_Rebuilder.
+ * Rebuilder for the indexables.
  *
  * Contains methods to find and build indexables.
  */

--- a/src/builders/indexable-social-image-trait.php
+++ b/src/builders/indexable-social-image-trait.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Trait for determine the social image to use in the indexable.
- *
- * @package Yoast\YoastSEO\Builders
- */
 
 namespace Yoast\WP\SEO\Builders;
 
@@ -14,6 +9,8 @@ use Yoast\WP\SEO\Helpers\Twitter\Image_Helper as Twitter_Image_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 
 /**
+ * Trait for determine the social image to use in the indexable.
+ *
  * Represents the trait used in builders for handling social images.
  */
 trait Indexable_Social_Image_Trait {

--- a/src/builders/indexable-system-page-builder.php
+++ b/src/builders/indexable-system-page-builder.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * System page builder for the indexables.
- *
- * @package Yoast\YoastSEO\Builders
- */
 
 namespace Yoast\WP\SEO\Builders;
 
@@ -11,6 +6,8 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 
 /**
+ * System page builder for the indexables.
+ *
  * Formats system pages ( search and error ) meta to indexable format.
  */
 class Indexable_System_Page_Builder {

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Term Builder for the indexables.
- *
- * @package Yoast\YoastSEO\Builders
- */
 
 namespace Yoast\WP\SEO\Builders;
 
@@ -11,6 +6,8 @@ use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 
 /**
+ * Term Builder for the indexables.
+ *
  * Formats the term meta to indexable format.
  */
 class Indexable_Term_Builder {

--- a/src/builders/primary-term-builder.php
+++ b/src/builders/primary-term-builder.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Primary term builder.
- *
- * @package Yoast\WP\SEO\Builders
- */
 
 namespace Yoast\WP\SEO\Builders;
 
@@ -12,6 +7,8 @@ use Yoast\WP\SEO\Helpers\Primary_Term_Helper;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 
 /**
+ * Primary term builder.
+ *
  * Creates the primary term for a post.
  */
 class Primary_Term_Builder {

--- a/src/commands/command-interface.php
+++ b/src/commands/command-interface.php
@@ -1,14 +1,11 @@
 <?php
-/**
- * WP CLI command interface definition.
- *
- * @package Yoast\WP\SEO\Commands
- */
 
 namespace Yoast\WP\SEO\Commands;
 
 /**
- * An interface for registering integrations with WordPress
+ * Interface definition for WP CLI commands.
+ *
+ * An interface for registering integrations with WordPress.
  */
 interface Command_Interface {
 

--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Command to generate indexables for all posts and terms.
- *
- * @package Yoast\WP\SEO\Commands
- */
 
 namespace Yoast\WP\SEO\Commands;
 

--- a/src/conditionals/admin-conditional.php
+++ b/src/conditionals/admin-conditional.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/conditionals/admin/posts-overview-or-ajax-conditional.php
+++ b/src/conditionals/admin/posts-overview-or-ajax-conditional.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 
 /**
- * Conditional that is only met when in the admin.
+ * Conditional that is only met when on a post overview page or during an ajax request.
  */
 class Posts_Overview_Or_Ajax_Conditional implements Conditional {
 

--- a/src/conditionals/breadcrumbs-enabled-conditional.php
+++ b/src/conditionals/breadcrumbs-enabled-conditional.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/conditionals/conditional-interface.php
+++ b/src/conditionals/conditional-interface.php
@@ -1,16 +1,9 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 
 /**
  * Conditional interface, used to prevent integrations from loading.
- *
- * @package Yoast\WP\SEO\Conditionals
  */
 interface Conditional {
 

--- a/src/conditionals/development-conditional.php
+++ b/src/conditionals/development-conditional.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/conditionals/feature-flag-conditional.php
+++ b/src/conditionals/feature-flag-conditional.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/conditionals/front-end-conditional.php
+++ b/src/conditionals/front-end-conditional.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 
 /**
- * Conditional that is only met when in the admin.
+ * Conditional that is only met when NOT in the admin.
  */
 class Front_End_Conditional implements Conditional {
 

--- a/src/conditionals/headless-rest-endpoints-enabled-conditional.php
+++ b/src/conditionals/headless-rest-endpoints-enabled-conditional.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/conditionals/jetpack-conditional.php
+++ b/src/conditionals/jetpack-conditional.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/conditionals/migrations-conditional.php
+++ b/src/conditionals/migrations-conditional.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/conditionals/no-conditionals-trait.php
+++ b/src/conditionals/no-conditionals-trait.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/conditionals/open-graph-conditional.php
+++ b/src/conditionals/open-graph-conditional.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/conditionals/primary-category-conditional.php
+++ b/src/conditionals/primary-category-conditional.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/conditionals/should-index-links-conditional.php
+++ b/src/conditionals/should-index-links-conditional.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 
 use Yoast\WP\SEO\Helpers\Options_Helper;
 
 /**
- * Index_Links_Conditional class
+ * Should_Index_Links_Conditional class.
  */
 class Should_Index_Links_Conditional implements Conditional {
 

--- a/src/conditionals/web-stories-conditional.php
+++ b/src/conditionals/web-stories-conditional.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/conditionals/woocommerce-conditional.php
+++ b/src/conditionals/woocommerce-conditional.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/conditionals/wpml-conditional.php
+++ b/src/conditionals/wpml-conditional.php
@@ -1,16 +1,9 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 
 /**
- * Class WPML_Conditional
- *
- * @package Yoast\WP\SEO\Conditionals
+ * Conditional that is only met when WPML is active.
  */
 class WPML_Conditional implements Conditional {
 

--- a/src/conditionals/xmlrpc-conditional.php
+++ b/src/conditionals/xmlrpc-conditional.php
@@ -1,16 +1,9 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 
 /**
  * Conditional that is met when the current request is an XML-RPC request.
- *
- * @package Yoast\WP\SEO\Conditionals
  */
 class XMLRPC_Conditional implements Conditional {
 

--- a/src/conditionals/yoast-admin-and-dashboard-conditional.php
+++ b/src/conditionals/yoast-admin-and-dashboard-conditional.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\YoastSEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/conditionals/yoast-tools-page-conditional.php
+++ b/src/conditionals/yoast-tools-page-conditional.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\WP\SEO\Conditionals
- */
 
 namespace Yoast\WP\SEO\Conditionals;
 

--- a/src/config/migration-status.php
+++ b/src/config/migration-status.php
@@ -1,14 +1,11 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Config
- */
 
 namespace Yoast\WP\SEO\Config;
 
 /**
- * Migration_Status class. Used to validate whether or not migrations have been run and whether or not they should be run again.
+ * Migration_Status class.
+ *
+ * Used to validate whether or not migrations have been run and whether or not they should be run again.
  */
 class Migration_Status {
 

--- a/src/config/migrations/20171228151840_WpYoastIndexable.php
+++ b/src/config/migrations/20171228151840_WpYoastIndexable.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package WPSEO\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 

--- a/src/config/migrations/20171228151841_WpYoastPrimaryTerm.php
+++ b/src/config/migrations/20171228151841_WpYoastPrimaryTerm.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package WPSEO\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 

--- a/src/config/migrations/20190529075038_WpYoastDropIndexableMetaTableIfExists.php
+++ b/src/config/migrations/20190529075038_WpYoastDropIndexableMetaTableIfExists.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package WPSEO\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Lib\Migrations\Migration;
 use Yoast\WP\Lib\Model;
 
 /**
- * Class DropIndexableMetaTableIfExists
+ * Class WpYoastDropIndexableMetaTableIfExists.
  */
 class WpYoastDropIndexableMetaTableIfExists extends Migration {
 

--- a/src/config/migrations/20191011111109_WpYoastIndexableHierarchy.php
+++ b/src/config/migrations/20191011111109_WpYoastIndexableHierarchy.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package WPSEO\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Lib\Migrations\Migration;
 use Yoast\WP\Lib\Model;
 
 /**
- * Class WpYoastIndexableHierarchy
+ * Class WpYoastIndexableHierarchy.
  */
 class WpYoastIndexableHierarchy extends Migration {
 

--- a/src/config/migrations/20200408101900_AddCollationToTables.php
+++ b/src/config/migrations/20200408101900_AddCollationToTables.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package WPSEO\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Lib\Migrations\Migration;
 use Yoast\WP\Lib\Model;
 
 /**
- * Class AddCollationToTables
+ * Class AddCollationToTables.
  */
 class AddCollationToTables extends Migration {
 

--- a/src/config/migrations/20200420073606_AddColumnsToIndexables.php
+++ b/src/config/migrations/20200420073606_AddColumnsToIndexables.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package WPSEO\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 

--- a/src/config/migrations/20200428123747_BreadcrumbTitleAndHierarchyReset.php
+++ b/src/config/migrations/20200428123747_BreadcrumbTitleAndHierarchyReset.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package WPSEO\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Lib\Migrations\Migration;
 use Yoast\WP\Lib\Model;
 
 /**
- * BreadcrumbTitleAndHierarchyReset
+ * Class BreadcrumbTitleAndHierarchyReset.
  */
 class BreadcrumbTitleAndHierarchyReset extends Migration {
 

--- a/src/config/migrations/20200428194858_ExpandIndexableColumnLengths.php
+++ b/src/config/migrations/20200428194858_ExpandIndexableColumnLengths.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package WPSEO\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Lib\Migrations\Migration;
 use Yoast\WP\Lib\Model;
 
 /**
- * ExpandIndexableColumnLengths
+ * Class ExpandIndexableColumnLengths.
  */
 class ExpandIndexableColumnLengths extends Migration {
 

--- a/src/config/migrations/20200429105310_TruncateIndexableTables.php
+++ b/src/config/migrations/20200429105310_TruncateIndexableTables.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package WPSEO\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Lib\Migrations\Migration;
 use Yoast\WP\Lib\Model;
 
 /**
- * TruncateIndexableTables
+ * Class TruncateIndexableTables.
  */
 class TruncateIndexableTables extends Migration {
 

--- a/src/config/migrations/20200430075614_AddIndexableObjectIdAndTypeIndex.php
+++ b/src/config/migrations/20200430075614_AddIndexableObjectIdAndTypeIndex.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package WPSEO\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Lib\Migrations\Migration;
 use Yoast\WP\Lib\Model;
 
 /**
- * AddIndexableObjectIdAndTypeIndex
+ * Class AddIndexableObjectIdAndTypeIndex.
  */
 class AddIndexableObjectIdAndTypeIndex extends Migration {
 

--- a/src/config/migrations/20200430150130_ClearIndexableTables.php
+++ b/src/config/migrations/20200430150130_ClearIndexableTables.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package WPSEO\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Lib\Migrations\Migration;
 use Yoast\WP\Lib\Model;
 
 /**
- * ClearIndexableTables
+ * Class ClearIndexableTables.
  */
 class ClearIndexableTables extends Migration {
 

--- a/src/config/migrations/20200507054848_DeleteDuplicateIndexables.php
+++ b/src/config/migrations/20200507054848_DeleteDuplicateIndexables.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package WPSEO\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Lib\Migrations\Migration;
 use Yoast\WP\Lib\Model;
 
 /**
- * DeleteDuplicateIndexables.
+ * Class DeleteDuplicateIndexables.
  */
 class DeleteDuplicateIndexables extends Migration {
 

--- a/src/config/migrations/20200513133401_ResetIndexableHierarchyTable.php
+++ b/src/config/migrations/20200513133401_ResetIndexableHierarchyTable.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package WPSEO\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Lib\Migrations\Migration;
 use Yoast\WP\Lib\Model;
 
 /**
- * TruncateIndexableTables
+ * Class ResetIndexableHierarchyTable.
  */
 class ResetIndexableHierarchyTable extends Migration {
 

--- a/src/config/migrations/20200609154515_AddHasAncestorsColumn.php
+++ b/src/config/migrations/20200609154515_AddHasAncestorsColumn.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package WPSEO\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 

--- a/src/config/migrations/20200616130143_ReplacePermalinkHashIndex.php
+++ b/src/config/migrations/20200616130143_ReplacePermalinkHashIndex.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\WP\SEO\Config\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 

--- a/src/config/migrations/20200617122511_CreateSEOLinksTable.php
+++ b/src/config/migrations/20200617122511_CreateSEOLinksTable.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\WP\SEO\Config\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 

--- a/src/config/migrations/20200702141921_CreateIndexableSubpagesIndex.php
+++ b/src/config/migrations/20200702141921_CreateIndexableSubpagesIndex.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\WP\SEO\Config\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 

--- a/src/config/migrations/20200728095334_AddIndexesForProminentWordsOnIndexables.php
+++ b/src/config/migrations/20200728095334_AddIndexesForProminentWordsOnIndexables.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\WP\SEO\Config\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 

--- a/src/config/schema-ids.php
+++ b/src/config/schema-ids.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Config
- */
 
 namespace Yoast\WP\SEO\Config;
 
 /**
- * Class Schema_IDs
+ * Class Schema_IDs.
  */
 class Schema_IDs {
 	/**

--- a/src/config/schema-types.php
+++ b/src/config/schema-types.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Config
- */
 
 namespace Yoast\WP\SEO\Config;
 

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Class that contains all relevant data for rendering the meta tags.
- *
- * @package Yoast\YoastSEO\Context
- */
 
 namespace Yoast\WP\SEO\Context;
 
@@ -22,7 +17,9 @@ use Yoast\WP\SEO\Presentations\Abstract_Presentation;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 
 /**
- * Class Meta_Tags_Context
+ * Class Meta_Tags_Context.
+ *
+ * Class that contains all relevant data for rendering the meta tags.
  *
  * @property string      $canonical
  * @property string      $title

--- a/src/exceptions/missing-method.php
+++ b/src/exceptions/missing-method.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Exception to use when a method does not exist.
- *
- * @package Yoast\YoastSEO\Exceptions
- */
 
 namespace Yoast\WP\SEO\Exceptions;
 
 use Exception;
 
 /**
- * The exception when a method does not exists.
+ * Exception to use when a method does not exist.
  */
 class Missing_Method extends Exception {
 

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Generator object for the breadcrumbs.
- *
- * @package Yoast\YoastSEO\Generators
- */
 
 namespace Yoast\WP\SEO\Generators;
 
@@ -17,7 +12,7 @@ use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
- * Represents the generator class for the Open Graph images.
+ * Represents the generator class for the breadcrumbs.
  */
 class Breadcrumbs_Generator implements Generator_Interface {
 

--- a/src/generators/generator-interface.php
+++ b/src/generators/generator-interface.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Generators
- */
 
 namespace Yoast\WP\SEO\Generators;
 

--- a/src/generators/open-graph-image-generator.php
+++ b/src/generators/open-graph-image-generator.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Generator object for the Open Graph image.
- *
- * @package Yoast\WP\SEO\Generators
- */
 
 namespace Yoast\WP\SEO\Generators;
 

--- a/src/generators/open-graph-locale-generator.php
+++ b/src/generators/open-graph-locale-generator.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Generators
- */
 
 namespace Yoast\WP\SEO\Generators;
 
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 
 /**
- * Class Open_Graph_Locale_Generator
+ * Class Open_Graph_Locale_Generator.
  */
 class Open_Graph_Locale_Generator implements Generator_Interface {
 

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Generators
- */
 
 namespace Yoast\WP\SEO\Generators;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Generators\Schema\Abstract_Schema_Piece;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 
 /**
- * Class Schema_Generator
+ * Class Schema_Generator.
  */
 class Schema_Generator implements Generator_Interface {
 

--- a/src/generators/schema/abstract-schema-piece.php
+++ b/src/generators/schema/abstract-schema-piece.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Generators\Schema
- */
 
 namespace Yoast\WP\SEO\Generators\Schema;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 
 /**
- * Class Abstract_Schema_Piece
+ * Class Abstract_Schema_Piece.
  */
 abstract class Abstract_Schema_Piece {
 

--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Generators\Schema
- */
 
 namespace Yoast\WP\SEO\Generators\Schema;
 

--- a/src/generators/schema/author.php
+++ b/src/generators/schema/author.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Generators\Schema
- */
 
 namespace Yoast\WP\SEO\Generators\Schema;
 
 use Yoast\WP\SEO\Config\Schema_IDs;
 
 /**
- * Returns schema Person data.
+ * Returns schema Author data.
  */
 class Author extends Person {
 

--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Generators\Schema
- */
 
 namespace Yoast\WP\SEO\Generators\Schema;
 

--- a/src/generators/schema/faq.php
+++ b/src/generators/schema/faq.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Generators\Schema
- */
 
 namespace Yoast\WP\SEO\Generators\Schema;
 

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Generators\Schema
- */
 
 namespace Yoast\WP\SEO\Generators\Schema;
 
 /**
- * Returns schema FAQ data.
+ * Returns schema HowTo data.
  */
 class HowTo extends Abstract_Schema_Piece {
 

--- a/src/generators/schema/main-image.php
+++ b/src/generators/schema/main-image.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Generators\Schema
- */
 
 namespace Yoast\WP\SEO\Generators\Schema;
 

--- a/src/generators/schema/organization.php
+++ b/src/generators/schema/organization.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Generators\Schema
- */
 
 namespace Yoast\WP\SEO\Generators\Schema;
 

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Generators\Schema
- */
 
 namespace Yoast\WP\SEO\Generators\Schema;
 

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Generators\Schema
- */
 
 namespace Yoast\WP\SEO\Generators\Schema;
 

--- a/src/generators/schema/website.php
+++ b/src/generators/schema/website.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Generators\Schema
- */
 
 namespace Yoast\WP\SEO\Generators\Schema;
 

--- a/src/generators/twitter-image-generator.php
+++ b/src/generators/twitter-image-generator.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Generator object for the Twitter image.
- *
- * @package Yoast\WP\SEO\Generators
- */
 
 namespace Yoast\WP\SEO\Generators;
 
@@ -16,7 +11,7 @@ use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Values\Images;
 
 /**
- * Represents the generator class for the Open Graph images.
+ * Represents the generator class for the Twitter images.
  */
 class Twitter_Image_Generator implements Generator_Interface {
 

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * A helper object for author archives.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 use Yoast\WP\Lib\Model;
 
 /**
- * Class Author_Archive_Helper
+ * A helper object for author archives.
  */
 class Author_Archive_Helper {
 

--- a/src/helpers/blocks-helper.php
+++ b/src/helpers/blocks-helper.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * A helper object for blocks.
- *
- * @package Yoast\WP\SEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 use WP_Block_Parser_Block;
 
 /**
- * Class Blocks_Helper
+ * A helper object for blocks.
  */
 class Blocks_Helper {
 

--- a/src/helpers/capability-helper.php
+++ b/src/helpers/capability-helper.php
@@ -1,16 +1,9 @@
 <?php
-/**
- * A helper object for user capabilities.
- *
- * @package Yoast\WP\SEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 /**
- * Class Capability_Helper
- *
- * @package Yoast\WP\SEO\Helpers
+ * A helper object for user capabilities.
  */
 class Capability_Helper {
 

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * A helper object for WordPress posts.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
 /**
- * Class Current_Post_Helper
+ * A helper object for WordPress posts.
  */
 class Current_Page_Helper {
 

--- a/src/helpers/date-helper.php
+++ b/src/helpers/date-helper.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * A helper object for dates.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 use WPSEO_Date_Helper;
 
 /**
- * Class Date_Helper
+ * A helper object for dates.
  */
 class Date_Helper {
 

--- a/src/helpers/home-url-helper.php
+++ b/src/helpers/home-url-helper.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * A helper object for the home url.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 /**
- * Class Home_Url_Helper
+ * A helper object for the home URL.
  */
 class Home_Url_Helper {
 

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * A helper object for images.
- *
- * @package Yoast\WP\SEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
@@ -11,7 +6,7 @@ use WPSEO_Image_Utils;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
- * Class Image_Helper
+ * A helper object for images.
  */
 class Image_Helper {
 

--- a/src/helpers/indexable-helper.php
+++ b/src/helpers/indexable-helper.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * A helper object for indexables.
- *
- * @package Yoast\WP\SEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 use Yoast\WP\SEO\Models\Indexable;
 
 /**
- * Class Indexable_Helper
+ * A helper object for indexables.
  */
 class Indexable_Helper {
 	/**

--- a/src/helpers/language-helper.php
+++ b/src/helpers/language-helper.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * A helper object for language features.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 /**
- * Class Language_Helper
+ * A helper object for language features.
  */
 class Language_Helper {
 

--- a/src/helpers/meta-helper.php
+++ b/src/helpers/meta-helper.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * A helper object for meta.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
@@ -11,7 +6,7 @@ use WPSEO_Meta;
 use WPSEO_Taxonomy_Meta;
 
 /**
- * Class Meta_Helper
+ * A helper object for meta.
  */
 class Meta_Helper {
 

--- a/src/helpers/open-graph/image-helper.php
+++ b/src/helpers/open-graph/image-helper.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * A helper object for Open Graph images.
- *
- * @package \Yoast\WP\SEO\Helpers\Open_Graph
- */
 
 namespace Yoast\WP\SEO\Helpers\Open_Graph;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Helpers\Image_Helper as Base_Image_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
 
 /**
- * Class Image_Helper
+ * A helper object for Open Graph images.
  */
 class Image_Helper {
 

--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * A helper object for options.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
@@ -11,7 +6,7 @@ use WPSEO_Option_Titles;
 use WPSEO_Options;
 
 /**
- * Class Options_Helper
+ * A helper object for options.
  */
 class Options_Helper {
 

--- a/src/helpers/pagination-helper.php
+++ b/src/helpers/pagination-helper.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * A helper object for pagination.
- *
- * @package Yoast\WP\SEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 use Yoast\WP\SEO\Wrappers\WP_Rewrite_Wrapper;
 
 /**
- * Class Pagination_Helper.
+ * A helper object for pagination.
  *
  * Used for the canonical URL and the rel "next" and "prev" meta tags.
  */

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * A helper object for post related things.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
@@ -12,7 +7,7 @@ use Yoast\WP\Lib\Model;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
- * Class Redirect_Helper
+ * A helper object for post related things.
  */
 class Post_Helper {
 

--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * A helper object for post types.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 /**
- * Class Post_Type_Helper
+ * A helper object for post types.
  */
 class Post_Type_Helper {
 

--- a/src/helpers/primary-term-helper.php
+++ b/src/helpers/primary-term-helper.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Primary term helper.
- *
- * @package Yoast\WP\SEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 use stdClass;
 
 /**
- * Class Primary_Term_Helper
+ * A helper object for primary terms.
  */
 class Primary_Term_Helper {
 

--- a/src/helpers/product-helper.php
+++ b/src/helpers/product-helper.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * A helper object to retrieve the product name.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 use WPSEO_Utils;
 
 /**
- * Class Product_Helper
+ * A helper object to retrieve the product name.
  */
 class Product_Helper {
 

--- a/src/helpers/redirect-helper.php
+++ b/src/helpers/redirect-helper.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * A helper object for redirects.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 /**
- * Class Redirect_Helper
+ * A helper object for redirects.
  */
 class Redirect_Helper {
 

--- a/src/helpers/robots-helper.php
+++ b/src/helpers/robots-helper.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * A helper object for the robots meta tag.
- *
- * @package Yoast\WP\SEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 /**
- * Class Robots_Helper
+ * A helper object for the robots meta tag.
  */
 class Robots_Helper {
 

--- a/src/helpers/schema/article-helper.php
+++ b/src/helpers/schema/article-helper.php
@@ -1,16 +1,9 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Helpers\Schema
- */
 
 namespace Yoast\WP\SEO\Helpers\Schema;
 
 /**
- * Class Article_Helper
- *
- * @package Yoast\WP\SEO\Helpers
+ * Class Article_Helper.
  */
 class Article_Helper {
 

--- a/src/helpers/schema/html-helper.php
+++ b/src/helpers/schema/html-helper.php
@@ -1,16 +1,9 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Helpers\Schema
- */
 
 namespace Yoast\WP\SEO\Helpers\Schema;
 
 /**
- * Class HTML_Helper
- *
- * @package Yoast\WP\SEO\Helpers\Schema
+ * Class HTML_Helper.
  */
 class HTML_Helper {
 

--- a/src/helpers/schema/id-helper.php
+++ b/src/helpers/schema/id-helper.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Helpers\Schema
- */
 
 namespace Yoast\WP\SEO\Helpers\Schema;
 

--- a/src/helpers/schema/image-helper.php
+++ b/src/helpers/schema/image-helper.php
@@ -1,18 +1,11 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Helpers\Schema
- */
 
 namespace Yoast\WP\SEO\Helpers\Schema;
 
 use Yoast\WP\SEO\Helpers\Image_Helper as Main_Image_Helper;
 
 /**
- * Class Image_Helper
- *
- * @package Yoast\WP\SEO\Helpers\Schema
+ * Class Image_Helper.
  */
 class Image_Helper {
 

--- a/src/helpers/schema/language-helper.php
+++ b/src/helpers/schema/language-helper.php
@@ -1,16 +1,9 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Helpers\Schema
- */
 
 namespace Yoast\WP\SEO\Helpers\Schema;
 
 /**
- * Class Language_Helper
- *
- * @package Yoast\WP\SEO\Helpers\Schema
+ * Class Language_Helper.
  */
 class Language_Helper {
 

--- a/src/helpers/site-helper.php
+++ b/src/helpers/site-helper.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * A helper object for site options.
- *
- * @package Yoast\WP\SEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 use WPSEO_Utils;
 
 /**
- * Class Site_Helper
+ * A helper object for site options.
  */
 class Site_Helper {
 

--- a/src/helpers/string-helper.php
+++ b/src/helpers/string-helper.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * A helper object for string operations.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 /**
- * Class String_Helper
+ * A helper object for string operations.
  */
 class String_Helper {
 

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * A helper object for terms.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
@@ -12,7 +7,7 @@ use WP_Term;
 use WPSEO_Taxonomy_Meta;
 
 /**
- * Class Taxonomy_Helper
+ * A helper object for terms.
  */
 class Taxonomy_Helper {
 

--- a/src/helpers/twitter/image-helper.php
+++ b/src/helpers/twitter/image-helper.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * A helper object for Twitter images.
- *
- * @package \Yoast\WP\SEO\Helpers\Twitter
- */
 
 namespace Yoast\WP\SEO\Helpers\Twitter;
 
 use Yoast\WP\SEO\Helpers\Image_Helper as Base_Image_Helper;
 
 /**
- * Class Image_Helper
+ * A helper object for Twitter images.
  */
 class Image_Helper {
 

--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * A helper object for urls.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
@@ -11,7 +6,7 @@ use WPSEO_Utils;
 use Yoast\WP\SEO\Models\SEO_Links;
 
 /**
- * Class Url_Helper
+ * A helper object for URLs.
  */
 class Url_Helper {
 

--- a/src/helpers/user-helper.php
+++ b/src/helpers/user-helper.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * A helper object for the user.
- *
- * @package Yoast\YoastSEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 
 /**
- * Class User_Helper
+ * A helper object for the user.
  */
 class User_Helper {
 

--- a/src/helpers/woocommerce-helper.php
+++ b/src/helpers/woocommerce-helper.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Helpers
- */
 
 namespace Yoast\WP\SEO\Helpers;
 

--- a/src/initializers/disable-core-sitemaps.php
+++ b/src/initializers/disable-core-sitemaps.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package WPSEO\Frontend
- */
 
 namespace Yoast\WP\SEO\Initializers;
 

--- a/src/initializers/initializer-interface.php
+++ b/src/initializers/initializer-interface.php
@@ -1,16 +1,13 @@
 <?php
-/**
- * Integration interface definition.
- *
- * @package Yoast\YoastSEO\WordPress
- */
 
 namespace Yoast\WP\SEO\Initializers;
 
 use Yoast\WP\SEO\Loadable_Interface;
 
 /**
- * An interface for registering integrations with WordPress
+ * Integration interface definition.
+ *
+ * An interface for registering integrations with WordPress.
  */
 interface Initializer_Interface extends Loadable_Interface {
 

--- a/src/initializers/migration-runner.php
+++ b/src/initializers/migration-runner.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Config
- */
 
 namespace Yoast\WP\SEO\Initializers;
 

--- a/src/integrations/admin/admin-columns-cache-integration.php
+++ b/src/integrations/admin/admin-columns-cache-integration.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Admin
- */
 
 namespace Yoast\WP\SEO\Integrations\Admin;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
- * Admin_Columns_Cache_Integration class
+ * Admin_Columns_Cache_Integration class.
  */
 class Admin_Columns_Cache_Integration implements Integration_Interface {
 

--- a/src/integrations/admin/disable-concatenate-scripts-integration.php
+++ b/src/integrations/admin/disable-concatenate-scripts-integration.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Admin
- */
 
 namespace Yoast\WP\SEO\Integrations\Admin;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
- * Disable_Concatenate_Scripts_Integration class
+ * Disable_Concatenate_Scripts_Integration class.
  */
 class Disable_Concatenate_Scripts_Integration implements Integration_Interface {
 

--- a/src/integrations/admin/indexation-integration.php
+++ b/src/integrations/admin/indexation-integration.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Admin
- */
 
 namespace Yoast\WP\SEO\Integrations\Admin;
 
@@ -26,7 +21,7 @@ use Yoast\WP\SEO\Presenters\Admin\Indexation_Warning_Presenter;
 use Yoast\WP\SEO\Routes\Indexable_Indexation_Route;
 
 /**
- * Indexation_Integration class
+ * Indexation_Integration class.
  */
 class Indexation_Integration implements Integration_Interface {
 

--- a/src/integrations/admin/link-count-columns-integration.php
+++ b/src/integrations/admin/link-count-columns-integration.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Admin
- */
 
 namespace Yoast\WP\SEO\Integrations\Admin;
 
@@ -19,7 +14,7 @@ use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
- * Link_Count_Columns_Integration class
+ * Link_Count_Columns_Integration class.
  */
 class Link_Count_Columns_Integration implements Integration_Interface {
 

--- a/src/integrations/admin/link-count-notification-integration.php
+++ b/src/integrations/admin/link-count-notification-integration.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Admin
- */
 
 namespace Yoast\WP\SEO\Integrations\Admin;
 

--- a/src/integrations/admin/link-count-tools-integration.php
+++ b/src/integrations/admin/link-count-tools-integration.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Admin
- */
 
 namespace Yoast\WP\SEO\Integrations\Admin;
 
@@ -19,7 +14,7 @@ use Yoast\WP\SEO\Presenters\Admin\Link_Count_Indexing_Modal_Presenter;
 use Yoast\WP\SEO\Routes\Link_Indexing_Route;
 
 /**
- * Link_Count_Tools_Integration class
+ * Link_Count_Tools_Integration class.
  */
 class Link_Count_Tools_Integration implements Integration_Interface {
 

--- a/src/integrations/admin/migration-error-integration.php
+++ b/src/integrations/admin/migration-error-integration.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Admin
- */
 
 namespace Yoast\WP\SEO\Integrations\Admin;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Migration_Error_Presenter;
 
 /**
- * Migration_Error_Integration class
+ * Migration_Error_Integration class.
  */
 class Migration_Error_Integration implements Integration_Interface {
 

--- a/src/integrations/blocks/abstract-dynamic-block.php
+++ b/src/integrations/blocks/abstract-dynamic-block.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Blocks
- */
 
 namespace Yoast\WP\SEO\Integrations\Blocks;
 
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
- * Breadcrumbs block class
+ * Dynamic_Block class.
  */
 abstract class Dynamic_Block implements Integration_Interface {
 

--- a/src/integrations/blocks/block-categories.php
+++ b/src/integrations/blocks/block-categories.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Blocks
- */
 
 namespace Yoast\WP\SEO\Integrations\Blocks;
 
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
- * Dynamic blocks category class
+ * Internal_Linking_Category block class.
  */
 class Internal_Linking_Category implements Integration_Interface {
 

--- a/src/integrations/blocks/structured-data-blocks.php
+++ b/src/integrations/blocks/structured-data-blocks.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package WPSEO\Admin
- */
 
 namespace Yoast\WP\SEO\Integrations\Blocks;
 

--- a/src/integrations/breadcrumbs-integration.php
+++ b/src/integrations/breadcrumbs-integration.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Integrations;
 

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Integrations
- */
 
 namespace Yoast\WP\SEO\Integrations;
 

--- a/src/integrations/front-end/backwards-compatibility.php
+++ b/src/integrations/front-end/backwards-compatibility.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Integrations\Front_End;
 

--- a/src/integrations/front-end/category-term-description.php
+++ b/src/integrations/front-end/category-term-description.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Integrations\Front_End;
 

--- a/src/integrations/front-end/comment-link-fixer.php
+++ b/src/integrations/front-end/comment-link-fixer.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package WPSEO\Frontend
- */
 
 namespace Yoast\WP\SEO\Integrations\Front_End;
 

--- a/src/integrations/front-end/force-rewrite-title.php
+++ b/src/integrations/front-end/force-rewrite-title.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Integrations\Front_End;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
 /**
- * Class Force_Rewrite_Title
+ * Class Force_Rewrite_Title.
  */
 class Force_Rewrite_Title implements Integration_Interface {
 

--- a/src/integrations/front-end/handle-404.php
+++ b/src/integrations/front-end/handle-404.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Integrations\Front_End;
 

--- a/src/integrations/front-end/indexing-controls.php
+++ b/src/integrations/front-end/indexing-controls.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Integrations\Front_End;
 
@@ -12,7 +7,7 @@ use Yoast\WP\SEO\Helpers\Robots_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
- * Class Indexing_Controls
+ * Class Indexing_Controls.
  */
 class Indexing_Controls implements Integration_Interface {
 

--- a/src/integrations/front-end/open-graph-oembed.php
+++ b/src/integrations/front-end/open-graph-oembed.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Integrations\Front_End;
 

--- a/src/integrations/front-end/redirects.php
+++ b/src/integrations/front-end/redirects.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Integrations\Front_End;
 
@@ -15,7 +10,7 @@ use Yoast\WP\SEO\Helpers\Redirect_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
- * Class Redirects
+ * Class Redirects.
  */
 class Redirects implements Integration_Interface {
 

--- a/src/integrations/front-end/rss-footer-embed.php
+++ b/src/integrations/front-end/rss-footer-embed.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package WPSEO\Frontend
- */
 
 namespace Yoast\WP\SEO\Integrations\Front_End;
 
@@ -12,7 +7,7 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
- * Class RSS_Footer_Embed
+ * Class RSS_Footer_Embed.
  */
 class RSS_Footer_Embed implements Integration_Interface {
 

--- a/src/integrations/front-end/theme-titles.php
+++ b/src/integrations/front-end/theme-titles.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package WPSEO\Frontend
- */
 
 namespace Yoast\WP\SEO\Integrations\Front_End;
 

--- a/src/integrations/integration-interface.php
+++ b/src/integrations/integration-interface.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Integration interface definition.
- *
- * @package Yoast\YoastSEO\WordPress
- */
 
 namespace Yoast\WP\SEO\Integrations;
 

--- a/src/integrations/primary-category.php
+++ b/src/integrations/primary-category.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Integrations;
 

--- a/src/integrations/third-party/amp.php
+++ b/src/integrations/third-party/amp.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Third_Party
- */
 
 namespace Yoast\WP\SEO\Integrations\Third_Party;
 
@@ -12,7 +7,7 @@ use Yoast\WP\SEO\Integrations\Front_End_Integration;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
- * AMP integration
+ * AMP integration.
  */
 class AMP implements Integration_Interface {
 

--- a/src/integrations/third-party/bbpress.php
+++ b/src/integrations/third-party/bbpress.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Third_Party
- */
 
 namespace Yoast\WP\SEO\Integrations\Third_Party;
 
@@ -12,7 +7,7 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
- * Class BbPress
+ * BbPress integration.
  */
 class BbPress implements Integration_Interface {
 

--- a/src/integrations/third-party/jetpack.php
+++ b/src/integrations/third-party/jetpack.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Third_Party
- */
 
 namespace Yoast\WP\SEO\Integrations\Third_Party;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Conditionals\Open_Graph_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
- * Class Jetpack
+ * Jetpack integration.
  */
 class Jetpack implements Integration_Interface {
 

--- a/src/integrations/third-party/web-stories.php
+++ b/src/integrations/third-party/web-stories.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Third_Party
- */
 
 namespace Yoast\WP\SEO\Integrations\Third_Party;
 
@@ -15,7 +10,7 @@ use Yoast\WP\SEO\Integrations\Front_End_Integration;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
- * Web Stories integration
+ * Web Stories integration.
  */
 class Web_Stories implements Integration_Interface {
 

--- a/src/integrations/third-party/woocommerce.php
+++ b/src/integrations/third-party/woocommerce.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Integrations\Third_Party
- */
 
 namespace Yoast\WP\SEO\Integrations\Third_Party;
 
@@ -18,7 +13,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
- * Class WooCommerce
+ * WooCommerce integration.
  */
 class WooCommerce implements Integration_Interface {
 

--- a/src/integrations/third-party/wpml.php
+++ b/src/integrations/third-party/wpml.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Integrations
- */
 
 namespace Yoast\WP\SEO\Integrations\Third_Party;
 
@@ -11,9 +6,7 @@ use Yoast\WP\SEO\Conditionals\WPML_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
- * Class WPML
- *
- * @package Yoast\WP\SEO\Integration\Third_Party
+ * WPML integration.
  */
 class WPML implements Integration_Interface {
 

--- a/src/integrations/watchers/indexable-ancestor-watcher.php
+++ b/src/integrations/watchers/indexable-ancestor-watcher.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Ancestor watcher to update the ancestor's children.
- *
- * @package Yoast\YoastSEO\Watchers
- */
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
@@ -15,6 +10,8 @@ use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
+ * Ancestor watcher to update the ancestor's children.
+ *
  * Watches an ancestor to save the meta information when updated.
  */
 class Indexable_Ancestor_Watcher implements Integration_Interface {

--- a/src/integrations/watchers/indexable-author-watcher.php
+++ b/src/integrations/watchers/indexable-author-watcher.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Author watcher to save the meta data to an Indexable.
- *
- * @package Yoast\YoastSEO\Watchers
- */
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
- * Watches an Author to save the meta information when updated.
+ * Watches an Author to save the meta information to an Indexable when updated.
  */
 class Indexable_Author_Watcher implements Integration_Interface {
 

--- a/src/integrations/watchers/indexable-category-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-category-permalink-watcher.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Watcher for the stripcategorybase key in wpseo_titles, in order to clear the permalink of the category indexables.
- *
- * @package Yoast\YoastSEO\Watchers
- */
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 

--- a/src/integrations/watchers/indexable-date-archive-watcher.php
+++ b/src/integrations/watchers/indexable-date-archive-watcher.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Date archive watcher to save the meta data to an Indexable.
- *
- * @package Yoast\YoastSEO\Watchers
- */
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
@@ -13,6 +8,8 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
+ * Date archive watcher to save the meta data to an Indexable.
+ *
  * Watches the date archive options to save the meta information when updated.
  */
 class Indexable_Date_Archive_Watcher implements Integration_Interface {

--- a/src/integrations/watchers/indexable-home-page-watcher.php
+++ b/src/integrations/watchers/indexable-home-page-watcher.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Home page watcher to save the meta data to an Indexable.
- *
- * @package Yoast\YoastSEO\Watchers
- */
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
@@ -13,6 +8,8 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
+ * Home page watcher to save the meta data to an Indexable.
+ *
  * Watches the home page options to save the meta information when updated.
  */
 class Indexable_Home_Page_Watcher implements Integration_Interface {

--- a/src/integrations/watchers/indexable-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-permalink-watcher.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WordPress Permalink structure watcher.
- *
- * @package Yoast\YoastSEO\Watchers
- */
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
@@ -19,6 +14,8 @@ use Yoast\WP\SEO\Presenters\Admin\Indexation_Permalink_Warning_Presenter;
 use Yoast\WP\SEO\WordPress\Wrapper;
 
 /**
+ * WordPress Permalink structure watcher.
+ *
  * Handles updates to the permalink_structure for the Indexables table.
  */
 class Indexable_Permalink_Watcher implements Integration_Interface {

--- a/src/integrations/watchers/indexable-post-meta-watcher.php
+++ b/src/integrations/watchers/indexable-post-meta-watcher.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WordPress post meta watcher.
- *
- * @package Yoast\YoastSEO\Watchers
- */
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
@@ -12,7 +7,7 @@ use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
- * Indexable_Postmeta_Watcher class
+ * WordPress post meta watcher.
  */
 class Indexable_Post_Meta_Watcher implements Integration_Interface {
 

--- a/src/integrations/watchers/indexable-post-type-archive-watcher.php
+++ b/src/integrations/watchers/indexable-post-type-archive-watcher.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Post type archive watcher to save the meta data to an Indexable.
- *
- * @package Yoast\YoastSEO\Watchers
- */
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
@@ -13,6 +8,8 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
+ * Post type archive watcher to save the meta data to an Indexable.
+ *
  * Watches the home page options to save the meta information when updated.
  */
 class Indexable_Post_Type_Archive_Watcher implements Integration_Interface {

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WordPress Post watcher.
- *
- * @package Yoast\YoastSEO\Watchers
- */
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
@@ -23,6 +18,8 @@ use Yoast\WP\SEO\Repositories\SEO_Links_Repository;
 use YoastSEO_Vendor\Psr\Log\LogLevel;
 
 /**
+ * WordPress Post watcher.
+ *
  * Fills the Indexable according to Post data.
  */
 class Indexable_Post_Watcher implements Integration_Interface {

--- a/src/integrations/watchers/indexable-static-home-page-watcher.php
+++ b/src/integrations/watchers/indexable-static-home-page-watcher.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Watcher that checks for changes in the page used as homepage.
- *
- * @package Yoast\YoastSEO\Watchers
- */
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
@@ -12,6 +7,8 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
+ * Watcher that checks for changes in the page used as homepage.
+ *
  * Watches the static homepage option and updates the permalinks accordingly.
  */
 class Indexable_Static_Home_Page_Watcher implements Integration_Interface {

--- a/src/integrations/watchers/indexable-system-page-watcher.php
+++ b/src/integrations/watchers/indexable-system-page-watcher.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Search result watcher to save the meta data to an Indexable.
- *
- * @package Yoast\YoastSEO\Watchers
- */
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
@@ -14,6 +9,8 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
+ * Search result watcher to save the meta data to an Indexable.
+ *
  * Watches the search result options to save the meta information when updated.
  */
 class Indexable_System_Page_Watcher implements Integration_Interface {

--- a/src/integrations/watchers/indexable-term-watcher.php
+++ b/src/integrations/watchers/indexable-term-watcher.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Term/Taxonomy watcher to fill the related Indexable.
- *
- * @package Yoast\YoastSEO\Watchers
- */
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
@@ -14,7 +9,7 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
- * Watcher for terms to fill the related Indexable.
+ * Watches Terms/Taxonomies to fill the related Indexable.
  */
 class Indexable_Term_Watcher implements Integration_Interface {
 

--- a/src/integrations/watchers/option-titles-watcher.php
+++ b/src/integrations/watchers/option-titles-watcher.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Watcher for the titles option.
- *
- * @package Yoast\YoastSEO\Watchers
- */
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
@@ -13,6 +8,8 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\WordPress\Wrapper;
 
 /**
+ * Watcher for the titles option.
+ *
  * Represents the option titles watcher.
  */
 class Option_Titles_Watcher implements Integration_Interface {

--- a/src/integrations/watchers/primary-term-watcher.php
+++ b/src/integrations/watchers/primary-term-watcher.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Primary Term watcher.
- *
- * @package Yoast\YoastSEO\Watchers
- */
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
@@ -15,6 +10,8 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 
 /**
+ * Primary Term watcher.
+ *
  * Watches Posts to save the primary term when set.
  */
 class Primary_Term_Watcher implements Integration_Interface {

--- a/src/integrations/xmlrpc.php
+++ b/src/integrations/xmlrpc.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package WPSEO\Frontend
- */
 
 namespace Yoast\WP\SEO\Integrations;
 

--- a/src/loadable-interface.php
+++ b/src/loadable-interface.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Integration interface definition.
- *
- * @package Yoast\YoastSEO\WordPress
- */
 
 namespace Yoast\WP\SEO;
 

--- a/src/loader.php
+++ b/src/loader.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\WP\SEO
- */
 
 namespace Yoast\WP\SEO;
 

--- a/src/loggers/logger.php
+++ b/src/loggers/logger.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast extension of the Model class.
- *
- * @package Yoast\YoastSEO\Loggers
- */
 
 namespace Yoast\WP\SEO\Loggers;
 

--- a/src/main.php
+++ b/src/main.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\WP\SEO
- */
 
 namespace Yoast\WP\SEO;
 
@@ -21,7 +16,7 @@ if ( ! \defined( 'WPSEO_VERSION' ) ) {
 }
 
 /**
- * Class Main
+ * Class Main.
  *
  * @property Classes_Surface $classes      The classes surface.
  * @property Meta_Surface    $meta         The meta surface.

--- a/src/memoizers/meta-tags-context-memoizer.php
+++ b/src/memoizers/meta-tags-context-memoizer.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * The meta tags context memoizer.
- *
- * @package Yoast\YoastSEO\Memoizers
- */
 
 namespace Yoast\WP\SEO\Memoizers;
 
@@ -14,7 +9,7 @@ use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
- * Class Meta_Tags_Context_Memoizer
+ * The meta tags context memoizer.
  */
 class Meta_Tags_Context_Memoizer {
 

--- a/src/memoizers/presentation-memoizer.php
+++ b/src/memoizers/presentation-memoizer.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * The presentation memoizer.
- *
- * @package Yoast\YoastSEO\Memoizers
- */
 
 namespace Yoast\WP\SEO\Memoizers;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class Presentation_Memoizer
+ * The presentation memoizer.
  */
 class Presentation_Memoizer {
 

--- a/src/models/indexable-extension.php
+++ b/src/models/indexable-extension.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Models
- */
 
 namespace Yoast\WP\SEO\Models;
 

--- a/src/models/indexable-hierarchy.php
+++ b/src/models/indexable-hierarchy.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Model for the Indexable Hierarchy table.
- *
- * @package Yoast\YoastSEO\Models
- */
 
 namespace Yoast\WP\SEO\Models;
 

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Model for the Indexable table.
- *
- * @package Yoast\YoastSEO\Models
- */
 
 namespace Yoast\WP\SEO\Models;
 

--- a/src/models/primary-term.php
+++ b/src/models/primary-term.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Model for the Primary Term table.
- *
- * @package Yoast\YoastSEO\Models
- */
 
 namespace Yoast\WP\SEO\Models;
 

--- a/src/models/seo-links.php
+++ b/src/models/seo-links.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Model for the SEO Meta table.
- *
- * @package Yoast\YoastSEO\Models
- */
 
 namespace Yoast\WP\SEO\Models;
 
 use Yoast\WP\Lib\Model;
 
 /**
- * Table definition for the SEO Meta table.
+ * Table definition for the SEO Links table.
  *
  * @property int    $id
  * @property string $url

--- a/src/models/seo-meta.php
+++ b/src/models/seo-meta.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Model for the SEO Meta table.
- *
- * @package Yoast\YoastSEO\Models
- */
 
 namespace Yoast\WP\SEO\Models;
 

--- a/src/oauth/client.php
+++ b/src/oauth/client.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast extension of the Model class.
- *
- * @package Yoast\WP\SEO\Oauth
- */
 
 namespace Yoast\WP\SEO\Oauth;
 

--- a/src/presentations/abstract-presentation.php
+++ b/src/presentations/abstract-presentation.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * The abstract presentation class.
- *
- * @package Yoast\YoastSEO\Presentations
- */
 
 namespace Yoast\WP\SEO\Presentations;
 
 use Exception;
 
 /**
- * Class Abstract_Presentation
+ * The abstract presentation class.
  */
 class Abstract_Presentation {
 

--- a/src/presentations/archive-adjacent-trait.php
+++ b/src/presentations/archive-adjacent-trait.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presentation object for indexables.
- *
- * @package Yoast\YoastSEO\Presentations
- */
 
 namespace Yoast\WP\SEO\Presentations;
 
@@ -11,7 +6,9 @@ use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 
 /**
- * Class Archive_Adjacent
+ * Class Archive_Adjacent.
+ *
+ * Presentation object for indexables.
  *
  * @property Indexable         $model      The indexable.
  * @property Pagination_Helper $pagination The pagination helper. Should be defined in the parent

--- a/src/presentations/indexable-author-archive-presentation.php
+++ b/src/presentations/indexable-author-archive-presentation.php
@@ -1,16 +1,13 @@
 <?php
-/**
- * Presentation object for indexables.
- *
- * @package Yoast\YoastSEO\Presentations
- */
 
 namespace Yoast\WP\SEO\Presentations;
 
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 
 /**
- * Class Indexable_Author_Archive_Presentation
+ * Class Indexable_Author_Archive_Presentation.
+ *
+ * Presentation object for indexables.
  */
 class Indexable_Author_Archive_Presentation extends Indexable_Presentation {
 	use Archive_Adjacent;

--- a/src/presentations/indexable-date-archive-presentation.php
+++ b/src/presentations/indexable-date-archive-presentation.php
@@ -1,16 +1,13 @@
 <?php
-/**
- * Presentation object for indexables.
- *
- * @package Yoast\YoastSEO\Presentations
- */
 
 namespace Yoast\WP\SEO\Presentations;
 
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 
 /**
- * Class Indexable_Date_Archive_Presentation
+ * Class Indexable_Date_Archive_Presentation.
+ *
+ * Presentation object for indexables.
  */
 class Indexable_Date_Archive_Presentation extends Indexable_Presentation {
 

--- a/src/presentations/indexable-error-page-presentation.php
+++ b/src/presentations/indexable-error-page-presentation.php
@@ -1,14 +1,11 @@
 <?php
-/**
- * Presentation object for indexables.
- *
- * @package Yoast\YoastSEO\Presentations
- */
 
 namespace Yoast\WP\SEO\Presentations;
 
 /**
- * Class Indexable_Error_Page_Presentation
+ * Class Indexable_Error_Page_Presentation.
+ *
+ * Presentation object for indexables.
  */
 class Indexable_Error_Page_Presentation extends Indexable_Presentation {
 

--- a/src/presentations/indexable-home-page-presentation.php
+++ b/src/presentations/indexable-home-page-presentation.php
@@ -1,14 +1,11 @@
 <?php
-/**
- * Presentation object for indexables.
- *
- * @package Yoast\YoastSEO\Presentations
- */
 
 namespace Yoast\WP\SEO\Presentations;
 
 /**
- * Class Indexable_Presentation
+ * Class Indexable_Home_Page_Presentation.
+ *
+ * Presentation object for indexables.
  */
 class Indexable_Home_Page_Presentation extends Indexable_Presentation {
 	use Archive_Adjacent;

--- a/src/presentations/indexable-post-type-archive-presentation.php
+++ b/src/presentations/indexable-post-type-archive-presentation.php
@@ -1,14 +1,11 @@
 <?php
-/**
- * Presentation object for indexables.
- *
- * @package Yoast\YoastSEO\Presentations
- */
 
 namespace Yoast\WP\SEO\Presentations;
 
 /**
- * Class Indexable_Post_Type_Archive_Presentation
+ * Class Indexable_Post_Type_Archive_Presentation.
+ *
+ * Presentation object for indexables.
  */
 class Indexable_Post_Type_Archive_Presentation extends Indexable_Presentation {
 	use Archive_Adjacent;

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presentation object for indexables.
- *
- * @package Yoast\YoastSEO\Presentations
- */
 
 namespace Yoast\WP\SEO\Presentations;
 
@@ -13,7 +8,9 @@ use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 
 /**
- * Class Indexable_Post_Type_Presentation
+ * Class Indexable_Post_Type_Presentation.
+ *
+ * Presentation object for indexables.
  */
 class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presentation object for indexables.
- *
- * @package Yoast\YoastSEO\Presentations
- */
 
 namespace Yoast\WP\SEO\Presentations;
 
@@ -21,7 +16,9 @@ use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 
 /**
- * Class Indexable_Presentation
+ * Class Indexable_Presentation.
+ *
+ * Presentation object for indexables.
  *
  * @property string $title
  * @property string $meta_description

--- a/src/presentations/indexable-search-result-page-presentation.php
+++ b/src/presentations/indexable-search-result-page-presentation.php
@@ -1,14 +1,11 @@
 <?php
-/**
- * Presentation object for indexables.
- *
- * @package Yoast\YoastSEO\Presentations
- */
 
 namespace Yoast\WP\SEO\Presentations;
 
 /**
- * Class Indexable_Search_Result_Page_Presentation
+ * Class Indexable_Search_Result_Page_Presentation.
+ *
+ * Presentation object for indexables.
  */
 class Indexable_Search_Result_Page_Presentation extends Indexable_Presentation {
 

--- a/src/presentations/indexable-static-home-page-presentation.php
+++ b/src/presentations/indexable-static-home-page-presentation.php
@@ -1,14 +1,11 @@
 <?php
-/**
- * Presentation object for indexables.
- *
- * @package Yoast\YoastSEO\Presentations
- */
 
 namespace Yoast\WP\SEO\Presentations;
 
 /**
- * Class Indexable_Static_Home_Page_Presentation
+ * Class Indexable_Static_Home_Page_Presentation.
+ *
+ * Presentation object for indexables.
  */
 class Indexable_Static_Home_Page_Presentation extends Indexable_Post_Type_Presentation {
 

--- a/src/presentations/indexable-static-posts-page-presentation.php
+++ b/src/presentations/indexable-static-posts-page-presentation.php
@@ -1,16 +1,13 @@
 <?php
-/**
- * Presentation object for indexables.
- *
- * @package Yoast\YoastSEO\Presentations
- */
 
 namespace Yoast\WP\SEO\Presentations;
 
 use Yoast\WP\SEO\Helpers\Pagination_Helper;
 
 /**
- * Class Indexable_Static_Posts_Page_Presentation
+ * Class Indexable_Static_Posts_Page_Presentation.
+ *
+ * Presentation object for indexables.
  */
 class Indexable_Static_Posts_Page_Presentation extends Indexable_Post_Type_Presentation {
 

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presentation object for indexables.
- *
- * @package Yoast\YoastSEO\Presentations
- */
 
 namespace Yoast\WP\SEO\Presentations;
 
@@ -12,7 +7,9 @@ use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
 /**
- * Class Indexable_Presentation
+ * Class Indexable_Term_Archive_Presentation.
+ *
+ * Presentation object for indexables.
  *
  * @property WP_Term $source
  */

--- a/src/presenters/abstract-indexable-presenter.php
+++ b/src/presenters/abstract-indexable-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Abstract presenter class for indexable presentations.
- *
- * @package Yoast\YoastSEO\Presenters
- */
 
 namespace Yoast\WP\SEO\Presenters;
 
@@ -12,7 +7,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 
 /**
- * Class Abstract_Indexable_Presenter
+ * Abstract presenter class for indexable presentations.
  */
 abstract class Abstract_Indexable_Presenter extends Abstract_Presenter {
 

--- a/src/presenters/abstract-indexable-tag-presenter.php
+++ b/src/presenters/abstract-indexable-tag-presenter.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * Abstract presenter class for indexable presentations.
- *
- * @package Yoast\YoastSEO\Presenters
- */
 
 namespace Yoast\WP\SEO\Presenters;
 
 /**
- * Abstract_Indexable_Tag_Presenter class
+ * Abstract presenter class for indexable tag presentations.
  */
 abstract class Abstract_Indexable_Tag_Presenter extends Abstract_Indexable_Presenter {
 

--- a/src/presenters/abstract-presenter.php
+++ b/src/presenters/abstract-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Abstract presenter class.
- *
- * @package Yoast\YoastSEO\Presenters
- */
 
 namespace Yoast\WP\SEO\Presenters;
 

--- a/src/presenters/admin/alert-presenter.php
+++ b/src/presenters/admin/alert-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for Alert boxes.
- *
- * @package Yoast\YoastSEO\Presenters\Admin
- */
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 
@@ -11,7 +6,7 @@ use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
 /**
- * Represents the class for Alerts.
+ * Represents the presenter class for Alert boxes.
  */
 class Alert_Presenter extends Abstract_Presenter {
 

--- a/src/presenters/admin/indexation-list-item-presenter.php
+++ b/src/presenters/admin/indexation-list-item-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the indexation modal.
- *
- * @package Yoast\YoastSEO\Presenters\Admin
- */
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 
@@ -11,7 +6,7 @@ use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
 /**
- * Indexation_List_Item_Presenter class.
+ * Presenter class for the indexation list item.
  */
 class Indexation_List_Item_Presenter extends Abstract_Presenter {
 

--- a/src/presenters/admin/indexation-modal-presenter.php
+++ b/src/presenters/admin/indexation-modal-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the indexation modal.
- *
- * @package Yoast\YoastSEO\Presenters\Admin
- */
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
 /**
- * Indexation_Modal_Presenter class.
+ * Presenter class for the indexation modal.
  */
 class Indexation_Modal_Presenter extends Abstract_Presenter {
 

--- a/src/presenters/admin/indexation-permalink-warning-presenter.php
+++ b/src/presenters/admin/indexation-permalink-warning-presenter.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * Presenter class for the warning that is given when the Category URLs (stripcategorybase) option is touched.
- *
- * @package Yoast\YoastSEO\Presenters\Admin
- */
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 
 /**
- * Indexation_Permalink_Warning_Presenter class.
+ * Presenter class for the warning that is given when the Category URLs (stripcategorybase) option is touched.
  */
 class Indexation_Permalink_Warning_Presenter extends Indexation_Warning_Presenter {
 

--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the indexation warning.
- *
- * @package Yoast\YoastSEO\Presenters\Admin
- */
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 
@@ -12,7 +7,7 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
 /**
- * Indexation_Warning_Presenter class.
+ * Presenter class for the indexation warning.
  */
 class Indexation_Warning_Presenter extends Abstract_Presenter {
 

--- a/src/presenters/admin/link-count-indexing-list-item-presenter.php
+++ b/src/presenters/admin/link-count-indexing-list-item-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the link count indexing tool.
- *
- * @package Yoast\YoastSEO\Presenters\Admin
- */
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
 /**
- * Link_Count_Indexing_List_Item_Presenter class
+ * Presenter class for the link count indexing tool.
  */
 class Link_Count_Indexing_List_Item_Presenter extends Abstract_Presenter {
 

--- a/src/presenters/admin/link-count-indexing-modal-presenter.php
+++ b/src/presenters/admin/link-count-indexing-modal-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the indexation modal.
- *
- * @package Yoast\YoastSEO\Presenters\Admin
- */
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
 /**
- * Link_Count_Indexing_Modal_Presenter class.
+ * Presenter class for the link count indexing modal.
  */
 class Link_Count_Indexing_Modal_Presenter extends Abstract_Presenter {
 

--- a/src/presenters/admin/meta-fields-presenter.php
+++ b/src/presenters/admin/meta-fields-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for meta fields in the post editor.
- *
- * @package Yoast\YoastSEO\Presenters\Admin
- */
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 
@@ -11,6 +6,8 @@ use WPSEO_Meta;
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
 /**
+ * Presenter class for meta fields in the post editor.
+ *
  * Outputs the hidden fields for a particular field group and post.
  */
 class Meta_Fields_Presenter extends Abstract_Presenter {

--- a/src/presenters/admin/migration-error-presenter.php
+++ b/src/presenters/admin/migration-error-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the indexation warning.
- *
- * @package Yoast\YoastSEO\Presenters\Admin
- */
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 
@@ -11,7 +6,7 @@ use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
 /**
- * Migration_Error_Presenter class.
+ * Presenter class for the migration error.
  */
 class Migration_Error_Presenter extends Abstract_Presenter {
 

--- a/src/presenters/bingbot-presenter.php
+++ b/src/presenters/bingbot-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Abstract presenter class for the bingbot output.
- *
- * @package Yoast\YoastSEO\Presenters
- */
 
 namespace Yoast\WP\SEO\Presenters;
 
@@ -12,7 +7,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 _deprecated_file( basename( __FILE__ ), 'WPSEO 14.9' );
 
 /**
- * Class Bingbot_Presenter
+ * Presenter class for the bingbot output.
  */
 class Bingbot_Presenter extends Abstract_Indexable_Presenter {
 

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the breadcrumbs.
- *
- * @package Yoast\YoastSEO\Presenters
- */
 
 namespace Yoast\WP\SEO\Presenters;
 
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 
 /**
- * Class Breadcrumbs_Presenter
+ * Presenter class for the breadcrumbs.
  */
 class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 

--- a/src/presenters/canonical-presenter.php
+++ b/src/presenters/canonical-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the canonical.
- *
- * @package Yoast\YoastSEO\Presenters
- */
 
 namespace Yoast\WP\SEO\Presenters;
 
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 
 /**
- * Class Abstract_Meta_Description_Presenter
+ * Presenter class for the canonical.
  */
 class Canonical_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/debug/marker-close-presenter.php
+++ b/src/presenters/debug/marker-close-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Final presenter class for the debug close marker.
- *
- * @package Yoast\YoastSEO\Presenters\Debug
- */
 
 namespace Yoast\WP\SEO\Presenters\Debug;
 
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 
 /**
- * Class Debug_Marker_Close_Presenter
+ * Presenter class for the debug close marker.
  */
 final class Marker_Close_Presenter extends Abstract_Indexable_Presenter {
 

--- a/src/presenters/debug/marker-open-presenter.php
+++ b/src/presenters/debug/marker-open-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Final presenter class for the debug open marker.
- *
- * @package Yoast\YoastSEO\Presenters\Debug
- */
 
 namespace Yoast\WP\SEO\Presenters\Debug;
 
@@ -11,7 +6,7 @@ use WPSEO_Utils;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 
 /**
- * Class Debug_Marker_Open_Presenter
+ * Presenter class for the debug open marker.
  */
 final class Marker_Open_Presenter extends Abstract_Indexable_Presenter {
 

--- a/src/presenters/googlebot-presenter.php
+++ b/src/presenters/googlebot-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Abstract presenter class for the googlebot output.
- *
- * @package Yoast\YoastSEO\Presenters
- */
 
 namespace Yoast\WP\SEO\Presenters;
 
@@ -12,7 +7,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 _deprecated_file( basename( __FILE__ ), 'WPSEO 14.9' );
 
 /**
- * Class Googlebot_Presenter
+ * Presenter class for the googlebot output.
  */
 class Googlebot_Presenter extends Abstract_Indexable_Presenter {
 

--- a/src/presenters/meta-description-presenter.php
+++ b/src/presenters/meta-description-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the meta description.
- *
- * @package Yoast\YoastSEO\Presenters
- */
 
 namespace Yoast\WP\SEO\Presenters;
 
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 
 /**
- * Class Abstract_Meta_Description_Presenter
+ * Presenter class for the meta description.
  */
 class Meta_Description_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/open-graph/article-author-presenter.php
+++ b/src/presenters/open-graph/article-author-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the Open Graph article author.
- *
- * @package Yoast\YoastSEO\Presenters\Open_Graph
- */
 
 namespace Yoast\WP\SEO\Presenters\Open_Graph;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Article_Author_Presenter
+ * Presenter class for the Open Graph article author.
  */
 class Article_Author_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/open-graph/article-modified-time-presenter.php
+++ b/src/presenters/open-graph/article-modified-time-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the Open Graph article modified time.
- *
- * @package Yoast\YoastSEO\Presenters\Open_Graph
- */
 
 namespace Yoast\WP\SEO\Presenters\Open_Graph;
 
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Article_Modified_Time_Presenter
+ * Presenter class for the Open Graph article modified time.
  */
 class Article_Modified_Time_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/open-graph/article-published-time-presenter.php
+++ b/src/presenters/open-graph/article-published-time-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the Open Graph article published time.
- *
- * @package Yoast\YoastSEO\Presenters\Open_Graph
- */
 
 namespace Yoast\WP\SEO\Presenters\Open_Graph;
 
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Article_Published_Time_Presenter
+ * Presenter class for the Open Graph article published time.
  */
 class Article_Published_Time_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/open-graph/article-publisher-presenter.php
+++ b/src/presenters/open-graph/article-publisher-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the Open Graph article publisher.
- *
- * @package Yoast\YoastSEO\Presenters\Open_Graph
- */
 
 namespace Yoast\WP\SEO\Presenters\Open_Graph;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Article_Publisher_Presenter
+ * Presenter class for the Open Graph article publisher.
  */
 class Article_Publisher_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/open-graph/description-presenter.php
+++ b/src/presenters/open-graph/description-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the Open Graph description.
- *
- * @package Yoast\YoastSEO\Presenters\Open_Graph
- */
 
 namespace Yoast\WP\SEO\Presenters\Open_Graph;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Description_Presenter
+ * Presenter class for the Open Graph description.
  */
 class Description_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/open-graph/fb-app-id-presenter.php
+++ b/src/presenters/open-graph/fb-app-id-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the Open Graph FB app ID.
- *
- * @package Yoast\YoastSEO\Presenters\Open_Graph
- */
 
 namespace Yoast\WP\SEO\Presenters\Open_Graph;
 
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class FB_App_ID_Presenter
+ * Presenter class for the Open Graph FB app ID.
  */
 class FB_App_ID_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the Open Graph image.
- *
- * @package Yoast\YoastSEO\Presenters\Open_Graph
- */
 
 namespace Yoast\WP\SEO\Presenters\Open_Graph;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 
 /**
- * Class Image_Presenter
+ * Presenter class for the Open Graph image.
  */
 class Image_Presenter extends Abstract_Indexable_Presenter {
 

--- a/src/presenters/open-graph/locale-presenter.php
+++ b/src/presenters/open-graph/locale-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Final presenter class for the Open Graph locale.
- *
- * @package Yoast\YoastSEO\Presenters\Open_Graph
- */
 
 namespace Yoast\WP\SEO\Presenters\Open_Graph;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Site_Open_Graph_Locale_Presenter
+ * Final presenter class for the Open Graph locale.
  */
 final class Locale_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/open-graph/site-name-presenter.php
+++ b/src/presenters/open-graph/site-name-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the Open Graph site name.
- *
- * @package Yoast\YoastSEO\Presenters\Open_Graph
- */
 
 namespace Yoast\WP\SEO\Presenters\Open_Graph;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Site_Name_Presenter
+ * Presenter class for the Open Graph site name.
  */
 class Site_Name_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/open-graph/title-presenter.php
+++ b/src/presenters/open-graph/title-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the Open Graph title.
- *
- * @package Yoast\YoastSEO\Presenters\Open_Graph
- */
 
 namespace Yoast\WP\SEO\Presenters\Open_Graph;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Title_Presenter
+ * Presenter class for the Open Graph title.
  */
 class Title_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/open-graph/type-presenter.php
+++ b/src/presenters/open-graph/type-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the Open Graph type.
- *
- * @package Yoast\YoastSEO\Presenters\Open_Graph
- */
 
 namespace Yoast\WP\SEO\Presenters\Open_Graph;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Type_Presenter
+ * Presenter class for the Open Graph type.
  */
 class Type_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/open-graph/url-presenter.php
+++ b/src/presenters/open-graph/url-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the Open Graph URL.
- *
- * @package Yoast\YoastSEO\Presenters\Open_Graph
- */
 
 namespace Yoast\WP\SEO\Presenters\Open_Graph;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Url_Presenter
+ * Presenter class for the Open Graph URL.
  */
 class Url_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/rel-next-presenter.php
+++ b/src/presenters/rel-next-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the rel next meta tag.
- *
- * @package Yoast\YoastSEO\Presenters
- */
 
 namespace Yoast\WP\SEO\Presenters;
 
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 
 /**
- * Class Rel_Next_Presenter
+ * Presenter class for the rel next meta tag.
  */
 class Rel_Next_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/rel-prev-presenter.php
+++ b/src/presenters/rel-prev-presenter.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * Presenter class for the rel prev meta tag.
- *
- * @package Yoast\YoastSEO\Presenters
- */
 
 namespace Yoast\WP\SEO\Presenters;
 
 /**
- * Class Rel_Prev_Presenter
+ * Presenter class for the rel prev meta tag.
  */
 class Rel_Prev_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/robots-presenter.php
+++ b/src/presenters/robots-presenter.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * Abstract presenter class for the robots output.
- *
- * @package Yoast\YoastSEO\Presenters
- */
 
 namespace Yoast\WP\SEO\Presenters;
 
 /**
- * Class Robots_Presenter
+ * Presenter class for the robots output.
  */
 class Robots_Presenter extends Abstract_Indexable_Presenter {
 

--- a/src/presenters/schema-presenter.php
+++ b/src/presenters/schema-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the schema object.
- *
- * @package Yoast\YoastSEO\Presenters
- */
 
 namespace Yoast\WP\SEO\Presenters;
 
 use WPSEO_Utils;
 
 /**
- * Class Schema_Presenter
+ * Presenter class for the schema object.
  */
 class Schema_Presenter extends Abstract_Indexable_Presenter {
 

--- a/src/presenters/title-presenter.php
+++ b/src/presenters/title-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the document title.
- *
- * @package Yoast\YoastSEO\Presenters
- */
 
 namespace Yoast\WP\SEO\Presenters;
 
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 
 /**
- * Class Title_Presenter
+ * Presenter class for the document title.
  */
 class Title_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/twitter/card-presenter.php
+++ b/src/presenters/twitter/card-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the Open Graph title.
- *
- * @package Yoast\YoastSEO\Presenters\Twitter
- */
 
 namespace Yoast\WP\SEO\Presenters\Twitter;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Card_Presenter
+ * Presenter class for the Twitter Card tag.
  */
 class Card_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/twitter/creator-presenter.php
+++ b/src/presenters/twitter/creator-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the Open Graph title.
- *
- * @package Yoast\YoastSEO\Presenters\Twitter
- */
 
 namespace Yoast\WP\SEO\Presenters\Twitter;
 
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Creator_Presenter
+ * Presenter class for the Twitter creator.
  */
 class Creator_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/twitter/description-presenter.php
+++ b/src/presenters/twitter/description-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the Twitter description.
- *
- * @package Yoast\YoastSEO\Presenters|Twitter
- */
 
 namespace Yoast\WP\SEO\Presenters\Twitter;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Description_Presenter
+ * Presenter class for the Twitter description.
  */
 class Description_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/twitter/image-presenter.php
+++ b/src/presenters/twitter/image-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the Twitter image.
- *
- * @package Yoast\YoastSEO\Presenters\Twitter
- */
 
 namespace Yoast\WP\SEO\Presenters\Twitter;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Image_Presenter
+ * Presenter class for the Twitter image.
  */
 class Image_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/twitter/site-presenter.php
+++ b/src/presenters/twitter/site-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the Twitter site.
- *
- * @package Yoast\YoastSEO\Presenters\Twitter
- */
 
 namespace Yoast\WP\SEO\Presenters\Twitter;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Site_Presenter
+ * Presenter class for the Twitter site tag.
  */
 class Site_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/twitter/title-presenter.php
+++ b/src/presenters/twitter/title-presenter.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Presenter class for the Twitter title.
- *
- * @package Yoast\YoastSEO\Presenters\Twitter
- */
 
 namespace Yoast\WP\SEO\Presenters\Twitter;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Title_Presenter
+ * Presenter class for the Twitter title.
  */
 class Title_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/url-list-presenter.php
+++ b/src/presenters/url-list-presenter.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * Presenter class for the document title.
- *
- * @package Yoast\YoastSEO\Presenters
- */
 
 namespace Yoast\WP\SEO\Presenters;
 
 /**
- * Class Url_List_Presenter
+ * Presenter class for the URL list.
  */
 class Url_List_Presenter extends Abstract_Presenter {
 

--- a/src/presenters/webmaster/baidu-presenter.php
+++ b/src/presenters/webmaster/baidu-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the Baidu Webmaster Tools verification setting.
- *
- * @package Yoast\YoastSEO\Presenters\Webmaster
- */
 
 namespace Yoast\WP\SEO\Presenters\Webmaster;
 
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Baidu_Presenter
+ * Presenter class for the Baidu Webmaster Tools verification setting.
  */
 class Baidu_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/webmaster/bing-presenter.php
+++ b/src/presenters/webmaster/bing-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the Bing Webmaster verification setting.
- *
- * @package Yoast\YoastSEO\Presenters\Webmaster
- */
 
 namespace Yoast\WP\SEO\Presenters\Webmaster;
 
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Bing_Presenter
+ * Presenter class for the Bing Webmaster verification setting.
  */
 class Bing_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/webmaster/google-presenter.php
+++ b/src/presenters/webmaster/google-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the Google Search Console verification setting.
- *
- * @package Yoast\YoastSEO\Presenters\Webmaster
- */
 
 namespace Yoast\WP\SEO\Presenters\Webmaster;
 
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Google_Presenter
+ * Presenter class for the Google Search Console verification setting.
  */
 class Google_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/webmaster/pinterest-presenter.php
+++ b/src/presenters/webmaster/pinterest-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the Pinterest Webmaster verification setting.
- *
- * @package Yoast\YoastSEO\Presenters\Webmaster
- */
 
 namespace Yoast\WP\SEO\Presenters\Webmaster;
 
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Pinterest_Presenter
+ * Presenter class for the Pinterest Webmaster verification setting.
  */
 class Pinterest_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/presenters/webmaster/yandex-presenter.php
+++ b/src/presenters/webmaster/yandex-presenter.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Presenter class for the Pinterest Webmaster verification setting.
- *
- * @package Yoast\YoastSEO\Presenters\Webmaster
- */
 
 namespace Yoast\WP\SEO\Presenters\Webmaster;
 
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Tag_Presenter;
 
 /**
- * Class Yandex_Presenter
+ * Presenter class for the Yandex Webmaster verification setting.
  */
 class Yandex_Presenter extends Abstract_Indexable_Tag_Presenter {
 

--- a/src/repositories/indexable-hierarchy-repository.php
+++ b/src/repositories/indexable-hierarchy-repository.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast extension of the Model class.
- *
- * @package Yoast\WP\SEO\Repositories
- */
 
 namespace Yoast\WP\SEO\Repositories;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder;
 use Yoast\WP\SEO\Models\Indexable;
 
 /**
- * Class Indexable_Hierarchy_Repository
+ * Class Indexable_Hierarchy_Repository.
  */
 class Indexable_Hierarchy_Repository {
 

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast extension of the Model class.
- *
- * @package Yoast\WP\SEO\Repositories
- */
 
 namespace Yoast\WP\SEO\Repositories;
 
@@ -18,7 +13,7 @@ use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Models\Indexable;
 
 /**
- * Class Indexable_Repository
+ * Class Indexable_Repository.
  */
 class Indexable_Repository {
 

--- a/src/repositories/primary-term-repository.php
+++ b/src/repositories/primary-term-repository.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast extension of the Model class.
- *
- * @package Yoast\WP\SEO\Repositories
- */
 
 namespace Yoast\WP\SEO\Repositories;
 
@@ -12,7 +7,7 @@ use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Models\Primary_Term;
 
 /**
- * Class Primary_Term_Repository
+ * Class Primary_Term_Repository.
  */
 class Primary_Term_Repository {
 

--- a/src/repositories/seo-links-repository.php
+++ b/src/repositories/seo-links-repository.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast extension of the Model class.
- *
- * @package Yoast\WP\SEO\Repositories
- */
 
 namespace Yoast\WP\SEO\Repositories;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Lib\Model;
 use Yoast\WP\Lib\ORM;
 
 /**
- * Class SEO_Links_Repository
+ * Class SEO_Links_Repository.
  */
 class SEO_Links_Repository {
 

--- a/src/repositories/seo-meta-repository.php
+++ b/src/repositories/seo-meta-repository.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast extension of the Model class.
- *
- * @package Yoast\WP\SEO\Repositories
- */
 
 namespace Yoast\WP\SEO\Repositories;
 
@@ -11,7 +6,7 @@ use Yoast\WP\Lib\Model;
 use Yoast\WP\Lib\ORM;
 
 /**
- * Class SEO_Meta_Repository
+ * Class SEO_Meta_Repository.
  */
 class SEO_Meta_Repository {
 

--- a/src/routes/abstract-indexation-route.php
+++ b/src/routes/abstract-indexation-route.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Reindexation route for indexables.
- *
- * @package Yoast\WP\SEO\Routes\Routes
- */
 
 namespace Yoast\WP\SEO\Routes;
 
@@ -12,6 +7,8 @@ use Yoast\WP\SEO\Actions\Indexation\Indexation_Action_Interface;
 
 /**
  * Abstract_Indexation_Route class.
+ *
+ * Reindexation route for indexables.
  */
 abstract class Abstract_Indexation_Route implements Route_Interface {
 

--- a/src/routes/indexable-indexation-route.php
+++ b/src/routes/indexable-indexation-route.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Reindexation route for indexables.
- *
- * @package Yoast\WP\SEO\Routes\Routes
- */
 
 namespace Yoast\WP\SEO\Routes;
 
@@ -19,7 +14,9 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Main;
 
 /**
- * Indexable_Reindexing_Route class.
+ * Indexable_Indexation_Route class.
+ *
+ * Reindexation route for indexables.
  */
 class Indexable_Indexation_Route extends Abstract_Indexation_Route {
 

--- a/src/routes/indexables-head-route.php
+++ b/src/routes/indexables-head-route.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Head route for indexables.
- *
- * @package Yoast\WP\SEO\Routes\Routes
- */
 
 namespace Yoast\WP\SEO\Routes;
 
@@ -14,7 +9,7 @@ use Yoast\WP\SEO\Conditionals\Headless_Rest_Endpoints_Enabled_Conditional;
 use Yoast\WP\SEO\Main;
 
 /**
- * Indexable_Reindexing_Route class.
+ * Head route for indexables.
  */
 class Indexables_Head_Route implements Route_Interface {
 

--- a/src/routes/link-indexing-route.php
+++ b/src/routes/link-indexing-route.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Reindexation route for indexables.
- *
- * @package Yoast\WP\SEO\Routes\Routes
- */
 
 namespace Yoast\WP\SEO\Routes;
 
@@ -14,7 +9,7 @@ use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Main;
 
 /**
- * Link_Indexing_Route class.
+ * Reindexation route for link indexables.
  */
 class Link_Indexing_Route extends Abstract_Indexation_Route {
 

--- a/src/routes/route-interface.php
+++ b/src/routes/route-interface.php
@@ -1,14 +1,12 @@
 <?php
-/**
- * Route interface.
- *
- * @package Yoast\WP\SEO\Routes
- */
 
 namespace Yoast\WP\SEO\Routes;
 
 use Yoast\WP\SEO\Loadable_Interface;
 
+/**
+ * Route interface.
+ */
 interface Route_Interface extends Loadable_Interface {
 
 	/**

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Registers the yoast head REST field.
- * Not technically a route but behaves the same so is included here.
- *
- * @package Yoast\WP\SEO\Routes\Routes
- */
 
 namespace Yoast\WP\SEO\Routes;
 
@@ -14,7 +8,10 @@ use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 
 /**
- * Yoast_Head_REST_Field class
+ * Yoast_Head_REST_Field class.
+ *
+ * Registers the yoast head REST field.
+ * Not technically a route but behaves the same so is included here.
  */
 class Yoast_Head_REST_Field implements Route_Interface {
 

--- a/src/surfaces/classes-surface.php
+++ b/src/surfaces/classes-surface.php
@@ -1,16 +1,13 @@
 <?php
-/**
- * Surface for the indexables.
- *
- * @package Yoast\YoastSEO\Surfaces
- */
 
 namespace Yoast\WP\SEO\Surfaces;
 
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class Classes_Surface
+ * Class Classes_Surface.
+ *
+ * Surface for the indexables.
  */
 class Classes_Surface {
 

--- a/src/surfaces/helpers-surface.php
+++ b/src/surfaces/helpers-surface.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Surface for the indexables.
- *
- * @package Yoast\YoastSEO\Surfaces
- */
 
 namespace Yoast\WP\SEO\Surfaces;
 
@@ -11,7 +6,9 @@ use Yoast\WP\SEO\Helpers;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class Helpers_Surface
+ * Class Helpers_Surface.
+ *
+ * Surface for the indexables.
  *
  * @property Helpers\Author_Archive_Helper $author_archive
  * @property Helpers\Blocks_Helper         $blocks

--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Surface for the indexables.
- *
- * @package Yoast\YoastSEO\Surfaces
- */
 
 namespace Yoast\WP\SEO\Surfaces;
 
@@ -18,6 +13,8 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Meta_Surface class.
+ *
+ * Surface for the indexables.
  */
 class Meta_Surface {
 

--- a/src/surfaces/open-graph-helpers-surface.php
+++ b/src/surfaces/open-graph-helpers-surface.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Surface for the indexables.
- *
- * @package Yoast\YoastSEO\Surfaces
- */
 
 namespace Yoast\WP\SEO\Surfaces;
 
@@ -11,7 +6,9 @@ use Yoast\WP\SEO\Helpers\Open_Graph;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class Open_Graph_Helpers_Surface
+ * Class Open_Graph_Helpers_Surface.
+ *
+ * Surface for the indexables.
  *
  * @property Open_Graph\Image_Helper $image
  */

--- a/src/surfaces/schema-helpers-surface.php
+++ b/src/surfaces/schema-helpers-surface.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Surface for the indexables.
- *
- * @package Yoast\YoastSEO\Surfaces
- */
 
 namespace Yoast\WP\SEO\Surfaces;
 
@@ -11,7 +6,9 @@ use Yoast\WP\SEO\Helpers\Schema;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class Schema_Helpers_Surface
+ * Class Schema_Helpers_Surface.
+ *
+ * Surface for the indexables.
  *
  * @property Schema\Article_Helper $article
  * @property Schema\HTML_Helper $html

--- a/src/surfaces/twitter-helpers-surface.php
+++ b/src/surfaces/twitter-helpers-surface.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Surface for the indexables.
- *
- * @package Yoast\YoastSEO\Surfaces
- */
 
 namespace Yoast\WP\SEO\Surfaces;
 
@@ -11,7 +6,9 @@ use Yoast\WP\SEO\Helpers\Twitter;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class Twitter_Helpers_Surface
+ * Class Twitter_Helpers_Surface.
+ *
+ * Surface for the indexables.
  *
  * @property Twitter\Image_Helper $image
  */

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Meta value object.
- *
- * @package Yoast\YoastSEO\Surfaces\Values
- */
 
 namespace Yoast\WP\SEO\Surfaces\Values;
 
@@ -18,7 +13,7 @@ use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class Meta
+ * Meta value object.
  *
  * @property array       $breadcrumbs                       The breadcrumbs array for the current page.
  * @property bool        $breadcrumbs_enabled               Whether breadcrumbs are enabled or not.

--- a/src/values/images.php
+++ b/src/values/images.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Value object for the Images.
- *
- * @package Yoast\WP\SEO\Values
- */
 
 namespace Yoast\WP\SEO\Values;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Helpers\Url_Helper;
 /**
  * Class Images
  *
- * @package Yoast\WP\SEO\Values
+ * Value object for the Images.
  */
 class Images {
 

--- a/src/values/open-graph/images.php
+++ b/src/values/open-graph/images.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Value object for the Open Graph Images.
- *
- * @package Yoast\WP\SEO\Values
- */
 
 namespace Yoast\WP\SEO\Values\Open_Graph;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper as Open_Graph_Image_Helper;
 use Yoast\WP\SEO\Values\Images as Base_Images;
 
 /**
- * Class Images.
+ * Value object for the Open Graph Images.
  */
 class Images extends Base_Images {
 

--- a/src/wordpress/wrapper.php
+++ b/src/wordpress/wrapper.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\WordPress
- */
 
 namespace Yoast\WP\SEO\WordPress;
 

--- a/src/wrappers/wp-query-wrapper.php
+++ b/src/wrappers/wp-query-wrapper.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Wrapper for WP_Query.
- *
- * @package Yoast\YoastSEO\Wrappers
- */
 
 namespace Yoast\WP\SEO\Wrappers;
 
 use WP_Query;
 
 /**
- * Class WP_Query_Wrapper
+ * Wrapper for WP_Query.
  */
 class WP_Query_Wrapper {
 

--- a/src/wrappers/wp-rewrite-wrapper.php
+++ b/src/wrappers/wp-rewrite-wrapper.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * Wrapper for WP_Rewrite.
- *
- * @package Yoast\YoastSEO\Wrappers
- */
 
 namespace Yoast\WP\SEO\Wrappers;
 
 use WP_Rewrite;
 
 /**
- * Class WP_Rewrite_Wrapper
+ * Wrapper for WP_Rewrite.
  */
 class WP_Rewrite_Wrapper {
 

--- a/tests/unit/actions/indexables/indexable-head-action-test.php
+++ b/tests/unit/actions/indexables/indexable-head-action-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Actions\Indexables
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Actions\Indexables;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Surfaces\Meta_Surface;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Indexable_Post_Indexation_Action_Test class
+ * Indexable_Head_Action_Test class.
  *
  * @group actions
  * @group indexables

--- a/tests/unit/builders/indexable-builder-test.php
+++ b/tests/unit/builders/indexable-builder-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Builders
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Builders;
 

--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Commands
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Commands;
 

--- a/tests/unit/conditionals/headless-rest-endpoints-enabled-conditional-test.php
+++ b/tests/unit/conditionals/headless-rest-endpoints-enabled-conditional-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Conditionals
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Conditionals;
 

--- a/tests/unit/conditionals/should-index-links-conditional-test.php
+++ b/tests/unit/conditionals/should-index-links-conditional-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Conditionals
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Conditionals;
 

--- a/tests/unit/conditionals/web-stories-conditional-test.php
+++ b/tests/unit/conditionals/web-stories-conditional-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Conditionals
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Conditionals;
 

--- a/tests/unit/doubles/context/meta-tags-context-mock.php
+++ b/tests/unit/doubles/context/meta-tags-context-mock.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Mocks
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Doubles\Context;
 
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 
 /**
- * Class Meta_Tags_Context_Mock
+ * Class Meta_Tags_Context_Mock.
  */
 class Meta_Tags_Context_Mock extends Meta_Tags_Context {
 

--- a/tests/unit/doubles/database/migration-double.php
+++ b/tests/unit/doubles/database/migration-double.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Mocks
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Doubles\Database;
 
@@ -11,7 +6,7 @@ use Exception;
 use Yoast\WP\Lib\Migrations\Migration;
 
 /**
- * Class Meta_Tags_Context_Mock
+ * Class Migration_Double.
  */
 class Migration_Double extends Migration {
 

--- a/tests/unit/doubles/models/indexable-double.php
+++ b/tests/unit/doubles/models/indexable-double.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Class Indexable.
- *
- * @package Yoast\Tests\Doubles\Models
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Doubles\Models;
 

--- a/tests/unit/doubles/oauth/client-double.php
+++ b/tests/unit/doubles/oauth/client-double.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\Tests\Doubles\Oauth
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Doubles\Oauth;
 
@@ -11,7 +6,7 @@ use Yoast\WP\SEO\Oauth\Client;
 use YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface;
 
 /**
- * Test Helper Class.
+ * Class Client_Double.
  */
 class Client_Double extends Client {
 

--- a/tests/unit/doubles/routes/abstract-indexation-route-mock.php
+++ b/tests/unit/doubles/routes/abstract-indexation-route-mock.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Mocks
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Doubles\Routes;
 

--- a/tests/unit/generators/breadcrumbs-generator-test.php
+++ b/tests/unit/generators/breadcrumbs-generator-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Generators
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Generators;
 
@@ -21,7 +16,7 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Open_Graph_Image_Generator_Test
+ * Class Breadcrumbs_Generator_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Generators\Breadcrumbs_Generator
  *

--- a/tests/unit/generators/open-graph-locale-generator-test.php
+++ b/tests/unit/generators/open-graph-locale-generator-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Generators
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Generators;
 
@@ -14,7 +9,7 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Open_Graph_Locale_Generator_Test
+ * Class Open_Graph_Locale_Generator_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Generators\Open_Graph_Locale_Generator
  *

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Generators
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Generators;
 
@@ -23,7 +18,7 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Schema_Generator_Test
+ * Class Schema_Generator_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Generators\Schema_Generator
  *

--- a/tests/unit/generators/schema/main-image-test.php
+++ b/tests/unit/generators/schema/main-image-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Generators\Schema
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Generators\Schema;
 
@@ -18,7 +13,7 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Main_Image_Test
+ * Class Main_Image_Test.
  *
  * @group generators
  * @group schema

--- a/tests/unit/generators/schema/organization-test.php
+++ b/tests/unit/generators/schema/organization-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Generators\Schema
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Generators\Schema;
 
@@ -19,7 +14,7 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Organization_Test
+ * Class Organization_Test.
  *
  * @group generators
  * @group schema

--- a/tests/unit/generators/schema/person-test.php
+++ b/tests/unit/generators/schema/person-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Generators\Schema
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Generators\Schema;
 
@@ -22,7 +17,7 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Person_Test
+ * Class Person_Test,
  *
  * @group generators
  * @group schema

--- a/tests/unit/initializers/disable-core-sitemaps-test.php
+++ b/tests/unit/initializers/disable-core-sitemaps-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Integrations
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Initializers;
 
@@ -15,7 +10,7 @@ use Yoast\WP\SEO\Initializers\Disable_Core_Sitemaps;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Unit Test Class.
+ * Class Disable_Core_Sitemaps_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Initializers\Disable_Core_Sitemaps
  *

--- a/tests/unit/integrations/admin/admin-columns-cache-integration-test.php
+++ b/tests/unit/integrations/admin/admin-columns-cache-integration-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Admin
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
 
@@ -17,7 +12,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Indexation_Integration_Test
+ * Class Admin_Columns_Cache_Integration_Test.
  *
  * @group integrations
  * @group indexation

--- a/tests/unit/integrations/admin/indexation-integration-test.php
+++ b/tests/unit/integrations/admin/indexation-integration-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Admin
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
 
@@ -24,7 +19,7 @@ use Yoast\WP\SEO\Integrations\Admin\Indexation_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Indexation_Integration_Test
+ * Class Indexation_Integration_Test.
  *
  * @group integrations
  * @group indexation

--- a/tests/unit/integrations/admin/migration-error-integration-test.php
+++ b/tests/unit/integrations/admin/migration-error-integration-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Admin
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
 
@@ -16,7 +11,7 @@ use Yoast\WP\SEO\Integrations\Admin\Migration_Error_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Migration_Error_Integration_Test
+ * Class Migration_Error_Integration_Test.
  *
  * @group integrations
  * @group migrations

--- a/tests/unit/integrations/breadcrumbs-integration-test.php
+++ b/tests/unit/integrations/breadcrumbs-integration-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Integrations
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations;
 
@@ -18,7 +13,7 @@ use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Unit Test Class.
+ * Class Breadcrumbs_Integration_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Breadcrumbs_Integration
  *

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Integrations
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations;
 
@@ -21,7 +16,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Unit Test Class.
+ * Class Front_End_Integration_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End_Integration
  *

--- a/tests/unit/integrations/front-end/category-term-description-test.php
+++ b/tests/unit/integrations/front-end/category-term-description-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Front_End;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Integrations\Front_End\Category_Term_Description;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Unit Test Class.
+ * Class Category_Term_Description_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\Category_Term_Description
  * @covers ::<!public>

--- a/tests/unit/integrations/front-end/comment-link-fixer-test.php
+++ b/tests/unit/integrations/front-end/comment-link-fixer-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Front_End;
 
@@ -16,7 +11,7 @@ use Yoast\WP\SEO\Integrations\Front_End\Comment_Link_Fixer;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Unit Test Class.
+ * Class Comment_Link_Fixer_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\Comment_Link_Fixer
  * @covers ::<!public>

--- a/tests/unit/integrations/front-end/force-rewrite-title-test.php
+++ b/tests/unit/integrations/front-end/force-rewrite-title-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Front_End;
 
@@ -16,7 +11,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
 /**
- * Unit Test Class.
+ * Class Force_Rewrite_Title_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\Force_Rewrite_Title
  * @covers ::<!public>

--- a/tests/unit/integrations/front-end/handle-404-test.php
+++ b/tests/unit/integrations/front-end/handle-404-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Front_End;
 
@@ -16,7 +11,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
 /**
- * Unit Test Class.
+ * Class Handle_404_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\Handle_404
  *

--- a/tests/unit/integrations/front-end/indexing-controls-test.php
+++ b/tests/unit/integrations/front-end/indexing-controls-test.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Front_End;
 
@@ -13,7 +10,7 @@ use Yoast\WP\SEO\Integrations\Front_End\Indexing_Controls;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Unit Test Class.
+ * Class Indexing_Controls_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\Indexing_Controls
  * @covers ::<!public>

--- a/tests/unit/integrations/front-end/open-graph-oembed-test.php
+++ b/tests/unit/integrations/front-end/open-graph-oembed-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Front_End;
 
@@ -16,7 +11,7 @@ use Yoast\WP\SEO\Surfaces\Meta_Surface;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Unit Test Class.
+ * Class Open_Graph_OEmbed_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\Open_Graph_OEmbed
  *

--- a/tests/unit/integrations/front-end/redirects-test.php
+++ b/tests/unit/integrations/front-end/redirects-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Front_End;
 
@@ -18,7 +13,7 @@ use Yoast\WP\SEO\Integrations\Front_End\Redirects;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Unit Test Class.
+ * Class Redirects_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\Redirects
  * @covers ::<!public>

--- a/tests/unit/integrations/front-end/rss-footer-embed-test.php
+++ b/tests/unit/integrations/front-end/rss-footer-embed-test.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Front_End;
 
@@ -13,7 +10,7 @@ use Yoast\WP\SEO\Integrations\Front_End\RSS_Footer_Embed;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Unit Test Class.
+ * Class RSS_Footer_Embed_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\RSS_Footer_Embed
  * @covers ::<!public>

--- a/tests/unit/integrations/front-end/theme-titles-test.php
+++ b/tests/unit/integrations/front-end/theme-titles-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Front_End
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Front_End;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Integrations\Front_End\Theme_Titles;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Unit Test Class.
+ * Class Theme_Titles_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\Theme_Titles
  * @covers ::<!public>

--- a/tests/unit/integrations/primary-category-test.php
+++ b/tests/unit/integrations/primary-category-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Integrations\Primary_Category;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Unit Test Class.
+ * Class Primary_Category_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Primary_Category
  *

--- a/tests/unit/integrations/third-party/amp-test.php
+++ b/tests/unit/integrations/third-party/amp-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party;
 

--- a/tests/unit/integrations/third-party/bbpress-test.php
+++ b/tests/unit/integrations/third-party/bbpress-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party;
 
@@ -14,7 +9,7 @@ use Yoast\WP\SEO\Integrations\Third_Party\BbPress;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Unit Test Class.
+ * Class BbPress_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\BbPress
  * @covers ::<!public>

--- a/tests/unit/integrations/third-party/jetpack-test.php
+++ b/tests/unit/integrations/third-party/jetpack-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party;
 
@@ -14,7 +9,7 @@ use Yoast\WP\SEO\Integrations\Third_Party\Jetpack;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Unit Test Class.
+ * Class Jetpack_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\Jetpack
  * @covers ::<!public>

--- a/tests/unit/integrations/third-party/web-stories-test.php
+++ b/tests/unit/integrations/third-party/web-stories-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party;
 

--- a/tests/unit/integrations/third-party/woocommerce-test.php
+++ b/tests/unit/integrations/third-party/woocommerce-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party;
 
@@ -21,7 +16,7 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Unit Test Class.
+ * Class WooCommerce_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\WooCommerce
  *

--- a/tests/unit/integrations/third-party/wpml-test.php
+++ b/tests/unit/integrations/third-party/wpml-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party;
 
@@ -12,7 +7,7 @@ use Yoast\WP\SEO\Integrations\Third_Party\WPML;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Unit Test Class.
+ * Class WPML_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\WPML
  * @covers ::<!public>

--- a/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Watchers
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 

--- a/tests/unit/integrations/watchers/indexable-author-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-author-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Watchers
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
@@ -16,7 +11,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Indexable_Author_Test.
+ * Class Indexable_Author_Watcher_Test.
  *
  * @group indexables
  * @group integrations

--- a/tests/unit/integrations/watchers/indexable-category-permalink-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-category-permalink-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Watchers
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 

--- a/tests/unit/integrations/watchers/indexable-date-archive-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-date-archive-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Watchers
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 

--- a/tests/unit/integrations/watchers/indexable-home-page-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-home-page-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Watchers
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 

--- a/tests/unit/integrations/watchers/indexable-permalink-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-permalink-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Watchers
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 

--- a/tests/unit/integrations/watchers/indexable-post-meta-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-meta-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Watchers
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 

--- a/tests/unit/integrations/watchers/indexable-post-type-archive-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-type-archive-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Watchers
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Watchers
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
@@ -24,7 +19,7 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Indexable_Post_Test.
+ * Class Indexable_Post_Watcher_Test.
  *
  * @group indexables
  * @group integrations

--- a/tests/unit/integrations/watchers/indexable-static-home-page-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-static-home-page-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Watchers
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 

--- a/tests/unit/integrations/watchers/indexable-system-page-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-system-page-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Watchers
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 

--- a/tests/unit/integrations/watchers/indexable-term-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-term-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Watchers
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
@@ -18,7 +13,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Indexable_Term_Test.
+ * Class Indexable_Term_Watcher_Test.
  *
  * @group indexables
  * @group integrations

--- a/tests/unit/integrations/watchers/option-titles-watcher-test.php
+++ b/tests/unit/integrations/watchers/option-titles-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Watchers
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 

--- a/tests/unit/integrations/watchers/primary-term-watcher-test.php
+++ b/tests/unit/integrations/watchers/primary-term-watcher-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Integrations\Watchers
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 

--- a/tests/unit/integrations/xmlrpc-test.php
+++ b/tests/unit/integrations/xmlrpc-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\YoastSEO\Integrations
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations;
 
@@ -12,7 +7,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 
 /**
- * Unit Test Class.
+ * Class XMLRPC_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\XMLRPC
  *

--- a/tests/unit/models/indexable-test.php
+++ b/tests/unit/models/indexable-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Models
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Models;
 
@@ -14,7 +9,7 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Double;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Indexable_Test
+ * Class Indexable_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Models\Indexable
  *

--- a/tests/unit/oauth/client-test.php
+++ b/tests/unit/oauth/client-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\Tests\Oauth
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Oauth;
 

--- a/tests/unit/presentations/indexable-author-archive-presentation/source-test.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/source-test.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Author_Archive_Presentation
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Author_Archive_Presentation;
 
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Source_Test
+ * Class Source_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presentations\Indexable_Author_Archive_Presentation
  *

--- a/tests/unit/presentations/indexable-post-type-archive-presentation/source-test.php
+++ b/tests/unit/presentations/indexable-post-type-archive-presentation/source-test.php
@@ -1,16 +1,11 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Post_Type_Archive_Presentation
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations\Indexable_Post_Type_Archive_Presentation;
 
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Source_Test
+ * Class Source_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presentations\Indexable_Post_Type_Archive_Presentation
  *

--- a/tests/unit/presenters/abstract-indexable-presenter-test.php
+++ b/tests/unit/presenters/abstract-indexable-presenter-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Presenters
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters;
 
@@ -14,7 +9,7 @@ use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Abstract_Presenter_Test
+ * Class Abstract_Indexable_Presenter_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter
  *

--- a/tests/unit/presenters/abstract-presenter-test.php
+++ b/tests/unit/presenters/abstract-presenter-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Presenters
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters;
 
@@ -12,7 +7,7 @@ use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Abstract_Presenter_Test
+ * Class Abstract_Presenter_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Abstract_Presenter
  *

--- a/tests/unit/presenters/admin/alert-presenter-test.php
+++ b/tests/unit/presenters/admin/alert-presenter-test.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Admin;
 
@@ -11,7 +8,7 @@ use Yoast\WP\SEO\Presenters\Admin\Alert_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Alert_Presenter_Test
+ * Class Alert_Presenter_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Admin\Alert_Presenter
  *

--- a/tests/unit/presenters/admin/indexation-list-item-presenter-test.php
+++ b/tests/unit/presenters/admin/indexation-list-item-presenter-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Presenters\Admin
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Admin;
 
@@ -12,7 +7,7 @@ use Yoast\WP\SEO\Presenters\Admin\Indexation_List_Item_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Indexation_List_Item_Presenter_Test
+ * Class Indexation_List_Item_Presenter_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Admin\Indexation_List_Item_Presenter
  *

--- a/tests/unit/presenters/admin/indexation-permalink-warning-presenter-test.php
+++ b/tests/unit/presenters/admin/indexation-permalink-warning-presenter-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Presenters\Admin
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Admin;
 
@@ -15,7 +10,7 @@ use Yoast\WP\SEO\Presenters\Admin\Indexation_Warning_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Indexation_Permalink_Warning_Presenter_Test
+ * Class Indexation_Permalink_Warning_Presenter_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Admin\Indexation_Permalink_Warning_Presenter
  *

--- a/tests/unit/presenters/admin/indexation-warning-presenter-test.php
+++ b/tests/unit/presenters/admin/indexation-warning-presenter-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Presenters\Admin
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Admin;
 
@@ -14,7 +9,7 @@ use Yoast\WP\SEO\Presenters\Admin\Indexation_Warning_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Indexation_Warning_Presenter_Test
+ * Class Indexation_Warning_Presenter_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Admin\Indexation_Warning_Presenter
  *

--- a/tests/unit/presenters/admin/migration-error-presenter-test.php
+++ b/tests/unit/presenters/admin/migration-error-presenter-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Presenters\Admin
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Admin;
 
@@ -13,7 +8,7 @@ use Yoast\WP\SEO\Presenters\Admin\Migration_Error_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Migration_Error_Presenter_Test
+ * Class Migration_Error_Presenter_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Admin\Migration_Error_Presenter
  *

--- a/tests/unit/presenters/breadcrumbs-presenter-test.php
+++ b/tests/unit/presenters/breadcrumbs-presenter-test.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters;
 
@@ -13,7 +10,7 @@ use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Breadcrumbs_Presenter_Test
+ * Class Breadcrumbs_Presenter_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter
  *

--- a/tests/unit/presenters/canonical-presenter-test.php
+++ b/tests/unit/presenters/canonical-presenter-test.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters;
 

--- a/tests/unit/presenters/debug/marker-close-presenter-test.php
+++ b/tests/unit/presenters/debug/marker-close-presenter-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Presenters
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Debug;
 

--- a/tests/unit/presenters/debug/marker-open-presenter-test.php
+++ b/tests/unit/presenters/debug/marker-open-presenter-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Presenters
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters\Debug;
 

--- a/tests/unit/presenters/rel-next-presenter-test.php
+++ b/tests/unit/presenters/rel-next-presenter-test.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters;
 
@@ -12,7 +9,7 @@ use Yoast\WP\SEO\Presenters\Rel_Next_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Rel_Next_Presenter_Test
+ * Class Rel_Next_Presenter_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Rel_Next_Presenter
  *

--- a/tests/unit/presenters/rel-prev-presenter-test.php
+++ b/tests/unit/presenters/rel-prev-presenter-test.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Presenters;
 
@@ -12,7 +9,7 @@ use Yoast\WP\SEO\Presenters\Rel_Prev_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Rel_Prev_Presenter_Test
+ * Class Rel_Prev_Presenter_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Presenters\Rel_Prev_Presenter
  *

--- a/tests/unit/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/unit/repositories/indexable-hierarchy-repository-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Repositories
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Repositories;
 

--- a/tests/unit/repositories/indexable-repository-test.php
+++ b/tests/unit/repositories/indexable-repository-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Repositories
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Repositories;
 

--- a/tests/unit/routes/abstract-indexation-route-test.php
+++ b/tests/unit/routes/abstract-indexation-route-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Routes
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Routes;
 
@@ -12,7 +7,7 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Routes\Abstract_Indexation_Route_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Abstract_Indexation_Route_Test
+ * Class Abstract_Indexation_Route_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Routes\Abstract_Indexation_Route
  *

--- a/tests/unit/routes/indexable-indexation-route-test.php
+++ b/tests/unit/routes/indexable-indexation-route-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Routes
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Routes;
 

--- a/tests/unit/routes/indexables-head-route-test.php
+++ b/tests/unit/routes/indexables-head-route-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Routes
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Routes;
 

--- a/tests/unit/routes/yoast-head-rest-field-test.php
+++ b/tests/unit/routes/yoast-head-rest-field-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Routes
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Routes;
 
@@ -17,7 +12,7 @@ use Yoast\WP\SEO\Routes\Yoast_Head_REST_Field;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Yoast_Head_REST_Field_Test class
+ * Yoast_Head_REST_Field_Test class.
  *
  * @coversDefaultClass Yoast\WP\SEO\Routes\Yoast_Head_REST_Field
  *

--- a/tests/unit/surfaces/meta-surface-test.php
+++ b/tests/unit/surfaces/meta-surface-test.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package Yoast\WP\SEO\Tests\Unit\Surfaces
- */
 
 namespace Yoast\WP\SEO\Tests\Unit\Surfaces;
 


### PR DESCRIPTION
## Context

* Code consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

YoastCS 1.2.0 introduced a new YoastCS native sniff which makes it unnecessary for namespaced classes to have a file comment.

For the relevant classes to which this currently applies, I've removed the file comments and where relevant, merged the file short description and class short description to provide a more comprehensive class description.

This commit includes:
* Fixing class description and (file) descriptions to be more accurate and more consistent.
* Removing redundant `@package` tags in the class docblocks.
* Remove redundant repetition of the class name in the class docblock if there is a proper description available.
* Minor punctuation fixes.

## Test instructions
This PR can be tested by following these steps:

* _N/A_ - this is a documentation only change