### PR TITLE
CS: fix a variety of whitespace and other small issues

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -139,7 +139,7 @@ class WPSEO_Admin_Init {
 	public function yoast_plugin_update_notification() {
 		$notification_center   = Yoast_Notification_Center::get();
 		$current_minor_version = $this->get_major_minor_version( WPSEO_Options::get( 'version', WPSEO_VERSION ) );
-		$file = plugin_dir_path( WPSEO_FILE ) . 'release-info.json';
+		$file                  = plugin_dir_path( WPSEO_FILE ) . 'release-info.json';
 
 		// Remove if file is not present.
 		if ( ! file_exists( $file ) ) {
@@ -160,7 +160,7 @@ class WPSEO_Admin_Init {
 		if ( is_null( $release_info )
 			|| empty( $release_info->version )
 			|| version_compare( $this->get_major_minor_version( $release_info->version ), $current_minor_version, '!=' )
-		 	|| empty( $release_info->release_description )
+			|| empty( $release_info->release_description )
 		) {
 			$notification_center->remove_notification_by_id( 'wpseo-plugin-updated' );
 			return;
@@ -171,7 +171,7 @@ class WPSEO_Admin_Init {
 		// Restore notification if it was dismissed in a previous minor version.
 		$last_dismissed_version = get_user_option( $notification->get_dismissal_key() );
 		if ( ! $last_dismissed_version
-			 || version_compare( $this->get_major_minor_version( $last_dismissed_version ), $current_minor_version, '<' )
+			|| version_compare( $this->get_major_minor_version( $last_dismissed_version ), $current_minor_version, '<' )
 		) {
 			Yoast_Notification_Center::restore_notification( $notification );
 		}
@@ -208,7 +208,7 @@ class WPSEO_Admin_Init {
 				$release_info->release_description;
 
 		if ( ! empty( $release_info->shortlink ) ) {
-			$link = esc_url( WPSEO_Shortlinker::get( $release_info->shortlink ) );
+			$link          = esc_url( WPSEO_Shortlinker::get( $release_info->shortlink ) );
 			$info_message .= ' <a href="' . esc_url( $link ) . '" target="_blank">' .
 							 sprintf(
 							 	/* translators: %s expands to the plugin version. */

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -164,9 +164,9 @@ class Yoast_Notification_Center {
 			return true;
 		}
 
-		$dismissal_key      = $notification->get_dismissal_key();
-		$notification_id    = $notification->get_id();
-		$notification_json  = $notification->get_json();
+		$dismissal_key     = $notification->get_dismissal_key();
+		$notification_id   = $notification->get_id();
+		$notification_json = $notification->get_json();
 
 		$is_dismissing = ( $dismissal_key === self::get_user_input( 'notification' ) );
 		if ( ! $is_dismissing ) {

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -77,7 +77,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$this->social_is_enabled            = WPSEO_Options::get( 'opengraph', false ) || WPSEO_Options::get( 'twitter', false );
 		$this->is_advanced_metadata_enabled = WPSEO_Capability_Utils::current_user_can( 'wpseo_edit_advanced_metadata' ) || WPSEO_Options::get( 'disableadvanced_meta' ) === false;
 
-		$this->seo_analysis = new WPSEO_Metabox_Analysis_SEO();
+		$this->seo_analysis         = new WPSEO_Metabox_Analysis_SEO();
 		$this->readability_analysis = new WPSEO_Metabox_Analysis_Readability();
 	}
 
@@ -325,13 +325,13 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		echo new Meta_Fields_Presenter( $this->get_metabox_post(), 'general' );
 
 		if ( $this->is_advanced_metadata_enabled ) {
-			echo new Meta_Fields_Presenter( $this->get_metabox_post(),'advanced' );
+			echo new Meta_Fields_Presenter( $this->get_metabox_post(), 'advanced' );
 		}
 
 		echo new Meta_Fields_Presenter( $this->get_metabox_post(), 'schema', $this->get_metabox_post()->post_type );
 
 		if ( $this->social_is_enabled ) {
-			echo new Meta_Fields_Presenter( $this->get_metabox_post(),'social' );
+			echo new Meta_Fields_Presenter( $this->get_metabox_post(), 'social' );
 		}
 
 		/**
@@ -450,8 +450,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		foreach ( $requested_tabs as $tab ) {
 			if ( is_array( $tab ) && array_key_exists( 'name', $tab ) && array_key_exists( 'link_content', $tab ) && array_key_exists( 'content', $tab ) ) {
-				$options    = array_key_exists( 'options', $tab ) ? $tab['options'] : [];
-				$tabs[] = new WPSEO_Metabox_Section_Additional(
+				$options = array_key_exists( 'options', $tab ) ? $tab['options'] : [];
+				$tabs[]  = new WPSEO_Metabox_Section_Additional(
 					$tab['name'],
 					$tab['link_content'],
 					$tab['content'],
@@ -822,7 +822,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$asset_manager->enqueue_style( 'select2' );
 		$asset_manager->enqueue_style( 'monorepo' );
 
-		$is_block_editor = WP_Screen::get()->is_block_editor();
+		$is_block_editor  = WP_Screen::get()->is_block_editor();
 		$post_edit_handle = 'post-edit';
 		if ( ! $is_block_editor ) {
 			$post_edit_handle = 'post-edit-classic';

--- a/admin/taxonomy/class-taxonomy-fields.php
+++ b/admin/taxonomy/class-taxonomy-fields.php
@@ -34,7 +34,7 @@ class WPSEO_Taxonomy_Fields {
 				break;
 		}
 
-		return  $this->filter_hidden_fields( $fields );
+		return $this->filter_hidden_fields( $fields );
 	}
 
 	/**

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -54,11 +54,11 @@ class WPSEO_Taxonomy_Metabox {
 	 * @param stdClass $term     The term.
 	 */
 	public function __construct( $taxonomy, $term ) {
-		$this->term                 = $term;
-		$this->taxonomy             = $taxonomy;
+		$this->term              = $term;
+		$this->taxonomy          = $taxonomy;
 		$this->is_social_enabled = WPSEO_Options::get( 'opengraph', false ) || WPSEO_Options::get( 'twitter', false );
 
-		$this->seo_analysis = new WPSEO_Metabox_Analysis_SEO();
+		$this->seo_analysis         = new WPSEO_Metabox_Analysis_SEO();
 		$this->readability_analysis = new WPSEO_Metabox_Analysis_Readability();
 	}
 
@@ -85,7 +85,7 @@ class WPSEO_Taxonomy_Metabox {
 	 * @return void
 	 */
 	protected function render_hidden_fields() {
-		$fields_presenter = new WPSEO_Taxonomy_Fields_Presenter( $this->term );
+		$fields_presenter  = new WPSEO_Taxonomy_Fields_Presenter( $this->term );
 		$field_definitions = new WPSEO_Taxonomy_Fields();
 
 		echo $fields_presenter->html( $field_definitions->get( 'content' ) );
@@ -131,7 +131,7 @@ class WPSEO_Taxonomy_Metabox {
 	private function get_tabs() {
 		$tabs = [];
 
-		$label        = __( 'SEO', 'wordpress-seo' );
+		$label = __( 'SEO', 'wordpress-seo' );
 		if ( $this->seo_analysis->is_enabled() ) {
 			$label = '<span class="wpseo-score-icon-container" id="wpseo-seo-score-icon"></span>' . $label;
 		}

--- a/admin/views/tabs/metas/paper-content/post_type/post-type.php
+++ b/admin/views/tabs/metas/paper-content/post_type/post-type.php
@@ -42,7 +42,7 @@ $editor = new WPSEO_Replacevar_Editor(
 $editor->render();
 
 // Schema settings.
-$article_helper 			= new Article_Helper();
+$article_helper             = new Article_Helper();
 $schema_page_type_option    = 'schema-page-type-' . $wpseo_post_type->name;
 $schema_article_type_option = 'schema-article-type-' . $wpseo_post_type->name;
 $yform->hidden( $schema_page_type_option );

--- a/composer.json
+++ b/composer.json
@@ -82,8 +82,8 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=655",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=278",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=617",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=276",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs-summary": [

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -435,7 +435,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 
 		foreach ( $value_change as $key ) {
 			if ( isset( $option_value[ $key ] )
-				 && in_array( $option_value[ $key ], $target_values, true )
+				&& in_array( $option_value[ $key ], $target_values, true )
 			) {
 				$option_value[ $key ] = true;
 			}

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2205,7 +2205,8 @@ class ORM implements \ArrayAccess {
 		] );
 
 		$success             = self::execute( $query, \array_merge( $values, $this->_values ) );
-		$this->_dirty_fields = $this->_expr_fields = [];
+		$this->_dirty_fields = [];
+		$this->_expr_fields  = [];
 
 		return $success;
 	}

--- a/src/actions/indexation/abstract-link-indexing-action.php
+++ b/src/actions/indexation/abstract-link-indexing-action.php
@@ -52,9 +52,9 @@ abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interf
 		Indexable_Repository $repository,
 		wpdb $wpdb
 	) {
-		$this->link_builder     = $link_builder;
-		$this->repository       = $repository;
-		$this->wpdb             = $wpdb;
+		$this->link_builder = $link_builder;
+		$this->repository   = $repository;
+		$this->wpdb         = $wpdb;
 	}
 
 	/**

--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -113,7 +113,7 @@ class Indexable_Link_Builder {
 	 * @return void
 	 */
 	public function delete( $indexable ) {
-		$links = ($this->seo_links_repository->find_all_by_indexable_id( $indexable->id ));
+		$links = ( $this->seo_links_repository->find_all_by_indexable_id( $indexable->id ) );
 		$this->seo_links_repository->delete_all_by_indexable_id( $indexable->id );
 
 		$linked_indexable_ids = [];
@@ -232,6 +232,7 @@ class Indexable_Link_Builder {
 			'indexable_id' => $indexable->id,
 			'post_id'      => $indexable->object_id,
 		] );
+
 		$model->parsed_url = $parsed_url;
 
 		if ( $model->type === SEO_Links::TYPE_INTERNAL || $model->type === SEO_Links::TYPE_INTERNAL_IMAGE ) {
@@ -250,6 +251,7 @@ class Indexable_Link_Builder {
 
 		if ( $is_image && $model->target_post_id ) {
 			list( , $width, $height ) = \wp_get_attachment_image_src( $model->target_post_id, 'full' );
+
 			$model->width  = $width;
 			$model->height = $height;
 			$model->size   = \filesize( \get_attached_file( $model->target_post_id ) );
@@ -272,7 +274,7 @@ class Indexable_Link_Builder {
 	 * @return bool. Whether or not the link should be filtered.
 	 */
 	protected function filter_link( SEO_Links $link, $current_url ) {
-		$url  = $link->parsed_url;
+		$url = $link->parsed_url;
 
 		// Always keep external links.
 		if ( $link->type === SEO_Links::TYPE_EXTERNAL ) {
@@ -331,7 +333,7 @@ class Indexable_Link_Builder {
 
 		foreach ( $links as $link ) {
 			if ( $link->type === SEO_Links::TYPE_INTERNAL ) {
-				$internal_link_count += 1;
+				++$internal_link_count;
 			}
 		}
 
@@ -353,7 +355,7 @@ class Indexable_Link_Builder {
 
 		// Get rid of URL ?query=string.
 		$url_split = \explode( '?', $link );
-		$link       = $url_split[0];
+		$link      = $url_split[0];
 
 		// Set the correct URL scheme.
 		$link = \set_url_scheme( $link, $home_url['scheme'] );

--- a/src/deprecated/admin/taxonomy/class-taxonomy-content-fields.php
+++ b/src/deprecated/admin/taxonomy/class-taxonomy-content-fields.php
@@ -19,7 +19,7 @@ class WPSEO_Taxonomy_Content_Fields {
 	public function get() {
 		_deprecated_function( __METHOD__, '14.9', 'WPSEO_Taxonomy_Fields::get' );
 
-		$fields =  new WPSEO_Taxonomy_Fields();
+		$fields = new WPSEO_Taxonomy_Fields();
 		return $fields->get( 'social' );
 	}
 }

--- a/src/deprecated/admin/taxonomy/class-taxonomy-settings-fields.php
+++ b/src/deprecated/admin/taxonomy/class-taxonomy-settings-fields.php
@@ -9,6 +9,7 @@
  * This class parses all the values for the general tab in the Yoast SEO settings metabox.
  */
 class WPSEO_Taxonomy_Settings_Fields {
+
 	/**
 	 * Returns array with the fields for the General tab.
 	 *
@@ -18,7 +19,7 @@ class WPSEO_Taxonomy_Settings_Fields {
 	public function get() {
 		_deprecated_function( __METHOD__, '14.9', 'WPSEO_Taxonomy_Fields::get' );
 
-		$fields =  new WPSEO_Taxonomy_Fields();
+		$fields = new WPSEO_Taxonomy_Fields();
 		return $fields->get( 'social' );
 	}
 }

--- a/src/deprecated/admin/taxonomy/class-taxonomy-social-fields.php
+++ b/src/deprecated/admin/taxonomy/class-taxonomy-social-fields.php
@@ -9,6 +9,7 @@
  * This class parses all the values for the social tab in the Yoast SEO settings metabox.
  */
 class WPSEO_Taxonomy_Social_Fields {
+
 	/**
 	 * Returning the fields for the social media tab.
 	 *
@@ -18,7 +19,7 @@ class WPSEO_Taxonomy_Social_Fields {
 	public function get() {
 		_deprecated_function( __METHOD__, '14.9', 'WPSEO_Taxonomy_Fields::get' );
 
-		$fields =  new WPSEO_Taxonomy_Fields();
+		$fields = new WPSEO_Taxonomy_Fields();
 		return $fields->get( 'social' );
 	}
 }

--- a/src/helpers/indexable-helper.php
+++ b/src/helpers/indexable-helper.php
@@ -8,6 +8,7 @@ use Yoast\WP\SEO\Models\Indexable;
  * A helper object for indexables.
  */
 class Indexable_Helper {
+
 	/**
 	 * Retrieves the permalink for an indexable.
 	 *

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -103,7 +103,7 @@ class Indexable_Post_Watcher implements Integration_Interface {
 		$this->repository           = $repository;
 		$this->builder              = $builder;
 		$this->hierarchy_repository = $hierarchy_repository;
-		$this->link_builder         = $link_builder        ;
+		$this->link_builder         = $link_builder;
 		$this->author_archive       = $author_archive;
 		$this->post                 = $post;
 		$this->logger               = $logger;

--- a/src/presenters/admin/indexation-warning-presenter.php
+++ b/src/presenters/admin/indexation-warning-presenter.php
@@ -166,7 +166,7 @@ class Indexation_Warning_Presenter extends Abstract_Presenter {
 	 */
 	protected function get_estimate() {
 		if ( $this->total_unindexed > 2500 ) {
-			$estimate = '<p>';
+			$estimate  = '<p>';
 			$estimate .= \esc_html__( 'We estimate this could take a long time, due to the size of your site. As an alternative to waiting, you could:', 'wordpress-seo' );
 			$estimate .= '<ul class="ul-disc">';
 			$estimate .= '<li>';

--- a/src/presenters/admin/meta-fields-presenter.php
+++ b/src/presenters/admin/meta-fields-presenter.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Presenters\Abstract_Presenter;
  * Outputs the hidden fields for a particular field group and post.
  */
 class Meta_Fields_Presenter extends Abstract_Presenter {
+
 	/**
 	 * @var array The meta fields for which we are going to output hidden input.
 	 */
@@ -29,7 +30,7 @@ class Meta_Fields_Presenter extends Abstract_Presenter {
 	 * @param string   $post_type   The post type.
 	 */
 	public function __construct( $post, $field_group, $post_type = 'post' ) {
-		$this->post = $post;
+		$this->post        = $post;
 		$this->meta_fields = WPSEO_Meta::get_meta_field_defs( $field_group, $post_type );
 	}
 

--- a/src/routes/link-indexing-route.php
+++ b/src/routes/link-indexing-route.php
@@ -71,7 +71,6 @@ class Link_Indexing_Route extends Abstract_Indexation_Route {
 		$this->term_link_indexing_action = $term_link_indexing_action;
 	}
 
-
 	/**
 	 * @inheritDoc
 	 */

--- a/tests/unit/admin/admin-features-test.php
+++ b/tests/unit/admin/admin-features-test.php
@@ -54,7 +54,7 @@ class Admin_Features_Test extends TestCase {
 		$current_page_helper = Mockery::mock( Current_Page_Helper::class );
 		$current_page_helper->expects( 'is_yoast_seo_page' )->twice()->andReturn( true );
 
-		$helper_surface = Mockery::mock( Helpers_Surface::class );
+		$helper_surface               = Mockery::mock( Helpers_Surface::class );
 		$helper_surface->current_page = $current_page_helper;
 
 		Monkey\Functions\expect( 'YoastSEO' )

--- a/tests/unit/builders/indexable-post-builder-test.php
+++ b/tests/unit/builders/indexable-post-builder-test.php
@@ -301,7 +301,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 			'id'     => 13,
 			'alt'    => '',
 			'pixels' => 307200,
-			'type'   => 'image/jpeg'
+			'type'   => 'image/jpeg',
 		];
 
 		// Mock that the open graph and twitter images have been set by the user.
@@ -313,7 +313,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$this->indexable->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$this->indexable->orm->expects( 'set' )
-			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES ) ) );
+			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ) );
 
 		// We expect the twitter image and its source to be set.
 		$this->indexable->orm->expects( 'set' )->with( 'twitter_image_source', 'set-by-user' );
@@ -364,7 +364,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 
 		$expected = [
 			'image_id' => 123,
-			'source'   => 'attachment-image'
+			'source'   => 'attachment-image',
 		];
 
 		$this->assertEquals( $expected, $actual );
@@ -395,7 +395,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 
 		$expected = [
 			'image_id' => 456,
-			'source'   => 'featured-image'
+			'source'   => 'featured-image',
 		];
 
 		$this->assertEquals( $expected, $actual );
@@ -484,7 +484,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 			'id'     => 13,
 			'alt'    => '',
 			'pixels' => 307200,
-			'type'   => 'image/jpeg'
+			'type'   => 'image/jpeg',
 		];
 
 		$this->image->allows( 'get_post_content_image' )
@@ -495,7 +495,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 
 		$expected = [
 			'image'  => $image_meta,
-			'source' => 'first-content-image'
+			'source' => 'first-content-image',
 		];
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/unit/builders/indexable-social-image-trait-test.php
+++ b/tests/unit/builders/indexable-social-image-trait-test.php
@@ -123,7 +123,7 @@ class Indexable_Social_Image_Trait_Test extends TestCase {
 			'id'     => 13,
 			'alt'    => '',
 			'pixels' => 307200,
-			'type'   => 'image/jpeg'
+			'type'   => 'image/jpeg',
 		];
 
 		$this->open_graph_image_set_by_user( $image_meta );
@@ -139,7 +139,7 @@ class Indexable_Social_Image_Trait_Test extends TestCase {
 		$this->indexable->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$this->indexable->orm->expects( 'set' )
-			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES ) ) );
+			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ) );
 
 		// We expect twitter image meta to be set.
 		$this->indexable->orm->expects( 'set' )
@@ -173,7 +173,7 @@ class Indexable_Social_Image_Trait_Test extends TestCase {
 			'id'     => 13,
 			'alt'    => '',
 			'pixels' => 307200,
-			'type'   => 'image/jpeg'
+			'type'   => 'image/jpeg',
 		];
 
 		$this->no_twitter_image();
@@ -190,7 +190,7 @@ class Indexable_Social_Image_Trait_Test extends TestCase {
 		$this->indexable->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$this->indexable->orm->expects( 'set' )
-			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES ) ) );
+			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ) );
 
 		$alternative_image = [
 			'image_id' => 'featured-image-id',
@@ -288,7 +288,7 @@ class Indexable_Social_Image_Trait_Test extends TestCase {
 			'id'     => 13,
 			'alt'    => '',
 			'pixels' => 307200,
-			'type'   => 'image/jpeg'
+			'type'   => 'image/jpeg',
 		];
 
 		$this->no_twitter_image();
@@ -305,7 +305,7 @@ class Indexable_Social_Image_Trait_Test extends TestCase {
 		$this->indexable->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$this->indexable->orm->expects( 'set' )
-			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES ) ) );
+			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ) );
 
 		$alternative_image = [
 			'image'  => 'featured-image.jpeg',
@@ -453,5 +453,4 @@ class Indexable_Social_Image_Trait_Test extends TestCase {
 			->with( 'open-graph-image-id' )
 			->andReturn( $image_meta );
 	}
-
 }

--- a/tests/unit/builders/indexable-term-builder-test.php
+++ b/tests/unit/builders/indexable-term-builder-test.php
@@ -271,7 +271,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 			'id'     => 13,
 			'alt'    => '',
 			'pixels' => 307200,
-			'type'   => 'image/jpeg'
+			'type'   => 'image/jpeg',
 		];
 
 		// Mock that the open graph and twitter images have been set by the user.
@@ -283,7 +283,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$indexable_mock->orm->expects( 'set' )
-			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES ) ) );
+			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ) );
 
 		// We expect the twitter image and its source to be set.
 		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image_source', 'set-by-user' );
@@ -404,7 +404,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 
 		$expected = [
 			'image'  => $image,
-			'source' => 'first-content-image'
+			'source' => 'first-content-image',
 		];
 		$actual   = $this->instance->find_alternative_image( $indexable_mock );
 	}
@@ -489,5 +489,4 @@ class Indexable_Term_Builder_Test extends TestCase {
 
 		$this->assertNull( $this->instance->get_meta_value( 'wpseo_title', $term_meta ) );
 	}
-
 }

--- a/tests/unit/generators/breadcrumbs-generator-test.php
+++ b/tests/unit/generators/breadcrumbs-generator-test.php
@@ -291,7 +291,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 				'front_page_id'    => 0,
 				'message'          => 'Tests with current request being not the home, search or a singular post page',
 			],
-			'on-singular-post-page-with-front-page-id' =>[
+			'on-singular-post-page-with-front-page-id' => [
 				'scenario'         => 'on-singular-post-page-with-front-page-id',
 				'page_for_posts'   => 1,
 				'breadcrumb_home'  => 'home',
@@ -307,6 +307,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 			],
 		];
 	}
+
 	/**
 	 * Tests the generation of the bread crumbs for a date archive.
 	 *
@@ -469,8 +470,8 @@ class Breadcrumbs_Generator_Test extends TestCase {
 		$is_month = false;
 		$is_year  = false;
 
-		switch( $scenario ) {
-			case 'day' :
+		switch ( $scenario ) {
+			case 'day':
 				$is_day = true;
 
 				Monkey\Functions\expect( 'get_the_date' )
@@ -483,7 +484,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 					->with( 'Y/m/d' )
 					->andReturn( '2020/08/11' );
 				break;
-			case 'month' :
+			case 'month':
 				$is_month = true;
 
 				Monkey\Functions\expect( 'single_month_title' )
@@ -498,7 +499,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 
 				break;
 
-			case 'year' :
+			case 'year':
 				$is_year = true;
 
 				Monkey\Functions\expect( 'get_the_date' )

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -381,7 +381,7 @@ class Schema_Generator_Test extends TestCase {
 		Monkey\Filters\expectApplied( 'wpseo_schema_website' )
 			->once()
 			->andReturn( [
-				'@type'           => [ 'WebSite' ] ,
+				'@type'           => [ 'WebSite' ],
 				'@id'             => '#website',
 				'url'             => null,
 				'name'            => '',
@@ -439,7 +439,7 @@ class Schema_Generator_Test extends TestCase {
 		Monkey\Filters\expectApplied( 'wpseo_schema_website' )
 			->once()
 			->andReturn( [
-				'@type'           => [ 'WebSite', 'WebSite', 'Something', 'Something', 'Something' ] ,
+				'@type'           => [ 'WebSite', 'WebSite', 'Something', 'Something', 'Something' ],
 				'@id'             => '#website',
 				'url'             => null,
 				'name'            => '',

--- a/tests/unit/generators/schema/webpage-test.php
+++ b/tests/unit/generators/schema/webpage-test.php
@@ -473,14 +473,14 @@ class WebPage_Test extends TestCase {
 		);
 
 		$expected = [
-			'@type'      => 'CollectionPage',
-			'@id'        => 'https://example.com/the-post/#webpage',
-			'url'        => 'https://example.com/the-post/',
-			'name'       => 'the-title',
-			'isPartOf'   => [
+			'@type'           => 'CollectionPage',
+			'@id'             => 'https://example.com/the-post/#webpage',
+			'url'             => 'https://example.com/the-post/',
+			'name'            => 'the-title',
+			'isPartOf'        => [
 				'@id' => 'https://example.com/#website',
 			],
-			'inLanguage' => 'the-language',
+			'inLanguage'      => 'the-language',
 			'potentialAction' => [
 				[
 					'@type'  => 'ReadAction',
@@ -514,16 +514,16 @@ class WebPage_Test extends TestCase {
 		);
 
 		$expected = [
-			'@type'         => 'CollectionPage',
-			'@id'           => 'https://example.com/the-post/#webpage',
-			'url'           => 'https://example.com/the-post/',
-			'name'          => 'the-title',
-			'datePublished' => '2345-12-12 12:12:12',
-			'dateModified'  => '2345-12-12 23:23:23',
-			'isPartOf'      => [
+			'@type'           => 'CollectionPage',
+			'@id'             => 'https://example.com/the-post/#webpage',
+			'url'             => 'https://example.com/the-post/',
+			'name'            => 'the-title',
+			'datePublished'   => '2345-12-12 12:12:12',
+			'dateModified'    => '2345-12-12 23:23:23',
+			'isPartOf'        => [
 				'@id' => 'https://example.com/#website',
 			],
-			'inLanguage'    => 'the-language',
+			'inLanguage'      => 'the-language',
 			'potentialAction' => [
 				[
 					'@type'  => 'ReadAction',

--- a/tests/unit/helpers/indexable-helper-test.php
+++ b/tests/unit/helpers/indexable-helper-test.php
@@ -95,7 +95,7 @@ class Indexable_Helper_Test extends TestCase {
 	 */
 	public function test_get_permalink_for_term_indexable() {
 		$indexable              = Mockery::mock( Indexable_Mock::class );
-		$indexable->object_id = 2;
+		$indexable->object_id   = 2;
 		$indexable->object_type = 'term';
 
 		$term = (object) [
@@ -127,7 +127,7 @@ class Indexable_Helper_Test extends TestCase {
 	 */
 	public function test_get_permalink_for_term_indexable_term_not_found() {
 		$indexable              = Mockery::mock( Indexable_Mock::class );
-		$indexable->object_id = 2;
+		$indexable->object_id   = 2;
 		$indexable->object_type = 'term';
 
 		Monkey\Functions\expect( 'get_term' )
@@ -147,7 +147,7 @@ class Indexable_Helper_Test extends TestCase {
 	 */
 	public function test_get_permalink_for_term_indexable_term_is_wp_error() {
 		$indexable              = Mockery::mock( Indexable_Mock::class );
-		$indexable->object_id = 2;
+		$indexable->object_id   = 2;
 		$indexable->object_type = 'term';
 
 		$term = (object) [

--- a/tests/unit/helpers/pagination-helper-test.php
+++ b/tests/unit/helpers/pagination-helper-test.php
@@ -56,6 +56,7 @@ class Pagination_Helper_Test extends TestCase {
 		$this->assertAttributeInstanceOf( WP_Rewrite_Wrapper::class, 'wp_rewrite_wrapper', $this->instance  );
 		$this->assertAttributeInstanceOf( WP_Query_Wrapper::class, 'wp_query_wrapper', $this->instance  );
 	}
+
 	/**
 	 * Tests that `is_disabled` returns false by default.
 	 *

--- a/tests/unit/helpers/site-helper-test.php
+++ b/tests/unit/helpers/site-helper-test.php
@@ -34,5 +34,4 @@ class Site_Helper_Test extends TestCase {
 
 		$this->assertEquals( 'name', $site_helper->get_site_name() );
 	}
-
 }

--- a/tests/unit/helpers/url-helper-test.php
+++ b/tests/unit/helpers/url-helper-test.php
@@ -290,7 +290,6 @@ class Url_Helper_Test extends TestCase {
 		$this->assertEquals( 'https://example.org/', $this->instance->home() );
 	}
 
-
 	/**
 	 * Tests the home url with the home in a subdirectory.
 	 *

--- a/tests/unit/integrations/admin/admin-columns-cache-integration-test.php
+++ b/tests/unit/integrations/admin/admin-columns-cache-integration-test.php
@@ -54,7 +54,7 @@ class Admin_Columns_Cache_Integration_Test extends TestCase {
 
 		$posts = [ Mockery::mock( WP_Post::class ) ];
 
-		$wp_query = Mockery::mock( WP_Query::class );
+		$wp_query        = Mockery::mock( WP_Query::class );
 		$wp_query->posts = [];
 		$wp_query->expects( 'get_posts' )->once()->andReturn( $posts );
 
@@ -81,7 +81,7 @@ class Admin_Columns_Cache_Integration_Test extends TestCase {
 
 		$posts = [ Mockery::mock( WP_Post::class ) ];
 
-		$wp_query = Mockery::mock( WP_Query::class );
+		$wp_query        = Mockery::mock( WP_Query::class );
 		$wp_query->posts = $posts;
 
 		Functions\expect( 'wp_list_pluck' )
@@ -105,9 +105,9 @@ class Admin_Columns_Cache_Integration_Test extends TestCase {
 	public function test_fill_cache_with_non_post_query() {
 		global $wp_query;
 
-		$posts = [ new stdClass ];
+		$posts = [ new stdClass() ];
 
-		$wp_query = Mockery::mock( WP_Query::class );
+		$wp_query        = Mockery::mock( WP_Query::class );
 		$wp_query->posts = [];
 		$wp_query->expects( 'get_posts' )->once()->andReturn( $posts );
 
@@ -136,7 +136,7 @@ class Admin_Columns_Cache_Integration_Test extends TestCase {
 
 		$posts = [];
 
-		$wp_query = Mockery::mock( WP_Query::class );
+		$wp_query        = Mockery::mock( WP_Query::class );
 		$wp_query->posts = [];
 		$wp_query->expects( 'get_posts' )->once()->andReturn( $posts );
 

--- a/tests/unit/presenters/webmaster/google-presenter-test.php
+++ b/tests/unit/presenters/webmaster/google-presenter-test.php
@@ -19,7 +19,7 @@ class Google_Presenter_Test extends TestCase {
 
 	/**
 	 * Represents the instance to test.
-	 * 
+	 *
 	 * @var Google_Presenter
 	 */
 	protected $instance;

--- a/tests/unit/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/unit/repositories/indexable-hierarchy-repository-test.php
@@ -98,7 +98,6 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 		$this->assertSame( $ancestors, $this->instance->find_ancestors( $indexable ) );
 	}
 
-
 	/**
 	 * Tests retrieval of the ancestors when having no results the first time we query.
 	 *

--- a/tests/unit/repositories/indexable-repository-test.php
+++ b/tests/unit/repositories/indexable-repository-test.php
@@ -94,7 +94,7 @@ class Indexable_Repository_Test extends TestCase {
 				$this->logger,
 				$this->hierarchy_repository,
 				$this->wpdb,
-				$this->indexable_helper
+				$this->indexable_helper,
 			]
 		)->makePartial();
 	}
@@ -336,7 +336,7 @@ class Indexable_Repository_Test extends TestCase {
 	 * @covers ::get_children
 	 */
 	public function test_get_children() {
-		$indexable = Mockery::mock( Indexable_Mock::class );
+		$indexable              = Mockery::mock( Indexable_Mock::class );
 		$indexable->object_type = 'post';
 
 		$indexable->expects( 'save' )->once();


### PR DESCRIPTION
## Context

* Code consistency.

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency.


## Relevant technical choices:

* One blank line between function declarations.
* No blank line at the end of a class.
* One space (or a new line) on either side of an operator.
* No precision alignment.
* One space between a keyword and what follows it.
* Only use tabs for indentation, not for alignment.
* One space on the inside of non-empty parenthesis.
* No space between `case` statement and the colon following it.
* No space before a comma and one space (or new line) after.
* No space before a semi-colon.
* No trailing whitespace.
* Alignment of assignment operators in assignment blocks.
* One assignment per statement.
* Always use parentheses when instantiating a class.
* Use pre-increment instead of `+= 1`.
* Comma after last array item in multi-line array.
* Multi-line array double arrow alignment.

Includes adjusting the thresholds.

## Test instructions
This PR can be tested by following these steps:

* _N/A_. This is a code only change and has no effect functionality

