### PR TITLE
Docs: various fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=617",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=609",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=276",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/actions/indexation/abstract-link-indexing-action.php
+++ b/src/actions/indexation/abstract-link-indexing-action.php
@@ -43,9 +43,9 @@ abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interf
 	/**
 	 * Indexable_Post_Indexing_Action constructor
 	 *
-	 * @param Indexable_Link_Builder $link_builder     The indexable link builder.
-	 * @param Indexable_Repository   $repository       The indexable repository.
-	 * @param wpdb                   $wpdb             The WordPress database instance.
+	 * @param Indexable_Link_Builder $link_builder The indexable link builder.
+	 * @param Indexable_Repository   $repository   The indexable repository.
+	 * @param wpdb                   $wpdb         The WordPress database instance.
 	 */
 	public function __construct(
 		Indexable_Link_Builder $link_builder,

--- a/src/exceptions/missing-method.php
+++ b/src/exceptions/missing-method.php
@@ -10,9 +10,9 @@ use Exception;
 class Missing_Method extends Exception {
 
 	/**
-	 * Creates exception for a method that does not exists in a class.
+	 * Creates exception for a method that does not exist in a class.
 	 *
-	 * @param string $method     The method that does not exists.
+	 * @param string $method     The method that does not exist.
 	 * @param string $class_name The class name.
 	 *
 	 * @return static Instance of the exception.

--- a/src/models/seo-meta.php
+++ b/src/models/seo-meta.php
@@ -35,6 +35,7 @@ class SEO_Meta extends Model {
 	 * SEO_Meta constructor.
 	 *
 	 * @deprecated 14.8
+	 * @codeCoverageIgnore
 	 */
 	public function __construct() {
 		_deprecated_function( __METHOD__, '14.8' );

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -307,6 +307,7 @@ class Indexable_Presentation extends Abstract_Presentation {
 	 * Generates the robots value for the googlebot tag.
 	 *
 	 * @deprecated 14.9 Values merged into the robots meta tag.
+	 * @codeCoverageIgnore
 	 *
 	 * @return array The robots value with opt-in snippets.
 	 */
@@ -320,6 +321,7 @@ class Indexable_Presentation extends Abstract_Presentation {
 	 * Generates the value for the bingbot tag.
 	 *
 	 * @deprecated 14.9 Values merged into the robots meta tag.
+	 * @codeCoverageIgnore
 	 *
 	 * @return array The robots value with opt-in snippets.
 	 */

--- a/src/presenters/bingbot-presenter.php
+++ b/src/presenters/bingbot-presenter.php
@@ -15,6 +15,7 @@ class Bingbot_Presenter extends Abstract_Indexable_Presenter {
 	 * Returns the bingbot output.
 	 *
 	 * @deprecated 14.9 Values merged into the robots meta tag.
+	 * @codeCoverageIgnore
 	 *
 	 * @return string The bingbot output tag.
 	 */
@@ -35,6 +36,7 @@ class Bingbot_Presenter extends Abstract_Indexable_Presenter {
 	 * Gets the raw value of a presentation.
 	 *
 	 * @deprecated 14.9 Values merged into the robots meta tag.
+	 * @codeCoverageIgnore
 	 *
 	 * @return array The raw value.
 	 */

--- a/src/presenters/googlebot-presenter.php
+++ b/src/presenters/googlebot-presenter.php
@@ -15,6 +15,7 @@ class Googlebot_Presenter extends Abstract_Indexable_Presenter {
 	 * Returns the googlebot output.
 	 *
 	 * @deprecated 14.9 Values merged into the robots meta tag.
+	 * @codeCoverageIgnore
 	 *
 	 * @return string The googlebot output tag.
 	 */
@@ -35,6 +36,7 @@ class Googlebot_Presenter extends Abstract_Indexable_Presenter {
 	 * Gets the raw value of a presentation.
 	 *
 	 * @deprecated 14.9 Values merged into the robots meta tag.
+	 * @codeCoverageIgnore
 	 *
 	 * @return array The raw value.
 	 */

--- a/src/repositories/seo-meta-repository.php
+++ b/src/repositories/seo-meta-repository.php
@@ -23,6 +23,7 @@ class SEO_Meta_Repository {
 	 * Starts a query for this repository.
 	 *
 	 * @deprecated 14.8
+	 * @codeCoverageIgnore
 	 *
 	 * @return ORM
 	 */

--- a/src/wordpress/wrapper.php
+++ b/src/wordpress/wrapper.php
@@ -9,6 +9,7 @@ use Yoast_Notification_Center;
 
 /**
  * Wrapper class for WordPress globals.
+ *
  * This consists of factory functions to inject WP globals into the dependency container.
  */
 class Wrapper {

--- a/tests/unit/doubles/builders/indexable-social-image-trait-double.php
+++ b/tests/unit/doubles/builders/indexable-social-image-trait-double.php
@@ -13,7 +13,7 @@ trait Indexable_Social_Image_Trait_Double {
 	/**
 	 * Tests method double, to be able to test the `reset_social_images` method.
 	 *
-	 * @param Indexable $indexable The indexable
+	 * @param Indexable $indexable The indexable.
 	 */
 	public function reset_social_images_double( Indexable $indexable ) {
 		$this->reset_social_images( $indexable );
@@ -22,7 +22,7 @@ trait Indexable_Social_Image_Trait_Double {
 	/**
 	 * Tests method double, to be able to test the `handle_social_images` method.
 	 *
-	 * @param Indexable $indexable The indexable
+	 * @param Indexable $indexable The indexable.
 	 */
 	public function handle_social_images_double( Indexable $indexable ) {
 		$this->handle_social_images( $indexable );

--- a/tests/unit/generators/breadcrumbs-generator-test.php
+++ b/tests/unit/generators/breadcrumbs-generator-test.php
@@ -452,9 +452,9 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	/**
 	 * Sets some expectations specific for the data archive tests.
 	 *
-	 * @param string $scenario   The scenario to set.
-	 * @param bool $is_paged     When the page is paged.
-	 * @param bool $current_page The current page number.
+	 * @param string $scenario     The scenario to set.
+	 * @param bool   $is_paged     When the page is paged.
+	 * @param bool   $current_page The current page number.
 	 */
 	protected function setup_expectations_for_date_archive( $scenario, $is_paged, $current_page ) {
 		$this->indexable                   = Mockery::mock( Indexable_Mock::class );

--- a/tests/unit/helpers/pagination-helper-test.php
+++ b/tests/unit/helpers/pagination-helper-test.php
@@ -50,7 +50,7 @@ class Pagination_Helper_Test extends TestCase {
 	/**
 	 * Tests if given dependencies are set as expected.
 	 *
-	 * @covers ::__construct()
+	 * @covers ::__construct
 	 */
 	public function test_constructor() {
 		$this->assertAttributeInstanceOf( WP_Rewrite_Wrapper::class, 'wp_rewrite_wrapper', $this->instance  );

--- a/tests/unit/surfaces/meta-surface-test.php
+++ b/tests/unit/surfaces/meta-surface-test.php
@@ -407,13 +407,13 @@ class Meta_Surface_Test extends TestCase {
 	/**
 	 * Tests the url function.
 	 *
-	 * @param string $object_type       The object type.
-	 * @param string $object_sub_type   The object sub type.
-	 * @param int    $object_id         The object id.
-	 * @param string $page_type         The page type.
-	 *
 	 * @covers ::for_url
 	 * @dataProvider for_url_provider
+	 *
+	 * @param string $object_type     The object type.
+	 * @param string $object_sub_type The object sub type.
+	 * @param int    $object_id       The object id.
+	 * @param string $page_type       The page type.
 	 */
 	public function test_for_url( $object_type, $object_sub_type, $object_id, $page_type ) {
 		$wp_rewrite = Mockery::mock( 'WP_Rewrite' );


### PR DESCRIPTION

## Context

* Docs consistency.

## Summary

This PR can be summarized in the following changelog entry:

* Docs consistency.


## Relevant technical choices:

* Minor grammar, spelling & punctuation fixes.
* Add `@codeCoverageIgnore` tag to deprecated functions.
* Fixing the tag order in select places.
* Tag alignment.
* Blank comment line between summary and description in a docblock.
* Fix formatting of a `@covers` tag.


## Test instructions
This PR can be tested by following these steps:

* _N/A_. This is a documentation only change and has no effect on functionality.

