### PR TITLE
Fix id column options in SEO Links migration

### DIFF
--- a/src/config/migrations/20200617122511_CreateSEOLinksTable.php
+++ b/src/config/migrations/20200617122511_CreateSEOLinksTable.php
@@ -35,7 +35,12 @@ class CreateSEOLinksTable extends Migration {
 		// If not, create it exactly as it was.
 		if ( ! $adapter->table_exists( $table_name ) ) {
 			$table = $this->create_table( $table_name, [ 'id' => false ] );
-			$table->column( 'id', 'biginteger', [ 'primary_key' => true, 'limit' => 20, 'unsigned' => true ] );
+			$table->column( 'id', 'biginteger', [
+				'primary_key' => true,
+				'limit' => 20,
+				'unsigned' => true,
+				'auto_increment' => true,
+			] );
 			$table->column( 'url', 'string', [ 'limit' => 255 ] );
 			$table->column( 'post_id', 'biginteger', [ 'limit' => 20, 'unsigned' => true ] );
 			$table->column( 'target_post_id', 'biginteger', [ 'limit' => 20, 'unsigned' => true ] );


### PR DESCRIPTION
## Context

* Database errors would show up when trying to add (attachment) URLs to the `yoast_seo_links` table. This happened because the primary key of the table was not set to auto-increment with each entry and the entries themselves did not define a unique ID either.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the SEO Links table on new installs not having auto-incrementing IDs.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure you have a clean install that doesn't have any existing Yoast tables.
* Activate the plugin.
* The SEO Links table should have auto-incrementing IDs.
* Create a post with links in it.
* The links should show up in the SEO Links table.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes `WordPress database error Duplicate entry '0' for key 'PRIMARY' for query INSERT INTO 'wp_yoast_seo_links'`
