### PR TITLE
P3-127 Backfill wp_get_environment_type for WP 5.4

### DIFF
--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -250,3 +250,72 @@ function wpseo_get_capabilities() {
 	}
 	return WPSEO_Capability_Manager_Factory::get()->get_capabilities();
 }
+
+if ( ! function_exists( 'wp_get_environment_type' ) ) {
+	/**
+	 * Retrieves the current environment type.
+	 *
+	 * The type can be set via the `WP_ENVIRONMENT_TYPE` global system variable,
+	 * or a constant of the same name.
+	 *
+	 * Possible values include 'local', 'development', 'staging', 'production'.
+	 * If not set, the type defaults to 'production'.
+	 *
+	 * Backfill for `wp_get_environment_type()` introduced in WordPress 5.5.
+	 *
+	 * @return string The current environment type.
+	 */
+	function wp_get_environment_type() {
+		static $current_env = '';
+
+		if ( $current_env ) {
+			return $current_env;
+		}
+
+		// phpcs:disable Generic.Arrays.DisallowLongArraySyntax.Found -- Reason: This is copied from WP core.
+		$wp_environments = array(
+			'local',
+			'development',
+			'staging',
+			'production',
+		);
+		// phpcs:enable Generic.Arrays.DisallowLongArraySyntax.Found
+
+		// Check if the environment variable has been set, if `getenv` is available on the system.
+		if ( function_exists( 'getenv' ) ) {
+			$has_env = getenv( 'WP_ENVIRONMENT_TYPES' );
+			// phpcs:disable Generic.ControlStructures.DisallowYodaConditions.Found -- Reason: This is copied from WP core.
+			if ( false !== $has_env ) {
+				$wp_environments = explode( ',', $has_env );
+			}
+			// phpcs:enable Generic.ControlStructures.DisallowYodaConditions.Found
+		}
+
+		// Fetch the environment types from a constant, this overrides the global system variable.
+		if ( defined( 'WP_ENVIRONMENT_TYPES' ) ) {
+			$wp_environments = WP_ENVIRONMENT_TYPES;
+		}
+
+		// Check if the environment variable has been set, if `getenv` is available on the system.
+		if ( function_exists( 'getenv' ) ) {
+			$has_env = getenv( 'WP_ENVIRONMENT_TYPE' );
+			// phpcs:disable Generic.ControlStructures.DisallowYodaConditions.Found -- Reason: This is copied from WP core.
+			if ( false !== $has_env ) {
+				$current_env = $has_env;
+			}
+			// phpcs:enable Generic.ControlStructures.DisallowYodaConditions.Found
+		}
+
+		// Fetch the environment from a constant, this overrides the global system variable.
+		if ( defined( 'WP_ENVIRONMENT_TYPE' ) ) {
+			$current_env = WP_ENVIRONMENT_TYPE;
+		}
+
+		// Make sure the environment is an allowed one, and not accidentally set to an invalid value.
+		if ( ! in_array( $current_env, $wp_environments, true ) ) {
+			$current_env = 'production';
+		}
+
+		return $current_env;
+	}
+}

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -261,7 +261,8 @@ if ( ! function_exists( 'wp_get_environment_type' ) ) {
 	 * Possible values include 'local', 'development', 'staging', 'production'.
 	 * If not set, the type defaults to 'production'.
 	 *
-	 * Backfill for `wp_get_environment_type()` introduced in WordPress 5.5.
+	 * Backfill for `wp_get_environment_type()` introduced in WordPress 5.5. Code
+	 * is adapted to the Yoast PHP coding standards.
 	 *
 	 * @return string The current environment type.
 	 */
@@ -272,23 +273,19 @@ if ( ! function_exists( 'wp_get_environment_type' ) ) {
 			return $current_env;
 		}
 
-		// phpcs:disable Generic.Arrays.DisallowLongArraySyntax.Found -- Reason: This is copied from WP core.
-		$wp_environments = array(
+		$wp_environments = [
 			'local',
 			'development',
 			'staging',
 			'production',
-		);
-		// phpcs:enable Generic.Arrays.DisallowLongArraySyntax.Found
+		];
 
 		// Check if the environment variable has been set, if `getenv` is available on the system.
 		if ( function_exists( 'getenv' ) ) {
 			$has_env = getenv( 'WP_ENVIRONMENT_TYPES' );
-			// phpcs:disable Generic.ControlStructures.DisallowYodaConditions.Found -- Reason: This is copied from WP core.
-			if ( false !== $has_env ) {
+			if ( $has_env !== false ) {
 				$wp_environments = explode( ',', $has_env );
 			}
-			// phpcs:enable Generic.ControlStructures.DisallowYodaConditions.Found
 		}
 
 		// Fetch the environment types from a constant, this overrides the global system variable.
@@ -299,11 +296,9 @@ if ( ! function_exists( 'wp_get_environment_type' ) ) {
 		// Check if the environment variable has been set, if `getenv` is available on the system.
 		if ( function_exists( 'getenv' ) ) {
 			$has_env = getenv( 'WP_ENVIRONMENT_TYPE' );
-			// phpcs:disable Generic.ControlStructures.DisallowYodaConditions.Found -- Reason: This is copied from WP core.
-			if ( false !== $has_env ) {
+			if ( $has_env !== false ) {
 				$current_env = $has_env;
 			}
-			// phpcs:enable Generic.ControlStructures.DisallowYodaConditions.Found
 		}
 
 		// Fetch the environment from a constant, this overrides the global system variable.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to have `wp_get_environment_type()` available in all the WP versions supported by Yoast SEO, which includes WP 5.4.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Backfill `wp_get_environment_type()` for WordPress 5.4.

## Relevant technical choices:

* I opted to put the backfilled function in the `inc/wpseo-functions.php` as it seems the most logical place
* Since the core PHP coding standards are different from the plugin ones, ~I had to disable some PHPCS rules (Short array syntax and Yoda conditions) to keep the original `wp_get_environment_type()` code unchanged. Alternatively we could just update the function code to our standards but I think the first option is preferable.~ I changed the function code to meet the Yoast coding standards.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- test on WordPress 5.4
- dump somewhere `var_dump( wp_get_environment_type() );` and see it returns the default value `production` with no errors
- test on WordPress 5.5
- dump somewhere `var_dump( wp_get_environment_type() );` and see it returns the default value `production` with no errors


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-127]
