### PR TITLE
Add modal location to social slots

### DIFF
--- a/js/src/components/modals/PostSettingsModal.js
+++ b/js/src/components/modals/PostSettingsModal.js
@@ -25,12 +25,12 @@ const modalContent = ( preferences ) => [
 	},
 	{
 		title: __( "Facebook preview", "wordpress-seo" ),
-		content: <FacebookContainer />,
+		content: <FacebookContainer location="modal" />,
 		shouldRender: preferences.displayFacebook,
 	},
 	{
 		title: __( "Twitter preview", "wordpress-seo" ),
-		content: <TwitterContainer />,
+		content: <TwitterContainer location="modal" />,
 		shouldRender: preferences.displayTwitter,
 	},
 	{

--- a/js/src/components/social/FacebookWrapper.js
+++ b/js/src/components/social/FacebookWrapper.js
@@ -25,7 +25,7 @@ const FacebookWrapper = ( props ) => {
 					? <Slot
 						name={
 							"YoastFacebookPremium" +
-							`${ props.location ? props.location.charAt( 0 ).toUpperCase() + props.location.slice( 1 ) : "" }`
+							`${ props.location.charAt( 0 ).toUpperCase() + props.location.slice( 1 ) }`
 						}
 						fillProps={ props }
 					/>

--- a/js/src/components/social/FacebookWrapper.js
+++ b/js/src/components/social/FacebookWrapper.js
@@ -23,7 +23,10 @@ const FacebookWrapper = ( props ) => {
 			{
 				props.isPremium
 					? <Slot
-						name="YoastFacebookPremium"
+						name={
+							"YoastFacebookPremium" +
+							`${ props.location ? props.location.charAt( 0 ).toUpperCase() + props.location.slice( 1 ) : "" }`
+						}
 						fillProps={ props }
 					/>
 					: <SocialForm { ...props } />
@@ -35,6 +38,11 @@ const FacebookWrapper = ( props ) => {
 FacebookWrapper.propTypes = {
 	isPremium: PropTypes.bool.isRequired,
 	onLoad: PropTypes.func.isRequired,
+	location: PropTypes.string,
+};
+
+FacebookWrapper.defaultProps = {
+	location: "",
 };
 
 export default FacebookWrapper;

--- a/js/src/components/social/TwitterWrapper.js
+++ b/js/src/components/social/TwitterWrapper.js
@@ -23,7 +23,10 @@ const TwitterWrapper = ( props ) => {
 			{
 				props.isPremium
 					? <Slot
-						name="YoastTwitterPremium"
+						name={
+							"YoastTwitterPremium" +
+							`${ props.location ? props.location.charAt( 0 ).toUpperCase() + props.location.slice( 1 ) : "" }`
+						}
 						fillProps={ props }
 					/>
 					: <SocialForm { ...props } />
@@ -37,4 +40,9 @@ export default TwitterWrapper;
 TwitterWrapper.propTypes = {
 	isPremium: PropTypes.bool.isRequired,
 	onLoad: PropTypes.func.isRequired,
+	location: PropTypes.string,
+};
+
+TwitterWrapper.defaultProps = {
+	location: "",
 };

--- a/js/src/components/social/TwitterWrapper.js
+++ b/js/src/components/social/TwitterWrapper.js
@@ -25,7 +25,7 @@ const TwitterWrapper = ( props ) => {
 					? <Slot
 						name={
 							"YoastTwitterPremium" +
-							`${ props.location ? props.location.charAt( 0 ).toUpperCase() + props.location.slice( 1 ) : "" }`
+							`${ props.location.charAt( 0 ).toUpperCase() + props.location.slice( 1 ) }`
 						}
 						fillProps={ props }
 					/>

--- a/js/src/containers/FacebookEditor.js
+++ b/js/src/containers/FacebookEditor.js
@@ -68,7 +68,7 @@ const openMedia = () => {
 };
 
 export default compose( [
-	withSelect( select => {
+	withSelect( ( select, ownProps ) => {
 		const {
 			getFacebookDescription,
 			getDescriptionFallback,
@@ -99,6 +99,7 @@ export default compose( [
 			titleInputPlaceholder,
 			descriptionInputPlaceholder,
 			socialMediumName,
+			location: ownProps.location || "",
 		};
 	} ),
 

--- a/js/src/containers/TwitterEditor.js
+++ b/js/src/containers/TwitterEditor.js
@@ -67,8 +67,9 @@ const openMedia = () => {
 	return getMedia().open();
 };
 
+/* eslint-disable complexity */
 export default compose( [
-	withSelect( select => {
+	withSelect( ( select, ownProps ) => {
 		const {
 			getTwitterDescription,
 			getTwitterTitle,
@@ -103,6 +104,7 @@ export default compose( [
 			titleInputPlaceholder,
 			descriptionInputPlaceholder,
 			socialMediumName,
+			location: ownProps.location || "",
 		};
 	} ),
 
@@ -123,3 +125,4 @@ export default compose( [
 		};
 	} ),
 ] )( TwitterWrapper );
+/* eslint-enable complexity */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* See https://github.com/Yoast/wordpress-seo-premium/pull/2979 for information

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Fixes an unreleased bug where Social Previews would be empty when the post settings modal was opened.

## Relevant technical choices:

* In the future we should investigate adding a modal location via locationproviders, so that there is no hassle with explicitly passing the props

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test in premium https://github.com/Yoast/wordpress-seo-premium/pull/2979
* Also test in free, should build without errors.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-158
