### PR TITLE
Tests: add missing `@covers` and fix an incorrect one

### DIFF
--- a/tests/unit/builders/indexable-social-image-trait-test.php
+++ b/tests/unit/builders/indexable-social-image-trait-test.php
@@ -73,6 +73,8 @@ class Indexable_Social_Image_Trait_Test extends TestCase {
 
 	/**
 	 * Tests setting the social image helpers.
+	 *
+	 * @covers ::set_social_image_helpers
 	 */
 	public function test_set_social_image_helpers() {
 		$this->instance->set_social_image_helpers( $this->image, $this->open_graph_image, $this->twitter_image );

--- a/tests/unit/generators/schema/organization-test.php
+++ b/tests/unit/generators/schema/organization-test.php
@@ -97,6 +97,7 @@ class Organization_Test extends TestCase {
 	 * Tests the generated schema is as expected.
 	 *
 	 * @dataProvider generate_provider
+	 * @covers       ::generate
 	 *
 	 * @param array $profiles_input    The social profiles input for the options.
 	 * @param array $profiles_expected The social profiles expected output.

--- a/tests/unit/helpers/site-helper-test.php
+++ b/tests/unit/helpers/site-helper-test.php
@@ -19,7 +19,7 @@ class Site_Helper_Test extends TestCase {
 	/**
 	 * Tests retrieval of the site name.
 	 *
-	 * @covers::get_site_name
+	 * @covers ::get_site_name
 	 */
 	public function test_get_site_name() {
 		Monkey\Functions\expect( 'wp_strip_all_tags' )

--- a/tests/unit/repositories/indexable-repository-test.php
+++ b/tests/unit/repositories/indexable-repository-test.php
@@ -186,6 +186,8 @@ class Indexable_Repository_Test extends TestCase {
 	/**
 	 * Tests that retrieving the ancestors of an indexable ensures
 	 * that the permalink of each ancestor is available.
+	 *
+	 * @covers ::get_ancestors
 	 */
 	public function test_get_ancestors_ensures_permalink() {
 		$indexable = Mockery::mock( Indexable_Mock::class );
@@ -215,6 +217,8 @@ class Indexable_Repository_Test extends TestCase {
 
 	/**
 	 * Tests that ensure permalink does not save when the permalink is still null.
+	 *
+	 * @covers ::get_ancestors
 	 */
 	public function test_get_ancestors_ensures_permalink_no_save() {
 		$indexable = Mockery::mock( Indexable_Mock::class );
@@ -243,6 +247,8 @@ class Indexable_Repository_Test extends TestCase {
 	/**
 	 * Tests that retrieving the ancestors of an indexable ensures
 	 * that the permalink of each ancestor is available when there is only one ancestor.
+	 *
+	 * @covers ::get_ancestors
 	 */
 	public function test_get_ancestors_one_ancestor_ensures_permalink() {
 		$indexable = Mockery::mock( Indexable_Mock::class );


### PR DESCRIPTION
## Context

* Code consistency.

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency.


## Relevant technical choices:

* Add some missing `@covers` tags and fix an incorrect one

## Test instructions
This PR can be tested by following these steps:

* _N/A_. This is a test doc only change and has no effect on functionality.

