### PR TITLE
CS: more minor fixes

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -148,6 +148,7 @@ class WPSEO_Admin_Init {
 		}
 
 		$release_json = file_get_contents( $file );
+
 		/**
 		 * Filter: 'wpseo_update_notice_content' - Allow filtering of the content
 		 * of the update notice read from the release-info.json file.

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -64,7 +64,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		$class = $this->get_html_class();
 
 		/* translators: %s expands to Yoast SEO Premium */
-		$button_text  = esc_html( sprintf( __( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' ) );
+		$button_text  = sprintf( esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 		$button_text .= '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>' .
 			'<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 

--- a/admin/config-ui/class-configuration-structure.php
+++ b/admin/config-ui/class-configuration-structure.php
@@ -88,6 +88,7 @@ class WPSEO_Configuration_Structure {
 		);
 
 		$this->add_step( 'title-template', __( 'Title settings', 'wordpress-seo' ), $this->fields['titleTemplate'] );
+		/* translators: %s expands to Yoast SEO */
 		$this->add_step( 'tracking', sprintf( __( 'Help us improve %s', 'wordpress-seo' ), 'Yoast SEO' ), $this->fields['tracking'] );
 		$this->add_step( 'newsletter', __( 'Continue learning', 'wordpress-seo' ), $this->fields['newsletter'], true, true );
 		$this->add_step( 'success', __( 'Success!', 'wordpress-seo' ), $this->fields['success'], true, true );

--- a/admin/import/plugins/class-abstract-plugin-importer.php
+++ b/admin/import/plugins/class-abstract-plugin-importer.php
@@ -43,8 +43,7 @@ abstract class WPSEO_Plugin_Importer {
 	/**
 	 * Class constructor.
 	 */
-	public function __construct() {
-	}
+	public function __construct() {}
 
 	/**
 	 * Returns the string for the plugin we're importing from.

--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -42,7 +42,7 @@ echo '<p class="desc label">';
 printf(
 	/* translators: %1$s expands to a link start tag to the Baidu Webmaster Tools site add page, %2$s is the link closing tag. */
 	esc_html__( 'Get your Baidu verification code in %1$sBaidu Webmaster Tools%2$s.', 'wordpress-seo' ),
-	/**
+	/*
 	 * Get the Baidu Webmaster Tools site add link from this 3rd party article.
 	 * {@link http://www.dragonmetrics.com/how-to-optimize-your-site-with-baidu-webmaster-tools/}
 	 * We are unable to create a Baidu Webmaster Tools account due to the Chinese phone number verification.

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -456,10 +456,10 @@ class WPSEO_Addon_Manager {
 	 */
 	protected function map_subscription( $subscription ) {
 		// @codingStandardsIgnoreStart
-		return (object) array(
+		return (object) [
 			'renewal_url' => $subscription->renewalUrl,
 			'expiry_date' => $subscription->expiryDate,
-			'product'     => (object) array(
+			'product'     => (object) [
 				'version'      => $subscription->product->version,
 				'name'         => $subscription->product->name,
 				'slug'         => $subscription->product->slug,
@@ -468,8 +468,8 @@ class WPSEO_Addon_Manager {
 				// Ternary operator is necessary because download can be undefined.
 				'download'     => isset( $subscription->product->download ) ? $subscription->product->download : null,
 				'changelog'    => $subscription->product->changelog,
-			),
-		);
+			],
+		];
 		// @codingStandardsIgnoreStop
 	}
 

--- a/src/config/migrations/20200617122511_CreateSEOLinksTable.php
+++ b/src/config/migrations/20200617122511_CreateSEOLinksTable.php
@@ -30,12 +30,16 @@ class CreateSEOLinksTable extends Migration {
 		// If not, create it exactly as it was.
 		if ( ! $adapter->table_exists( $table_name ) ) {
 			$table = $this->create_table( $table_name, [ 'id' => false ] );
-			$table->column( 'id', 'biginteger', [
-				'primary_key'    => true,
-				'limit'          => 20,
-				'unsigned'       => true,
-				'auto_increment' => true,
-			] );
+			$table->column(
+				'id',
+				'biginteger',
+				[
+					'primary_key'    => true,
+					'limit'          => 20,
+					'unsigned'       => true,
+					'auto_increment' => true,
+				]
+			);
 			$table->column( 'url', 'string', [ 'limit' => 255 ] );
 			$table->column(
 				'post_id',

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -394,7 +394,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 
 				$type = [ 'WebPage', $additional_type ];
 
-				// Is this indexable set as a page for posts, e.g. in the wordpress reading settings as a static homepage?
+				// Is this indexable set as a page for posts, e.g. in the WordPress reading settings as a static homepage?
 				if ( (int) \get_option( 'page_for_posts' ) === $this->indexable->object_id ) {
 					$type[] = 'CollectionPage';
 				}

--- a/src/repositories/seo-meta-repository.php
+++ b/src/repositories/seo-meta-repository.php
@@ -14,6 +14,7 @@ class SEO_Meta_Repository {
 	 * SEO_Meta_Repository constructor.
 	 *
 	 * @deprecated 14.8
+	 * @codeCoverageIgnore
 	 */
 	public function __construct() {
 		\_deprecated_function( __METHOD__, '14.8' );

--- a/src/values/open-graph/images.php
+++ b/src/values/open-graph/images.php
@@ -37,8 +37,7 @@ class Images extends Base_Images {
 	 *
 	 * @return void
 	 */
-	public function show() {
-	}
+	public function show() {}
 
 	/**
 	 * Adds an image to the list by image ID.

--- a/tests/integration/doubles/wpseo-capability-manager-double.php
+++ b/tests/integration/doubles/wpseo-capability-manager-double.php
@@ -13,14 +13,12 @@ class WPSEO_Capability_Manager_Double extends WPSEO_Abstract_Capability_Manager 
 	/**
 	 * Adds the registered capabilities to the system.
 	 */
-	public function add() {
-	}
+	public function add() {}
 
 	/**
 	 * Removes the registered capabilities from the system.
 	 */
-	public function remove() {
-	}
+	public function remove() {}
 
 	public function get_registered_capabilities() {
 		return $this->capabilities;

--- a/tests/unit/helpers/language-helper-test.php
+++ b/tests/unit/helpers/language-helper-test.php
@@ -83,7 +83,7 @@ class Language_Helper_Test extends TestCase {
 			[ 'sv' ],
 			[ 'id' ],
 			[ 'he' ],
-			[ 'ar' ]
+			[ 'ar' ],
 		];
 	}
 }

--- a/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
@@ -52,6 +52,7 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 	 * @var Mockery\MockInterface|Indexable_Helper
 	 */
 	protected $indexable_helper;
+
 	/**
 	 * @var Mockery\LegacyMockInterface|Mockery\MockInterface|Indexable_Hierarchy_Builder
 	 */
@@ -255,7 +256,12 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 		$additional_indexable = Mockery::mock( Indexable_Mock::class );
 
 		$this->indexable_repository->expects( 'find_by_ids' )
-			->with( [ 0 => 566, 2 => 569 ] )
+			->with(
+				[
+					0 => 566,
+					2 => 569,
+				]
+			)
 			->andReturn( [ $additional_indexable ] );
 
 		$this->set_expectations_for_update_hierarchy_and_permalink( $indexable_term_1, $indexable_term_2, $additional_indexable );
@@ -301,13 +307,30 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 		$indexable_term_1->id = 567;
 
 		$this->indexable_repository->expects( 'find_by_multiple_ids_and_type' )
-			->with( [ 0 => 431, 2 => 21 ], 'post', false )
+			->with(
+				[
+					0 => 431,
+					2 => 21,
+				],
+				'post',
+				false
+			)
 			->andReturn( [ $indexable_term_1, $indexable_term_2 ] );
 
-		Functions\expect( 'wp_list_pluck' )->once()->andReturn( [ 0 => 431, 2 => 21 ] );
+		Functions\expect( 'wp_list_pluck' )->once()->andReturn(
+			[
+				0 => 431,
+				2 => 21,
+			]
+		);
 
 		$this->indexable_hierarchy_repository->expects( 'find_children_by_ancestor_ids' )
-			->with( [ 0 => 431, 2 => 21 ] )
+			->with(
+				[
+					0 => 431,
+					2 => 21,
+				]
+			)
 			->andReturn( [ 566, 567, 569 ] );
 
 		Functions\expect( 'wp_list_pluck' )->once()->andReturn( [ 567 ] );
@@ -315,7 +338,12 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 		$additional_indexable_2 = Mockery::mock( Indexable_Mock::class );
 
 		$this->indexable_repository->expects( 'find_by_ids' )
-			->with( [ 0 => 566, 2 => 569 ] )
+			->with(
+				[
+					0 => 566,
+					2 => 569,
+				]
+			)
 			->andReturn( [ $additional_indexable_2 ] );
 
 		$actual = $this->instance->get_children_for_term( 1, [ $indexable_1, $indexable_2, $indexable_3, $indexable_4 ] );
@@ -333,21 +361,27 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 		$this->wpdb->term_relationships = 'wp_term_relationships';
 
 		$this->wpdb->expects( 'prepare' )
-			->with( '
-				SELECT term_taxonomy_id
-				FROM wp_term_taxonomy
-				WHERE term_id IN( ' . \implode( ', ', \array_fill( 0, ( \count( $object_ids ) ), '%s' ) ) . ' )
-			', ...$object_ids );
+			->with(
+				'
+					SELECT term_taxonomy_id
+					FROM wp_term_taxonomy
+					WHERE term_id IN( ' . \implode( ', ', \array_fill( 0, ( \count( $object_ids ) ), '%s' ) ) . ' )
+				',
+				...$object_ids
+			);
 
 		$this->wpdb->expects( 'get_col' )
 			->andReturn( [ 321, 322, 323 ] );
 
 		$this->wpdb->expects( 'prepare' )
-			->with( '
-				SELECT DISTINCT object_id
-				FROM wp_term_relationships
-				WHERE term_taxonomy_id IN( %s, %s, %s )
-			', [ 321, 322, 323 ] );
+			->with(
+				'
+					SELECT DISTINCT object_id
+					FROM wp_term_relationships
+					WHERE term_taxonomy_id IN( %s, %s, %s )
+				',
+				[ 321, 322, 323 ]
+			);
 
 		$this->wpdb->expects( 'get_col' )
 			->andReturn( [ 431, 23, 21 ] );

--- a/tests/unit/integrations/xmlrpc-test.php
+++ b/tests/unit/integrations/xmlrpc-test.php
@@ -5,7 +5,6 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations;
 use Yoast\WP\SEO\Integrations\XMLRPC;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
-
 /**
  * Class XMLRPC_Test.
  *

--- a/tests/unit/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/unit/repositories/indexable-hierarchy-repository-test.php
@@ -269,7 +269,12 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 			->expects( 'query' )
 			->andReturn( $orm_object );
 
-		Functions\expect( 'wp_list_pluck' )->once()->andReturn( [ 0 => 2, 1 => 3 ] );
+		Functions\expect( 'wp_list_pluck' )->once()->andReturn(
+			[
+				0 => 2,
+				1 => 3,
+			]
+		);
 
 		$this->assertSame( [ 2, 3 ], $this->instance->find_children( $indexable ) );
 	}


### PR DESCRIPTION
## Context

* Code consistency.

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency.


## Relevant technical choices:

Follow up on #15950 and #15951, fixing yet more (mostly) recently introduced violations against the coding standards.

Includes a few fixes which couldn't be pulled until the switch over to YoastCS 2.0.


## Test instructions
This PR can be tested by following these steps:

* _N/A_. This is a code only change and has no effect on functionality.

