### PR TITLE
PHPCS: clean up and fix ignore annotations

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -147,6 +147,7 @@ class WPSEO_Admin_Init {
 			return;
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Retrieving a local file.
 		$release_json = file_get_contents( $file );
 
 		/**

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -471,7 +471,7 @@ class WPSEO_Admin_Init {
 				'WPSEO ' . $deprecation_info['version'],
 				$deprecation_info['alternative']
 			);
-			// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped.
+			// phpcs:enable
 		}
 	}
 

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -637,8 +637,7 @@ class WPSEO_Admin_Init {
 		$blog_description         = get_bloginfo( 'description' );
 		$default_blog_description = 'Just another WordPress site';
 
-		// We are checking against the WordPress internal translation.
-		// @codingStandardsIgnoreLine
+		// We are using the WordPress internal translation.
 		$translated_blog_description = __( 'Just another WordPress site', 'default' );
 
 		return $translated_blog_description === $blog_description || $default_blog_description === $blog_description;

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -465,7 +465,7 @@ class WPSEO_Admin_Init {
 		// Show notice for each deprecated filter or action that has been registered.
 		foreach ( $deprecated_notices as $deprecated_filter ) {
 			$deprecation_info = $deprecated_filters[ $deprecated_filter ];
-			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- only uses the hardcoded values from above.
+			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Only uses the hardcoded values from above.
 			_deprecated_hook(
 				$deprecated_filter,
 				'WPSEO ' . $deprecation_info['version'],

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -169,7 +169,7 @@ class WPSEO_Admin {
 	 * Maps the manage_options cap on saving an options page to wpseo_manage_options.
 	 */
 	public function map_manage_options_cap() {
-		// phpcs:ignore -- The variable is only used in strpos and thus safe to not unslash and escape.
+		// phpcs:ignore WordPress.Security -- The variable is only used in strpos and thus safe to not unslash or sanitize.
 		$option_page = ! empty( $_POST['option_page'] ) ? $_POST['option_page'] : '';
 
 		if ( strpos( $option_page, 'yoast_wpseo' ) === 0 ) {

--- a/admin/class-bulk-description-editor-list-table.php
+++ b/admin/class-bulk-description-editor-list-table.php
@@ -72,7 +72,7 @@ class WPSEO_Bulk_Description_List_Table extends WPSEO_Bulk_List_Table {
 				// @todo Inconsistent return/echo behavior R.
 				// I traced the escaping of the attributes to WPSEO_Bulk_List_Table::column_attributes. Alexander.
 				// The output of WPSEO_Bulk_List_Table::parse_meta_data_field is properly escaped.
-				// phpcs:ignore WordPress.Security.EscapeOutput
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo $this->parse_meta_data_field( $record->ID, $attributes );
 				break;
 		}

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -914,7 +914,6 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		$id = "wpseo-existing-$record_id-$this->target_db_field";
 
 		// $attributes correctly escaped, verified by Alexander. See WPSEO_Bulk_Description_List_Table::parse_page_specific_column.
-		// phpcs:ignore WordPress.Security.EscapeOutput
 		return sprintf( '<td %2$s id="%3$s">%1$s</td>', esc_html( $meta_value ), $attributes, esc_attr( $id ) );
 	}
 

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -221,11 +221,13 @@ class WPSEO_Meta_Columns {
 		echo '<label class="screen-reader-text" for="wpseo-filter">' . esc_html__( 'Filter by SEO Score', 'wordpress-seo' ) . '</label>';
 		echo '<select name="seo_filter" id="wpseo-filter">';
 
+		// phpcs:ignore WordPress.Security.EscapeOutput -- Output is correctly escaped in the generate_option() method.
 		echo $this->generate_option( '', __( 'All SEO Scores', 'wordpress-seo' ) );
 
 		foreach ( $ranks as $rank ) {
 			$selected = selected( $this->get_current_seo_filter(), $rank->get_rank(), false );
 
+			// phpcs:ignore WordPress.Security.EscapeOutput -- Output is correctly escaped in the generate_option() method.
 			echo $this->generate_option( $rank->get_rank(), $rank->get_drop_down_label(), $selected );
 		}
 
@@ -247,11 +249,13 @@ class WPSEO_Meta_Columns {
 		echo '<label class="screen-reader-text" for="wpseo-readability-filter">' . esc_html__( 'Filter by Readability Score', 'wordpress-seo' ) . '</label>';
 		echo '<select name="readability_filter" id="wpseo-readability-filter">';
 
+		// phpcs:ignore WordPress.Security.EscapeOutput -- Output is correctly escaped in the generate_option() method.
 		echo $this->generate_option( '', __( 'All Readability Scores', 'wordpress-seo' ) );
 
 		foreach ( $ranks as $rank ) {
 			$selected = selected( $this->get_current_readability_filter(), $rank->get_rank(), false );
 
+			// phpcs:ignore WordPress.Security.EscapeOutput -- Output is correctly escaped in the generate_option() method.
 			echo $this->generate_option( $rank->get_rank(), $rank->get_drop_down_readability_labels(), $selected );
 		}
 

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -117,12 +117,12 @@ class WPSEO_Meta_Columns {
 
 		switch ( $column_name ) {
 			case 'wpseo-score':
-				// @phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Correctly escaped in render_score_indicator() method.
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Correctly escaped in render_score_indicator() method.
 				echo $this->parse_column_score( $post_id );
 				return;
 
 			case 'wpseo-score-readability':
-				// @phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Correctly escaped in render_score_indicator() method.
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Correctly escaped in render_score_indicator() method.
 				echo $this->parse_column_score_readability( $post_id );
 				return;
 

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -89,7 +89,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Correctly escaped in $this->get_argument_html() method.
 		echo '<ul class="' . esc_attr( $class . '--motivation' ) . '">' . $arguments_html . '</ul>';
 
-		// @phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Correctly escaped in $upgrade_button and $button_text above.
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Correctly escaped in $upgrade_button and $button_text above.
 		echo '<p>' . $upgrade_button . '</p>';
 		echo '</div>';
 

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -85,6 +85,8 @@ class WPSEO_Premium_Upsell_Admin_Block {
 				'Yoast SEO Premium'
 			) .
 		'</h2>';
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Correctly escaped in $this->get_argument_html() method.
 		echo '<ul class="' . esc_attr( $class . '--motivation' ) . '">' . $arguments_html . '</ul>';
 
 		// @phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Correctly escaped in $upgrade_button and $button_text above.

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -113,15 +113,17 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration, WPSEO_WordPres
 			return;
 		}
 
+		// phpcs:disable WordPress.Security.NonceVerification -- Nonce verified via `verify_request()` above.
 		foreach ( $whitelist_options as $option_name ) {
 			$value = null;
-			if ( isset( $_POST[ $option_name ] ) ) { // WPCS: CSRF ok.
+			if ( isset( $_POST[ $option_name ] ) ) {
 				// Adding sanitize_text_field around this will break the saving of settings because it expects a string: https://github.com/Yoast/wordpress-seo/issues/12440.
-				$value = wp_unslash( $_POST[ $option_name ] ); // WPCS: CSRF ok.
+				$value = wp_unslash( $_POST[ $option_name ] );
 			}
 
 			WPSEO_Options::update_site_option( $option_name, $value );
 		}
+		// phpcs:enable WordPress.Security.NonceVerification
 
 		$settings_errors = get_settings_errors();
 		if ( empty( $settings_errors ) ) {
@@ -141,7 +143,8 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration, WPSEO_WordPres
 
 		$option_group = 'wpseo_ms';
 
-		$site_id = ! empty( $_POST[ $option_group ]['site_id'] ) ? (int) $_POST[ $option_group ]['site_id'] : 0; // WPCS: CSRF ok.
+		// phpcs:ignore WordPress.Security.NonceVerification -- Nonce verified via `verify_request()` above.
+		$site_id = ! empty( $_POST[ $option_group ]['site_id'] ) ? (int) $_POST[ $option_group ]['site_id'] : 0;
 		if ( ! $site_id ) {
 			add_settings_error( $option_group, 'settings_updated', __( 'No site has been selected to restore.', 'wordpress-seo' ), 'error' );
 

--- a/admin/import/plugins/class-abstract-plugin-importer.php
+++ b/admin/import/plugins/class-abstract-plugin-importer.php
@@ -187,6 +187,7 @@ abstract class WPSEO_Plugin_Importer {
 		// First we create a temp table with all the values for meta_key.
 		$result = $wpdb->query(
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- This is intentional + temporary.
 				"CREATE TEMPORARY TABLE tmp_meta_table SELECT * FROM {$wpdb->postmeta} WHERE meta_key = %s",
 				$old_key
 			)
@@ -224,6 +225,7 @@ abstract class WPSEO_Plugin_Importer {
 		$wpdb->query( "INSERT INTO {$wpdb->postmeta} SELECT * FROM tmp_meta_table" );
 
 		// Now we drop our temporary table.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- This is intentional + a temporary table.
 		$wpdb->query( 'DROP TEMPORARY TABLE IF EXISTS tmp_meta_table' );
 
 		return true;

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -349,7 +349,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 */
 	protected function render_tabs() {
 		echo '<div class="wpseo-metabox-content">';
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $this->get_product_title is considered safe.
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $this->get_product_title() returns a hard-coded string.
 		printf( '<div class="wpseo-metabox-menu"><ul role="tablist" class="yoast-aria-tabs" aria-label="%s">', $this->get_product_title() );
 
 		$tabs = $this->get_tabs();

--- a/admin/roles/class-role-manager-wp.php
+++ b/admin/roles/class-role-manager-wp.php
@@ -29,7 +29,6 @@ final class WPSEO_Role_Manager_WP extends WPSEO_Abstract_Role_Manager {
 			return;
 		}
 
-		// @codingStandardsIgnoreLine
 		add_role( $role, $display_name, $capabilities );
 	}
 

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -66,7 +66,7 @@ class WPSEO_Taxonomy_Metabox {
 	 * Shows the Yoast SEO metabox for the term.
 	 */
 	public function display() {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $product_title is hardcoded.
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $this->get_product_title() returns a hard-coded string.
 		printf( '<div id="wpseo_meta" class="postbox yoast wpseo-taxonomy-metabox-postbox"><h2><span>%1$s</span></h2>', $this->get_product_title() );
 
 		echo '<div class="inside">';
@@ -105,7 +105,7 @@ class WPSEO_Taxonomy_Metabox {
 	 */
 	protected function render_tabs() {
 		echo '<div class="wpseo-metabox-content">';
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $this->get_product_title is considered safe.
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $this->get_product_title() returns a hard-coded string.
 		printf( '<div class="wpseo-metabox-menu"><ul role="tablist" class="yoast-aria-tabs" aria-label="%s">', $this->get_product_title() );
 
 		$tabs = $this->get_tabs();

--- a/admin/tracking/class-tracking-server-data.php
+++ b/admin/tracking/class-tracking-server-data.php
@@ -57,7 +57,6 @@ class WPSEO_Tracking_Server_Data implements WPSEO_Collection {
 		$curl = curl_version();
 
 		$ssl_support = true;
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.curl_curl_version_ssl -- This only concerns the basic act of getting the curl version.
 		if ( ! $curl['features'] && CURL_VERSION_SSL ) {
 			$ssl_support = false;
 		}

--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -41,7 +41,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 				// phpcs:ignore WordPress.Security.EscapeOutput -- $button_id_attr is escaped above.
 				$button_id_attr,
 				esc_attr( $collapsible_config['expanded'] ),
-				// phpcs:ignore WordPress.Security.EscapeOutput -- $help_text is and instance of WPSEO_Admin_Help_Panel, which escapes it's own output.
+				// phpcs:ignore WordPress.Security.EscapeOutput -- $help_text is an instance of WPSEO_Admin_Help_Panel, which escapes it's own output.
 				$help_text->get_button_html(),
 				esc_html( $title ) . wp_kses_post( $title_after ),
 				wp_kses_post( $collapsible_config['toggle_icon'] )
@@ -51,7 +51,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 			echo '<div class="paper-title"><h2 class="help-button-inline">',
 				esc_html( $title ),
 				wp_kses_post( $title_after ),
-				// phpcs:ignore WordPress.Security.EscapeOutput -- $help_text is and instance of WPSEO_Admin_Help_Panel, which escapes it's own output.
+				// phpcs:ignore WordPress.Security.EscapeOutput -- $help_text is an instance of WPSEO_Admin_Help_Panel, which escapes it's own output.
 				$help_text->get_button_html(),
 				'</h2></div>';
 		}
@@ -59,7 +59,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	?>
 	<?php
 
-	// phpcs:ignore WordPress.Security.EscapeOutput -- $help_text is and instance of WPSEO_Admin_Help_Panel, which escapes it's own output.
+	// phpcs:ignore WordPress.Security.EscapeOutput -- $help_text is an instance of WPSEO_Admin_Help_Panel, which escapes it's own output.
 	echo $help_text->get_panel_html();
 
 	$container_id_attr = '';

--- a/admin/views/paper-collapsible.php
+++ b/admin/views/paper-collapsible.php
@@ -72,7 +72,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 		// phpcs:ignore WordPress.Security.EscapeOutput -- $container_id_attr is escaped above.
 		$container_id_attr,
 		esc_attr( 'paper-container ' . $collapsible_config['class'] ),
-		// phpcs:ignore WordPress.Security.EscapeOutput -- $content is escaped above.
 		$content
 	);
 	?>

--- a/admin/views/partial-notifications-template.php
+++ b/admin/views/partial-notifications-template.php
@@ -82,7 +82,7 @@ if ( ! $active ) {
 
 		<div class="container yoast-notifications-active" id="<?php echo esc_attr( 'yoast-' . $type . '-active' ); ?>">
 			<?php
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: _yoast_display_notifications is considered a safe function.
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: _yoast_display_notifications() as declared above is safe.
 			echo _yoast_display_notifications( $active, 'active' );
 			?>
 		</div>
@@ -101,7 +101,7 @@ if ( ! $active ) {
 					'collapsible_header_class' => 'yoast-notification',
 				]
 			);
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: current usage is considered safe.
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: get_output() output is properly escaped.
 			echo $dismissed_paper->get_output();
 		}
 		?>

--- a/admin/views/partial-notifications-template.php
+++ b/admin/views/partial-notifications-template.php
@@ -52,9 +52,9 @@ if ( ! function_exists( '_yoast_display_notifications' ) ) {
 				esc_attr( $notification->get_id() ),
 				esc_attr( $notification->get_nonce() ),
 				esc_attr( $notification->get_json() ),
-				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: Needs to be fixed in https://github.com/Yoast/wordpress-seo-premium/issues/2548.
+				// This needs to be fixed in https://github.com/Yoast/wordpress-seo-premium/issues/2548.
 				$notification,
-				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $button is properly escaped.
+				// Note: $button is properly escaped above.
 				$button
 			);
 		}

--- a/admin/views/tabs/dashboard/dashboard.php
+++ b/admin/views/tabs/dashboard/dashboard.php
@@ -28,7 +28,10 @@ $wpseo_contributors_phrase = sprintf(
 <div class="tab-block">
 	<div class="yoast-notifications">
 
-		<?php echo $notifier->notify(); ?>
+		<?php
+		// phpcs:ignore WordPress.Security.EscapeOutput -- WPSEO_Configuration_Notifier::notify() escapes correctly.
+		echo $notifier->notify();
+		?>
 
 		<div class="yoast-container yoast-container__error">
 			<?php require WPSEO_PATH . 'admin/views/partial-notifications-errors.php'; ?>

--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -20,9 +20,9 @@ $webmaster_tools_help = new WPSEO_Admin_Help_Panel(
 	'has-wrapper'
 );
 
-// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_button_html output is properly escaped.
+// phpcs:ignore WordPress.Security.EscapeOutput -- get_button_html() output is properly escaped.
 echo '<h2 class="help-button-inline">' . esc_html__( 'Webmaster Tools verification', 'wordpress-seo' ) . $webmaster_tools_help->get_button_html() . '</h2>';
-// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_panel_html output is properly escaped.
+// phpcs:ignore WordPress.Security.EscapeOutput -- get_panel_html() output is properly escaped.
 echo $webmaster_tools_help->get_panel_html();
 
 $msverify_link = 'https://www.bing.com/toolbox/webmaster/#/Dashboard/?url=' .

--- a/admin/views/tabs/metas/archives.php
+++ b/admin/views/tabs/metas/archives.php
@@ -49,7 +49,7 @@ foreach ( $wpseo_archives as $wpseo_archive_index => $wpseo_archive ) {
 		]
 	);
 
-	// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_output output is properly escaped.
+	// phpcs:ignore WordPress.Security.EscapeOutput -- get_output() output is properly escaped.
 	echo $wpseo_archive_presenter->get_output();
 }
 

--- a/admin/views/tabs/metas/archives/help.php
+++ b/admin/views/tabs/metas/archives/help.php
@@ -28,6 +28,7 @@ $archives_help = new WPSEO_Admin_Help_Panel(
 	'has-wrapper'
 );
 
+// phpcs:ignore WordPress.Security.EscapeOutput -- get_button_html() output is properly escaped.
 echo '<p class="help-button-inline"><strong>' . esc_html__( 'Archives settings help', 'wordpress-seo' ) . $archives_help->get_button_html() . '</strong><p>';
 
 // phpcs:ignore WordPress.Security.EscapeOutput -- get_panel_html() output is properly escaped.

--- a/admin/views/tabs/metas/archives/help.php
+++ b/admin/views/tabs/metas/archives/help.php
@@ -30,5 +30,5 @@ $archives_help = new WPSEO_Admin_Help_Panel(
 
 echo '<p class="help-button-inline"><strong>' . esc_html__( 'Archives settings help', 'wordpress-seo' ) . $archives_help->get_button_html() . '</strong><p>';
 
-// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_output output is properly escaped.
+// phpcs:ignore WordPress.Security.EscapeOutput -- get_panel_html() output is properly escaped.
 echo $archives_help->get_panel_html();

--- a/admin/views/tabs/metas/breadcrumbs.php
+++ b/admin/views/tabs/metas/breadcrumbs.php
@@ -20,5 +20,5 @@ $wpseo_breadcrumbs_presenter = new WPSEO_Paper_Presenter(
 	]
 );
 
-// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_output output is properly escaped.
+// phpcs:ignore WordPress.Security.EscapeOutput -- get_output() output is properly escaped.
 echo $wpseo_breadcrumbs_presenter->get_output();

--- a/admin/views/tabs/metas/general.php
+++ b/admin/views/tabs/metas/general.php
@@ -20,5 +20,5 @@ $wpseo_general_presenter = new WPSEO_Paper_Presenter(
 	]
 );
 
-// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_output output is properly escaped.
+// phpcs:ignore WordPress.Security.EscapeOutput -- get_output() output is properly escaped.
 echo $wpseo_general_presenter->get_output();

--- a/admin/views/tabs/metas/media.php
+++ b/admin/views/tabs/metas/media.php
@@ -26,5 +26,5 @@ $wpseo_media_presenter = new WPSEO_Paper_Presenter(
 	]
 );
 
-// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_output output is properly escaped.
+// phpcs:ignore WordPress.Security.EscapeOutput -- get_output() output is properly escaped.
 echo $wpseo_media_presenter->get_output();

--- a/admin/views/tabs/metas/paper-content/general/homepage.php
+++ b/admin/views/tabs/metas/paper-content/general/homepage.php
@@ -18,9 +18,9 @@
 			'has-wrapper'
 		);
 
-		// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_button_html output is properly escaped.
+		// phpcs:ignore WordPress.Security.EscapeOutput -- get_button_html() output is properly escaped.
 		echo '<h2 class="help-button-inline">', esc_html__( 'Homepage', 'wordpress-seo' ), $homepage_help->get_button_html(), '</h2>';
-		// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_panel_html output is properly escaped.
+		// phpcs:ignore WordPress.Security.EscapeOutput -- get_panel_html() output is properly escaped.
 		echo $homepage_help->get_panel_html();
 
 		$editor = new WPSEO_Replacevar_Editor(

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -23,12 +23,12 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 
 	<h2 class="help-button-inline">
 		<?php
-		// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_button_html output is properly escaped.
+		// phpcs:ignore WordPress.Security.EscapeOutput -- get_button_html() output is properly escaped.
 		echo esc_html__( 'Knowledge Graph & Schema.org', 'wordpress-seo' ) . $knowledge_graph_help->get_button_html();
 		?>
 	</h2>
 	<?php
-	// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_panel_html output is properly escaped.
+	// phpcs:ignore WordPress.Security.EscapeOutput -- get_panel_html() output is properly escaped.
 	echo $knowledge_graph_help->get_panel_html();
 	/**
 	 * Filter: 'wpseo_knowledge_graph_setting_msg' - Allows adding a message above these settings.

--- a/admin/views/tabs/metas/paper-content/general/title-separator.php
+++ b/admin/views/tabs/metas/paper-content/general/title-separator.php
@@ -17,12 +17,12 @@ $title_separator_help = new WPSEO_Admin_Help_Panel(
 <div class="tab-block">
 	<h2 class="help-button-inline">
 		<?php
-		// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_button_html output is properly escaped.
+		// phpcs:ignore WordPress.Security.EscapeOutput -- get_button_html() output is properly escaped.
 		echo esc_html__( 'Title Separator', 'wordpress-seo' ) . $title_separator_help->get_button_html();
 		?>
 	</h2>
 	<?php
-	// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_panel_html output is properly escaped.
+	// phpcs:ignore WordPress.Security.EscapeOutput -- get_panel_html() output is properly escaped.
 	echo $title_separator_help->get_panel_html();
 	$legend      = __( 'Title separator symbol', 'wordpress-seo' );
 	$legend_attr = [ 'class' => 'radiogroup screen-reader-text' ];

--- a/admin/views/tabs/metas/paper-content/media-content.php
+++ b/admin/views/tabs/metas/paper-content/media-content.php
@@ -46,7 +46,7 @@ $yform->toggle_switch(
 			'</a>'
 		);
 
-		// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- $description is properly escaped above.
+		// phpcs:ignore WordPress.Security.EscapeOutput -- $description is properly escaped above.
 		echo '<div style="clear:both; background-color: #ffeb3b; color: #000000; padding: 16px; max-width: 450px; margin-bottom: 32px;">' . $description . '</div>';
 	}
 

--- a/admin/views/tabs/metas/paper-content/rss-content.php
+++ b/admin/views/tabs/metas/paper-content/rss-content.php
@@ -21,9 +21,9 @@ $rss_variables_help = new WPSEO_Admin_Help_Panel(
 	'has-wrapper'
 );
 
-// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_button_html output is properly escaped.
+// phpcs:ignore WordPress.Security.EscapeOutput -- get_button_html() output is properly escaped.
 echo '<h2 class="help-button-inline">' . esc_html__( 'Available variables', 'wordpress-seo' ) . $rss_variables_help->get_button_html() . '</h2>';
-// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_panel_html output is properly escaped.
+// phpcs:ignore WordPress.Security.EscapeOutput -- get_panel_html() output is properly escaped.
 echo $rss_variables_help->get_panel_html();
 ?>
 <table class="wpseo yoast_help yoast-table-scrollable">

--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -50,7 +50,7 @@ if ( is_array( $wpseo_post_types ) && $wpseo_post_types !== [] ) {
 			]
 		);
 
-		// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_output output is properly escaped.
+		// phpcs:ignore WordPress.Security.EscapeOutput -- get_output() output is properly escaped.
 		echo $wpseo_post_type_presenter->get_output();
 	}
 }

--- a/admin/views/tabs/metas/rss.php
+++ b/admin/views/tabs/metas/rss.php
@@ -26,5 +26,5 @@ $wpseo_rss_presenter = new WPSEO_Paper_Presenter(
 	]
 );
 
-// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_output output is properly escaped.
+// phpcs:ignore WordPress.Security.EscapeOutput -- get_output() output is properly escaped.
 echo $wpseo_rss_presenter->get_output();

--- a/admin/views/tabs/metas/taxonomies.php
+++ b/admin/views/tabs/metas/taxonomies.php
@@ -39,7 +39,7 @@ if ( is_array( $wpseo_taxonomies ) && $wpseo_taxonomies !== [] ) {
 			]
 		);
 
-		// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_output output is properly escaped.
+		// phpcs:ignore WordPress.Security.EscapeOutput -- get_output() output is properly escaped.
 		echo $wpseo_taxonomy_presenter->get_output();
 	}
 

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -98,9 +98,9 @@ if ( $company_or_person === 'person' ) {
 }
 
 if ( $company_or_person === 'company' ) {
-	// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_button_html output is properly escaped.
+	// phpcs:ignore WordPress.Security.EscapeOutput -- get_button_html() output is properly escaped.
 	echo '<h2 class="help-button-inline">' . esc_html__( 'Organization social profiles', 'wordpress-seo' ) . $social_profiles_help->get_button_html() . '</h2>';
-	// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_panel_html output is properly escaped.
+	// phpcs:ignore WordPress.Security.EscapeOutput -- get_panel_html() output is properly escaped.
 	echo $social_profiles_help->get_panel_html();
 
 	foreach ( $organization_social_fields as $organization ) {

--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -36,9 +36,9 @@ if ( get_option( 'show_on_front' ) === 'posts' ) {
 		esc_html__( 'These are the title, description and image used in the Open Graph meta tags on the front page of your site.', 'wordpress-seo' ),
 		'has-wrapper'
 	);
-	// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_button_html output is properly escaped.
+	// phpcs:ignore WordPress.Security.EscapeOutput -- get_button_html() output is properly escaped.
 	echo '<h2 class="help-button-inline">' . esc_html__( 'Frontpage settings', 'wordpress-seo' ) . $social_facebook_frontpage_help->get_button_html() . '</h2>';
-	// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_panel_html output is properly escaped.
+	// phpcs:ignore WordPress.Security.EscapeOutput -- get_panel_html() output is properly escaped.
 	echo $social_facebook_frontpage_help->get_panel_html();
 
 	$yform->media_input( 'og_frontpage_image', __( 'Image URL', 'wordpress-seo' ) );
@@ -65,12 +65,12 @@ if ( get_option( 'show_on_front' ) === 'posts' ) {
 
 		echo '<input type="hidden" id="meta_description" value="', esc_attr( $homepage_meta_description ), '" />';
 		echo '<div class="label desc copy-home-meta-description">' .
-			 	// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- $copy_home_description_button_label is escaped above.
-				'<button type="button" id="copy-home-meta-description" class="button">', $copy_home_description_button_label, '</button>' .
-				// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_button_html output is properly escaped.
-				$copy_home_meta_desc_help->get_button_html() .
-				// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- get_panel_html output is properly escaped.
-				$copy_home_meta_desc_help->get_panel_html() .
+			// phpcs:ignore WordPress.Security.EscapeOutput -- $copy_home_description_button_label is escaped above.
+			'<button type="button" id="copy-home-meta-description" class="button">', $copy_home_description_button_label, '</button>' .
+			// phpcs:ignore WordPress.Security.EscapeOutput -- get_button_html() output is properly escaped.
+			$copy_home_meta_desc_help->get_button_html() .
+			// phpcs:ignore WordPress.Security.EscapeOutput -- get_panel_html() output is properly escaped.
+			$copy_home_meta_desc_help->get_panel_html() .
 			'</div>';
 	}
 }

--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -58,7 +58,7 @@ if ( get_option( 'show_on_front' ) === 'posts' ) {
 				esc_html__( 'Click the "%3$s" button to use the meta description already set in the %1$sSearch Appearance Homepage%2$s setting.', 'wordpress-seo' ),
 				'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_titles' ) ) . '">',
 				'</a>',
-				// phpcs:ignore WordPress --sniffs=WordPress.Security.EscapeOutput -- $copy_home_description_button_label is escaped above.
+				// $copy_home_description_button_label is escaped above.
 				$copy_home_description_button_label
 			)
 		);

--- a/admin/views/tool-bulk-editor.php
+++ b/admin/views/tool-bulk-editor.php
@@ -94,7 +94,7 @@ function wpseo_get_rendered_tab( $table, $id ) {
 
 ?>
 <script>
-	// phpcs:ignore WordPress.Security.OutputEscaping -- WPSEO_Utils::format_json_encode is safe.
+	<?php /* phpcs:ignore WordPress.Security.EscapeOutput -- WPSEO_Utils::format_json_encode is safe. */ ?>
 	var wpseoBulkEditorNonce = <?php echo WPSEO_Utils::format_json_encode( wp_create_nonce( 'wpseo-bulk-editor' ) ); ?>;
 
 	// eslint-disable-next-line

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -82,7 +82,6 @@ if ( isset( $_POST['submithtaccess'] ) ) {
 	check_admin_referer( 'wpseo-htaccess' );
 
 	if ( isset( $_POST['htaccessnew'] ) && file_exists( $ht_access_file ) ) {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Writing to .htaccess file and escaping for HTML will break functionality.
 		$ht_access_new = wp_unslash( $_POST['htaccessnew'] );
 		if ( is_writable( $ht_access_file ) ) {
 			$f = fopen( $ht_access_file, 'w+' );

--- a/composer.json
+++ b/composer.json
@@ -82,8 +82,8 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=568",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=273",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=558",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=253",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs-summary": [

--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -370,6 +370,7 @@ TPL;
 
 		echo "Running coding standards checks, this may take some time.\n";
 		$command = 'composer check-cs-summary';
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Non-WP context, this is fine.
 		@exec( $command, $phpcs_output, $return );
 
 		$statistics = self::extract_cs_statistics( $phpcs_output );

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -455,7 +455,7 @@ class WPSEO_Addon_Manager {
 	 * @return object Mapped subscription.
 	 */
 	protected function map_subscription( $subscription ) {
-		// @codingStandardsIgnoreStart
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Not our properties.
 		return (object) [
 			'renewal_url' => $subscription->renewalUrl,
 			'expiry_date' => $subscription->expiryDate,
@@ -470,7 +470,7 @@ class WPSEO_Addon_Manager {
 				'changelog'    => $subscription->product->changelog,
 			],
 		];
-		// @codingStandardsIgnoreStop
+		// phpcs:enable
 	}
 
 	/**

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -66,7 +66,7 @@ class WPSEO_Image_Utils {
 			return $id;
 		}
 
-		// phpcs:ignore WordPress.VIP.RestrictedFunctions -- We use the WP COM version if we can, see above.
+		// Note: We use the WP COM version if we can, see above.
 		$id = attachment_url_to_postid( $url );
 
 		if ( empty( $id ) ) {

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -249,7 +249,7 @@ class WPSEO_Image_Utils {
 
 		// If the file size for the file is over our limit, we're going to go for a smaller version.
 		// @todo Save the filesize to the image metadata.
-		// phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged -- If file size doesn't properly return, we'll not fail.
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- If file size doesn't properly return, we'll not fail.
 		return @filesize( self::get_absolute_path( $image['path'] ) );
 	}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1120,7 +1120,7 @@ SVG;
 			'postTypeNamePlural'   => ( $page_type === 'post' ) ? $label_object->label : $label_object->name,
 			'postTypeNameSingular' => ( $page_type === 'post' ) ? $label_object->labels->singular_name : $label_object->singular_name,
 			'breadcrumbsDisabled'  => WPSEO_Options::get( 'breadcrumbs-enable', false ) !== true && ! current_theme_supports( 'yoast-seo-breadcrumbs' ),
-			// phpcs:ignore Generic.ControlStructures.DisallowYodaConditions.Found -- This is not a Yoda condition.
+			// phpcs:ignore Generic.ControlStructures.DisallowYodaConditions -- Bug: squizlabs/PHP_CodeSniffer#2962.
 			'privateBlog'          => ( (string) get_option( 'blog_public' ) ) === '0',
 		];
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -469,6 +469,7 @@ class WPSEO_Utils {
 			return $value;
 		}
 		elseif ( is_float( $value ) ) {
+			// phpcs:ignore WordPress.PHP.StrictComparisons -- Purposeful loose comparison.
 			if ( (int) $value == $value && ! is_nan( $value ) ) {
 				return (int) $value;
 			}
@@ -604,7 +605,7 @@ class WPSEO_Utils {
 				if ( $bc ) {
 					$result = bcdiv( $number1, $number2, $precision ); // String, or NULL if right_operand is 0.
 				}
-				elseif ( $number2 != 0 ) {
+				elseif ( $number2 != 0 ) { // phpcs:ignore WordPress.PHP.StrictComparisons -- Purposeful loose comparison.
 					$result = ( $number1 / $number2 );
 				}
 
@@ -619,7 +620,7 @@ class WPSEO_Utils {
 				if ( $bc ) {
 					$result = bcmod( $number1, $number2 ); // String, or NULL if modulus is 0.
 				}
-				elseif ( $number2 != 0 ) {
+				elseif ( $number2 != 0 ) { // phpcs:ignore WordPress.PHP.StrictComparisons -- Purposeful loose comparison.
 					$result = ( $number1 % $number2 );
 				}
 
@@ -636,6 +637,7 @@ class WPSEO_Utils {
 					$result = bccomp( $number1, $number2, $precision ); // Returns int 0, 1 or -1.
 				}
 				else {
+					// phpcs:ignore WordPress.PHP.StrictComparisons -- Purposeful loose comparison.
 					$result = ( $number1 == $number2 ) ? 0 : ( ( $number1 > $number2 ) ? 1 : -1 );
 				}
 				break;
@@ -650,6 +652,7 @@ class WPSEO_Utils {
 					}
 				}
 				else {
+					// phpcs:ignore WordPress.PHP.StrictComparisons -- Purposeful loose comparison.
 					$result = ( intval( $result ) == $result ) ? intval( $result ) : floatval( $result );
 				}
 			}

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -255,7 +255,7 @@ class WPSEO_Utils {
 		 * @param string $filtered The sanitized string.
 		 * @param string $str      The string prior to being sanitized.
 		 */
-		return apply_filters( 'sanitize_text_field', $filtered, $value );
+		return apply_filters( 'sanitize_text_field', $filtered, $value ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- Using WP native filter.
 	}
 
 	/**

--- a/inc/health-check-default-tagline.php
+++ b/inc/health-check-default-tagline.php
@@ -58,8 +58,7 @@ class WPSEO_Health_Check_Default_Tagline extends WPSEO_Health_Check {
 		$blog_description         = get_option( 'blogdescription' );
 		$default_blog_description = 'Just another WordPress site';
 
-		// We are checking against the WordPress internal translation.
-		// @codingStandardsIgnoreLine WordPress.WP.I18n.TextDomainMismatch
+		// We are using the WordPress internal translation.
 		$translated_blog_description = __( 'Just another WordPress site', 'default' );
 
 		return $translated_blog_description === $blog_description || $default_blog_description === $blog_description;

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -334,9 +334,11 @@ class WPSEO_Options {
 		if ( $value === false ) {
 			$passed_default = func_num_args() > 1;
 
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- Using WP native filter.
 			return apply_filters( "default_option_{$option}", $default, $option, $passed_default );
 		}
 
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- Using WP native filter.
 		return apply_filters( "option_{$option}", maybe_unserialize( $value ), $option );
 	}
 

--- a/lib/migrations/constants.php
+++ b/lib/migrations/constants.php
@@ -6,7 +6,6 @@ namespace Yoast\WP\Lib\Migrations;
  * Yoast migrations constants class.
  */
 class Constants {
-	// @codingStandardsIgnoreLine WordPress.DB.RestrictedFunctions.mysql
 	const MYSQL_MAX_IDENTIFIER_LENGTH = 64;
 	const SQL_UNKNOWN_QUERY_TYPE      = 1;
 	const SQL_SELECT                  = 2;

--- a/lib/model.php
+++ b/lib/model.php
@@ -458,8 +458,7 @@ class Model implements JsonSerializable {
 		$key_to_base_table       = static::build_foreign_key_name( $key_to_base_table, $base_table_name );
 		$key_to_associated_table = static::build_foreign_key_name( $key_to_associated_table, $associated_table_name );
 
-		// @codingStandardsIgnoreLine
-		/* // phpcs:ignore Squiz.PHP.CommentedOutCode.Found -- Reason: This is commented out code.
+		/* phpcs:ignore Squiz.PHP.CommentedOutCode.Found -- Reason: This is commented out code.
 			"   SELECT {$associated_table_name}.*
 				FROM {$associated_table_name} JOIN {$join_table_name}
 					ON {$associated_table_name}.{$associated_table_id_column} = {$join_table_name}.{$key_to_associated_table}

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -535,8 +535,8 @@ class ORM implements \ArrayAccess {
 			if ( ! \is_numeric( $result->{$alias} ) ) {
 				$return_value = $result->{$alias};
 			}
-			// @codingStandardsIgnoreLine
-			elseif ( (int) $result->{$alias} == (float) $result->{$alias} ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison -- Reason: This loose comparison seems intended.
+			// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison -- Reason: This loose comparison seems intended.
+			elseif ( (int) $result->{$alias} == (float) $result->{$alias} ) {
 				$return_value = (int) $result->{$alias};
 			}
 			else {

--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -207,6 +207,9 @@ class Index_Command implements Command_Interface {
 	protected function clear() {
 		global $wpdb;
 
+		// For the PreparedSQLPlaceholders issue, see: https://github.com/WordPress/WordPress-Coding-Standards/issues/1903
+		// For the DirectDBQuery issue, see: https://github.com/WordPress/WordPress-Coding-Standards/issues/1947
+		// phpcs:disable WordPress.DB -- Table names should not be quoted and truncate queries can not be cached.
 		$wpdb->query(
 			$wpdb->prepare(
 				'TRUNCATE TABLE %1$s',
@@ -219,5 +222,6 @@ class Index_Command implements Command_Interface {
 				Model::get_table_name( 'Indexable_Hierarchy' )
 			)
 		);
+		// phpcs:enable
 	}
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -16,9 +16,13 @@ use Yoast\WP\SEO\Main;
 /**
  * Retrieves the main instance.
  *
+ * @phpcs:disable WordPress.NamingConventions -- Should probably be renamed, but leave for now.
+ *
  * @return Main The main instance.
  */
-function YoastSEO() { // @codingStandardsIgnoreLine
+function YoastSEO() {
+	// phpcs:enable
+
 	static $main;
 
 	if ( $main === null ) {

--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -131,8 +131,7 @@ class Article extends Abstract_Schema_Piece {
 		}
 
 		$callback = function( $term ) {
-			// We are checking against the WordPress internal translation.
-			// @codingStandardsIgnoreLine
+			// We are using the WordPress internal translation.
 			return $term->name !== \__( 'Uncategorized', 'default' );
 		};
 		$terms    = \array_filter( $terms, $callback );

--- a/tests/integration/admin/test-class-plugin-suggestions.php
+++ b/tests/integration/admin/test-class-plugin-suggestions.php
@@ -37,10 +37,13 @@ class WPSEO_Plugin_Suggestions_Test extends WPSEO_UnitTestCase {
 		/*
 		 * Silencing errors for PHP 7.4 in combination with the Mock Builder.
 		 * See WPSEO_UnitTestCase::bypass_php74_mockbuilder_deprecation_warning() for context.
+		 *
+		 * phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
 		 */
 		@$notification_center_mock = $this->getMockBuilder( 'Yoast_Notification_Center_Double' )
 			->setMethods( [ 'add_notification', 'remove_notification' ] )
 			->getMock();
+		// phpcs:enable
 
 		$this->class_instance = new WPSEO_Suggested_Plugins_Double( $plugin_availability, $notification_center_mock );
 

--- a/tests/integration/admin/test-class-yoast-network-admin.php
+++ b/tests/integration/admin/test-class-yoast-network-admin.php
@@ -282,7 +282,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		$e = null;
 		try {
 			$admin->verify_request( 'my_action' );
-		} catch ( WPDieException $e ) {
+		} catch ( WPDieException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
 			// WP_die has been called in the verify request function.
 		}
 
@@ -342,7 +342,7 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		$e = null;
 		try {
 			$admin->verify_request( 'my_action' );
-		} catch ( WPDieException $e ) {
+		} catch ( WPDieException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
 			// WP_die has been called in the verify request function.
 		}
 

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -74,7 +74,7 @@ abstract class TestCase extends BaseTestCase {
 				},
 				'wp_strip_all_tags'    => function( $string, $remove_breaks = false ) {
 					$string = \preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $string );
-					// phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags -- We are stubbing the wp_strip_all_tags.
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags -- We are stubbing the wp_strip_all_tags.
 					$string = \strip_tags( $string );
 
 					if ( $remove_breaks ) {

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -53,6 +53,7 @@ abstract class TestCase extends BaseTestCase {
 				'wp_kses_post'         => null,
 				'site_url'             => 'https://www.example.org',
 				'wp_json_encode'       => function( $data, $options = 0, $depth = 512 ) {
+					// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encodeWithAdditionalParams -- Usage in tests is fine.
 					return \json_encode( $data, $options, $depth );
 				},
 				'wp_slash'             => null,

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -290,6 +290,7 @@ function wpseo_init() {
 
 	if ( version_compare( WPSEO_Options::get( 'version', 1 ), WPSEO_VERSION, '<' ) ) {
 		if ( function_exists( 'opcache_reset' ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Prevent notices when opcache.restrict_api is set.
 			@opcache_reset();
 		}
 


### PR DESCRIPTION
## Context

* Code consistency.

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency.


## Relevant technical choices:

This PR does a couple of things, please refer to the individual commits for the full details:
1. Remove PHPCS ignore annotations which have become redundant.
    * Some annotations were in place to ignore bugs in PHPCS/WPCS, which have since been fixed.
    * Some "old-style" ignore annotations `@codingStandards...` were in place for the old ruleset, while "new-style" `// phpcs:ignore` annotations were also in place in anticipation of the upgrade. The duplicate/old-style annotations have been removed.
    * Some annotations are no longer needed when the updated ruleset is in place.
    * Some annotations were not ignoring anything at all.
2. Replace "old-style" PHPCS/WPCS ignore annotations with "new-style" selective ignore annotations.
3. Fix a number of annotations which were incorrect.
    * We don't allow non-selective ignores.
    * Some were using an invalid format/syntax.
    * Some were using an incorrect/outdated sniff error code.
4. Add numerous extra ignore annotations for valid code patterns.
5. Minor punctuation, grammar etc fixes in the ignore _reasons_.

## Test instructions
This PR can be tested by following these steps:

* _N/A_. This is a PHPCS ignore annotation only change and has no effect on functionality.

