### PR TITLE
Refactor TopLevelProviders and provide modal location

### DIFF
--- a/js/src/components/AdvancedSettings.js
+++ b/js/src/components/AdvancedSettings.js
@@ -5,6 +5,7 @@ import { TextInput } from "@yoast/components";
 import { Fragment, useEffect } from "@wordpress/element";
 import { Alert } from "@yoast/components";
 import PropTypes from "prop-types";
+import { LocationConsumer } from "./contexts/location";
 
 /**
  * Boolean that tells whether the current object refers to a post or a taxonomy.
@@ -79,36 +80,40 @@ const getNoIndexOptions = ( editorContext ) => {
  *
  * @returns {Component} The Meta Robots No-Index component.
  */
-const MetaRobotsNoIndex = ( { noIndex, onNoIndexChange, editorContext, isPrivateBlog, location } ) => {
+const MetaRobotsNoIndex = ( { noIndex, onNoIndexChange, editorContext, isPrivateBlog } ) => {
 	const metaRobotsNoIndexOptions = getNoIndexOptions( editorContext );
-	const id = appendLocation( "yoast_wpseo_meta-robots-noindex-react", location );
-	return <Fragment>
-		{
-			isPrivateBlog &&
-			<Alert type="warning">
-				{ __(
-					"Even though you can set the meta robots setting here, the entire site is set to noindex in the sitewide privacy settings, " +
-					"so these settings won't have an effect.",
-					"wordpress-seo"
-				) }
-			</Alert>
-		}
-		<Select
-			label={
-				sprintf(
-					/* Translators: %s translates to the Post Label in singular form */
-					__( "Allow search engines to show this %s in search results?", "wordpress-seo" ),
-					editorContext.postTypeNameSingular,
-				) }
-			onChange={ onNoIndexChange }
-			name={ "yoast_wpseo_meta-robots-noindex-react" }
-			id={ id }
-			options={ metaRobotsNoIndexOptions }
-			selected={ noIndex }
-			linkTo={ "https://yoa.st/allow-search-engines" }
-			linkText={ __( "Learn more about the no-index setting on our help page.", "wordpress-seo" ) }
-		/>
-	</Fragment>;
+	return <LocationConsumer>
+		{ location => {
+			return <Fragment>
+				{
+					isPrivateBlog &&
+					<Alert type="warning">
+						{ __(
+							"Even though you can set the meta robots setting here, " +
+							"the entire site is set to noindex in the sitewide privacy settings, " +
+							"so these settings won't have an effect.",
+							"wordpress-seo"
+						) }
+					</Alert>
+				}
+				<Select
+					label={
+						sprintf(
+							/* Translators: %s translates to the Post Label in singular form */
+							__( "Allow search engines to show this %s in search results?", "wordpress-seo" ),
+							editorContext.postTypeNameSingular,
+						) }
+					onChange={ onNoIndexChange }
+					name={ "yoast_wpseo_meta-robots-noindex-react" }
+					id={ appendLocation( "yoast_wpseo_meta-robots-noindex-react", location ) }
+					options={ metaRobotsNoIndexOptions }
+					selected={ noIndex }
+					linkTo={ "https://yoa.st/allow-search-engines" }
+					linkText={ __( "Learn more about the no-index setting on our help page.", "wordpress-seo" ) }
+				/>
+			</Fragment>;
+		} }
+	</LocationConsumer>;
 };
 
 MetaRobotsNoIndex.propTypes = {
@@ -116,12 +121,10 @@ MetaRobotsNoIndex.propTypes = {
 	onNoIndexChange: PropTypes.func.isRequired,
 	editorContext: PropTypes.object.isRequired,
 	isPrivateBlog: PropTypes.bool,
-	location: PropTypes.string,
 };
 
 MetaRobotsNoIndex.defaultProps = {
 	isPrivateBlog: false,
-	location: "",
 };
 
 /**
@@ -158,33 +161,30 @@ MetaRobotsNoFollow.propTypes = {
  *
  * @returns {Component} The Meta Robots advanced field component.
  */
-const MetaRobotsAdvanced = ( { advanced, onAdvancedChange, location } ) => {
-	const id = appendLocation( "yoast_wpseo_meta-robots-adv-react", location );
-
-	return <MultiSelect
-		label={ __( "Meta robots advanced", "wordpress-seo" ) }
-		onChange={ onAdvancedChange }
-		name="yoast_wpseo_meta-robots-adv-react"
-		id={ id }
-		options={ [
-			{ name: __( "No Image Index", "wordpress-seo" ), value: "noimageindex" },
-			{ name: __( "No Archive", "wordpress-seo" ), value: "noarchive" },
-			{ name: __( "No Snippet", "wordpress-seo" ), value: "nosnippet" },
-		] }
-		selected={ advanced }
-		linkTo={ "https://yoa.st/meta-robots-advanced" }
-		linkText={ __( "Learn more about advanced meta robots settings on our help page.", "wordpress-seo" ) }
-	/>;
+const MetaRobotsAdvanced = ( { advanced, onAdvancedChange } ) => {
+	return <LocationConsumer>
+		{ location => {
+			return <MultiSelect
+				label={ __( "Meta robots advanced", "wordpress-seo" ) }
+				onChange={ onAdvancedChange }
+				name="yoast_wpseo_meta-robots-adv-react"
+				id={ appendLocation( "yoast_wpseo_meta-robots-adv-react", location ) }
+				options={ [
+					{ name: __( "No Image Index", "wordpress-seo" ), value: "noimageindex" },
+					{ name: __( "No Archive", "wordpress-seo" ), value: "noarchive" },
+					{ name: __( "No Snippet", "wordpress-seo" ), value: "nosnippet" },
+				] }
+				selected={ advanced }
+				linkTo={ "https://yoa.st/meta-robots-advanced" }
+				linkText={ __( "Learn more about advanced meta robots settings on our help page.", "wordpress-seo" ) }
+			/>;
+		} }
+	</LocationConsumer>;
 };
 
 MetaRobotsAdvanced.propTypes = {
 	advanced: PropTypes.array.isRequired,
 	onAdvancedChange: PropTypes.func.isRequired,
-	location: PropTypes.string,
-};
-
-MetaRobotsAdvanced.defaultProps = {
-	location: "",
 };
 
 /**
@@ -194,28 +194,27 @@ MetaRobotsAdvanced.defaultProps = {
  *
  * @returns {Component} The Breadcrumbs title component.
  */
-const BreadcrumbsTitle = ( { breadcrumbsTitle, onBreadcrumbsTitleChange, location } ) => {
-	const id = appendLocation( "yoast_wpseo_bctitle-react", location );
-
-	return <TextInput
-		label={ __( "Breadcrumbs Title", "wordpress-seo" ) }
-		id={ id }
-		name="yoast_wpseo_bctitle-react"
-		onChange={ onBreadcrumbsTitleChange }
-		value={ breadcrumbsTitle }
-		linkTo={ "https://yoa.st/breadcrumbs-title" }
-		linkText={ __( "Learn more about the breadcrumbs title setting on our help page.", "wordpress-seo" ) }
-	/>;
+const BreadcrumbsTitle = ( { breadcrumbsTitle, onBreadcrumbsTitleChange } ) => {
+	return <LocationConsumer>
+		{
+			location => {
+				return <TextInput
+					label={ __( "Breadcrumbs Title", "wordpress-seo" ) }
+					id={ appendLocation( "yoast_wpseo_bctitle-react", location ) }
+					name="yoast_wpseo_bctitle-react"
+					onChange={ onBreadcrumbsTitleChange }
+					value={ breadcrumbsTitle }
+					linkTo={ "https://yoa.st/breadcrumbs-title" }
+					linkText={ __( "Learn more about the breadcrumbs title setting on our help page.", "wordpress-seo" ) }
+				/>;
+			}
+		}
+	</LocationConsumer>;
 };
 
 BreadcrumbsTitle.propTypes = {
 	breadcrumbsTitle: PropTypes.string.isRequired,
 	onBreadcrumbsTitleChange: PropTypes.func.isRequired,
-	location: PropTypes.string,
-};
-
-BreadcrumbsTitle.defaultProps = {
-	location: "",
 };
 
 /**
@@ -225,28 +224,27 @@ BreadcrumbsTitle.defaultProps = {
  *
  * @returns {Component} The canonical URL component.
  */
-const CanonicalURL = ( { canonical, onCanonicalChange, location } ) => {
-	const id = appendLocation( "yoast_wpseo_canonical-react", location );
-
-	return <TextInput
-		label={ __( "Canonical URL", "wordpress-seo" ) }
-		id={ id }
-		name="yoast_wpseo_canonical-react"
-		onChange={ onCanonicalChange }
-		value={ canonical }
-		linkTo={ "https://yoa.st/canonical-url" }
-		linkText={ __( "Learn more about canonical URLs on our help page.", "wordpress-seo" ) }
-	/>;
+const CanonicalURL = ( { canonical, onCanonicalChange } ) => {
+	return <LocationConsumer>
+		{
+			location => {
+				return <TextInput
+					label={ __( "Canonical URL", "wordpress-seo" ) }
+					id={ appendLocation( "yoast_wpseo_canonical-react", location ) }
+					name="yoast_wpseo_canonical-react"
+					onChange={ onCanonicalChange }
+					value={ canonical }
+					linkTo={ "https://yoa.st/canonical-url" }
+					linkText={ __( "Learn more about canonical URLs on our help page.", "wordpress-seo" ) }
+				/>;
+			}
+		}
+	</LocationConsumer>;
 };
 
 CanonicalURL.propTypes = {
 	canonical: PropTypes.string.isRequired,
 	onCanonicalChange: PropTypes.func.isRequired,
-	location: PropTypes.string,
-};
-
-CanonicalURL.defaultProps = {
-	location: "",
 };
 
 /**
@@ -263,7 +261,6 @@ const AdvancedSettings = ( props ) => {
 		advanced,
 		breadcrumbsTitle,
 		canonical,
-		location,
 		onNoIndexChange,
 		onNoFollowChange,
 		onAdvancedChange,
@@ -287,7 +284,6 @@ const AdvancedSettings = ( props ) => {
 	const noIndexProps = {
 		noIndex,
 		onNoIndexChange,
-		location,
 		editorContext,
 		isPrivateBlog,
 	};
@@ -295,25 +291,21 @@ const AdvancedSettings = ( props ) => {
 	const noFollowProps = {
 		noFollow,
 		onNoFollowChange,
-		location,
 		postTypeName: editorContext.postTypeNameSingular,
 	};
 
 	const advancedProps = {
 		advanced,
 		onAdvancedChange,
-		location,
 	};
 	const breadcrumbsTitleProps = {
 		breadcrumbsTitle,
 		onBreadcrumbsTitleChange,
-		location,
 	};
 
 	const canonicalProps = {
 		canonical,
 		onCanonicalChange,
-		location,
 	};
 
 	if ( isLoading ) {
@@ -349,11 +341,9 @@ AdvancedSettings.propTypes = {
 	onNoFollowChange: PropTypes.func,
 	breadcrumbsTitle: PropTypes.string,
 	onBreadcrumbsTitleChange: PropTypes.func,
-	location: PropTypes.string,
 };
 
 AdvancedSettings.defaultProps = {
-	location: "",
 	advanced: [],
 	onAdvancedChange: () => {},
 	noFollow: "",

--- a/js/src/components/TopLevelProviders.js
+++ b/js/src/components/TopLevelProviders.js
@@ -31,7 +31,7 @@ const TopLevelProviders = ( { store, theme, location, children } ) => {
 TopLevelProviders.propTypes = {
 	store: PropTypes.object.isRequired,
 	theme: PropTypes.object.isRequired,
-	location: PropTypes.oneOf( [ "sidebar", "metabox" ] ).isRequired,
+	location: PropTypes.oneOf( [ "sidebar", "metabox", "modal" ] ).isRequired,
 	children: PropTypes.element.isRequired,
 };
 

--- a/js/src/components/fills/MetaboxFill.js
+++ b/js/src/components/fills/MetaboxFill.js
@@ -63,11 +63,11 @@ export default function MetaboxFill( { settings } ) {
 			{ settings.displaySchemaSettings && <SidebarItem renderPriority={ 50 }>
 				<SchemaTabContainer />
 			</SidebarItem> }
-			<Fragment
+			<SidebarItem
 				renderPriority={ -1 }
 			>
 				<SocialMetadataPortal target="wpseo-section-social" />
-			</Fragment>
+			</SidebarItem>
 		</Fill>
 	);
 }

--- a/js/src/components/fills/MetaboxFill.js
+++ b/js/src/components/fills/MetaboxFill.js
@@ -74,7 +74,5 @@ export default function MetaboxFill( { settings } ) {
 
 MetaboxFill.propTypes = {
 	settings: PropTypes.object.isRequired,
-	store: PropTypes.object.isRequired,
-	theme: PropTypes.object.isRequired,
 };
 

--- a/js/src/components/fills/MetaboxFill.js
+++ b/js/src/components/fills/MetaboxFill.js
@@ -1,6 +1,5 @@
 /* External dependencies */
 import { Fill } from "@wordpress/components";
-import { Fragment } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 
@@ -17,6 +16,7 @@ import AdvancedSettings from "../../containers/AdvancedSettings";
 import SocialMetadataPortal from "../portals/SocialMetadataPortal";
 import SchemaTabContainer from "../../containers/SchemaTab";
 
+/* eslint-disable complexity */
 /**
  * Creates the Metabox component.
  *
@@ -75,4 +75,4 @@ export default function MetaboxFill( { settings } ) {
 MetaboxFill.propTypes = {
 	settings: PropTypes.object.isRequired,
 };
-
+/* eslint-ensable complexity */

--- a/js/src/components/fills/MetaboxFill.js
+++ b/js/src/components/fills/MetaboxFill.js
@@ -75,4 +75,4 @@ export default function MetaboxFill( { settings } ) {
 MetaboxFill.propTypes = {
 	settings: PropTypes.object.isRequired,
 };
-/* eslint-ensable complexity */
+/* eslint-enable complexity */

--- a/js/src/components/fills/MetaboxFill.js
+++ b/js/src/components/fills/MetaboxFill.js
@@ -26,7 +26,7 @@ import SchemaTabContainer from "../../containers/SchemaTab";
  *
  * @returns {wp.Element} The Metabox component.
  */
-export default function MetaboxFill( { settings, store, theme } ) {
+export default function MetaboxFill( { settings } ) {
 	return (
 		<Fill name="YoastMetabox">
 			<SidebarItem renderPriority={ 1 }>

--- a/js/src/components/fills/MetaboxFill.js
+++ b/js/src/components/fills/MetaboxFill.js
@@ -1,5 +1,6 @@
 /* External dependencies */
 import { Fill } from "@wordpress/components";
+import { Fragment } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 
@@ -29,95 +30,52 @@ import SchemaTabContainer from "../../containers/SchemaTab";
 export default function MetaboxFill( { settings, store, theme } ) {
 	return (
 		<Fill name="YoastMetabox">
-			<SidebarItem renderPriority={ 1 }>
-				<TopLevelProviders
-					store={ store }
-					theme={ theme }
-					location={ "metabox" }
-				>
-					<Warning />
-				</TopLevelProviders>
-			</SidebarItem>
-			{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
-				<TopLevelProviders
-					store={ store }
-					theme={ theme }
-					location={ "metabox" }
-				>
-					<KeywordInput />
-				</TopLevelProviders>
-			</SidebarItem> }
-			<SidebarItem renderPriority={ 9 }>
-				<TopLevelProviders
-					store={ store }
-					theme={ theme }
-					location={ "metabox" }
-				>
-					<MetaboxCollapsible
-						id={ "yoast-snippet-editor-metabox" }
-						title={ __( "Google preview", "wordpress-seo" ) } initialIsOpen={ true }
-					>
-						<SnippetEditor hasPaperStyle={ false } />
-					</MetaboxCollapsible>
-				</TopLevelProviders>
-			</SidebarItem>
-			{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
-				<TopLevelProviders
-					store={ store }
-					theme={ theme }
-					location={ "metabox" }
-				>
-					<ReadabilityAnalysis />
-				</TopLevelProviders>
-			</SidebarItem> }
-			{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
-				<TopLevelProviders
-					store={ store }
-					theme={ theme }
-					location={ "metabox" }
-				>
-					<SeoAnalysis
-						shouldUpsell={ settings.shouldUpsell }
-						shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
-					/>
-				</TopLevelProviders>
-			</SidebarItem> }
-			{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
-				<TopLevelProviders
-					store={ store }
-					theme={ theme }
-					location={ "metabox" }
-				>
-					<CollapsibleCornerstone />
-				</TopLevelProviders>
-			</SidebarItem> }
-			{ settings.displayAdvancedTab && <SidebarItem renderPriority={ 40 }>
-				<TopLevelProviders
-					store={ store }
-					theme={ theme }
-					location={ "metabox" }
-				>
-					<MetaboxCollapsible id={ "collapsible-advanced-settings" } title={ __( "Advanced", "wordpress-seo" ) }>
-						<AdvancedSettings />
-					</MetaboxCollapsible>
-				</TopLevelProviders>
-			</SidebarItem> }
-			{ settings.displaySchemaSettings && <SidebarItem renderPriority={ 50 }>
-				<TopLevelProviders
-					store={ store }
-					theme={ theme }
-					location={ "metabox" }
-				>
-					<SchemaTabContainer />
-				</TopLevelProviders>
-			</SidebarItem> }
 			<TopLevelProviders
-				renderPriority={ -1 }
 				store={ store }
 				theme={ theme }
 				location={ "metabox" }
 			>
-				<SocialMetadataPortal target="wpseo-section-social" />
+				<Fragment>
+					<SidebarItem renderPriority={ 1 }>
+						<Warning />
+					</SidebarItem>
+					{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
+						<KeywordInput />
+					</SidebarItem> }
+					<SidebarItem renderPriority={ 9 }>
+						<MetaboxCollapsible
+							id={ "yoast-snippet-editor-metabox" }
+							title={ __( "Google preview", "wordpress-seo" ) } initialIsOpen={ true }
+						>
+							<SnippetEditor hasPaperStyle={ false } />
+						</MetaboxCollapsible>
+					</SidebarItem>
+					{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
+						<ReadabilityAnalysis />
+					</SidebarItem> }
+					{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
+						<SeoAnalysis
+							shouldUpsell={ settings.shouldUpsell }
+							shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
+						/>
+					</SidebarItem> }
+					{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
+						<CollapsibleCornerstone />
+					</SidebarItem> }
+					{ settings.displayAdvancedTab && <SidebarItem renderPriority={ 40 }>
+						<MetaboxCollapsible id={ "collapsible-advanced-settings" } title={ __( "Advanced", "wordpress-seo" ) }>
+							<AdvancedSettings />
+						</MetaboxCollapsible>
+					</SidebarItem> }
+					{ settings.displaySchemaSettings && <SidebarItem renderPriority={ 50 }>
+						<SchemaTabContainer />
+					</SidebarItem> }
+					<Fragment
+						renderPriority={ -1 }
+					>
+						<SocialMetadataPortal target="wpseo-section-social" />
+					</Fragment>
+				</Fragment>
 			</TopLevelProviders>
 		</Fill>
 	);

--- a/js/src/components/fills/MetaboxFill.js
+++ b/js/src/components/fills/MetaboxFill.js
@@ -13,7 +13,6 @@ import ReadabilityAnalysis from "../contentAnalysis/ReadabilityAnalysis";
 import SeoAnalysis from "../contentAnalysis/SeoAnalysis";
 import MetaboxCollapsible from "../MetaboxCollapsible";
 import SidebarItem from "../SidebarItem";
-import TopLevelProviders from "../TopLevelProviders";
 import AdvancedSettings from "../../containers/AdvancedSettings";
 import SocialMetadataPortal from "../portals/SocialMetadataPortal";
 import SchemaTabContainer from "../../containers/SchemaTab";
@@ -30,53 +29,45 @@ import SchemaTabContainer from "../../containers/SchemaTab";
 export default function MetaboxFill( { settings, store, theme } ) {
 	return (
 		<Fill name="YoastMetabox">
-			<TopLevelProviders
-				store={ store }
-				theme={ theme }
-				location={ "metabox" }
+			<SidebarItem renderPriority={ 1 }>
+				<Warning />
+			</SidebarItem>
+			{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
+				<KeywordInput />
+			</SidebarItem> }
+			<SidebarItem renderPriority={ 9 }>
+				<MetaboxCollapsible
+					id={ "yoast-snippet-editor-metabox" }
+					title={ __( "Google preview", "wordpress-seo" ) } initialIsOpen={ true }
+				>
+					<SnippetEditor hasPaperStyle={ false } />
+				</MetaboxCollapsible>
+			</SidebarItem>
+			{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
+				<ReadabilityAnalysis />
+			</SidebarItem> }
+			{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
+				<SeoAnalysis
+					shouldUpsell={ settings.shouldUpsell }
+					shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
+				/>
+			</SidebarItem> }
+			{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
+				<CollapsibleCornerstone />
+			</SidebarItem> }
+			{ settings.displayAdvancedTab && <SidebarItem renderPriority={ 40 }>
+				<MetaboxCollapsible id={ "collapsible-advanced-settings" } title={ __( "Advanced", "wordpress-seo" ) }>
+					<AdvancedSettings />
+				</MetaboxCollapsible>
+			</SidebarItem> }
+			{ settings.displaySchemaSettings && <SidebarItem renderPriority={ 50 }>
+				<SchemaTabContainer />
+			</SidebarItem> }
+			<Fragment
+				renderPriority={ -1 }
 			>
-				<Fragment>
-					<SidebarItem renderPriority={ 1 }>
-						<Warning />
-					</SidebarItem>
-					{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
-						<KeywordInput />
-					</SidebarItem> }
-					<SidebarItem renderPriority={ 9 }>
-						<MetaboxCollapsible
-							id={ "yoast-snippet-editor-metabox" }
-							title={ __( "Google preview", "wordpress-seo" ) } initialIsOpen={ true }
-						>
-							<SnippetEditor hasPaperStyle={ false } />
-						</MetaboxCollapsible>
-					</SidebarItem>
-					{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
-						<ReadabilityAnalysis />
-					</SidebarItem> }
-					{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
-						<SeoAnalysis
-							shouldUpsell={ settings.shouldUpsell }
-							shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
-						/>
-					</SidebarItem> }
-					{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
-						<CollapsibleCornerstone />
-					</SidebarItem> }
-					{ settings.displayAdvancedTab && <SidebarItem renderPriority={ 40 }>
-						<MetaboxCollapsible id={ "collapsible-advanced-settings" } title={ __( "Advanced", "wordpress-seo" ) }>
-							<AdvancedSettings />
-						</MetaboxCollapsible>
-					</SidebarItem> }
-					{ settings.displaySchemaSettings && <SidebarItem renderPriority={ 50 }>
-						<SchemaTabContainer />
-					</SidebarItem> }
-					<Fragment
-						renderPriority={ -1 }
-					>
-						<SocialMetadataPortal target="wpseo-section-social" />
-					</Fragment>
-				</Fragment>
-			</TopLevelProviders>
+				<SocialMetadataPortal target="wpseo-section-social" />
+			</Fragment>
 		</Fill>
 	);
 }

--- a/js/src/components/fills/SidebarFill.js
+++ b/js/src/components/fills/SidebarFill.js
@@ -14,11 +14,11 @@ import SidebarItem from "../SidebarItem";
 import GooglePreviewModal from "../modals/editorModals/GooglePreviewModal";
 import TwitterPreviewModal from "../modals/editorModals/TwitterPreviewModal";
 import FacebookPreviewModal from "../modals/editorModals/FacebookPreviewModal";
-import TopLevelProviders from "../TopLevelProviders";
 import SchemaTabContainer from "../../containers/SchemaTab";
 import SidebarCollapsible from "../SidebarCollapsible";
 import AdvancedSettings from "../../containers/AdvancedSettings";
 
+/* eslint-disable complexity */
 /**
  * Creates the SidebarFill component.
  *
@@ -83,3 +83,4 @@ export default function SidebarFill( { settings } ) {
 SidebarFill.propTypes = {
 	settings: PropTypes.object.isRequired,
 };
+/* eslint-enable complexity */

--- a/js/src/components/fills/SidebarFill.js
+++ b/js/src/components/fills/SidebarFill.js
@@ -30,110 +30,50 @@ import AdvancedSettings from "../../containers/AdvancedSettings";
  *
  * @constructor
  */
-export default function SidebarFill( { settings, store, theme } ) {
+export default function SidebarFill( { settings } ) {
 	return (
 		<Fragment>
 			<Fill name="YoastSidebar">
 				<SidebarItem renderPriority={ 1 }>
-					<TopLevelProviders
-						store={ store }
-						theme={ theme }
-						location={ "sidebar" }
-					>
-						<Warning />
-					</TopLevelProviders>
+					<Warning />
 				</SidebarItem>
 				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
-					<TopLevelProviders
-						store={ store }
-						theme={ theme }
-						location={ "sidebar" }
-					>
-						<KeywordInput />
-					</TopLevelProviders>
+					<KeywordInput />
 				</SidebarItem> }
 				<SidebarItem renderPriority={ 23 }>
-					<TopLevelProviders
-						store={ store }
-						theme={ theme }
-						location={ "sidebar" }
-					>
-						<GooglePreviewModal />
-					</TopLevelProviders>
+					<GooglePreviewModal />
 				</SidebarItem>
 				{ settings.displayFacebook && <SidebarItem renderPriority={ 24 }>
-					<TopLevelProviders
-						store={ store }
-						theme={ theme }
-						location={ "sidebar" }
-					>
-						<FacebookPreviewModal />
-					</TopLevelProviders>
+					<FacebookPreviewModal />
 				</SidebarItem> }
 				{ settings.displayTwitter && <SidebarItem renderPriority={ 25 }>
-					<TopLevelProviders
-						store={ store }
-						theme={ theme }
-						location={ "sidebar" }
-					>
-						<TwitterPreviewModal />
-					</TopLevelProviders>
+					<TwitterPreviewModal />
 				</SidebarItem> }
 				{ settings.displaySchemaSettings && <SidebarItem renderPriority={ 26 }>
-					<TopLevelProviders
-						store={ store }
-						theme={ theme }
-						location={ "sidebar" }
+					<SidebarCollapsible
+						title={ __( "Schema", "wordpress-seo" ) }
 					>
-						<SidebarCollapsible
-							title={ __( "Schema", "wordpress-seo" ) }
-						>
-							<SchemaTabContainer />
-						</SidebarCollapsible>
-					</TopLevelProviders>
+						<SchemaTabContainer />
+					</SidebarCollapsible>
 				</SidebarItem> }
 				{ settings.displayAdvancedTab && <SidebarItem renderPriority={ 27 }>
-					<TopLevelProviders
-						store={ store }
-						theme={ theme }
-						location={ "sidebar" }
+					<SidebarCollapsible
+						title={ __( "Advanced", "wordpress-seo" ) }
 					>
-						<SidebarCollapsible
-							title={ __( "Advanced", "wordpress-seo" ) }
-						>
-							<AdvancedSettings />
-						</SidebarCollapsible>
-					</TopLevelProviders>
+						<AdvancedSettings />
+					</SidebarCollapsible>
 				</SidebarItem> }
 				{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
-					<TopLevelProviders
-						store={ store }
-						theme={ theme }
-						location={ "sidebar" }
-					>
-						<ReadabilityAnalysis />
-					</TopLevelProviders>
+					<ReadabilityAnalysis />
 				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
-					<TopLevelProviders
-						store={ store }
-						theme={ theme }
-						location={ "sidebar" }
-					>
-						<SeoAnalysis
-							shouldUpsell={ settings.shouldUpsell }
-							shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
-						/>
-					</TopLevelProviders>
+					<SeoAnalysis
+						shouldUpsell={ settings.shouldUpsell }
+						shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
+					/>
 				</SidebarItem> }
 				{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
-					<TopLevelProviders
-						store={ store }
-						theme={ theme }
-						location={ "sidebar" }
-					>
-						<CollapsibleCornerstone />
-					</TopLevelProviders>
+					<CollapsibleCornerstone />
 				</SidebarItem> }
 			</Fill>
 		</Fragment>
@@ -142,6 +82,4 @@ export default function SidebarFill( { settings, store, theme } ) {
 
 SidebarFill.propTypes = {
 	settings: PropTypes.object.isRequired,
-	store: PropTypes.object.isRequired,
-	theme: PropTypes.object.isRequired,
 };

--- a/js/src/components/fills/SidebarFill.js
+++ b/js/src/components/fills/SidebarFill.js
@@ -101,7 +101,7 @@ export default function SidebarFill( { settings, store, theme } ) {
 						<SidebarCollapsible
 							title={ __( "Advanced", "wordpress-seo" ) }
 						>
-							<AdvancedSettings location="sidebar" />
+							<AdvancedSettings />
 						</SidebarCollapsible>
 					</TopLevelProviders>
 				</SidebarItem> }

--- a/js/src/components/modals/editorModals/EditorModal.js
+++ b/js/src/components/modals/editorModals/EditorModal.js
@@ -3,6 +3,7 @@ import { useState, useCallback, Fragment } from "@wordpress/element";
 import Modal from "../Modal";
 import PropTypes from "prop-types";
 import SidebarButton from "../../SidebarButton";
+import { LocationProvider } from "../../contexts/location";
 
 /**
  * Returns false for events passed to onRequestClose, that should not lead to the modal closing.
@@ -47,38 +48,40 @@ const EditorModal = ( { postTypeName, children, title } ) => {
 	return (
 		<Fragment>
 			{ isOpen && (
-				<Modal
-					title={ title }
-					onRequestClose={ closeModal }
-					additionalClassName="yoast-collapsible-modal yoast-post-settings-modal"
-				>
-					<div className="yoast-content-container">
-						<div className="yoast-modal-content">
-							{ children }
+				<LocationProvider value="modal">
+					<Modal
+						title={ title }
+						onRequestClose={ closeModal }
+						additionalClassName="yoast-collapsible-modal yoast-post-settings-modal"
+					>
+						<div className="yoast-content-container">
+							<div className="yoast-modal-content">
+								{ children }
+							</div>
 						</div>
-					</div>
-					<div className="yoast-notice-container">
-						<hr />
-						<div className="yoast-button-container">
-							<p>
-								{
-									/* Translators: %s translates to the Post Label in singular form */
-									sprintf( __( "Make sure to save your %s for changes to take effect", "wordpress-seo" ), postTypeName )
-								}
-							</p>
-							<button
-								className="yoast-button yoast-button--primary yoast-button--post-settings-modal"
-								type="button"
-								onClick={ closeModal }
-							>
-								{
-									/* Translators: %s translates to the Post Label in singular form */
-									sprintf( __( "Return to your %s", "wordpress-seo" ), postTypeName )
-								}
-							</button>
+						<div className="yoast-notice-container">
+							<hr />
+							<div className="yoast-button-container">
+								<p>
+									{
+										/* Translators: %s translates to the Post Label in singular form */
+										sprintf( __( "Make sure to save your %s for changes to take effect", "wordpress-seo" ), postTypeName )
+									}
+								</p>
+								<button
+									className="yoast-button yoast-button--primary yoast-button--post-settings-modal"
+									type="button"
+									onClick={ closeModal }
+								>
+									{
+										/* Translators: %s translates to the Post Label in singular form */
+										sprintf( __( "Return to your %s", "wordpress-seo" ), postTypeName )
+									}
+								</button>
+							</div>
 						</div>
-					</div>
-				</Modal>
+					</Modal>
+				</LocationProvider>
 			) }
 			<SidebarButton
 				title={ title }

--- a/js/src/components/portals/MetaboxPortal.js
+++ b/js/src/components/portals/MetaboxPortal.js
@@ -16,7 +16,7 @@ import Portal from "./Portal";
 export default function MetaboxPortal( { target, store, theme } ) {
 	return (
 		<Portal target={ target }>
-			<MetaboxSlot />
+			<MetaboxSlot store={ store } theme={ theme } />
 			<MetaboxFill store={ store } theme={ theme } />
 		</Portal>
 	);

--- a/js/src/components/slots/MetaboxSlot.js
+++ b/js/src/components/slots/MetaboxSlot.js
@@ -1,17 +1,24 @@
 import { Slot } from "@wordpress/components";
 import sortComponentsByRenderPriority from "../../helpers/sortComponentsByRenderPriority";
+import TopLevelProviders from "../TopLevelProviders";
 
 /**
  * Renders the metabox portal.
  *
  * @returns {null|wp.Element} The element.
  */
-export default function MetaboxSlot() {
+export default function MetaboxSlot( { store, theme } ) {
 	return (
-		<Slot name="YoastMetabox">
-			{ ( fills ) => {
-				return sortComponentsByRenderPriority( fills );
-			} }
-		</Slot>
+		<TopLevelProviders
+			store={ store }
+			theme={ theme }
+			location={ "metabox" }
+		>
+			<Slot name="YoastMetabox">
+				{ ( fills ) => {
+					return sortComponentsByRenderPriority( fills );
+				} }
+			</Slot>
+		</TopLevelProviders>
 	);
 }

--- a/js/src/components/slots/SidebarSlot.js
+++ b/js/src/components/slots/SidebarSlot.js
@@ -7,7 +7,7 @@ import TopLevelProviders from "../TopLevelProviders";
  *
  * @returns {null|wp.Element} The element.
  */
-export default function SidebarSlot() {
+export default function SidebarSlot( { store, theme } ) {
 	return (
 		<TopLevelProviders
 			store={ store }

--- a/js/src/components/slots/SidebarSlot.js
+++ b/js/src/components/slots/SidebarSlot.js
@@ -1,5 +1,6 @@
 import { Slot } from "@wordpress/components";
 import sortComponentsByRenderPriority from "../../helpers/sortComponentsByRenderPriority";
+import TopLevelProviders from "../TopLevelProviders";
 
 /**
  * Renders the Sidebar slot.
@@ -8,10 +9,16 @@ import sortComponentsByRenderPriority from "../../helpers/sortComponentsByRender
  */
 export default function SidebarSlot() {
 	return (
-		<Slot name="YoastSidebar">
-			{ ( fills ) => {
-				return sortComponentsByRenderPriority( fills );
-			} }
-		</Slot>
+		<TopLevelProviders
+			store={ store }
+			theme={ theme }
+			location={ "sidebar" }
+		>
+			<Slot name="YoastSidebar">
+				{ ( fills ) => {
+					return sortComponentsByRenderPriority( fills );
+				} }
+			</Slot>
+		</TopLevelProviders>
 	);
 }

--- a/js/src/components/social/FacebookWrapper.js
+++ b/js/src/components/social/FacebookWrapper.js
@@ -1,8 +1,9 @@
-import { Fragment, useEffect } from "@wordpress/element";
+import { useEffect } from "@wordpress/element";
 import { Slot } from "@wordpress/components";
 import PropTypes from "prop-types";
 
 import SocialForm from "../social/SocialForm";
+import { LocationConsumer } from "../contexts/location";
 
 /**
  * This wrapper is connected to the facebook container. So the data is connected to both components.
@@ -19,30 +20,25 @@ const FacebookWrapper = ( props ) => {
 	}, [] );
 
 	return (
-		<Fragment>
-			{
-				props.isPremium
+		<LocationConsumer>
+			{ location => {
+				return props.isPremium
 					? <Slot
 						name={
 							"YoastFacebookPremium" +
-							`${ props.location.charAt( 0 ).toUpperCase() + props.location.slice( 1 ) }`
+							`${ location.charAt( 0 ).toUpperCase() + location.slice( 1 ) }`
 						}
 						fillProps={ props }
 					/>
-					: <SocialForm { ...props } />
-			}
-		</Fragment>
+					: <SocialForm { ...props } />;
+			} }
+		</LocationConsumer>
 	);
 };
 
 FacebookWrapper.propTypes = {
 	isPremium: PropTypes.bool.isRequired,
 	onLoad: PropTypes.func.isRequired,
-	location: PropTypes.string,
-};
-
-FacebookWrapper.defaultProps = {
-	location: "",
 };
 
 export default FacebookWrapper;

--- a/js/src/components/social/TwitterWrapper.js
+++ b/js/src/components/social/TwitterWrapper.js
@@ -1,8 +1,9 @@
-import { Fragment, useEffect } from "@wordpress/element";
+import { useEffect } from "@wordpress/element";
 import { Slot } from "@wordpress/components";
 import PropTypes from "prop-types";
 
 import SocialForm from "../social/SocialForm";
+import { LocationConsumer } from "../contexts/location";
 
 /**
  * This wrapper is connected to the twitter container. So the data is connected to both components.
@@ -19,19 +20,21 @@ const TwitterWrapper = ( props ) => {
 	}, [] );
 
 	return (
-		<Fragment>
+		<LocationConsumer>
 			{
-				props.isPremium
-					? <Slot
-						name={
-							"YoastTwitterPremium" +
-							`${ props.location.charAt( 0 ).toUpperCase() + props.location.slice( 1 ) }`
-						}
-						fillProps={ props }
-					/>
-					: <SocialForm { ...props } />
+				location => {
+					return props.isPremium
+						? <Slot
+							name={
+								"YoastTwitterPremium" +
+								`${ props.location.charAt( 0 ).toUpperCase() + props.location.slice( 1 ) }`
+							}
+							fillProps={ props }
+						/>
+						: <SocialForm { ...props } />;
+				}
 			}
-		</Fragment>
+		</LocationConsumer>
 	);
 };
 
@@ -40,9 +43,4 @@ export default TwitterWrapper;
 TwitterWrapper.propTypes = {
 	isPremium: PropTypes.bool.isRequired,
 	onLoad: PropTypes.func.isRequired,
-	location: PropTypes.string,
-};
-
-TwitterWrapper.defaultProps = {
-	location: "",
 };

--- a/js/src/components/social/TwitterWrapper.js
+++ b/js/src/components/social/TwitterWrapper.js
@@ -27,7 +27,7 @@ const TwitterWrapper = ( props ) => {
 						? <Slot
 							name={
 								"YoastTwitterPremium" +
-								`${ props.location.charAt( 0 ).toUpperCase() + props.location.slice( 1 ) }`
+								`${ location.charAt( 0 ).toUpperCase() + location.slice( 1 ) }`
 							}
 							fillProps={ props }
 						/>

--- a/js/src/initializers/block-editor-integration.js
+++ b/js/src/initializers/block-editor-integration.js
@@ -111,7 +111,7 @@ function registerFills( store ) {
 				name="seo-sidebar"
 				title={ pluginTitle }
 			>
-				<SidebarSlot />
+				<SidebarSlot store={ store } theme={ theme } />
 			</PluginSidebar>
 			<Fragment>
 				<SidebarFill store={ store } theme={ theme } />


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* I wanted to use the context providers for context rather than passing props to the containers. AdvancedSettings and FacebookEditor/TwitterEditor had such flow, to avoid conflicts when rendering both in the modal and in the metabox.

I then figured that we call `TopLevelProviders` a lot in `MetaboxFill` and `SidebarFill`, and I thought that that could be refactored. I think I was correct in that, but I want to have some extra eyes on this.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* The MetaboxFill was refactored to not call TopLevelProviders around each item. Rather, TopLevelProviders is now around the MetaboxSlot.
* The SidebarFill was refactored to not call TopLevelProviders around each item. Rather, TopLevelProviders is now around the SidebarSlot.
* The AdvancedSettings, FacebookEditor, and TwitterEditor components now use location context rather than a location prop.

## Relevant technical choices:

* Providers are around the slot, rather than around each metaboxfill item.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Build all the things.
* Verify that the Metabox and Sidebar work as you'd expect.
* Crucial things to test are elements that are _both_ in the metabox and in the sidebar.
	* It should be possible to open both at the same time.
	* Labels in the sidebar should point to sidebar inputs, metabox labels to metabox inputs.
	* Social previews, Google preview etc, should be able to open and close without disturbing the social previews in the metabox.
* While you are at it, give it a test on premium with https://github.com/Yoast/wordpress-seo-premium/pull/2982 and merge that if it works

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
