### PR TITLE
Build/PHPCS: fix the ruleset to work with YoastCS 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,8 +82,8 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=558",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=253",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=961",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=264",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs-summary": [

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -41,7 +41,15 @@
 	#############################################################################
 	-->
 
-	<rule ref="Yoast"/>
+	<rule ref="Yoast">
+		<properties>
+			<!-- Provide the plugin specific prefixes for all naming related sniffs. -->
+			<property name="prefixes" type="array">
+				<element value="Yoast\WP\SEO"/>
+				<element value="yoast_seo"/>
+			</property>
+		</properties>
+	</rule>
 
 
 	<!--
@@ -61,7 +69,10 @@
 
 	<rule ref="Yoast.NamingConventions.NamespaceName">
 		<properties>
-			<property name="prefixes" type="array" value="Yoast\WP\SEO\,Yoast\WP\SEO\Tests\Unit\"/>
+			<!-- Allow for the tests being in a non-standard directory in YoastSEO Free. -->
+			<property name="prefixes" type="array" extend="true">
+				<element value="Yoast\WP\SEO\Tests\Unit"/>
+			</property>
 		</properties>
 	</rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,9 +20,6 @@
 	<arg value="sp"/>
 
 	<rule ref="Yoast">
-		<exclude name="WordPress.WP.PreparedSQL.NotPrepared"/><!-- TODO audit raw queries -->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
-
 		<!-- See https://github.com/Yoast/wordpress-seo/pull/15713 - We discovered that WP_Filesystem can lead to unexpected behaviour. -->
 		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fopen"/>
 		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fwrite"/>
@@ -30,9 +27,6 @@
 		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fread"/>
 		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents"/>
 	</rule>
-
-	<!-- Demand short arrays. -->
-	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
 	<rule ref="Yoast.Files.FileName.InvalidFunctionsFileName">
 		<exclude-pattern>wp-seo-main\.php</exclude-pattern>
@@ -42,21 +36,11 @@
 	<rule ref="WordPress.Files.FileName.UnderscoresNotAllowed">
 		<exclude-pattern>migrations/*</exclude-pattern>
 	</rule>
-
-	<rule ref="Generic.Files.LowercasedFilename.NotFound">
-		<exclude-pattern>migrations/*</exclude-pattern>
-	</rule>
 	<!-- /Exclude migrations folder -->
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" value="wordpress-seo"/>
-		</properties>
-	</rule>
-
-	<rule ref="WordPress.NamingConventions.ValidVariableName">
-		<properties>
-			<property name="customVariablesWhitelist" type="array" value="pageUrl,responseCode,siteEntry,siteUrl,countPerTypes,urlCrawlErrorSample,buyUrl,infoUrl"/>
 		</properties>
 	</rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -75,6 +75,33 @@
 		</properties>
 	</rule>
 
+	<rule ref="Yoast.Files.FileName">
+		<properties>
+			<property name="excluded_files_strict_check" type="array">
+				<!-- Don't trigger on the main file(s) as renaming it would deactivate the plugin. -->
+				<element value="wp-seo.php"/>
+				<element value="wp-seo-main.php"/>
+				<!-- Don't trigger on select view related files. -->
+				<element value="admin/views/tool-bulk-editor.php"/>
+				<!-- Don't trigger on test bootstrap files. -->
+				<element value="tests/integration/bootstrap.php"/>
+				<element value="tests/unit/bootstrap.php"/>
+			</property>
+
+			<!-- Remove the following prefixes from the names of object structures. -->
+			<property name="oo_prefixes" type="array">
+				<element value="yoast_seo"/>
+
+				<!-- Temporary: once all prefixes have been fixed, these two elements should be removed. -->
+				<element value="wpseo"/>
+				<element value="yoast"/>
+			</property>
+		</properties>
+
+		<!-- Exclude the migrations directory from filename checks, as we do not have control over this format -->
+		<exclude-pattern>/src/config/migrations/*\.php$</exclude-pattern>
+	</rule>
+
 	<rule ref="Yoast.NamingConventions.NamespaceName">
 		<properties>
 			<!-- Allow for the tests being in a non-standard directory in YoastSEO Free. -->
@@ -101,23 +128,6 @@
 	Exclude specific files for specific sniffs.
 	#############################################################################
 	-->
-
-	<rule ref="Yoast.Files.FileName.InvalidFunctionsFileName">
-		<exclude-pattern>wp-seo-main\.php</exclude-pattern>
-	</rule>
-
-	<!-- Exclude migrations folder from filename checks, as we do not have control over this format -->
-	<rule ref="WordPress.Files.FileName.UnderscoresNotAllowed">
-		<exclude-pattern>migrations/*</exclude-pattern>
-	</rule>
-	<!-- /Exclude migrations folder -->
-
-	<!-- Exclude old code from filename conventions, new code needs to be added to `src/`. -->
-	<rule ref="Yoast.Files.FileName">
-		<exclude-pattern>admin/*</exclude-pattern>
-		<exclude-pattern>tests/integration/*</exclude-pattern>
-		<exclude-pattern>inc/*</exclude-pattern>
-	</rule>
 
 	<!-- Composer scripts are not WordPress and have console output. -->
 	<rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,17 +14,10 @@
 
 	<file>.</file>
 
-	<exclude-pattern>tests/*</exclude-pattern>
-	<exclude-pattern>vendor/*</exclude-pattern>
-	<exclude-pattern>vendor_prefixed/*</exclude-pattern>
-	<exclude-pattern>node_modules/*</exclude-pattern>
-	<exclude-pattern>deprecated/*</exclude-pattern>
-	<exclude-pattern>languages/*</exclude-pattern>
-	<exclude-pattern>artifact/*</exclude-pattern>
-	<exclude-pattern>.wordpress-svn/*</exclude-pattern>
-	<exclude-pattern>config/php-scoper/*</exclude-pattern>
-	<exclude-pattern>src/generated/*</exclude-pattern>
-	<exclude-pattern>polyfills/*</exclude-pattern>
+	<!-- Exclude dependency related files and generated files from being scanned. -->
+	<exclude-pattern type="relative">^artifact/*\.php$</exclude-pattern>
+	<exclude-pattern type="relative">^config/php-scoper/*\.php$</exclude-pattern>
+	<exclude-pattern type="relative">^src/generated/*\.php$</exclude-pattern>
 
 	<!-- Only check PHP files. -->
 	<arg name="extensions" value="php"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -41,14 +41,7 @@
 	#############################################################################
 	-->
 
-	<rule ref="Yoast">
-		<!-- See https://github.com/Yoast/wordpress-seo/pull/15713 - We discovered that WP_Filesystem can lead to unexpected behaviour. -->
-		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fopen"/>
-		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fwrite"/>
-		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fclose"/>
-		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fread"/>
-		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents"/>
-	</rule>
+	<rule ref="Yoast"/>
 
 
 	<!--
@@ -69,6 +62,16 @@
 	<rule ref="Yoast.NamingConventions.NamespaceName">
 		<properties>
 			<property name="prefixes" type="array" value="Yoast\WP\SEO\,Yoast\WP\SEO\Tests\Unit\"/>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.WP.AlternativeFunctions">
+		<properties>
+			<!-- We discovered that WP_Filesystem can lead to unexpected behaviour.
+				 See https://github.com/Yoast/wordpress-seo/pull/15713 -->
+			<property name="exclude" type="array" extend="true">
+				<element value="file_system_read"/>
+			</property>
 		</properties>
 	</rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -138,6 +138,12 @@
 		</properties>
 	</rule>
 
+	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
+		<properties>
+			<property name="maxColumn" value="70"/>
+		</properties>
+	</rule>
+
 
 	<!--
 	##########################################################################

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -59,7 +59,10 @@
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" value="wordpress-seo"/>
+			<property name="text_domain" type="array">
+				<element value="wordpress-seo"/>
+				<element value="default"/>
+			</property>
 		</properties>
 	</rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -154,12 +154,12 @@
 
 	<!-- Composer scripts are not WordPress and have console output. -->
 	<rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped">
-		<exclude-pattern>config/composer/*</exclude-pattern>
+		<exclude-pattern>/config/composer/*</exclude-pattern>
 	</rule>
 
 	<!-- Exclude php-codeshift from being checked too roughly. -->
 	<rule ref="Yoast.NamingConventions.ObjectNameDepth">
-		<exclude-pattern>config/php-codeshift/*</exclude-pattern>
+		<exclude-pattern>/config/php-codeshift/*</exclude-pattern>
 	</rule>
 
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,93 +1,94 @@
 <?xml version="1.0"?>
 <ruleset name="Yoast SEO">
-    <description>Yoast SEO rules for PHP_CodeSniffer</description>
+	<description>Yoast SEO rules for PHP_CodeSniffer</description>
 
-    <file>.</file>
+	<file>.</file>
 
-    <exclude-pattern>tests/*</exclude-pattern>
-    <exclude-pattern>vendor/*</exclude-pattern>
-    <exclude-pattern>vendor_prefixed/*</exclude-pattern>
-    <exclude-pattern>node_modules/*</exclude-pattern>
-    <exclude-pattern>deprecated/*</exclude-pattern>
-    <exclude-pattern>languages/*</exclude-pattern>
-    <exclude-pattern>artifact/*</exclude-pattern>
-    <exclude-pattern>.wordpress-svn/*</exclude-pattern>
-    <exclude-pattern>config/php-scoper/*</exclude-pattern>
-    <exclude-pattern>src/generated/*</exclude-pattern>
-    <exclude-pattern>polyfills/*</exclude-pattern>
+	<exclude-pattern>tests/*</exclude-pattern>
+	<exclude-pattern>vendor/*</exclude-pattern>
+	<exclude-pattern>vendor_prefixed/*</exclude-pattern>
+	<exclude-pattern>node_modules/*</exclude-pattern>
+	<exclude-pattern>deprecated/*</exclude-pattern>
+	<exclude-pattern>languages/*</exclude-pattern>
+	<exclude-pattern>artifact/*</exclude-pattern>
+	<exclude-pattern>.wordpress-svn/*</exclude-pattern>
+	<exclude-pattern>config/php-scoper/*</exclude-pattern>
+	<exclude-pattern>src/generated/*</exclude-pattern>
+	<exclude-pattern>polyfills/*</exclude-pattern>
 
-    <arg name="extensions" value="php"/>
-    <arg value="sp"/>
+	<arg name="extensions" value="php"/>
+	<arg value="sp"/>
 
-    <rule ref="Yoast">
-        <exclude name="WordPress.WP.PreparedSQL.NotPrepared"/><!-- TODO audit raw queries -->
-        <exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+	<rule ref="Yoast">
+		<exclude name="WordPress.WP.PreparedSQL.NotPrepared"/><!-- TODO audit raw queries -->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
 
-        <!-- See https://github.com/Yoast/wordpress-seo/pull/15713 - We discovered that WP_Filesystem can lead to unexpected behaviour. -->
-        <exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fopen" />
-        <exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fwrite" />
-        <exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fclose" />
-        <exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fread" />
-        <exclude name="WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents" />
-    </rule>
+		<!-- See https://github.com/Yoast/wordpress-seo/pull/15713 - We discovered that WP_Filesystem can lead to unexpected behaviour. -->
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fopen"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fwrite"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fclose"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_fread"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents"/>
+	</rule>
 
-    <!-- Demand short arrays. -->
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+	<!-- Demand short arrays. -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
-    <rule ref="Yoast.Files.FileName.InvalidFunctionsFileName">
-        <exclude-pattern>wp-seo-main\.php</exclude-pattern>
-    </rule>
+	<rule ref="Yoast.Files.FileName.InvalidFunctionsFileName">
+		<exclude-pattern>wp-seo-main\.php</exclude-pattern>
+	</rule>
 
-    <!-- Exclude migrations folder from filename checks, as we do not have control over this format -->
-    <rule ref="WordPress.Files.FileName.UnderscoresNotAllowed">
-        <exclude-pattern>migrations/*</exclude-pattern>
-    </rule>
+	<!-- Exclude migrations folder from filename checks, as we do not have control over this format -->
+	<rule ref="WordPress.Files.FileName.UnderscoresNotAllowed">
+		<exclude-pattern>migrations/*</exclude-pattern>
+	</rule>
 
-    <rule ref="Generic.Files.LowercasedFilename.NotFound">
-        <exclude-pattern>migrations/*</exclude-pattern>
-    </rule>
-    <!-- /Exclude migrations folder -->
+	<rule ref="Generic.Files.LowercasedFilename.NotFound">
+		<exclude-pattern>migrations/*</exclude-pattern>
+	</rule>
+	<!-- /Exclude migrations folder -->
 
-    <rule ref="WordPress.WP.I18n">
-        <properties>
-            <property name="text_domain" value="wordpress-seo"/>
-        </properties>
-    </rule>
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" value="wordpress-seo"/>
+		</properties>
+	</rule>
 
-    <rule ref="WordPress.NamingConventions.ValidVariableName">
-        <properties>
-            <property name="customVariablesWhitelist" type="array" value="pageUrl,responseCode,siteEntry,siteUrl,countPerTypes,urlCrawlErrorSample,buyUrl,infoUrl" />
-        </properties>
-    </rule>
+	<rule ref="WordPress.NamingConventions.ValidVariableName">
+		<properties>
+			<property name="customVariablesWhitelist" type="array" value="pageUrl,responseCode,siteEntry,siteUrl,countPerTypes,urlCrawlErrorSample,buyUrl,infoUrl"/>
+		</properties>
+	</rule>
 
-    <rule ref="Yoast.NamingConventions.NamespaceName">
-        <properties>
-            <property name="prefixes" type="array" value="Yoast\WP\SEO\,Yoast\WP\SEO\Tests\Unit\" />
-        </properties>
-    </rule>
+	<rule ref="Yoast.NamingConventions.NamespaceName">
+		<properties>
+			<property name="prefixes" type="array" value="Yoast\WP\SEO\,Yoast\WP\SEO\Tests\Unit\"/>
+		</properties>
+	</rule>
 
-    <!-- Exclude old code from filename conventions, new code needs to be added to `src/`. -->
-    <rule ref="Yoast.Files.FileName">
-        <exclude-pattern>admin/*</exclude-pattern>
-        <exclude-pattern>tests/integration/*</exclude-pattern>
-        <exclude-pattern>inc/*</exclude-pattern>
-    </rule>
+	<!-- Exclude old code from filename conventions, new code needs to be added to `src/`. -->
+	<rule ref="Yoast.Files.FileName">
+		<exclude-pattern>admin/*</exclude-pattern>
+		<exclude-pattern>tests/integration/*</exclude-pattern>
+		<exclude-pattern>inc/*</exclude-pattern>
+	</rule>
 
-    <rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped">
-        <exclude-pattern>config/composer/*</exclude-pattern> <!-- Composer scripts are not WordPress and have console output. -->
-    </rule>
+	<!-- Composer scripts are not WordPress and have console output. -->
+	<rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped">
+		<exclude-pattern>config/composer/*</exclude-pattern>
+	</rule>
 
-    <!-- Exclude php-codeshift from being checked too roughly. -->
-    <rule ref="Yoast.NamingConventions.ObjectNameDepth">
-        <exclude-pattern>config/php-codeshift/*</exclude-pattern>
-    </rule>
+	<!-- Exclude php-codeshift from being checked too roughly. -->
+	<rule ref="Yoast.NamingConventions.ObjectNameDepth">
+		<exclude-pattern>config/php-codeshift/*</exclude-pattern>
+	</rule>
 
-    <!--
-    #############################################################################
-    SNIFF FOR PHP CROSS-VERSION COMPATIBILITY
-    #############################################################################
-    -->
-    <config name="testVersion" value="5.6-"/>
-    <rule ref="PHPCompatibilityWP"/>
+	<!--
+	#############################################################################
+	SNIFF FOR PHP CROSS-VERSION COMPATIBILITY
+	#############################################################################
+	-->
+	<config name="testVersion" value="5.6-"/>
+	<rule ref="PHPCompatibilityWP"/>
 
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -25,6 +25,15 @@
 	<!-- Show progress, show the error codes for each message (source). -->
 	<arg value="sp"/>
 
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="."/>
+
+	<!-- Check up to 12 files simultaneously. -->
+	<arg name="parallel" value="12"/>
+
+	<!-- Cache the results between runs. -->
+	<arg name="cache" value="./.cache/phpcs-free.cache"/>
+
 
 	<!--
 	#############################################################################

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -165,4 +165,20 @@
 		<exclude-pattern>/config/php-codeshift/*</exclude-pattern>
 	</rule>
 
+	<!-- DEPRECATED CODE -->
+
+	<!-- Files which are excluded for code-coverage in the phpunit.xml.dist file should
+		 also be excluded for this sniff.
+		 Note: the lists in phpunit.xml.dist and here should be kept in sync! -->
+	<rule ref="Yoast.Commenting.CodeCoverageIgnoreDeprecated">
+		<exclude-pattern>/src/deprecated/*</exclude-pattern>
+		<exclude-pattern>/inc/wpseo-functions-deprecated\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Ignore unused function parameters in deprecated functionality. -->
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter">
+		<exclude-pattern>/src/deprecated/*</exclude-pattern>
+		<exclude-pattern>/inc/wpseo-functions-deprecated\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -102,6 +102,15 @@
 		<exclude-pattern>/src/config/migrations/*\.php$</exclude-pattern>
 	</rule>
 
+	<rule ref="Yoast.Files.TestDoubles">
+		<properties>
+			<property name="doubles_path" type="array" extend="true">
+				<element value="/tests/integration/doubles"/>
+				<element value="/tests/unit/doubles"/>
+			</property>
+		</properties>
+	</rule>
+
 	<rule ref="Yoast.NamingConventions.NamespaceName">
 		<properties>
 			<!-- Allow for the tests being in a non-standard directory in YoastSEO Free. -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -181,4 +181,52 @@
 		<exclude-pattern>/inc/wpseo-functions-deprecated\.php$</exclude-pattern>
 	</rule>
 
+	<!-- TEST CODE -->
+
+	<!-- Valid usage: For testing purposes, some non-prefixed globals are being created, which is fine. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<exclude-pattern>/tests/*/bootstrap\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Direct DB queries to retrieve the comparison data for tests or to create a test case, is fine. -->
+	<rule ref="WordPress.DB.DirectDatabaseQuery">
+		<exclude-pattern>/tests/*</exclude-pattern>
+	</rule>
+
+	<!-- Test code does not go into production, so security is not an issue. -->
+	<rule ref="WordPress.Security">
+		<exclude-pattern>/tests/*</exclude-pattern>
+	</rule>
+
+	<!-- Changing the cron interval to test things, is fine. -->
+	<rule ref="WordPress.WP.CronInterval">
+		<exclude-pattern>/tests/*</exclude-pattern>
+	</rule>
+
+	<!-- Allow for the double/mock classes to override methods just to change the visibility. -->
+	<rule ref="Generic.CodeAnalysis.UselessOverridingMethod">
+		<exclude-pattern>/tests/integration/doubles/*</exclude-pattern>
+		<exclude-pattern>/tests/unit/doubles/*</exclude-pattern>
+	</rule>
+
+	<!-- Test mock/double classes do not have to be prefixed. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
+		<exclude-pattern>/tests/integration/doubles/*</exclude-pattern>
+		<exclude-pattern>/tests/unit/doubles/*</exclude-pattern>
+	</rule>
+
+	<!-- For documentation of the double/mock classes, please refer to the _real_ classes. -->
+	<rule ref="Squiz.Commenting.FunctionComment.Missing">
+		<exclude-pattern>/tests/integration/doubles/*</exclude-pattern>
+		<exclude-pattern>/tests/unit/doubles/*</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FunctionComment.MissingParamTag">
+		<exclude-pattern>/tests/integration/doubles/*</exclude-pattern>
+		<exclude-pattern>/tests/unit/doubles/*</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.VariableComment.Missing">
+		<exclude-pattern>/tests/integration/doubles/*</exclude-pattern>
+		<exclude-pattern>/tests/unit/doubles/*</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -156,6 +156,9 @@
 	<rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped">
 		<exclude-pattern>/config/composer/*</exclude-pattern>
 	</rule>
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
+		<exclude-pattern>/config/composer/*</exclude-pattern>
+	</rule>
 
 	<!-- Exclude php-codeshift from being checked too roughly. -->
 	<rule ref="Yoast.NamingConventions.ObjectNameDepth">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -113,6 +113,14 @@
 
 	<rule ref="Yoast.NamingConventions.NamespaceName">
 		<properties>
+			<!-- Indicate which directories should be treated as project root directories for
+				 path-to-namespace translations. -->
+			<property name="src_directory" type="array">
+				<element value="config"/>
+				<element value="src"/>
+				<element value="tests/unit"/>
+			</property>
+
 			<!-- Allow for the tests being in a non-standard directory in YoastSEO Free. -->
 			<property name="prefixes" type="array" extend="true">
 				<element value="Yoast\WP\SEO\Tests\Unit"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -48,6 +48,14 @@
 				<element value="Yoast\WP\SEO"/>
 				<element value="yoast_seo"/>
 			</property>
+
+			<!-- Set the custom test class whitelist for all sniffs which use it in one go.
+				 Ref: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-unit-test-classes
+			-->
+			<property name="custom_test_class_whitelist" type="array">
+				<element value="WPSEO_UnitTestCase"/>
+				<element value="Yoast\WP\SEO\Tests\Unit\TestCase"/>
+			</property>
 		</properties>
 	</rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -67,12 +67,4 @@
 		<exclude-pattern>config/php-codeshift/*</exclude-pattern>
 	</rule>
 
-	<!--
-	#############################################################################
-	SNIFF FOR PHP CROSS-VERSION COMPATIBILITY
-	#############################################################################
-	-->
-	<config name="testVersion" value="5.6-"/>
-	<rule ref="PHPCompatibilityWP"/>
-
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -229,4 +229,39 @@
 		<exclude-pattern>/tests/unit/doubles/*</exclude-pattern>
 	</rule>
 
+
+	<!--
+	#############################################################################
+	TEMPORARY ADJUSTMENTS
+	Adjustments which should be removed once the associated issue has been resolved.
+	#############################################################################
+	-->
+
+	<!-- Temporary: Only enable the file name rules for the "new" code for now.
+		 The "old" code has a lot of violations against this rule.
+		 Fixing this should be a coordinated effort, which is why we will ignore
+		 this rule for the "old" code for now.
+	-->
+	<rule ref="Yoast.Files.FileName">
+		<include-pattern>/config/*\.php$</include-pattern>
+		<include-pattern>/lib/*\.php$</include-pattern>
+		<include-pattern>/src/*\.php$</include-pattern>
+		<include-pattern>/tests/unit/*\.php$</include-pattern>
+	</rule>
+
+	<!-- Only enable the prefix all globals rules for the "new" code for now.
+		 The "old" code has a lot of violations against this rule, mostly inconsistent
+		 prefixes. Fixing this should be a coordinated effort, which is why we will ignore
+		 this rule for the "old" code for now.
+	-->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<include-pattern>*/config/*\.php$</include-pattern>
+		<include-pattern>*/lib/*\.php$</include-pattern>
+		<include-pattern>*/src/*\.php$</include-pattern>
+		<include-pattern>*/tests/unit/*\.php$</include-pattern>
+
+		<!-- Exclude hooks everywhere for the time being until the prefixes will be fixed. -->
+		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound"/>
+	</rule>
+
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,16 @@
 <?xml version="1.0"?>
-<ruleset name="Yoast SEO">
-	<description>Yoast SEO rules for PHP_CodeSniffer</description>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	name="Yoast SEO Free"
+	xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+	<description>Yoast SEO Free rules for PHP_CodeSniffer</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	#############################################################################
+	-->
 
 	<file>.</file>
 
@@ -16,8 +26,18 @@
 	<exclude-pattern>src/generated/*</exclude-pattern>
 	<exclude-pattern>polyfills/*</exclude-pattern>
 
+	<!-- Only check PHP files. -->
 	<arg name="extensions" value="php"/>
+
+	<!-- Show progress, show the error codes for each message (source). -->
 	<arg value="sp"/>
+
+
+	<!--
+	#############################################################################
+	USE THE YoastCS RULESET
+	#############################################################################
+	-->
 
 	<rule ref="Yoast">
 		<!-- See https://github.com/Yoast/wordpress-seo/pull/15713 - We discovered that WP_Filesystem can lead to unexpected behaviour. -->
@@ -28,15 +48,12 @@
 		<exclude name="WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents"/>
 	</rule>
 
-	<rule ref="Yoast.Files.FileName.InvalidFunctionsFileName">
-		<exclude-pattern>wp-seo-main\.php</exclude-pattern>
-	</rule>
 
-	<!-- Exclude migrations folder from filename checks, as we do not have control over this format -->
-	<rule ref="WordPress.Files.FileName.UnderscoresNotAllowed">
-		<exclude-pattern>migrations/*</exclude-pattern>
-	</rule>
-	<!-- /Exclude migrations folder -->
+	<!--
+	#############################################################################
+	SNIFF SPECIFIC CONFIGURATION
+	#############################################################################
+	-->
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
@@ -49,6 +66,24 @@
 			<property name="prefixes" type="array" value="Yoast\WP\SEO\,Yoast\WP\SEO\Tests\Unit\"/>
 		</properties>
 	</rule>
+
+
+	<!--
+	##########################################################################
+	SELECTIVE EXCLUSIONS
+	Exclude specific files for specific sniffs.
+	#############################################################################
+	-->
+
+	<rule ref="Yoast.Files.FileName.InvalidFunctionsFileName">
+		<exclude-pattern>wp-seo-main\.php</exclude-pattern>
+	</rule>
+
+	<!-- Exclude migrations folder from filename checks, as we do not have control over this format -->
+	<rule ref="WordPress.Files.FileName.UnderscoresNotAllowed">
+		<exclude-pattern>migrations/*</exclude-pattern>
+	</rule>
+	<!-- /Exclude migrations folder -->
 
 	<!-- Exclude old code from filename conventions, new code needs to be added to `src/`. -->
 	<rule ref="Yoast.Files.FileName">


### PR DESCRIPTION
## Context

* Code consistency.

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency.


## Relevant technical choices:

Update the ruleset for YoastCS 2.0, WPCS 2.x and PHPCS 3.x.

Includes:
* Enabling parallel scanning and caching of the scan results between scans.
* Enabling PHPCS for all Yoast code in the repo.
* Adding appropriate configuration for a number of sniffs.
* Making selective allowances for exceptions to the rules for, for instance, deprecated code and tests.
* For the time being - temporarily!! - disabling the `PrefixAllGlobals` and `FileName` rules for the "old" code.
* Adding substantial inline documentation to the ruleset.

Please see the individual commits for full detail.


## Test instructions
This PR can be tested by following these steps:

* _N/A_. This is a PHPCS ruleset only change and has no effect on functionality.

