### PR TITLE
P3 142 fix travis monorepo feature branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -198,7 +198,11 @@ before_script:
       if [[ -z "$PLUGIN_TAGS" ]]; then
         git clone https://github.com/yoast/javascript /tmp/javascript
         echo '{"monorepo-location":"/tmp/javascript"}' > .yoast
-        yarn link-monorepo
+        if [[ ( $TRAVIS_BRANCH =~ ^feature\/* || $TRAVIS_BRANCH =~ ^release\/* || $TRAVIS_BRANCH = "trunk" ) && $TRAVIS_EVENT_TYPE = "pull_request" ]]; then
+          AUTO_CHECKOUT_MONOREPO_BRANCH=1 yarn link-monorepo
+        else
+          yarn link-monorepo
+        fi
       fi
     fi
   - phpenv rehash


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When creating a PR for a feature branch of the Free plugin, job #1 in Travis should check out the matching feature branch of the javascript monorepo to perform `yarn link-monorepo` with it.
As we can see [in this log](https://travis-ci.org/github/Yoast/wordpress-seo/jobs/721664027)  we expected to see the feature/semrush branch of monorepo checked out, but instead we got (lines 947-948)
```
Already on 'develop'
Checking out develop on the monorepo.
```
thus triggering an error since the plugin feature branch relied on code in the monorepo feature branch that was different from the `develop` branch.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Make sure that the matching monorepo feature branch is checked out when Travis runs on a pull request based on a feature branch

## Relevant technical choices:

* Please note that the PR has been based on `feature/semrush` branch since it was here that the problem was discovered and we need to run the tests on a feature branch to check that the changes work as expected.
If the changes are accepted and merged to the feature branch, they will need to be ported (e.g. cherry picked) to the `trunk` branch.
**It is not advised to merge this PR in `trunk` since it would merge all the commits regarding the SEMrush integration.**

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check [the log for the first Travis job](https://travis-ci.org/github/Yoast/wordpress-seo/jobs/723377086#L948) (lines  948-949) and see that the feature branch of the monorepo is checked out when `yarn link-monorepo` runs:
```
Switched to a new branch 'feature/semrush'
Checking out feature/semrush on the monorepo.
```
Observe how it's different from the example provided in the _Context_ part, above.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
