### PR TITLE
Use SingleSelect

### DIFF
--- a/css/src/modal.css
+++ b/css/src/modal.css
@@ -572,6 +572,13 @@
 	position: relative;
 }
 
+ #yoast-semrush-country-selector {
+	 position: relative;
+	 border: none;
+	 padding: 0;
+	 margin: 0 0 24px 0;
+ }
+
 .yoast-related-keyphrases-modal__chart {
 	display: block;
 }

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -299,24 +299,19 @@ class SEMrushCountrySelector extends Component {
 				label={ __( "Show results for:", "wordpress-seo" ) }
 				wrapperClassName="yoast-field-group"
 			>
-				<div style={ { display: "flex", flexDirection: "row", height: 62, width: "70%" } }>
-					<div style={ { flexGrow: 1, padding: 0, margin: 0, paddingRight: 10 } }>
-						<SingleSelect
-							id={ id }
-							name="semrush-country-code"
-							options={ countries }
-							selected={ this.props.countryCode }
-							onChange={ this.onChangeHandler }
-						/>
-					</div>
-					<button
-						style={ { height: 42, alignSelf: "center" } }
-						className="yoast-button yoast-button--secondary"
-						onClick={ this.relatedKeyphrasesRequest }
-					>
-						{ __( "Change Country", "wordpress-seo" ) }
-					</button>
-				</div>
+				<SingleSelect
+					id={ id }
+					name="semrush-country-code"
+					options={ countries }
+					selected={ this.props.countryCode }
+					onChange={ this.onChangeHandler }
+				/>
+				<button
+					className="yoast-button yoast-button--secondary"
+					onClick={ this.relatedKeyphrasesRequest }
+				>
+					{ __( "Change Country", "wordpress-seo" ) }
+				</button>
 			</FieldGroup>
 		);
 	}

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -287,22 +287,26 @@ class SEMrushCountrySelector extends Component {
 				label={ __( "Show results for:", "wordpress-seo" ) }
 				wrapperClassName="yoast-field-group"
 			>
-				<SingleSelect
-					label="Test single select"
-					id={ id }
-					name="semrush-country-code"
-					options={ countries }
-					selected={ this.props.countryCode }
-					onChange={ ( selected ) =>
-						this.props.setCountry( selected )
+				<div style={ { display: "flex", flexDirection: "row", height: 62, width: "70%" } }>
+					<div style={ { flexGrow: 1, padding: 0, margin: 0, paddingRight: 10 } }>
+						<SingleSelect
+							id={ id }
+							name="semrush-country-code"
+							options={ countries }
+							selected={ this.props.countryCode }
+							onChange={ ( selected ) =>
+								this.props.setCountry( selected )
 					 }
-				/>
-				<button
-					className="yoast-button yoast-button--secondary"
-					onClick={ this.relatedKeyphrasesRequest }
-				>
-					{ __( "Change Country", "wordpress-seo" ) }
-				</button>
+						/>
+					</div>
+					<button
+						style={ { height: 42, alignSelf: "center" } }
+						className="yoast-button yoast-button--secondary"
+						onClick={ this.relatedKeyphrasesRequest }
+					>
+						{ __( "Change Country", "wordpress-seo" ) }
+					</button>
+				</div>
 			</FieldGroup>
 		);
 	}

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -6,7 +6,7 @@ import { addQueryArgs } from "@wordpress/url";
 import { __ } from "@wordpress/i18n";
 
 /* Yoast dependencies */
-import { ErrorBoundary, FieldGroup } from "@yoast/components";
+import { ErrorBoundary, FieldGroup, SingleSelect } from "@yoast/components";
 
 /**
  * The ID of the SEMrush Country Selection component.
@@ -14,21 +14,6 @@ import { ErrorBoundary, FieldGroup } from "@yoast/components";
  * @type {string} id The ID of the component.
  */
 const id = "semrush-country-selector";
-
-/**
- * Renders a HTML option based on a name and value.
- *
- * @param {string} name  The name of the option.
- * @param {string} value The value of the option.
- *
- * @returns {React.Component} An HTML option.
- */
-const Option = ( { name, value } ) => <option key={ value } value={ value }>{ name }</option>;
-
-Option.propTypes = {
-	name: PropTypes.string.isRequired,
-	value: PropTypes.string.isRequired,
-};
 
 /**
  * List of all available database countries for the SEMrush API.
@@ -167,14 +152,8 @@ class SEMrushCountrySelector extends Component {
 	 * @returns {void}
 	 */
 	constructor( props ) {
-		// Make sure that both jQuery and select2 are defined on the global window.
-		if ( typeof window.jQuery().select2 === "undefined" ) {
-			throw new Error( "No Select2 found." );
-		}
-
 		super( props );
 
-		this.onChangeHandler = this.onChangeHandler.bind( this );
 		this.relatedKeyphrasesRequest = this.relatedKeyphrasesRequest.bind( this );
 	}
 
@@ -184,29 +163,10 @@ class SEMrushCountrySelector extends Component {
 	 * @returns {void}
 	 */
 	componentDidMount() {
-		this.select2 = jQuery( `#${ id }` );
-		this.select2.select2( {
-			theme: "default yoast-select2--inline",
-			dropdownCssClass: "yoast-select__dropdown",
-			dropdownParent: jQuery( ".yoast-related-keyphrases-modal__content" ),
-		} );
-		this.select2.on( "change.select2", this.onChangeHandler );
-
 		//	Fire a new request when the modal is first opened
 		if ( ! this.props.response ) {
 			this.relatedKeyphrasesRequest();
 		}
-	}
-
-	/**
-	 * Handler for the onChange event.
-	 *
-	 * @returns {void}
-	 */
-	onChangeHandler() {
-		const selection = this.select2.select2( "data" ).map( option => option.id )[ 0 ];
-
-		this.props.setCountry( selection );
 	}
 
 	/**
@@ -327,13 +287,13 @@ class SEMrushCountrySelector extends Component {
 				label={ __( "Show results for:", "wordpress-seo" ) }
 				wrapperClassName="yoast-field-group"
 			>
-				<select
+				<SingleSelect
+					label="Test single select"
 					id={ id }
 					name="semrush-country-code"
-					defaultValue={ this.props.countryCode }
-				>
-					{ countries.map( Option ) }
-				</select>
+					options={ countries }
+					selected={ this.props.countryCode }
+				/>
 				<button
 					className="yoast-button yoast-button--secondary"
 					onClick={ this.relatedKeyphrasesRequest }

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -6,7 +6,7 @@ import { addQueryArgs } from "@wordpress/url";
 import { __ } from "@wordpress/i18n";
 
 /* Yoast dependencies */
-import { ErrorBoundary, FieldGroup, SingleSelect } from "@yoast/components";
+import { ErrorBoundary, SingleSelect } from "@yoast/components";
 
 /**
  * The ID of the SEMrush Country Selection component.
@@ -242,7 +242,7 @@ class SEMrushCountrySelector extends Component {
 	handleFailedResponse( response ) {
 		const { setRequestLimitReached, setRequestFailed } = this.props;
 
-		if ( "error" in response === false ) {
+		if ( ! ( "error" in response ) ) {
 			return;
 		}
 
@@ -294,25 +294,23 @@ class SEMrushCountrySelector extends Component {
 	 */
 	render() {
 		return (
-			<FieldGroup
-				htmlFor={ id }
-				label={ __( "Show results for:", "wordpress-seo" ) }
-				wrapperClassName="yoast-field-group"
-			>
+			<div id={ id }>
 				<SingleSelect
-					id={ id }
+					id={ id + "-select" }
+					label={ __( "Show results for:", "wordpress-seo" ) }
 					name="semrush-country-code"
 					options={ countries }
 					selected={ this.props.countryCode }
 					onChange={ this.onChangeHandler }
 				/>
 				<button
+					id={ id + "-button" }
 					className="yoast-button yoast-button--secondary"
 					onClick={ this.relatedKeyphrasesRequest }
 				>
 					{ __( "Change Country", "wordpress-seo" ) }
 				</button>
-			</FieldGroup>
+			</div>
 		);
 	}
 }

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -13,7 +13,7 @@ import { ErrorBoundary, SingleSelect } from "@yoast/components";
  *
  * @type {string} id The ID of the component.
  */
-const id = "semrush-country-selector";
+const id = "yoast-semrush-country-selector";
 
 /**
  * List of all available database countries for the SEMrush API.

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -293,6 +293,9 @@ class SEMrushCountrySelector extends Component {
 					name="semrush-country-code"
 					options={ countries }
 					selected={ this.props.countryCode }
+					onChange={ ( selected ) =>
+						this.props.setCountry( selected )
+					 }
 				/>
 				<button
 					className="yoast-button yoast-button--secondary"

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -155,6 +155,7 @@ class SEMrushCountrySelector extends Component {
 		super( props );
 
 		this.relatedKeyphrasesRequest = this.relatedKeyphrasesRequest.bind( this );
+		this.onChangeHandler = this.onChangeHandler.bind( this );
 	}
 
 	/**
@@ -276,6 +277,17 @@ class SEMrushCountrySelector extends Component {
 	}
 
 	/**
+	 * Save the selected value in the store.
+	 *
+	 * @param {string} selected The user selection.
+	 *
+	 * @returns {void}
+	 */
+	onChangeHandler( selected ) {
+		this.props.setCountry( selected );
+	}
+
+	/**
 	 * Renders the SEMrush Country Selector.
 	 *
 	 * @returns {wp.Element} The SEMrush Country Selector.
@@ -294,9 +306,7 @@ class SEMrushCountrySelector extends Component {
 							name="semrush-country-code"
 							options={ countries }
 							selected={ this.props.countryCode }
-							onChange={ ( selected ) =>
-								this.props.setCountry( selected )
-					 }
+							onChange={ this.onChangeHandler }
 						/>
 					</div>
 					<button

--- a/js/tests/components/SEMrushCountrySelector.test.js
+++ b/js/tests/components/SEMrushCountrySelector.test.js
@@ -29,7 +29,7 @@ describe( "SEMrushCountrySelector", () => {
 			setRequestSucceeded={ noop } setRequestLimitReached={ noop } setRequestFailed={ noop } setNoResultsFound={ noop }
 		/> );
 
-		component.find( "#semrush-country-selector-select" ).simulate( "change" );
+		component.find( "#yoast-semrush-country-selector-select" ).simulate( "change" );
 
 		expect( setCountryMock ).toHaveBeenCalled();
 	} );

--- a/js/tests/components/SEMrushCountrySelector.test.js
+++ b/js/tests/components/SEMrushCountrySelector.test.js
@@ -22,12 +22,15 @@ describe( "SEMrushCountrySelector", () => {
 
 		expect( onClickMock ).toHaveBeenCalled();
 	} );
-	it( "validates the amount of options loaded within the select", () => {
+	it( "successfully calls the associated setCountry function when the selected option has changed", () => {
+		const setCountryMock = jest.fn();
 		const component = shallow( <SEMrushCountrySelector
-			setCountry={ noop } newRequest={ noop } setNoResultsFoundnewRequest={ noop }
+			setCountry={ setCountryMock } newRequest={ noop } setNoResultsFoundnewRequest={ noop }
 			setRequestSucceeded={ noop } setRequestLimitReached={ noop } setRequestFailed={ noop } setNoResultsFound={ noop }
 		/> );
 
-		expect( component.find( "select" ).getElement().props.children.length ).toEqual( 117 );
+		component.find( "#semrush-country-selector" ).simulate( "change" );
+
+		expect( setCountryMock ).toHaveBeenCalled();
 	} );
 } );

--- a/js/tests/components/SEMrushCountrySelector.test.js
+++ b/js/tests/components/SEMrushCountrySelector.test.js
@@ -29,7 +29,7 @@ describe( "SEMrushCountrySelector", () => {
 			setRequestSucceeded={ noop } setRequestLimitReached={ noop } setRequestFailed={ noop } setNoResultsFound={ noop }
 		/> );
 
-		component.find( "#semrush-country-selector" ).simulate( "change" );
+		component.find( "#semrush-country-selector-select" ).simulate( "change" );
 
 		expect( setCountryMock ).toHaveBeenCalled();
 	} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
After some issues arose due to refactoring of the css, it was decided that the select2 implementation in the `SEMrushCountrySelector` component should be replaced with a react-select component from the monorepo (see [javascript#851](https://github.com/Yoast/javascript/pull/851) for the adjustments made in the monorepo). 

IMPORTANT: the styling of the `SEMrushCountrySelector` component is not completely correct yet (i.e., the placement of the button next to the Select, it is currently still below the Select). An issue has already been added to the board of Team Frontend. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Uses react-select instead of select2 for the SEMrushCountrySelector component.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout `P3-144-adjust-multiselect` on wordpress-seo and the monorepo 
* Run `yarn link-monorepo` and build free
* Edit a post and delete the errors in the console as they are not related
* inster a ckeyphrase and click the "Get related keyphrases button"
* Make sure the styling of the select is correct
* Make sure the search function works
* Make sure the `countryCode` value in the store is updated when you change the country
* check the console, see that a warning is reaised but it depends on the internal implementation of the `SingleSelect` component so it's not due to our PR (if you open the `Advanced` accordion item below, which uses the ReactSelect as well, you'll see the same warning):
```
Warning: Using UNSAFE_componentWillReceiveProps in strict mode is not recommended and may indicate bugs in your code. See https://fb.me/react-async-component-lifecycle-hooks for details.
* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
Please update the following components: AutosizeInput, Select
```
* Check anything else you can think of :)
* run `yarn test` to see that all the tests are passing (currently there are two `console.error` calls in another test that passes anyway, so ignore them)
* Beware that the styling has yet to be fixed (the button goes below the select, and if you use the searching in the select there is a blueish border on focus of the internal text input)

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-144]
