### PR TITLE
P3-146 Make the Yoast replace var plugin available on edit terms page

### DIFF
--- a/config/grunt/task-config/eslint.js
+++ b/config/grunt/task-config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 127,
+			maxWarnings: 123,
 		},
 	},
 	tests: {

--- a/js/src/initializers/term-scraper.js
+++ b/js/src/initializers/term-scraper.js
@@ -1,4 +1,4 @@
-/* global YoastSEO: true, wpseoScriptData */
+/* global wpseoScriptData */
 
 // External dependencies.
 import { App, TaxonomyAssessor } from "yoastseo";
@@ -118,7 +118,7 @@ export default function initTermScraper( $, store, editorData ) {
 			slug: termSlugInput.val(),
 		};
 
-		YoastSEO.store.dispatch( updateData( snippetEditorData ) );
+		window.YoastSEO.store.dispatch( updateData( snippetEditorData ) );
 	}
 
 	/**
@@ -308,37 +308,41 @@ export default function initTermScraper( $, store, editorData ) {
 		window.YoastSEO.store = store;
 		window.YoastSEO.analysis = {};
 		window.YoastSEO.analysis.worker = createAnalysisWorker();
-		window.YoastSEO.analysis.collectData = () => collectAnalysisData( editorData, YoastSEO.store, customAnalysisData, YoastSEO.app.pluggable );
-		window.YoastSEO.analysis.applyMarks = ( paper, result ) => getApplyMarks( YoastSEO.store )( paper, result );
+		window.YoastSEO.analysis.collectData = () => collectAnalysisData(
+			editorData,
+			window.YoastSEO.store,
+			customAnalysisData,
+			window.YoastSEO.app.pluggable
+		);
+		window.YoastSEO.analysis.applyMarks = ( paper, result ) => getApplyMarks( window.YoastSEO.store )( paper, result );
 
 		// YoastSEO.app overwrites.
-		YoastSEO.app.refresh = debounce( () => refreshAnalysis(
-			YoastSEO.analysis.worker,
-			YoastSEO.analysis.collectData,
-			YoastSEO.analysis.applyMarks,
-			YoastSEO.store,
+		window.YoastSEO.app.refresh = debounce( () => refreshAnalysis(
+			window.YoastSEO.analysis.worker,
+			window.YoastSEO.analysis.collectData,
+			window.YoastSEO.analysis.applyMarks,
+			window.YoastSEO.store,
 			termScraper
 		), refreshDelay );
-		YoastSEO.app.registerCustomDataCallback = customAnalysisData.register;
-		YoastSEO.app.pluggable = new Pluggable( YoastSEO.app.refresh );
-		YoastSEO.app.registerPlugin = YoastSEO.app.pluggable._registerPlugin;
-		YoastSEO.app.pluginReady = YoastSEO.app.pluggable._ready;
-		YoastSEO.app.pluginReloaded = YoastSEO.app.pluggable._reloaded;
-		YoastSEO.app.registerModification = YoastSEO.app.pluggable._registerModification;
-		YoastSEO.app.registerAssessment = ( name, assessment, pluginName ) => {
-			if ( ! isUndefined( YoastSEO.app.seoAssessor ) ) {
-				return YoastSEO.app.pluggable._registerAssessment( YoastSEO.app.defaultSeoAssessor, name, assessment, pluginName ) &&
-					YoastSEO.app.pluggable._registerAssessment( YoastSEO.app.cornerStoneSeoAssessor, name, assessment, pluginName );
+		window.YoastSEO.app.registerCustomDataCallback = customAnalysisData.register;
+		window.YoastSEO.app.pluggable = new Pluggable( window.YoastSEO.app.refresh );
+		window.YoastSEO.app.registerPlugin = window.YoastSEO.app.pluggable._registerPlugin;
+		window.YoastSEO.app.pluginReady = window.YoastSEO.app.pluggable._ready;
+		window.YoastSEO.app.pluginReloaded = window.YoastSEO.app.pluggable._reloaded;
+		window.YoastSEO.app.registerModification = window.YoastSEO.app.pluggable._registerModification;
+		window.YoastSEO.app.registerAssessment = ( name, assessment, pluginName ) => {
+			if ( ! isUndefined( app.seoAssessor ) ) {
+				return window.YoastSEO.app.pluggable._registerAssessment( app.defaultSeoAssessor, name, assessment, pluginName ) &&
+					window.YoastSEO.app.pluggable._registerAssessment( app.cornerStoneSeoAssessor, name, assessment, pluginName );
 			}
 		};
-		YoastSEO.app.changeAssessorOptions = function( assessorOptions ) {
-			YoastSEO.analysis.worker.initialize( assessorOptions ).catch( handleWorkerError );
-			YoastSEO.app.refresh();
+		window.YoastSEO.app.changeAssessorOptions = function( assessorOptions ) {
+			window.YoastSEO.analysis.worker.initialize( assessorOptions ).catch( handleWorkerError );
+			window.YoastSEO.app.refresh();
 		};
 
-		initializeUsedKeywords( YoastSEO.app.refresh, "get_term_keyword_usage", store );
-
-		store.subscribe( handleStoreChange.bind( null, store, YoastSEO.app.refresh ) );
+		initializeUsedKeywords( app.refresh, "get_term_keyword_usage", store );
+		store.subscribe( handleStoreChange.bind( null, store, app.refresh ) );
 
 		if ( isKeywordAnalysisActive() ) {
 			app.seoAssessor = new TaxonomyAssessor( app.i18n );
@@ -348,18 +352,18 @@ export default function initTermScraper( $, store, editorData ) {
 		termScraper.initKeywordTabTemplate();
 
 		// Init Plugins.
-		YoastSEO.wp = {};
-		YoastSEO.wp.replaceVarsPlugin = new YoastReplaceVarPlugin( app, store );
+		window.YoastSEO.wp = {};
+		window.YoastSEO.wp.replaceVarsPlugin = new YoastReplaceVarPlugin( app, store );
 
 		// For backwards compatibility.
-		YoastSEO.analyzerArgs = args;
+		window.YoastSEO.analyzerArgs = args;
 
 		initTermSlugWatcher();
 		termScraper.bindElementEvents( debounce( () => refreshAnalysis(
-			YoastSEO.analysis.worker,
-			YoastSEO.analysis.collectData,
-			YoastSEO.analysis.applyMarks,
-			YoastSEO.store,
+			window.YoastSEO.analysis.worker,
+			window.YoastSEO.analysis.collectData,
+			window.YoastSEO.analysis.applyMarks,
+			window.YoastSEO.store,
 			termScraper,
 		), refreshDelay ) );
 
@@ -372,7 +376,7 @@ export default function initTermScraper( $, store, editorData ) {
 		}
 
 		// Initialize the analysis worker.
-		YoastSEO.analysis.worker.initialize( getAnalysisConfiguration( { useTaxonomy: true } ) )
+		window.YoastSEO.analysis.worker.initialize( getAnalysisConfiguration( { useTaxonomy: true } ) )
 			.then( () => {
 				jQuery( window ).trigger( "YoastSEO:ready" );
 			} )
@@ -396,7 +400,7 @@ export default function initTermScraper( $, store, editorData ) {
 		store.dispatch( updateData( snippetEditorData ) );
 
 		let focusKeyword = store.getState().focusKeyword;
-		requestWordsToHighlight( YoastSEO.analysis.worker.runResearch, YoastSEO.store, focusKeyword );
+		requestWordsToHighlight( window.YoastSEO.analysis.worker.runResearch, window.YoastSEO.store, focusKeyword );
 
 		const refreshAfterFocusKeywordChange = debounce( () => {
 			app.refresh();
@@ -410,7 +414,7 @@ export default function initTermScraper( $, store, editorData ) {
 			if ( focusKeyword !== newFocusKeyword ) {
 				focusKeyword = newFocusKeyword;
 
-				requestWordsToHighlight( YoastSEO.analysis.worker.runResearch, YoastSEO.store, focusKeyword );
+				requestWordsToHighlight( window.YoastSEO.analysis.worker.runResearch, window.YoastSEO.store, focusKeyword );
 
 				document.getElementById( "hidden_wpseo_focuskw" ).value = focusKeyword;
 				refreshAfterFocusKeywordChange();
@@ -437,7 +441,7 @@ export default function initTermScraper( $, store, editorData ) {
 		} );
 
 		initializationDone();
-		YoastSEO.app.refresh();
+		window.YoastSEO.app.refresh();
 	}
 
 	jQuery( document ).ready( initializeTermAnalysis );

--- a/js/src/initializers/term-scraper.js
+++ b/js/src/initializers/term-scraper.js
@@ -49,6 +49,9 @@ setWordPressSeoL10n();
 
 window.yoastHideMarkers = true;
 
+// Plugin class prototypes (not the instances) are being used by other plugins from the window.
+window.YoastReplaceVarPlugin = YoastReplaceVarPlugin;
+
 /**
  * @summary Initializes the term scraper script.
  *


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Yoast replacement variables plugin was not available on edit terms page for usage by other plugins.

## Relevant technical choices:

* Followed the pattern used on the post scraper, where the YoastReplaceVarPlugin class prototype is made available on the window object for usage by other plugins.
* removed the YoastSEO global usage to make the coding pattern in term scraper consistent with the one in post scraper
* lowered the ESLint maxwarnings limit to 123

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- install and activate Yoast SEO trunk, Advanced Custom Fields 5.9.0, and ACF Content Analysis for Yoast SEO 2.7 (cloning and building the develop repo is fine: https://github.com/Yoast/yoast-acf-analysis )
- create an Advanced Custom Fields group with at least one simple input field of type text
- make it available for Taxonomies:

<img width="1006" alt="Screenshot 2020-09-04 at 11 18 49" src="https://user-images.githubusercontent.com/1682452/92225021-ef973c00-eea2-11ea-8a64-eb03ddb5249d.png">

- edit a term (a category or a tag)
- observe there are no JS errors in your browser's dev tools console 
- in the Google preview title and meta description, insert some replacement variables (e.g. the `Term title`) and observe they work and there are no JS errors

**To test the analysis works and analyzes also the ACF fields:**
- in the Description textarea (the WordPress one that uses TinyMCE) insert 10 words, for example: `this is my description and it gets a SEO analysis`
- Update the term
- after the page reloads, see the SEO analysis "Text length" assessment reports: "The text contains 10 words."
- add three words in the ACF input field
- Update the term
- after the page reloads, see the SEO analysis "Text length" assessment reports: "The text contains 13 words."

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-146]
