### PR TITLE
Add website field from a user's WordPress profile SameAs array

### DIFF
--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -149,10 +149,7 @@ class Person extends Abstract_Schema_Piece {
 			$data['description'] = $this->helpers->schema->html->smart_strip_tags( $user_data->description );
 		}
 
-		$social_profiles = $this->get_social_profiles( $user_id );
-		if ( ! empty( $social_profiles ) ) {
-			$data['sameAs'] = $social_profiles;
-		}
+		$data = $this->add_same_as_urls( $data, $user_data, $user_id );
 
 		return $data;
 	}
@@ -267,5 +264,30 @@ class Person extends Abstract_Schema_Piece {
 
 		// Author archive from the same user as the site represents.
 		return $this->context->indexable->object_type === 'user' && $this->context->site_user_id === $this->context->indexable->object_id;
+	}
+
+	/**
+	 * Builds our SameAs array.
+	 *
+	 * @param array   $data      The Person schema data.
+	 * @param WP_User $user_data The user data object.
+	 * @param int     $user_id   The user ID to use.
+	 *
+	 * @return array The Person schema data.
+	 */
+	private function add_same_as_urls( array $data, WP_User $user_data, $user_id ) {
+		// Add the "Website" field from WordPress' contact info.
+		if ( ! empty( $user_data->user_url ) ) {
+			$same_as_urls[] = $user_data->user_url;
+		}
+
+		// Add the social profiles.
+		$same_as_urls = $this->get_social_profiles( $user_id );
+
+		if ( ! empty( $same_as_urls ) ) {
+			$data['sameAs'] = $same_as_urls;
+		}
+
+		return $data;
 	}
 }

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -87,11 +87,12 @@ class Person extends Abstract_Schema_Piece {
 	/**
 	 * Retrieve a list of social profile URLs for Person.
 	 *
-	 * @param int $user_id User ID.
+	 * @param array $same_as_urls Array of SameAs URLs.
+	 * @param int   $user_id      User ID.
 	 *
-	 * @return string[] $output A list of social profiles.
+	 * @return string[] $same_as_urls A list of SameAs URLs.
 	 */
-	protected function get_social_profiles( $user_id ) {
+	protected function get_social_profiles( $same_as_urls, $user_id ) {
 		/**
 		 * Filter: 'wpseo_schema_person_social_profiles' - Allows filtering of social profiles per user.
 		 *
@@ -101,11 +102,10 @@ class Person extends Abstract_Schema_Piece {
 		 *                                key. As they are retrieved using the WordPress function `get_the_author_meta`.
 		 */
 		$social_profiles = \apply_filters( 'wpseo_schema_person_social_profiles', $this->social_profiles, $user_id );
-		$output          = [];
 
 		// We can only handle an array.
 		if ( ! \is_array( $social_profiles ) ) {
-			return $output;
+			return $same_as_urls;
 		}
 
 		foreach ( $social_profiles as $profile ) {
@@ -116,11 +116,11 @@ class Person extends Abstract_Schema_Piece {
 
 			$social_url = $this->url_social_site( $profile, $user_id );
 			if ( $social_url ) {
-				$output[] = $social_url;
+				$same_as_urls[] = $social_url;
 			}
 		}
 
-		return $output;
+		return $same_as_urls;
 	}
 
 	/**
@@ -275,14 +275,16 @@ class Person extends Abstract_Schema_Piece {
 	 *
 	 * @return array The Person schema data.
 	 */
-	private function add_same_as_urls( array $data, WP_User $user_data, $user_id ) {
+	protected function add_same_as_urls( $data, $user_data, $user_id ) {
+		$same_as_urls = [];
+
 		// Add the "Website" field from WordPress' contact info.
 		if ( ! empty( $user_data->user_url ) ) {
 			$same_as_urls[] = $user_data->user_url;
 		}
 
 		// Add the social profiles.
-		$same_as_urls = $this->get_social_profiles( $user_id );
+		$same_as_urls = $this->get_social_profiles( $same_as_urls, $user_id );
 
 		if ( ! empty( $same_as_urls ) ) {
 			$data['sameAs'] = $same_as_urls;

--- a/tests/unit/generators/schema/author-test.php
+++ b/tests/unit/generators/schema/author-test.php
@@ -92,6 +92,7 @@ class Author_Test extends TestCase {
 			'caption' => 'Ad Minnie',
 		],
 		'sameAs' => [
+			'https://piet.blog/',
 			'https://facebook.example.org/admin',
 			'https://instagram.example.org/admin',
 			'https://linkedin.example.org/admin',
@@ -212,6 +213,7 @@ class Author_Test extends TestCase {
 		$user_data       = (object) [
 			'display_name' => $this->person_data['name'],
 			'user_email'   => 'bla@example.org',
+			'user_url'     => 'https://piet.blog/',
 		];
 
 		$this->instance->context->site_represents = 'person';
@@ -288,7 +290,7 @@ class Author_Test extends TestCase {
 	 * @param int   $user_id    The user id.
 	 * @param array $site_array The array of socials, mapping social site name to URL.
 	 *
-	 * @throws ExpectationArgsRequired
+	 * @throws ExpectationArgsRequired When args missing / wrong.
 	 */
 	private function expect_socials( $user_id, $site_array ) {
 		Filters\expectApplied( 'wpseo_schema_person_social_profiles' )
@@ -312,6 +314,7 @@ class Author_Test extends TestCase {
 		$person_logo_id                                  = 'person_logo_id';
 		$user_data                                       = (object) [
 			'display_name' => 'Piet',
+			'user_url'     => 'https://piet.blog/',
 		];
 		$this->instance->context->site_user_id           = 123;
 		$this->instance->context->site_url               = 'http://example.com';
@@ -343,6 +346,7 @@ class Author_Test extends TestCase {
 		$person_logo_id                                  = 'person_logo_id';
 		$user_data                                       = (object) [
 			'display_name' => 'Piet',
+			'user_url'     => 'https://piet.blog/',
 		];
 		$this->instance->context->site_user_id           = 123;
 		$this->instance->context->site_url               = 'http://example.com';


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* If a user has a `website` set in their WordPress profile, use it in their `SameAs` array in the Schema output.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go into your WordPress profile, add a URL to your `website` field.
* Go to a post you authored, check the schema.
* See the website as part of the `sameAs` for your `author` section.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes PROD-231
