### PR TITLE
Restrict Schema output on password-protected pages

### DIFF
--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -130,7 +130,7 @@ class Schema_Generator implements Generator_Interface {
 	}
 
 	/**
-	 * Allow filtering the graph piece by its schema type.
+	 * Allows filtering the graph piece by its schema type.
 	 *
 	 * @param array             $graph_piece The graph piece we're filtering.
 	 * @param string            $identifier  The identifier of the graph piece that is being filtered.
@@ -220,18 +220,47 @@ class Schema_Generator implements Generator_Interface {
 	 * @return Abstract_Schema_Piece[] A filtered array of graph pieces.
 	 */
 	protected function get_graph_pieces( $context ) {
-		$schema_pieces = [
-			new Schema\Organization(),
-			new Schema\Person(),
-			new Schema\Website(),
-			new Schema\Main_Image(),
-			new Schema\WebPage(),
-			new Schema\Breadcrumb(),
-			new Schema\Article(),
-			new Schema\Author(),
-			new Schema\FAQ(),
-			new Schema\HowTo(),
-		];
+		if ( \post_password_required() ){
+			$schema_pieces = [
+				new Schema\Organization(),
+				new Schema\Website(),
+				new Schema\WebPage(),
+				];
+
+			// The WebPage graph piece should only have selected properties, and @type should always be set to WebPage.
+			\add_filter( 'wpseo_schema_webpage', function( $graph_piece ) {
+				$webpage_public_properties = \array_flip( [
+					'@type',
+					'@id',
+					'url',
+					'name',
+					'isPartOf',
+					'inLanguage',
+					'datePublished',
+					'dateModified',
+					'breadcrumb'
+				] );
+
+				$graph_piece          = \array_intersect_key( $graph_piece, $webpage_public_properties );
+				print_r( $graph_piece );
+				$graph_piece['@type'] = 'WebPage';
+
+				return $graph_piece;
+			});
+		} else {
+			$schema_pieces = [
+				new Schema\Organization(),
+				new Schema\Person(),
+				new Schema\Website(),
+				new Schema\Main_Image(),
+				new Schema\WebPage(),
+				new Schema\Breadcrumb(),
+				new Schema\Article(),
+				new Schema\Author(),
+				new Schema\FAQ(),
+				new Schema\HowTo(),
+			];
+		}
 
 		/**
 		 * Filter: 'wpseo_schema_graph_pieces' - Allows adding pieces to the graph.

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -168,14 +168,14 @@ class Schema_Generator implements Generator_Interface {
 	 * @return Abstract_Schema_Piece[] A filtered array of graph pieces.
 	 */
 	protected function get_graph_pieces( $context ) {
-		if ( \post_password_required() ) {
+		if ( \is_single() && \post_password_required() ) {
 			$schema_pieces = [
 				new Schema\Organization(),
 				new Schema\Website(),
 				new Schema\WebPage(),
 			];
 
-			\add_filter( 'wpseo_schema_webpage', [ $this, 'protected_webpage_schema' ] );
+			\add_filter( 'wpseo_schema_webpage', [ $this, 'protected_webpage_schema' ], 1 );
 		}
 		else {
 			$schema_pieces = [

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -171,8 +171,10 @@ class Schema_Generator implements Generator_Interface {
 			if ( \is_array( $piece['@type'] ) ) {
 				return $piece['@type'];
 			}
+
 			return [ $piece['@type'] ];
 		}
+
 		return [];
 	}
 
@@ -229,7 +231,8 @@ class Schema_Generator implements Generator_Interface {
 
 			// The WebPage graph piece should only have selected properties, and @type should always be set to WebPage.
 			\add_filter( 'wpseo_schema_webpage', [ $this, 'protected_webpage_schema' ] );
-		} else {
+		}
+		else {
 			$schema_pieces = [
 				new Schema\Organization(),
 				new Schema\Person(),
@@ -265,17 +268,19 @@ class Schema_Generator implements Generator_Interface {
 	 * @return array The WebPage graph piece that has been adapted for password-protected posts.
 	 */
 	public function protected_webpage_schema( $graph_piece ) {
-		$properties_to_show = \array_flip( [
-			'@type',
-			'@id',
-			'url',
-			'name',
-			'isPartOf',
-			'inLanguage',
-			'datePublished',
-			'dateModified',
-			'breadcrumb'
-		] );
+		$properties_to_show = \array_flip(
+			[
+				'@type',
+				'@id',
+				'url',
+				'name',
+				'isPartOf',
+				'inLanguage',
+				'datePublished',
+				'dateModified',
+				'breadcrumb',
+			]
+		);
 
 		$graph_piece          = \array_intersect_key( $graph_piece, $properties_to_show );
 		$graph_piece['@type'] = 'WebPage';

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -220,32 +220,15 @@ class Schema_Generator implements Generator_Interface {
 	 * @return Abstract_Schema_Piece[] A filtered array of graph pieces.
 	 */
 	protected function get_graph_pieces( $context ) {
-		if ( \post_password_required() ){
+		if ( \post_password_required() ) {
 			$schema_pieces = [
 				new Schema\Organization(),
 				new Schema\Website(),
 				new Schema\WebPage(),
-				];
+			];
 
 			// The WebPage graph piece should only have selected properties, and @type should always be set to WebPage.
-			\add_filter( 'wpseo_schema_webpage', function( $graph_piece ) {
-				$webpage_public_properties = \array_flip( [
-					'@type',
-					'@id',
-					'url',
-					'name',
-					'isPartOf',
-					'inLanguage',
-					'datePublished',
-					'dateModified',
-					'breadcrumb'
-				] );
-
-				$graph_piece          = \array_intersect_key( $graph_piece, $webpage_public_properties );
-				$graph_piece['@type'] = 'WebPage';
-
-				return $graph_piece;
-			});
+			\add_filter( 'wpseo_schema_webpage', [ $this, 'protected_webpage_schema' ] );
 		} else {
 			$schema_pieces = [
 				new Schema\Organization(),
@@ -269,5 +252,34 @@ class Schema_Generator implements Generator_Interface {
 		 * @api array $pieces The schema pieces.
 		 */
 		return \apply_filters( 'wpseo_schema_graph_pieces', $schema_pieces, $context );
+	}
+
+	/**
+	 * Adapts the WebPage graph piece for password-protected posts.
+	 *
+	 * It should only have certain whitelisted properties.
+	 * The type should always be WebPage.
+	 *
+	 * @param array $graph_piece The WebPage graph piece that should be adapted for password-protected posts.
+	 *
+	 * @return array The WebPage graph piece that has been adapted for password-protected posts.
+	 */
+	public function protected_webpage_schema( $graph_piece ) {
+		$properties_to_show = \array_flip( [
+			'@type',
+			'@id',
+			'url',
+			'name',
+			'isPartOf',
+			'inLanguage',
+			'datePublished',
+			'dateModified',
+			'breadcrumb'
+		] );
+
+		$graph_piece          = \array_intersect_key( $graph_piece, $properties_to_show );
+		$graph_piece['@type'] = 'WebPage';
+
+		return $graph_piece;
 	}
 }

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -82,7 +82,7 @@ class Schema_Generator implements Generator_Interface {
 		foreach ( $pieces_to_generate as $identifier => $piece ) {
 			$graph_pieces = $piece->generate();
 			// If only a single graph piece was returned.
-			if ( isset( $graph_pieces['@type'] ) ) {
+			if ( \array_key_exists( '@type', $graph_pieces ) ) {
 				$graph_pieces = [ $graph_pieces ];
 			}
 

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -242,7 +242,6 @@ class Schema_Generator implements Generator_Interface {
 				] );
 
 				$graph_piece          = \array_intersect_key( $graph_piece, $webpage_public_properties );
-				print_r( $graph_piece );
 				$graph_piece['@type'] = 'WebPage';
 
 				return $graph_piece;

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -130,6 +130,79 @@ class Schema_Generator implements Generator_Interface {
 	}
 
 	/**
+	 * Adapts the WebPage graph piece for password-protected posts.
+	 *
+	 * It should only have certain whitelisted properties.
+	 * The type should always be WebPage.
+	 *
+	 * @param array $graph_piece The WebPage graph piece that should be adapted for password-protected posts.
+	 *
+	 * @return array The WebPage graph piece that has been adapted for password-protected posts.
+	 */
+	public function protected_webpage_schema( $graph_piece ) {
+		$properties_to_show = \array_flip(
+			[
+				'@type',
+				'@id',
+				'url',
+				'name',
+				'isPartOf',
+				'inLanguage',
+				'datePublished',
+				'dateModified',
+				'breadcrumb',
+			]
+		);
+
+		$graph_piece          = \array_intersect_key( $graph_piece, $properties_to_show );
+		$graph_piece['@type'] = 'WebPage';
+
+		return $graph_piece;
+	}
+
+	/**
+	 * Gets all the graph pieces we need.
+	 *
+	 * @param Meta_Tags_Context $context The meta tags context.
+	 *
+	 * @return Abstract_Schema_Piece[] A filtered array of graph pieces.
+	 */
+	protected function get_graph_pieces( $context ) {
+		if ( \post_password_required() ) {
+			$schema_pieces = [
+				new Schema\Organization(),
+				new Schema\Website(),
+				new Schema\WebPage(),
+			];
+
+			\add_filter( 'wpseo_schema_webpage', [ $this, 'protected_webpage_schema' ] );
+		}
+		else {
+			$schema_pieces = [
+				new Schema\Organization(),
+				new Schema\Person(),
+				new Schema\Website(),
+				new Schema\Main_Image(),
+				new Schema\WebPage(),
+				new Schema\Breadcrumb(),
+				new Schema\Article(),
+				new Schema\Author(),
+				new Schema\FAQ(),
+				new Schema\HowTo(),
+			];
+		}
+
+		/**
+		 * Filter: 'wpseo_schema_graph_pieces' - Allows adding pieces to the graph.
+		 *
+		 * @param Meta_Tags_Context $context An object with context variables.
+		 *
+		 * @api array $pieces The schema pieces.
+		 */
+		return \apply_filters( 'wpseo_schema_graph_pieces', $schema_pieces, $context );
+	}
+
+	/**
 	 * Allows filtering the graph piece by its schema type.
 	 *
 	 * @param array             $graph_piece The graph piece we're filtering.
@@ -212,79 +285,5 @@ class Schema_Generator implements Generator_Interface {
 		}
 
 		return $piece;
-	}
-
-	/**
-	 * Gets all the graph pieces we need.
-	 *
-	 * @param Meta_Tags_Context $context The meta tags context.
-	 *
-	 * @return Abstract_Schema_Piece[] A filtered array of graph pieces.
-	 */
-	protected function get_graph_pieces( $context ) {
-		if ( \post_password_required() ) {
-			$schema_pieces = [
-				new Schema\Organization(),
-				new Schema\Website(),
-				new Schema\WebPage(),
-			];
-
-			// The WebPage graph piece should only have selected properties, and @type should always be set to WebPage.
-			\add_filter( 'wpseo_schema_webpage', [ $this, 'protected_webpage_schema' ] );
-		}
-		else {
-			$schema_pieces = [
-				new Schema\Organization(),
-				new Schema\Person(),
-				new Schema\Website(),
-				new Schema\Main_Image(),
-				new Schema\WebPage(),
-				new Schema\Breadcrumb(),
-				new Schema\Article(),
-				new Schema\Author(),
-				new Schema\FAQ(),
-				new Schema\HowTo(),
-			];
-		}
-
-		/**
-		 * Filter: 'wpseo_schema_graph_pieces' - Allows adding pieces to the graph.
-		 *
-		 * @param Meta_Tags_Context $context An object with context variables.
-		 *
-		 * @api array $pieces The schema pieces.
-		 */
-		return \apply_filters( 'wpseo_schema_graph_pieces', $schema_pieces, $context );
-	}
-
-	/**
-	 * Adapts the WebPage graph piece for password-protected posts.
-	 *
-	 * It should only have certain whitelisted properties.
-	 * The type should always be WebPage.
-	 *
-	 * @param array $graph_piece The WebPage graph piece that should be adapted for password-protected posts.
-	 *
-	 * @return array The WebPage graph piece that has been adapted for password-protected posts.
-	 */
-	public function protected_webpage_schema( $graph_piece ) {
-		$properties_to_show = \array_flip(
-			[
-				'@type',
-				'@id',
-				'url',
-				'name',
-				'isPartOf',
-				'inLanguage',
-				'datePublished',
-				'dateModified',
-				'breadcrumb',
-			]
-		);
-
-		$graph_piece          = \array_intersect_key( $graph_piece, $properties_to_show );
-		$graph_piece['@type'] = 'WebPage';
-
-		return $graph_piece;
 	}
 }

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -203,7 +203,7 @@ class Schema_Generator_Test extends TestCase {
 						'inLanguage'      => 'English',
 					],
 					[
-						'@id'   => '#website',
+						'@id' => '#website',
 					],
 					[
 						[
@@ -300,7 +300,8 @@ class Schema_Generator_Test extends TestCase {
 			->andReturnArg( 0 );
 
 		$this->assertEquals(
-			$this->get_expected_schema(), $this->instance->generate( $this->context )
+			$this->get_expected_schema(),
+			$this->instance->generate( $this->context )
 		);
 	}
 

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -212,13 +212,20 @@ class Schema_Generator_Test extends TestCase {
 						'inLanguage'      => 'English',
 					],
 					[
-						'@id' => '#website',
-					],
-					[
-						[
-							'@type'  => 'ReadAction',
-							'target' => [
-								null,
+						'@type'           => null,
+						'@id'             => '#webpage',
+						'url'             => null,
+						'name'            => '',
+						'isPartOf'        => [
+							'@id' => '#website',
+						],
+						'inLanguage'      => 'English',
+						'potentialAction' => [
+							[
+								'@type'  => 'ReadAction',
+								'target' => [
+									null,
+								],
 							],
 						],
 					],

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -300,65 +300,7 @@ class Schema_Generator_Test extends TestCase {
 			->andReturnArg( 0 );
 
 		$this->assertEquals(
-			[
-				'@context' => 'https://schema.org',
-				'@graph'   => [
-					[
-						'@type'           => 'WebSite',
-						'@id'             => '#website',
-						'url'             => null,
-						'name'            => '',
-						'description'     => 'description',
-						'potentialAction' => [
-							[
-								'@type'       => 'SearchAction',
-								'target'      => '?s={search_term_string}',
-								'query-input' => 'required name=search_term_string',
-							],
-						],
-						'inLanguage'      => 'English',
-					],
-					[
-						'@type'           => [ null, 'FAQPage' ],
-						'@id'             => '#webpage',
-						'url'             => null,
-						'name'            => '',
-						'isPartOf'        => [
-							'@id' => '#website',
-						],
-						'inLanguage'      => 'English',
-						'potentialAction' => [
-							[
-								'@type'  => 'ReadAction',
-								'target' => [
-									null,
-								],
-							],
-						],
-					],
-					[
-						'@type'            => 'ItemList',
-						'mainEntityOfPage' => [ '@id' => null ],
-						'numberOfItems'    => 1,
-						'itemListElement'  => [ [ '@id' => '#id-1' ] ],
-					],
-					[
-						'@type'          => 'Question',
-						'@id'            => '#id-1',
-						'position'       => 1,
-						'url'            => '#id-1',
-						'name'           => 'This is a question',
-						'answerCount'    => 1,
-						'acceptedAnswer' => [
-							'@type'      => 'Answer',
-							'text'       => 'This is an answer',
-							'inLanguage' => 'English',
-						],
-						'inLanguage'     => 'English',
-					],
-				],
-			],
-			$this->instance->generate( $this->context )
+			$this->get_expected_schema(), $this->instance->generate( $this->context )
 		);
 	}
 

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -8,10 +8,14 @@ use Yoast\WP\SEO\Generators\Schema\FAQ;
 use Yoast\WP\SEO\Generators\Schema\Organization;
 use Yoast\WP\SEO\Generators\Schema_Generator;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
+use Yoast\WP\SEO\Helpers\Site_Helper;
+use Yoast\WP\SEO\Helpers\Url_Helper;
+use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
@@ -106,12 +110,12 @@ class Schema_Generator_Test extends TestCase {
 			Meta_Tags_Context_Mock::class,
 			[
 				$helpers->options,
-				Mockery::mock( \Yoast\WP\SEO\Helpers\Url_Helper::class ),
-				Mockery::mock( \Yoast\WP\SEO\Helpers\Image_Helper::class ),
-				Mockery::mock( \Yoast\WP\SEO\Helpers\Schema\ID_Helper::class ),
+				Mockery::mock( Url_Helper::class ),
+				Mockery::mock( Image_Helper::class ),
+				Mockery::mock( ID_Helper::class ),
 				Mockery::mock( \WPSEO_Replace_Vars::class ),
-				Mockery::mock( \Yoast\WP\SEO\Helpers\Site_Helper::class ),
-				Mockery::mock( \Yoast\WP\SEO\Helpers\User_Helper::class ),
+				Mockery::mock( Site_Helper::class ),
+				Mockery::mock( User_Helper::class ),
 			]
 		)->shouldAllowMockingProtectedMethods();
 

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -83,7 +83,7 @@ class Schema_Generator_Test extends TestCase {
 		parent::setUp();
 
 		$this->id           = Mockery::mock( ID_Helper::class );
-		$this->current_page = Mockery::mock( Current_Page_Helper::class )->makePartial();
+		$this->current_page = Mockery::mock( Current_Page_Helper::class );
 
 		$this->html = Mockery::mock( HTML_Helper::class )->makePartial();
 

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -176,7 +176,7 @@ class Schema_Generator_Test extends TestCase {
 	public function test_generate_with_no_blocks() {
 		$this->context->indexable->object_sub_type = 'super-custom-post-type';
 
-		Monkey\Functions\expect( 'post_password_required' )
+		Monkey\Functions\expect( 'is_single' )
 			->once()
 			->withNoArgs()
 			->andReturnFalse();
@@ -248,6 +248,11 @@ class Schema_Generator_Test extends TestCase {
 			->withNoArgs()
 			->andReturnFalse();
 
+		Monkey\Functions\expect( 'is_single' )
+			->once()
+			->withNoArgs()
+			->andReturnTrue();
+
 		$this->current_page
 			->expects( 'is_home_static_page' )
 			->twice()
@@ -306,6 +311,11 @@ class Schema_Generator_Test extends TestCase {
 	 * @covers ::get_graph_pieces
 	 */
 	public function test_generate_with_block_not_having_generated_output() {
+		Monkey\Functions\expect( 'is_single' )
+			->once()
+			->withNoArgs()
+			->andReturnTrue();
+
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
 			->withNoArgs()
@@ -341,6 +351,11 @@ class Schema_Generator_Test extends TestCase {
 	 */
 	public function test_validate_type_singular_array() {
 		$this->context->blocks = [];
+
+		Monkey\Functions\expect( 'is_single' )
+			->once()
+			->withNoArgs()
+			->andReturnTrue();
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
@@ -407,6 +422,11 @@ class Schema_Generator_Test extends TestCase {
 	public function test_validate_type_unique_array() {
 		$this->context->blocks = [];
 
+		Monkey\Functions\expect( 'is_single' )
+			->once()
+			->withNoArgs()
+			->andReturnTrue();
+
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
 			->withNoArgs()
@@ -467,7 +487,12 @@ class Schema_Generator_Test extends TestCase {
 	 * @covers ::generate
 	 * @covers ::get_graph_pieces
 	 */
-	public function test_get_graph_pieces_when_password_required() {
+	public function test_get_graph_pieces_on_single_post_with_password_required() {
+		Monkey\Functions\expect( 'is_single' )
+			->once()
+			->withNoArgs()
+			->andReturnTrue();
+
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
 			->withNoArgs()


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Restricts Schema output on posts that are password-protected.

## Relevant technical choices:

* In `schema-generator.php`, I [changed](https://github.com/Yoast/wordpress-seo/pull/16015/commits/979747672f36c5b9b70b45741df6b5ed761ef819) an `isset` to an `array_key_exists`. The aim of this check was/is to evaluate whether a graph piece consists of a single graph piece (in the form of `[ '@type' = 'aa', 'name' = 'bb' ]`), or multiple pieces (in the form of `[ [ '@type' = 'aa', 'name' = 'bb' ], [ '@type' = 'cc, 'name' = 'dd' ] ]`). However, a single graph piece in the form of `[ '@type' = NULL, 'name' = 'bb' ]` would not have been recognized as being a single piece, because `isset` evaluates to false when the `@type` is `NULL`. In the same scenario, `array_key_exists` will evaluate to true. This is a bug that already existed in the code, but only was discovered now. @herregroen has approved this fix.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

In `release/15.0`:
* Create a post with an FAQ block and fill it with dummy data.
* Set the visibility of the post to password protected
* Publish the post and visit it. See that it asks for a password.
* Check the source of the page, see it will output the schema with the "confidential" information.
* See that the `@type` property for the `WebPage` graph piece is set to an array containing `WebPage` and `FAQPage`.

In this branch:
* Repeat the above steps.
* See that the Schema output only contains graph pieces for `WebSite`, `WebPage` and potentially `Organization`.
    * Whether or not you see `Organization` depends on your settings.
* See that the `@type` property for the `WebPage` graph piece is set to `WebPage` only.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/13594 and https://yoast.atlassian.net/browse/P2-338
