### PR TITLE
[P3-266] Remove the admin bar on block editor pages

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -77,7 +77,8 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	public function add_menu( WP_Admin_Bar $wp_admin_bar ) {
 
 		// On block editor pages, the admin bar only shows on mobile, where having this menu icon is not very helpful.
-		if ( get_current_screen()->is_block_editor() ) {
+		$screen = get_current_screen();
+		if ( isset( $screen ) && $screen->is_block_editor() ) {
 			return;
 		}
 

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -527,6 +527,10 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return string Score markup, or empty string if none available.
 	 */
 	protected function get_post_score( $post ) {
+		if ( get_current_screen()->is_block_editor() ) {
+			return '';
+		}
+
 		if ( ! is_object( $post ) || ! property_exists( $post, 'ID' ) ) {
 			return '';
 		}
@@ -580,6 +584,10 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return string Score markup, or empty string if none available.
 	 */
 	protected function get_term_score( $term ) {
+		if ( get_current_screen()->is_block_editor() ) {
+			return '';
+		}
+
 		if ( ! is_object( $term ) || ! property_exists( $term, 'term_id' ) || ! property_exists( $term, 'taxonomy' ) ) {
 			return '';
 		}

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -76,6 +76,11 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 */
 	public function add_menu( WP_Admin_Bar $wp_admin_bar ) {
 
+		// On block editor pages, the admin bar only shows on mobile, where having this menu icon is not very helpful.
+		if ( get_current_screen()->is_block_editor() ) {
+			return;
+		}
+
 		// If the current user can't write posts, this is all of no use, so let's not output an admin menu.
 		if ( ! current_user_can( 'edit_posts' ) ) {
 			return;
@@ -527,10 +532,6 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return string Score markup, or empty string if none available.
 	 */
 	protected function get_post_score( $post ) {
-		if ( get_current_screen()->is_block_editor() ) {
-			return '';
-		}
-
 		if ( ! is_object( $post ) || ! property_exists( $post, 'ID' ) ) {
 			return '';
 		}
@@ -584,10 +585,6 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return string Score markup, or empty string if none available.
 	 */
 	protected function get_term_score( $term ) {
-		if ( get_current_screen()->is_block_editor() ) {
-			return '';
-		}
-
 		if ( ! is_object( $term ) || ! property_exists( $term, 'term_id' ) || ! property_exists( $term, 'taxonomy' ) ) {
 			return '';
 		}


### PR DESCRIPTION
Before:

<img width="375" alt="Screenshot 2020-09-07 at 19 39 12" src="https://user-images.githubusercontent.com/487629/92409721-df50bc80-f141-11ea-9789-4d1d76229fcb.png">

After:

<img width="375" alt="Screenshot 2020-09-07 at 19 38 05" src="https://user-images.githubusercontent.com/487629/92409728-e4157080-f141-11ea-9e65-01e19f5b0a10.png">

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Remove the admin bar menu on block editor pages. This only shows on mobile anyway, and there it's annoying when there's too much stuff in the admin bar as it blocks access to the block editor's toolbars.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Open a page in the block editor, switch to mobile view, see there's no Yoast admin bar menu + score. See screenshots above.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
