### PR TITLE
Replace mention of modal

### DIFF
--- a/release-info.json
+++ b/release-info.json
@@ -1,5 +1,5 @@
 {
   "version": "15.0",
-  "release_description": "Arabic readability analysis and an optimization modal in the Yoast sidebar for the block editor.",
+  "release_description": "Arabic readability analysis and all settings are now in the Yoast sidebar for the block editor.",
   "shortlink": "https://yoa.st/yoast15-0"
 }


### PR DESCRIPTION
We don't use the modal anymore, so we can't mention it here.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* We still mentioned the modal in the notification, but we don't have a modal anymore. That's fixed now.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
