### PR TITLE
Fix sanitization in term descriptions and remove unused filters

### DIFF
--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -242,21 +242,13 @@ class WPSEO_Taxonomy {
 	}
 
 	/**
-	 * Allows post-kses-filtered HTML in descriptions.
+	 * Allows post-kses-filtered HTML in term descriptions.
 	 */
 	public function custom_category_descriptions_allow_html() {
-		$filters = [
-			'pre_term_description',
-			'pre_link_description',
-			'pre_link_notes',
-			'pre_user_description',
-			'term_description',
-		];
-
-		foreach ( $filters as $filter ) {
-			remove_filter( $filter, 'wp_filter_kses' );
-			add_filter( $filter, 'wp_filter_post_kses' );
-		}
+		remove_filter( 'term_description', 'wp_kses_data');
+		remove_filter( 'pre_term_description', 'wp_filter_kses');
+		add_filter( 'term_description', 'wp_kses_post' );
+		add_filter( 'pre_term_description', 'wp_filter_post_kses' );
 	}
 
 	/**

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -242,7 +242,7 @@ class WPSEO_Taxonomy {
 	}
 
 	/**
-	 * Allows HTML in descriptions.
+	 * Allows post-kses-filtered HTML in descriptions.
 	 */
 	public function custom_category_descriptions_allow_html() {
 		$filters = [
@@ -250,15 +250,13 @@ class WPSEO_Taxonomy {
 			'pre_link_description',
 			'pre_link_notes',
 			'pre_user_description',
+			'term_description',
 		];
 
 		foreach ( $filters as $filter ) {
 			remove_filter( $filter, 'wp_filter_kses' );
-			if ( ! current_user_can( 'unfiltered_html' ) ) {
-				add_filter( $filter, 'wp_filter_post_kses' );
-			}
+			add_filter( $filter, 'wp_filter_post_kses' );
 		}
-		remove_filter( 'term_description', 'wp_kses_data' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We received warnings from concerned users about unfiltered HTML in taxonomy descriptions. While this was only possible for users with `unfiltered_html` capabilities, it wasn't optimal. WordPress itself normally does not allow this, so we should at least filter the "dangerous" stuff.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where unfiltered HTML could be inserted in taxonomy descriptions by administrators and editors.

## Relevant technical choices:

* Rewritten the function to remove unused filters:
  * The pre_link_* filters are for outdated WordPress functionality (blogroll) and no longer needed.
  * There was / is no reason to remove kses from user descriptions.
  * The description filters have their hard kses filters removed and replaced with post_kses filters to allow for HTML tags that are allowed in normal posts (but no 'dangerous' tags).
  * The difference between the different kses filters is that one expects slashed and one expects unslashed data, this makes them not inter-changeable and this can't be written with a foreach loop.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Without this change:
1. Install Yoast (14.9)
1. create and edit a category
1. Switch to the text tab of the description field
1. Insert `<script>alert(0)</script>`
1. Save and return to the category overview
1. Your browser should pop up a message "0"

With this change
* Perform the same steps, notice that there is no "0" message
* Check if the other elements of the description still work (bolding text, italics, images, et cetera)

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes several security reports
