### PR TITLE
Disabling the Yoast SEO sitemap feature does not automatically disable WordPress' own sitemap anymore.

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -149,6 +149,10 @@ class WPSEO_Admin {
 			$asset_manager = new WPSEO_Admin_Asset_Manager();
 			$asset_manager->enqueue_style( 'extensions' );
 		}
+		if ( filter_input( INPUT_GET, 'page' ) === 'wpseo_dashboard' ) {
+			$asset_manager = new WPSEO_Admin_Asset_Manager();
+			$asset_manager->enqueue_style( 'alert' );
+		}
 	}
 
 	/**

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -119,6 +119,10 @@ class WPSEO_Admin_Pages {
 			];
 		}
 
+		if ( $page === 'wpseo_dashboard' ) {
+			$script_data['isDashboard'] = true;
+		}
+
 		if ( $page === 'wpseo_tools' ) {
 			$this->enqueue_tools_scripts();
 		}

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -5,6 +5,8 @@
  * @package WPSEO\Admin
  */
 
+use Yoast\WP\SEO\Presenters\Admin\Alert_Presenter;
+
 /**
  * Admin form class.
  *
@@ -811,13 +813,10 @@ class Yoast_Form {
 	 * @return string The warning to show as an HTML string.
 	 */
 	protected function get_warning_if_off( $name, $warning_text ) {
-		$out  = '<div class="yoast-toggle-warning yoast-alert yoast-alert--warning" id="' . $name . '-warning" style="display:none">';
-		$out .= '<span>';
-		$out .= '<img class="yoast-alert__icon" src="' . \esc_url( \plugin_dir_url( \WPSEO_FILE ) . 'images/alert-warning-icon.svg' ) . '" alt="" />';
-		$out .= '</span>';
-
-		$out .= '<span>' . $warning_text . '</span>';
-		$out .= '</div>';
+		$out   = '<div class="yoast-toggle-warning" id="' . $name . '-warning" style="display:none">';
+		$alert = new Alert_Presenter( $warning_text, 'warning' );
+		$out   .= $alert->present();
+		$out   .= '</div>';
 
 		return $out;
 	}

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -707,6 +707,7 @@ class Yoast_Form {
 		echo '<a></a></div></fieldset>';
 
 		if ( $warning_if_off ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is already escaped.
 			echo $this->get_warning_if_off( $name, $warning_if_off );
 		}
 
@@ -815,8 +816,8 @@ class Yoast_Form {
 	protected function get_warning_if_off( $name, $warning_text ) {
 		$out   = '<div class="yoast-toggle-warning" id="' . $name . '-warning" style="display:none">';
 		$alert = new Alert_Presenter( $warning_text, 'warning' );
-		$out   .= $alert->present();
-		$out   .= '</div>';
+		$out  .= $alert->present();
+		$out  .= '</div>';
 
 		return $out;
 	}

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -655,12 +655,12 @@ class Yoast_Form {
 	 *
 	 * @since 3.1
 	 *
-	 * @param string $var    The variable within the option to create the radio buttons for.
-	 * @param array  $values Associative array of on/off keys and their values to be used as
-	 *                       the label elements text for the radio buttons. Optionally, each
-	 *                       value can be an array of visible label text and screen reader text.
-	 * @param string $label  The visual label for the radio buttons group, used as the fieldset legend.
-	 * @param string $help   Inline Help that will be printed out before the visible toggles text.
+	 * @param string $var            The variable within the option to create the radio buttons for.
+	 * @param array  $values         Associative array of on/off keys and their values to be used as
+	 *                               the label elements text for the radio buttons. Optionally, each
+	 *                               value can be an array of visible label text and screen reader text.
+	 * @param string $label          The visual label for the radio buttons group, used as the fieldset legend.
+	 * @param string $help           Inline Help that will be printed out before the visible toggles text.
 	 * @param string $warning_if_off Inline warning to show when the toggle is switched to `off`.
 	 */
 	public function toggle_switch( $var, $values, $label, $help = '', $warning_if_off = '' ) {

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -661,8 +661,9 @@ class Yoast_Form {
 	 *                       value can be an array of visible label text and screen reader text.
 	 * @param string $label  The visual label for the radio buttons group, used as the fieldset legend.
 	 * @param string $help   Inline Help that will be printed out before the visible toggles text.
+	 * @param string $warning_if_off Inline warning to show when the toggle is switched to `off`.
 	 */
-	public function toggle_switch( $var, $values, $label, $help = '' ) {
+	public function toggle_switch( $var, $values, $label, $help = '', $warning_if_off = '' ) {
 		if ( ! is_array( $values ) || $values === [] ) {
 			return;
 		}
@@ -684,6 +685,8 @@ class Yoast_Form {
 		echo $this->get_disabled_note( $var );
 		echo '<div class="switch-toggle switch-candy switch-yoast-seo">';
 
+		$name = esc_attr( $this->option_name ) . '[' . $var_esc . ']';
+
 		foreach ( $values as $key => $value ) {
 			$screen_reader_text_html = '';
 
@@ -695,11 +698,17 @@ class Yoast_Form {
 
 			$key_esc = esc_attr( $key );
 			$for     = $var_esc . '-' . $key_esc;
-			echo '<input type="radio" id="' . $for . '" name="' . esc_attr( $this->option_name ) . '[' . $var_esc . ']" value="' . $key_esc . '" ' . checked( $val, $key_esc, false ) . disabled( $this->is_control_disabled( $var ), true, false ) . ' />',
+			echo '<input type="radio" id="' . $for . '" name="' . $name . '" value="' . $key_esc . '" ' . checked( $val, $key_esc, false ) . disabled( $this->is_control_disabled( $var ), true, false ) . ' />',
 			'<label for="', $for, '">', esc_html( $value ), $screen_reader_text_html, '</label>';
 		}
 
-		echo '<a></a></div></fieldset><div class="clear"></div></div>' . PHP_EOL . PHP_EOL;
+		echo '<a></a></div></fieldset>';
+
+		if ( $warning_if_off ) {
+			echo $this->get_warning_if_off( $name, $warning_if_off );
+		}
+
+		echo '<div class="clear"></div></div>' . PHP_EOL . PHP_EOL;
 	}
 
 	/**
@@ -791,5 +800,25 @@ class Yoast_Form {
 		}
 
 		return '<p class="disabled-note">' . esc_html__( 'This feature has been disabled by the network admin.', 'wordpress-seo' ) . '</p>';
+	}
+
+	/**
+	 * Creates a warning alert element to show when a toggle is set to 'off'.
+	 *
+	 * @param string $name         The name of the toggle element.
+	 * @param string $warning_text The warning text.
+	 *
+	 * @return string The warning to show as an HTML string.
+	 */
+	protected function get_warning_if_off( $name, $warning_text ) {
+		$out  = '<div class="yoast-toggle-warning yoast-alert yoast-alert--warning" id="' . $name . '-warning" style="display:none">';
+		$out .= '<span>';
+		$out .= '<img class="yoast-alert__icon" src="' . \esc_url( \plugin_dir_url( \WPSEO_FILE ) . 'images/alert-warning-icon.svg' ) . '" alt="" />';
+		$out .= '</span>';
+
+		$out .= '<span>' . $warning_text . '</span>';
+		$out .= '</div>';
+
+		return $out;
 	}
 }

--- a/admin/views/class-yoast-feature-toggle.php
+++ b/admin/views/class-yoast-feature-toggle.php
@@ -53,6 +53,13 @@ class Yoast_Feature_Toggle {
 	protected $extra = '';
 
 	/**
+	 * Optional warning to show when the toggle is set to 'off'.
+	 *
+	 * @var string
+	 */
+	protected $warning_if_off = '';
+
+	/**
 	 * Value to specify the feature toggle order.
 	 *
 	 * @var string

--- a/admin/views/class-yoast-feature-toggles.php
+++ b/admin/views/class-yoast-feature-toggles.php
@@ -108,6 +108,7 @@ class Yoast_Feature_Toggles {
 				'read_more_label' => __( 'Read why XML Sitemaps are important for your site.', 'wordpress-seo' ),
 				'read_more_url'   => 'https://yoa.st/2a-',
 				'extra'           => $xml_sitemap_extra,
+				'warning_if_off'  => __( 'Disabling Yoast SEO’s XML sitemaps will not disable WordPress’ core sitemaps. In some cases, this <a href="#">may result in SEO errors on your site</a>. These may be reported in Google Search Console and other tools.', 'wordpress-seo' ),
 				'order'           => 60,
 			],
 			(object) [

--- a/admin/views/class-yoast-feature-toggles.php
+++ b/admin/views/class-yoast-feature-toggles.php
@@ -108,7 +108,8 @@ class Yoast_Feature_Toggles {
 				'read_more_label' => __( 'Read why XML Sitemaps are important for your site.', 'wordpress-seo' ),
 				'read_more_url'   => 'https://yoa.st/2a-',
 				'extra'           => $xml_sitemap_extra,
-				'warning_if_off'  => __( 'Disabling Yoast SEO’s XML sitemaps will not disable WordPress’ core sitemaps. In some cases, this <a href="#">may result in SEO errors on your site</a>. These may be reported in Google Search Console and other tools.', 'wordpress-seo' ),
+				/* translators: %1$s: expands to an opening anchor tag, %2$s: expands to a closing anchor tag */
+				'warning_if_off'  => \sprintf( esc_html__( 'Disabling Yoast SEO\'s XML sitemaps will not disable WordPress\' core sitemaps. In some cases, this %1$s may result in SEO errors on your site%2$s. These may be reported in Google Search Console and other tools.', 'wordpress-seo' ), '<a href="#">', '</a>' ),
 				'order'           => 60,
 			],
 			(object) [

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -53,7 +53,8 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 				'off' => __( 'Off', 'wordpress-seo' ),
 			],
 			'<strong>' . $feature->name . '</strong>',
-			$feature_help->get_button_html() . $feature_help->get_panel_html()
+			$feature_help->get_button_html() . $feature_help->get_panel_html(),
+			$feature->warning_if_off
 		);
 	}
 	?>

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -1,4 +1,4 @@
-/* global wpseoScriptData */
+/* global wpseoScriptData, jQuery */
 import initAdminMedia from "./initializers/admin-media";
 import initAdmin from "./initializers/admin";
 import initSearchAppearance from "./initializers/search-appearance";
@@ -9,4 +9,21 @@ if ( wpseoScriptData && typeof wpseoScriptData.media !== "undefined" ) {
 }
 if ( wpseoScriptData && typeof wpseoScriptData.searchAppearance !== "undefined" ) {
 	initSearchAppearance();
+}
+if ( wpseoScriptData && wpseoScriptData.isDashboard ) {
+	jQuery( document ).ready( function() {
+		jQuery( ".switch-container input[type=radio]" ).change( function() {
+			/*
+			 * Use document.getElementById, because the name is in the form `wpseo[some-name]`.
+			 * jQuery cannot handle the square brackets in the ID.
+			 */
+			const warningPanel = document.getElementById( `${ this.name }-warning` );
+
+			if ( this.value === "off" ) {
+				jQuery( warningPanel ).show();
+			} else {
+				jQuery( warningPanel ).hide();
+			}
+		} );
+	} );
 }

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -11,6 +11,7 @@ if ( wpseoScriptData && typeof wpseoScriptData.searchAppearance !== "undefined" 
 	initSearchAppearance();
 }
 if ( wpseoScriptData && wpseoScriptData.isDashboard ) {
+	// Show a warning below the XML sitemap toggle when it is set to 'off'.
 	jQuery( document ).ready( function() {
 		jQuery( ".switch-container input[type=radio]" ).change( function() {
 			/*

--- a/src/initializers/disable-core-sitemaps.php
+++ b/src/initializers/disable-core-sitemaps.php
@@ -44,9 +44,8 @@ class Disable_Core_Sitemaps implements Initializer_Interface {
 	 * Disable the WP core XML sitemaps.
 	 */
 	public function initialize() {
-		\add_filter( 'wp_sitemaps_enabled', '__return_false' );
-
 		if ( $this->options->get( 'enable_xml_sitemap' ) ) {
+			\add_filter( 'wp_sitemaps_enabled', '__return_false' );
 			\add_action( 'template_redirect', [ $this, 'template_redirect' ], 0 );
 		}
 	}

--- a/tests/unit/initializers/disable-core-sitemaps-test.php
+++ b/tests/unit/initializers/disable-core-sitemaps-test.php
@@ -51,7 +51,8 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the situation when primary term id isn't to the category id, the id should get updated.
+	 * Tests the situation when Yoast sitemaps are enabled.
+	 * WordPress sitemaps should be disabled and a redirect should be added to the WP sitemap URL.
 	 *
 	 * @covers ::__construct
 	 * @covers ::initialize
@@ -66,7 +67,8 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the situation when primary term id isn't to the category id, the id should get updated.
+	 * Tests the situation when Yoast sitemaps are disabled.
+	 * WordPress sitemaps should not be disabled and no redirects should be added to the WP sitemap URL.
 	 *
 	 * @covers ::__construct
 	 * @covers ::initialize
@@ -76,7 +78,7 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 
 		$this->instance->initialize();
 
-		$this->assertTrue( \has_filter( 'wp_sitemaps_enabled', '__return_false' ), 'Does not have expected wp_sitemaps_enabled filter' );
+		$this->assertFalse( \has_filter( 'wp_sitemaps_enabled', '__return_false' ), 'Does not have expected wp_sitemaps_enabled filter' );
 		$this->assertFalse( \has_action( 'template_redirect', [ $this->instance, 'template_redirect' ] ), 'Has unexpected template_redirect action' );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disabling the Yoast SEO sitemap feature does not automatically disable WordPress' own sitemap anymore.

## Relevant technical choices:

* I added a `phpcs:ignore` comment to an `echo` statement I introduced, considering that the variables used in the statement are already escaped. But, while reviewing, *please check* if this ignore check is a valid use case! (I am alone in the office right now, so I can't check it with the team right now).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the _Features_ tab on the Yoast SEO admin dashboard.
* Toggle the XML sitemap feature to 'Off'.
  * You should see a warning below the XML sitemap feature toggle, with the following text:
    ```
    Disabling Yoast SEO’s XML sitemaps will not disable WordPress’ core sitemaps. In some cases, this may result in SEO errors on your site. These may be reported in Google Search Console and other tools.
    ```
* Toggle the XML sitemap feature to 'On'.
  * The warning should disappear.
* Toggle the XML sitemap feature to 'Off'.
  * The warning should appear again. 
* Save the changes you made on the page.
* The warning should disappear.

### Check if the WordPress sitemaps are re-instated.
* Go to `https://your-wordpress-site/sitemap.xml`.
  * You should be redirected to `https://your-wordpress-site/wp-sitemap.xml`.
  * Make sure that (the wordpress core function) `WP_Sitemaps->redirect_sitemapxml` is being called after reinstating the wordpress sitemap.

### Check if toggling the Yoast SEO sitemaps to 'on' still works.
* Go to `https://your-wordpress-site/sitemap.xml`.
  * You should be redirected to `https://your-wordpress-site/wp-sitemap.xml`.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
