### PR TITLE
Use core sitemaps when yoast seo sitemaps are disabled

### DIFF
--- a/admin/views/class-yoast-feature-toggle.php
+++ b/admin/views/class-yoast-feature-toggle.php
@@ -53,6 +53,13 @@ class Yoast_Feature_Toggle {
 	protected $extra = '';
 
 	/**
+	 * Additional content to be rendered after the toggle.
+	 *
+	 * @var string
+	 */
+	protected $after = '';
+
+	/**
 	 * Value to specify the feature toggle order.
 	 *
 	 * @var string

--- a/admin/views/class-yoast-feature-toggles.php
+++ b/admin/views/class-yoast-feature-toggles.php
@@ -5,6 +5,8 @@
  * @package WPSEO\Admin
  */
 
+use Yoast\WP\SEO\Presenters\Admin\Alert_Presenter;
+
 /**
  * Class for managing feature toggles.
  */
@@ -108,6 +110,7 @@ class Yoast_Feature_Toggles {
 				'read_more_label' => __( 'Read why XML Sitemaps are important for your site.', 'wordpress-seo' ),
 				'read_more_url'   => 'https://yoa.st/2a-',
 				'extra'           => $xml_sitemap_extra,
+				'after'           => $this->sitemaps_toggle_after(),
 				'order'           => 60,
 			],
 			(object) [
@@ -179,6 +182,24 @@ class Yoast_Feature_Toggles {
 		usort( $feature_toggles, [ $this, 'sort_toggles_callback' ] );
 
 		return $feature_toggles;
+	}
+
+	/**
+	 * Returns html for a warning that core sitemaps are enabled when yoast seo sitemaps are disabled.
+	 *
+	 * @return string HTML string for the warning.
+	 */
+	protected function sitemaps_toggle_after() {
+		$out   = '<div id="yoast-seo-sitemaps-disabled-warning" style="display:none;">';
+		$alert = new Alert_Presenter(
+			/* translators: %1$s: expands to an opening anchor tag, %2$s: expands to a closing anchor tag */
+			\sprintf( esc_html__( 'Disabling Yoast SEO\'s XML sitemaps will not disable WordPress\' core sitemaps. In some cases, this %1$s may result in SEO errors on your site%2$s. These may be reported in Google Search Console and other tools.', 'wordpress-seo' ), '<a target="_blank" href="' . WPSEO_Shortlinker::get( 'https://yoa.st/44z' ) . '">', '</a>' ),
+			'warning'
+		);
+		$out .= $alert->present();
+		$out .= '</div>';
+
+		return $out;
 	}
 
 	/**

--- a/admin/views/tabs/dashboard/features.php
+++ b/admin/views/tabs/dashboard/features.php
@@ -55,6 +55,10 @@ $feature_toggles = Yoast_Feature_Toggles::instance()->get_all();
 			'<strong>' . $feature->name . '</strong>',
 			$feature_help->get_button_html() . $feature_help->get_panel_html()
 		);
+
+		if ( ! empty( $feature->after ) ) {
+			echo $feature->after;
+		}
 	}
 	?>
 </div>

--- a/js/src/initializers/admin.js
+++ b/js/src/initializers/admin.js
@@ -267,10 +267,6 @@ export default function initAdmin( jQuery ) {
 
 		const xmlSitemapWarning = jQuery( "#yoast-seo-sitemaps-disabled-warning" );
 
-		if ( jQuery( "#enable_xml_sitemap input[type=radio]:checked" ).val() === "off" ) {
-			xmlSitemapWarning.show();
-		}
-
 		jQuery( "#enable_xml_sitemap input[type=radio]" ).change( function() {
 			if ( this.value === "off" ) {
 				xmlSitemapWarning.show();

--- a/js/src/initializers/admin.js
+++ b/js/src/initializers/admin.js
@@ -253,6 +253,33 @@ export default function initAdmin( jQuery ) {
 		onViewportChange();
 	}
 
+	/**
+	 * Toggles a warning under the xml sitemap feature toggle when it is disabled.
+	 *
+	 * @returns {void}
+	 */
+	function initXmlSitemapsWarning() {
+		const radioButtons = jQuery( "#enable_xml_sitemap input[type=radio]" );
+
+		if ( ! radioButtons.length ) {
+			return;
+		}
+
+		const xmlSitemapWarning = jQuery( "#yoast-seo-sitemaps-disabled-warning" );
+
+		if ( jQuery( "#enable_xml_sitemap input[type=radio]:checked" ).val() === "off" ) {
+			xmlSitemapWarning.show();
+		}
+
+		jQuery( "#enable_xml_sitemap input[type=radio]" ).change( function() {
+			if ( this.value === "off" ) {
+				xmlSitemapWarning.show();
+			} else {
+				xmlSitemapWarning.hide();
+			}
+		} );
+	}
+
 	window.wpseoDetectWrongVariables = wpseoDetectWrongVariables;
 	window.setWPOption = setWPOption;
 	window.wpseoCopyHomeMeta = wpseoCopyHomeMeta;
@@ -389,6 +416,7 @@ export default function initAdmin( jQuery ) {
 		wpseoCopyHomeMeta();
 		setInitialActiveTab();
 		initSelect2();
+		initXmlSitemapsWarning();
 		// Should be called after the initial active tab has been set.
 		setFixedSubmitButtonVisibility();
 	} );

--- a/src/initializers/disable-core-sitemaps.php
+++ b/src/initializers/disable-core-sitemaps.php
@@ -44,9 +44,9 @@ class Disable_Core_Sitemaps implements Initializer_Interface {
 	 * Disable the WP core XML sitemaps.
 	 */
 	public function initialize() {
-		\add_filter( 'wp_sitemaps_enabled', '__return_false' );
-
 		if ( $this->options->get( 'enable_xml_sitemap' ) ) {
+			\add_filter( 'wp_sitemaps_enabled', '__return_false' );
+
 			\add_action( 'template_redirect', [ $this, 'template_redirect' ], 0 );
 		}
 	}

--- a/tests/unit/initializers/disable-core-sitemaps-test.php
+++ b/tests/unit/initializers/disable-core-sitemaps-test.php
@@ -40,7 +40,7 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 	private $redirect;
 
 	/**
-	 * @inheritDoc
+	 * Set up the test fixtures.
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -52,6 +52,7 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 
 	/**
 	 * Tests the situation when primary term id isn't to the category id, the id should get updated.
+	 * WordPress sitemaps should be disabled and a redirect should be added to the WP sitemap URL.
 	 *
 	 * @covers ::__construct
 	 * @covers ::initialize
@@ -67,6 +68,7 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 
 	/**
 	 * Tests the situation when primary term id isn't to the category id, the id should get updated.
+	 * WordPress sitemaps should be disabled and a redirect should be added to the WP sitemap URL.
 	 *
 	 * @covers ::__construct
 	 * @covers ::initialize
@@ -76,7 +78,7 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 
 		$this->instance->initialize();
 
-		$this->assertTrue( \has_filter( 'wp_sitemaps_enabled', '__return_false' ), 'Does not have expected wp_sitemaps_enabled filter' );
+		$this->assertFalse( \has_filter( 'wp_sitemaps_enabled', '__return_false' ), 'Does not have expected wp_sitemaps_enabled filter' );
 		$this->assertFalse( \has_action( 'template_redirect', [ $this->instance, 'template_redirect' ] ), 'Has unexpected template_redirect action' );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disabling the Yoast SEO sitemap feature does not automatically disable WordPress' own sitemap anymore.

## Relevant technical choices:

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the _Features_ tab on the Yoast SEO admin dashboard.
* Toggle the XML sitemap feature to 'Off'.
  * You should see a warning below the XML sitemap feature toggle, with the following text:
    ```
    Disabling Yoast SEO’s XML sitemaps will not disable WordPress’ core sitemaps. In some cases, this may result in SEO errors on your site. These may be reported in Google Search Console and other tools.
    ```
* Toggle the XML sitemap feature to 'On'.
  * The warning should disappear.
* Toggle the XML sitemap feature to 'Off'.
  * The warning should appear again. 
* Save the changes you made on the page.
* The warning should disappear.

### Check if the WordPress sitemaps are re-instated.
* Go to `https://your-wordpress-site/sitemap.xml`.
  * You should be redirected to `https://your-wordpress-site/wp-sitemap.xml`.
  * Make sure that (the wordpress core function) `WP_Sitemaps->redirect_sitemapxml` is being called after reinstating the wordpress sitemap.

### Check if toggling the Yoast SEO sitemaps to 'on' still works.
* Go to `https://your-wordpress-site/sitemap.xml`.
  * You should be redirected to `https://your-wordpress-site/wp-sitemap.xml`.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-339
