### PR TITLE
P3-166 Vendor prefix symphony/polyfill-intl-idn

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,8 @@
 			"@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/psr --config=config/php-scoper/psr.inc.php --force --quiet"
 		],
 		"prefix-symfony": [
-			"@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/symfony/dependency-injection --config=config/php-scoper/dependency-injection.inc.php --force --quiet"
+			"@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/symfony/dependency-injection --config=config/php-scoper/dependency-injection.inc.php --force --quiet",
+			"@php ./vendor/humbug/php-scoper/bin/php-scoper add-prefix --prefix=YoastSEO_Vendor --output-dir=./vendor_prefixed/symfony/polyfill-intl-idn --config=config/php-scoper/polyfill-intl-idn.inc.php --force --quiet"
 		],
 		"remove-vendor-prefixed-uses": [
 			"@php ./vendor/atanamo/php-codeshift/bin/codeshift --mod=config/php-codeshift/remove-vendor-prefixing-codemod.php --src=artifact-composer/src",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
 		"pimple/pimple": "^3.2",
 		"psr/log": "^1.0",
 		"league/oauth2-client": "^2.4",
-		"symfony/dependency-injection": "^3.4"
+		"symfony/dependency-injection": "^3.4",
+		"symfony/polyfill-intl-idn": "^1.11"
 	},
 	"require-dev": {
 		"yoast/php-development-environment": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1345e51656013ba26b14af575dad4c3",
+    "content-hash": "5f6d70af39c382daab01773c4ad2b052",
     "packages": [
         {
             "name": "composer/installers",
@@ -727,6 +727,322 @@
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
             "time": "2019-05-19T14:11:39+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.18.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "5dcab1bc7146cf8c1beaa4502a3d9be344334251"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/5dcab1bc7146cf8c1beaa4502a3d9be344334251",
+                "reference": "5dcab1bc7146cf8c1beaa4502a3d9be344334251",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/polyfill-intl-normalizer": "^1.10",
+                "symfony/polyfill-php70": "^1.10",
+                "symfony/polyfill-php72": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-04T06:02:08+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.18.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e",
+                "reference": "37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-14T12:35:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php70",
+            "version": "v1.18.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php70.git",
+                "reference": "0dd93f2c578bdc9c72697eaa5f1dd25644e618d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/0dd93f2c578bdc9c72697eaa5f1dd25644e618d3",
+                "reference": "0dd93f2c578bdc9c72697eaa5f1dd25644e618d3",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "~1.0|~2.0|~9.99",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php70\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-14T12:35:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.18.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "639447d008615574653fb3bc60d1986d7172eaae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/639447d008615574653fb3bc60d1986d7172eaae",
+                "reference": "639447d008615574653fb3bc60d1986d7172eaae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "yoast/i18n-module",

--- a/config/php-scoper/polyfill-intl-idn.inc.php
+++ b/config/php-scoper/polyfill-intl-idn.inc.php
@@ -29,7 +29,7 @@ return array(
 	 */
 	'patchers'                   => [
 		/**
-		 * Removes the namespace from the bootstrap file
+		 * Removes the namespace from the bootstrap file.
 		 *
 		 * @param string $filePath The path of the current file.
 		 * @param string $prefix   The prefix to be used.

--- a/config/php-scoper/polyfill-intl-idn.inc.php
+++ b/config/php-scoper/polyfill-intl-idn.inc.php
@@ -1,0 +1,56 @@
+<?php
+
+declare( strict_types=1 );
+
+use Isolated\Symfony\Component\Finder\Finder;
+
+return array(
+
+	/*
+	 * By default when running php-scoper add-prefix, it will prefix all relevant code found in the current working
+	 * directory. You can however define which files should be scoped by defining a collection of Finders in the
+	 * following configuration key.
+	 *
+	 * For more see: https://github.com/humbug/php-scoper#finders-and-paths
+	 */
+	'finders'                    => [
+		Finder::create()->files()->in( 'vendor/symfony/polyfill-intl-idn' )->name( [
+			'bootstrap.php', 'Idn.php', 'LICENSE', 'composer.json'
+		] ),
+	],
+
+	/*
+	 * When scoping PHP files, there will be scenarios where some of the code being scoped indirectly references the
+	 * original namespace. These will include, for example, strings or string manipulations. PHP-Scoper has limited
+	 * support for prefixing such strings. To circumvent that, you can define patchers to manipulate the file to your
+	 * heart contents.
+	 *
+	 * For more see: https://github.com/humbug/php-scoper#patchers
+	 */
+	'patchers'                   => [
+		/**
+		 * Removes the namespace from the bootstrap file
+		 *
+		 * @param string $filePath The path of the current file.
+		 * @param string $prefix   The prefix to be used.
+		 * @param string $content  The content of the specific file.
+		 *
+		 * @return string The modified content.
+		 */
+		function( $file_path, $prefix, $content ) {
+			// 13 is the length of the bootstrap.php file name.
+			if ( substr( $file_path, -13 ) !== 'bootstrap.php' ) {
+				return $content;
+			}
+
+			$replaced = str_replace(
+				sprintf ('namespace %s;', $prefix ),
+				'',
+				$content
+			);
+
+			return $replaced;
+		},
+	]
+
+);

--- a/src/functions.php
+++ b/src/functions.php
@@ -13,6 +13,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 
 use Yoast\WP\SEO\Main;
 
+require_once WPSEO_PATH . 'vendor_prefixed/symfony/polyfill-intl-idn/bootstrap.php';
 require_once WPSEO_PATH . 'vendor_prefixed/guzzlehttp/guzzle/src/functions.php';
 require_once WPSEO_PATH . 'vendor_prefixed/guzzlehttp/psr7/src/functions_include.php';
 require_once WPSEO_PATH . 'vendor_prefixed/guzzlehttp/promises/src/functions_include.php';


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When creating ZIP for Premium, we encountered a problem since a newer version of guzzlehttp/guzzle is used instead of a older one in Free. The new version relies on constants and functions from the php-intl package which is not a standard one included in most server configurations.
One possible solution that was explored was to force the use of the earlier version in Premium, but it has obvious maintenance issues.
While investigating on why the problem didn't occur when running from the repo instead of from the ZIP, we found that in that case there is a symfony/polyfill-intl-idn package in vendor that provides the missing constants and functions.
We have to vendor_prefix it and make sure it's autoloaded correctly.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Vendor-prefix symphony/polyfill-intl-idn 

## Relevant technical choices:

* The change must be applied in Free for the following reasons:
  *  Free is often merged on Premium so the change won't be overwritten
  *  It could (will?) happen that the packages are upgraded in Free, so the fix will be needed there as well.
* The `bootstrap.php` file is imported directly since it can't be autoloaded. Also, the namespace is removed to make sure the functions it exposes are not namespaced and can be used as replacements of root namespace functions (the ones from `php-intl`)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* checkout Premium `feature/semrush` branch, be sure it's up to date with the latest fix (see comment below for more)
* merge this branch into Premium. **You can ignore `composer.lock` conflicts** (keep `composer.lock` from Premium unchanged - `composer install` will complain but will go on), otherwise you can:
  * accept all non conflicting from `feature/semrush`
  * accept all non conflicting from this PR
  * leave hash untouched
  * run `composer update --lock`
* create Premium zip following [these instructions](https://yoast.atlassian.net/wiki/spaces/PLUGIN/pages/741703735/How+to+create+a+zip+from+a+specific+branch)
* install the zip in a test enviroment and check that requests to SEMrush are correctly performed. If not, you shoud get a console error complaining about wrong JSON response data (this should be addressed, actually)

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-166]
