### PR TITLE
Move two utils to the Yoast helper and implement these

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -353,7 +353,7 @@ class WPSEO_Admin_Init {
 	 * @return void
 	 */
 	private function register_premium_upsell_admin_block() {
-		if ( ! WPSEO_Utils::is_yoast_seo_premium() ) {
+		if ( ! YoastSEO()->helpers->yoast->is_premium() ) {
 			$upsell_block = new WPSEO_Premium_Upsell_Admin_Block( 'wpseo_admin_promo_footer' );
 			$upsell_block->register_hooks();
 		}

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -84,7 +84,7 @@ class WPSEO_Admin {
 
 		$this->initialize_cornerstone_content();
 
-		if ( WPSEO_Utils::is_plugin_network_active() ) {
+		if ( YoastSEO()->helpers->yoast->is_plugin_network_active() ) {
 			$integrations[] = new Yoast_Network_Admin();
 		}
 
@@ -225,7 +225,7 @@ class WPSEO_Admin {
 		}
 
 		$addon_manager = new WPSEO_Addon_Manager();
-		if ( WPSEO_Utils::is_yoast_seo_premium() && $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) ) {
+		if ( YoastSEO()->helpers->yoast->is_premium() && $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) ) {
 			return $links;
 		}
 

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -157,7 +157,7 @@ class WPSEO_Admin_Pages {
 	private function should_show_local_seo_upsell() {
 		$addon_manager = new WPSEO_Addon_Manager();
 
-		return ! WPSEO_Utils::is_yoast_seo_premium()
+		return ! YoastSEO()->helpers->yoast->is_premium()
 			&& ! ( defined( 'WPSEO_LOCAL_FILE' ) );
 	}
 

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -182,7 +182,7 @@ class Yoast_Form {
 	public function admin_sidebar() {
 		// No banners in Premium.
 		$addon_manager = new WPSEO_Addon_Manager();
-		if ( WPSEO_Utils::is_yoast_seo_premium() && $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) ) {
+		if ( YoastSEO()->helpers->yoast->is_premium() && $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) ) {
 			return;
 		}
 

--- a/admin/config-ui/components/class-component-suggestions.php
+++ b/admin/config-ui/components/class-component-suggestions.php
@@ -28,7 +28,7 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 		$field = new WPSEO_Config_Field_Suggestions();
 
 		// Only show Premium upsell when we are not inside a Premium install.
-		if ( ! WPSEO_Utils::is_yoast_seo_premium() ) {
+		if ( ! YoastSEO()->helpers->yoast->is_premium() ) {
 			$field->add_suggestion(
 				/* translators: %s resolves to Yoast SEO Premium */
 				sprintf( __( 'Outrank the competition with %s', 'wordpress-seo' ), 'Yoast SEO Premium' ),
@@ -73,7 +73,7 @@ class WPSEO_Config_Component_Suggestions implements WPSEO_Config_Component {
 		);
 
 		// When we are running in Yoast SEO Premium and don't have Local SEO installed, show Local SEO as suggestion.
-		if ( WPSEO_Utils::is_yoast_seo_premium() && ! defined( 'WPSEO_LOCAL_FILE' ) ) {
+		if ( YoastSEO()->helpers->yoast->is_premium() && ! defined( 'WPSEO_LOCAL_FILE' ) ) {
 			$field->add_suggestion(
 				__( 'Attract more customers near you', 'wordpress-seo' ),
 				/* translators: %1$s resolves to Local SEO */

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -75,7 +75,7 @@ class WPSEO_Metabox_Formatter {
 			'cornerstoneActive'         => WPSEO_Options::get( 'enable_cornerstone_content', false ) ? 1 : 0,
 			'intl'                      => $this->get_content_analysis_component_translations(),
 			'isRtl'                     => is_rtl(),
-			'isPremium'                 => WPSEO_Utils::is_yoast_seo_premium(),
+			'isPremium'                 => YoastSEO()->helpers->yoast->is_premium(),
 			'addKeywordUpsell'          => $this->get_add_keyword_upsell_translations(),
 			'wordFormRecognitionActive' => YoastSEO()->helpers->language->is_word_form_recognition_active( WPSEO_Language_Utils::get_language( get_locale() ) ),
 			'siteIconUrl'               => get_site_icon_url(),

--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -139,7 +139,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 		$keyword = WPSEO_Meta::get_value( 'focuskw', $this->post->ID );
 		$usage   = [ $keyword => $this->get_keyword_usage_for_current_post( $keyword ) ];
 
-		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+		if ( YoastSEO()->helpers->yoast->is_premium() ) {
 			return $this->get_premium_keywords( $usage );
 		}
 

--- a/admin/menu/class-menu.php
+++ b/admin/menu/class-menu.php
@@ -35,7 +35,7 @@ class WPSEO_Menu implements WPSEO_WordPress_Integration {
 		$admin_menu = new WPSEO_Admin_Menu( $this );
 		$admin_menu->register_hooks();
 
-		if ( WPSEO_Utils::is_plugin_network_active() ) {
+		if ( YoastSEO()->helpers->yoast->is_plugin_network_active() ) {
 			$network_admin_menu = new WPSEO_Network_Admin_Menu( $this );
 			$network_admin_menu->register_hooks();
 		}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -1083,7 +1083,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	protected function get_product_title() {
 		$product_title = 'Yoast SEO';
 
-		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+		if ( YoastSEO()->helpers->yoast->is_premium() ) {
 			$product_title .= ' Premium';
 		}
 

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -164,7 +164,7 @@ class WPSEO_Taxonomy_Metabox {
 	protected function get_product_title() {
 		$product_title = 'Yoast SEO';
 
-		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+		if ( YoastSEO()->helpers->yoast->is_premium() ) {
 			$product_title .= ' Premium';
 		}
 

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -102,7 +102,7 @@ if ( WPSEO_Utils::is_woocommerce_active() ) {
 }
 
 $addon_manager                  = new WPSEO_Addon_Manager();
-$has_valid_premium_subscription = WPSEO_Utils::is_yoast_seo_premium() && $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG );
+$has_valid_premium_subscription = YoastSEO()->helpers->yoast->is_premium() && $addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG );
 
 /* translators: %1$s expands to Yoast SEO. */
 $wpseo_extensions_header = sprintf( __( '%1$s Extensions', 'wordpress-seo' ), 'Yoast SEO' );

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -17,7 +17,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	 */
 	public function register_hooks() {
 		// If the current plugin is Yoast SEO Premium, stop registering.
-		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+		if ( YoastSEO()->helpers->yoast->is_premium() ) {
 			return;
 		}
 

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -364,7 +364,7 @@ class WPSEO_Addon_Manager {
 		$addons = self::$addons;
 
 		// Yoast SEO Free isn't an addon, but we needed it in Premium to fetch translations.
-		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+		if ( YoastSEO()->helpers->yoast->is_premium() ) {
 			$addons['wp-seo.php'] = self::FREE_SLUG;
 		}
 

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -138,7 +138,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 */
 	public function meets_requirements() {
 		if ( is_network_admin() ) {
-			return WPSEO_Utils::is_plugin_network_active();
+			return YoastSEO()->helpers->yoast->is_plugin_network_active();
 		}
 
 		if ( WPSEO_Options::get( 'enable_admin_bar_menu' ) !== true ) {

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -1018,7 +1018,7 @@ class WPSEO_Meta {
 		 * In that case there's no use for an additional query as we already know
 		 * that the keyword has been used multiple times before.
 		 */
-		if ( WPSEO_Utils::is_yoast_seo_premium() && count( $post_ids ) < 2 ) {
+		if ( YoastSEO()->helpers->yoast->is_premium() && count( $post_ids ) < 2 ) {
 			$query = [
 				'meta_query'     => [
 					[

--- a/inc/class-wpseo-shortlinker.php
+++ b/inc/class-wpseo-shortlinker.php
@@ -97,7 +97,7 @@ class WPSEO_Shortlinker {
 	 * @return string The software name + activation state.
 	 */
 	private function get_software() {
-		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+		if ( YoastSEO()->helpers->yoast->is_premium() ) {
 			return 'premium';
 		}
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -829,7 +829,7 @@ class WPSEO_Utils {
 	 * @return bool True when we are in the premium plugin.
 	 */
 	public static function is_yoast_seo_premium() {
-		return defined( 'WPSEO_PREMIUM_PLUGIN_FILE' );
+		return YoastSEO()->helpers->yoast->is_premium();
 	}
 
 	/**
@@ -842,26 +842,7 @@ class WPSEO_Utils {
 	 * @return bool
 	 */
 	public static function is_development_mode() {
-		$development_mode = false;
-
-		if ( defined( 'YOAST_ENVIRONMENT' ) && YOAST_ENVIRONMENT === 'development' ) {
-			$development_mode = true;
-		}
-		elseif ( defined( 'WPSEO_DEBUG' ) ) {
-			$development_mode = WPSEO_DEBUG;
-		}
-		elseif ( site_url() && strpos( site_url(), '.' ) === false ) {
-			$development_mode = true;
-		}
-
-		/**
-		 * Filter the Yoast SEO development mode.
-		 *
-		 * @since 3.0
-		 *
-		 * @param bool $development_mode Is Yoast SEOs development mode active.
-		 */
-		return apply_filters( 'yoast_seo_development_mode', $development_mode );
+		return YoastSEO()->helpers->yoast->is_development_mode();
 	}
 
 	/**
@@ -1037,24 +1018,7 @@ SVG;
 	 * @return bool Whether or not the plugin is network-active.
 	 */
 	public static function is_plugin_network_active() {
-		static $network_active = null;
-
-		if ( ! is_multisite() ) {
-			return false;
-		}
-
-		// If a cached result is available, bail early.
-		if ( $network_active !== null ) {
-			return $network_active;
-		}
-
-		$network_active_plugins = wp_get_active_network_plugins();
-
-		// Consider MU plugins and network-activated plugins as network-active.
-		$network_active = strpos( wp_normalize_path( WPSEO_FILE ), wp_normalize_path( WPMU_PLUGIN_DIR ) ) === 0
-			|| in_array( WP_PLUGIN_DIR . '/' . WPSEO_BASENAME, $network_active_plugins, true );
-
-		return $network_active;
+		return YoastSEO()->helpers->yoast->is_plugin_network_active();
 	}
 
 	/**

--- a/inc/health-check-ryte.php
+++ b/inc/health-check-ryte.php
@@ -95,7 +95,7 @@ class WPSEO_Health_Check_Ryte extends WPSEO_Health_Check {
 	 * @return bool True when debug mode is on and Yoast development mode is not on.
 	 */
 	protected function is_development_mode() {
-		return wp_debug_mode() && ! WPSEO_Utils::is_development_mode();
+		return wp_debug_mode() && ! YoastSEO()->helpers->yoast->is_development_mode();
 	}
 
 	/**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -176,6 +176,12 @@
 		<exclude-pattern>/inc/wpseo-functions-deprecated\.php$</exclude-pattern>
 	</rule>
 
+	<!-- These files have intentionally yoast in the filename. -->
+	<rule ref="Yoast.Files.FileName.InvalidClassFileName">
+		<exclude-pattern>/src/helpers/yoast-helper.php</exclude-pattern>
+		<exclude-pattern>/tests/unit/helpers/yoast-helper-test.php</exclude-pattern>
+	</rule>
+
 	<!-- Ignore unused function parameters in deprecated functionality. -->
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter">
 		<exclude-pattern>/src/deprecated/*</exclude-pattern>

--- a/src/conditionals/development-conditional.php
+++ b/src/conditionals/development-conditional.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\SEO\Conditionals;
 
-use WPSEO_Utils;
-
 /**
  * Conditional that is only met when in development mode.
  */

--- a/src/conditionals/development-conditional.php
+++ b/src/conditionals/development-conditional.php
@@ -15,6 +15,6 @@ class Development_Conditional implements Conditional {
 	 * @return boolean Whether or not the conditional is met.
 	 */
 	public function is_met() {
-		return WPSEO_Utils::is_development_mode();
+		return YoastSEO()->helpers->yoast->is_development_mode();
 	}
 }

--- a/src/helpers/product-helper.php
+++ b/src/helpers/product-helper.php
@@ -17,7 +17,7 @@ class Product_Helper {
 	/**
 	 * Site_Helper constructor.
 	 *
-	 * @param Yoast_Helper $yoast_helper
+	 * @param Yoast_Helper $yoast_helper The yoast helper.
 	 */
 	public function __construct( Yoast_Helper $yoast_helper ) {
 		$this->yoast_helper = $yoast_helper;

--- a/src/helpers/product-helper.php
+++ b/src/helpers/product-helper.php
@@ -2,12 +2,26 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
-use WPSEO_Utils;
-
 /**
  * A helper object to retrieve the product name.
  */
 class Product_Helper {
+
+	/**
+	 * Represents the yoast helper.
+	 *
+	 * @var Yoast_Helper
+	 */
+	protected $yoast_helper;
+
+	/**
+	 * Site_Helper constructor.
+	 *
+	 * @param Yoast_Helper $yoast_helper
+	 */
+	public function __construct( Yoast_Helper $yoast_helper ) {
+		$this->yoast_helper = $yoast_helper;
+	}
 
 	/**
 	 * Get the product name in the head section.
@@ -15,21 +29,10 @@ class Product_Helper {
 	 * @return string
 	 */
 	public function get_name() {
-		if ( $this->is_premium() ) {
+		if ( $this->yoast_helper->is_premium() ) {
 			return 'Yoast SEO Premium plugin';
 		}
 
 		return 'Yoast SEO plugin';
-	}
-
-	/**
-	 * Checks if the installed version is Yoast SEO Premium.
-	 *
-	 * @codeCoverageIgnore It just wraps a static method.
-	 *
-	 * @return bool True when is premium.
-	 */
-	protected function is_premium() {
-		return YoastSEO()->helpers->yoast->is_premium();
 	}
 }

--- a/src/helpers/product-helper.php
+++ b/src/helpers/product-helper.php
@@ -30,6 +30,6 @@ class Product_Helper {
 	 * @return bool True when is premium.
 	 */
 	protected function is_premium() {
-		return WPSEO_Utils::is_yoast_seo_premium();
+		return YoastSEO()->helpers->yoast->is_premium();
 	}
 }

--- a/src/helpers/site-helper.php
+++ b/src/helpers/site-helper.php
@@ -2,28 +2,10 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
-use WPSEO_Utils;
-
 /**
  * A helper object for site options.
  */
 class Site_Helper {
-
-	/**
-	 * Represents the yoast helper.
-	 *
-	 * @var Yoast_Helper
-	 */
-	protected $yoast_helper;
-
-	/**
-	 * Site_Helper constructor.
-	 *
-	 * @param Yoast_Helper $yoast_helper
-	 */
-	public function __construct( Yoast_Helper $yoast_helper ) {
-		$this->yoast_helper = $yoast_helper;
-	}
 
 	/**
 	 * Retrieves the site name.

--- a/src/helpers/site-helper.php
+++ b/src/helpers/site-helper.php
@@ -10,6 +10,22 @@ use WPSEO_Utils;
 class Site_Helper {
 
 	/**
+	 * Represents the yoast helper.
+	 *
+	 * @var Yoast_Helper
+	 */
+	protected $yoast_helper;
+
+	/**
+	 * Site_Helper constructor.
+	 *
+	 * @param Yoast_Helper $yoast_helper
+	 */
+	public function __construct( Yoast_Helper $yoast_helper ) {
+		$this->yoast_helper = $yoast_helper;
+	}
+
+	/**
 	 * Retrieves the site name.
 	 *
 	 * @return string

--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
-use WPSEO_Utils;
 use Yoast\WP\SEO\Models\SEO_Links;
 
 /**

--- a/src/helpers/yoast-helper.php
+++ b/src/helpers/yoast-helper.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Yoast\WP\SEO\Helpers;
+
+/**
+ * A helper object for Yoast SEO plugin related logic.
+ */
+class Yoast_Helper {
+
+	/**
+	 * Determines whether the plugin is active for the entire network.
+	 *
+	 * @return bool Whether or not the plugin is network-active.
+	 */
+	public function is_plugin_network_active() {
+		static $network_active = null;
+
+		if ( ! is_multisite() ) {
+			return false;
+		}
+
+		// If a cached result is available, bail early.
+		if ( $network_active !== null ) {
+			return $network_active;
+		}
+
+		$network_active_plugins = wp_get_active_network_plugins();
+
+		// Consider MU plugins and network-activated plugins as network-active.
+		$network_active = strpos( wp_normalize_path( WPSEO_FILE ), wp_normalize_path( WPMU_PLUGIN_DIR ) ) === 0
+		                  || in_array( WP_PLUGIN_DIR . '/' . WPSEO_BASENAME, $network_active_plugins, true );
+
+		return $network_active;
+	}
+
+	/**
+	 * Determines if Yoast SEO is in development mode?
+	 *
+	 * Inspired by JetPack (https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L1383-L1406).
+	 * @return bool
+	 */
+	public function is_development_mode() {
+		$development_mode = false;
+
+		if ( defined( 'YOAST_ENVIRONMENT' ) && YOAST_ENVIRONMENT === 'development' ) {
+			$development_mode = true;
+		}
+		elseif ( defined( 'WPSEO_DEBUG' ) ) {
+			$development_mode = WPSEO_DEBUG;
+		}
+		elseif ( site_url() && strpos( site_url(), '.' ) === false ) {
+			$development_mode = true;
+		}
+
+		/**
+		 * Filter the Yoast SEO development mode.
+		 *
+		 * @since 3.0
+		 *
+		 * @param bool $development_mode Is Yoast SEOs development mode active.
+		 */
+		return apply_filters( 'yoast_seo_development_mode', $development_mode );
+	}
+
+	/**
+	 * Checks if the installed version is Yoast SEO Premium.
+	 *
+	 * @return bool True when is premium.
+	 */
+	public function is_premium() {
+		return defined( 'WPSEO_PREMIUM_PLUGIN_FILE' );
+	}
+
+}

--- a/src/helpers/yoast-helper.php
+++ b/src/helpers/yoast-helper.php
@@ -28,7 +28,7 @@ class Yoast_Helper {
 
 		// Consider MU plugins and network-activated plugins as network-active.
 		$network_active = strpos( wp_normalize_path( WPSEO_FILE ), wp_normalize_path( WPMU_PLUGIN_DIR ) ) === 0
-		                  || in_array( WP_PLUGIN_DIR . '/' . WPSEO_BASENAME, $network_active_plugins, true );
+							|| in_array( WP_PLUGIN_DIR . '/' . WPSEO_BASENAME, $network_active_plugins, true );
 
 		return $network_active;
 	}
@@ -37,6 +37,7 @@ class Yoast_Helper {
 	 * Determines if Yoast SEO is in development mode?
 	 *
 	 * Inspired by JetPack (https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L1383-L1406).
+	 *
 	 * @return bool
 	 */
 	public function is_development_mode() {
@@ -70,5 +71,4 @@ class Yoast_Helper {
 	public function is_premium() {
 		return defined( 'WPSEO_PREMIUM_PLUGIN_FILE' );
 	}
-
 }

--- a/src/presenters/debug/marker-open-presenter.php
+++ b/src/presenters/debug/marker-open-presenter.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Presenters\Debug;
 
-use WPSEO_Utils;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 
 /**

--- a/src/presenters/debug/marker-open-presenter.php
+++ b/src/presenters/debug/marker-open-presenter.php
@@ -33,7 +33,7 @@ final class Marker_Open_Presenter extends Abstract_Indexable_Presenter {
 			 *
 			 * @api bool
 			 */
-			( ( \apply_filters( 'wpseo_hide_version', false ) && WPSEO_Utils::is_yoast_seo_premium() ) ? '' : 'v' . \WPSEO_VERSION )
+			( ( \apply_filters( 'wpseo_hide_version', false ) && $this->helpers->yoast->is_premium() ) ? '' : 'v' . \WPSEO_VERSION )
 		);
 	}
 

--- a/src/surfaces/helpers-surface.php
+++ b/src/surfaces/helpers-surface.php
@@ -34,6 +34,7 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
  * @property Helpers\Url_Helper            $url
  * @property Helpers\User_Helper           $user
  * @property Helpers\Woocommerce_Helper    $woocommerce
+ * @property Helpers\Yoast_Helper          $yoast
  */
 class Helpers_Surface {
 

--- a/tests/unit/helpers/yoast-helper-test.php
+++ b/tests/unit/helpers/yoast-helper-test.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Helpers;
+
+use Yoast\WP\SEO\Helpers\Yoast_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Yoast_Helper_Test
+ *
+ * @group helpers
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Helpers\Yoast_Helper
+ */
+class Yoast_Helper_Test extends TestCase {
+
+	/**
+	 * Tests whether the plugin is network-active or not.
+	 *
+	 * @covers ::is_plugin_network_active
+	 */
+	public function test_is_plugin_network_active() {
+		$yoast_helper = new Yoast_Helper();
+
+		static::assertFalse( $yoast_helper->is_plugin_network_active() );
+	}
+}

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -188,7 +188,7 @@ function _wpseo_activate() {
 	}
 
 	// Reset tracking to be disabled by default.
-	if ( ! WPSEO_Utils::is_yoast_seo_premium() ) {
+	if ( ! YoastSEO()->helpers->yoast->is_premium() ) {
 		WPSEO_Options::set( 'tracking', false );
 	}
 
@@ -371,7 +371,7 @@ function wpseo_admin_init() {
  * on PHP 5.3+, the constant should only be set when requirements are met.
  */
 function wpseo_cli_init() {
-	if ( WPSEO_Utils::is_yoast_seo_premium() ) {
+	if ( YoastSEO()->helpers->yoast->is_premium() ) {
 		WP_CLI::add_command(
 			'yoast redirect list',
 			'WPSEO_CLI_Redirect_List_Command',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to use helpers and not static util methods.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It is just a code movemement

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Verify that the licenses page still shows expected values. Checkout premium, merge this branch into premium and see a change: premium shouldn't be suggested anymore.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
