### PR TITLE
Move one location use methods

### DIFF
--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -39,7 +39,7 @@ class WPSEO_Admin_Menu extends WPSEO_Base_Menu {
 				$this->get_manage_capability(),
 				$this->get_page_identifier(),
 				$this->get_admin_page_callback(),
-				WPSEO_Utils::get_icon_svg(),
+				$this->get_icon_svg(),
 				'99.31337'
 			);
 

--- a/admin/menu/class-base-menu.php
+++ b/admin/menu/class-base-menu.php
@@ -136,7 +136,7 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 			$submenu_page[3],
 			$submenu_page[4],
 			$submenu_page[5],
-			WPSEO_Utils::get_icon_svg(),
+			$this->get_icon_svg(),
 			'99.31337'
 		);
 
@@ -268,5 +268,22 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 		}
 
 		return $title;
+	}
+
+	/**
+	 * Returns a base64 URL for the svg for use in the menu.
+	 *
+	 * @param bool $base64 Whether or not to return base64'd output.
+	 *
+	 * @return string
+	 */
+	protected function get_icon_svg( $base64 = true ) {
+		$svg = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="100%" height="100%" style="fill:#82878c" viewBox="0 0 512 512" role="img" aria-hidden="true" focusable="false"><g><g><g><g><path d="M203.6,395c6.8-17.4,6.8-36.6,0-54l-79.4-204h70.9l47.7,149.4l74.8-207.6H116.4c-41.8,0-76,34.2-76,76V357c0,41.8,34.2,76,76,76H173C189,424.1,197.6,410.3,203.6,395z"/></g><g><path d="M471.6,154.8c0-41.8-34.2-76-76-76h-3L285.7,365c-9.6,26.7-19.4,49.3-30.3,68h216.2V154.8z"/></g></g><path stroke-width="2.974" stroke-miterlimit="10" d="M338,1.3l-93.3,259.1l-42.1-131.9h-89.1l83.8,215.2c6,15.5,6,32.5,0,48c-7.4,19-19,37.3-53,41.9l-7.2,1v76h8.3c81.7,0,118.9-57.2,149.6-142.9L431.6,1.3H338z M279.4,362c-32.9,92-67.6,128.7-125.7,131.8v-45c37.5-7.5,51.3-31,59.1-51.1c7.5-19.3,7.5-40.7,0-60l-75-192.7h52.8l53.3,166.8l105.9-294h58.1L279.4,362z"/></g></g></svg>';
+
+		if ( $base64 ) {
+			return 'data:image/svg+xml;base64,' . base64_encode( $svg );
+		}
+
+		return $svg;
 	}
 }

--- a/admin/menu/class-network-admin-menu.php
+++ b/admin/menu/class-network-admin-menu.php
@@ -36,7 +36,7 @@ class WPSEO_Network_Admin_Menu extends WPSEO_Base_Menu {
 			$this->get_manage_capability(),
 			$this->get_page_identifier(),
 			[ $this, 'network_config_page' ],
-			WPSEO_Utils::get_icon_svg()
+			$this->get_icon_svg()
 		);
 
 		$submenu_pages = $this->get_submenu_pages();

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -606,14 +606,32 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return string Score markup.
 	 */
 	protected function get_score( $score ) {
-		$score_class      = WPSEO_Utils::translate_score( $score );
-		$translated_score = WPSEO_Utils::translate_score( $score, false );
+		$score_class      = $this->translate_score( $score );
+		$translated_score = $this->translate_score( $score, false );
 		/* translators: %s expands to the SEO score. */
 		$screen_reader_text = sprintf( __( 'SEO score: %s', 'wordpress-seo' ), $translated_score );
 
 		$score_adminbar_element = '<div class="wpseo-score-icon adminbar-seo-score ' . $score_class . '"><span class="adminbar-seo-score-text screen-reader-text">' . $screen_reader_text . '</span></div>';
 
 		return $score_adminbar_element;
+	}
+
+	/**
+	 * Translates a decimal analysis score into a textual one.
+	 *
+	 * @param int  $val       The decimal score to translate.
+	 * @param bool $css_value Whether to return the i18n translated score or the CSS class value.
+	 *
+	 * @return string
+	 */
+	protected function translate_score( $val, $css_value = true ) {
+		$seo_rank = WPSEO_Rank::from_numeric_score( $val );
+
+		if ( $css_value ) {
+			return $seo_rank->get_css_class();
+		}
+
+		return $seo_rank->get_label();
 	}
 
 	/**

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -156,15 +156,15 @@ class WPSEO_Replace_Vars {
 
 		// Let's see if we can bail super early.
 		if ( strpos( $string, '%%' ) === false ) {
-			return WPSEO_Utils::standardize_whitespace( $string );
+			return $this->standardize_whitespace( $string );
 		}
 
 		$args = (array) $args;
 		if ( isset( $args['post_content'] ) && ! empty( $args['post_content'] ) ) {
-			$args['post_content'] = WPSEO_Utils::strip_shortcode( $args['post_content'] );
+			$args['post_content'] = $this->strip_shortcode( $args['post_content'] );
 		}
 		if ( isset( $args['post_excerpt'] ) && ! empty( $args['post_excerpt'] ) ) {
-			$args['post_excerpt'] = WPSEO_Utils::strip_shortcode( $args['post_excerpt'] );
+			$args['post_excerpt'] = $this->strip_shortcode( $args['post_excerpt'] );
 		}
 		$this->args = (object) wp_parse_args( $args, $this->defaults );
 
@@ -220,7 +220,7 @@ class WPSEO_Replace_Vars {
 		}
 
 		// Remove superfluous whitespace.
-		$string = WPSEO_Utils::standardize_whitespace( $string );
+		$string = $this->standardize_whitespace( $string );
 
 		return $string;
 	}
@@ -431,7 +431,24 @@ class WPSEO_Replace_Vars {
 	 * @return string
 	 */
 	private function retrieve_sep() {
-		return WPSEO_Utils::get_title_separator();
+		$replacement = WPSEO_Options::get_default( 'wpseo_titles', 'separator' );
+
+		// Get the titles option and the separator options.
+		$separator         = WPSEO_Options::get( 'separator' );
+		$seperator_options = WPSEO_Option_Titles::get_instance()->get_separator_options();
+
+		// This should always be set, but just to be sure.
+		if ( isset( $seperator_options[ $separator ] ) ) {
+			// Set the new replacement.
+			$replacement = $seperator_options[ $separator ];
+		}
+
+		/**
+		 * Filter: 'wpseo_replacements_filter_sep' - Allow customization of the separator character(s).
+		 *
+		 * @api string $replacement The current separator.
+		 */
+		return apply_filters( 'wpseo_replacements_filter_sep', $replacement );
 	}
 
 	/**
@@ -1363,6 +1380,31 @@ class WPSEO_Replace_Vars {
 		 * @api    string    $taxonomy  The taxonomy of the terms.
 		 */
 		return apply_filters( 'wpseo_terms', $output, $taxonomy );
+	}
+
+	/**
+	 * Standardize whitespace in a string.
+	 *
+	 * Replace line breaks, carriage returns, tabs with a space, then remove double spaces.
+	 *
+	 * @param string $string String input to standardize.
+	 *
+	 * @return string
+	 */
+	protected function standardize_whitespace( $string ) {
+		return trim( str_replace( '  ', ' ', str_replace( [ "\t", "\n", "\r", "\f" ], ' ', $string ) ) );
+	}
+
+	/**
+	 * First strip out registered and enclosing shortcodes using native WordPress strip_shortcodes function.
+	 * Then strip out the shortcodes with a filthy regex, because people don't properly register their shortcodes.
+	 *
+	 * @param string $text Input string that might contain shortcodes.
+	 *
+	 * @return string $text String without shortcodes.
+	 */
+	protected function strip_shortcode( $text ) {
+		return preg_replace( '`\[[^\]]+\]`s', '', strip_shortcodes( $text ) );
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -135,35 +135,6 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Standardize whitespace in a string.
-	 *
-	 * Replace line breaks, carriage returns, tabs with a space, then remove double spaces.
-	 *
-	 * @since 1.8.0
-	 *
-	 * @param string $string String input to standardize.
-	 *
-	 * @return string
-	 */
-	public static function standardize_whitespace( $string ) {
-		return trim( str_replace( '  ', ' ', str_replace( [ "\t", "\n", "\r", "\f" ], ' ', $string ) ) );
-	}
-
-	/**
-	 * First strip out registered and enclosing shortcodes using native WordPress strip_shortcodes function.
-	 * Then strip out the shortcodes with a filthy regex, because people don't properly register their shortcodes.
-	 *
-	 * @since 1.8.0
-	 *
-	 * @param string $text Input string that might contain shortcodes.
-	 *
-	 * @return string $text String without shortcodes.
-	 */
-	public static function strip_shortcode( $text ) {
-		return preg_replace( '`\[[^\]]+\]`s', '', strip_shortcodes( $text ) );
-	}
-
-	/**
 	 * Recursively trim whitespace round a string value or of string values within an array.
 	 * Only trims strings to avoid typecasting a variable (to string).
 	 *
@@ -759,34 +730,6 @@ class WPSEO_Utils {
 	 */
 	public static function get_site_name() {
 		return YoastSEO()->helpers->site->get_site_name();
-	}
-
-	/**
-	 * Retrieves the title separator.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @return string
-	 */
-	public static function get_title_separator() {
-		$replacement = WPSEO_Options::get_default( 'wpseo_titles', 'separator' );
-
-		// Get the titles option and the separator options.
-		$separator         = WPSEO_Options::get( 'separator' );
-		$seperator_options = WPSEO_Option_Titles::get_instance()->get_separator_options();
-
-		// This should always be set, but just to be sure.
-		if ( isset( $seperator_options[ $separator ] ) ) {
-			// Set the new replacement.
-			$replacement = $seperator_options[ $separator ];
-		}
-
-		/**
-		 * Filter: 'wpseo_replacements_filter_sep' - Allow customization of the separator character(s).
-		 *
-		 * @api string $replacement The current separator.
-		 */
-		return apply_filters( 'wpseo_replacements_filter_sep', $replacement );
 	}
 
 	/**
@@ -1425,5 +1368,71 @@ SVG;
 		$enabled_features = apply_filters( 'wpseo_enable_feature', $enabled_features );
 
 		return $enabled_features;
+	}
+
+	/**
+	 * Standardize whitespace in a string.
+	 *
+	 * Replace line breaks, carriage returns, tabs with a space, then remove double spaces.
+	 *
+	 * @deprecated 15.1
+	 * @codeCoverageIgnore
+	 *
+	 * @param string $string String input to standardize.
+	 *
+	 * @return string
+	 */
+	public static function standardize_whitespace( $string ) {
+		_deprecated_function( __METHOD__, 'WPSEO 15.1' );
+
+		return trim( str_replace( '  ', ' ', str_replace( [ "\t", "\n", "\r", "\f" ], ' ', $string ) ) );
+	}
+
+	/**
+	 * First strip out registered and enclosing shortcodes using native WordPress strip_shortcodes function.
+	 * Then strip out the shortcodes with a filthy regex, because people don't properly register their shortcodes.
+	 *
+	 * @deprecated 15.1
+	 * @codeCoverageIgnore
+	 *
+	 * @param string $text Input string that might contain shortcodes.
+	 *
+	 * @return string $text String without shortcodes.
+	 */
+	public static function strip_shortcode( $text ) {
+		_deprecated_function( __METHOD__, 'WPSEO 15.1' );
+
+		return preg_replace( '`\[[^\]]+\]`s', '', strip_shortcodes( $text ) );
+	}
+
+	/**
+	 * Retrieves the title separator.
+	 *
+	 * @deprecated 15.1
+	 * @codeCoverageIgnore
+	 *
+	 * @return string
+	 */
+	public static function get_title_separator() {
+		_deprecated_function( __METHOD__, 'WPSEO 15.1' );
+
+		$replacement = WPSEO_Options::get_default( 'wpseo_titles', 'separator' );
+
+		// Get the titles option and the separator options.
+		$separator         = WPSEO_Options::get( 'separator' );
+		$seperator_options = WPSEO_Option_Titles::get_instance()->get_separator_options();
+
+		// This should always be set, but just to be sure.
+		if ( isset( $seperator_options[ $separator ] ) ) {
+			// Set the new replacement.
+			$replacement = $seperator_options[ $separator ];
+		}
+
+		/**
+		 * Filter: 'wpseo_replacements_filter_sep' - Allow customization of the separator character(s).
+		 *
+		 * @api string $replacement The current separator.
+		 */
+		return apply_filters( 'wpseo_replacements_filter_sep', $replacement );
 	}
 }

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -822,25 +822,6 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Returns a base64 URL for the svg for use in the menu.
-	 *
-	 * @since 3.3.0
-	 *
-	 * @param bool $base64 Whether or not to return base64'd output.
-	 *
-	 * @return string
-	 */
-	public static function get_icon_svg( $base64 = true ) {
-		$svg = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="100%" height="100%" style="fill:#82878c" viewBox="0 0 512 512" role="img" aria-hidden="true" focusable="false"><g><g><g><g><path d="M203.6,395c6.8-17.4,6.8-36.6,0-54l-79.4-204h70.9l47.7,149.4l74.8-207.6H116.4c-41.8,0-76,34.2-76,76V357c0,41.8,34.2,76,76,76H173C189,424.1,197.6,410.3,203.6,395z"/></g><g><path d="M471.6,154.8c0-41.8-34.2-76-76-76h-3L285.7,365c-9.6,26.7-19.4,49.3-30.3,68h216.2V154.8z"/></g></g><path stroke-width="2.974" stroke-miterlimit="10" d="M338,1.3l-93.3,259.1l-42.1-131.9h-89.1l83.8,215.2c6,15.5,6,32.5,0,48c-7.4,19-19,37.3-53,41.9l-7.2,1v76h8.3c81.7,0,118.9-57.2,149.6-142.9L431.6,1.3H338z M279.4,362c-32.9,92-67.6,128.7-125.7,131.8v-45c37.5-7.5,51.3-31,59.1-51.1c7.5-19.3,7.5-40.7,0-60l-75-192.7h52.8l53.3,166.8l105.9-294h58.1L279.4,362z"/></g></g></svg>';
-
-		if ( $base64 ) {
-			return 'data:image/svg+xml;base64,' . base64_encode( $svg );
-		}
-
-		return $svg;
-	}
-
-	/**
 	 * Returns the SVG for the traffic light in the metabox.
 	 *
 	 * @return string
@@ -1434,5 +1415,26 @@ SVG;
 		 * @api string $replacement The current separator.
 		 */
 		return apply_filters( 'wpseo_replacements_filter_sep', $replacement );
+	}
+	/**
+	 * Returns a base64 URL for the svg for use in the menu.
+	 *
+	 * @deprecated 15.1
+	 * @codeCoverageIgnore
+	 *
+	 * @param bool $base64 Whether or not to return base64'd output.
+	 *
+	 * @return string
+	 */
+	public static function get_icon_svg( $base64 = true ) {
+		_deprecated_function( __METHOD__, 'WPSEO 15.1' );
+
+		$svg = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="100%" height="100%" style="fill:#82878c" viewBox="0 0 512 512" role="img" aria-hidden="true" focusable="false"><g><g><g><g><path d="M203.6,395c6.8-17.4,6.8-36.6,0-54l-79.4-204h70.9l47.7,149.4l74.8-207.6H116.4c-41.8,0-76,34.2-76,76V357c0,41.8,34.2,76,76,76H173C189,424.1,197.6,410.3,203.6,395z"/></g><g><path d="M471.6,154.8c0-41.8-34.2-76-76-76h-3L285.7,365c-9.6,26.7-19.4,49.3-30.3,68h216.2V154.8z"/></g></g><path stroke-width="2.974" stroke-miterlimit="10" d="M338,1.3l-93.3,259.1l-42.1-131.9h-89.1l83.8,215.2c6,15.5,6,32.5,0,48c-7.4,19-19,37.3-53,41.9l-7.2,1v76h8.3c81.7,0,118.9-57.2,149.6-142.9L431.6,1.3H338z M279.4,362c-32.9,92-67.6,128.7-125.7,131.8v-45c37.5-7.5,51.3-31,59.1-51.1c7.5-19.3,7.5-40.7,0-60l-75-192.7h52.8l53.3,166.8l105.9-294h58.1L279.4,362z"/></g></g></svg>';
+
+		if ( $base64 ) {
+			return 'data:image/svg+xml;base64,' . base64_encode( $svg );
+		}
+
+		return $svg;
 	}
 }

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -156,26 +156,6 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Translates a decimal analysis score into a textual one.
-	 *
-	 * @since 1.8.0
-	 *
-	 * @param int  $val       The decimal score to translate.
-	 * @param bool $css_value Whether to return the i18n translated score or the CSS class value.
-	 *
-	 * @return string
-	 */
-	public static function translate_score( $val, $css_value = true ) {
-		$seo_rank = WPSEO_Rank::from_numeric_score( $val );
-
-		if ( $css_value ) {
-			return $seo_rank->get_css_class();
-		}
-
-		return $seo_rank->get_label();
-	}
-
-	/**
 	 * Emulate the WP native sanitize_text_field function in a %%variable%% safe way.
 	 *
 	 * @link https://core.trac.wordpress.org/browser/trunk/src/wp-includes/formatting.php for the original.
@@ -1436,5 +1416,28 @@ SVG;
 		}
 
 		return $svg;
+	}
+
+	/**
+	 * Translates a decimal analysis score into a textual one.
+	 *
+	 * @deprecated 15.1
+	 * @codeCoverageIgnore
+	 *
+	 * @param int  $val       The decimal score to translate.
+	 * @param bool $css_value Whether to return the i18n translated score or the CSS class value.
+	 *
+	 * @return string
+	 */
+	public static function translate_score( $val, $css_value = true ) {
+		_deprecated_function( __METHOD__, 'WPSEO 15.1' );
+
+		$seo_rank = WPSEO_Rank::from_numeric_score( $val );
+
+		if ( $css_value ) {
+			return $seo_rank->get_css_class();
+		}
+
+		return $seo_rank->get_label();
 	}
 }

--- a/tests/integration/test-class-wpseo-utils.php
+++ b/tests/integration/test-class-wpseo-utils.php
@@ -81,50 +81,6 @@ class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests translate_score function.
-	 *
-	 * @dataProvider translate_score_provider
-	 * @covers       WPSEO_Utils::translate_score
-	 *
-	 * @param int    $score     The decimal score to translate.
-	 * @param bool   $css_value Whether to return the i18n translated score or the CSS class value.
-	 * @param string $expected  Expected function result.
-	 */
-	public function test_translate_score( $score, $css_value, $expected ) {
-		$this->assertEquals( $expected, WPSEO_Utils::translate_score( $score, $css_value ) );
-	}
-
-	/**
-	 * Provides test data for test_translate_score().
-	 *
-	 * @return array
-	 */
-	public function translate_score_provider() {
-		return [
-			[ 0, true, 'na' ],
-			[ 1, true, 'bad' ],
-			[ 23, true, 'bad' ],
-			[ 40, true, 'bad' ],
-			[ 41, true, 'ok' ],
-			[ 55, true, 'ok' ],
-			[ 70, true, 'ok' ],
-			[ 71, true, 'good' ],
-			[ 83, true, 'good' ],
-			[ 100, true, 'good' ],
-			[ 0, false, 'Not available' ],
-			[ 1, false, 'Needs improvement' ],
-			[ 23, false, 'Needs improvement' ],
-			[ 40, false, 'Needs improvement' ],
-			[ 41, false, 'OK' ],
-			[ 55, false, 'OK' ],
-			[ 70, false, 'OK' ],
-			[ 71, false, 'Good' ],
-			[ 83, false, 'Good' ],
-			[ 100, false, 'Good' ],
-		];
-	}
-
-	/**
 	 * When current page is not in the list of Yoast SEO Free, is_yoast_seo_free_page() should return false.
 	 *
 	 * @covers WPSEO_Utils::is_yoast_seo_free_page


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Some methodes are introduces as utils, but only used in one specific class. We should move these to the class where they are needed and just makes them protected. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It just moves some code.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check if the admin menu is rendered right.
* Check if the replace vars still work

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
