### PR TITLE
New filter: sitemaps page type archive url

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -385,6 +385,19 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			// Deprecated, kept for backwards data compat. R.
 			$front_page['chf'] = 'daily';
 			$front_page['pri'] = 1;
+			
+			/**
+			 * Filter the URL Yoast SEO uses in the XML sitemap for this post type
+			 * archive.
+			 *
+			 * @param string $archive_url The URL of this archive
+			 * @param string $post_type   The post type this archive is for.
+			 */
+			$front_page['loc'] = apply_filters(
+				'wpseo_sitemap_page_type_archive_link',
+				$front_page['loc'],
+				$post_type
+			);
 
 			$links[] = $front_page;
 		}


### PR DESCRIPTION
## Context
Add a new filter for sitemaps. There's already an existing filter for non page post types that provides developers the ability to filter non page archive URLs; however, there is no filter that allows the filter of the page post type archive URL (aka front page).

This is problematic when trying to render different URLs (in a headless WordPress environment, for instance) because developers have the ability to change other post archive URLs and sitemap entry URLs with filters except for this URL. As a result, the first URL in the `/page-sitemap.xml` file is unalterable.


## Summary
This PR can be summarized in the following changelog entry:

* [changelog:enhancement] Adds a new `wpseo_sitemap_page_type_archive_link` sitemap filter



## Test instructions
This PR can be tested by following these steps:

* write a new  filter where appropriate (theme, plugin, mu-plugin):
```php
add_filter('wpseo_sitemap_page_type_archive_link', function($link, $post_type) {
  return 'https://my_filtered_link.com';
}, 10, 2);
```
* load the `/page-sitemap.xml` route

Expected behaviors:
* the first URL should be 'https://my_filtered_link.com'
* all other links should not be altered

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
n/a
