### PR TITLE
Flush permalink home url changes

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -58,6 +58,7 @@ class WPSEO_Upgrade {
 			'14.2-RC0'   => 'upgrade_142',
 			'14.5-RC0'   => 'upgrade_145',
 			'14.9-RC0'   => 'upgrade_149',
+			'15.1-RC0'   => 'upgrade_151',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -731,6 +732,13 @@ class WPSEO_Upgrade {
 	}
 
 	/**
+	 * Performs the 14.5 upgrade.
+	 */
+	private function upgrade_151() {
+		add_action( 'init', [ $this, 'set_home_url_option_for_151' ] );
+	}
+
+	/**
 	 * Checks if the indexable indexation is completed.
 	 * If so, sets the `indexables_indexation_completed` option to `true`,
 	 * else to `false`.
@@ -986,5 +994,12 @@ class WPSEO_Upgrade {
 
 			WPSEO_Options::set( 'noindex-ptarchive-product', false );
 		}
+	}
+
+	/**
+	 * Stores the initial `home_url` option.
+	 */
+	public function set_home_url_option_for_151() {
+		WPSEO_Options::set( 'home_url', get_home_url() );
 	}
 }

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -732,7 +732,9 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Performs the 14.5 upgrade.
+	 * Performs the 15.1 upgrade routine.
+	 *
+	 * @return void
 	 */
 	private function upgrade_151() {
 		add_action( 'init', [ $this, 'set_home_url_option_for_151' ] );
@@ -998,6 +1000,8 @@ class WPSEO_Upgrade {
 
 	/**
 	 * Stores the initial `home_url` option.
+	 *
+	 * @return void
 	 */
 	public function set_home_url_option_for_151() {
 		WPSEO_Options::set( 'home_url', get_home_url() );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -737,7 +737,11 @@ class WPSEO_Upgrade {
 	 * @return void
 	 */
 	private function upgrade_151() {
-		add_action( 'init', [ $this, 'set_home_url_option_for_151' ] );
+		$home_url = WPSEO_Options::get( 'home_url' );
+
+		if ( empty( $home_url ) ) {
+			WPSEO_Options::set( 'home_url', get_home_url() );
+		}
 	}
 
 	/**
@@ -996,14 +1000,5 @@ class WPSEO_Upgrade {
 
 			WPSEO_Options::set( 'noindex-ptarchive-product', false );
 		}
-	}
-
-	/**
-	 * Stores the initial `home_url` option.
-	 *
-	 * @return void
-	 */
-	public function set_home_url_option_for_151() {
-		WPSEO_Options::set( 'home_url', get_home_url() );
 	}
 }

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -64,6 +64,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			],
 			'access_tokens' => [],
 		],
+		'home_url'                                 => '',
 	];
 
 	/**
@@ -246,6 +247,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 					break;
 				case 'previous_version':
 				case 'license_server_version':
+				case 'home_url':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = $dirty[ $key ];
 					}

--- a/src/integrations/watchers/indexable-homeurl-watcher.php
+++ b/src/integrations/watchers/indexable-homeurl-watcher.php
@@ -49,7 +49,7 @@ class Indexable_HomeUrl_Watcher implements Integration_Interface {
 	}
 
 	/**
-	 * Indexable_Permalink_Watcher constructor.
+	 * Indexable_HomeUrl_Watcher constructor.
 	 *
 	 * @param Post_Type_Helper $post_type The post type helper.
 	 * @param Options_Helper   $options   The options helper.
@@ -113,7 +113,6 @@ class Indexable_HomeUrl_Watcher implements Integration_Interface {
 	 * @return bool Whether the request ran.
 	 */
 	public function force_reset_permalinks() {
-		var_dump('hello');
 		if ( $this->should_reset_permalinks() ) {
 			$this->reset_permalinks();
 

--- a/src/integrations/watchers/indexable-homeurl-watcher.php
+++ b/src/integrations/watchers/indexable-homeurl-watcher.php
@@ -4,7 +4,7 @@ namespace Yoast\WP\SEO\Integrations\Watchers;
 
 use WP_CLI;
 use WP_CLI\Utils;
-use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
@@ -45,7 +45,7 @@ class Indexable_HomeUrl_Watcher implements Integration_Interface {
 	 * @return array
 	 */
 	public static function get_conditionals() {
-		return [ Admin_Conditional::class ];
+		return [ Migrations_Conditional::class ];
 	}
 
 	/**
@@ -118,6 +118,10 @@ class Indexable_HomeUrl_Watcher implements Integration_Interface {
 
 			// Reset the home_url option.
 			$this->options_helper->set( 'home_url', get_home_url() );
+
+			if ( \defined( 'WP_CLI' ) && \WP_CLI ) {
+				WP_CLI::success( __( 'All permalinks were succesfully reset', 'wordpress-seo' ) );
+			}
 
 			return true;
 		}

--- a/src/integrations/watchers/indexable-homeurl-watcher.php
+++ b/src/integrations/watchers/indexable-homeurl-watcher.php
@@ -69,7 +69,7 @@ class Indexable_HomeUrl_Watcher implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_action( 'update_option_home',   [ $this, 'reset_permalinks' ] );
+		\add_action( 'update_option_home', [ $this, 'reset_permalinks' ] );
 		\add_action( 'wpseo_home_url_check', [ $this, 'force_reset_permalinks' ] );
 	}
 

--- a/src/integrations/watchers/indexable-homeurl-watcher.php
+++ b/src/integrations/watchers/indexable-homeurl-watcher.php
@@ -120,7 +120,7 @@ class Indexable_HomeUrl_Watcher implements Integration_Interface {
 			$this->options_helper->set( 'home_url', get_home_url() );
 
 			if ( \defined( 'WP_CLI' ) && \WP_CLI ) {
-				WP_CLI::success( __( 'All permalinks were succesfully reset', 'wordpress-seo' ) );
+				WP_CLI::success( __( 'All permalinks were successfully reset', 'wordpress-seo' ) );
 			}
 
 			return true;

--- a/src/integrations/watchers/indexable-homeurl-watcher.php
+++ b/src/integrations/watchers/indexable-homeurl-watcher.php
@@ -95,6 +95,9 @@ class Indexable_HomeUrl_Watcher implements Integration_Interface {
 		$this->indexable_helper->reset_permalink_indexables( 'user', null, Indexation_Permalink_Warning_Presenter::REASON_HOME_URL_OPTION );
 		$this->indexable_helper->reset_permalink_indexables( 'date-archive', null, Indexation_Permalink_Warning_Presenter::REASON_HOME_URL_OPTION );
 		$this->indexable_helper->reset_permalink_indexables( 'system-page', null, Indexation_Permalink_Warning_Presenter::REASON_HOME_URL_OPTION );
+
+		// Reset the home_url option.
+		$this->options_helper->set( 'home_url', get_home_url() );
 	}
 
 	/**
@@ -115,9 +118,6 @@ class Indexable_HomeUrl_Watcher implements Integration_Interface {
 	public function force_reset_permalinks() {
 		if ( $this->should_reset_permalinks() ) {
 			$this->reset_permalinks();
-
-			// Reset the home_url option.
-			$this->options_helper->set( 'home_url', get_home_url() );
 
 			if ( \defined( 'WP_CLI' ) && \WP_CLI ) {
 				WP_CLI::success( __( 'All permalinks were successfully reset', 'wordpress-seo' ) );

--- a/src/integrations/watchers/indexable-homeurl-watcher.php
+++ b/src/integrations/watchers/indexable-homeurl-watcher.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
+use WP_CLI;
+use WP_CLI\Utils;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
@@ -111,6 +113,7 @@ class Indexable_HomeUrl_Watcher implements Integration_Interface {
 	 * @return bool Whether the request ran.
 	 */
 	public function force_reset_permalinks() {
+		var_dump('hello');
 		if ( $this->should_reset_permalinks() ) {
 			$this->reset_permalinks();
 

--- a/tests/unit/integrations/watchers/indexable-homeurl-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-homeurl-watcher-test.php
@@ -4,7 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
 use Brain\Monkey;
 use Mockery;
-use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
@@ -79,7 +79,7 @@ class Indexable_HomeUrl_Watcher_Test extends TestCase {
 	 */
 	public function test_get_conditionals() {
 		$this->assertEquals(
-			[ Admin_Conditional::class ],
+			[ Migrations_Conditional::class ],
 			Indexable_HomeUrl_Watcher::get_conditionals()
 		);
 	}

--- a/tests/unit/integrations/watchers/indexable-homeurl-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-homeurl-watcher-test.php
@@ -57,6 +57,13 @@ class Indexable_HomeUrl_Watcher_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
+		Monkey\Functions\stubs(
+			[
+				'wp_next_scheduled' => false,
+				'wp_schedule_event' => false,
+			]
+		);
+
 		$this->post_type        = Mockery::mock( Post_Type_Helper::class );
 		$this->options          = Mockery::mock( Options_Helper::class );
 		$this->indexable_helper = Mockery::mock( Indexable_Helper::class );
@@ -118,5 +125,84 @@ class Indexable_HomeUrl_Watcher_Test extends TestCase {
 		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'post-type-archive', 'post', Indexation_Permalink_Warning_Presenter::REASON_HOME_URL_OPTION )->once();
 
 		$this->instance->reset_permalinks_post_type( 'post' );
+	}
+
+	/**
+	 * Test forced flushing of permalinks.
+	 *
+	 * @covers ::force_reset_permalinks
+	 */
+	public function test_force_reset_permalinks() {
+		$this->instance
+			->expects( 'should_reset_permalinks' )
+			->once()
+			->andReturnTrue();
+
+		$this->instance
+			->expects( 'reset_permalinks' )
+			->once();
+
+		Monkey\Functions\expect( 'get_home_url' )
+			->once()
+			->andReturn( 'http://example.com' );
+
+		$this->options
+			->expects( 'set' )
+			->with( 'home_url', 'http://example.com' )
+			->once();
+
+		$this->assertTrue( $this->instance->force_reset_permalinks() );
+	}
+
+	/**
+	 * Test forced flushing of permalinks not executing.
+	 *
+	 * @covers ::force_reset_permalinks
+	 */
+	public function test_force_reset_permalinks_not_executing() {
+		$this->instance
+			->expects( 'should_reset_permalinks' )
+			->once()
+			->andReturnFalse();
+
+		$this->assertFalse( $this->instance->force_reset_permalinks() );
+	}
+
+	/**
+	 * Test that permalinks should be reset.
+	 *
+	 * @covers ::should_reset_permalinks
+	 */
+	public function test_should_reset_permalinks() {
+		Monkey\Functions\expect( 'get_home_url' )
+			->once()
+			->andReturn( 'http://example-old.com' );
+
+		$this->options
+			->expects( 'get' )
+			->with( 'home_url' )
+			->once()
+			->andReturn( 'http://example.com' );
+
+		$this->assertTrue( $this->instance->should_reset_permalinks() );
+	}
+
+	/**
+	 * Test that permalinks should not be reset.
+	 *
+	 * @covers ::should_reset_permalinks
+	 */
+	public function test_shouldnt_reset_permalinks() {
+		Monkey\Functions\expect( 'get_home_url' )
+			->once()
+			->andReturn( 'http://example.com' );
+
+		$this->options
+			->expects( 'get' )
+			->with( 'home_url' )
+			->once()
+			->andReturn( 'http://example.com' );
+
+		$this->assertFalse( $this->instance->should_reset_permalinks() );
 	}
 }

--- a/tests/unit/integrations/watchers/indexable-homeurl-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-homeurl-watcher-test.php
@@ -112,6 +112,15 @@ class Indexable_HomeUrl_Watcher_Test extends TestCase {
 		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'date-archive', null, Indexation_Permalink_Warning_Presenter::REASON_HOME_URL_OPTION )->once();
 		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'system-page', null, Indexation_Permalink_Warning_Presenter::REASON_HOME_URL_OPTION )->once();
 
+		Monkey\Functions\expect( 'get_home_url' )
+			->once()
+			->andReturn( 'http://example.com' );
+
+		$this->options
+			->expects( 'set' )
+			->with( 'home_url', 'http://example.com' )
+			->once();
+
 		$this->instance->reset_permalinks();
 	}
 
@@ -140,15 +149,6 @@ class Indexable_HomeUrl_Watcher_Test extends TestCase {
 
 		$this->instance
 			->expects( 'reset_permalinks' )
-			->once();
-
-		Monkey\Functions\expect( 'get_home_url' )
-			->once()
-			->andReturn( 'http://example.com' );
-
-		$this->options
-			->expects( 'set' )
-			->with( 'home_url', 'http://example.com' )
 			->once();
 
 		$this->assertTrue( $this->instance->force_reset_permalinks() );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Registers a cron job that checks whether the `home_url` was changed manually and resets the permalinks accordingly.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Registers a cron job that checks whether the `home_url` was changed manually and resets the permalinks accordingly.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Ensure you've checked out this branch and have built everything.
* Ensure you've installed the Yoast Test helper.
* To trigger the the upgrade routine, first bump the version in the test helper to something like `15.1-RC0` and then downgrade it again to `15.0-RC6`.
* Check your database and ensure the `home_url` property exists for the `wpseo` key and isn't empty.
* In your terminal, navigate to your Docker environment and run `./wp.sh cron event list`. See that the `wpseo_home_url_check` cron is registered and is set for ~24 hours.
* In your database, change the `home_url` property under the `wpseo` key and to something different than the current value. **Please replace a character instead of adding one as this won't break serialization**
* Force the cron to run by running `./wp.sh cron event run wpseo_home_url_check`. You should receive a message saying 'Success: All permalinks were successfully reset'
* Check your database and ensure the `home_url` property still exists for the `wpseo` key and see that it has been restored to the proper home URL (i.e. `basic.wordpress.test`).
* Check the `wp_yoast_indexable` table and see that all permalinks have been reset.
* Log into your admin and re-run indexation.
* Check the `wp_yoast_indexable` table and see that permalinks have returned.
* Run the `./wp.sh cron event run wpseo_home_url_check` command again, this time you should **not** see the success message.
* Check the `wp_yoast_indexable` table and see that permalinks remain untouched.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-154]
