### PR TITLE
P3-150 monitor permalink structure flush indexable permalinks

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -733,6 +733,8 @@ class WPSEO_Upgrade {
 
 	/**
 	 * Performs the 15.1 upgrade.
+	 *
+	 * @return void
 	 */
 	private function upgrade_151() {
 		add_action( 'init', [ $this, 'set_permalink_structure_option_for_151' ] );
@@ -998,6 +1000,8 @@ class WPSEO_Upgrade {
 
 	/**
 	 * Stores the initial `permalink_structure` option.
+	 *
+	 * @return void
 	 */
 	public function set_permalink_structure_option_for_151() {
 		WPSEO_Options::set( 'permalink_structure', get_option( 'permalink_structure' ) );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -58,6 +58,7 @@ class WPSEO_Upgrade {
 			'14.2-RC0'   => 'upgrade_142',
 			'14.5-RC0'   => 'upgrade_145',
 			'14.9-RC0'   => 'upgrade_149',
+			'15.1-RC0'   => 'upgrade_151',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -728,6 +729,14 @@ class WPSEO_Upgrade {
 		$version = get_option( 'wpseo_license_server_version', WPSEO_License_Page_Manager::VERSION_BACKWARDS_COMPATIBILITY );
 		WPSEO_Options::set( 'license_server_version', $version );
 		delete_option( 'wpseo_license_server_version' );
+	}
+
+	/**
+	 * Performs the 15.1 upgrade.
+	 */
+	private function upgrade_151() {
+		$permalink_structure = get_option( 'permalink_structure' );
+		WPSEO_Options::set( 'permalink_structure', $permalink_structure );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -735,8 +735,7 @@ class WPSEO_Upgrade {
 	 * Performs the 15.1 upgrade.
 	 */
 	private function upgrade_151() {
-		$permalink_structure = get_option( 'permalink_structure' );
-		WPSEO_Options::set( 'permalink_structure', $permalink_structure );
+		add_action( 'init', [ $this, 'set_permalink_structure_option_for_151' ] );
 	}
 
 	/**
@@ -995,5 +994,12 @@ class WPSEO_Upgrade {
 
 			WPSEO_Options::set( 'noindex-ptarchive-product', false );
 		}
+	}
+
+	/**
+	 * Stores the initial `permalink_structure` option.
+	 */
+	public function set_permalink_structure_option_for_151() {
+		WPSEO_Options::set( 'permalink_structure', get_option( 'permalink_structure' ) );
 	}
 }

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -341,6 +341,10 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 					break;
 
 				/*
+				 * Boolean (checkbox) fields.
+				 */
+
+				/*
 				 * Covers:
 				 *  'disableadvanced_meta'
 				 *  'enable_headless_rest_endpoints'

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -64,6 +64,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			],
 			'access_tokens' => [],
 		],
+		'permalink_structure'                      => '',
 	];
 
 	/**
@@ -331,9 +332,13 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 					$clean[ $key ] = ( isset( $dirty[ $key ] ) ? WPSEO_Utils::validate_bool( $dirty[ $key ] ) : null );
 					break;
 
-				/*
-				 * Boolean (checkbox) fields.
-				 */
+				case 'permalink_structure':
+					if ( isset( $dirty[ $key ] ) ) {
+						// Check this as sanitize_option also sets a WordPress global settings
+						// error via add_settings_error() to print out an admin notice.
+						$clean[ $key ] = sanitize_option( 'permalink_structure', $dirty[ $key ] );
+					}
+					break;
 
 				/*
 				 * Covers:

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -334,8 +334,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 
 				case 'permalink_structure':
 					if ( isset( $dirty[ $key ] ) ) {
-						// Check this as sanitize_option also sets a WordPress global settings
-						// error via add_settings_error() to print out an admin notice.
 						$clean[ $key ] = sanitize_option( 'permalink_structure', $dirty[ $key ] );
 					}
 					break;

--- a/src/integrations/watchers/indexable-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-permalink-watcher.php
@@ -60,6 +60,8 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 		$this->post_type        = $post_type;
 		$this->options_helper   = $options;
 		$this->indexable_helper = $indexable;
+
+		$this->schedule_cron();
 	}
 
 	/**
@@ -69,6 +71,7 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 		\add_action( 'update_option_permalink_structure', [ $this, 'reset_permalinks' ] );
 		\add_action( 'update_option_category_base', [ $this, 'reset_permalinks_term' ], 10, 3 );
 		\add_action( 'update_option_tag_base', [ $this, 'reset_permalinks_term' ], 10, 3 );
+		\add_action( 'wpseo_permalink_structure_check', [ $this, 'force_reset_permalinks' ] );
 	}
 
 	/**
@@ -123,6 +126,33 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 	}
 
 	/**
+	 * Resets the permalink indexables automatically, if necessary.
+	 *
+	 * @return bool Whether the reset request ran.
+	 */
+	public function force_reset_permalinks() {
+		if ( $this->should_reset_permalinks() ) {
+			$this->reset_permalinks();
+
+			// Update the permalink_structure option.
+			$this->options_helper->set( 'permalink_structure', \get_option( 'permalink_structure' ) );
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks whether permalinks should be reset.
+	 *
+	 * @return bool Whether the permalinks should be reset.
+	 */
+	public function should_reset_permalinks() {
+		return \get_option( 'permalink_structure' ) !== $this->options_helper->get( 'permalink_structure' );
+	}
+
+	/**
 	 * Retrieves a list with the public post types.
 	 *
 	 * @return array The post types.
@@ -157,6 +187,19 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 		$taxonomies = \array_unique( $taxonomies );
 
 		return $taxonomies;
+	}
+
+	/**
+	 * Schedules the WP-Cron job to check the permalink_structure status.
+	 *
+	 * @return void
+	 */
+	protected function schedule_cron() {
+		if ( \wp_next_scheduled( 'wpseo_permalink_structure_check' ) ) {
+			return;
+		}
+
+		\wp_schedule_event( time(), 'daily', 'wpseo_permalink_structure_check' );
 	}
 
 	/* ********************* DEPRECATED METHODS ********************* */

--- a/src/integrations/watchers/indexable-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-permalink-watcher.php
@@ -91,6 +91,9 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 		$this->indexable_helper->reset_permalink_indexables( 'user' );
 		$this->indexable_helper->reset_permalink_indexables( 'date-archive' );
 		$this->indexable_helper->reset_permalink_indexables( 'system-page' );
+
+		// Always update `permalink_structure` in the wpseo option.
+		$this->options_helper->set( 'permalink_structure', \get_option( 'permalink_structure' ) );
 	}
 
 	/**
@@ -133,9 +136,6 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 	public function force_reset_permalinks() {
 		if ( $this->should_reset_permalinks() ) {
 			$this->reset_permalinks();
-
-			// Update the permalink_structure option.
-			$this->options_helper->set( 'permalink_structure', \get_option( 'permalink_structure' ) );
 
 			return true;
 		}

--- a/tests/unit/integrations/watchers/indexable-category-permalink-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-category-permalink-watcher-test.php
@@ -14,6 +14,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 /**
  * Class Indexable_Category_Permalink_Watcher_Test.
  *
+ * @group indexables
  * @group integrations
  * @group watchers
  *
@@ -46,7 +47,7 @@ class Indexable_Category_Permalink_Watcher_Test extends TestCase {
 	/**
 	 * Represents the indexable helper.
 	 *
-	 * @var Mockery\MockInterface|Indexable_Helperex
+	 * @var Mockery\MockInterface|Indexable_Helper
 	 */
 	protected $indexable_helper;
 
@@ -54,6 +55,13 @@ class Indexable_Category_Permalink_Watcher_Test extends TestCase {
 	 * @inheritDoc
 	 */
 	public function setUp() {
+		Monkey\Functions\stubs(
+			[
+				'wp_next_scheduled' => false,
+				'wp_schedule_event' => false,
+			]
+		);
+
 		$this->options          = Mockery::mock( Options_Helper::class );
 		$this->post_type        = Mockery::mock( Post_Type_Helper::class );
 		$this->indexable_helper = Mockery::mock( Indexable_Helper::class );

--- a/tests/unit/integrations/watchers/indexable-permalink-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-permalink-watcher-test.php
@@ -46,7 +46,7 @@ class Indexable_Permalink_Watcher_Test extends TestCase {
 	/**
 	 * Represents the indexable helper.
 	 *
-	 * @var Mockery\MockInterface|Indexable_Helperex
+	 * @var Mockery\MockInterface|Indexable_Helper
 	 */
 	protected $indexable_helper;
 
@@ -55,6 +55,13 @@ class Indexable_Permalink_Watcher_Test extends TestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
+
+		Monkey\Functions\stubs(
+			[
+				'wp_next_scheduled' => false,
+				'wp_schedule_event' => false,
+			]
+		);
 
 		$this->post_type        = Mockery::mock( Post_Type_Helper::class );
 		$this->options          = Mockery::mock( Options_Helper::class );

--- a/tests/unit/integrations/watchers/indexable-permalink-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-permalink-watcher-test.php
@@ -112,6 +112,16 @@ class Indexable_Permalink_Watcher_Test extends TestCase {
 		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'date-archive' )->once();
 		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'system-page' )->once();
 
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'permalink_structure' )
+			->andReturn( '/%postname%/' );
+
+		$this->options
+			->expects( 'set' )
+			->with( 'permalink_structure', '/%postname%/' )
+			->once();
+
 		$this->instance->reset_permalinks();
 	}
 
@@ -168,16 +178,6 @@ class Indexable_Permalink_Watcher_Test extends TestCase {
 
 		$this->instance
 			->expects( 'reset_permalinks' )
-			->once();
-
-		Monkey\Functions\expect( 'get_option' )
-			->once()
-			->with( 'permalink_structure' )
-			->andReturn( '/%postname%/' );
-
-		$this->options
-			->expects( 'set' )
-			->with( 'permalink_structure', '/%postname%/' )
 			->once();
 
 		$this->assertTrue( $this->instance->force_reset_permalinks() );

--- a/tests/unit/integrations/watchers/indexable-permalink-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-permalink-watcher-test.php
@@ -154,4 +154,86 @@ class Indexable_Permalink_Watcher_Test extends TestCase {
 
 		$this->instance->reset_permalinks_term( null, null, 'tag_base' );
 	}
+
+	/**
+	 * Test forced flushing of permalinks.
+	 *
+	 * @covers ::force_reset_permalinks
+	 */
+	public function test_force_reset_permalinks() {
+		$this->instance
+			->expects( 'should_reset_permalinks' )
+			->once()
+			->andReturnTrue();
+
+		$this->instance
+			->expects( 'reset_permalinks' )
+			->once();
+
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'permalink_structure' )
+			->andReturn( '/%postname%/' );
+
+		$this->options
+			->expects( 'set' )
+			->with( 'permalink_structure', '/%postname%/' )
+			->once();
+
+		$this->assertTrue( $this->instance->force_reset_permalinks() );
+	}
+
+	/**
+	 * Test forced flushing of permalinks not executing.
+	 *
+	 * @covers ::force_reset_permalinks
+	 */
+	public function test_force_reset_permalinks_not_executing() {
+		$this->instance
+			->expects( 'should_reset_permalinks' )
+			->once()
+			->andReturnFalse();
+
+		$this->assertFalse( $this->instance->force_reset_permalinks() );
+	}
+
+	/**
+	 * Test that permalinks should be reset.
+	 *
+	 * @covers ::should_reset_permalinks
+	 */
+	public function test_should_reset_permalinks() {
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'permalink_structure' )
+			->andReturn( '/%postname%/' );
+
+		$this->options
+			->expects( 'get' )
+			->with( 'permalink_structure' )
+			->once()
+			->andReturn( '/%year%/%monthnum%/%postname%/' );
+
+		$this->assertTrue( $this->instance->should_reset_permalinks() );
+	}
+
+	/**
+	 * Test that permalinks should not be reset.
+	 *
+	 * @covers ::should_reset_permalinks
+	 */
+	public function test_shouldnt_reset_permalinks() {
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'permalink_structure' )
+			->andReturn( '/%postname%/' );
+
+		$this->options
+			->expects( 'get' )
+			->with( 'permalink_structure' )
+			->once()
+			->andReturn( '/%postname%/' );
+
+		$this->assertFalse( $this->instance->should_reset_permalinks() );
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make sure any change to the `permalink_structure` option triggers a re-generation of the permalinks stored in the indexables.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Monitors changes to the `permalink_structure` option to flush and regenerate the posts permalinks in the Indexable.

## Relevant technical choices:

- Uses a daily WP-Cron job to monitor changes
- Uses an upgrade routine currently set to version 15.1
- Uses `sanitize_option()` to validate `permalink_structure` as that's WordPress uses to validate this option as well. **Important:** please double check this as `sanitize_option()` also sets a WordPress global "settings error" via `add_settings_error()` to print out an admin notice. Alternatively, we should build our own validation function.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:


**To test, you will need:**
- a tool of your choice to inspect the database e.g. Sequel Pro
- a WP installation with a working WP-CLI e.g. the Docker environment

**Preliminary steps:**
- test with a site that has more than 25 posts
- on trunk
- go to WordPress > Settings > Permalinks
- change the permalink structure to something else than your current setting for example "Month and name"
- the notice to reprocess the SEO data appears
- run the re-indexation by clicking the button in the notice
- at this point everything is set up to actually test the PR

**Test on single site:**
- switch to this PR and build
- activate Yoast SEO and the Yoast Test Helper plugin
- trigger the upgrade routine included in this PR by using the Yoast Test Helper plugin
  - go to WordPress > Tools > Yoast Test
  - set the Yoast SEO DB Version to a value lower than the actual one
  - e.g. if the real value is `15.0-RC6`, set it to `15.0-RC1` and save
- inspect the database:
  - check the `wpseo` option in the `wp_options` table
  - it must contain a new item `permalink_structure` with the value of your permalink structure e.g. `/%year%/%monthnum%/%postname%/`
- go to WordPress > Settings > Permalinks
- change the permalink structure to something else than your current setting for example "Numeric"
- observe the change is normally detected by our code and the notice to reprocess the SEO data appears in the admin
- run the re-indexation
- use WP-CLI from the root of the Docker installation
	- change the permalink_structure via WP-CLI with this command:
	- `./wp.sh option update permalink_structure "/%year%/%monthnum%/%postname%/"`
	- if you have multiple Docker container running, specify the container for the command:
	- `./wp.sh basic-wordpress option update permalink_structure "/%year%/%monthnum%/%postname%/"`
- observe the change is normally detected by our code and the notice to reprocess the SEO data appears in the admin
- run the re-indexation
- use WP-CLI to verify the WP-Cron job added by this PR is correctly set:
	- `./wp.sh cron event list`
	- in the displayed list, check there's a job named `wpseo_permalink_structure_check `
- now let's change the permalink_structure in a way that the change can't be detected via code
- inspect the database
- go in the in the `wp_options` table and search for the option with name `permalink_structure`
- manually change its value directly in the database to, for example, `/%postname%/`
- go back to the WordPress admin > SEO and see the notice doesn't appear: the change hasn't been detected
- refresh the page just to be sure, or navigate to other SEO pages: no notice appears
- inspect the database:
	- go to the `wp_yoast_indexable` table and see all the permalinks are still there (with some exceptions for special objects)
	- this means the permalinks in the table haven't been flushed because no change was detected
- the WP-Cron job added in this PR covers this case by checking the stored value with the current value and flushing the permalinks if the values don't match
- the job runs daily so normally you would need to wait for 24 hour :)
- thanks to WP-CLI we can run the job immediately with this command:
	- `./wp.sh cron event run wpseo_permalink_structure_check`
	- if you have more than one Docker container running, specify the container for the command:
	- `./wp.sh basic-wordpress cron event run wpseo_permalink_structure_check`
- inspect the database:
	- go to the `wp_yoast_indexable` table and see all the permalinks have been flushed
- go back to the WordPress admin > SEO and see the notice appears
- run the re-indexation
- inspect the `wp_yoast_indexable` table again and see the permalinks have been regenerated
- run the `./wp.sh cron event run wpseo_permalink_structure_check` command again, this time you should _not_ see the admin notice
- check the `wp_yoast_indexable` table and see that permalinks remain untouched


**On multisite:**
Testing on multisite basically means repeating the steps above for all the sites in the network. Some WP-CLI commands differ. The main goal here is to make sure that a change on one of the sites flushes the permalinks of only that site.
- you can use the Docker environment and run the `multisite-wordpress` container
- in the terminal, stop Docker press Ctrl + C in the terminal tab where Docker is running
- also run `docker-compose down` to be sure all containers are stopped
- use this command to start both the basic (single site) and the multisite containers:
	- `./start.sh basic-wordpress multisite-wordpress`
- go to `http://multisite.wordpress.test/wp-admin/`
- by default, it has the main site (with 101 posts) and a "Site2" (with 101 posts)
- create a third site: "Site3" and add more than 25 posts: you can use Duplicate posts to speed up the posts creation
- network-activate Yoast SEO and the Yoast Test Helper plugin
- repeat the "Preliminary steps" listed above for all 3 sites
- (skipping some steps)
- with the Yoast Test Helper plugin, run the upgrade routine on all 3 sites
- inspect the database and make sure all 3 sites have the new item `permalink_structure` in the `wpseo` option in the `wp_options` tables of all 3 sites (table names: wp_options, wp_2_options, wp_3_options)
- in the database:
	- go in the in the `wp_2_options` table of Site2 and search for the option with name `permalink_structure`
	- manually change its value directly in the database to, for example, `/%year%/%monthnum%/%postname%/` (other valid value: `/%postname%/`)
	- go to the `wp_2_yoast_indexable` table of Site2 and see all the permalinks are still there
	- this means the permalinks in the table haven't been flushed because no change was detected
- use WP-CLI to immediately run the job with this command:
	- `./wp.sh multisite-wordpress cron event run wpseo_permalink_structure_check --url=http://multisite.wordpress.test/site2`
- inspect the database:
	- go to the `wp_2_yoast_indexable` table and see all the permalinks have been flushed
	- check that the indexable tables of the other sites have _not_ been flushed
- go back to the Site2 WordPress admin > SEO and see the notice appears
- run the re-indexation
- inspect the `wp_2_yoast_indexable` table again and see the permalinks have been regenerated
- run the `./wp.sh multisite-wordpress cron event run wpseo_permalink_structure_check --url=http://multisite.wordpress.test/site2` command again, this time you should _not_ see the admin notice
- check the `wp_yoast_indexable` table and see that permalinks remain untouched




## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-150]