### PR TITLE
Fix indefinite loop

### DIFF
--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2175,7 +2175,8 @@ class ORM implements \ArrayAccess {
 				if ( \is_array( $column ) ) {
 					$column = \reset( $column );
 				}
-				$this->_data[ $column ] = $wpdb->insert_id;
+				// Explicitly cast to int to make dealing with Id's simpler.
+				$this->_data[ $column ] = (int) $wpdb->insert_id;
 			}
 		}
 		$this->_dirty_fields = [];

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -271,6 +271,7 @@ class Indexable_Builder {
 	 */
 	private function save_indexable( $indexable, $indexable_before = null ) {
 
+		// Save the indexable before running the wordpress hook.
 		$indexable->save();
 
 		if ( $indexable_before ) {
@@ -283,8 +284,6 @@ class Indexable_Builder {
 			 * @api Indexable The saved indexable.
 			 */
 			\do_action( 'wpseo_save_indexable', $indexable, $indexable_before );
-
-			$indexable->save();
 		}
 
 		return $indexable;

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -179,7 +179,7 @@ class Indexable_Builder {
 			);
 		}
 
-		$this->save_indexable( $indexable, $indexable_before );
+		$indexable = $this->save_indexable( $indexable, $indexable_before );
 
 		if ( \in_array( $object_type, [ 'post', 'term' ], true ) && $indexable->post_status !== 'unindexed' ) {
 			$this->hierarchy_builder->build( $indexable );
@@ -271,7 +271,7 @@ class Indexable_Builder {
 	 */
 	private function save_indexable( $indexable, $indexable_before = null ) {
 
-		// Save the indexable before running the wordpress hook.
+		// Save the indexable before running the WordPress hook.
 		$indexable->save();
 
 		if ( $indexable_before ) {

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -270,6 +270,9 @@ class Indexable_Builder {
 	 * @return Indexable The indexable.
 	 */
 	private function save_indexable( $indexable, $indexable_before = null ) {
+
+		$indexable->save();
+
 		if ( $indexable_before ) {
 			/**
 			 * Action: 'wpseo_save_indexable' - Allow developers to perform an action
@@ -280,9 +283,9 @@ class Indexable_Builder {
 			 * @api Indexable The saved indexable.
 			 */
 			\do_action( 'wpseo_save_indexable', $indexable, $indexable_before );
-		}
 
-		$indexable->save();
+			$indexable->save();
+		}
 
 		return $indexable;
 	}

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -123,9 +123,17 @@ class Indexable_Hierarchy_Builder {
 	 * @return void
 	 */
 	private function save_ancestors( $indexable ) {
-		$depth = \count( $indexable->ancestors );
+		$depth           = \count( $indexable->ancestors );
+		$saved_ancestors = [];
 		foreach ( $indexable->ancestors as $ancestor ) {
+			if ( in_array( $ancestor->id, $saved_ancestors, true ) ) {
+				continue;
+			}
+
 			$this->indexable_hierarchy_repository->add_ancestor( $indexable->id, $ancestor->id, $depth-- );
+
+			$saved_ancestors[] = $ancestor->id;
+
 		}
 	}
 

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -93,9 +93,7 @@ class Indexable_Hierarchy_Builder {
 	 * @return Indexable The indexable.
 	 */
 	public function build( Indexable $indexable ) {
-		if ( $indexable->has_ancestors ) {
-			$this->indexable_hierarchy_repository->clear_ancestors( $indexable->id );
-		}
+		$this->indexable_hierarchy_repository->clear_ancestors( $indexable->id );
 
 		$indexable_id = $this->get_indexable_id( $indexable );
 		$ancestors    = [];
@@ -108,7 +106,7 @@ class Indexable_Hierarchy_Builder {
 		}
 		$indexable->ancestors     = \array_reverse( \array_values( $ancestors ) );
 		$indexable->has_ancestors = ! empty( $ancestors );
-		if ( ! \is_null( $indexable->id ) ) {
+		if ( ! $indexable->id ) {
 			$this->save_ancestors( $indexable );
 		}
 

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -123,17 +123,9 @@ class Indexable_Hierarchy_Builder {
 	 * @return void
 	 */
 	private function save_ancestors( $indexable ) {
-		$depth           = \count( $indexable->ancestors );
-		$saved_ancestors = [];
+		$depth = \count( $indexable->ancestors );
 		foreach ( $indexable->ancestors as $ancestor ) {
-			if ( in_array( $ancestor->id, $saved_ancestors, true ) ) {
-				continue;
-			}
-
 			$this->indexable_hierarchy_repository->add_ancestor( $indexable->id, $ancestor->id, $depth-- );
-
-			$saved_ancestors[] = $ancestor->id;
-
 		}
 	}
 

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -20,6 +20,13 @@ use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 class Indexable_Hierarchy_Builder {
 
 	/**
+	 * Holds a list of indexables where the ancestors are saved for.
+	 *
+	 * @var array
+	 */
+	protected $saved_ancestors = [];
+
+	/**
 	 * The indexable repository.
 	 *
 	 * @var Indexable_Repository
@@ -93,6 +100,10 @@ class Indexable_Hierarchy_Builder {
 	 * @return Indexable The indexable.
 	 */
 	public function build( Indexable $indexable ) {
+		if ( $this->hierarchy_is_built( $indexable ) ) {
+			return $indexable;
+		}
+
 		$this->indexable_hierarchy_repository->clear_ancestors( $indexable->id );
 
 		$indexable_id = $this->get_indexable_id( $indexable );
@@ -106,11 +117,29 @@ class Indexable_Hierarchy_Builder {
 		}
 		$indexable->ancestors     = \array_reverse( \array_values( $ancestors ) );
 		$indexable->has_ancestors = ! empty( $ancestors );
-		if ( ! $indexable->id ) {
+
+		if ( $indexable->id ) {
 			$this->save_ancestors( $indexable );
 		}
 
 		return $indexable;
+	}
+
+	/**
+	 * Checks if a hierarchy is built already for the given indexable.
+	 *
+	 * @param Indexable $indexable The indexable to check.
+	 *
+	 * @return bool True when indexable has a built hierarchy.
+	 */
+	protected function hierarchy_is_built( Indexable $indexable ) {
+		if ( \in_array( $indexable->id, $this->saved_ancestors, true ) ) {
+			return true;
+		}
+
+		$this->saved_ancestors[] = $indexable->id;
+
+		return false;
 	}
 
 	/**

--- a/src/repositories/indexable-hierarchy-repository.php
+++ b/src/repositories/indexable-hierarchy-repository.php
@@ -59,6 +59,7 @@ class Indexable_Hierarchy_Repository {
 				'blog_id'      => \get_current_blog_id(),
 			]
 		);
+
 		return $hierarchy->save();
 	}
 

--- a/tests/integration/test-class-wpseo-breadcrumbs.php
+++ b/tests/integration/test-class-wpseo-breadcrumbs.php
@@ -15,24 +15,6 @@ class WPSEO_Breadcrumbs_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @covers WPSEO_Breadcrumbs::breadcrumb
 	 */
-	/*
-	public function test_breadcrumb_home() {
-
-		// Test for home breadcrumb.
-		$expected = '<span prefix="v: http://rdf.data-vocabulary.org/#">
-			<span typeof="v:Breadcrumb"><span class="breadcrumb_last" property="v:title">Home</span></span>
-		</span>';
-		$output = WPSEO_Breadcrumbs::breadcrumb( '', '', false );
-		$this->assertSame( $expected, trim( $output ) );
-
-		// @todo Test actual breadcrumb output.
-	}*/
-
-	/**
-	 * Placeholder test to prevent PHPUnit from throwing errors.
-	 *
-	 * @covers WPSEO_Breadcrumbs::breadcrumb
-	 */
 	public function test_breadcrumb_before() {
 
 		// Test before argument.

--- a/tests/integration/test-class-wpseo-breadcrumbs.php
+++ b/tests/integration/test-class-wpseo-breadcrumbs.php
@@ -15,7 +15,8 @@ class WPSEO_Breadcrumbs_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @covers WPSEO_Breadcrumbs::breadcrumb
 	 */
-	/*public function test_breadcrumb_home() {
+	/*
+	public function test_breadcrumb_home() {
 
 		// Test for home breadcrumb.
 		$expected = '<span prefix="v: http://rdf.data-vocabulary.org/#">

--- a/tests/unit/builders/indexable-hierarchy-builder-test.php
+++ b/tests/unit/builders/indexable-hierarchy-builder-test.php
@@ -22,9 +22,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group builders
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder
- * @covers ::<!public>
- * @covers ::__construct
- * @covers ::set_indexable_repository
+ * @covers \Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder
  *
  * @package Yoast\Tests\Builders
  */


### PR DESCRIPTION
Move the save above the hook to make sure the indexable is saved already

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When the indexables aren't indexed, there can be an infinated loop in some cases: on the frontend, post overview in the admin and post edit.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It fixes a bug that is introduced in the same branch :)

## Relevant technical choices:

* moved the save function before the hook to ensure the event is triggered with a saved indexable.
* added an int cast in the orm layer to force inserted id's to int instead of string (this was already in place in selects, but now in inserts too.) this reduces a bunch of duplicate key errors because int keys were being compared to string keys.
* added a method to prevent indexables being added to the hierarchy more than once.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* clear both indexable tables
* go to wordpress admin page > posts > all posts overview
* You should NOT see an error along the lines of 'bad JSON output'
* the query debug bar should NOT show any database errors.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
