### PR TITLE
Compare the current focus keyword with the last SEMrush request on modal open

### DIFF
--- a/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -79,6 +79,7 @@ export function hasMaximumRelatedKeyphrases( relatedKeyphrases ) {
 export default function RelatedKeyphraseModalContent( props ) {
 	const {
 		response,
+		lastRequestKeyphrase,
 		keyphrase,
 		newRequest,
 		setCountry,
@@ -110,6 +111,7 @@ export default function RelatedKeyphraseModalContent( props ) {
 						setRequestSucceeded={ setRequestSucceeded }
 						setRequestLimitReached={ setRequestLimitReached }
 						response={ response }
+						lastRequestKeyphrase={ lastRequestKeyphrase }
 					/>
 				</Fragment>
 			) }
@@ -140,6 +142,7 @@ RelatedKeyphraseModalContent.propTypes = {
 	setRequestFailed: PropTypes.func.isRequired,
 	setNoResultsFound: PropTypes.func.isRequired,
 	response: PropTypes.object,
+	lastRequestKeyphrase: PropTypes.object,
 };
 
 RelatedKeyphraseModalContent.defaultProps = {
@@ -148,4 +151,5 @@ RelatedKeyphraseModalContent.defaultProps = {
 	renderAction: null,
 	requestLimitReached: false,
 	response: {},
+	lastRequestKeyphrase: {},
 };

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -165,7 +165,7 @@ class SEMrushCountrySelector extends Component {
 	 */
 	componentDidMount() {
 		//	Fire a new request when the modal is first opened
-		if ( ! this.props.response ) {
+		if ( ! this.props.response || this.props.keyphrase !== this.props.lastRequestKeyphrase ) {
 			this.relatedKeyphrasesRequest();
 		}
 	}
@@ -320,6 +320,7 @@ SEMrushCountrySelector.propTypes = {
 	keyphrase: PropTypes.string,
 	countryCode: PropTypes.string,
 	response: PropTypes.object,
+	lastRequestKeyphrase: PropTypes.string,
 	setCountry: PropTypes.func.isRequired,
 	newRequest: PropTypes.func.isRequired,
 	setNoResultsFound: PropTypes.func.isRequired,
@@ -332,6 +333,7 @@ SEMrushCountrySelector.defaultProps = {
 	keyphrase: "",
 	countryCode: "us",
 	response: {},
+	lastRequestKeyphrase: "",
 };
 
 /**

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -159,12 +159,12 @@ class SEMrushCountrySelector extends Component {
 	}
 
 	/**
-	 * Creates a select2 component from the select, listens to the change action and fires the first SEMrush request.
+	 * Listens to the change action and fires the SEMrush request.
 	 *
 	 * @returns {void}
 	 */
 	componentDidMount() {
-		//	Fire a new request when the modal is first opened
+		// Fire a new request when the modal is first opened and when the keyphrase has been changed.
 		if ( ! this.props.response || this.props.keyphrase !== this.props.lastRequestKeyphrase ) {
 			this.relatedKeyphrasesRequest();
 		}

--- a/js/src/containers/SEMrushRelatedKeyphrases.js
+++ b/js/src/containers/SEMrushRelatedKeyphrases.js
@@ -15,6 +15,7 @@ export default compose( [
 			getSEMrushRequestIsSuccess,
 			getSEMrushIsRequestPending,
 			getSEMrushRequestHasData,
+			getSEMrushRequestKeyphrase,
 		} = select( "yoast-seo/editor" );
 
 		return {
@@ -25,6 +26,7 @@ export default compose( [
 			isSuccess: getSEMrushRequestIsSuccess(),
 			isPending: getSEMrushIsRequestPending(),
 			requestHasData: getSEMrushRequestHasData(),
+			lastRequestKeyphrase: getSEMrushRequestKeyphrase(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* **Problem**:
Currently, we only fire a request the first time the SEMrush modal is opened since the page has last refreshed. The cached data is stored for a day with `set_transient` (see `src/actions/semrush/semrush-phrases-action.php` line 71). When a SEMrush token is unexpectedly changed and is not valid anymore (manual database changes for instance) the cached results are still shown, even when the keyword is changed. When a new request is fired, an error will be displayed that something went wrong because your token is not valid.
**Solution**: 
We want to always fire a request when the modal is opened if the requested keyphrase has been changed since the last request. If not, the cached data should be presented. This way the token will be checked since the only way to validate the token is by sending a request and you do not fire unnecessary requests if you did not change your keyword.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Send a new request to SEMrush if the focus keyword has changed since the last one

## Relevant technical choices:

* A possible alternative approach was to purge the request object from the Redux state when the focus keyword changes. I ruled out that because we would have had one state change for every small change in the focus keyword, and even deleting and then restoring the same keyphrase would have resulted in a new request to the server (though it would have been cached as a transient, so not useful to test the tokens anyway).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* first, have a look at the problem if you're not familiar with it:
  * build from `trunk`
  * edit a post
  * enter a keyphrase and get related keyphrases from SEMrush
  * close the modal
  * change the keyphrase and get related keyphrases from SEMrush
  * see that when the modal opens, the previous results are shown until you click on the button to send a new request.
* checkout this branch and build
* edit a post
* enter a keyphrase and get related keyphrases from SEMrush. It can be the last one you've queried if you want (the cached results from the transient will be shown in that case)
* close the modal
* change the keyphrase and get related keyphrases from SEMrush. Use a keyphrase that you haven't queried at all so there are no cached results.
* see that when the modal opens, a new request to SEMrush is sent: you should see the "loading" message before the table with results in shown.
* close the modal
* _do not change the keyphrase_ and click the button to open the modal again
* see that when the modal opens, the table with the results is already there and no request is sent to the server to get results (whether cached in a transient or not)
* close the modal
* _change the keyphrase and then revert the change_ (e.g, delete one letter and then type the same letter again in the same place) and click the button to open the modal again
* see that when the modal opens, the table with the results is already there and no request is sent to the server to get results (whether cached in a transient or not)

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-179]
