### PR TITLE
add check and rewrite SVN stable version in readme.txt for RC release…

### DIFF
--- a/config/grunt/custom-tasks/check-deploy-allowed.js
+++ b/config/grunt/custom-tasks/check-deploy-allowed.js
@@ -30,7 +30,7 @@ module.exports = function( grunt ) {
 			if ( ! versionMatch ) {
 				grunt.fail.fatal(
 					"The Stable tag specified in the readme.txt file is not set to the stable tag currently on WordPress: " + stableVersion + ". " +
-					"Therefor you cannot deploy with this readme.txt file.\n" +
+					"Therefore, you cannot deploy with this readme.txt file.\n" +
 					"The release process has been stopped."
 				);
 			}

--- a/config/grunt/custom-tasks/check-deploy-allowed.js
+++ b/config/grunt/custom-tasks/check-deploy-allowed.js
@@ -1,5 +1,7 @@
-/**
- * Checks if the stable tag is an RC version and aborts the release process if so.
+const wordpressApi = require( "../lib/wordpress-api" );
+
+/*
+ * Checks if the stable tag in the readme.txt is set to the version currently on wordpress.org and aborts the RC release process if not so.
  *
  * @param {Object} grunt The grunt helper object.
  *
@@ -8,17 +10,29 @@
 module.exports = function( grunt ) {
 	grunt.registerTask(
 		"check-deploy-allowed",
-		"Checks if the stable tag is an RC version and aborts the release process if so.",
-		function() {
-			const contents = grunt.file.read( "readme.txt" );
-			const regex = new RegExp( "Stable tag: .*-RC.*" );
-			const isRCVersion = contents.search( regex ) !== -1;
-			if ( isRCVersion ) {
+		"Checks if the stable tag in the readme.txt is set to the version currently on wordpress.org and aborts the release process if not so.",
+		async function() {
+			var done = this.async();
+			const stableVerion = await wordpressApi.getPluginStableVersionFromWordPressApi( grunt.config.data.pluginSlug );
+			if ( stableVerion === null ){
 				grunt.fail.fatal(
-					"The Stable tag specified in the readme.txt file contains RC tag. You cannot deploy an RC version. " +
+					"The Stable tag for plugin: " + grunt.config.data.pluginSlug + " could not be retrieved from api.wordpress.org\n" +
 					"The release process has been stopped."
 				);
 			}
+			grunt.verbose.writeln( "Worpress api stable tag verion: " + stableVerion + " for plugin: " + grunt.config.data.pluginSlug )
+			let contents = grunt.file.read( "readme.txt" );
+			contents = contents.split( "\n" ).slice( 0, 9 ).join( "\n" );
+            grunt.verbose.writeln("first 10 lines of readme.txt file: \n"+ contents );
+			const regex = new RegExp( "\nStable tag: " + stableVerion + "\n" );
+			const notVersionMatch = contents.search( regex ) == -1;
+			if ( notVersionMatch ) {
+				grunt.fail.fatal(
+					"The Stable tag specified in the readme.txt file is not set to the stable tag curently on wordpress: " + stableVerion + ". There for you cannot deploy with this readme.txt file.\n" +
+					"The release process has been stopped."
+				);
+			};
+			done();
 		}
 	);
 };

--- a/config/grunt/custom-tasks/check-deploy-allowed.js
+++ b/config/grunt/custom-tasks/check-deploy-allowed.js
@@ -26,8 +26,8 @@ module.exports = function( grunt ) {
 			contents = contents.split( "\n" ).slice( 0, 9 ).join( "\n" );
 			grunt.verbose.writeln( "First 10 lines of readme.txt file: \n" + contents );
 			const regex = new RegExp( "\nStable tag: " + stableVersion + "\n" );
-			const notVersionMatch = contents.search( regex ) === -1;
-			if ( notVersionMatch ) {
+			const versionMatch = contents.search( regex ) !== -1;
+			if ( ! versionMatch ) {
 				grunt.fail.fatal(
 					"The Stable tag specified in the readme.txt file is not set to the stable tag currently on WordPress: " + stableVersion + ". " +
 					"Therefor you cannot deploy with this readme.txt file.\n" +

--- a/config/grunt/custom-tasks/check-deploy-allowed.js
+++ b/config/grunt/custom-tasks/check-deploy-allowed.js
@@ -12,26 +12,28 @@ module.exports = function( grunt ) {
 		"check-deploy-allowed",
 		"Checks if the stable tag in the readme.txt is set to the version currently on wordpress.org and aborts the release process if not so.",
 		async function() {
-			var done = this.async();
-			const stableVerion = await wordpressApi.getPluginStableVersionFromWordPressApi( grunt.config.data.pluginSlug );
-			if ( stableVerion === null ){
+			const done = this.async();
+			const stableVersion = await wordpressApi.getPluginStableVersionFromWordPressApi( grunt.config.data.pluginSlug );
+			if ( stableVersion === null ) {
 				grunt.fail.fatal(
 					"The Stable tag for plugin: " + grunt.config.data.pluginSlug + " could not be retrieved from api.wordpress.org\n" +
 					"The release process has been stopped."
 				);
 			}
-			grunt.verbose.writeln( "Worpress api stable tag verion: " + stableVerion + " for plugin: " + grunt.config.data.pluginSlug )
+			grunt.verbose.writeln( "WordPress API stable tag version: " + stableVersion + " for plugin: " + grunt.config.data.pluginSlug );
 			let contents = grunt.file.read( "readme.txt" );
+			// Get the first 10 lines of the readme.txt file.
 			contents = contents.split( "\n" ).slice( 0, 9 ).join( "\n" );
-            grunt.verbose.writeln("first 10 lines of readme.txt file: \n"+ contents );
-			const regex = new RegExp( "\nStable tag: " + stableVerion + "\n" );
-			const notVersionMatch = contents.search( regex ) == -1;
+			grunt.verbose.writeln( "First 10 lines of readme.txt file: \n" + contents );
+			const regex = new RegExp( "\nStable tag: " + stableVersion + "\n" );
+			const notVersionMatch = contents.search( regex ) === -1;
 			if ( notVersionMatch ) {
 				grunt.fail.fatal(
-					"The Stable tag specified in the readme.txt file is not set to the stable tag curently on wordpress: " + stableVerion + ". There for you cannot deploy with this readme.txt file.\n" +
+					"The Stable tag specified in the readme.txt file is not set to the stable tag currently on WordPress: " + stableVersion + ". " +
+					"Therefor you cannot deploy with this readme.txt file.\n" +
 					"The release process has been stopped."
 				);
-			};
+			}
 			done();
 		}
 	);

--- a/config/grunt/custom-tasks/sync-readme-stable-tag.js
+++ b/config/grunt/custom-tasks/sync-readme-stable-tag.js
@@ -1,42 +1,17 @@
 const wordpressApi = require( "../lib/wordpress-api" );
 
 module.exports = function( grunt ) {
-	grunt.registerTask(
-		"sync-readme-stable-tag",
-		"Makes sure the Stable version is set to the latest released on wordpress.org.",
-		async function() {
-			const done = this.async();
-
-			const targetFile = "readme.txt";
-			const stableVerion = await wordpressApi.getPluginStableVersionFromWordPressApi( grunt.config.data.pluginSlug );
-			if ( stableVerion === null ){
-				grunt.fail.fatal(
-					"The Stable tag for plugin: " + grunt.config.data.pluginSlug + " could not be retrieved from api.wordpress.org\n" +
-					"The release process has been stopped."
-				);
-			}
-
-			const currentVersion = getVersion( targetFile, /(\n?)(Stable tag: )(\d+(\.\d+){0,3})(\n)/, 3 );
-			//grunt.verbose.writeln ( "stable Tag version in readme.txt: " + currentVersion + "\nretrieved verion: " + stableVerion );
-			// Only change the file if the version does not match.
-			if ( currentVersion !== stableVerion ) {
-				grunt.verbose.writeln ( "stable Tag version in readme.txt: " + currentVersion + "\nretrieved version: " + stableVerion + "\nWill set it to the retrieved worpress.org value now." );
-				setVersion( targetFile, /(\n?)(Stable tag: )(\d+(\.\d+){0,3})(\n)/, "$1$2" + stableVerion + "\n" );
-			}
-
-			return done();
-		}
-	);
-
 	/**
 	 * Helper function to update the content of the file.
 	 *
 	 * @param {string} file Target file.
 	 * @param {RegExp} pattern Pattern to search for.
 	 * @param {string} version Version to insert.
+	 *
+	 * @returns {void}
 	 */
 	function setVersion( file, pattern, version ) {
-		let contents = grunt.file.read( file ).replace(
+		const contents = grunt.file.read( file ).replace(
 			pattern,
 			version
 		);
@@ -51,9 +26,38 @@ module.exports = function( grunt ) {
 	 * @param {RegExp} pattern Pattern to search for.
 	 * @param {int} index Index to return.
 	 *
-	 * @return {string} The version from the file.
+	 * @returns {string} The version from the file.
 	 */
 	function getVersion( file, pattern, index ) {
 		return pattern.exec( grunt.file.read( file ) )[ index ];
 	}
+
+	grunt.registerTask(
+		"sync-readme-stable-tag",
+		"Makes sure the Stable version is set to the latest released on wordpress.org.",
+		async function() {
+			const done = this.async();
+
+			const targetFile = "readme.txt";
+			const stableVersion = await wordpressApi.getPluginStableVersionFromWordPressApi( grunt.config.data.pluginSlug );
+			if ( stableVersion === null ) {
+				grunt.fail.fatal(
+					"The Stable tag for plugin: " + grunt.config.data.pluginSlug + " could not be retrieved from api.wordpress.org\n" +
+					"The release process has been stopped."
+				);
+			}
+
+			const currentVersion = getVersion( targetFile, /(\n?)(Stable tag: )(\d+(\.\d+){0,3})(\n)/, 3 );
+			//grunt.verbose.writeln ( "stable Tag version in readme.txt: " + currentVersion + "\nretrieved verion: " + stableVersion );
+			// Only change the file if the version does not match.
+			if ( currentVersion !== stableVersion ) {
+				grunt.verbose.writeln( "Stable tag version in readme.txt: " + currentVersion + "\n" +
+					"Retrieved version from wordpress.org: " + stableVersion + "\n" +
+					"Will set the version in readme.txt to the retrieved wordpress.org value now." );
+				setVersion( targetFile, /(\n?)(Stable tag: )(\d+(\.\d+){0,3})(\n)/, "$1$2" + stableVersion + "\n" );
+			}
+
+			return done();
+		}
+	);
 };

--- a/config/grunt/custom-tasks/sync-readme-stable-tag.js
+++ b/config/grunt/custom-tasks/sync-readme-stable-tag.js
@@ -48,7 +48,6 @@ module.exports = function( grunt ) {
 			}
 
 			const currentVersion = getVersion( targetFile, /(\n?)(Stable tag: )(\d+(\.\d+){0,3})(\n)/, 3 );
-			//grunt.verbose.writeln ( "stable Tag version in readme.txt: " + currentVersion + "\nretrieved verion: " + stableVersion );
 			// Only change the file if the version does not match.
 			if ( currentVersion !== stableVersion ) {
 				grunt.verbose.writeln( "Stable tag version in readme.txt: " + currentVersion + "\n" +

--- a/config/grunt/custom-tasks/sync-readme-stable-tag.js
+++ b/config/grunt/custom-tasks/sync-readme-stable-tag.js
@@ -1,0 +1,59 @@
+const wordpressApi = require( "../lib/wordpress-api" );
+
+module.exports = function( grunt ) {
+	grunt.registerTask(
+		"sync-readme-stable-tag",
+		"Makes sure the Stable version is set to the latest released on wordpress.org.",
+		async function() {
+			const done = this.async();
+
+			const targetFile = "readme.txt";
+			const stableVerion = await wordpressApi.getPluginStableVersionFromWordPressApi( grunt.config.data.pluginSlug );
+			if ( stableVerion === null ){
+				grunt.fail.fatal(
+					"The Stable tag for plugin: " + grunt.config.data.pluginSlug + " could not be retrieved from api.wordpress.org\n" +
+					"The release process has been stopped."
+				);
+			}
+
+			const currentVersion = getVersion( targetFile, /(\n?)(Stable tag: )(\d+(\.\d+){0,3})(\n)/, 3 );
+			//grunt.verbose.writeln ( "stable Tag version in readme.txt: " + currentVersion + "\nretrieved verion: " + stableVerion );
+			// Only change the file if the version does not match.
+			if ( currentVersion !== stableVerion ) {
+				grunt.verbose.writeln ( "stable Tag version in readme.txt: " + currentVersion + "\nretrieved version: " + stableVerion + "\nWill set it to the retrieved worpress.org value now." );
+				setVersion( targetFile, /(\n?)(Stable tag: )(\d+(\.\d+){0,3})(\n)/, "$1$2" + stableVerion + "\n" );
+			}
+
+			return done();
+		}
+	);
+
+	/**
+	 * Helper function to update the content of the file.
+	 *
+	 * @param {string} file Target file.
+	 * @param {RegExp} pattern Pattern to search for.
+	 * @param {string} version Version to insert.
+	 */
+	function setVersion( file, pattern, version ) {
+		let contents = grunt.file.read( file ).replace(
+			pattern,
+			version
+		);
+
+		grunt.file.write( file, contents );
+	}
+
+	/**
+	 * Reads the value pattern from the file.
+	 *
+	 * @param {string} file Target file.
+	 * @param {RegExp} pattern Pattern to search for.
+	 * @param {int} index Index to return.
+	 *
+	 * @return {string} The version from the file.
+	 */
+	function getVersion( file, pattern, index ) {
+		return pattern.exec( grunt.file.read( file ) )[ index ];
+	}
+};

--- a/config/grunt/lib/wordpress-api.js
+++ b/config/grunt/lib/wordpress-api.js
@@ -10,7 +10,7 @@ const fetch = require( "node-fetch" );
 
 async function getPluginStableVersionFromWordPressApi( pluginSlug ) {
 	pluginSlug = pluginSlug.toLowerCase();
-	const wordpressResponse = await fetch( "https://api.wordpress.org/plugins/info/1.0/${ pluginSlug }.json" );
+	const wordpressResponse = await fetch( `https://api.wordpress.org/plugins/info/1.0/${ pluginSlug }.json` );
 	if ( ! wordpressResponse.ok ) {
 		return null;
 	}
@@ -27,7 +27,7 @@ module.exports.getPluginStableVersionFromWordPressApi = getPluginStableVersionFr
  */
 
 async function getLatestWordpressFromWordPressApi() {
-	const wordpressResponse = await fetch( "http://api.wordpress.org/core/version-check/1.7/" );
+	const wordpressResponse = await fetch( `http://api.wordpress.org/core/version-check/1.7/` );
 	if ( ! wordpressResponse.ok ) {
 		return null;
 	}

--- a/config/grunt/lib/wordpress-api.js
+++ b/config/grunt/lib/wordpress-api.js
@@ -10,7 +10,7 @@ const fetch = require( "node-fetch" );
 
 async function getPluginStableVersionFromWordPressApi( pluginSlug ) {
 	pluginSlug = pluginSlug.toLowerCase();
-	const wordpressResponse = await fetch( `https://api.wordpress.org/plugins/info/1.0/${ pluginSlug }.json` );
+	const wordpressResponse = await fetch( "https://api.wordpress.org/plugins/info/1.0/${ pluginSlug }.json" );
 	if ( ! wordpressResponse.ok ) {
 		return null;
 	}
@@ -27,7 +27,7 @@ module.exports.getPluginStableVersionFromWordPressApi = getPluginStableVersionFr
  */
 
 async function getLatestWordpressFromWordPressApi() {
-	const wordpressResponse = await fetch( `http://api.wordpress.org/core/version-check/1.7/` );
+	const wordpressResponse = await fetch( "http://api.wordpress.org/core/version-check/1.7/" );
 	if ( ! wordpressResponse.ok ) {
 		return null;
 	}

--- a/config/grunt/lib/wordpress-api.js
+++ b/config/grunt/lib/wordpress-api.js
@@ -1,9 +1,9 @@
 const fetch = require( "node-fetch" );
 
 /**
- * Gets stable version for a WordPress plugin from the wordpress api.
+ * Gets stable version for a WordPress plugin from the WordPress API.
  *
- * @param {string} pluginSlug The name of the plugin .
+ * @param {string} pluginSlug The name of the plugin.
  *
  * @returns {Promise<object|null>} A promise resolving to the version.
  */
@@ -21,20 +21,18 @@ async function getPluginStableVersionFromWordPressApi( pluginSlug ) {
 module.exports.getPluginStableVersionFromWordPressApi = getPluginStableVersionFromWordPressApi;
 
 /**
- * Gets the latest WordPress version from the wordpress api.
- *
- * 
+ * Gets the latest WordPress version from the WordPress API.
  *
  * @returns {Promise<object|null>} A promise resolving to the version.
  */
 
-async function getLatestWordpressFromWordPressApi( ) {
+async function getLatestWordpressFromWordPressApi() {
 	const wordpressResponse = await fetch( `http://api.wordpress.org/core/version-check/1.7/` );
 	if ( ! wordpressResponse.ok ) {
 		return null;
 	}
 	const ResponseJson = await wordpressResponse.json();
-	return ResponseJson.offers[0].version || null;
+	return ResponseJson.offers[ 0 ].version || null;
 }
 
 module.exports.getLatestWordpressFromWordPressApi = getLatestWordpressFromWordPressApi;

--- a/config/grunt/lib/wordpress-api.js
+++ b/config/grunt/lib/wordpress-api.js
@@ -1,0 +1,40 @@
+const fetch = require( "node-fetch" );
+
+/**
+ * Gets stable version for a WordPress plugin from the wordpress api.
+ *
+ * @param {string} pluginSlug The name of the plugin .
+ *
+ * @returns {Promise<object|null>} A promise resolving to the version.
+ */
+
+async function getPluginStableVersionFromWordPressApi( pluginSlug ) {
+	pluginSlug = pluginSlug.toLowerCase();
+	const wordpressResponse = await fetch( `https://api.wordpress.org/plugins/info/1.0/${ pluginSlug }.json` );
+	if ( ! wordpressResponse.ok ) {
+		return null;
+	}
+	const ResponseJson = await wordpressResponse.json();
+	return ResponseJson.version || null;
+}
+
+module.exports.getPluginStableVersionFromWordPressApi = getPluginStableVersionFromWordPressApi;
+
+/**
+ * Gets the latest WordPress version from the wordpress api.
+ *
+ * 
+ *
+ * @returns {Promise<object|null>} A promise resolving to the version.
+ */
+
+async function getLatestWordpressFromWordPressApi( ) {
+	const wordpressResponse = await fetch( `http://api.wordpress.org/core/version-check/1.7/` );
+	if ( ! wordpressResponse.ok ) {
+		return null;
+	}
+	const ResponseJson = await wordpressResponse.json();
+	return ResponseJson.offers[0].version || null;
+}
+
+module.exports.getLatestWordpressFromWordPressApi = getLatestWordpressFromWordPressApi;

--- a/config/grunt/task-config/aliases.yaml
+++ b/config/grunt/task-config/aliases.yaml
@@ -122,8 +122,10 @@ clean:build-assets:
   - 'artifact'
   - 'github-pre-release'
   - 'notify-slack:rc'
+  - 'sync-readme-stable-tag'
   - 'check-deploy-allowed'
   - 'wp_deploy:trunk'
+  - 'shell:readme-reset-txt'
   - 'verify-zip-size'
   - 'celebrate'
 

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -209,6 +209,12 @@ module.exports = function( grunt ) {
 				callback: throwUncommittedChangesError,
 			},
 		},
+		"readme-reset-txt": {
+			command: "git checkout readme.txt",
+			options: {
+				failOnError: false,
+			},
+		},
 	};
 	/* eslint-enable require-jsdoc */
 };


### PR DESCRIPTION
## Context
* Add a check to the readme.txt file to make sure the stable version is set to the same as we currently have on Wordpress SVN.
* Add a rewrite SVN stable version in readme.txt to set it to the current SVN stable tag
* Add a reset to the readme.txt to reset it to the current Github version.
* changed RC release to first update to the correct stable tag than check and pus to SVN than reset.
* All of this is to ensure a RC release will not change the stable version on Wordpress

## Summary

This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

* All of this is to ensure a RC release will not change the stable version on Wordpress SVN
* before we used the stable tag specified on github (in readme.txt),  as we want more flexibility, we need a other way  to ensure we are not changeing the stable tag on SVN.  
* use https://api.wordpress.org/plugins/info/1.0/wordpress-seo.json to retreive stable tag

## Test instructions
This PR can be tested by following these steps:

* unfortunately it is only possible to test the component:
 change the stable tag in the readme.txt and run: these tasks:
* `grunt check-deploy-allowed` - should fail if stable tag in readme.txt =! stable tag on wordpress 
* `grunt shell:readme-reset-txt` - should reset the readme.txt to the last commited one
* `grunt sync-readme-stable-tag` - should write the stable tag to the one on worpress.org

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
