### PR TITLE
Web Stories: ensure that there’s always a meta description

### DIFF
--- a/src/integrations/third-party/web-stories.php
+++ b/src/integrations/third-party/web-stories.php
@@ -8,6 +8,7 @@ use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Web_Stories_Conditional;
 use Yoast\WP\SEO\Integrations\Front_End_Integration;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 
 /**
  * Web Stories integration.
@@ -51,6 +52,7 @@ class Web_Stories implements Integration_Interface {
 		\add_action( 'web_stories_story_head', [ $this->front_end, 'call_wpseo_head' ], 9 );
 		\add_filter( 'wpseo_schema_article_post_types', [ $this, 'filter_schema_article_post_types' ] );
 		\add_action( 'admin_enqueue_scripts', [ $this, 'dequeue_admin_assets' ] );
+		\add_filter( 'wpseo_metadesc', [ $this, 'filter_meta_description' ], 10, 2 );
 	}
 
 	/**
@@ -104,5 +106,20 @@ class Web_Stories implements Integration_Interface {
 	public function filter_schema_article_post_types( $post_types ) {
 		$post_types[] = Google_Web_Stories\Story_Post_Type::POST_TYPE_SLUG;
 		return $post_types;
+	}
+
+	/**
+	 * Filters the meta description for stories.
+	 *
+	 * @param string $description The description sentence.
+	 * @param Indexable_Presentation $presentation The presentation of an indexable.
+	 * @return string The description sentence.
+	 */
+	public function filter_meta_description( $description, $presentation ) {
+		if ( $description || $presentation->model->object_sub_type !== Google_Web_Stories\Story_Post_Type::POST_TYPE_SLUG ) {
+			return $description;
+		}
+
+		return \get_the_excerpt( $presentation->model->object_id );
 	}
 }


### PR DESCRIPTION
## Context

In order for Web Stories to be discoverable, it makes sense to always have a meta description.

Since Web Stories for WordPress does not _yet_ have support for the Yoast meta boxes, this seems like the easiest way to ensure meta descriptions being present, without the user having to change the Search Appearance settings.

If there's a better suited filter for this, please let me know.

## Summary

This PR can be summarized in the following changelog entry:

* Web Stories: ensure that there’s always a meta description

## Relevant technical choices:

* Uses the `wpseo_metadesc` filter to fall back to displaying the post excerpt if there's no meta description present.

## Test instructions

This PR can be tested by following these steps:

1. Create a new web story
1. Add some excerpt in the document panel
1. Publish the story
1. Verify that the meta description is added on the frontend

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
