### PR TITLE
Swap Structured Data tool with Rich Results.

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -326,8 +326,8 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			],
 			[
 				'id'     => 'wpseo-structureddata',
-				'title'  => __( 'Google Structured Data Test', 'wordpress-seo' ),
-				'href'   => 'https://search.google.com/structured-data/testing-tool#url=' . $encoded_url,
+				'title'  => __( 'Google Rich Results Test', 'wordpress-seo' ),
+				'href'   => 'https://search.google.com/test/rich-results?url=' . $encoded_url,
 			],
 			[
 				'id'     => 'wpseo-facebookdebug',


### PR DESCRIPTION
Do I need to change the ID?
changelog: bugfix

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* changes structured data test which is being deprecated to rich results test.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where we linked to Google's Structured Data Test, which is deprecated. We now link to Google's Rich Results Test. Props to [wormeyman](https://github.com/wormeyman).

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure you are an editor (and NOT an admin)
* Open a blog post while logged in and the admin bar active
* Hover over the yoast icon
* scroll down to analyze this page
* click Structured Data Test

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #16105 
