### PR TITLE
Add the upstream branch to push to

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -133,6 +133,7 @@ module.exports = function( grunt ) {
 				gitcommit: "grunt-git",
 				gitcheckout: "grunt-git",
 				gitpull: "grunt-git",
+				gitpush: "grunt-git",
 				"update-version": "@yoast/grunt-plugin-tasks",
 				"set-version": "@yoast/grunt-plugin-tasks",
 				"register-prompt": "grunt-prompt",

--- a/config/grunt/custom-tasks/bump-rc-version.js
+++ b/config/grunt/custom-tasks/bump-rc-version.js
@@ -98,7 +98,7 @@ module.exports = function( grunt ) {
 				grunt.config( "gitcommit.versionBump.options.message", "Update the plugin version to " + grunt.config.data.pluginVersion );
 				grunt.task.run( "gitcommit:versionBump" );
 
-				grunt.config( "gitpush.versionBump.options", { remote: "origin", upstream: true } );
+				grunt.config( "gitpush.versionBump.options", { remote: "origin", upstream: true, branch: grunt.config.data.branchForRC } );
 				grunt.task.run( "gitpush:versionBump" );
 			}
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* If the release branch doesn't yet exist upstream (and is created locally in the `create-rc` task), it fails with a fatal error when pushing to GitHub. While the error message (see the screenshot in the issue) suggests that this is due to a missing `--set-upstream`, it was [explained on Slack](https://yoast.slack.com/archives/CUXBV0FR6/p1601024595013100?thread_ts=1601021983.010200&cid=CUXBV0FR6) that the error message is wrong and that actually the branch that you want to push to, is undefined. This PR fixes that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug in the RC automatization where the upstream branch was not defined.

## Relevant technical choices:

* I also specified that we want to use `grunt-git` for the `gitpush` command (it is unclear why this was missing from the code, although the code did seem to be working without it).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new release branch locally that doesn't exist remotely yet.
* For example, run `grunt create-rc --plugin-version=15.2 --type=release`.
* Without this PR, the automatization should fail at the step: `Running "gitpush:versionBump" (gitpush) task`.
* With this PR, it should not fail and push the branch to GitHub.
* You should break off the script directly after you see the push to GitHub succeeding, to avoid unwanted pushes to GitHub releases and more. (We are still waiting for a `--dry-run` option [to be implemented](https://yoast.atlassian.net/browse/P2-320) to solve this).
* Don't forget to delete the release branch you created, both locally and (especially) on the remote.
* This PR can only be tested once it has been merged into trunk, because otherwise the code from this PR is not available in the release branch.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-384
