### PR TITLE
Travis: fix Premium builds not reporting failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -252,9 +252,7 @@ script:
     if [[ "$PHPLINT" == "1" ]]; then
       travis_fold start "PHP.check" && travis_time_start
       if [[ "$IS_PREMIUM" == "1" ]]; then
-        cd premium
-        composer lint
-        cd -
+        cd premium && composer lint && cd -
       else
         composer lint
       fi
@@ -265,9 +263,7 @@ script:
     if [[ "$PHPCS" == "1" ]]; then
       travis_fold start "PHP.code-style" && travis_time_start
       if [[ "$IS_PREMIUM" == "1" ]]; then
-        cd premium
-        composer check-cs
-        cd -
+        cd premium && composer check-cs && cd -
       else
         composer check-cs-threshold
       fi


### PR DESCRIPTION
## Context

* QA

## Summary

This PR can be summarized in the following changelog entry:

* QA

## Relevant technical choices:

Travis only takes the exit code of the LAST command into account and as a number of the scripts related to Premium now contain `cd` commands, the `cd` command was the one from which the exit code was being taken.

In reality, the Premium builds should have been failing for quite a while now, but due to the above, the failures weren't being reported.

## Test instructions

This PR can be tested by following these steps:

* _N/A_ This won't show any significant difference in the Travis output until it is merged back to Premium and I've been fixing a number of the errors already, though there may still be some which will cause the builds to fail once the merge back is done.
    Seeing those failures is the whole point of this PR.