### PR TITLE
Fix lastRequestKeyphrase prop type.

### DIFF
--- a/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -142,7 +142,7 @@ RelatedKeyphraseModalContent.propTypes = {
 	setRequestFailed: PropTypes.func.isRequired,
 	setNoResultsFound: PropTypes.func.isRequired,
 	response: PropTypes.object,
-	lastRequestKeyphrase: PropTypes.object,
+	lastRequestKeyphrase: PropTypes.string,
 };
 
 RelatedKeyphraseModalContent.defaultProps = {
@@ -151,5 +151,5 @@ RelatedKeyphraseModalContent.defaultProps = {
 	renderAction: null,
 	requestLimitReached: false,
 	response: {},
-	lastRequestKeyphrase: {},
+	lastRequestKeyphrase: "",
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

This is a quick PR to fix a prop type.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a JS warning is thrown in the console when opening the "Get related keyphrases" modal dialog.

## Relevant technical choices:

* See related PR https://github.com/Yoast/wordpress-seo/pull/16098

## Test instructions
I'm not sure why but, for me, the warning is visible in the console only on **Premium trunk**. However, the root cause of the warning is also on Free and in the release/15.1 branch.

- test on Premium trunk
- edit a post
- add a keyphrase and click "Get related keyphrases" to open the modal
- see the warning in your browser's dev tools console

`Warning: Failed prop type: Invalid prop `lastRequestKeyphrase` of type `string` supplied to `RelatedKeyphraseModalContent`, expected `object`. in RelatedKeyphraseModalContent (created by WithDispatch(RelatedKeyphraseModalContent))`

![Screenshot 2020-09-29 at 12 21 42](https://user-images.githubusercontent.com/1682452/94547262-55cb7080-024f-11eb-949e-a79541257b18.png)

The keyphrase is always a string so the `lastRequestKeyphrase` should always be a string.
- switch to Free and to this branch, build
- repeat the steps above
- observe there's no JS warning (as said above, the warning is not visible in the console for me but this might be because of other warnings or quirks in the react-devtools extension)


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended


