### PR TITLE
Use HTML button to fix broken import of new `Button` component

### DIFF
--- a/js/src/indexation.js
+++ b/js/src/indexation.js
@@ -2,7 +2,6 @@
 import { render, Component, Fragment } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { ProgressBar } from "@yoast/components";
-import { Button } from "@yoast/components/src/button/Button";
 import { Alert } from "@yoast/components";
 import { colors } from "@yoast/style-guide";
 
@@ -249,9 +248,13 @@ class Indexing extends Component {
 		if ( this.settings.disabled ) {
 			return <Fragment>
 				<p>
-					<Button disabled={ true } variant="grey">
+					<button
+						className="yoast-button yoast-button--secondary"
+						type="button"
+						disabled={ true }
+					>
 						{ __( "Start SEO data optimization", "wordpress-seo" ) }
-					</Button>
+					</button>
 				</p>
 				<Alert type={ "info" }>
 					{ __( "This button to optimize the SEO data for your website is disabled for non-production environments.", "wordpress-seo" ) }
@@ -286,12 +289,20 @@ class Indexing extends Component {
 				}
 				{
 					this.state.inProgress
-						? <Button onClick={ this.stopIndexing } variant="grey">
+						? <button
+							className="yoast-button yoast-button--secondary"
+							type="button"
+							onClick={ this.stopIndexing }
+						>
 							{ __( "Stop SEO data optimization", "wordpress-seo" ) }
-						</Button>
-						: <Button onClick={ this.startIndexing } variant="purple">
+						</button>
+						: <button
+							className="yoast-button yoast-button--primary"
+							type="button"
+							onClick={ this.startIndexing }
+						>
 							{ __( "Start SEO data optimization", "wordpress-seo" ) }
-						</Button>
+						</button>
 				}
 			</Fragment>
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The previous code caused the `webpack:buildProd` task to fail when building RC's.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Replaces a React `Button` with an HTML button to fix an import problem when the monorepo is unlinked.

## Relevant technical choices:

* Direct imports from the node modules don't work, because they don't have an `src` folder. The reason we had a direct import in the code is because we wanted to have the newly styled React Buttons, and due to a naming conflict with the old buttons we can only have them via direct imports (which only works well with linked monorepo, but for RC building the monorepo has to be unlinked).
* Therefore, in this PR I am replacing the React `Button` with an HTML button, so we don't need the import anymore.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* The behaviour of the button should be the same as described in the test instructions in https://github.com/Yoast/wordpress-seo/pull/16056.

**To test whether the button is properly disabled on non-production websites (also see https://github.com/Yoast/wordpress-seo/pull/16049):**
* Use the Yoast_Test_Tools plugin to clear indexable data.
* switch the wordpress site to a staging site, ( in other words, make \wpseo_functions\wp_get_environment_type return something other than 'production' )
* navigate to the Yoast SEO plugin menu.
* Expected: The button should now be disabled and an additional warning should appear.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
