### PR TITLE
P3-190 Add Integrations tab for Network admin

### DIFF
--- a/admin/pages/network.php
+++ b/admin/pages/network.php
@@ -17,6 +17,7 @@ $yform->admin_header( true, 'wpseo_ms' );
 $tabs = new WPSEO_Option_Tabs( 'network' );
 $tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ) ) );
 $tabs->add_tab( new WPSEO_Option_Tab( 'features', __( 'Features', 'wordpress-seo' ) ) );
+$tabs->add_tab( new WPSEO_Option_Tab( 'integrations', __( 'Integrations', 'wordpress-seo' ) ) );
 $tabs->add_tab( new WPSEO_Option_Tab( 'restore-site', __( 'Restore Site', 'wordpress-seo' ), [ 'save_button' => false ] ) );
 $tabs->display( $yform );
 

--- a/admin/views/tabs/dashboard/integrations.php
+++ b/admin/views/tabs/dashboard/integrations.php
@@ -43,7 +43,7 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 
 			$feature_help = new WPSEO_Admin_Help_Panel(
 				$integration->setting,
-				/* translators: %s expands to a integration's name */
+				/* translators: %s expands to an integration's name */
 				sprintf( esc_html__( 'Help on: %s', 'wordpress-seo' ), esc_html( $integration->name ) ),
 				$help_text
 			);

--- a/admin/views/tabs/network/integrations.php
+++ b/admin/views/tabs/network/integrations.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Admin\Views
+ *
+ * @uses Yoast_Form $yform Form object.
+ */
+
+if ( ! defined( 'WPSEO_VERSION' ) ) {
+	header( 'Status: 403 Forbidden' );
+	header( 'HTTP/1.1 403 Forbidden' );
+	exit();
+}
+
+$integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
+
+?>
+	<h2><?php esc_html_e( 'Integrations', 'wordpress-seo' ); ?></h2>
+	<div class="yoast-measure">
+		<?php
+		echo sprintf(
+		/* translators: %1$s expands to Yoast SEO */
+			esc_html__( 'This tab allows you to selectively disable %1$s integrations with third parties products for all sites in the network. By default all integrations are enabled, which allows site admins to choose for themselves if they want to toggle an integration on or off for their site. When you disable an integration here, site admins will not be able to use that integration at all.', 'wordpress-seo' ),
+			'Yoast SEO'
+		);
+
+		foreach ( $integration_toggles as $integration ) {
+			$help_text = esc_html( $integration->label );
+
+			if ( ! empty( $integration->extra ) ) {
+				$help_text .= ' ' . $integration->extra;
+			}
+
+			if ( ! empty( $integration->read_more_label ) ) {
+				$help_text .= ' ';
+				$help_text .= sprintf(
+					'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
+					esc_url( WPSEO_Shortlinker::get( $integration->read_more_url ) ),
+					esc_html( $integration->read_more_label )
+				);
+			}
+
+			$feature_help = new WPSEO_Admin_Help_Panel(
+				WPSEO_Option::ALLOW_KEY_PREFIX . $integration->setting,
+				/* translators: %s expands to a integration's name */
+				sprintf( esc_html__( 'Help on: %s', 'wordpress-seo' ), esc_html( $integration->name ) ),
+				$help_text
+			);
+
+			$yform->toggle_switch(
+				WPSEO_Option::ALLOW_KEY_PREFIX . $integration->setting,
+				[
+					'on'  => __( 'On', 'wordpress-seo' ),
+					'off' => __( 'Off', 'wordpress-seo' ),
+				],
+				'<strong>' . $integration->name . '</strong>',
+				$feature_help->get_button_html() . $feature_help->get_panel_html()
+			);
+		}
+		?>
+	</div>
+<?php
+/*
+ * Required to prevent our settings framework from saving the default because the field isn't
+ * explicitly set when saving the Dashboard page.
+ */
+$yform->hidden( 'show_onboarding_notice', 'wpseo_show_onboarding_notice' );

--- a/admin/views/tabs/network/integrations.php
+++ b/admin/views/tabs/network/integrations.php
@@ -21,7 +21,7 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 		<?php
 		echo sprintf(
 		/* translators: %1$s expands to Yoast SEO */
-			esc_html__( 'This tab allows you to selectively disable %1$s integrations with third parties products for all sites in the network. By default all integrations are enabled, which allows site admins to choose for themselves if they want to toggle an integration on or off for their site. When you disable an integration here, site admins will not be able to use that integration at all.', 'wordpress-seo' ),
+			esc_html__( 'This tab allows you to selectively disable %1$s integrations with third-party products for all sites in the network. By default all integrations are enabled, which allows site admins to choose for themselves if they want to toggle an integration on or off for their site. When you disable an integration here, site admins will not be able to use that integration at all.', 'wordpress-seo' ),
 			'Yoast SEO'
 		);
 
@@ -43,7 +43,7 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 
 			$feature_help = new WPSEO_Admin_Help_Panel(
 				WPSEO_Option::ALLOW_KEY_PREFIX . $integration->setting,
-				/* translators: %s expands to a integration's name */
+				/* translators: %s expands to an integration's name */
 				sprintf( esc_html__( 'Help on: %s', 'wordpress-seo' ), esc_html( $integration->name ) ),
 				$help_text
 			);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The integrations tab is missing in Network admin for multisite, so SEMrush can't be enabled/disabled network-wide (this also measn that subsites may not be able to enable/disable the SEMrush integration for themselves)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes integrations tab non-existence for network admin 

## Relevant technical choices:

* The copy for the integrations tab message was adapted from the one in the features tab. This should be reviewed by Product afterwards, we're going on anyway with fixing the bug since it's blocking

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* On a multisite installation with the plugin installed and active network-wide, visit the network Dashboard
* visit SEO → General and observe the integration tab is now present
* visit SEO → General in a subsite and observe that in the integration tab you can enable/disable the SEMrush integration (you can test whether the "Get related keyphrase" is hidden in a post edit screen when the integration is disabled)
* visit SEO → General in the network Dashboard again and disable the SEMrush integration, then save
* visit SEO → General in a subsite and observe that in the integration tab you can't enable the SEMrush integration (a message will warn you that it's disabled at network level). Check also that you won't see the "Get related keyphrases" button while editing a post.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-190] [P3-188]
