### PR TITLE
Fix SEMrush network switch naming

### DIFF
--- a/admin/views/tabs/network/integrations.php
+++ b/admin/views/tabs/network/integrations.php
@@ -51,8 +51,8 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 			$yform->toggle_switch(
 				WPSEO_Option::ALLOW_KEY_PREFIX . $integration->setting,
 				[
-					'on'  => __( 'On', 'wordpress-seo' ),
-					'off' => __( 'Off', 'wordpress-seo' ),
+					'on'  => __( 'Allow Control', 'wordpress-seo' ),
+					'off' => __( 'Disable', 'wordpress-seo' ),
 				],
 				'<strong>' . $integration->name . '</strong>',
 				$feature_help->get_button_html() . $feature_help->get_panel_html()


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes the naming of the SEMrush switch as network admin from 'on' and 'off' to 'Allow Control' and 'Disable'.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the naming

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
