### PR TITLE
Change wording of Premium upsell in the plugins overview

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -230,7 +230,7 @@ class WPSEO_Admin {
 		}
 
 		// Add link to premium support landing page.
-		$premium_link = '<a style="font-weight: bold;" href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1yb' ) ) . '" target="_blank">' . __( 'Premium Support', 'wordpress-seo' ) . '</a>';
+		$premium_link = '<a style="font-weight: bold;" href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/1yb' ) ) . '" target="_blank">' . __( 'Get Premium', 'wordpress-seo' ) . '</a>';
 		array_unshift( $links, $premium_link );
 
 		// Add link to docs.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* As discussed with Joost and Olga on Slack, the wording of the premium upsell on the plugin page should be changed from 'Premium Support' to 'Get Premium'.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the wording of the premium upsell on the plugin page from 'Premium Support' to 'Get Premium'

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Activate Free.
* Navigate to the plugin overview screen.
* See 'Get Premium' instead of 'Premium Support'

Before: 
![Screenshot 2020-10-01 at 09 58 04](https://user-images.githubusercontent.com/17744553/94800137-77aa2c00-03e4-11eb-8fdd-1000acef4669.png)

After:
<img width="1111" alt="Schermafbeelding 2020-10-01 om 12 45 08" src="https://user-images.githubusercontent.com/17744553/94800157-80026700-03e4-11eb-96fb-ed1389bd034b.png">


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
