### PR TITLE
Start indexation if redirected from notification

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=851",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=829",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=259",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/js/src/indexation.js
+++ b/js/src/indexation.js
@@ -240,6 +240,23 @@ class Indexing extends Component {
 	}
 
 	/**
+	 * Start indexation on mount, when redirected from the "Start SEO data optimization" button in the dashboard notification.
+	 *
+	 * @returns {void}
+	 */
+	componentDidMount() {
+		if ( this.settings.disabled ) {
+			return;
+		}
+
+		const shouldStart = new URLSearchParams( window.location.search ).get( "start-indexation" ) === "true";
+
+		if ( shouldStart ) {
+			this.startIndexing();
+		}
+	}
+
+	/**
 	 * Renders the component
 	 *
 	 * @returns {JSX.Element} The rendered component.

--- a/release-info.json
+++ b/release-info.json
@@ -1,5 +1,5 @@
 {
   "version": "15.1",
-  "release_description": "Easily finding related keyphrases with the SEMRush integration, Farsi keyphrase recognition and improved display of cornerstone content in internal linking suggestions.",
+  "release_description": "Easily find related keyphrases and their actual Google search volume with the SEMRush integration; Farsi keyphrase recognition.",
   "shortlink": "https://yoa.st/yoast15-1"
 }

--- a/src/helpers/notification-helper.php
+++ b/src/helpers/notification-helper.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Yoast\WP\SEO\Helpers;
+
+use Yoast_Notification;
+use Yoast_Notification_Center;
+
+/**
+ * A helper object for notifications.
+ */
+class Notification_Helper{
+
+	/**
+	 * Restores a notification (wrapper function).
+	 *
+	 * @param Yoast_Notification $notification The notification to restore.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return bool True if restored, false otherwise.
+	 */
+	public function restore_notification( Yoast_Notification $notification ) {
+		return Yoast_Notification_Center::restore_notification( $notification );
+	}
+}

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -179,6 +179,7 @@ class Indexing_Notification_Integration implements Integration_Interface {
 
 		$notification = $this->notification();
 		$this->notification_helper->restore_notification( $notification );
+		$this->options_helper->set( 'indexation_warning_hide_until', false );
 		$this->notification_center->add_notification( $notification );
 	}
 

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -223,9 +223,13 @@ class Indexing_Notification_Integration implements Integration_Interface {
 		 * Show the notification when it is not in the hide notification period.
 		 * (E.g. when the user clicked on 'hide this notification for a week').
 		 */
-		$hide_until = (int) $this->options_helper->get( 'indexation_warning_hide_until' );
+		$hide_until = $this->options_helper->get( 'indexation_warning_hide_until', false );
 
-		return ( $hide_until !== 0 && $hide_until >= $this->date_helper->current_time() );
+		if ( $hide_until === false ) {
+			return true;
+		}
+
+		return ( $this->date_helper->current_time() > ( (int) $hide_until ) );
 	}
 
 	/**

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -138,6 +138,9 @@ class Indexing_Notification_Integration implements Integration_Interface {
 
 		if ( ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {
 			\wp_schedule_event( $this->date_helper->current_time(), 'daily', self::NOTIFICATION_ID );
+			\add_action( 'admin_init', [ $this, 'create_notification' ] );
+
+			return;
 		}
 
 		\add_action( self::NOTIFICATION_ID, [ $this, 'create_notification' ] );

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Date_Helper;
+use Yoast\WP\SEO\Helpers\Notification_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
@@ -15,7 +16,7 @@ use Yoast_Notification;
 use Yoast_Notification_Center;
 
 /**
- * Class Indexing_Notification_Integration
+ * Class Indexing_Notification_Integration.
  *
  * @package Yoast\WP\SEO\Integrations\Admin
  */
@@ -96,6 +97,13 @@ class Indexing_Notification_Integration implements Integration_Interface {
 	protected $short_link_helper;
 
 	/**
+	 * The notification helper.
+	 *
+	 * @var Notification_Helper
+	 */
+	protected $notification_helper;
+
+	/**
 	 * Prominent_Words_Notifier constructor.
 	 *
 	 * @param Indexing_Integration      $indexing_integration The indexing integration.
@@ -105,6 +113,7 @@ class Indexing_Notification_Integration implements Integration_Interface {
 	 * @param Current_Page_Helper       $page_helper          The current page helper.
 	 * @param Date_Helper               $date_helper          The date helper.
 	 * @param Short_Link_Helper         $short_link_helper    The short link helper.
+	 * @param Notification_Helper       $notification_helper  The notification helper.
 	 */
 	public function __construct(
 		Indexing_Integration $indexing_integration,
@@ -113,7 +122,8 @@ class Indexing_Notification_Integration implements Integration_Interface {
 		Product_Helper $product_helper,
 		Current_Page_Helper $page_helper,
 		Date_Helper $date_helper,
-		Short_Link_Helper $short_link_helper
+		Short_Link_Helper $short_link_helper,
+		Notification_Helper $notification_helper
 	) {
 		$this->indexing_integration = $indexing_integration;
 		$this->notification_center  = $notification_center;
@@ -122,6 +132,7 @@ class Indexing_Notification_Integration implements Integration_Interface {
 		$this->page_helper          = $page_helper;
 		$this->date_helper          = $date_helper;
 		$this->short_link_helper    = $short_link_helper;
+		$this->notification_helper  = $notification_helper;
 	}
 
 	/**
@@ -167,7 +178,7 @@ class Indexing_Notification_Integration implements Integration_Interface {
 		}
 
 		$notification = $this->notification();
-		$this->notification_center->restore_notification( $notification );
+		$this->notification_helper->restore_notification( $notification );
 		$this->notification_center->add_notification( $notification );
 	}
 

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -162,13 +162,13 @@ class Indexing_Notification_Integration implements Integration_Interface {
 	 * it to the notification center if this is the case.
 	 */
 	public function create_notification() {
-		$notification = $this->notification_center->get_notification_by_id( self::NOTIFICATION_ID );
-
-		if ( $notification || ! $this->should_show_notification() ) {
+		if ( ! $this->should_show_notification() ) {
 			return;
 		}
 
-		$this->notification_center->add_notification( $this->notification() );
+		$notification = $this->notification();
+		$this->notification_center->restore_notification( $notification );
+		$this->notification_center->add_notification( $notification );
 	}
 
 	/**

--- a/src/presenters/admin/indexing-notification-presenter.php
+++ b/src/presenters/admin/indexing-notification-presenter.php
@@ -54,7 +54,7 @@ class Indexing_Notification_Presenter extends Abstract_Presenter {
 	public function present() {
 		$notification_text  = '<p>' . $this->message . '</p>';
 		$notification_text .= '<p>' . $this->get_time_estimate( $this->total_unindexed ) . '</p>';
-		$notification_text .= '<a class="button" href="' . \get_admin_url( null, 'admin.php?page=wpseo_tools' ) . '">';
+		$notification_text .= '<a class="button" href="' . \get_admin_url( null, 'admin.php?page=wpseo_tools&start-indexation=true' ) . '">';
 		$notification_text .= \esc_html__( 'Start SEO data optimization', 'wordpress-seo' );
 		$notification_text .= '</a>';
 

--- a/src/surfaces/helpers-surface.php
+++ b/src/surfaces/helpers-surface.php
@@ -20,6 +20,7 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
  * @property Helpers\Indexable_Helper      $indexable
  * @property Helpers\Language_Helper       $language
  * @property Helpers\Meta_Helper           $meta
+ * @property Helpers\Notification_Helper   $notification
  * @property Helpers\Options_Helper        $options
  * @property Helpers\Pagination_Helper     $pagination
  * @property Helpers\Post_Helper           $post

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -411,6 +411,107 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	}
 
 	/**
+	 * Tests whether a notification is shown when the "Hide for 7 days" is clicked and the 7 days have expired.
+	 * 
+	 * @covers ::create_notification
+	 * @covers ::should_show_notification
+	 * @covers ::notification
+	 */
+	public function test_create_notification_when_hide_has_expired() {
+		$mocked_time = 1653426177;
+
+		$this->date_helper
+			->expects( 'current_time' )
+			->twice()
+			->andReturn( $mocked_time );
+
+		$this->notification_center
+			->expects( 'get_notification_by_id' )
+			->once()
+			->andReturnNull();
+
+		$this->indexing_integration
+			->expects( 'get_total_unindexed' )
+			->twice()
+			->andReturn( 40 );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'indexables_indexation_reason', '' )
+			->twice()
+			->andReturn( '' );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'indexation_started' )
+			->once()
+			->andReturn( 1593426177 );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'indexation_warning_hide_until', false )
+			->once()
+			->andReturn( 1653426176 );
+
+		Monkey\Functions\expect( 'wp_get_current_user' )
+			->andReturn( 'user' );
+
+		$this->notification_center
+			->expects( 'add_notification' )
+			->once();
+
+		$this->instance->create_notification();
+	}
+
+	/**
+	 * Tests whether a notification is shown when the "Hide for 7 days" is clicked and the 7 days have NOT expired.
+	 * 
+	 * @covers ::create_notification
+	 * @covers ::should_show_notification
+	 */
+	public function test_create_notification_when_hide_has_not_expired() {
+		$mocked_time = 1653426177;
+
+		$this->date_helper
+			->expects( 'current_time' )
+			->twice()
+			->andReturn( $mocked_time );
+
+		$this->notification_center
+			->expects( 'get_notification_by_id' )
+			->once()
+			->andReturnNull();
+
+		$this->indexing_integration
+			->expects( 'get_total_unindexed' )
+			->once()
+			->andReturn( 40 );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'indexables_indexation_reason', '' )
+			->once()
+			->andReturn( '' );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'indexation_started' )
+			->once()
+			->andReturn( 1593426177 );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'indexation_warning_hide_until', false )
+			->once()
+			->andReturn( 1653426178 );
+
+		Monkey\Functions\expect( 'wp_get_current_user' )
+			->andReturn( 'user' );
+
+		$this->instance->create_notification();
+	}
+
+	/**
 	 * Tests that no notification is created when the user stopped the
 	 * indexing process manually.
 	 *

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -4,6 +4,7 @@ use Brain\Monkey;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Date_Helper;
+use Yoast\WP\SEO\Helpers\Notification_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
@@ -76,6 +77,13 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	protected $short_link_helper;
 
 	/**
+	 * The notification helper.
+	 *
+	 * @var Notification_Helper
+	 */
+	protected $notification_helper;
+
+	/**
 	 * Sets up the tests.
 	 */
 	public function setUp() {
@@ -88,6 +96,7 @@ class Indexing_Notification_Integration_Test extends TestCase {
 		$this->page_helper          = Mockery::mock( Current_Page_Helper::class );
 		$this->date_helper          = Mockery::mock( Date_Helper::class );
 		$this->short_link_helper    = Mockery::mock( Short_Link_Helper::class );
+		$this->notification_helper  = Mockery::mock( Notification_Helper::class );
 
 		$this->instance = new Indexing_Notification_Integration(
 			$this->indexing_integration,
@@ -96,7 +105,8 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			$this->product_helper,
 			$this->page_helper,
 			$this->date_helper,
-			$this->short_link_helper
+			$this->short_link_helper,
+			$this->notification_helper
 		);
 	}
 
@@ -124,6 +134,26 @@ class Indexing_Notification_Integration_Test extends TestCase {
 		$this->assertAttributeInstanceOf(
 			Product_Helper::class,
 			'product_helper',
+			$this->instance
+		);
+		$this->assertAttributeInstanceOf(
+			Current_Page_Helper::class,
+			'page_helper',
+			$this->instance
+		);
+		$this->assertAttributeInstanceOf(
+			Date_Helper::class,
+			'date_helper',
+			$this->instance
+		);
+		$this->assertAttributeInstanceOf(
+			Short_Link_Helper::class,
+			'short_link_helper',
+			$this->instance
+		);
+		$this->assertAttributeInstanceOf(
+			Notification_Helper::class,
+			'notification_helper',
 			$this->instance
 		);
 	}
@@ -219,39 +249,12 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests creating the notification when it already exists.
-	 *
-	 * @covers ::create_notification
-	 */
-	public function test_create_existing_notification() {
-		$this->notification_center
-			->expects( 'get_notification_by_id' )
-			->once()
-			->andReturn( 'the_notification' );
-
-		$this->options_helper
-			->expects( 'get' )
-			->never();
-
-		$this->notification_center
-			->expects( 'add_notification' )
-			->never();
-
-		$this->instance->create_notification();
-	}
-
-	/**
 	 * Tests creating the notification when there are no unindexed items.
 	 *
 	 * @covers ::create_notification
 	 * @covers ::should_show_notification
 	 */
 	public function test_create_notification_no_unindexed_items() {
-		$this->notification_center
-			->expects( 'get_notification_by_id' )
-			->once()
-			->andReturnNull();
-
 		$this->indexing_integration
 			->expects( 'get_total_unindexed' )
 			->once()
@@ -276,11 +279,6 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	 * @covers ::notification
 	 */
 	public function test_create_notification_with_indexing_failed_reason() {
-		$this->notification_center
-			->expects( 'get_notification_by_id' )
-			->once()
-			->andReturnNull();
-
 		$this->indexing_integration
 			->expects( 'get_total_unindexed' )
 			->once()
@@ -294,6 +292,14 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		Monkey\Functions\expect( 'wp_get_current_user' )
 			->andReturn( 'user' );
+
+		$this->notification_helper
+			->expects( 'restore_notification' )
+			->once();
+
+		$this->options_helper
+			->expects( 'set' )
+			->once();
 
 		$this->notification_center
 			->expects( 'add_notification' )
@@ -315,11 +321,6 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	 * @param string $reason The reason for indexing.
 	 */
 	public function test_create_notification_with_indexing_reasons( $reason ) {
-		$this->notification_center
-			->expects( 'get_notification_by_id' )
-			->once()
-			->andReturnNull();
-
 		$this->indexing_integration
 			->expects( 'get_total_unindexed' )
 			->twice()
@@ -335,6 +336,14 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		Monkey\Functions\expect( 'wp_get_current_user' )
 			->andReturn( 'user' );
+
+		$this->notification_helper
+			->expects( 'restore_notification' )
+			->once();
+
+		$this->options_helper
+			->expects( 'set' )
+			->once();
 
 		$this->notification_center
 			->expects( 'add_notification' )
@@ -372,11 +381,6 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $mocked_time );
 
-		$this->notification_center
-			->expects( 'get_notification_by_id' )
-			->once()
-			->andReturnNull();
-
 		$this->indexing_integration
 			->expects( 'get_total_unindexed' )
 			->twice()
@@ -403,6 +407,14 @@ class Indexing_Notification_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_get_current_user' )
 			->andReturn( 'user' );
 
+		$this->notification_helper
+			->expects( 'restore_notification' )
+			->once();
+
+		$this->options_helper
+			->expects( 'set' )
+			->once();
+
 		$this->notification_center
 			->expects( 'add_notification' )
 			->once();
@@ -412,7 +424,7 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 	/**
 	 * Tests whether a notification is shown when the "Hide for 7 days" is clicked and the 7 days have expired.
-	 * 
+	 *
 	 * @covers ::create_notification
 	 * @covers ::should_show_notification
 	 * @covers ::notification
@@ -424,11 +436,6 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->expects( 'current_time' )
 			->twice()
 			->andReturn( $mocked_time );
-
-		$this->notification_center
-			->expects( 'get_notification_by_id' )
-			->once()
-			->andReturnNull();
 
 		$this->indexing_integration
 			->expects( 'get_total_unindexed' )
@@ -456,6 +463,14 @@ class Indexing_Notification_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_get_current_user' )
 			->andReturn( 'user' );
 
+		$this->notification_helper
+			->expects( 'restore_notification' )
+			->once();
+
+		$this->options_helper
+			->expects( 'set' )
+			->once();
+
 		$this->notification_center
 			->expects( 'add_notification' )
 			->once();
@@ -465,7 +480,7 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 	/**
 	 * Tests whether a notification is shown when the "Hide for 7 days" is clicked and the 7 days have NOT expired.
-	 * 
+	 *
 	 * @covers ::create_notification
 	 * @covers ::should_show_notification
 	 */
@@ -476,11 +491,6 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->expects( 'current_time' )
 			->twice()
 			->andReturn( $mocked_time );
-
-		$this->notification_center
-			->expects( 'get_notification_by_id' )
-			->once()
-			->andReturnNull();
 
 		$this->indexing_integration
 			->expects( 'get_total_unindexed' )
@@ -527,11 +537,6 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->expects( 'current_time' )
 			->andReturn( $mocked_time );
 
-		$this->notification_center
-			->expects( 'get_notification_by_id' )
-			->once()
-			->andReturnNull();
-
 		$this->indexing_integration
 			->expects( 'get_total_unindexed' )
 			->once()
@@ -551,6 +556,14 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		Monkey\Functions\expect( 'wp_get_current_user' )
 			->andReturn( 'user' );
+
+		$this->notification_helper
+			->expects( 'restore_notification' )
+			->never();
+
+		$this->options_helper
+			->expects( 'set' )
+			->never();
 
 		$this->notification_center
 			->expects( 'add_notification' )

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -369,7 +369,7 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		$this->date_helper
 			->expects( 'current_time' )
-			->twice()
+			->once()
 			->andReturn( $mocked_time );
 
 		$this->notification_center
@@ -396,9 +396,9 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		$this->options_helper
 			->expects( 'get' )
-			->with( 'indexation_warning_hide_until' )
+			->with( 'indexation_warning_hide_until', false )
 			->once()
-			->andReturn( 1693426177 );
+			->andReturn( false );
 
 		Monkey\Functions\expect( 'wp_get_current_user' )
 			->andReturn( 'user' );


### PR DESCRIPTION
Fixes https://yoast.atlassian.net/browse/P2-390
Fixes https://yoast.atlassian.net/browse/P2-393

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where indexation wouldn't start automatically after being redirected to the tools page from the SEO dashboard notification.

## Relevant technical choices:

* Made small change to `register_hooks` where I call `create_notification` on `admin_init` instead of relying on wp-cron, because it was more reliable in my experience. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Start after redirect
* Clear the indexables using the Yoast test helper.
* Make sure the notification is shown by running `\wp_clear_scheduled_hook( self::NOTIFICATION_ID );` before `if ( ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {` in `indexing-notification-integration::register_hooks`.
* Go to the Yoast SEO dashboard, and click the `Start SEO data optimization` button in the notification.
* You should be redirected to the tools page and indexation should start automatically.

### Show notification again after 7 days
* Create 2500 posts. You can run this in your plugin-development-docker folder in the terminal: `docker exec -it --user www-data basic-wordpress wp post generate --count=2500`.
* Clear the indexables using the Yoast test helper.
* Add the following code to your `functions.php`:
```
add_action( 'admin_init', function() { wp_clear_scheduled_hook( 'wpseo-reindex' ); }, 1 );
```
* Click "remind me in a week" in the notification.
* Refresh the page. (You might see the notification disappear from the Hidden notifications, if so, then that's a [known bug](https://yoast.atlassian.net/browse/P2-408) that we are currently fixing).
* Look up the `wpseo` option in the `wp-options` table, and change the value of `indexation_warning_hide_until` to something small (i.e. `1`) to represent a date at least 7 days ago.
* Make sure the notification is shown again.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
