### PR TITLE
P3-186 purge SEMrush tokens when integration is disabled

### DIFF
--- a/src/integrations/watchers/option-wpseo-watcher.php
+++ b/src/integrations/watchers/option-wpseo-watcher.php
@@ -45,7 +45,7 @@ class Option_Wpseo_Watcher implements Integration_Interface {
 	 */
 	public function check_semrush_option( $old_value, $new_value ) {
 		if ( \array_key_exists( 'semrush_integration_active', $new_value )
-			 && $new_value['semrush_integration_active'] === false ) {
+			&& $new_value['semrush_integration_active'] === false ) {
 			YoastSEO()->helpers->options->set( 'semrush_tokens', [] );
 			return true;
 		}

--- a/src/integrations/watchers/option-wpseo-watcher.php
+++ b/src/integrations/watchers/option-wpseo-watcher.php
@@ -3,7 +3,7 @@
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
 use Yoast\WP\SEO\Integrations\Integration_Interface;
-use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
 
 /**
  * Watcher for the wpseo option.
@@ -11,6 +11,8 @@ use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
  * Represents the option wpseo watcher.
  */
 class Option_Wpseo_Watcher implements Integration_Interface {
+
+	use No_Conditionals;
 
 	/**
 	 * Initializes the integration.
@@ -21,15 +23,6 @@ class Option_Wpseo_Watcher implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'update_option_wpseo', [ $this, 'check_semrush_option' ], 10, 2 );
-	}
-
-	/**
-	 * Returns the conditionals based in which this loadable should be active.
-	 *
-	 * @return array
-	 */
-	public static function get_conditionals() {
-		return [ Migrations_Conditional::class ];
 	}
 
 	/**

--- a/src/integrations/watchers/option-wpseo-watcher.php
+++ b/src/integrations/watchers/option-wpseo-watcher.php
@@ -22,13 +22,13 @@ class Option_Wpseo_Watcher implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_action( 'update_option_wpseo', [ $this, 'check_semrush_option' ], 10, 2 );
+		\add_action( 'update_option_wpseo', [ $this, 'check_semrush_option_disabled' ], 10, 2 );
 	}
 
 	/**
 	 * Checks if the SEMrush integration is disabled; if so, deletes the tokens.
 	 *
-	 * We delete the tokens it the SEMrush integration is disabled, no matter if
+	 * We delete the tokens if the SEMrush integration is disabled, no matter if
 	 * the value has actually changed or not.
 	 *
 	 * @param array $old_value The old value of the option.
@@ -36,7 +36,7 @@ class Option_Wpseo_Watcher implements Integration_Interface {
 	 *
 	 * @return bool Whether the SEMrush tokens have been deleted or not.
 	 */
-	public function check_semrush_option( $old_value, $new_value ) {
+	public function check_semrush_option_disabled( $old_value, $new_value ) {
 		if ( \array_key_exists( 'semrush_integration_active', $new_value )
 			&& $new_value['semrush_integration_active'] === false ) {
 			YoastSEO()->helpers->options->set( 'semrush_tokens', [] );

--- a/src/integrations/watchers/option-wpseo-watcher.php
+++ b/src/integrations/watchers/option-wpseo-watcher.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Watchers;
+
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+
+/**
+ * Watcher for the wpseo option.
+ *
+ * Represents the option wpseo watcher.
+ */
+class Option_Wpseo_Watcher implements Integration_Interface {
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * This is the place to register hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'update_option_wpseo', [ $this, 'check_semrush_option' ], 10, 2 );
+	}
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * @return array
+	 */
+	public static function get_conditionals() {
+		return [ Migrations_Conditional::class ];
+	}
+
+	/**
+	 * Checks if the SEMrush integration is disabled; if so, deletes the tokens.
+	 *
+	 * We delete the tokens it the SEMrush integration is disabled, no matter if
+	 * the value has actually changed or not.
+	 *
+	 * @param array $old_value The old value of the option.
+	 * @param array $new_value The new value of the option.
+	 *
+	 * @return bool Whether the SEMrush tokens have been deleted or not.
+	 */
+	public function check_semrush_option( $old_value, $new_value ) {
+		if ( \array_key_exists( 'semrush_integration_active', $new_value )
+			 && $new_value['semrush_integration_active'] === false ) {
+			YoastSEO()->helpers->options->set( 'semrush_tokens', [] );
+			return true;
+		}
+		return false;
+	}
+}

--- a/tests/unit/integrations/watchers/option-wpseo-watcher-test.php
+++ b/tests/unit/integrations/watchers/option-wpseo-watcher-test.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
 use Brain\Monkey;
 use Mockery;
-use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Watchers\Option_Wpseo_Watcher;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
@@ -32,18 +31,6 @@ class Option_Wpseo_Watcher_Test extends TestCase {
 		parent::setUp();
 
 		$this->instance = new Option_Wpseo_Watcher();
-	}
-
-	/**
-	 * Tests if the expected conditionals are in place.
-	 *
-	 * @covers \Yoast\WP\SEO\Integrations\Watchers\Option_Wpseo_Watcher::get_conditionals
-	 */
-	public function test_get_conditionals() {
-		$this->assertEquals(
-			[ Migrations_Conditional::class ],
-			Option_Wpseo_Watcher::get_conditionals()
-		);
 	}
 
 	/**

--- a/tests/unit/integrations/watchers/option-wpseo-watcher-test.php
+++ b/tests/unit/integrations/watchers/option-wpseo-watcher-test.php
@@ -41,24 +41,24 @@ class Option_Wpseo_Watcher_Test extends TestCase {
 	public function test_register_hooks() {
 		$this->instance->register_hooks();
 
-		$this->assertTrue( Monkey\Actions\has( 'update_option_wpseo', [ $this->instance, 'check_semrush_option' ] ) );
+		$this->assertTrue( Monkey\Actions\has( 'update_option_wpseo', [ $this->instance, 'check_semrush_option_disabled' ] ) );
 	}
 
 	/**
 	 * Tests with the new value being true.
 	 *
-	 * @covers \Yoast\WP\SEO\Integrations\Watchers\Option_Wpseo_Watcher::check_semrush_option
+	 * @covers \Yoast\WP\SEO\Integrations\Watchers\Option_Wpseo_Watcher::check_semrush_option_disabled
 	 */
-	public function test_check_semrush_option_with_new_value_being_true() {
-		$this->assertFalse( $this->instance->check_semrush_option( null, [ 'semrush_integration_active' => true ] ) );
+	public function test_check_semrush_option_disabled_with_new_value_being_true() {
+		$this->assertFalse( $this->instance->check_semrush_option_disabled( null, [ 'semrush_integration_active' => true ] ) );
 	}
 
 	/**
 	 * Tests with the new value being false .
 	 *
-	 * @covers \Yoast\WP\SEO\Integrations\Watchers\Option_Wpseo_Watcher::check_semrush_option
+	 * @covers \Yoast\WP\SEO\Integrations\Watchers\Option_Wpseo_Watcher::check_semrush_option_disabled
 	 */
-	public function test_check_semrush_option_with_new_value_being_false() {
+	public function test_check_semrush_option_disabled_with_new_value_being_false() {
 		$options_helper = Mockery::mock( Options_Helper::class );
 		$options_helper->expects( 'set' )->once()->andReturn( true );
 
@@ -68,6 +68,6 @@ class Option_Wpseo_Watcher_Test extends TestCase {
 		Monkey\Functions\expect( 'YoastSEO' )
 			->andReturn( (object) [ 'helpers' => $helper_surface ] );
 
-		$this->assertTrue( $this->instance->check_semrush_option( null, [ 'semrush_integration_active' => false ] ) );
+		$this->assertTrue( $this->instance->check_semrush_option_disabled( null, [ 'semrush_integration_active' => false ] ) );
 	}
 }

--- a/tests/unit/integrations/watchers/option-wpseo-watcher-test.php
+++ b/tests/unit/integrations/watchers/option-wpseo-watcher-test.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Watchers\Option_Wpseo_Watcher;
+use Yoast\WP\SEO\Surfaces\Helpers_Surface;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Option_Wpseo_Watcher_Test.
+ *
+ * @group integrations
+ * @group watchers
+ */
+class Option_Wpseo_Watcher_Test extends TestCase {
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Option_Wpseo_Watcher
+	 */
+	protected $instance;
+
+	/**
+	 * Does the setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = new Option_Wpseo_Watcher();
+	}
+
+	/**
+	 * Tests if the expected conditionals are in place.
+	 *
+	 * @covers \Yoast\WP\SEO\Integrations\Watchers\Option_Wpseo_Watcher::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals(
+			[ Migrations_Conditional::class ],
+			Option_Wpseo_Watcher::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers \Yoast\WP\SEO\Integrations\Watchers\Option_Wpseo_Watcher::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertTrue( Monkey\Actions\has( 'update_option_wpseo', [ $this->instance, 'check_semrush_option' ] ) );
+	}
+
+	/**
+	 * Tests with the new value being true.
+	 *
+	 * @covers \Yoast\WP\SEO\Integrations\Watchers\Option_Wpseo_Watcher::check_semrush_option
+	 */
+	public function test_check_semrush_option_with_new_value_being_true() {
+		$this->assertFalse( $this->instance->check_semrush_option( null, [ 'semrush_integration_active' => true ] ) );
+	}
+
+	/**
+	 * Tests with the new value being false .
+	 *
+	 * @covers \Yoast\WP\SEO\Integrations\Watchers\Option_Wpseo_Watcher::check_semrush_option
+	 */
+	public function test_check_semrush_option_with_new_value_being_false() {
+		$options_helper = Mockery::mock( Options_Helper::class );
+		$options_helper->expects( 'set' )->once()->andReturn( true );
+
+		$helper_surface          = Mockery::mock( Helpers_Surface::class );
+		$helper_surface->options = $options_helper;
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->andReturn( (object) [ 'helpers' => $helper_surface ] );
+
+		$this->assertTrue( $this->instance->check_semrush_option( null, [ 'semrush_integration_active' => false ] ) );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Currently there is no way to reset the SEMrush auth tokens without direct manipulation of the DB. If the SEMrush integration is disabled via the toggle, the tokens should be purged.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Purges the SEMrush auth tokens if the integration is disabled.

## Relevant technical choices:

* A watcher for the `wpseo` options array has been added, currently used only to check the `semrush_integration_active` flag but it will be triggered anytime an option in the array changes.
* This is also one of the reasons why we don't check for changes but only check if the integration is currently disabled: the checks are reduced to what is strictly needed to minimize the overhead on option changes.
* Also, if the SEMrush integration flag is set to false in any other way than by using the WP options API (e.g. manually on the DB), the first change in the `wpseo` options will trigger a purging of the tokens anyway.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Make sure the SEMrush integration is enabled
* edit a post and insert a keyphrase, then click on "Get related keyphrases" to make sure the plugin is authenticated with SEMrush (if not, a popup to login/authorize with SEMrush will popup).
* inspect the DB, table `wp_options`, option `wpseo` and check that the SEMrush tokens are stored in it, e.g.:
```
"semrush_tokens";a:5:{s:12:"access_token";s:40:"YME3bghHUO2AX7taM0LqVVNPXfeNp7ppR4pq7wg1";s:13:"refresh_token";s:40:"3Q6C8Efxh3ygUYcDj3IkTtHh945AaaGKWCStgNVR";s:7:"expires";i:1602164623;s:11:"has_expired";b:0;s:10:"created_at";i:1601559823;}
```
* visit SEO→General, Integrations tab, disable SEMrush and save
* inspect the DB, table `wp_options`, option `wpseo` and check that the SEMrush tokens are now empty:
```
"semrush_tokens";a:0:{}
```
* visit SEO→General, Integrations tab, enable SEMrush and save
* edit a post, inset a focus keyphrase, click on "Get related keyphrases" and observe you need to authorize SEMrush again
* plus: you can check on multisite that disallowing the SEMrush integration at network level, while effectively disabling it for the subsites, **does not** set the option to `false` in the DB (the same happens for every other toggle in the Features and Integrations tab: disallowing them at network level does not change the option value for every subsite) and then the auth tokens are not purged and their use can be resumed when the integrations is allowed again.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [X] I have added unittests to verify the code works as intended

Fixes [P3-186]
