### PR TITLE
P2-391 correctly handle failed indexing requests

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -79,7 +79,7 @@ function wpseo_set_ignore() {
 	WPSEO_Options::set( 'ignore_' . $ignore_key, true );
 
 	if ( $ignore_key === 'indexation_warning' ) {
-		WPSEO_Options::set( 'indexables_indexation_reason', '' );
+		WPSEO_Options::set( 'indexing_reason', '' );
 	}
 
 	die( '1' );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -737,13 +737,34 @@ class WPSEO_Upgrade {
 	 * @return void
 	 */
 	private function upgrade_151() {
+		$this->set_home_url_for_151();
+		$this->move_indexables_indexation_reason_for_151();
+
+		add_action( 'init', [ $this, 'set_permalink_structure_option_for_151' ] );
+	}
+
+	/**
+	 * Sets the home_url option for the 15.1 upgrade routine.
+	 *
+	 * @return void
+	 */
+	protected function set_home_url_for_151() {
 		$home_url = WPSEO_Options::get( 'home_url' );
 
 		if ( empty( $home_url ) ) {
 			WPSEO_Options::set( 'home_url', get_home_url() );
 		}
+	}
 
-		add_action( 'init', [ $this, 'set_permalink_structure_option_for_151' ] );
+	/**
+	 * Moves the `indexables_indexation_reason` option to the
+	 * renamed `indexing_reason` option if one exists.
+	 *
+	 * @return void
+	 */
+	protected function move_indexables_indexation_reason_for_151() {
+		$reason = WPSEO_Options::get( 'indexables_indexation_reason', '' );
+		WPSEO_Options::set( 'indexing_reason', $reason );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -758,7 +758,7 @@ class WPSEO_Upgrade {
 
 	/**
 	 * Moves the `indexables_indexation_reason` option to the
-	 * renamed `indexing_reason` option if one exists.
+	 * renamed `indexing_reason` option.
 	 *
 	 * @return void
 	 */

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -32,7 +32,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'ignore_search_engines_discouraged_notice' => false,
 		'indexation_warning_hide_until'            => false,
 		'indexation_started'                       => null,
-		'indexables_indexation_reason'             => '',
+		'indexing_reason'                          => '',
 		'indexables_indexation_completed'          => false,
 		// Non-form field, should only be set via validation routine.
 		'version'                                  => '', // Leave default as empty to ensure activation/upgrade works.
@@ -257,7 +257,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 						$clean[ $key ] = $dirty[ $key ];
 					}
 					break;
-				case 'indexables_indexation_reason':
+				case 'indexing_reason':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = sanitize_text_field( $dirty[ $key ] );
 					}

--- a/js/src/indexation.js
+++ b/js/src/indexation.js
@@ -122,7 +122,15 @@ class Indexing extends Component {
 				"X-WP-Nonce": nonce,
 			},
 		} );
-		return response.json();
+
+		const data = await response.json();
+
+		// Throw an error when the response's status code is not in the 200-299 range.
+		if ( ! response.ok ) {
+			throw new Error( data.message );
+		}
+
+		return data;
 	}
 
 	/**

--- a/src/actions/indexation/indexable-complete-indexation-action.php
+++ b/src/actions/indexation/indexable-complete-indexation-action.php
@@ -32,7 +32,7 @@ class Indexable_Complete_Indexation_Action {
 	 */
 	public function complete() {
 		$this->options->set( 'indexation_started', null );
-		$this->options->set( 'indexables_indexation_reason', '' );
+		$this->options->set( 'indexing_reason', '' );
 		$this->options->set( 'indexables_indexation_completed', true );
 	}
 }

--- a/src/helpers/indexable-helper.php
+++ b/src/helpers/indexable-helper.php
@@ -110,7 +110,7 @@ class Indexable_Helper {
 		$result = $this->repository->reset_permalink( $type, $subtype );
 
 		if ( $result !== false && $result > 0 ) {
-			$this->options_helper->set( 'indexables_indexation_reason', $reason );
+			$this->options_helper->set( 'indexing_reason', $reason );
 			$this->options_helper->set( 'indexation_warning_hide_until', false );
 
 			\delete_transient( Indexable_Post_Indexation_Action::TRANSIENT_CACHE_KEY );

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -195,7 +195,7 @@ class Indexing_Notification_Integration implements Integration_Interface {
 			return false;
 		}
 
-		$indexing_reason = $this->options_helper->get( 'indexables_indexation_reason', '' );
+		$indexing_reason = $this->options_helper->get( 'indexing_reason', '' );
 
 		/*
 		 * Show a notification when we have a reason to do so.
@@ -265,7 +265,7 @@ class Indexing_Notification_Integration implements Integration_Interface {
 	 * @return Yoast_Notification The notification to show.
 	 */
 	protected function notification() {
-		$reason = $this->options_helper->get( 'indexables_indexation_reason', '' );
+		$reason = $this->options_helper->get( 'indexing_reason', '' );
 
 		$presenter = $this->get_presenter( $reason );
 

--- a/src/routes/indexable-indexation-route.php
+++ b/src/routes/indexable-indexation-route.php
@@ -295,7 +295,7 @@ class Indexable_Indexation_Route extends Abstract_Indexation_Route {
 		try {
 			return parent::run_indexation_action( $indexation_action, $url );
 		} catch ( \Exception $exception ) {
-			$this->options_helper->set( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
+			$this->options_helper->set( 'indexing_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
 
 			return new WP_Error( 'wpseo_error_indexing', $exception->getMessage() );
 		}

--- a/src/routes/indexable-indexation-route.php
+++ b/src/routes/indexable-indexation-route.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Routes;
 
+use WP_Error;
 use WP_REST_Response;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Complete_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_General_Indexation_Action;
@@ -288,9 +289,7 @@ class Indexable_Indexation_Route extends Abstract_Indexation_Route {
 	 * @param Indexation_Action_Interface $indexation_action The indexation action.
 	 * @param string                      $url               The url of the indexation route.
 	 *
-	 * @return WP_REST_Response The response.
-	 *
-	 * @throws \Exception If the indexation action fails.
+	 * @return WP_REST_Response|WP_Error The response, or an error when running the indexing action failed.
 	 */
 	protected function run_indexation_action( Indexation_Action_Interface $indexation_action, $url ) {
 		try {
@@ -298,7 +297,7 @@ class Indexable_Indexation_Route extends Abstract_Indexation_Route {
 		} catch ( \Exception $exception ) {
 			$this->options_helper->set( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
 
-			throw $exception;
+			return new WP_Error( 'wpseo_error_indexing', $exception->getMessage() );
 		}
 	}
 }

--- a/src/routes/link-indexing-route.php
+++ b/src/routes/link-indexing-route.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Routes;
 
+use WP_Error;
 use WP_REST_Response;
 use Yoast\WP\SEO\Actions\Indexation\Indexation_Action_Interface;
 use Yoast\WP\SEO\Actions\Indexation\Post_Link_Indexing_Action;
@@ -132,9 +133,7 @@ class Link_Indexing_Route extends Abstract_Indexation_Route {
 	 * @param Indexation_Action_Interface $indexation_action The indexation action.
 	 * @param string                      $url               The url of the indexation route.
 	 *
-	 * @return WP_REST_Response The response.
-	 *
-	 * @throws \Exception If the indexation action fails.
+	 * @return WP_REST_Response|WP_Error The response, or an error when running the indexing action failed.
 	 */
 	protected function run_indexation_action( Indexation_Action_Interface $indexation_action, $url ) {
 		try {
@@ -142,7 +141,7 @@ class Link_Indexing_Route extends Abstract_Indexation_Route {
 		} catch ( \Exception $exception ) {
 			$this->options_helper->set( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
 
-			throw $exception;
+			return new WP_Error( 'wpseo_error_indexing', __( 'An error occurred during the indexing process.', 'wordpress-seo' ) );
 		}
 	}
 }

--- a/src/routes/link-indexing-route.php
+++ b/src/routes/link-indexing-route.php
@@ -139,7 +139,7 @@ class Link_Indexing_Route extends Abstract_Indexation_Route {
 		try {
 			return parent::run_indexation_action( $indexation_action, $url );
 		} catch ( \Exception $exception ) {
-			$this->options_helper->set( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
+			$this->options_helper->set( 'indexing_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
 
 			return new WP_Error( 'wpseo_error_indexing', $exception->getMessage() );
 		}

--- a/src/routes/link-indexing-route.php
+++ b/src/routes/link-indexing-route.php
@@ -141,7 +141,7 @@ class Link_Indexing_Route extends Abstract_Indexation_Route {
 		} catch ( \Exception $exception ) {
 			$this->options_helper->set( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
 
-			return new WP_Error( 'wpseo_error_indexing', __( 'An error occurred during the indexing process.', 'wordpress-seo' ) );
+			return new WP_Error( 'wpseo_error_indexing', $exception->getMessage() );
 		}
 	}
 }

--- a/tests/unit/actions/indexation/indexable-complete-indexation-action-test.php
+++ b/tests/unit/actions/indexation/indexable-complete-indexation-action-test.php
@@ -61,7 +61,7 @@ class Indexable_Complete_Indexation_Action_Test extends TestCase {
 	 */
 	public function test_complete_method() {
 		$this->options->expects( 'set' )->with( 'indexation_started', 0 );
-		$this->options->expects( 'set' )->with( 'indexables_indexation_reason', '' );
+		$this->options->expects( 'set' )->with( 'indexing_reason', '' );
 		$this->options->expects( 'set' )->with( 'indexables_indexation_completed', true );
 
 		$this->instance->complete();

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -288,7 +288,7 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		$this->options_helper
 			->expects( 'get' )
-			->with( 'indexables_indexation_reason', '' )
+			->with( 'indexing_reason', '' )
 			->twice()
 			->andReturn( 'indexing_failed' );
 
@@ -327,7 +327,7 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		$this->options_helper
 			->expects( 'get' )
-			->with( 'indexables_indexation_reason', '' )
+			->with( 'indexing_reason', '' )
 			->twice()
 			->andReturn( $reason );
 
@@ -384,7 +384,7 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		$this->options_helper
 			->expects( 'get' )
-			->with( 'indexables_indexation_reason', '' )
+			->with( 'indexing_reason', '' )
 			->twice()
 			->andReturn( '' );
 
@@ -438,7 +438,7 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		$this->options_helper
 			->expects( 'get' )
-			->with( 'indexables_indexation_reason', '' )
+			->with( 'indexing_reason', '' )
 			->once()
 			->andReturn( '' );
 
@@ -499,7 +499,7 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		$this->options_helper
 			->expects( 'get' )
-			->with( 'indexables_indexation_reason', '' )
+			->with( 'indexing_reason', '' )
 			->once()
 			->andReturn( 'indexing_failed' );
 

--- a/tests/unit/routes/indexable-indexation-route-test.php
+++ b/tests/unit/routes/indexable-indexation-route-test.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Type_Archive_Indexation_Actio
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Prepare_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
 use Yoast\WP\SEO\Routes\Indexable_Indexation_Route;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -307,5 +308,23 @@ class Indexable_Indexation_Route_Test extends TestCase {
 			->andReturn( true );
 
 		$this->assertTrue( $this->instance->can_index() );
+	}
+
+	/**
+	 * Tests the index_general method when an error occurs.
+	 *
+	 * @covers ::index_general
+	 * @covers ::run_indexation_action
+	 */
+	public function test_index_general_when_error_occurs() {
+		$this->general_indexation_action->expects( 'index' )->andThrow( new \Exception( 'An exception during indexing' ) );
+
+		$this->options_helper->expects( 'set' )->with( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
+
+		Mockery::mock( 'overload:WP_Error' )
+			->expects( '__construct' )
+			->with( 'wpseo_error_indexing', 'An exception during indexing' );
+
+		$this->instance->index_general();
 	}
 }

--- a/tests/unit/routes/indexable-indexation-route-test.php
+++ b/tests/unit/routes/indexable-indexation-route-test.php
@@ -319,7 +319,7 @@ class Indexable_Indexation_Route_Test extends TestCase {
 	public function test_index_general_when_error_occurs() {
 		$this->general_indexation_action->expects( 'index' )->andThrow( new \Exception( 'An exception during indexing' ) );
 
-		$this->options_helper->expects( 'set' )->with( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
+		$this->options_helper->expects( 'set' )->with( 'indexing_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
 
 		Mockery::mock( '\WP_Error' );
 

--- a/tests/unit/routes/indexable-indexation-route-test.php
+++ b/tests/unit/routes/indexable-indexation-route-test.php
@@ -321,9 +321,7 @@ class Indexable_Indexation_Route_Test extends TestCase {
 
 		$this->options_helper->expects( 'set' )->with( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
 
-		Mockery::mock( 'overload:WP_Error' )
-			->expects( '__construct' )
-			->with( 'wpseo_error_indexing', 'An exception during indexing' );
+		Mockery::mock( '\WP_Error' );
 
 		$this->instance->index_general();
 	}

--- a/tests/unit/routes/link-indexing-route-test.php
+++ b/tests/unit/routes/link-indexing-route-test.php
@@ -139,7 +139,7 @@ class Link_Indexing_Route_Test extends TestCase {
 
 		$this->options_helper
 			->expects( 'set' )
-			->with( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
+			->with( 'indexing_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
 
 		Mockery::mock( '\WP_Error' );
 
@@ -221,7 +221,7 @@ class Link_Indexing_Route_Test extends TestCase {
 			->andThrow( new \Exception( 'An exception during indexing' ) );
 
 		$this->options_helper->expects( 'set' )
-			->with( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
+			->with( 'indexing_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
 
 		Mockery::mock( '\WP_Error' );
 

--- a/tests/unit/routes/link-indexing-route-test.php
+++ b/tests/unit/routes/link-indexing-route-test.php
@@ -88,10 +88,12 @@ class Link_Indexing_Route_Test extends TestCase {
 
 		Mockery::mock( 'overload:WP_REST_Response' )
 			->expects( '__construct' )
-			->with( [
-				'objects'  => $indexables,
-				'next_url' => 'resturl',
-			] );
+			->with(
+				[
+					'objects'  => $indexables,
+					'next_url' => 'resturl',
+				]
+			);
 
 		$this->instance->index_posts();
 	}
@@ -114,10 +116,12 @@ class Link_Indexing_Route_Test extends TestCase {
 
 		Mockery::mock( 'overload:WP_REST_Response' )
 			->expects( '__construct' )
-			->with( [
-				'objects'  => $indexables,
-				'next_url' => false,
-			] );
+			->with(
+				[
+					'objects'  => $indexables,
+					'next_url' => false,
+				]
+			);
 
 		$this->instance->index_posts();
 	}
@@ -137,9 +141,7 @@ class Link_Indexing_Route_Test extends TestCase {
 			->expects( 'set' )
 			->with( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
 
-		Mockery::mock( 'overload:WP_Error' )
-			->expects( '__construct' )
-			->with( 'wpseo_error_indexing', 'An exception during indexing' );
+		Mockery::mock( '\WP_Error' );
 
 		$this->instance->index_posts();
 	}
@@ -163,16 +165,21 @@ class Link_Indexing_Route_Test extends TestCase {
 
 		$this->term_link_indexing_action->expects( 'get_limit' )->andReturn( 3 );
 
-		Monkey\Functions\expect( 'rest_url' )->with( Link_Indexing_Route::FULL_POSTS_ROUTE )->andReturn( 'resturl' );
+		Monkey\Functions\expect( 'rest_url' )
+			->with( Link_Indexing_Route::FULL_POSTS_ROUTE )
+			->andReturn( 'resturl' );
 
-		Mockery::mock( 'overload:WP_REST_Response' )->expects( '__construct' )->with( [
-			'objects'  => $indexables,
-			'next_url' => 'resturl',
-		] );
+		Mockery::mock( 'overload:WP_REST_Response' )
+			->expects( '__construct' )
+			->with(
+				[
+					'objects'  => $indexables,
+					'next_url' => 'resturl',
+				]
+			);
 
 		$this->instance->index_terms();
 	}
-
 
 	/**
 	 * Tests the index_terms method when the nr of terms is below the limit.
@@ -192,10 +199,12 @@ class Link_Indexing_Route_Test extends TestCase {
 
 		Mockery::mock( 'overload:WP_REST_Response' )
 			->expects( '__construct' )
-			->with( [
-				'objects'  => $indexables,
-				'next_url' => false,
-			] );
+			->with(
+				[
+					'objects'  => $indexables,
+					'next_url' => false,
+				]
+			);
 
 		$this->instance->index_terms();
 	}
@@ -207,13 +216,14 @@ class Link_Indexing_Route_Test extends TestCase {
 	 * @covers ::run_indexation_action
 	 */
 	public function test_index_terms_when_error_occurs() {
-		$this->term_link_indexing_action->expects( 'index' )->andThrow( new \Exception( 'An exception during indexing' ) );
+		$this->term_link_indexing_action
+			->expects( 'index' )
+			->andThrow( new \Exception( 'An exception during indexing' ) );
 
-		$this->options_helper->expects( 'set' )->with( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
+		$this->options_helper->expects( 'set' )
+			->with( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
 
-		Mockery::mock( 'overload:WP_Error' )
-			->expects( '__construct' )
-			->with( 'wpseo_error_indexing', 'An exception during indexing' );
+		Mockery::mock( '\WP_Error' );
 
 		$this->instance->index_terms();
 	}

--- a/tests/unit/routes/link-indexing-route-test.php
+++ b/tests/unit/routes/link-indexing-route-test.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Routes;
+
+use Mockery;
+use Brain\Monkey;
+use Yoast\WP\SEO\Actions\Indexation\Post_Link_Indexing_Action;
+use Yoast\WP\SEO\Actions\Indexation\Term_Link_Indexing_Action;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
+use Yoast\WP\SEO\Routes\Link_Indexing_Route;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Link_Indexing_Route_Test
+ *
+ * @package Yoast\WP\SEO\Tests\Unit\Routes
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Routes\Link_Indexing_Route
+ * @covers  \Yoast\WP\SEO\Routes\Link_Indexing_Route
+ */
+class Link_Indexing_Route_Test extends TestCase {
+
+	/**
+	 * Instance under test.
+	 *
+	 * @var Link_Indexing_Route
+	 */
+	protected $instance;
+
+	/**
+	 * Mocked post link action.
+	 *
+	 * @var Mockery\MockInterface|Post_Link_Indexing_Action
+	 */
+	protected $post_link_indexing_action;
+
+	/**
+	 * Mocked term link action.
+	 *
+	 * @var Mockery\MockInterface|Term_Link_Indexing_Action
+	 */
+	protected $term_link_indexing_action;
+
+	/**
+	 * Mocked options helper.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
+	 * Sets up the tests.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->post_link_indexing_action = Mockery::mock( Post_Link_Indexing_Action::class );
+		$this->term_link_indexing_action = Mockery::mock( Term_Link_Indexing_Action::class );
+		$this->options_helper            = Mockery::mock( Options_Helper::class );
+
+		$this->instance = new Link_Indexing_Route( $this->post_link_indexing_action, $this->term_link_indexing_action, $this->options_helper );
+	}
+
+	/**
+	 * Tests the index_posts method.
+	 *
+	 * @covers ::index_posts
+	 * @covers ::run_indexation_action
+	 */
+	public function test_index_posts_above_limit() {
+		$indexables = [
+			Mockery::mock( Indexable_Mock::class ),
+			Mockery::mock( Indexable_Mock::class ),
+			Mockery::mock( Indexable_Mock::class ),
+			Mockery::mock( Indexable_Mock::class ),
+			Mockery::mock( Indexable_Mock::class ),
+		];
+
+		$this->post_link_indexing_action->expects( 'index' )->andReturn( $indexables );
+
+		$this->post_link_indexing_action->expects( 'get_limit' )->andReturn( 3 );
+
+		Monkey\Functions\expect( 'rest_url' )
+			->with( Link_Indexing_Route::FULL_POSTS_ROUTE )
+			->andReturn( 'resturl' );
+
+		Mockery::mock( 'overload:WP_REST_Response' )
+			->expects( '__construct' )
+			->with( [
+				'objects'  => $indexables,
+				'next_url' => 'resturl',
+			] );
+
+		$this->instance->index_posts();
+	}
+
+	/**
+	 * Tests the index_posts method.
+	 *
+	 * @covers ::index_posts
+	 * @covers ::run_indexation_action
+	 */
+	public function test_index_posts_below_limit() {
+		$indexables = [
+			Mockery::mock( Indexable_Mock::class ),
+			Mockery::mock( Indexable_Mock::class ),
+		];
+
+		$this->post_link_indexing_action->expects( 'index' )->andReturn( $indexables );
+
+		$this->post_link_indexing_action->expects( 'get_limit' )->andReturn( 3 );
+
+		Mockery::mock( 'overload:WP_REST_Response' )
+			->expects( '__construct' )
+			->with( [
+				'objects'  => $indexables,
+				'next_url' => false,
+			] );
+
+		$this->instance->index_posts();
+	}
+
+	/**
+	 * Tests the index_posts method.
+	 *
+	 * @covers ::index_posts
+	 * @covers ::run_indexation_action
+	 */
+	public function test_index_posts_when_error_occurs() {
+		$this->post_link_indexing_action
+			->expects( 'index' )
+			->andThrow( new \Exception( 'An exception during indexing' ) );
+
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
+
+		Mockery::mock( 'overload:WP_Error' )
+			->expects( '__construct' )
+			->with( 'wpseo_error_indexing', 'An exception during indexing' );
+
+		$this->instance->index_posts();
+	}
+
+	/**
+	 * Tests the index_terms method.
+	 *
+	 * @covers ::index_terms
+	 * @covers ::run_indexation_action
+	 */
+	public function test_index_terms_above_limit() {
+		$indexables = [
+			Mockery::mock( Indexable_Mock::class ),
+			Mockery::mock( Indexable_Mock::class ),
+			Mockery::mock( Indexable_Mock::class ),
+			Mockery::mock( Indexable_Mock::class ),
+			Mockery::mock( Indexable_Mock::class ),
+		];
+
+		$this->term_link_indexing_action->expects( 'index' )->andReturn( $indexables );
+
+		$this->term_link_indexing_action->expects( 'get_limit' )->andReturn( 3 );
+
+		Monkey\Functions\expect( 'rest_url' )->with( Link_Indexing_Route::FULL_POSTS_ROUTE )->andReturn( 'resturl' );
+
+		Mockery::mock( 'overload:WP_REST_Response' )->expects( '__construct' )->with( [
+			'objects'  => $indexables,
+			'next_url' => 'resturl',
+		] );
+
+		$this->instance->index_terms();
+	}
+
+
+	/**
+	 * Tests the index_terms method when the nr of terms is below the limit.
+	 *
+	 * @covers ::index_terms
+	 * @covers ::run_indexation_action
+	 */
+	public function test_index_terms_below_limit() {
+		$indexables = [
+			Mockery::mock( Indexable_Mock::class ),
+			Mockery::mock( Indexable_Mock::class ),
+		];
+
+		$this->term_link_indexing_action->expects( 'index' )->andReturn( $indexables );
+
+		$this->term_link_indexing_action->expects( 'get_limit' )->andReturn( 3 );
+
+		Mockery::mock( 'overload:WP_REST_Response' )
+			->expects( '__construct' )
+			->with( [
+				'objects'  => $indexables,
+				'next_url' => false,
+			] );
+
+		$this->instance->index_terms();
+	}
+
+	/**
+	 * Tests the index_terms method when an error occurs.
+	 *
+	 * @covers ::index_terms
+	 * @covers ::run_indexation_action
+	 */
+	public function test_index_terms_when_error_occurs() {
+		$this->term_link_indexing_action->expects( 'index' )->andThrow( new \Exception( 'An exception during indexing' ) );
+
+		$this->options_helper->expects( 'set' )->with( 'indexables_indexation_reason', Indexing_Notification_Integration::REASON_INDEXING_FAILED );
+
+		Mockery::mock( 'overload:WP_Error' )
+			->expects( '__construct' )
+			->with( 'wpseo_error_indexing', 'An exception during indexing' );
+
+		$this->instance->index_terms();
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want an error alert to be shown on the tools page when a request to the indexing endpoint fails. Right now this error is not handled, leading to the indexing tool on the tools page to disappear instead of showing an error alert.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the indexing progress bar and button would disappear from the tools page if a request to one of the indexing endpoints would fail during the indexing process.
* Refactors the way errors are thrown inside the indexing flow.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Testing a failing response
* We need to simulate a failure in one of the endpoints to be able to test this PR.
  * Replace the `respond_with` method in `abstract-indexation-route.php` with this:
    ```php
    protected function respond_with( $objects, $next_url ) {
		return new WP_REST_Response(
			[
				'objects'  => $objects,
				'next_url' => $next_url,
			],
			403 // <- Note this addition.
		);
	}
    ```
  * This makes sure that we always return an `403` error respons when doing an indexing request.
* Now open the Yoast SEO Tools page (_SEO_ > _Tools_ in the admin).
* Start the indexing process by clicking on the button labeled _Start SEO Optimization_.
* After a few seconds it should fail, curtesy of the `403` response we introduced above.
* The indexing tool should not disappear, but should show an error instead.

### Testing error handling in the indexing endpoints
* We need to simulate an error in one of the endpoints again.
  * Add this statement somewhere in the `index` method of `post-indexation-action.php`:
    ```php
    throw new \Exception( 'An error occurred in the indexing process.' );
    ```
  * This simulates an internal server error in the `post` indexing endpoint.
* Now open the Yoast SEO Tools page (_SEO_ > _Tools_ in the admin).
* Start the indexing process by clicking on the button labeled _Start SEO Optimization_.
* After a few seconds it should fail, curtesy of the error we introduced above.
* The indexing tool should not disappear, but should show an error instead.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
