### PR TITLE
P3-197 temporarily fix get related keyphrases button styling

### DIFF
--- a/js/src/components/SEMrushRelatedKeyphrasesModal.js
+++ b/js/src/components/SEMrushRelatedKeyphrasesModal.js
@@ -6,7 +6,7 @@ import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 
 /* Yoast dependencies */
-import { Button, ButtonStyledLink } from "@yoast/components";
+import { ButtonStyledLink } from "@yoast/components";
 
 /* Internal dependencies */
 import { ModalContainer } from "./modals/Container";
@@ -167,13 +167,13 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 		return (
 			<Fragment>
 				{ isLoggedIn && <div className={ "yoast" }>
-					<Button
-						variant={ "secondary" }
+					<button
+						className="yoast-button yoast-button--secondary"
 						id={ `yoast-get-related-keyphrases-${location}` }
 						onClick={ this.onModalOpen }
 					>
 						{ __( "Get related keyphrases", "wordpress-seo" ) }
-					</Button>
+					</button>
 				</div> }
 				{ keyphrase && whichModalOpen === location &&
 					<Modal

--- a/js/tests/components/SEMrushRelatedKeyphrasesModal.test.js
+++ b/js/tests/components/SEMrushRelatedKeyphrasesModal.test.js
@@ -174,6 +174,7 @@ describe( "SEMrushRelatedKeyphrasesModal", () => {
 			const component = mount( <SEMrushRelatedKeyphrasesModal { ...props } /> );
 			const instance = component.instance();
 			instance.popup = { close: () => {} };
+			console.error = jest.fn();
 
 			await instance.listenToMessages( {
 				origin: "https://oauth.semrush.com",
@@ -198,6 +199,7 @@ describe( "SEMrushRelatedKeyphrasesModal", () => {
 			const component = mount( <SEMrushRelatedKeyphrasesModal { ...props } /> );
 			const instance = component.instance();
 			instance.popup = { close: () => {} };
+			console.error = jest.fn();
 
 			await instance.listenToMessages( {
 				origin: "https://oauth.semrush.com",

--- a/release-info.json
+++ b/release-info.json
@@ -1,5 +1,5 @@
 {
-  "version": "15.0",
-  "release_description": "Arabic readability analysis and all settings are now in the Yoast sidebar for the block editor.",
-  "shortlink": "https://yoa.st/yoast15-0"
+  "version": "15.1",
+  "release_description": "Easily finding related keyphrases with the SEMRush integration, Farsi keyphrase recognition and improved display of cornerstone content in internal linking suggestions.",
+  "shortlink": "https://yoa.st/yoast15-1"
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The "Get related keyphrases" button uses the old `Button` component which does not match the expected styling. We can't use the `NewButton` component since it's not present (as such) in the `release/15.1` branch of the monorepo.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Use plain HTML for "Get related keyphrases" button while the new component is unaccessible

## Relevant technical choices:

* The style that's displayed is just the one calculated by using the classes `yoast-button yoast-button--secondary`. It seems that there is a little mismatch between the expected value for `box-shadow`:
```
box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.1);
```
and the actual one from the `yoast-button` class:
```
box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.3);
```
This should be addressed either by having the style changed in the monorepo or updating the design.
* This fixes also a small issue that made expected calls to `console.error` to pop up in the test results, with a confusing effect.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* `yarn link-monorepo` against `release/15.1` branch
* build
* edit a post, make sure you are connected to SEMrush and have approved the authorization (otherwise you'll see a link styled as a button to open the auth popup instead of the button)
* check the style of the "Get related keyphrases" button and see it matches the expected design, except for the minor difference above.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [] I have added unittests to verify the code works as intended

Fixes [P3-197]
