### PR TITLE
Use NewButton alias on release/15.1

### DIFF
--- a/js/src/components/SEMrushRelatedKeyphrasesModal.js
+++ b/js/src/components/SEMrushRelatedKeyphrasesModal.js
@@ -6,7 +6,7 @@ import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 
 /* Yoast dependencies */
-import { ButtonStyledLink } from "@yoast/components";
+import { NewButton, ButtonStyledLink } from "@yoast/components";
 
 /* Internal dependencies */
 import { ModalContainer } from "./modals/Container";
@@ -167,13 +167,13 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 		return (
 			<Fragment>
 				{ isLoggedIn && <div className={ "yoast" }>
-					<button
-						className="yoast-button yoast-button--secondary"
+					<NewButton
+						variant={ "secondary" }
 						id={ `yoast-get-related-keyphrases-${location}` }
 						onClick={ this.onModalOpen }
 					>
 						{ __( "Get related keyphrases", "wordpress-seo" ) }
-					</button>
+					</NewButton>
 				</div> }
 				{ keyphrase && whichModalOpen === location &&
 					<Modal

--- a/js/src/components/modals/SEMrushCountrySelector.js
+++ b/js/src/components/modals/SEMrushCountrySelector.js
@@ -6,7 +6,7 @@ import { addQueryArgs } from "@wordpress/url";
 import { __ } from "@wordpress/i18n";
 
 /* Yoast dependencies */
-import { ErrorBoundary, SingleSelect } from "@yoast/components";
+import { ErrorBoundary, SingleSelect, NewButton } from "@yoast/components";
 
 /**
  * The ID of the SEMrush Country Selection component.
@@ -304,13 +304,13 @@ class SEMrushCountrySelector extends Component {
 					onChange={ this.onChangeHandler }
 					wrapperClassName={ "yoast-field-group yoast-field-group--inline" }
 				/>
-				<button
+				<NewButton
 					id={ id + "-button" }
-					className="yoast-button yoast-button--secondary"
+					variant="secondary"
 					onClick={ this.relatedKeyphrasesRequest }
 				>
 					{ __( "Select country", "wordpress-seo" ) }
-				</button>
+				</NewButton>
 			</div>
 		);
 	}

--- a/js/src/indexation.js
+++ b/js/src/indexation.js
@@ -1,8 +1,7 @@
 /* global jQuery, yoastIndexingData */
 import { render, Component, Fragment } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
-import { ProgressBar } from "@yoast/components";
-import { Alert } from "@yoast/components";
+import { Alert, NewButton, ProgressBar } from "@yoast/components";
 import { colors } from "@yoast/style-guide";
 
 const preIndexingActions = {};
@@ -248,13 +247,12 @@ class Indexing extends Component {
 		if ( this.settings.disabled ) {
 			return <Fragment>
 				<p>
-					<button
-						className="yoast-button yoast-button--secondary"
-						type="button"
+					<NewButton
+						variant="secondary"
 						disabled={ true }
 					>
 						{ __( "Start SEO data optimization", "wordpress-seo" ) }
-					</button>
+					</NewButton>
 				</p>
 				<Alert type={ "info" }>
 					{ __( "This button to optimize the SEO data for your website is disabled for non-production environments.", "wordpress-seo" ) }
@@ -289,20 +287,18 @@ class Indexing extends Component {
 				}
 				{
 					this.state.inProgress
-						? <button
-							className="yoast-button yoast-button--secondary"
-							type="button"
+						? <NewButton
+							variant="secondary"
 							onClick={ this.stopIndexing }
 						>
 							{ __( "Stop SEO data optimization", "wordpress-seo" ) }
-						</button>
-						: <button
-							className="yoast-button yoast-button--primary"
-							type="button"
+						</NewButton>
+						: <NewButton
+							variant="primary"
 							onClick={ this.startIndexing }
 						>
 							{ __( "Start SEO data optimization", "wordpress-seo" ) }
-						</button>
+						</NewButton>
 				}
 			</Fragment>
 		);

--- a/js/tests/components/SEMrushCountrySelector.test.js
+++ b/js/tests/components/SEMrushCountrySelector.test.js
@@ -18,7 +18,7 @@ describe( "SEMrushCountrySelector", () => {
 			setRequestSucceeded={ noop } setRequestLimitReached={ noop } setRequestFailed={ noop } setNoResultsFound={ noop }
 		/> );
 
-		component.find( "button" ).simulate( "click" );
+		component.find( "#yoast-semrush-country-selector-button" ).simulate( "click" );
 
 		expect( onClickMock ).toHaveBeenCalled();
 	} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* A fix for an import issue with new Buttons has been deployed to trunk and develop, but is actually needed on release/15.1. This PR cherrypicks the needed fixes.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allows importing of the new React Button via the NewButton alias.

## Relevant technical choices:

* See https://github.com/Yoast/wordpress-seo/pull/16123

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See the free PR https://github.com/Yoast/wordpress-seo/pull/16123 and the premium PR https://github.com/Yoast/wordpress-seo-premium/pull/3021 only substitute all mentions of P1-202-use-temporary-alias-for-newer-button-component with P3-138-fix-border-and-use-new-button.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P3-138
