### PR TITLE
P3-199 Allow non admins to authorize with SEMrush

### DIFF
--- a/src/routes/semrush-route.php
+++ b/src/routes/semrush-route.php
@@ -106,7 +106,7 @@ class SEMrush_Route implements Route_Interface {
 		$authentication_route_args = [
 			'methods'             => 'POST',
 			'callback'            => [ $this, 'authenticate' ],
-			'permission_callback' => [ $this, 'can_authenticate' ],
+			'permission_callback' => [ $this, 'can_use_semrush' ],
 			'args'                => [
 				'code' => [
 					'validate_callback' => [ $this, 'has_valid_code' ],
@@ -120,7 +120,7 @@ class SEMrush_Route implements Route_Interface {
 		$set_country_code_option_route_args = [
 			'methods'             => 'POST',
 			'callback'            => [ $this, 'set_country_code_option' ],
-			'permission_callback' => [ $this, 'can_edit' ],
+			'permission_callback' => [ $this, 'can_use_semrush' ],
 			'args'                => [
 				'country_code' => [
 					'validate_callback' => [ $this, 'has_valid_country_code' ],
@@ -134,7 +134,7 @@ class SEMrush_Route implements Route_Interface {
 		$related_keyphrases_route_args = [
 			'methods'             => 'GET',
 			'callback'            => [ $this, 'get_related_keyphrases' ],
-			'permission_callback' => [ $this, 'can_edit' ],
+			'permission_callback' => [ $this, 'can_use_semrush' ],
 			'args'                => [
 				'keyphrase' => [
 					'validate_callback' => [ $this, 'has_valid_keyphrase' ],
@@ -231,20 +231,11 @@ class SEMrush_Route implements Route_Interface {
 	}
 
 	/**
-	 * Whether or not the current user is allowed to edit post and thus access the SEMrush modal.
+	 * Whether or not the current user is allowed to edit post/pages and thus use the SEMrush integration.
 	 *
-	 * @return bool Whether or not the current user is allowed to edit posts.
+	 * @return bool Whether or not the current user is allowed to use SEMrush.
 	 */
-	public function can_edit() {
-		return \current_user_can( 'edit_posts' );
-	}
-
-	/**
-	 * Determines whether the current user can authenticate with SEMrush.
-	 *
-	 * @return bool Whether or not the current user can authenticate with SEMrush.
-	 */
-	public function can_authenticate() {
-		return \current_user_can( 'manage_options' );
+	public function can_use_semrush() {
+		return \current_user_can( 'edit_posts' ) || \current_user_can( 'edit_pages' );
 	}
 }

--- a/tests/unit/routes/semrush-route-test.php
+++ b/tests/unit/routes/semrush-route-test.php
@@ -7,7 +7,6 @@ use Mockery;
 use Yoast\WP\SEO\Actions\Semrush\SEMrush_Login_Action;
 use Yoast\WP\SEO\Actions\Semrush\SEMrush_Options_Action;
 use Yoast\WP\SEO\Actions\SEMrush\SEMrush_Phrases_Action;
-use Yoast\WP\SEO\Routes\SEMrush_Route;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -93,7 +92,7 @@ class SEMrush_Route_Test extends TestCase {
 				[
 					'methods'             => 'POST',
 					'callback'            => [ $this->instance, 'authenticate' ],
-					'permission_callback' => [ $this->instance, 'can_authenticate' ],
+					'permission_callback' => [ $this->instance, 'can_use_semrush' ],
 					'args'                => [
 						'code' => [
 							'validate_callback' => [ $this->instance, 'has_valid_code' ],
@@ -110,7 +109,7 @@ class SEMrush_Route_Test extends TestCase {
 				[
 					'methods'             => 'POST',
 					'callback'            => [ $this->instance, 'set_country_code_option' ],
-					'permission_callback' => [ $this->instance, 'can_edit' ],
+					'permission_callback' => [ $this->instance, 'can_use_semrush' ],
 					'args'                => [
 						'country_code' => [
 							'validate_callback' => [ $this->instance, 'has_valid_country_code' ],
@@ -127,7 +126,7 @@ class SEMrush_Route_Test extends TestCase {
 				[
 					'methods'             => 'GET',
 					'callback'            => [ $this->instance, 'get_related_keyphrases' ],
-					'permission_callback' => [ $this->instance, 'can_edit' ],
+					'permission_callback' => [ $this->instance, 'can_use_semrush' ],
 					'args'                => [
 						'keyphrase' => [
 							'validate_callback' => [ $this->instance, 'has_valid_keyphrase' ],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The SEMrush authorization currently must be performed by a user that has `manage_options` capability (usually, just the admins). Once that the tokens stored, as long as they are valid (or can be refreshed) the SEMrush integration can be used by any user.
if non-admin users try to use SEMrush without valid tokens, they see the popup, clciking on "approve" closes it but then they get a 403 Forbidden error to their AJAX call to store the tokens, and they stay unauthorised.
It has been decided to address this issue by allowing every user that can use SEMrush to perform authorization with it.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adjust capability checks for using and authenticating with SEMrush

## Relevant technical choices:

* I've added a check on the `edit_pages` capability since there could be the unlikely, but non impossible case of a user that is allowed to edit just Pages but not Posts. Since the SEMrush integration is present in the page edit screen as well, we should use the right capability.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* make sure there are no valid SEMrush tokens in the DB (you can follow the steps in the test instructions [here](https://github.com/Yoast/wordpress-seo/pull/15943))
* make sue you have a valid SEMrush account.
* switch to a user with the `edit_posts` capability but not the `manage_options` capability: this means usually Editor/Author/Contributor but non an Administrator.  (you can use [this extremely useful plugin](https://it.wordpress.org/plugins/user-switching/) to do the switching)
* edit a post, insert a keyphrase and click on the "Get related keyphrases" button.
* see the popup for SEMrush, log in if needed and approve the authorization
* observe that the popup closes, the modal opens to show the results and no `403 Forbidden` error is thrown in the console.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-199]
