### PR TITLE
P2-409 Improve warning copy for disabled data optimization

### DIFF
--- a/js/src/indexation.js
+++ b/js/src/indexation.js
@@ -255,7 +255,7 @@ class Indexing extends Component {
 					</NewButton>
 				</p>
 				<Alert type={ "info" }>
-					{ __( "SEO data optimization is disabled for non-production environments..", "wordpress-seo" ) }
+					{ __( "SEO data optimization is disabled for non-production environments.", "wordpress-seo" ) }
 				</Alert>
 			</Fragment>;
 		}

--- a/js/src/indexation.js
+++ b/js/src/indexation.js
@@ -255,7 +255,7 @@ class Indexing extends Component {
 					</NewButton>
 				</p>
 				<Alert type={ "info" }>
-					{ __( "This button to optimize the SEO data for your website is disabled for non-production environments.", "wordpress-seo" ) }
+					{ __( "SEO data optimization is disabled for non-production environments..", "wordpress-seo" ) }
 				</Alert>
 			</Fragment>;
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Improves the copy of the alert that is shown when indexing is disabled for non-production environments.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Set your WordPress environment to anything but production (for example `staging`).
  * You can do this by adding or replacing this line in your `wordpress-config.php`:
    ```php
    define( 'WP_ENVIRONMENT_TYPE', 'staging' );
    ```
  * Note: for the `basic.wordpress.test` development environment, this file is `config/basic-wordpress-config.php`.
* Go to the Yoast SEO tools page (e.g. `http://basic.wordpress.test/wp-admin/admin.php?page=wpseo_tools`).
* The button labeled _Start SEO optimization_ should be disabled and the info alert below it should read:
   > SEO data optimization is disabled for non-production environments.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
