### PR TITLE
Add first time indexing alert

### DIFF
--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -31,6 +31,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'ms_defaults_set'                          => false,
 		'ignore_search_engines_discouraged_notice' => false,
 		'indexation_warning_hide_until'            => false,
+		'indexing_first_time'                      => true,
 		'indexation_started'                       => null,
 		'indexables_indexation_reason'             => '',
 		'indexables_indexation_completed'          => false,
@@ -370,6 +371,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				 *  'enable_headless_rest_endpoints'
 				 *  'yoast_tracking'
 				 *  'dynamic_permalinks'
+				 *  'indexing_first_time'
 				 */
 				default:
 					$clean[ $key ] = ( isset( $dirty[ $key ] ) ? WPSEO_Utils::validate_bool( $dirty[ $key ] ) : false );

--- a/js/src/indexation.js
+++ b/js/src/indexation.js
@@ -180,7 +180,7 @@ class Indexing extends Component {
 				this.setState( {
 					inProgress: false,
 					firstTime: false,
-					error
+					error,
 				} );
 			}
 		}

--- a/js/src/indexation.js
+++ b/js/src/indexation.js
@@ -100,6 +100,7 @@ class Indexing extends Component {
 			processed: 0,
 			amount: this.settings.amount,
 			error: null,
+			firstTime: ( this.settings.firstTime === "1" ),
 		};
 
 		this.startIndexing = this.startIndexing.bind( this );
@@ -168,12 +169,19 @@ class Indexing extends Component {
 				await this.doPostIndexingAction( endpoint, response );
 
 				this.setState( previousState => (
-					{ processed: previousState.processed + response.objects.length }
+					{
+						processed: previousState.processed + response.objects.length,
+						firstTime: false,
+					}
 				) );
 
 				url = response.next_url;
 			} catch ( error ) {
-				this.setState( { inProgress: false, error } );
+				this.setState( {
+					inProgress: false,
+					firstTime: false,
+					error
+				} );
 			}
 		}
 	}
@@ -300,6 +308,11 @@ class Indexing extends Component {
 					this.state.error && <Alert type={ "error" }>
 						{ __( "Oops, something has gone wrong and we couldn't complete the optimization of your SEO data. " +
 							  "Please click the button again to re-start the process.", "wordpress-seo" ) }
+					</Alert>
+				}
+				{
+					! this.state.inProgress && this.state.firstTime && <Alert type={ "info" }>
+						{ __( "This feature includes and replaces the Text Link Counter and Internal Linking Analysis", "wordpress-seo" ) }
 					</Alert>
 				}
 				{

--- a/js/src/indexation.js
+++ b/js/src/indexation.js
@@ -264,6 +264,23 @@ class Indexing extends Component {
 	}
 
 	/**
+	 * Renders a notice if it is the first time the indexation is performed.
+	 *
+	 * @returns {JSX.Element} The rendered component.
+	 */
+	renderFirstIndexationNotice() {
+		if ( this.state.inProgress || ! this.state.firstTime ) {
+			return null;
+		}
+
+		return (
+			<Alert type={ "info" }>
+				{ __( "This feature includes and replaces the Text Link Counter and Internal Linking Analysis", "wordpress-seo" ) }
+			</Alert>
+		);
+	}
+
+	/**
 	 * Renders the component
 	 *
 	 * @returns {JSX.Element} The rendered component.
@@ -310,11 +327,7 @@ class Indexing extends Component {
 							  "Please click the button again to re-start the process.", "wordpress-seo" ) }
 					</Alert>
 				}
-				{
-					! this.state.inProgress && this.state.firstTime && <Alert type={ "info" }>
-						{ __( "This feature includes and replaces the Text Link Counter and Internal Linking Analysis", "wordpress-seo" ) }
-					</Alert>
-				}
+				{ this.renderFirstIndexationNotice() }
 				{
 					this.state.inProgress
 						? <NewButton

--- a/src/actions/indexation/indexable-prepare-indexation-action.php
+++ b/src/actions/indexation/indexable-prepare-indexation-action.php
@@ -44,6 +44,7 @@ class Indexable_Prepare_Indexation_Action {
 	 * @return void
 	 */
 	public function prepare() {
+		$this->options->set( 'indexing_first_time', false );
 		$this->options->set( 'indexation_started', $this->date->current_time() );
 	}
 }

--- a/src/helpers/notification-helper.php
+++ b/src/helpers/notification-helper.php
@@ -8,7 +8,7 @@ use Yoast_Notification_Center;
 /**
  * A helper object for notifications.
  */
-class Notification_Helper{
+class Notification_Helper {
 
 	/**
 	 * Restores a notification (wrapper function).

--- a/src/integrations/admin/indexing-indexables-integration.php
+++ b/src/integrations/admin/indexing-indexables-integration.php
@@ -170,6 +170,8 @@ class Indexing_Indexables_Integration implements Indexing_Interface, Integration
 
 	/**
 	 * Retrieves the shutdown limit. This limit is the amount that indexables that is generated in the background.
+	 *
+	 * @retur int The shutdown limit.
 	 */
 	protected function get_shutdown_limit() {
 		/**

--- a/src/integrations/admin/indexing-indexables-integration.php
+++ b/src/integrations/admin/indexing-indexables-integration.php
@@ -115,15 +115,8 @@ class Indexing_Indexables_Integration implements Indexing_Interface, Integration
 			$this->complete_indexation_action->complete();
 		}
 
-		/**
-		 * Filter 'wpseo_shutdown_indexation_limit' - Allow filtering the number of objects that can be indexed during shutdown.
-		 *
-		 * @api int The maximum number of objects indexed.
-		 */
-		$shutdown_limit = \apply_filters( 'wpseo_shutdown_indexation_limit', 25 );
-
-		if ( $total_unindexed < $shutdown_limit ) {
-			\register_shutdown_function( [ $this, 'shutdown_indexation' ] );
+		if ( $total_unindexed < $this->get_shutdown_limit() ) {
+			 \register_shutdown_function( [ $this, 'shutdown_indexation' ] );
 		}
 	}
 
@@ -168,6 +161,22 @@ class Indexing_Indexables_Integration implements Indexing_Interface, Integration
 			$this->total_unindexed += $this->post_type_archive_indexation->get_total_unindexed();
 		}
 
+		if ( $this->total_unindexed < $this->get_shutdown_limit() ) {
+			return 0;
+		}
+
 		return $this->total_unindexed;
+	}
+
+	/**
+	 * Retrieves the shutdown limit. This limit is the amount that indexables that is generated in the background.
+	 */
+	protected function get_shutdown_limit() {
+		/**
+		 * Filter 'wpseo_shutdown_indexation_limit' - Allow filtering the number of objects that can be indexed during shutdown.
+		 *
+		 * @api int The maximum number of objects indexed.
+		 */
+		return \apply_filters( 'wpseo_shutdown_indexation_limit', 25 );
 	}
 }

--- a/src/integrations/admin/indexing-indexables-integration.php
+++ b/src/integrations/admin/indexing-indexables-integration.php
@@ -169,9 +169,9 @@ class Indexing_Indexables_Integration implements Indexing_Interface, Integration
 	}
 
 	/**
-	 * Retrieves the shutdown limit. This limit is the amount that indexables that is generated in the background.
+	 * Retrieves the shutdown limit. This limit is the amount of indexables that is generated in the background.
 	 *
-	 * @retur int The shutdown limit.
+	 * @return int The shutdown limit.
 	 */
 	protected function get_shutdown_limit() {
 		/**

--- a/src/integrations/admin/indexing-indexables-integration.php
+++ b/src/integrations/admin/indexing-indexables-integration.php
@@ -116,7 +116,7 @@ class Indexing_Indexables_Integration implements Indexing_Interface, Integration
 		}
 
 		if ( $total_unindexed < $this->get_shutdown_limit() ) {
-			 \register_shutdown_function( [ $this, 'shutdown_indexation' ] );
+			\register_shutdown_function( [ $this, 'shutdown_indexation' ] );
 		}
 	}
 

--- a/src/integrations/admin/indexing-integration.php
+++ b/src/integrations/admin/indexing-integration.php
@@ -6,6 +6,7 @@ use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Tools_Page_Conditional;
 use Yoast\WP\SEO\Helpers\Environment_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Integrations\Indexing_Interface;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -54,6 +55,13 @@ class Indexing_Integration implements Integration_Interface {
 	protected $short_link_helper;
 
 	/**
+	 * Represents the options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
 	 * Returns the conditionals based on which this integration should be active.
 	 *
 	 * @return array The array of conditionals.
@@ -72,16 +80,19 @@ class Indexing_Integration implements Integration_Interface {
 	 * @param WPSEO_Admin_Asset_Manager       $asset_manager                   The admin asset manager.
 	 * @param Environment_Helper              $environment_helper              The environment helper.
 	 * @param Short_Link_Helper               $short_link_helper               The short link helper.
+	 * @param Options_Helper                  $options_helper                  The options helper.
 	 */
 	public function __construct(
 		Indexing_Indexables_Integration $indexing_indexables_integration,
 		WPSEO_Admin_Asset_Manager $asset_manager,
 		Environment_Helper $environment_helper,
-		Short_Link_Helper $short_link_helper
+		Short_Link_Helper $short_link_helper,
+		Options_Helper $options_helper
 	) {
 		$this->asset_manager      = $asset_manager;
 		$this->environment_helper = $environment_helper;
 		$this->short_link_helper  = $short_link_helper;
+		$this->options_helper     = $options_helper;
 
 		$this->indexing_integrations[] = $indexing_indexables_integration;
 	}
@@ -118,9 +129,10 @@ class Indexing_Integration implements Integration_Interface {
 		$this->asset_manager->enqueue_style( 'monorepo' );
 
 		$data = [
-			'disabled' => ! $this->environment_helper->is_production_mode(),
-			'amount'   => $this->get_total_unindexed(),
-			'restApi'  => [
+			'disabled'  => ! $this->environment_helper->is_production_mode(),
+			'amount'    => $this->get_total_unindexed(),
+			'firstTime' => ( $this->options_helper->get( 'indexing_first_time', true ) === true ),
+			'restApi'   => [
 				'root'      => \esc_url_raw( \rest_url() ),
 				'endpoints' => $this->get_endpoints(),
 				'nonce'     => \wp_create_nonce( 'wp_rest' ),

--- a/tests/unit/actions/indexation/indexable-prepare-indexation-action-test.php
+++ b/tests/unit/actions/indexation/indexable-prepare-indexation-action-test.php
@@ -74,6 +74,9 @@ class Indexable_Prepare_Indexation_Action_Test extends TestCase {
 			->andReturn( $mocked_time );
 
 		$this->options->expects( 'set' )
+			->with( 'indexing_first_time', false );
+
+		$this->options->expects( 'set' )
 			->with( 'indexation_started', $mocked_time );
 
 		$this->instance->prepare();

--- a/tests/unit/integrations/admin/indexing-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-integration-test.php
@@ -8,6 +8,7 @@ use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Tools_Page_Conditional;
 use Yoast\WP\SEO\Helpers\Environment_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Indexing_Indexables_Integration;
 use Yoast\WP\SEO\Integrations\Admin\Indexing_Integration;
@@ -59,6 +60,13 @@ class Indexing_Integration_Test extends TestCase {
 	protected $short_link_helper;
 
 	/**
+	 * Represents the options helper.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
 	 * Sets up the tests.
 	 */
 	protected function setUp() {
@@ -68,12 +76,14 @@ class Indexing_Integration_Test extends TestCase {
 		$this->asset_manager                   = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
 		$this->environment_helper              = Mockery::mock( Environment_Helper::class );
 		$this->short_link_helper               = Mockery::mock( Short_Link_Helper::class );
+		$this->options_helper                  = Mockery::mock( Options_Helper::class );
 
 		$this->instance = new Indexing_Integration(
 			$this->indexing_indexables_integration,
 			$this->asset_manager,
 			$this->environment_helper,
-			$this->short_link_helper
+			$this->short_link_helper,
+			$this->options_helper
 		);
 	}
 
@@ -99,6 +109,7 @@ class Indexing_Integration_Test extends TestCase {
 		$this->assertAttributeInstanceOf( WPSEO_Admin_Asset_Manager::class, 'asset_manager', $this->instance );
 		$this->assertAttributeInstanceOf( Environment_Helper::class, 'environment_helper', $this->instance );
 		$this->assertAttributeInstanceOf( Short_Link_Helper::class, 'short_link_helper', $this->instance );
+		$this->assertAttributeInstanceOf( Options_Helper::class, 'options_helper', $this->instance );
 
 		$this->assertAttributeEquals( [ $this->indexing_indexables_integration ], 'indexing_integrations', $this->instance );
 	}
@@ -201,10 +212,16 @@ class Indexing_Integration_Test extends TestCase {
 			->with( 'wp_rest' )
 			->andReturn( 'nonce_value' );
 
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'indexing_first_time', true )
+			->andReturnTrue();
+
 		$injected_data = [
-			'amount'   => 72,
-			'disabled' => false,
-			'restApi'  =>
+			'amount'    => 72,
+			'disabled'  => false,
+			'firstTime' => true,
+			'restApi'   =>
 				[
 					'root'      => 'https://example.org/wp-ajax/',
 					'endpoints' =>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Show an alert to tell the user we have combine the different analyzing buttons.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Shows a notice to clarify that the difference indexing buttons are combined to one.

## Relevant technical choices:

* Moved the logic for the limit (the hook) to a separate method.
* Used that method for the `get_total_unindexed` - when there are items being calculated in the background we can assume that there is nothing to index. This prevents showing the button and showing a notification. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Reset the indexables
* Visit the tools page and see a notice above the indexing button
* Run the indexing
* The alert is gone. 
* Have some indexables that needs to be indexed and remove the transients. Or use the test helper to reset the indexables.
* The button should be still gone.

* Troubleshoot: You probably have to remove the transients during the steps. 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
