### PR TITLE
P3-200 Prevent authorization errors when CA cert files are not configured in the server

### DIFF
--- a/src/config/semrush-client.php
+++ b/src/config/semrush-client.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Config;
 use Yoast\WP\SEO\Exceptions\OAuth\Authentication_Failed_Exception;
 use Yoast\WP\SEO\Exceptions\SEMrush\Tokens\Empty_Property_Exception;
 use Yoast\WP\SEO\Exceptions\SEMrush\Tokens\Failed_Storage_Exception;
+use \YoastSEO_Vendor\GuzzleHttp\Client;
 use YoastSEO_Vendor\League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use YoastSEO_Vendor\League\OAuth2\Client\Provider\GenericProvider;
 use Yoast\WP\SEO\Exceptions\OAuth\OAuth_Authentication_Failed_Exception;
@@ -61,7 +62,13 @@ class SEMrush_Client {
 				'urlAuthorize'            => 'https://oauth.semrush.com/oauth2/authorize',
 				'urlAccessToken'          => 'https://oauth.semrush.com/oauth2/access_token',
 				'urlResourceOwnerDetails' => 'https://oauth.semrush.com/oauth2/resource',
-				'verify'                  => \ABSPATH . \WPINC . '/certificates/ca-bundle.crt',
+			],
+			[
+				'httpClient' => new Client(
+					[
+						'verify' => ABSPATH . WPINC . '/certificates/ca-bundle.crt',
+					]
+				),
 			]
 		);
 

--- a/src/config/semrush-client.php
+++ b/src/config/semrush-client.php
@@ -66,7 +66,7 @@ class SEMrush_Client {
 			[
 				'httpClient' => new Client(
 					[
-						'verify' => ABSPATH . WPINC . '/certificates/ca-bundle.crt',
+						'verify' => ABSPATH . 'wp-includes/certificates/ca-bundle.crt',
 					]
 				),
 			]

--- a/src/config/semrush-client.php
+++ b/src/config/semrush-client.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Config;
 use Yoast\WP\SEO\Exceptions\OAuth\Authentication_Failed_Exception;
 use Yoast\WP\SEO\Exceptions\SEMrush\Tokens\Empty_Property_Exception;
 use Yoast\WP\SEO\Exceptions\SEMrush\Tokens\Failed_Storage_Exception;
-use \YoastSEO_Vendor\GuzzleHttp\Client;
+use YoastSEO_Vendor\GuzzleHttp\Client;
 use YoastSEO_Vendor\League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use YoastSEO_Vendor\League\OAuth2\Client\Provider\GenericProvider;
 use Yoast\WP\SEO\Exceptions\OAuth\OAuth_Authentication_Failed_Exception;

--- a/src/config/semrush-client.php
+++ b/src/config/semrush-client.php
@@ -61,6 +61,7 @@ class SEMrush_Client {
 				'urlAuthorize'            => 'https://oauth.semrush.com/oauth2/authorize',
 				'urlAccessToken'          => 'https://oauth.semrush.com/oauth2/access_token',
 				'urlResourceOwnerDetails' => 'https://oauth.semrush.com/oauth2/resource',
+				'verify'                  => \ABSPATH . \WPINC . '/certificates/ca-bundle.crt',
 			]
 		);
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* During testing of 15.1-RC3 on a Windows installation we noticed that the authentication with SEMrush couldn't be performed due to a `401 Unauthorized` error.
Actually it was due to cURL (used by the Guzzle library which in turn is a dependency of the OAuth2 library we are using) that couldn't find the CA certificates to verify the server-to-server connections. It's a know issue that has been experienced by many projects using the Guzzle library.
Since WordPress, to prevent similar issues with its own HTTP client, ships a CA cert bundle, we can use it to prevent the error from happening.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug on some hosting configurations where the SEMrush authentication would fail

## Relevant technical choices:

* To set the path of the CA cert bundle, we can use the `verify` option of the Guzzle Client class. The OAuth2 class has a `verify` parameter that is passed to the Client, but _only if a proxy option is set_. So we have to instantiate the Guzzle Client on our own and pass it to the OAuth2 Provider explicitly.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Reproduce the bug
* Make sure you have a Windows machine to test on. You can get a testing virtual machine [here](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/)
* Install a WAMP solution on your Windows machine. You can use Local by Flywheel or WampServer that have been shown to be affected by the issue. Do not use the Docker environment, or VVV, or any other solution that use a Linux virtual machine.
* if you are installing the WAMP stack for the first time you are not authorized with SEMrush and that's ok. if you have already authorized your website with SEMrush please delete the tokens in the `wpseo` array of options.
* get the zip for RC3 (ask me on slack if needed) and install+activate it
* edit a post, insert a focus keyphrase
* open the js console and empty it
* click on the "Get related keyphrases" button. in the popup, login to SEMrush an click on "approve"
* in the console you should seen an error like this: 
![error](https://user-images.githubusercontent.com/15989132/95193623-61311580-07d4-11eb-940d-042b7d0f3b38.png)
if you open the error, it should show this message:
![error2](https://user-images.githubusercontent.com/15989132/95193660-7017c800-07d4-11eb-89ff-ea5f124b4037.png)
plus, the modal won't open, and if you click on the button the popup will open again (you can also check the DB to see that still there are no tokens).

### Test the fix
* checkout this branch and build
* run this branch on the Windows site. If you are using a virtual machine, the easiest way is to create a zip following [these instructions](https://yoast.atlassian.net/wiki/spaces/PLUGIN/pages/741703735/How+to+create+a+zip+from+a+specific+branch), then pass the zip someway to the virtual machine and install it by uploading it. 
* edit a post, insert a focus keyphrase
* open the js console and empty it
* click on the "Get related keyphrases" button. in the popup, login to SEMrush an click on "approve"
* the popup should close and the modal with the SEMrush results should open. The console should not show any errors related to the communication with SEMrush (you can also check the DB to see that now there are tokens stored).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-200]
