### PR TITLE
Revert rename. Just use the indexable helper for this

### DIFF
--- a/src/integrations/admin/indexing-integration.php
+++ b/src/integrations/admin/indexing-integration.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Tools_Page_Conditional;
-use Yoast\WP\SEO\Helpers\Environment_Helper;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Integrations\Indexing_Interface;
@@ -41,11 +41,11 @@ class Indexing_Integration implements Integration_Interface {
 	protected $indexing_integrations = [];
 
 	/**
-	 * Represents the environment helper.
+	 * Represents the indexables helper.
 	 *
-	 * @var Environment_Helper
+	 * @var Indexable_Helper
 	 */
-	protected $environment_helper;
+	protected $indexable_helper;
 
 	/**
 	 * The short link helper.
@@ -78,21 +78,21 @@ class Indexing_Integration implements Integration_Interface {
 	 *
 	 * @param Indexing_Indexables_Integration $indexing_indexables_integration The indexables_indexing integration.
 	 * @param WPSEO_Admin_Asset_Manager       $asset_manager                   The admin asset manager.
-	 * @param Environment_Helper              $environment_helper              The environment helper.
+	 * @param Indexable_Helper                $indexable_helper                The indexable helper.
 	 * @param Short_Link_Helper               $short_link_helper               The short link helper.
 	 * @param Options_Helper                  $options_helper                  The options helper.
 	 */
 	public function __construct(
 		Indexing_Indexables_Integration $indexing_indexables_integration,
 		WPSEO_Admin_Asset_Manager $asset_manager,
-		Environment_Helper $environment_helper,
+		Indexable_Helper $indexable_helper,
 		Short_Link_Helper $short_link_helper,
 		Options_Helper $options_helper
 	) {
-		$this->asset_manager      = $asset_manager;
-		$this->environment_helper = $environment_helper;
-		$this->short_link_helper  = $short_link_helper;
-		$this->options_helper     = $options_helper;
+		$this->asset_manager     = $asset_manager;
+		$this->indexable_helper  = $indexable_helper;
+		$this->short_link_helper = $short_link_helper;
+		$this->options_helper    = $options_helper;
 
 		$this->indexing_integrations[] = $indexing_indexables_integration;
 	}
@@ -129,7 +129,7 @@ class Indexing_Integration implements Integration_Interface {
 		$this->asset_manager->enqueue_style( 'monorepo' );
 
 		$data = [
-			'disabled'  => ! $this->environment_helper->is_production_mode(),
+			'disabled'  => ! $this->indexable_helper->should_index_indexables(),
 			'amount'    => $this->get_total_unindexed(),
 			'firstTime' => ( $this->options_helper->get( 'indexing_first_time', true ) === true ),
 			'restApi'   => [

--- a/tests/unit/integrations/admin/indexing-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-integration-test.php
@@ -7,7 +7,7 @@ use Mockery;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Tools_Page_Conditional;
-use Yoast\WP\SEO\Helpers\Environment_Helper;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Indexing_Indexables_Integration;
@@ -46,11 +46,11 @@ class Indexing_Integration_Test extends TestCase {
 	protected $asset_manager;
 
 	/**
-	 * The environment helper.
+	 * The indexable helper.
 	 *
-	 * @var Mockery\MockInterface|Environment_Helper
+	 * @var Mockery\MockInterface|Indexable_Helper
 	 */
-	protected $environment_helper;
+	protected $indexable_helper;
 
 	/**
 	 * The short link helper.
@@ -74,14 +74,14 @@ class Indexing_Integration_Test extends TestCase {
 
 		$this->indexing_indexables_integration = Mockery::mock( Indexing_Indexables_Integration::class );
 		$this->asset_manager                   = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
-		$this->environment_helper              = Mockery::mock( Environment_Helper::class );
+		$this->indexable_helper                = Mockery::mock( Indexable_Helper::class );
 		$this->short_link_helper               = Mockery::mock( Short_Link_Helper::class );
 		$this->options_helper                  = Mockery::mock( Options_Helper::class );
 
 		$this->instance = new Indexing_Integration(
 			$this->indexing_indexables_integration,
 			$this->asset_manager,
-			$this->environment_helper,
+			$this->indexable_helper,
 			$this->short_link_helper,
 			$this->options_helper
 		);
@@ -107,7 +107,7 @@ class Indexing_Integration_Test extends TestCase {
 	 */
 	public function test_constructor() {
 		$this->assertAttributeInstanceOf( WPSEO_Admin_Asset_Manager::class, 'asset_manager', $this->instance );
-		$this->assertAttributeInstanceOf( Environment_Helper::class, 'environment_helper', $this->instance );
+		$this->assertAttributeInstanceOf( Indexable_Helper::class, 'indexable_helper', $this->instance );
 		$this->assertAttributeInstanceOf( Short_Link_Helper::class, 'short_link_helper', $this->instance );
 		$this->assertAttributeInstanceOf( Options_Helper::class, 'options_helper', $this->instance );
 
@@ -204,8 +204,8 @@ class Indexing_Integration_Test extends TestCase {
 			->expects( 'enqueue_style' )
 			->with( 'monorepo' );
 
-		$this->environment_helper
-			->expects( 'is_production_mode' )
+		$this->indexable_helper
+			->expects( 'should_index_indexables' )
 			->andReturnTrue();
 
 		Monkey\Functions\expect( 'wp_create_nonce' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Did a rename without thinking about the reasons for its original name.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - Just reverted a name change.

## Relevant technical choices:

* I think `Indexable_Helper` isn't the best class for such function, but I have no idea what should the alternative. Just keeping it this way. Perhaps `Indexing_Helper` might be a good place, but we should discuss that.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

This PR does not change any behavior, but the disabling / enabling of the SEO button based on the environment type should still work as expected.

* Set your WordPress environment type to non-production, for example `staging`.
  * You can do this by adding or replacing this line in your `wp-config.php` file:
    ```
    define( 'WP_ENVIRONMENT_TYPE', 'staging' );
    ```
* Go to the Yoast SEO tools page in the WordPress admin.
* The button to optimize your SEO data should be disabled and an info alert should be shown below.
* Set your WordPress environment type to production.
  * You can do this by adding or replacing this line in your `wp-config.php` file:
    ```
    define( 'WP_ENVIRONMENT_TYPE', 'production' );
    ```
* Go to the Yoast SEO tools page in the WordPress admin.
* The button to optimize your SEO data should be enabled again.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
