### PR TITLE
Fix tracking of SEMrush settings

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -46,9 +46,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'youtube_url',
 		'wikipedia_url',
 		'fbadminapp',
-		'semrush_integration_active',
 		'semrush_tokens',
-		'semrush_country_code',
 	];
 
 	/**
@@ -162,6 +160,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'indexables_indexation_completed',
 		'semrush_integration_active',
 		'semrush_tokens',
+		'semrush_country_code',
 	];
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The tracking of the SEMrush-related settings has some mistakes that we need to fix:
  * `semrush_integration_active` is tracked as anonymous even though it's just a flag
  * `semrush_country_code` is listed as anonymous though it's actually not tracked: we should make sure it's tracked non-anonymously (it contains just the country code for the database used to query SEMrush).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the SEMrush setting where not properly tracked.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* build
* edit `/admin/class-admin.php`, and at the end of the constructor (should be line 121) add the following lines:
```
		if ( filter_input( INPUT_GET, 'action' ) === 'collect' ) {
			$collector = new WPSEO_Collector();
			$collector->add_collection( new WPSEO_Tracking_Settings_Data() );
			echo '<pre>';
			print_r( $collector->collect() );
			echo '</pre>';
		}
```
* visit http://basic.wordpress.test/wp-admin/admin.php?page=wpseo_dashboard&action=collect 
* the array which is displayed should contain lines like these:
```
            [semrush_integration_active] => 1
            [semrush_tokens] => used
            [semrush_country_code] => us
```
* obviously, the first one will be 0 if SEMrush is disabled, the last might be a different country code if it's been set in the modal, and the tokens could be shown as an empty array if no tokens are stored.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-208]
