### PR TITLE
Move the utils to the class that is using them

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -220,7 +220,7 @@ class WPSEO_Replace_Vars {
 		}
 
 		// Remove superfluous whitespace.
-		$string = $this->standardize_whitespace( $string );
+		$string = YoastSEO()->helpers->string->standardize_whitespace( $string );
 
 		return $string;
 	}

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -156,15 +156,15 @@ class WPSEO_Replace_Vars {
 
 		// Let's see if we can bail super early.
 		if ( strpos( $string, '%%' ) === false ) {
-			return WPSEO_Utils::standardize_whitespace( $string );
+			return $this->standardize_whitespace( $string );
 		}
 
 		$args = (array) $args;
 		if ( isset( $args['post_content'] ) && ! empty( $args['post_content'] ) ) {
-			$args['post_content'] = WPSEO_Utils::strip_shortcode( $args['post_content'] );
+			$args['post_content'] = $this->strip_shortcode( $args['post_content'] );
 		}
 		if ( isset( $args['post_excerpt'] ) && ! empty( $args['post_excerpt'] ) ) {
-			$args['post_excerpt'] = WPSEO_Utils::strip_shortcode( $args['post_excerpt'] );
+			$args['post_excerpt'] = $this->strip_shortcode( $args['post_excerpt'] );
 		}
 		$this->args = (object) wp_parse_args( $args, $this->defaults );
 
@@ -220,7 +220,7 @@ class WPSEO_Replace_Vars {
 		}
 
 		// Remove superfluous whitespace.
-		$string = WPSEO_Utils::standardize_whitespace( $string );
+		$string = $this->standardize_whitespace( $string );
 
 		return $string;
 	}
@@ -431,7 +431,24 @@ class WPSEO_Replace_Vars {
 	 * @return string
 	 */
 	private function retrieve_sep() {
-		return WPSEO_Utils::get_title_separator();
+		$replacement = WPSEO_Options::get_default( 'wpseo_titles', 'separator' );
+
+		// Get the titles option and the separator options.
+		$separator         = WPSEO_Options::get( 'separator' );
+		$seperator_options = WPSEO_Option_Titles::get_instance()->get_separator_options();
+
+		// This should always be set, but just to be sure.
+		if ( isset( $seperator_options[ $separator ] ) ) {
+			// Set the new replacement.
+			$replacement = $seperator_options[ $separator ];
+		}
+
+		/**
+		 * Filter: 'wpseo_replacements_filter_sep' - Allow customization of the separator character(s).
+		 *
+		 * @api string $replacement The current separator.
+		 */
+		return apply_filters( 'wpseo_replacements_filter_sep', $replacement );
 	}
 
 	/**
@@ -1297,6 +1314,31 @@ class WPSEO_Replace_Vars {
 	}
 
 	/* *********************** GENERAL HELPER METHODS ************************** */
+
+	/**
+	 * Standardize whitespace in a string.
+	 *
+	 * Replace line breaks, carriage returns, tabs with a space, then remove double spaces.
+	 *
+	 * @param string $string String input to standardize.
+	 *
+	 * @return string
+	 */
+	protected function standardize_whitespace( $string ) {
+		return trim( str_replace( '  ', ' ', str_replace( [ "\t", "\n", "\r", "\f" ], ' ', $string ) ) );
+	}
+
+	/**
+	 * First strip out registered and enclosing shortcodes using native WordPress strip_shortcodes function.
+	 * Then strip out the shortcodes with a filthy regex, because people don't properly register their shortcodes.
+	 *
+	 * @param string $text Input string that might contain shortcodes.
+	 *
+	 * @return string $text String without shortcodes.
+	 */
+	protected function strip_shortcode( $text ) {
+		return preg_replace( '`\[[^\]]+\]`s', '', strip_shortcodes( $text ) );
+	}
 
 	/**
 	 * Remove the '%%' delimiters from a variable string.

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -156,15 +156,15 @@ class WPSEO_Replace_Vars {
 
 		// Let's see if we can bail super early.
 		if ( strpos( $string, '%%' ) === false ) {
-			return $this->standardize_whitespace( $string );
+			return YoastSEO()->helpers->string->standardize_whitespace( $string );
 		}
 
 		$args = (array) $args;
 		if ( isset( $args['post_content'] ) && ! empty( $args['post_content'] ) ) {
-			$args['post_content'] = $this->strip_shortcode( $args['post_content'] );
+			$args['post_content'] = YoastSEO()->helpers->string->strip_shortcode( $args['post_content'] );
 		}
 		if ( isset( $args['post_excerpt'] ) && ! empty( $args['post_excerpt'] ) ) {
-			$args['post_excerpt'] = $this->strip_shortcode( $args['post_excerpt'] );
+			$args['post_excerpt'] = YoastSEO()->helpers->string->strip_shortcode( $args['post_excerpt'] );
 		}
 		$this->args = (object) wp_parse_args( $args, $this->defaults );
 
@@ -1314,31 +1314,6 @@ class WPSEO_Replace_Vars {
 	}
 
 	/* *********************** GENERAL HELPER METHODS ************************** */
-
-	/**
-	 * Standardize whitespace in a string.
-	 *
-	 * Replace line breaks, carriage returns, tabs with a space, then remove double spaces.
-	 *
-	 * @param string $string String input to standardize.
-	 *
-	 * @return string
-	 */
-	protected function standardize_whitespace( $string ) {
-		return trim( str_replace( '  ', ' ', str_replace( [ "\t", "\n", "\r", "\f" ], ' ', $string ) ) );
-	}
-
-	/**
-	 * First strip out registered and enclosing shortcodes using native WordPress strip_shortcodes function.
-	 * Then strip out the shortcodes with a filthy regex, because people don't properly register their shortcodes.
-	 *
-	 * @param string $text Input string that might contain shortcodes.
-	 *
-	 * @return string $text String without shortcodes.
-	 */
-	protected function strip_shortcode( $text ) {
-		return preg_replace( '`\[[^\]]+\]`s', '', strip_shortcodes( $text ) );
-	}
 
 	/**
 	 * Remove the '%%' delimiters from a variable string.

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -135,35 +135,6 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Standardize whitespace in a string.
-	 *
-	 * Replace line breaks, carriage returns, tabs with a space, then remove double spaces.
-	 *
-	 * @since 1.8.0
-	 *
-	 * @param string $string String input to standardize.
-	 *
-	 * @return string
-	 */
-	public static function standardize_whitespace( $string ) {
-		return trim( str_replace( '  ', ' ', str_replace( [ "\t", "\n", "\r", "\f" ], ' ', $string ) ) );
-	}
-
-	/**
-	 * First strip out registered and enclosing shortcodes using native WordPress strip_shortcodes function.
-	 * Then strip out the shortcodes with a filthy regex, because people don't properly register their shortcodes.
-	 *
-	 * @since 1.8.0
-	 *
-	 * @param string $text Input string that might contain shortcodes.
-	 *
-	 * @return string $text String without shortcodes.
-	 */
-	public static function strip_shortcode( $text ) {
-		return preg_replace( '`\[[^\]]+\]`s', '', strip_shortcodes( $text ) );
-	}
-
-	/**
 	 * Recursively trim whitespace round a string value or of string values within an array.
 	 * Only trims strings to avoid typecasting a variable (to string).
 	 *
@@ -759,34 +730,6 @@ class WPSEO_Utils {
 	 */
 	public static function get_site_name() {
 		return YoastSEO()->helpers->site->get_site_name();
-	}
-
-	/**
-	 * Retrieves the title separator.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @return string
-	 */
-	public static function get_title_separator() {
-		$replacement = WPSEO_Options::get_default( 'wpseo_titles', 'separator' );
-
-		// Get the titles option and the separator options.
-		$separator         = WPSEO_Options::get( 'separator' );
-		$seperator_options = WPSEO_Option_Titles::get_instance()->get_separator_options();
-
-		// This should always be set, but just to be sure.
-		if ( isset( $seperator_options[ $separator ] ) ) {
-			// Set the new replacement.
-			$replacement = $seperator_options[ $separator ];
-		}
-
-		/**
-		 * Filter: 'wpseo_replacements_filter_sep' - Allow customization of the separator character(s).
-		 *
-		 * @api string $replacement The current separator.
-		 */
-		return apply_filters( 'wpseo_replacements_filter_sep', $replacement );
 	}
 
 	/**
@@ -1425,5 +1368,77 @@ SVG;
 		$enabled_features = apply_filters( 'wpseo_enable_feature', $enabled_features );
 
 		return $enabled_features;
+	}
+
+	/**
+	 * Standardize whitespace in a string.
+	 *
+	 * Replace line breaks, carriage returns, tabs with a space, then remove double spaces.
+	 *
+	 * @deprecated 15.2
+	 * @codeCoverageIgnore
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param string $string String input to standardize.
+	 *
+	 * @return string
+	 */
+	public static function standardize_whitespace( $string ) {
+		_deprecated_function( __METHOD__, 'WPSEO 15.2' );
+
+		return trim( str_replace( '  ', ' ', str_replace( [ "\t", "\n", "\r", "\f" ], ' ', $string ) ) );
+	}
+
+	/**
+	 * First strip out registered and enclosing shortcodes using native WordPress strip_shortcodes function.
+	 * Then strip out the shortcodes with a filthy regex, because people don't properly register their shortcodes.
+	 *
+	 * @deprecated 15.2
+	 * @codeCoverageIgnore
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param string $text Input string that might contain shortcodes.
+	 *
+	 * @return string $text String without shortcodes.
+	 */
+	public static function strip_shortcode( $text ) {
+		_deprecated_function( __METHOD__, 'WPSEO 15.2' );
+
+		return preg_replace( '`\[[^\]]+\]`s', '', strip_shortcodes( $text ) );
+	}
+
+	/**
+	 * Retrieves the title separator.
+	 *
+	 * @deprecated 15.2
+	 * @codeCoverageIgnore
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return string
+	 */
+	public static function get_title_separator() {
+		_deprecated_function( __METHOD__, 'WPSEO 15.2' );
+
+		$replacement = WPSEO_Options::get_default( 'wpseo_titles', 'separator' );
+
+		// Get the titles option and the separator options.
+		$separator         = WPSEO_Options::get( 'separator' );
+		$seperator_options = WPSEO_Option_Titles::get_instance()->get_separator_options();
+
+		// This should always be set, but just to be sure.
+		if ( isset( $seperator_options[ $separator ] ) ) {
+			// Set the new replacement.
+			$replacement = $seperator_options[ $separator ];
+		}
+
+		/**
+		 * Filter: 'wpseo_replacements_filter_sep' - Allow customization of the separator character(s).
+		 *
+		 * @api string $replacement The current separator.
+		 */
+		return apply_filters( 'wpseo_replacements_filter_sep', $replacement );
 	}
 }

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1387,7 +1387,7 @@ SVG;
 	public static function standardize_whitespace( $string ) {
 		_deprecated_function( __METHOD__, 'WPSEO 15.2' );
 
-		return trim( str_replace( '  ', ' ', str_replace( [ "\t", "\n", "\r", "\f" ], ' ', $string ) ) );
+		return YoastSEO()->helpers->string->standardize_whitespace( $string );
 	}
 
 	/**
@@ -1406,7 +1406,7 @@ SVG;
 	public static function strip_shortcode( $text ) {
 		_deprecated_function( __METHOD__, 'WPSEO 15.2' );
 
-		return preg_replace( '`\[[^\]]+\]`s', '', strip_shortcodes( $text ) );
+		return YoastSEO()->helpers->string->strip_shortcode( $text );
 	}
 
 	/**

--- a/src/helpers/string-helper.php
+++ b/src/helpers/string-helper.php
@@ -12,11 +12,34 @@ class String_Helper {
 	 *
 	 * @param string $string The string to strip the tags from.
 	 *
-	 * @codeCoverageIgnore It only wraps a WordPress function.
-	 *
 	 * @return string The processed string.
 	 */
 	public function strip_all_tags( $string ) {
 		return \wp_strip_all_tags( $string );
+	}
+
+	/**
+	 * Standardize whitespace in a string.
+	 *
+	 * Replace line breaks, carriage returns, tabs with a space, then remove double spaces.
+	 *
+	 * @param string $string String input to standardize.
+	 *
+	 * @return string
+	 */
+	public function standardize_whitespace( $string ) {
+		return \trim( \str_replace( '  ', ' ', \str_replace( [ "\t", "\n", "\r", "\f" ], ' ', $string ) ) );
+	}
+
+	/**
+	 * First strip out registered and enclosing shortcodes using native WordPress strip_shortcodes function.
+	 * Then strip out the shortcodes with a filthy regex, because people don't properly register their shortcodes.
+	 *
+	 * @param string $text Input string that might contain shortcodes.
+	 *
+	 * @return string $text String without shortcodes.
+	 */
+	public function strip_shortcode( $text ) {
+		return \preg_replace( '`\[[^\]]+\]`s', '', \strip_shortcodes( $text ) );
 	}
 }

--- a/tests/unit/helpers/string-helper-test.php
+++ b/tests/unit/helpers/string-helper-test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\SEO\Tests\Helpers;
+namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 
 use Brain\Monkey;
 use Yoast\WP\SEO\Helpers\Site_Helper;

--- a/tests/unit/helpers/string-helper-test.php
+++ b/tests/unit/helpers/string-helper-test.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Helpers;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Helpers\Site_Helper;
+use Yoast\WP\SEO\Helpers\String_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class String_Helper_Test
+ *
+ * @group helpers
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Helpers\String_Helper
+ */
+class String_Helper_Test extends TestCase {
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var String_Helper
+	 */
+	protected $instance;
+
+	/**
+	 * Setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = new String_Helper();
+	}
+
+	/**
+	 * Tests the stripping of all tags.
+	 *
+	 * @covers ::strip_all_tags
+	 */
+	public function test_strip_all_tags() {
+		static::assertSame( 'This is an anchor', $this->instance->strip_all_tags( 'This is an <a>anchor</a>' ) );
+	}
+
+	/**
+	 * Tests the standardization of the whitespace.
+	 *
+	 * @covers ::standardize_whitespace
+	 */
+	public function test_standardize_whitespace() {
+		static::assertSame( 'this is a string', $this->instance->standardize_whitespace( " \nthis\r\ris  a string \t" ) );
+	}
+
+	/**
+	 * Tests the stripping of shortcodes from a string.
+	 *
+	 * @covers ::strip_shortcode
+	 */
+	public function test_strip_shortcode() {
+		Monkey\Functions\expect( 'strip_shortcodes' )
+			->with( 'this is a [shortcode] ' )
+			->andReturn( 'this is a shortcode ' );
+
+		static::assertSame( 'this is a shortcode ', $this->instance->strip_shortcode( 'this is a [shortcode] ' ) );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Some utils are used in one class only. These should be moved to that classes.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A - It just moved some methods from the utils to the replace vars class.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* It is a code move change only and it should work as before.
* Verify that the replacement variables in the templates are replaced correctly. You can set/manage the templates in the search appareance settings. You can also use these in social previews which can you find in the post edit. 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
