### PR TITLE
Fixed the notification not being shown immediately when permalink settings change

### DIFF
--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -147,10 +147,12 @@ class Indexing_Notification_Integration implements Integration_Interface {
 			\add_action( 'admin_init', [ $this, 'cleanup_notification' ] );
 		}
 
+		if ( $this->options_helper->get( 'indexing_reason' ) || ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {
+			\add_action( 'admin_init', [ $this, 'create_notification' ] );
+		}
+
 		if ( ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {
 			\wp_schedule_event( $this->date_helper->current_time(), 'daily', self::NOTIFICATION_ID );
-			\add_action( 'admin_init', [ $this, 'create_notification' ] );
-
 			return;
 		}
 

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -180,7 +180,9 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		$this->options_helper
 			->expects( 'get' )
-			->once();
+			->with( 'indexing_reason' )
+			->once()
+			->andReturn( '' );
 
 		$this->instance->register_hooks();
 	}
@@ -211,7 +213,9 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		$this->options_helper
 			->expects( 'get' )
-			->once();
+			->with( 'indexing_reason' )
+			->once()
+			->andReturn( '' );
 
 		$this->instance->register_hooks();
 	}
@@ -243,7 +247,43 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		$this->options_helper
 			->expects( 'get' )
-			->once();
+			->with( 'indexing_reason' )
+			->once()
+			->andReturn( '' );
+
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 * Tests whether the notification is shown when there is a reason set.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks_create_notification_on_reason() {
+		$this->page_helper
+			->expects( 'get_current_yoast_seo_page' )
+			->once()
+			->andReturn( 'another_page' );
+
+		Monkey\Functions\expect( 'wp_next_scheduled' )
+			->once()
+			->andReturn( false );
+
+		$mocked_time = 1234567;
+
+		$this->date_helper
+			->expects( 'current_time' )
+			->andReturn( $mocked_time );
+
+		Monkey\Functions\expect( 'wp_schedule_event' )
+			->with( $mocked_time, 'daily', Indexing_Notification_Integration::NOTIFICATION_ID );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'indexing_reason' )
+			->once()
+			->andReturn( Indexing_Notification_Integration::REASON_CATEGORY_BASE_PREFIX );
 
 		$this->instance->register_hooks();
 	}

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -171,11 +171,15 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->andReturn( 'another_page' );
 
 		Monkey\Functions\expect( 'wp_next_scheduled' )
-			->once()
+			->twice()
 			->andReturn( true );
 
 		Monkey\Actions\expectAdded( Indexing_Notification_Integration::NOTIFICATION_ID )
 			->with( [ $this->instance, 'create_notification' ] )
+			->once();
+
+		$this->options_helper
+			->expects( 'get' )
 			->once();
 
 		$this->instance->register_hooks();
@@ -198,11 +202,15 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->once();
 
 		Monkey\Functions\expect( 'wp_next_scheduled' )
-			->once()
+			->twice()
 			->andReturn( true );
 
 		Monkey\Actions\expectAdded( Indexing_Notification_Integration::NOTIFICATION_ID )
 			->with( [ $this->instance, 'create_notification' ] )
+			->once();
+
+		$this->options_helper
+			->expects( 'get' )
 			->once();
 
 		$this->instance->register_hooks();
@@ -221,7 +229,7 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->andReturn( 'another_page' );
 
 		Monkey\Functions\expect( 'wp_next_scheduled' )
-			->once()
+			->twice()
 			->andReturn( false );
 
 		$mocked_time = 1234567;
@@ -232,6 +240,10 @@ class Indexing_Notification_Integration_Test extends TestCase {
 
 		Monkey\Functions\expect( 'wp_schedule_event' )
 			->with( $mocked_time, 'daily', Indexing_Notification_Integration::NOTIFICATION_ID );
+
+		$this->options_helper
+			->expects( 'get' )
+			->once();
 
 		$this->instance->register_hooks();
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the notification to re-index your indexable does not immediately appear when the permalinks, home url or category base is changed.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Reproducing the bug
* Checkout the release branch (`release/15.1`).
* Change your permalink settings.
  * E.g. go to _Settings_ > _Permalinks_ and change your permalink structure.
* Notice that you do not immediately get a new notification to re-index your site.

### Checking that the bug has been fixed
* Checkout this branch (`fix-notification-not-being-shown-when-permalink-changes`).
* Change your permalink settings.
  * E.g. go to _Settings_ > _Permalinks_ and change your permalink structure.
* Notice that you do get a new notification to re-index your site.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
