### PR TITLE
P3-213 Prevent the SEMrush popup to stay open if auth is gone OK

### DIFF
--- a/js/src/components/SEMrushRelatedKeyphrasesModal.js
+++ b/js/src/components/SEMrushRelatedKeyphrasesModal.js
@@ -147,6 +147,8 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 			if ( response.status === 200 ) {
 				this.props.onAuthentication( true );
 				this.onModalOpen();
+				// Close the popup if it's been opened again by mistake.
+				this.popup.close();
 			} else {
 				console.error( response.error );
 			}


### PR DESCRIPTION


## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Reported by @ma0sm:
  * With SEMrush unauthenticated, select Get related keyphrases when adding a new post.
  * The SEMrush authenticator pops up, you select approve, it disappears.
  * Select Get related keyphrases again straight after, and the authenticator appears again.
  * Wait a few seconds and the results will appear in the main window, while the authenticator popup just stays there useless.

This can occur because the authentication can took a bit on some systems, and it can happen that the user clicks again on the link to open the popup in the meantime

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the SEMrush popup could stay opened even after authorization has been performed successfully

## Relevant technical choices:

* I decided to just call `close()` on the popup again after the authorization is gone because disabling the link that opens the popup turned out a bit trickier than expected, and it seemed to dangerous to hack the components while in RC stage

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* make sure you have non SEMrush tokens in the DB: if needed, disable the integration with the toggle and re-enable it again.
* edit a post, insert a keyphrase, click on "Get Related Keyphrases" and see the popup opening
* be really quick (it may help if you move the popup so the "Approve" button is right in front of the "Get Related Keyphrases" button): click on "Approve" and _**as soon as the popup closes**_ click again on "Get Related Keyphrases".
* see that the popups opens again, but as soon as the modal appears, it closes.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-213]
