### PR TITLE
Show indexing notification on clean install of Yoast SEO

### DIFF
--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -28,11 +28,6 @@ class Indexing_Notification_Integration implements Integration_Interface {
 	const NOTIFICATION_ID = 'wpseo-reindex';
 
 	/**
-	 * Represents the reason that the plugin has just been installed.
-	 */
-	const REASON_FIRST_INSTALL = 'first_install';
-
-	/**
 	 * Represents the reason that the indexing process failed and should be tried again.
 	 */
 	const REASON_INDEXING_FAILED = 'indexing_failed';
@@ -155,7 +150,6 @@ class Indexing_Notification_Integration implements Integration_Interface {
 		if ( ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {
 			\wp_schedule_event( $this->date_helper->current_time(), 'daily', self::NOTIFICATION_ID );
 			\add_action( self::NOTIFICATION_ID, [ $this, 'create_notification' ] );
-			$this->options_helper->set( 'indexing_reason', self::REASON_FIRST_INSTALL );
 		}
 
 		if ( $this->options_helper->get( 'indexing_reason' ) ) {

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -153,10 +153,8 @@ class Indexing_Notification_Integration implements Integration_Interface {
 
 		if ( ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {
 			\wp_schedule_event( $this->date_helper->current_time(), 'daily', self::NOTIFICATION_ID );
-			return;
+			\add_action( self::NOTIFICATION_ID, [ $this, 'create_notification' ] );
 		}
-
-		\add_action( self::NOTIFICATION_ID, [ $this, 'create_notification' ] );
 	}
 
 	/**

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -147,8 +147,8 @@ class Indexing_Notification_Integration implements Integration_Interface {
 			\add_action( 'admin_init', [ $this, 'cleanup_notification' ] );
 		}
 
-			\add_action( 'admin_init', [ $this, 'create_notification' ] );
 		if ( $this->should_show_notification() || ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {
+			$this->create_notification();
 		}
 
 		if ( ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -147,14 +147,16 @@ class Indexing_Notification_Integration implements Integration_Interface {
 			\add_action( 'admin_init', [ $this, 'cleanup_notification' ] );
 		}
 
-		if ( ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {
-			\wp_schedule_event( $this->date_helper->current_time(), 'daily', self::NOTIFICATION_ID );
-			\add_action( self::NOTIFICATION_ID, [ $this, 'create_notification' ] );
+		if ( $this->options_helper->get( 'indexing_reason' ) || ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {
+			\add_action( 'admin_init', [ $this, 'create_notification' ] );
 		}
 
-		if ( $this->options_helper->get( 'indexing_reason' ) ) {
-			$this->create_notification();
+		if ( ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {
+			\wp_schedule_event( $this->date_helper->current_time(), 'daily', self::NOTIFICATION_ID );
+			return;
 		}
+
+		\add_action( self::NOTIFICATION_ID, [ $this, 'create_notification' ] );
 	}
 
 	/**

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -147,8 +147,8 @@ class Indexing_Notification_Integration implements Integration_Interface {
 			\add_action( 'admin_init', [ $this, 'cleanup_notification' ] );
 		}
 
-		if ( $this->options_helper->get( 'indexing_reason' ) || ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {
 			\add_action( 'admin_init', [ $this, 'create_notification' ] );
+		if ( $this->should_show_notification() || ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {
 		}
 
 		if ( ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -28,6 +28,11 @@ class Indexing_Notification_Integration implements Integration_Interface {
 	const NOTIFICATION_ID = 'wpseo-reindex';
 
 	/**
+	 * Represents the reason that the plugin has just been installed.
+	 */
+	const REASON_FIRST_INSTALL = 'first_install';
+
+	/**
 	 * Represents the reason that the indexing process failed and should be tried again.
 	 */
 	const REASON_INDEXING_FAILED = 'indexing_failed';
@@ -147,13 +152,14 @@ class Indexing_Notification_Integration implements Integration_Interface {
 			\add_action( 'admin_init', [ $this, 'cleanup_notification' ] );
 		}
 
-		if ( $this->should_show_notification() || ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {
-			$this->create_notification();
-		}
-
 		if ( ! \wp_next_scheduled( self::NOTIFICATION_ID ) ) {
 			\wp_schedule_event( $this->date_helper->current_time(), 'daily', self::NOTIFICATION_ID );
 			\add_action( self::NOTIFICATION_ID, [ $this, 'create_notification' ] );
+			$this->options_helper->set( 'indexing_reason', self::REASON_FIRST_INSTALL );
+		}
+
+		if ( $this->options_helper->get( 'indexing_reason' ) ) {
+			$this->create_notification();
 		}
 	}
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -192,6 +192,8 @@ function _wpseo_activate() {
 		WPSEO_Options::set( 'tracking', false );
 	}
 
+	WPSEO_Options::set( 'indexing_reason', 'first_install' );
+
 	do_action( 'wpseo_register_roles' );
 	WPSEO_Role_Manager_Factory::get()->add();
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the notification to index your site wasn't shown when installing Yoast SEO for the first time.

## Relevant technical choices:

* As advised by @herregroen, we are setting an indexing reason when the plugin gets activated. `$this->options_helper->get( 'indexing_reason' )` will then evaluate to `true`, and as a result the notification will be created.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Reset your WordPress environment (in `plugin-development-docker`: `./clean.sh`, `./make.sh`, `./start.sh`).
* Install and activate Yoast SEO.
* See that the indexing notification immediately pops up with the following text: "'You can speed up your site and get insight into your internal linking structure by letting us perform a few optimizations to the way SEO data is stored."

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-419
