### PR TITLE
Add wpseo_image_get_data filter.

### DIFF
--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -89,10 +89,11 @@ class WPSEO_Image_Utils {
 	 *     Array of image data
 	 *
 	 *     @type string $alt      Image's alt text.
-	 *     @type string $alt      Image's alt text.
+	 *     @type int    $path     Path of image.
 	 *     @type int    $width    Width of image.
 	 *     @type int    $height   Height of image.
 	 *     @type string $type     Image's MIME type.
+	 *     @type string $size     Image's size.
 	 *     @type string $url      Image's URL.
 	 *     @type int    $filesize The file size in bytes, if already set.
 	 * }
@@ -118,14 +119,19 @@ class WPSEO_Image_Utils {
 		/**
 		 * Filter: 'wpseo_image_get_data' - Filter image data.
 		 *
+		 * Elements with keys not listed in the section will be discarded.
+		 *
 		 * @api array {
 		 *     Array of image data
 		 *
+		 *     @type int    id       Image's ID as an attachment.
 		 *     @type string alt      Image's alt text.
-		 *     @type string alt      Image's alt text.
+		 *     @type string path     Image's path.
 		 *     @type int    width    Width of image.
 		 *     @type int    height   Height of image.
+		 *     @type int    pixels   Number of pixels in the image.
 		 *     @type string type     Image's MIME type.
+		 *     @type string size     Image's size.
 		 *     @type string url      Image's URL.
 		 *     @type int    filesize The file size in bytes, if already set.
 		 * }

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -118,18 +118,18 @@ class WPSEO_Image_Utils {
 		/**
 		 * Filter: 'wpseo_image_get_data' - Filter image data.
 		 *
-		 * @api array $image {
+		 * @api array {
 		 *     Array of image data
 		 *
-		 *     @type string $alt      Image's alt text.
-		 *     @type string $alt      Image's alt text.
-		 *     @type int    $width    Width of image.
-		 *     @type int    $height   Height of image.
-		 *     @type string $type     Image's MIME type.
-		 *     @type string $url      Image's URL.
-		 *     @type int    $filesize The file size in bytes, if already set.
+		 *     @type string alt      Image's alt text.
+		 *     @type string alt      Image's alt text.
+		 *     @type int    width    Width of image.
+		 *     @type int    height   Height of image.
+		 *     @type string type     Image's MIME type.
+		 *     @type string url      Image's URL.
+		 *     @type int    filesize The file size in bytes, if already set.
 		 * }
-		 * @api int $attachment_id Attachment ID.
+		 * @api int  Attachment ID.
 		 */
 		$image = apply_filters( 'wpseo_image_get_data', $image, $attachment_id );
 

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -89,7 +89,7 @@ class WPSEO_Image_Utils {
 	 *     Array of image data
 	 *
 	 *     @type string $alt      Image's alt text.
-	 *     @type int    $path     Path of image.
+	 *     @type string $path     Path of image.
 	 *     @type int    $width    Width of image.
 	 *     @type int    $height   Height of image.
 	 *     @type string $type     Image's MIME type.

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -115,6 +115,24 @@ class WPSEO_Image_Utils {
 			$image['type'] = get_post_mime_type( $attachment_id );
 		}
 
+		/**
+		 * Filter: 'wpseo_image_get_data' - Filter image data.
+		 *
+		 * @api array $image {
+		 *     Array of image data
+		 *
+		 *     @type string $alt      Image's alt text.
+		 *     @type string $alt      Image's alt text.
+		 *     @type int    $width    Width of image.
+		 *     @type int    $height   Height of image.
+		 *     @type string $type     Image's MIME type.
+		 *     @type string $url      Image's URL.
+		 *     @type int    $filesize The file size in bytes, if already set.
+		 * }
+		 * @api int $attachment_id Attachment ID.
+		 */
+		$image = apply_filters( 'wpseo_image_get_data', $image, $attachment_id );
+
 		// Keep only the keys we need, and nothing else.
 		return array_intersect_key( $image, array_flip( [ 'id', 'alt', 'path', 'width', 'height', 'pixels', 'type', 'size', 'url', 'filesize' ] ) );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add a filter to `WPSEO_Image_Utils` class, to allow highjacking of image meta data. 
This filter is specially useful for those using a plugin that loads image from a third party source like S3 or Unsplash. It is a workaround for #15437 

## Summary

This PR can be summarized in the following changelog entry:

* Adds a filter to `WPSEO_Image_Utils` class to allow changes to image meta data. Props to [Jonny Harris](https://github.com/spacedmonkey)

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #16119 #15437 
