### PR TITLE
P2-367 Wrong incoming links count on initial indexation

### DIFF
--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -265,6 +265,10 @@ class Indexable_Link_Builder {
 				$target  = $this->indexable_repository->find_by_id_and_type( $post_id, 'post' );
 			}
 
+			if ( ! $target ) {
+				return $model;
+			}
+
 			$model->target_indexable_id = $target->id;
 			if ( $target->object_type === 'post' ) {
 				$model->target_post_id = $target->object_id;

--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -210,6 +210,22 @@ class Indexable_Link_Builder {
 	}
 
 	/**
+	 * Get the post ID based on the link's type and its target's permalink.
+	 *
+	 * @param string $type      The type of link (either SEO_Links::TYPE_INTERNAL or SEO_Links::TYPE_INTERNAL_IMAGE).
+	 * @param string $permalink The permalink of the link's target.
+	 *
+	 * @return int The post ID.
+	 */
+	protected function get_post_id( $type, $permalink ) {
+		if ( $type === SEO_Links::TYPE_INTERNAL ) {
+			return \url_to_postid( $permalink );
+		}
+
+		return $this->image_helper->get_attachment_by_url( $permalink );
+	}
+
+	/**
 	 * Creates an internal link.
 	 *
 	 * @param string    $url       The url of the link.
@@ -245,13 +261,8 @@ class Indexable_Link_Builder {
 
 			if ( ! $target ) {
 				// If target indexable cannot be found, create one based on the post's post ID.
-				if ( $model->type === SEO_Links::TYPE_INTERNAL ) {
-					$post_id = \url_to_postid( $permalink );
-				}
-				else {
-					$post_id = $this->image_helper->get_attachment_by_url( $permalink );
-				}
-				$target = $this->indexable_repository->find_by_id_and_type( $post_id, 'post' );
+				$post_id = $this->get_post_id( $model->type, $permalink );
+				$target  = $this->indexable_repository->find_by_id_and_type( $post_id, 'post' );
 			}
 
 			$model->target_indexable_id = $target->id;

--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -264,7 +264,9 @@ class Indexable_Link_Builder {
 			if ( ! $target ) {
 				// If target indexable cannot be found, create one based on the post's post ID.
 				$post_id = $this->get_post_id( $model->type, $permalink );
-				$target  = $this->indexable_repository->find_by_id_and_type( $post_id, 'post' );
+				if ( $post_id && $post_id !== 0 ) {
+					$target = $this->indexable_repository->find_by_id_and_type( $post_id, 'post' );
+				}
 			}
 
 			if ( ! $target ) {

--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -93,6 +93,8 @@ class Indexable_Link_Builder {
 
 		if ( empty( $links ) && empty( $images ) ) {
 			$indexable->link_count = 0;
+			$this->update_related_indexables( $indexable, [] );
+
 			return [];
 		}
 

--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -244,7 +244,7 @@ class Indexable_Link_Builder {
 		/**
 		 * ORM representing a link in the SEO Links table.
 		 *
-		 * @var SEO_Links
+		 * @var SEO_Links $model
 		 */
 		$model = $this->seo_links_repository->query()->create(
 			[

--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -224,6 +224,8 @@ class Indexable_Link_Builder {
 		$link_type  = $this->url_helper->get_link_type( $parsed_url, $home_url, $is_image );
 
 		/**
+		 * ORM representing a link in the SEO Links table.
+		 *
 		 * @var SEO_Links
 		 */
 		$model = $this->seo_links_repository->query()->create(
@@ -242,7 +244,14 @@ class Indexable_Link_Builder {
 			$target    = $this->indexable_repository->find_by_permalink( $permalink );
 
 			if ( ! $target ) {
-				return $model;
+				// If target indexable cannot be found, create one based on the post's post ID.
+				if ( $model->type === SEO_Links::TYPE_INTERNAL ) {
+					$post_id = \url_to_postid( $permalink );
+				}
+				else {
+					$post_id = $this->image_helper->get_attachment_by_url( $permalink );
+				}
+				$target = $this->indexable_repository->find_by_id_and_type( $post_id, 'post' );
 			}
 
 			$model->target_indexable_id = $target->id;

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -16,13 +16,6 @@ class Indexable_Post_Builder {
 	use Indexable_Social_Image_Trait;
 
 	/**
-	 * The link builder.
-	 *
-	 * @var Indexable_Link_Builder
-	 */
-	protected $link_builder;
-
-	/**
 	 * The indexable repository.
 	 *
 	 * @var Indexable_Repository
@@ -39,15 +32,12 @@ class Indexable_Post_Builder {
 	/**
 	 * Indexable_Post_Builder constructor.
 	 *
-	 * @param Indexable_Link_Builder $link_builder The link builder.
-	 * @param Post_Helper            $post         The post helper.
+	 * @param Post_Helper $post The post helper.
 	 */
 	public function __construct(
-		Indexable_Link_Builder $link_builder,
 		Post_Helper $post
 	) {
-		$this->link_builder = $link_builder;
-		$this->post         = $post;
+		$this->post = $post;
 	}
 
 	/**
@@ -112,8 +102,6 @@ class Indexable_Post_Builder {
 		}
 
 		$this->handle_social_images( $indexable );
-
-		$this->link_builder->build( $indexable, $post->post_content );
 
 		$indexable->author_id   = $post->post_author;
 		$indexable->post_parent = $post->post_parent;

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -21,24 +21,14 @@ class Indexable_Term_Builder {
 	private $taxonomy;
 
 	/**
-	 * The link builder.
-	 *
-	 * @var Indexable_Link_Builder
-	 */
-	protected $link_builder;
-
-	/**
 	 * Indexable_Term_Builder constructor.
 	 *
-	 * @param Taxonomy_Helper        $taxonomy     The taxonomy helper.
-	 * @param Indexable_Link_Builder $link_builder The link builder.
+	 * @param Taxonomy_Helper $taxonomy The taxonomy helper.
 	 */
 	public function __construct(
-		Taxonomy_Helper $taxonomy,
-		Indexable_Link_Builder $link_builder
+		Taxonomy_Helper $taxonomy
 	) {
-		$this->taxonomy     = $taxonomy;
-		$this->link_builder = $link_builder;
+		$this->taxonomy = $taxonomy;
 	}
 
 	/**
@@ -89,7 +79,6 @@ class Indexable_Term_Builder {
 		}
 
 		$this->handle_social_images( $indexable );
-		$this->link_builder->build( $indexable, $term->description );
 
 		$indexable->is_cornerstone = $this->get_meta_value( 'wpseo_is_cornerstone', $term_meta );
 

--- a/src/integrations/admin/admin-columns-cache-integration.php
+++ b/src/integrations/admin/admin-columns-cache-integration.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 use WP_Post;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**

--- a/src/integrations/admin/admin-columns-cache-integration.php
+++ b/src/integrations/admin/admin-columns-cache-integration.php
@@ -94,7 +94,7 @@ class Admin_Columns_Cache_Integration implements Integration_Interface {
 			\_prime_post_caches( $post_ids );
 		}
 
-		$indexables = $this->indexable_repository->find_by_multiple_ids_and_type( $post_ids, 'post' );
+		$indexables = $this->indexable_repository->find_by_multiple_ids_and_type( $post_ids, 'post', false );
 
 		foreach ( $indexables as $indexable ) {
 			$this->indexable_cache[ $indexable->object_id ] = $indexable;

--- a/src/integrations/admin/indexing-links-integration.php
+++ b/src/integrations/admin/indexing-links-integration.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use Yoast\WP\SEO\Actions\Indexation\Post_Link_Indexing_Action;
+use Yoast\WP\SEO\Actions\Indexation\Term_Link_Indexing_Action;
+use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Conditionals\Yoast_Tools_Page_Conditional;
+use Yoast\WP\SEO\Integrations\Indexing_Interface;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Routes\Link_Indexing_Route;
+
+/**
+ * Class Indexing_Links_Integration.
+ *
+ * @package Yoast\WP\SEO\Integrations\Admin
+ */
+class Indexing_Links_Integration implements Indexing_Interface, Integration_Interface {
+
+	/**
+	 * The post link indexing action.
+	 *
+	 * @var Post_Link_Indexing_Action
+	 */
+	protected $post_link_indexing_action;
+
+	/**
+	 * The term link indexing action.
+	 *
+	 * @var Term_Link_Indexing_Action
+	 */
+	protected $term_link_indexing_action;
+
+	/**
+	 * The total number of unindexed objects.
+	 *
+	 * @var int
+	 */
+	protected $total_unindexed;
+
+	/**
+	 * Returns the conditionals based on which this integration should be active.
+	 *
+	 * @return array The array of conditionals.
+	 */
+	public static function get_conditionals() {
+		return [
+			Yoast_Tools_Page_Conditional::class,
+			Migrations_Conditional::class,
+		];
+	}
+
+	/**
+	 * Indexing_Links_Integration constructor.
+	 *
+	 * @param Post_Link_Indexing_Action $post_link_indexing_action The post indexing action.
+	 * @param Term_Link_Indexing_Action $term_link_indexing_action The term indexing action.
+	 */
+	public function __construct(
+		Post_Link_Indexing_Action $post_link_indexing_action,
+		Term_Link_Indexing_Action $term_link_indexing_action
+	) {
+		$this->post_link_indexing_action = $post_link_indexing_action;
+		$this->term_link_indexing_action = $term_link_indexing_action;
+	}
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * This is the place to register hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_filter( 'wpseo_indexing_instances', [ $this, 'register_instance' ] );
+	}
+
+	/**
+	 * Registers the instance.
+	 *
+	 * @param Indexing_Interface[] $instances The interfaces to extend.
+	 *
+	 * @return Indexing_Interface[] The extended instances.
+	 */
+	public function register_instance( $instances ) {
+		$instances[] = $this;
+
+		return $instances;
+	}
+
+	/**
+	 * Retrieves the endpoints to call.
+	 *
+	 * @return array The endpoints.
+	 */
+	public function get_endpoints() {
+		return [
+			'post_link' => Link_Indexing_Route::FULL_POSTS_ROUTE,
+			'term_link' => Link_Indexing_Route::FULL_TERMS_ROUTE,
+		];
+	}
+
+	/**
+	 * Returns the total number of unindexed objects.
+	 *
+	 * @return int The total number of unindexed objects.
+	 */
+	public function get_total_unindexed() {
+		if ( \is_null( $this->total_unindexed ) ) {
+			$this->total_unindexed  = $this->post_link_indexing_action->get_total_unindexed();
+			$this->total_unindexed += $this->term_link_indexing_action->get_total_unindexed();
+		}
+
+		return $this->total_unindexed;
+	}
+}

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -14,7 +14,6 @@ use Yoast\WP\SEO\Loggers\Logger;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
-use Yoast\WP\SEO\Repositories\SEO_Links_Repository;
 use YoastSEO_Vendor\Psr\Log\LogLevel;
 
 /**
@@ -160,9 +159,15 @@ class Indexable_Post_Watcher implements Integration_Interface {
 			return;
 		}
 
+		$post = $this->post->get_post( $updated_indexable->object_id );
+
 		// When the indexable is public or has a change in its public state.
 		if ( $updated_indexable->is_public || $updated_indexable->is_public !== $old_indexable->is_public ) {
-			$this->update_relations( $this->post->get_post( $updated_indexable->object_id ) );
+			$this->update_relations( $post );
+		}
+
+		if ( $post ) {
+			$this->link_builder->build( $updated_indexable, $post->post_content );
 		}
 
 		$this->update_has_public_posts( $updated_indexable );

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -171,6 +171,8 @@ class Indexable_Post_Watcher implements Integration_Interface {
 		}
 
 		$this->update_has_public_posts( $updated_indexable );
+
+		$updated_indexable->save();
 	}
 
 	/**

--- a/src/integrations/watchers/indexable-term-watcher.php
+++ b/src/integrations/watchers/indexable-term-watcher.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
 use Yoast\WP\SEO\Builders\Indexable_Builder;
+use Yoast\WP\SEO\Builders\Indexable_Link_Builder;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Site_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -28,6 +29,13 @@ class Indexable_Term_Watcher implements Integration_Interface {
 	protected $builder;
 
 	/**
+	 * The link builder.
+	 *
+	 * @var Indexable_Link_Builder
+	 */
+	protected $link_builder;
+
+	/**
 	 * Represents the site helper.
 	 *
 	 * @var Site_Helper
@@ -44,14 +52,21 @@ class Indexable_Term_Watcher implements Integration_Interface {
 	/**
 	 * Indexable_Term_Watcher constructor.
 	 *
-	 * @param Indexable_Repository $repository The repository to use.
-	 * @param Indexable_Builder    $builder    The post builder to use.
-	 * @param Site_Helper          $site       The site helper.
+	 * @param Indexable_Repository   $repository   The repository to use.
+	 * @param Indexable_Builder      $builder      The post builder to use.
+	 * @param Indexable_Link_Builder $link_builder The lint builder to use.
+	 * @param Site_Helper            $site         The site helper.
 	 */
-	public function __construct( Indexable_Repository $repository, Indexable_Builder $builder, Site_Helper $site ) {
-		$this->repository = $repository;
-		$this->builder    = $builder;
-		$this->site       = $site;
+	public function __construct(
+		Indexable_Repository $repository,
+		Indexable_Builder $builder,
+		Indexable_Link_Builder $link_builder,
+		Site_Helper $site
+	) {
+		$this->repository   = $repository;
+		$this->builder      = $builder;
+		$this->link_builder = $link_builder;
+		$this->site         = $site;
 	}
 
 	/**
@@ -110,6 +125,9 @@ class Indexable_Term_Watcher implements Integration_Interface {
 		$indexable = $this->repository->find_by_id_and_type( $term_id, 'term', false );
 
 		// If we haven't found an existing indexable, create it. Otherwise update it.
-		$this->builder->build_for_id_and_type( $term_id, 'term', $indexable );
+		$indexable = $this->builder->build_for_id_and_type( $term_id, 'term', $indexable );
+
+		// Update links.
+		$this->link_builder->build( $indexable, $term->description );
 	}
 }

--- a/src/integrations/watchers/indexable-term-watcher.php
+++ b/src/integrations/watchers/indexable-term-watcher.php
@@ -129,5 +129,7 @@ class Indexable_Term_Watcher implements Integration_Interface {
 
 		// Update links.
 		$this->link_builder->build( $indexable, $term->description );
+
+		$indexable->save();
 	}
 }

--- a/tests/unit/builders/indexable-link-builder-test.php
+++ b/tests/unit/builders/indexable-link-builder-test.php
@@ -62,7 +62,7 @@ class Indexable_Link_Builder_Test extends TestCase {
 	protected $instance;
 
 	/**
-	 * @inheritDoc
+	 * Sets up the tests.
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -160,6 +160,115 @@ class Indexable_Link_Builder_Test extends TestCase {
 		$links = $this->instance->build( $indexable, $content );
 
 		$this->assertEquals( 1, \count( $links ) );
+		$this->assertEquals( $seo_link, $links[0] );
+	}
+
+	/**
+	 * Tests the build function for an internal link when the target indexable does not exist yet.
+	 *
+	 * @covers ::__construct
+	 * @covers ::set_dependencies
+	 * @covers ::build
+	 */
+	public function test_build_target_indexable_does_not_exist() {
+		$content   = '<a href="https://site.com/target">link</a>';
+		$link_type = SEO_Links::TYPE_INTERNAL;
+
+		$indexable              = Mockery::mock( Indexable_Mock::class );
+		$indexable->id          = 1;
+		$indexable->object_id   = 2;
+		$indexable->object_type = 'post';
+		$indexable->permalink   = 'https://site.com/page';
+
+		$target_indexable              = Mockery::mock( Indexable_Mock::class );
+		$target_indexable->id          = 2;
+		$target_indexable->object_id   = 3;
+		$target_indexable->object_type = 'post';
+		$target_indexable->permalink   = 'https://site.com/target';
+		$target_indexable->language    = 'nl';
+		$target_indexable->region      = 'NL';
+
+		Filters\expectApplied( 'the_content' )->with( $content )->andReturnFirstArg();
+
+		$parsed_home_url = [
+			'scheme' => 'https',
+			'host'   => 'site.com',
+		];
+		$parsed_page_url = [
+			'scheme' => 'https',
+			'host'   => 'site.com',
+			'path'   => 'page',
+		];
+		$parsed_link_url = [
+			'scheme' => 'https',
+			'host'   => 'link.com',
+			'path'   => 'target',
+		];
+
+		Functions\expect( 'home_url' )->once()->andReturn( 'https://site.com' );
+		Functions\expect( 'wp_parse_url' )->once()->with( 'https://site.com' )->andReturn( $parsed_home_url );
+		Functions\expect( 'wp_parse_url' )->once()->with( 'https://site.com/page' )->andReturn( $parsed_page_url );
+		Functions\expect( 'wp_parse_url' )->once()->with( 'https://site.com/target' )->andReturn( $parsed_link_url );
+		Functions\expect( 'set_url_scheme' )->once()->with( 'https://site.com/target', 'https' )->andReturnFirstArg();
+
+		$this->url_helper->expects( 'get_link_type' )->with( $parsed_link_url, $parsed_home_url, false )->andReturn( $link_type );
+
+		$query_mock             = Mockery::mock();
+		$seo_link               = Mockery::mock( SEO_Links_Mock::class );
+		$seo_link->type         = $link_type;
+		$seo_link->url          = $target_indexable->permalink;
+		$seo_link->indexable_id = $indexable->id;
+		$seo_link->post_id      = $indexable->object_id;
+
+		$this->seo_links_repository->expects( 'query' )->once()->andReturn( $query_mock );
+		$query_mock->expects( 'create' )->once()->with(
+			[
+				'url'          => $target_indexable->permalink,
+				'type'         => $link_type,
+				'indexable_id' => $indexable->id,
+				'post_id'      => $indexable->object_id,
+			]
+		)->andReturn( $seo_link );
+
+		$old_seo_link                      = new SEO_Links_Mock();
+		$old_seo_link->target_indexable_id = 3;
+		$this->seo_links_repository->expects( 'find_all_by_indexable_id' )->once()->with( $indexable->id )->andReturn( [ $old_seo_link ] );
+		$this->seo_links_repository->expects( 'delete_all_by_indexable_id' )->once()->with( $indexable->id );
+		$this->seo_links_repository->expects( 'delete_all_by_post_id' )->once()->with( $indexable->object_id );
+		$this->seo_links_repository->expects( 'get_incoming_link_counts_for_indexable_ids' )
+			->with( [ 2, 3 ] )
+			->andReturn(
+				[
+					[
+						'target_indexable_id' => 2,
+						'incoming'            => 0,
+					],
+					[
+						'target_indexable_id' => 3,
+						'incoming'            => 0,
+					],
+				]
+			);
+
+		$this->indexable_repository->expects( 'update_incoming_link_count' )->once()->with( 2, 0 );
+		$this->indexable_repository->expects( 'update_incoming_link_count' )->once()->with( 3, 0 );
+		$this->indexable_repository->expects( 'find_by_permalink' )
+			->once()
+			->with( $target_indexable->permalink )
+			->andReturn( null );
+		$this->indexable_repository->expects( 'find_by_id_and_type' )
+			->with( 3, 'post' )
+			->andReturn( $target_indexable );
+
+		Functions\expect( 'url_to_postid' )
+			->with( $target_indexable->permalink )
+			->andReturn( $target_indexable->object_id );
+
+		$seo_link->expects( 'save' )->once();
+
+		$links = $this->instance->build( $indexable, $content );
+
+		$this->assertCount( 1, $links );
 		$this->assertEquals( $seo_link, $links[0] );
 	}
 

--- a/tests/unit/builders/indexable-link-builder-test.php
+++ b/tests/unit/builders/indexable-link-builder-test.php
@@ -213,12 +213,14 @@ class Indexable_Link_Builder_Test extends TestCase {
 
 		$this->url_helper->expects( 'get_link_type' )->with( $parsed_link_url, $parsed_home_url, false )->andReturn( $link_type );
 
-		$query_mock             = Mockery::mock();
-		$seo_link               = Mockery::mock( SEO_Links_Mock::class );
-		$seo_link->type         = $link_type;
-		$seo_link->url          = $target_indexable->permalink;
-		$seo_link->indexable_id = $indexable->id;
-		$seo_link->post_id      = $indexable->object_id;
+		$query_mock                    = Mockery::mock();
+		$seo_link                      = Mockery::mock( SEO_Links_Mock::class );
+		$seo_link->type                = $link_type;
+		$seo_link->url                 = $target_indexable->permalink;
+		$seo_link->indexable_id        = $indexable->id;
+		$seo_link->post_id             = $indexable->object_id;
+		$seo_link->target_indexable_id = $target_indexable->id;
+		$seo_link->target_post_id      = $target_indexable->object_id;
 
 		$this->seo_links_repository->expects( 'query' )->once()->andReturn( $query_mock );
 		$query_mock->expects( 'create' )->once()->with(
@@ -270,6 +272,8 @@ class Indexable_Link_Builder_Test extends TestCase {
 
 		$this->assertCount( 1, $links );
 		$this->assertEquals( $seo_link, $links[0] );
+		$this->assertEquals( $seo_link->target_indexable_id, $links[0]->target_indexable_id );
+		$this->assertEquals( $seo_link->target_post_id, $links[0]->target_post_id );
 	}
 
 	/**

--- a/tests/unit/builders/indexable-post-builder-test.php
+++ b/tests/unit/builders/indexable-post-builder-test.php
@@ -63,13 +63,6 @@ class Indexable_Post_Builder_Test extends TestCase {
 	protected $twitter_image;
 
 	/**
-	 * Holds the link builder instance.
-	 *
-	 * @var Indexable_Link_Builder|Mockery\MockInterface
-	 */
-	protected $link_builder;
-
-	/**
 	 * Holds the Post_Helper instance.
 	 *
 	 * @var Post_Helper|Mockery\MockInterface
@@ -92,11 +85,9 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$this->image                = Mockery::mock( Image_Helper::class );
 		$this->open_graph_image     = Mockery::mock( Open_Graph_Image_Helper::class );
 		$this->twitter_image        = Mockery::mock( Twitter_Image_Helper::class );
-		$this->link_builder         = Mockery::mock( Indexable_Link_Builder::class );
 		$this->post                 = Mockery::mock( Post_Helper::class );
 
 		$this->instance = new Indexable_Post_Builder_Double(
-			$this->link_builder,
 			$this->post
 		);
 
@@ -173,7 +164,6 @@ class Indexable_Post_Builder_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Indexable_Link_Builder::class, 'link_builder', $this->instance );
 		$this->assertAttributeInstanceOf( Post_Helper::class, 'post', $this->instance );
 	}
 
@@ -275,8 +265,6 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$this->indexable->orm = Mockery::mock( ORM::class );
 
 		$this->set_indexable_set_expectations( $this->indexable, $indexable_expectations );
-
-		$this->link_builder->expects( 'build' )->with( $this->indexable, 'The content of the post' );
 
 		// Reset all social images first.
 		$this->set_indexable_set_expectations(

--- a/tests/unit/builders/indexable-term-builder-test.php
+++ b/tests/unit/builders/indexable-term-builder-test.php
@@ -69,24 +69,15 @@ class Indexable_Term_Builder_Test extends TestCase {
 	protected $twitter_image;
 
 	/**
-	 * The link builder mock.
-	 *
-	 * @var Mockery\MockInterface|Indexable_Link_Builder
-	 */
-	protected $link_builder;
-
-	/**
 	 * Sets up the tests.
 	 */
 	public function setUp() {
 		parent::setUp();
 
-		$this->taxonomy     = Mockery::mock( Taxonomy_Helper::class );
-		$this->link_builder = Mockery::mock( Indexable_Link_Builder::class );
+		$this->taxonomy = Mockery::mock( Taxonomy_Helper::class );
 
 		$this->instance = new Indexable_Term_Builder_Double(
-			$this->taxonomy,
-			$this->link_builder
+			$this->taxonomy
 		);
 
 		$this->image            = Mockery::mock( Image_Helper::class );
@@ -166,9 +157,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$instance = new Indexable_Term_Builder( $this->taxonomy, $this->link_builder );
-		$this->assertAttributeInstanceOf( Taxonomy_Helper::class, 'taxonomy', $instance );
-		$this->assertAttributeInstanceOf( Indexable_Link_Builder::class, 'link_builder', $instance );
+		$this->assertAttributeInstanceOf( Taxonomy_Helper::class, 'taxonomy', $this->instance );
 	}
 
 	/**
@@ -215,8 +204,6 @@ class Indexable_Term_Builder_Test extends TestCase {
 
 		$indexable_mock      = Mockery::mock( Indexable::class );
 		$indexable_mock->orm = Mockery::mock( ORM::class );
-
-		$this->link_builder->expects( 'build' )->with( $indexable_mock, 'description' );
 
 		$indexable_expectations = [
 			'object_id'                   => 1,

--- a/tests/unit/doubles/models/indexable-mock.php
+++ b/tests/unit/doubles/models/indexable-mock.php
@@ -102,4 +102,8 @@ class Indexable_Mock extends Indexable {
 	public $schema_page_type;
 
 	public $schema_article_type;
+
+	public $language;
+
+	public $region;
 }

--- a/tests/unit/doubles/models/seo-links-mock.php
+++ b/tests/unit/doubles/models/seo-links-mock.php
@@ -24,4 +24,8 @@ class SEO_Links_Mock extends SEO_Links {
 	public $indexable_id;
 
 	public $target_indexable_id;
+
+	public $language;
+
+	public $region;
 }

--- a/tests/unit/integrations/admin/admin-columns-cache-integration-test.php
+++ b/tests/unit/integrations/admin/admin-columns-cache-integration-test.php
@@ -65,7 +65,7 @@ class Admin_Columns_Cache_Integration_Test extends TestCase {
 
 		$results = [ (object) [ 'object_id' => 1 ] ];
 
-		$this->indexable_repository->expects( 'find_by_multiple_ids_and_type' )->once()->with( [ 1 ], 'post' )->andReturn( $results );
+		$this->indexable_repository->expects( 'find_by_multiple_ids_and_type' )->once()->with( [ 1 ], 'post', false )->andReturn( $results );
 
 		$this->instance->fill_cache();
 	}
@@ -91,7 +91,7 @@ class Admin_Columns_Cache_Integration_Test extends TestCase {
 
 		$results = [ (object) [ 'object_id' => 1 ] ];
 
-		$this->indexable_repository->expects( 'find_by_multiple_ids_and_type' )->once()->with( [ 1 ], 'post' )->andReturn( $results );
+		$this->indexable_repository->expects( 'find_by_multiple_ids_and_type' )->once()->with( [ 1 ], 'post', false )->andReturn( $results );
 
 		$this->instance->fill_cache();
 	}
@@ -120,7 +120,7 @@ class Admin_Columns_Cache_Integration_Test extends TestCase {
 
 		$results = [ (object) [ 'object_id' => 1 ] ];
 
-		$this->indexable_repository->expects( 'find_by_multiple_ids_and_type' )->once()->with( [ 1 ], 'post' )->andReturn( $results );
+		$this->indexable_repository->expects( 'find_by_multiple_ids_and_type' )->once()->with( [ 1 ], 'post', false )->andReturn( $results );
 
 		$this->instance->fill_cache();
 	}

--- a/tests/unit/integrations/admin/indexing-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-integration-test.php
@@ -163,7 +163,7 @@ class Indexing_Integration_Test extends TestCase {
 			->once()
 			->andReturn( 84 );
 
-		$this->assertEquals( 145, $this->instance->get_total_unindexed() );
+		$this->assertEquals( 84, $this->instance->get_total_unindexed() );
 	}
 
 	/**
@@ -231,8 +231,6 @@ class Indexing_Integration_Test extends TestCase {
 							'terms'     => 'yoast/v1/indexation/terms',
 							'archives'  => 'yoast/v1/indexation/post-type-archives',
 							'general'   => 'yoast/v1/indexation/general',
-							'post-link' => 'yoast/v1/link-indexing/posts',
-							'term-link' => 'yoast/v1/link-indexing/terms',
 							'complete'  => 'yoast/v1/indexation/complete',
 						],
 					'nonce'     => 'nonce_value',

--- a/tests/unit/integrations/admin/indexing-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-integration-test.php
@@ -163,7 +163,7 @@ class Indexing_Integration_Test extends TestCase {
 			->once()
 			->andReturn( 84 );
 
-		$this->assertEquals( 84, $this->instance->get_total_unindexed() );
+		$this->assertEquals( 145, $this->instance->get_total_unindexed() );
 	}
 
 	/**
@@ -226,12 +226,14 @@ class Indexing_Integration_Test extends TestCase {
 					'root'      => 'https://example.org/wp-ajax/',
 					'endpoints' =>
 						[
-							'prepare'  => 'yoast/v1/indexation/prepare',
-							'posts'    => 'yoast/v1/indexation/posts',
-							'terms'    => 'yoast/v1/indexation/terms',
-							'archives' => 'yoast/v1/indexation/post-type-archives',
-							'general'  => 'yoast/v1/indexation/general',
-							'complete' => 'yoast/v1/indexation/complete',
+							'prepare'   => 'yoast/v1/indexation/prepare',
+							'posts'     => 'yoast/v1/indexation/posts',
+							'terms'     => 'yoast/v1/indexation/terms',
+							'archives'  => 'yoast/v1/indexation/post-type-archives',
+							'general'   => 'yoast/v1/indexation/general',
+							'post-link' => 'yoast/v1/link-indexing/posts',
+							'term-link' => 'yoast/v1/link-indexing/terms',
+							'complete'  => 'yoast/v1/indexation/complete',
 						],
 					'nonce'     => 'nonce_value',
 				],

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -365,6 +365,10 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->expects( 'build' )
 			->with( $updated_indexable, 'This is post content with a <a href="">link</a>.' );
 
+		$updated_indexable
+			->expects( 'save' )
+			->once();
+
 		$this->instance->updated_indexable( $updated_indexable, $old_indexable );
 	}
 
@@ -395,6 +399,10 @@ class Indexable_Post_Watcher_Test extends TestCase {
 		$this->instance
 			->expects( 'update_has_public_posts' )
 			->with( $updated_indexable )
+			->once();
+
+		$updated_indexable
+			->expects( 'save' )
 			->once();
 
 		$this->instance->updated_indexable( $updated_indexable, $old_indexable );

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -344,12 +344,26 @@ class Indexable_Post_Watcher_Test extends TestCase {
 
 		$updated_indexable              = Mockery::mock( Indexable_Mock::class );
 		$updated_indexable->object_type = 'post';
+		$updated_indexable->object_id   = 23;
 		$updated_indexable->is_public   = false;
 
 		$this->instance
 			->expects( 'update_has_public_posts' )
 			->with( $updated_indexable )
 			->once();
+
+		$post = (object) [
+			'post_content' => 'This is post content with a <a href="">link</a>.',
+		];
+
+		$this->post
+			->expects( 'get_post' )
+			->with( 23 )
+			->andReturn( $post );
+
+		$this->link_builder
+			->expects( 'build' )
+			->with( $updated_indexable, 'This is post content with a <a href="">link</a>.' );
 
 		$this->instance->updated_indexable( $updated_indexable, $old_indexable );
 	}

--- a/tests/unit/integrations/watchers/indexable-term-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-term-watcher-test.php
@@ -188,6 +188,10 @@ class Indexable_Term_Watcher_Test extends TestCase {
 				'This is a term description, with a <a href="https://example.org/target">link</a>.'
 			);
 
+		$indexable
+			->expects( 'save' )
+			->once();
+
 		$this->instance->build_indexable( 1 );
 	}
 
@@ -332,6 +336,10 @@ class Indexable_Term_Watcher_Test extends TestCase {
 				$indexable,
 				'This is a term description, with a <a href="https://example.org/target">link</a>.'
 			);
+
+		$indexable
+			->expects( 'save' )
+			->once();
 
 		$this->instance->build_indexable( 1 );
 	}

--- a/tests/unit/integrations/watchers/indexable-term-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-term-watcher-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
+use Yoast\WP\SEO\Builders\Indexable_Link_Builder;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Site_Helper;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Term_Watcher;
@@ -39,6 +40,13 @@ class Indexable_Term_Watcher_Test extends TestCase {
 	private $builder;
 
 	/**
+	 * The link builder.
+	 *
+	 * @var Mockery\MockInterface|Indexable_Link_Builder
+	 */
+	protected $link_builder;
+
+	/**
 	 * Represents the site helper.
 	 *
 	 * @var Mockery\MockInterface|Site_Helper
@@ -58,10 +66,17 @@ class Indexable_Term_Watcher_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->repository = Mockery::mock( Indexable_Repository::class );
-		$this->builder    = Mockery::mock( Indexable_Builder::class );
-		$this->site       = Mockery::mock( Site_Helper::class );
-		$this->instance   = new Indexable_Term_Watcher( $this->repository, $this->builder, $this->site );
+		$this->repository   = Mockery::mock( Indexable_Repository::class );
+		$this->builder      = Mockery::mock( Indexable_Builder::class );
+		$this->link_builder = Mockery::mock( Indexable_Link_Builder::class );
+		$this->site         = Mockery::mock( Site_Helper::class );
+
+		$this->instance = new Indexable_Term_Watcher(
+			$this->repository,
+			$this->builder,
+			$this->link_builder,
+			$this->site
+		);
 	}
 
 	/**
@@ -134,7 +149,10 @@ class Indexable_Term_Watcher_Test extends TestCase {
 			->expects( 'is_multisite_and_switched' )
 			->andReturnFalse();
 
-		$term = (object) [ 'taxonomy' => 'tag' ];
+		$term = (object) [
+			'taxonomy'    => 'tag',
+			'description' => 'This is a term description, with a <a href="https://example.org/target">link</a>.',
+		];
 
 		Monkey\Functions\expect( 'get_term' )
 			->once()
@@ -162,6 +180,13 @@ class Indexable_Term_Watcher_Test extends TestCase {
 			->once()
 			->with( 1, 'term', $indexable )
 			->andReturn( $indexable );
+
+		$this->link_builder
+			->expects( 'build' )
+			->with(
+				$indexable,
+				'This is a term description, with a <a href="https://example.org/target">link</a>.'
+			);
 
 		$this->instance->build_indexable( 1 );
 	}
@@ -269,7 +294,10 @@ class Indexable_Term_Watcher_Test extends TestCase {
 			->expects( 'is_multisite_and_switched' )
 			->andReturnFalse();
 
-		$term = (object) [ 'taxonomy' => 'tag' ];
+		$term = (object) [
+			'taxonomy'    => 'tag',
+			'description' => 'This is a term description, with a <a href="https://example.org/target">link</a>.',
+		];
 
 		Monkey\Functions\expect( 'get_term' )
 			->once()
@@ -297,6 +325,13 @@ class Indexable_Term_Watcher_Test extends TestCase {
 			->once()
 			->with( 1, 'term', false )
 			->andReturn( $indexable );
+
+		$this->link_builder
+			->expects( 'build' )
+			->with(
+				$indexable,
+				'This is a term description, with a <a href="https://example.org/target">link</a>.'
+			);
 
 		$this->instance->build_indexable( 1 );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the incoming link counts, as shown on the post overview page, was incorrect.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Reproducing the bug.
* Reset the indexables so you start of with a clean indexable table in your database. 
  * E.g. by using the Yoast Test Helper.
* Open a post.
* Add a link to another post on your website.
* Go to the post overview page. 
* Check the incoming link count in its column, it should be off by one.
  * In other words: the link you added should be counted to its target post's incoming link count.

### Checking that the bug is fixed.
* Reset the indexables so you start of with a clean indexable table in your database. 
  * E.g. by using the Yoast Test Helper.
* Open a post.
* Add a link to another post on your website.
* Go to the post overview page. 
* Check the incoming link count in its column, it should be correct.
  * In other words: the link you added should be counted to its target post's incoming link count.

### Checking that the bug is fixed when running the site wide indexing process.
* Reset the indexables so you start of with a clean indexable table in your database. 
  * E.g. by using the Yoast Test Helper.
* Re-run the site wide indexing process (via de Yoast Tools page).
* Check the incoming link count in its column, it should be correct.
  * In other words: the link you added should be counted to its target post's incoming link count.

### Check that the indexable tables has no incorrect entries.
These steps are to check two other bugs that occurred during development that should be fixed by this PR:
* After running the site wide indexing process, make sure that your `wp_yoast_indexable` table in your DB...
  * Does not have any duplicate entries for a post or term (two rows with the same permalink, object_id and object_type values).
  * Does not have any 'empty' rows, containing only NULL values except for a object_id of 0 and a non-zero incoming link count. 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
