### PR TITLE
P3-220 Fix background indexation on taxonomy base change

### DIFF
--- a/src/conditionals/get-request-conditional.php
+++ b/src/conditionals/get-request-conditional.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Conditional that is only met when the current request uses the GET method.
+ */
+class Get_Request_Conditional implements Conditional {
+
+	/**
+	 * Returns whether or not this conditional is met.
+	 *
+	 * @return boolean Whether or not the conditional is met.
+	 */
+	public function is_met() {
+		if ( isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'GET' ) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -7,6 +7,7 @@ use Yoast\WP\SEO\Actions\Indexation\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Type_Archive_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Term_Indexation_Action;
+use Yoast\WP\SEO\Conditionals\Get_Request_Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -69,6 +70,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 		return [
 			Yoast_Admin_And_Dashboard_Conditional::class,
 			Migrations_Conditional::class,
+			Get_Request_Conditional::class,
 		];
 	}
 

--- a/tests/unit/conditionals/get-request-conditional-test.php
+++ b/tests/unit/conditionals/get-request-conditional-test.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Conditionals;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Conditionals\Get_Request_Conditional;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Get_Request_Conditional_Test
+ *
+ * @group indexables
+ * @group conditionals
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Conditionals\Get_Request_Conditional
+ */
+class Get_Request_Conditional_Test extends TestCase {
+
+	/**
+	 * Holds the GET request conditional under test.
+	 *
+	 * @var Get_Request_Conditional
+	 */
+	private $instance;
+
+	/**
+	 * Set up the test fixtures.
+	 */
+	public function setUp() {
+		$this->instance = new Get_Request_Conditional();
+	}
+
+	/**
+	 * Tests that the conditional is met on a GET request.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_met_on_get_request() {
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		$is_met = $this->instance->is_met();
+
+		$this->assertEquals( true, $is_met );
+	}
+
+	/**
+	 * Tests that the conditional is not met on a POST request.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_met_on_post_request() {
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+
+		$is_met = $this->instance->is_met();
+
+		$this->assertEquals( false, $is_met );
+	}
+
+	/**
+	 * Tests that the conditional is not met when method is not set in server vars.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_met_on_method_unset() {
+		unset( $_SERVER['REQUEST_METHOD'] );
+
+		$is_met = $this->instance->is_met();
+
+		$this->assertEquals( false, $is_met );
+	}
+}

--- a/tests/unit/integrations/admin/background-indexing-integration-test.php
+++ b/tests/unit/integrations/admin/background-indexing-integration-test.php
@@ -9,6 +9,7 @@ use Yoast\WP\SEO\Actions\Indexation\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Post_Type_Archive_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexation\Indexable_Term_Indexation_Action;
+use Yoast\WP\SEO\Conditionals\Get_Request_Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
 use Yoast\WP\SEO\Integrations\Admin\Background_Indexing_Integration;
@@ -98,6 +99,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 			[
 				Yoast_Admin_And_Dashboard_Conditional::class,
 				Migrations_Conditional::class,
+				Get_Request_Conditional::class,
 			],
 			Background_Indexing_Integration::get_conditionals()
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When changing category or taxonomy base, `Background_Indexing_Integration` runs immediately so it starts to fill again the indexable tables with permalink for the terms. Unfortunately, `get_term_link` will return wrong results at this stage as that's based directly on the rewrite rules which are only set at the start of a request.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Make sure the background indexation is run only on `GET` requests.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Reproduce the bug
* checkout and build from `release/15.1` without these commits
* have more than 25 categories and/or more than 25 tags
* start from empty indexable table, perform SEO optimization, see the table is OK
* change category and/or tag base in Settings->Permalinks, perform SEO optimization again
* inspect the indexable table, see that some of the category permalinks have the old category base (same for tags). It should happen that 25 records show the old taxonomy base since the background indexation works on batches of 25 items.

### Test the fix
* checkout and build from this PR
* start from empty indexable table, perform SEO optimization, see the table is OK
* change category and/or tag base in Settings->Permalinks
* inspect the indexable table, see that the permalinks for the category and/or tag are NULL
* perform SEO optimization again
* inspect the indexable table, see that the permalinks are correct.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-220]
