### PR TITLE
Fix woocommerce permalink reset

### DIFF
--- a/src/integrations/third-party/woocommerce-permalinks.php
+++ b/src/integrations/third-party/woocommerce-permalinks.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Third_Party;
+
+use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * The permalink watcher.
+ */
+class Woocommerce_Permalinks implements Integration_Interface {
+
+	/**
+	 * Represents the indexable helper.
+	 *
+	 * @var Indexable_Helper
+	 */
+	protected $indexable_helper;
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * @return array
+	 */
+	public static function get_conditionals() {
+		return [ WooCommerce_Conditional::class, Migrations_Conditional::class ];
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Indexable_Helper $indexable_helper
+	 */
+	public function __construct( Indexable_Helper $indexable_helper ) {
+		$this->indexable_helper = $indexable_helper;
+	}
+
+	/**
+	 * Registers the hooks.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function register_hooks() {
+		\add_filter( 'wpseo_post_types_reset_permalinks', [ $this, 'filter_product_from_post_types' ] );
+		\add_action( 'update_option_woocommerce_permalinks', [ $this, 'reset_woocommerce_permalinks' ], 10, 2 );
+	}
+
+	/**
+	 * Filters the product post type from the post type.
+	 *
+	 * @param array $post_types The post types to filter.
+	 *
+	 * @return array The filtered post types.
+	 */
+	public function filter_product_from_post_types( $post_types ) {
+		unset( $post_types['product'] );
+
+		return $post_types;
+	}
+
+	/**
+	 * Resets the indexables for WooCommerce based on the changed permalink fields.
+	 *
+	 * @param array $old The old value.
+	 * @param array $new The new value.
+	 */
+	public function reset_woocommerce_permalinks( $old, $new ) {
+		$changed_options = \array_diff( $old, $new );
+
+		if ( \array_key_exists( 'product_base', $changed_options ) ) {
+			$this->indexable_helper->reset_permalink_indexables( 'post', 'product' );
+		}
+
+		if ( \array_key_exists( 'attribute_base', $changed_options ) ) {
+			$attribute_taxonomies = $this->get_attribute_taxonomies();
+
+			foreach ( $attribute_taxonomies as $attribute_name ) {
+				$this->indexable_helper->reset_permalink_indexables( 'term', $attribute_name );
+			}
+		}
+
+		if ( \array_key_exists( 'category_base', $changed_options ) ) {
+			$this->indexable_helper->reset_permalink_indexables( 'term', 'product_cat' );
+		}
+
+		if ( \array_key_exists( 'tag_base', $changed_options ) ) {
+			$this->indexable_helper->reset_permalink_indexables( 'term', 'product_tag' );
+		}
+	}
+
+	/**
+	 * Retrieves the taxonomies based on the attributes.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return array The taxonomies.
+	 */
+	protected function get_attribute_taxonomies() {
+		$taxonomies = [];
+		foreach ( \wc_get_attribute_taxonomies() as $attribute_taxonomy ) {
+			$taxonomies[] = \wc_attribute_taxonomy_name( $attribute_taxonomy->attribute_name );
+		}
+
+		$taxonomies = \array_filter( $taxonomies );
+
+		return $taxonomies;
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the woocommerce product permalinks were not updated after a permalink structure change.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

1. Activate Woocommerce.
2. Create 1 product.
3. Change permalinks for products in _Settings_ > _Permalinks_.
4. Save the change.
5. Visit any SEO Admin page
6. It is now expected that product would receive updated permalink in indexables table. But if I check DB it is not changed.
7. Checkout this branch.
8. Step 6 should be solved now.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
