### PR TITLE
Fix stop indexation

### DIFF
--- a/js/src/components/Indexation.js
+++ b/js/src/components/Indexation.js
@@ -265,7 +265,7 @@ export class Indexation extends Component {
 					this.state.inProgress
 						? <NewButton
 							variant="secondary"
-							disabled={ true }
+							onClick={ this.stopIndexing }
 						>
 							{ __( "Stop SEO data optimization", "wordpress-seo" ) }
 						</NewButton>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug that wouldn't allow users to stop the indexation by pressing the `Stop SEO Data optimization` button.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Reset the indexables.
* Go to `Yoast` > `Tools` page.
* Start the indexation, let it index a few indexables.
* Stop the indexation and restart it.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
