### PR TITLE
Always index links to account for partially filled legacy SEO links

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -208,6 +208,13 @@ Your question has most likely been answered on our knowledge base: [kb.yoast.com
 
 == Changelog ==
 
+= 15.1.1 =
+Release Date: October 15th, 2020
+
+Bugfixes:
+
+* Fixes a bug where the indexing button on the Tools page would keep showing up because certain objects would be detected as requiring indexing but would not actually be indexed during the indexing process.
+
 = 15.1 =
 Release Date: October 14th, 2020
 

--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -93,12 +93,8 @@ abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interf
 		$indexables = [];
 		foreach ( $objects as $object ) {
 			$indexable = $this->repository->find_by_id_and_type( $object->id, $object->type );
-
-			// It's possible the indexable was created without having its links indexed.
-			if ( $indexable->link_count === null ) {
-				$this->link_builder->build( $indexable, $object->content );
-				$indexable->save();
-			}
+			$this->link_builder->build( $indexable, $object->content );
+			$indexable->save();
 
 			$indexables[] = $indexable;
 		}

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -104,6 +104,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 							target_indexable_id IS NULL
 							AND `type` = 'internal'
 							AND target_post_id IS NOT NULL
+							AND target_post_id != 0
 					)
 				)
 				AND post_status = 'publish'

--- a/tests/unit/actions/indexation/post-link-indexing-action-test.php
+++ b/tests/unit/actions/indexation/post-link-indexing-action-test.php
@@ -129,6 +129,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 							target_indexable_id IS NULL
 							AND `type` = 'internal'
 							AND target_post_id IS NOT NULL
+							AND target_post_id != 0
 					)
 				)
 				AND post_status = 'publish'
@@ -208,6 +209,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 							target_indexable_id IS NULL
 							AND `type` = 'internal'
 							AND target_post_id IS NOT NULL
+							AND target_post_id != 0
 					)
 				)
 				AND post_status = 'publish'
@@ -263,6 +265,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 							target_indexable_id IS NULL
 							AND `type` = 'internal'
 							AND target_post_id IS NOT NULL
+							AND target_post_id != 0
 					)
 				)
 				AND post_status = 'publish'
@@ -297,11 +300,17 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 				]
 			);
 
-		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 1, 'post' )->andReturn( (object) [ 'link_count' => 10 ] );
-		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 3, 'post' )->andReturn( (object) [ 'link_count' => 10 ] );
-		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'post' )->andReturn( (object) [ 'link_count' => 10 ] );
+		$indexable             = Mockery::mock( Indexable_Mock::class );
+		$indexable->link_count = 10;
+		$indexable->expects( 'save' )->times( 3 );
+
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 1, 'post' )->andReturn( $indexable );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 3, 'post' )->andReturn( $indexable );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'post' )->andReturn( $indexable );
 
 		Functions\expect( 'delete_transient' )->once()->with( Post_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT );
+
+		$this->link_builder->expects( 'build' )->times( 3 )->with( $indexable, 'foo' );
 
 		$this->instance->index();
 	}
@@ -340,6 +349,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 							target_indexable_id IS NULL
 							AND `type` = 'internal'
 							AND target_post_id IS NOT NULL
+							AND target_post_id != 0
 					)
 				)
 				AND post_status = 'publish'

--- a/tests/unit/actions/indexation/term-link-indexing-action-test.php
+++ b/tests/unit/actions/indexation/term-link-indexing-action-test.php
@@ -245,11 +245,17 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 				]
 			);
 
-		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 1, 'term' )->andReturn( (object) [ 'link_count' => 10 ] );
-		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 3, 'term' )->andReturn( (object) [ 'link_count' => 10 ] );
-		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'term' )->andReturn( (object) [ 'link_count' => 10 ] );
+		$indexable             = Mockery::mock( Indexable_Mock::class );
+		$indexable->link_count = null;
+		$indexable->expects( 'save' )->times( 3 );
+
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 1, 'term' )->andReturn( $indexable );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 3, 'term' )->andReturn( $indexable );
+		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'term' )->andReturn( $indexable );
 
 		Functions\expect( 'delete_transient' )->once()->with( Term_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT );
+
+		$this->link_builder->expects( 'build' )->times( 3 )->with( $indexable, 'foo' );
 
 		$this->instance->index();
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes the indexing tool on the tools page always showing more work to be done.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the indexing button on the Tools page would keep showing up because certain objects would be detected as requiring indexing but would not actually be indexed during the indexing process.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Have a site that has a few internal links.
* Make sure at least one SEO link does have a target_post_id and does not have a target_indexable_id.
* Run the indexing process.
* It should keep showing as completed after a reload.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/QAK-2331
