### PR TITLE
Fix ORDER BY clause for get_last_modifiet_gmt

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -502,13 +502,16 @@ class WPSEO_Sitemaps {
 			if ( ! empty( $post_type_names ) ) {
 				$post_statuses = array_map( 'esc_sql', self::get_post_statuses() );
 
+				$post_statuses_in = "'" . implode( "','", $post_statuses ) . "'";
+				$post_type_names_in = "'" . implode( "','", $post_type_names ) . "'";
+
 				$sql = "
 					SELECT post_type, MAX(post_modified_gmt) AS date
 					FROM $wpdb->posts
-					WHERE post_status IN ('" . implode( "','", $post_statuses ) . "')
-						AND post_type IN ('" . implode( "','", $post_type_names ) . "')
+					WHERE post_status IN ( $post_statuses_in )
+						AND post_type IN ( $post_type_names_in )
 					GROUP BY post_type
-					ORDER BY date DESC
+					ORDER BY MAX(post_modified_gmt) DESC
 				";
 
 				foreach ( $wpdb->get_results( $sql ) as $obj ) {


### PR DESCRIPTION
## Context

* Fix `ORDER BY` clause.
* Create scope variables to statuses and types names for better organization

## Summary

* Improve ORDER BY clause to match desired aggregated value 

## Relevant technical choices:

* This is a non-brake change. I use Postgres as RDBMS. This is compatible with standard MySQL/MariaDB installations and as also "non-supported" as PG. :-)

## Test instructions

This PR can be tested by following these steps:

* N/A - this is a code-only change and should have no effect on the functionality.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
