### PR TITLE
Add flex-grow to fix the replacevar dropdown being hidden on release branch

### DIFF
--- a/css/src/modal.css
+++ b/css/src/modal.css
@@ -406,6 +406,7 @@
 /* Set overflow-y to scroll and hide the scrollbar on FireFox. */
 .yoast-post-settings-modal .yoast-content-container {
 	overflow-y: auto;
+	flex-grow: 1;
 }
 
 .yoast-post-settings-modal .yoast-button-container {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* First fixed on `trunk` in https://github.com/Yoast/wordpress-seo/pull/16219, but we'll introduce the flex-grow fix as a fix-before-release here as well. Because the bug was quite ugly. The `trunk` fix also has css deduplication.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the replacement variable dropdown menu was partially hidden for the description inputs in all preview modals.

## Relevant technical choices:

* See https://github.com/Yoast/wordpress-seo/pull/16219

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test the preview modals (Google Preview, Twitter Preview, Facebook Preview) and verify that the replacement variable dropdown is fully visible in all input fields.
Pay some extra attention to the padding and top border of the modal content (see code comments below). They are expected to be unchanged.
* Verify that the SEMrush modal still looks the same.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
