### PR TITLE
P2 145 rc automization fails on unchanged changelog

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -130,6 +130,7 @@ module.exports = function( grunt ) {
 				gittag: "grunt-git",
 				gitfetch: "grunt-git",
 				gitadd: "grunt-git",
+				gitstatus: "grunt-git",
 				gitcommit: "grunt-git",
 				gitcheckout: "grunt-git",
 				gitpull: "grunt-git",

--- a/config/grunt/custom-tasks/update-readme.js
+++ b/config/grunt/custom-tasks/update-readme.js
@@ -107,9 +107,9 @@ module.exports = function( grunt ) {
 			// Check if there is something to commit with `git status` first.
 			grunt.config( "gitstatus.checkChangelog.options.callback", function( changedFiles ) {
 				// File's code has two parts: first character codes the status in the index (staged files).
-				const hasStagedChanges = changedFiles.some( file => file.code[ 0 ] !== " " );
+				const hasStagedChangelog = changedFiles.some( file => file.code[ 0 ] !== " " && file.file === "readme.txt" );
 
-				if ( hasStagedChanges ) {
+				if ( hasStagedChangelog ) {
 					// Commit the changed readme.txt.
 					grunt.config( "gitcommit.commitChangelog.options.message", "Add changelog" );
 					grunt.task.run( "gitcommit:commitChangelog" );

--- a/config/grunt/custom-tasks/update-readme.js
+++ b/config/grunt/custom-tasks/update-readme.js
@@ -105,9 +105,9 @@ module.exports = function( grunt ) {
 			grunt.task.run( "gitadd:addChangelog" );
 
 			// Check if there is something to commit with `git status` first.
-			grunt.config( "gitstatus.checkChangelog.options.callback", function( changedFiles ) {
-				// File's code has two parts: first character codes the status in the index (staged files).
-				const hasStagedChangelog = changedFiles.some( file => file.code[ 0 ] !== " " && file.file === "readme.txt" );
+			grunt.config( "gitstatus.checkChangelog.options.callback", function( changes ) {
+				// First character of the code checks the status in the index.
+				const hasStagedChangelog = changes.some( change => change.code[ 0 ] !== " " && change.file === "readme.txt" );
 
 				if ( hasStagedChangelog ) {
 					// Commit the changed readme.txt.

--- a/config/grunt/custom-tasks/update-readme.js
+++ b/config/grunt/custom-tasks/update-readme.js
@@ -100,13 +100,22 @@ module.exports = function( grunt ) {
 				} );
 			}
 
-			// Stage the changed readme.txt.
-			grunt.config( "gitadd.addChangelog.files", { src: [ "./readme.txt" ] } );
-			grunt.task.run( "gitadd:addChangelog" );
+			// Check if there is something to stage and commit with `git status` first.
+			grunt.config( "gitstatus.checkChangelog.options.callback", function( changedFiles ) {
+				if ( changedFiles.length > 0 ) {
+					// Stage the changed readme.txt.
+					grunt.config( "gitadd.addChangelog.files", { src: [ "./readme.txt" ] } );
+					grunt.task.run( "gitadd:addChangelog" );
 
-			// Commit the changed readme.txt.
-			grunt.config( "gitcommit.commitChangelog.options.message", "Add changelog" );
-			grunt.task.run( "gitcommit:commitChangelog" );
+					// Commit the changed readme.txt.
+					grunt.config( "gitcommit.commitChangelog.options.message", "Add changelog" );
+					grunt.task.run( "gitcommit:commitChangelog" );
+				} else {
+					grunt.log.writeln( "Changelog is unchanged. Nothing to commit." );
+				}
+			} );
+
+			grunt.task.run( "gitstatus:checkChangelog" );
 		}
 	);
 };

--- a/config/grunt/custom-tasks/update-readme.js
+++ b/config/grunt/custom-tasks/update-readme.js
@@ -2,12 +2,6 @@ const getUserInput = require( "../lib/get-user-input" );
 const parseVersion = require( "../lib/parse-version" );
 const _isEmpty = require( "lodash/isEmpty" );
 
-function commit( grunt ) {
-	// Commit the changed readme.txt.
-	grunt.config( "gitcommit.commitChangelog.options.message", "Add changelog" );
-	grunt.task.run( "gitcommit:commitChangelog" );
-}
-
 /**
  * ...
  *

--- a/config/grunt/custom-tasks/update-readme.js
+++ b/config/grunt/custom-tasks/update-readme.js
@@ -2,6 +2,12 @@ const getUserInput = require( "../lib/get-user-input" );
 const parseVersion = require( "../lib/parse-version" );
 const _isEmpty = require( "lodash/isEmpty" );
 
+function commit( grunt ) {
+	// Commit the changed readme.txt.
+	grunt.config( "gitcommit.commitChangelog.options.message", "Add changelog" );
+	grunt.task.run( "gitcommit:commitChangelog" );
+}
+
 /**
  * ...
  *
@@ -100,13 +106,16 @@ module.exports = function( grunt ) {
 				} );
 			}
 
-			// Check if there is something to stage and commit with `git status` first.
-			grunt.config( "gitstatus.checkChangelog.options.callback", function( changedFiles ) {
-				if ( changedFiles.length > 0 ) {
-					// Stage the changed readme.txt.
-					grunt.config( "gitadd.addChangelog.files", { src: [ "./readme.txt" ] } );
-					grunt.task.run( "gitadd:addChangelog" );
+			// Stage the changed readme.txt.
+			grunt.config( "gitadd.addChangelog.files", { src: [ "./readme.txt" ] } );
+			grunt.task.run( "gitadd:addChangelog" );
 
+			// Check if there is something to commit with `git status` first.
+			grunt.config( "gitstatus.checkChangelog.options.callback", function( changedFiles ) {
+				// File's code has two parts: first character codes the status in the index (staged files).
+				const hasStagedChanges = changedFiles.some( file => file.code[ 0 ] !== " " );
+
+				if ( hasStagedChanges ) {
 					// Commit the changed readme.txt.
 					grunt.config( "gitcommit.commitChangelog.options.message", "Add changelog" );
 					grunt.task.run( "gitcommit:commitChangelog" );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When there are no changes in the user-facing change log, the automated RC script should not fail when trying to commit the absent changes in the change log to the Git repository.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug in the automated RC process where an unchanged user-facing change log would crash the RC script.

## Relevant technical choices:

* I could not directly compare the old and new change log, due to the asynchronous nature of editing the change log during the RC script.
* Instead, and to make it more robust, I decided to check the status of the Git index for any uncommitted changes.
  * If there are any uncommitted changes in the `readme.txt`, it commits them.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Running the `update-readme` task without changes in the changelog.
* Run `grunt update-readme --plugin-version=15.2`.
* An editor should pop up with the contents of the plugin's `readme.txt` file.
* Close this editor without entering any changes.
* You should see the message `Changelog is unchanged. Nothing to commit.` in the console.
* The Grunt task should succeed (it should say `Done` in the console, in green letters).

### Running the `update-readme` task with changes in the changelog.
* Run `grunt update-readme --plugin-version=15.2`.
* An editor should pop up with the contents of the plugin's `readme.txt` file.
* Add a change to the `readme.txt` (e.g. a whitespace).
* Save the file and close the editor.
* You should see the Grunt task `gitcommit:commitChangelog` being run in the console.
* The Grunt task should succeed (it should say `Done` in the console, in green letters).
* **Note**: this adds a local commit to your branch, which you can remove again by entering this command in the console:
  ```
  git reset HEAD^ --hard.
  ```

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
