### PR TITLE
P2-466 The option never will have a '0' value

### DIFF
--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -200,7 +200,7 @@ class Indexing_Notification_Integration implements Integration_Interface {
 	 */
 	protected function should_show_notification() {
 		// Don't show a notification if the indexation has already been started earlier.
-		if ( $this->options_helper->get( 'indexation_started' ) !== null ) {
+		if ( $this->options_helper->get( 'indexation_started' ) > 0 ) {
 			return false;
 		}
 

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -200,7 +200,7 @@ class Indexing_Notification_Integration implements Integration_Interface {
 	 */
 	protected function should_show_notification() {
 		// Don't show a notification if the indexation has already been started earlier.
-		if ( $this->options_helper->get( 'indexation_started' ) === 0 ) {
+		if ( $this->options_helper->get( 'indexation_started' ) !== null ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes a bug where we check against a value that the option will never have. It only can contain `null` or a timestamp (like 123456789). 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a regression where the notification always show up when indexing is started and aborted during the process

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Reset indexing data
* Deactivate/activate the plugin to have a reason
* Start indexing and press the button to stop it.
* Verify that the notification isn't visible when visiting the dashboard. 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
