### PR TITLE
Moves the logic to its own integration.

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -482,17 +482,6 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Flush W3TC cache after succesfull update/add of taxonomy meta option.
-	 *
-	 * @since 1.8.0
-	 */
-	public static function flush_w3tc_cache() {
-		if ( defined( 'W3TC_DIR' ) && function_exists( 'w3tc_objectcache_flush' ) ) {
-			w3tc_objectcache_flush();
-		}
-	}
-
-	/**
 	 * Clear rewrite rules.
 	 *
 	 * @since 1.8.0
@@ -1440,5 +1429,17 @@ SVG;
 		 * @api string $replacement The current separator.
 		 */
 		return apply_filters( 'wpseo_replacements_filter_sep', $replacement );
+	}
+
+	/**
+	 * Flush W3TC cache after successful update/add of taxonomy meta option.
+	 *
+	 * @deprecated 15.3
+	 * @codeCoverageIgnore
+	 *
+	 * @since 1.8.0
+	 */
+	public static function flush_w3tc_cache() {
+		_deprecated_function( __METHOD__, 'WPSEO 15.3' );
 	}
 }

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -100,10 +100,6 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 		parent::__construct();
 
 		self::$name = $this->option_name;
-
-		/* On succesfull update/add of the option, flush the W3TC cache. */
-		add_action( 'add_option_' . $this->option_name, [ 'WPSEO_Utils', 'flush_w3tc_cache' ] );
-		add_action( 'update_option_' . $this->option_name, [ 'WPSEO_Utils', 'flush_w3tc_cache' ] );
 	}
 
 	/**

--- a/src/conditionals/third-party/w3-total-cache-conditional.php
+++ b/src/conditionals/third-party/w3-total-cache-conditional.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Conditionals\Third_Party;
 
+use Yoast\WP\SEO\Conditionals\Conditional;
+
 /**
  * Conditional that is only met when in the admin.
  */

--- a/src/conditionals/third-party/w3-total-cache-conditional.php
+++ b/src/conditionals/third-party/w3-total-cache-conditional.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals\Third_Party;
+
+/**
+ * Conditional that is only met when in the admin.
+ */
+class W3_Total_Cache_Conditional implements Conditional {
+
+	/**
+	 * Returns whether or not this conditional is met.
+	 *
+	 * @return boolean Whether or not the conditional is met.
+	 */
+	public function is_met() {
+		if ( ! \defined( 'W3TC_DIR' ) ) {
+			return false;
+		}
+
+		return \function_exists( 'w3tc_objectcache_flush' );
+	}
+}

--- a/src/integrations/third-party/w3-total-cache.php
+++ b/src/integrations/third-party/w3-total-cache.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Third_Party;
+
+use Yoast\WP\SEO\Conditionals\Third_Party\W3_Total_Cache_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * W3 Total Cache integration.
+ */
+class W3_Total_Cache implements Integration_Interface {
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * @return array
+	 */
+	public static function get_conditionals() {
+		return [ W3_Total_Cache_Conditional::class ];
+	}
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * On successful update/add of the taxonomy meta option, flush the W3TC cache.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'add_option_wpseo_taxonomy_meta', 'w3tc_objectcache_flush' );
+		\add_action( 'update_option_wpseo_taxonomy_meta', 'w3tc_objectcache_flush' );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Replace the static util and implementation for a separate third-party integration.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Moves the flushing logic for w3tc to its own integration. This integration resets the cache when taxonomy data has been changed.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Install W3 Total cache
* Open a term page for example a category. Make some changes in the settings: things like meta description, cornerstone value and some advanced settings
* Save it, refresh the page and verify the values are still saved.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
