### PR TITLE
Always show a notification when resetting the permalinks.

### DIFF
--- a/src/helpers/indexable-helper.php
+++ b/src/helpers/indexable-helper.php
@@ -118,9 +118,9 @@ class Indexable_Helper {
 	public function reset_permalink_indexables( $type = null, $subtype = null, $reason = Indexing_Notification_Integration::REASON_PERMALINK_SETTINGS ) {
 		$result = $this->repository->reset_permalink( $type, $subtype );
 
-		if ( $result !== false && $result > 0 ) {
-			$this->indexing_helper->set_reason( $reason );
+		$this->indexing_helper->set_reason( $reason );
 
+		if ( $result !== false && $result > 0 ) {
 			\delete_transient( Indexable_Post_Indexation_Action::TRANSIENT_CACHE_KEY );
 			\delete_transient( Indexable_Post_Type_Archive_Indexation_Action::TRANSIENT_CACHE_KEY );
 			\delete_transient( Indexable_Term_Indexation_Action::TRANSIENT_CACHE_KEY );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to show the reindex notification whenever the permalinks are reset.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where no notification to reindex your site was shown when changing the permalink structure, category base or home URL multiple times in a row and hiding the notification in between.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Change the permalink structure of your website.
* Hide the reindex notification that is shown on the Yoast SEO Dashboard.
* Change the permalink structure again.
* The notification should be unhidden again.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
