### PR TITLE
Notify the plugin testers on Slack when an RC has been created

### DIFF
--- a/config/grunt/task-config/notify-slack.js
+++ b/config/grunt/task-config/notify-slack.js
@@ -2,6 +2,6 @@
 module.exports = {
 	rc: {
 		slackToken: process.env.SLACK_TEST_CHANNEL_TOKEN,
-		message: "An RC has been created: ",
+		message: "@plugin-testers An RC has been created: ",
 	},
 };

--- a/config/grunt/task-config/notify-slack.js
+++ b/config/grunt/task-config/notify-slack.js
@@ -2,6 +2,6 @@
 module.exports = {
 	rc: {
 		slackToken: process.env.SLACK_TEST_CHANNEL_TOKEN,
-		message: "@plugin-testers An RC has been created: ",
+		message: "@plugin-testers @product-team An RC has been created: ",
 	},
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a handle to notify the plugin testers when an RC has been created automatically.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run the automatic RC script.
* See that the plugin testers are pinged.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
