### PR TITLE
Move notification reasons into standalone class

### DIFF
--- a/src/config/indexing-reasons.php
+++ b/src/config/indexing-reasons.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Yoast\WP\SEO\Config;
+
+/**
+ * Class Indexing_Reasons. Contains constants that aren't context specific.
+ */
+class Indexing_Reasons {
+
+	/**
+	 * Represents the reason that the indexing process failed and should be tried again.
+	 */
+	const REASON_INDEXING_FAILED = 'indexing_failed';
+
+	/**
+	 * Represents the reason that the permalink settings are changed.
+	 */
+	const REASON_PERMALINK_SETTINGS = 'permalink_settings_changed';
+
+	/**
+	 * Represents the reason that the category base is changed.
+	 */
+	const REASON_CATEGORY_BASE_PREFIX = 'category_base_changed';
+
+	/**
+	 * Represents the reason that the tag base is changed.
+	 */
+	const REASON_TAG_BASE_PREFIX = 'tag_base_changed';
+
+	/**
+	 * Represents the reason that the home url option is changed.
+	 */
+	const REASON_HOME_URL_OPTION = 'home_url_option_changed';
+}

--- a/src/helpers/indexable-helper.php
+++ b/src/helpers/indexable-helper.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Helpers;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Type_Archive_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
-use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
+use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
@@ -115,7 +115,7 @@ class Indexable_Helper {
 	 * @param null|string $subtype The subtype. Can be null.
 	 * @param string      $reason  The reason that the permalink has been changed.
 	 */
-	public function reset_permalink_indexables( $type = null, $subtype = null, $reason = Indexing_Notification_Integration::REASON_PERMALINK_SETTINGS ) {
+	public function reset_permalink_indexables( $type = null, $subtype = null, $reason = Indexing_Reasons::REASON_PERMALINK_SETTINGS ) {
 		$result = $this->repository->reset_permalink( $type, $subtype );
 
 		if ( $result !== false && $result > 0 ) {

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -28,28 +28,38 @@ class Indexing_Notification_Integration implements Integration_Interface {
 
 	/**
 	 * Represents the reason that the indexing process failed and should be tried again.
+	 *
+	 * @deprecated 15.3
 	 */
-	const REASON_INDEXING_FAILED = 'indexing_failed';
+	const REASON_INDEXING_FAILED = Indexing_Reasons::REASON_INDEXING_FAILED;
 
 	/**
 	 * Represents the reason that the permalink settings are changed.
+	 *
+	 * @deprecated 15.3
 	 */
-	const REASON_PERMALINK_SETTINGS = 'permalink_settings_changed';
+	const REASON_PERMALINK_SETTINGS = Indexing_Reasons::REASON_PERMALINK_SETTINGS;
 
 	/**
 	 * Represents the reason that the category base is changed.
+	 *
+	 * @deprecated 15.3
 	 */
-	const REASON_CATEGORY_BASE_PREFIX = 'category_base_changed';
+	const REASON_CATEGORY_BASE_PREFIX = Indexing_Reasons::REASON_CATEGORY_BASE_PREFIX;
 
 	/**
 	 * Represents the reason that the tag base is changed.
+	 *
+	 * @deprecated 15.3
 	 */
-	const REASON_TAG_BASE_PREFIX = 'tag_base_changed';
+	const REASON_TAG_BASE_PREFIX = Indexing_Reasons::REASON_TAG_BASE_PREFIX;
 
 	/**
 	 * Represents the reason that the home url option is changed.
+	 *
+	 * @deprecated 15.3
 	 */
-	const REASON_HOME_URL_OPTION = 'home_url_option_changed';
+	const REASON_HOME_URL_OPTION = Indexing_Reasons::REASON_HOME_URL_OPTION;
 
 	/**
 	 * The Yoast notification center.

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Integrations\Admin;
 
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Helpers\Notification_Helper;
@@ -237,7 +238,7 @@ class Indexing_Notification_Integration implements Integration_Interface {
 	 * @return Indexing_Failed_Notification_Presenter|Indexing_Notification_Presenter
 	 */
 	protected function get_presenter( $reason ) {
-		if ( $reason === self::REASON_INDEXING_FAILED ) {
+		if ( $reason === Indexing_Reasons::REASON_INDEXING_FAILED ) {
 			$presenter = new Indexing_Failed_Notification_Presenter( $this->product_helper );
 		}
 		else {

--- a/src/integrations/watchers/indexable-category-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-category-permalink-watcher.php
@@ -2,7 +2,7 @@
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
-use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
+use Yoast\WP\SEO\Config\Indexing_Reasons;
 
 /**
  * Watches the stripcategorybase key in wpseo_titles, in order to clear the permalink of the category indexables.
@@ -47,7 +47,7 @@ class Indexable_Category_Permalink_Watcher extends Indexable_Permalink_Watcher {
 
 		// If a new value has been set for 'stripcategorybase', clear the category permalinks.
 		if ( $old_value['stripcategorybase'] !== $new_value['stripcategorybase'] ) {
-			$this->indexable_helper->reset_permalink_indexables( 'term', 'category', Indexing_Notification_Integration::REASON_CATEGORY_BASE_PREFIX );
+			$this->indexable_helper->reset_permalink_indexables( 'term', 'category', Indexing_Reasons::REASON_CATEGORY_BASE_PREFIX );
 		}
 	}
 }

--- a/src/integrations/watchers/indexable-homeurl-watcher.php
+++ b/src/integrations/watchers/indexable-homeurl-watcher.php
@@ -5,10 +5,10 @@ namespace Yoast\WP\SEO\Integrations\Watchers;
 use WP_CLI;
 use WP_CLI\Utils;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
-use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
@@ -86,13 +86,13 @@ class Indexable_HomeUrl_Watcher implements Integration_Interface {
 
 		$taxonomies = $this->get_taxonomies_for_post_types( $post_types );
 		foreach ( $taxonomies as $taxonomy ) {
-			$this->indexable_helper->reset_permalink_indexables( 'term', $taxonomy, Indexing_Notification_Integration::REASON_HOME_URL_OPTION );
+			$this->indexable_helper->reset_permalink_indexables( 'term', $taxonomy, Indexing_Reasons::REASON_HOME_URL_OPTION );
 		}
 
-		$this->indexable_helper->reset_permalink_indexables( 'home-page', null, Indexing_Notification_Integration::REASON_HOME_URL_OPTION );
-		$this->indexable_helper->reset_permalink_indexables( 'user', null, Indexing_Notification_Integration::REASON_HOME_URL_OPTION );
-		$this->indexable_helper->reset_permalink_indexables( 'date-archive', null, Indexing_Notification_Integration::REASON_HOME_URL_OPTION );
-		$this->indexable_helper->reset_permalink_indexables( 'system-page', null, Indexing_Notification_Integration::REASON_HOME_URL_OPTION );
+		$this->indexable_helper->reset_permalink_indexables( 'home-page', null, Indexing_Reasons::REASON_HOME_URL_OPTION );
+		$this->indexable_helper->reset_permalink_indexables( 'user', null, Indexing_Reasons::REASON_HOME_URL_OPTION );
+		$this->indexable_helper->reset_permalink_indexables( 'date-archive', null, Indexing_Reasons::REASON_HOME_URL_OPTION );
+		$this->indexable_helper->reset_permalink_indexables( 'system-page', null, Indexing_Reasons::REASON_HOME_URL_OPTION );
 
 		// Reset the home_url option.
 		$this->options_helper->set( 'home_url', get_home_url() );
@@ -104,8 +104,8 @@ class Indexable_HomeUrl_Watcher implements Integration_Interface {
 	 * @param string $post_type The post type to reset.
 	 */
 	public function reset_permalinks_post_type( $post_type ) {
-		$this->indexable_helper->reset_permalink_indexables( 'post', $post_type, Indexing_Notification_Integration::REASON_HOME_URL_OPTION );
-		$this->indexable_helper->reset_permalink_indexables( 'post-type-archive', $post_type, Indexing_Notification_Integration::REASON_HOME_URL_OPTION );
+		$this->indexable_helper->reset_permalink_indexables( 'post', $post_type, Indexing_Reasons::REASON_HOME_URL_OPTION );
+		$this->indexable_helper->reset_permalink_indexables( 'post-type-archive', $post_type, Indexing_Reasons::REASON_HOME_URL_OPTION );
 	}
 
 	/**

--- a/src/integrations/watchers/indexable-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-permalink-watcher.php
@@ -2,10 +2,6 @@
 
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
-use Yoast\WP\Lib\Model;
-use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
-use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Type_Archive_Indexation_Action;
-use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
@@ -13,8 +9,6 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
-use Yoast\WP\SEO\Presenters\Admin\Indexation_Permalink_Warning_Presenter;
-use Yoast\WP\SEO\WordPress\Wrapper;
 
 /**
  * WordPress Permalink structure watcher.

--- a/src/integrations/watchers/indexable-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-permalink-watcher.php
@@ -7,11 +7,11 @@ use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Type_Archive_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
-use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Indexation_Permalink_Warning_Presenter;
 use Yoast\WP\SEO\WordPress\Wrapper;
@@ -132,7 +132,7 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 	public function reset_permalinks_term( $old, $new, $type ) {
 		$subtype = $type;
 
-		$reason = Indexing_Notification_Integration::REASON_PERMALINK_SETTINGS;
+		$reason = Indexing_Reasons::REASON_PERMALINK_SETTINGS;
 
 		// When the subtype contains _base, just strip it.
 		if ( \strstr( $subtype, '_base' ) ) {
@@ -141,11 +141,11 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 
 		if ( $subtype === 'tag' ) {
 			$subtype = 'post_tag';
-			$reason  = Indexing_Notification_Integration::REASON_TAG_BASE_PREFIX;
+			$reason  = Indexing_Reasons::REASON_TAG_BASE_PREFIX;
 		}
 
 		if ( $subtype === 'category' ) {
-			$reason = Indexing_Notification_Integration::REASON_CATEGORY_BASE_PREFIX;
+			$reason = Indexing_Reasons::REASON_CATEGORY_BASE_PREFIX;
 		}
 
 		$this->indexable_helper->reset_permalink_indexables( 'term', $subtype, $reason );
@@ -275,9 +275,9 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 	 * @param null|string $subtype The subtype. Can be null.
 	 * @param string      $reason  The reason that the permalink has been changed.
 	 */
-	public function reset_permalink_indexables( $type, $subtype = null, $reason = Indexation_Permalink_Warning_Presenter::REASON_PERMALINK_SETTINGS ) {
+	public function reset_permalink_indexables( $type, $subtype = null, $reason = Indexing_Reasons::REASON_PERMALINK_SETTINGS ) {
 		_deprecated_function( __METHOD__, 'WPSEO 15.1', 'Indexable_Helper::reset_permalink_indexables' );
 
-		return $this->indexable_helper->reset_permalink_indexables( $type, $subtype, $reason );
+		$this->indexable_helper->reset_permalink_indexables( $type, $subtype, $reason );
 	}
 }

--- a/src/presenters/admin/indexing-notification-presenter.php
+++ b/src/presenters/admin/indexing-notification-presenter.php
@@ -2,8 +2,8 @@
 
 namespace Yoast\WP\SEO\Presenters\Admin;
 
+use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
-use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
 /**
@@ -71,16 +71,16 @@ class Indexing_Notification_Presenter extends Abstract_Presenter {
 	 */
 	protected function get_message( $reason ) {
 		switch ( $reason ) {
-			case Indexing_Notification_Integration::REASON_PERMALINK_SETTINGS:
+			case Indexing_Reasons::REASON_PERMALINK_SETTINGS:
 				$text = \esc_html__( 'Because of a change in your permalink structure, some of your SEO data needs to be reprocessed.', 'wordpress-seo' );
 				break;
-			case Indexing_Notification_Integration::REASON_HOME_URL_OPTION:
+			case Indexing_Reasons::REASON_HOME_URL_OPTION:
 				$text = \esc_html__( 'Because of a change in your home URL setting, some of your SEO data needs to be reprocessed.', 'wordpress-seo' );
 				break;
-			case Indexing_Notification_Integration::REASON_CATEGORY_BASE_PREFIX:
+			case Indexing_Reasons::REASON_CATEGORY_BASE_PREFIX:
 				$text = \esc_html__( 'Because of a change in your category base setting, some of your SEO data needs to be reprocessed.', 'wordpress-seo' );
 				break;
-			case Indexing_Notification_Integration::REASON_TAG_BASE_PREFIX:
+			case Indexing_Reasons::REASON_TAG_BASE_PREFIX:
 				$text = \esc_html__( 'Because of a change in your tag base setting, some of your SEO data needs to be reprocessed.', 'wordpress-seo' );
 				break;
 			default:

--- a/src/routes/indexing-route.php
+++ b/src/routes/indexing-route.php
@@ -15,9 +15,9 @@ use Yoast\WP\SEO\Actions\Indexing\Indexing_Complete_Action;
 use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
 use Yoast\WP\SEO\Main;
 
 /**
@@ -419,7 +419,7 @@ class Indexing_Route extends Abstract_Indexation_Route {
 		try {
 			return parent::run_indexation_action( $indexation_action, $url );
 		} catch ( \Exception $exception ) {
-			$this->indexing_helper->set_reason( Indexing_Notification_Integration::REASON_INDEXING_FAILED );
+			$this->indexing_helper->set_reason( Indexing_Reasons::REASON_INDEXING_FAILED );
 
 			return new WP_Error( 'wpseo_error_indexing', $exception->getMessage() );
 		}

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
 
 use Brain\Monkey;
 use Mockery;
+use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast_Notification_Center;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
@@ -299,7 +300,7 @@ class Indexing_Notification_Integration_Test extends TestCase {
 		$this->indexing_helper
 			->expects( 'get_reason' )
 			->once()
-			->andReturn( Indexing_Notification_Integration::REASON_INDEXING_FAILED );
+			->andReturn( Indexing_Reasons::REASON_INDEXING_FAILED );
 
 		Monkey\Functions\expect( 'wp_get_current_user' )
 			->andReturn( 'user' );

--- a/tests/unit/integrations/watchers/indexable-category-permalink-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-category-permalink-watcher-test.php
@@ -4,11 +4,11 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 
 use Brain\Monkey;
 use Mockery;
+use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
-use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Category_Permalink_Watcher;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -156,7 +156,7 @@ class Indexable_Category_Permalink_Watcher_Test extends TestCase {
 	public function test_check_option_stripcategorybase_changed() {
 		$this->indexable_helper
 			->expects( 'reset_permalink_indexables' )
-			->with( 'term', 'category', Indexing_Notification_Integration::REASON_CATEGORY_BASE_PREFIX )
+			->with( 'term', 'category', Indexing_Reasons::REASON_CATEGORY_BASE_PREFIX )
 			->once();
 
 		$this->instance->check_option( [ 'stripcategorybase' => 0 ], [ 'stripcategorybase' => 1 ] );

--- a/tests/unit/integrations/watchers/indexable-homeurl-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-homeurl-watcher-test.php
@@ -5,10 +5,10 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
-use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_HomeUrl_Watcher;
 use Yoast\WP\SEO\Presenters\Admin\Indexing_Permalink_Warning_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -105,13 +105,13 @@ class Indexable_HomeUrl_Watcher_Test extends TestCase {
 		$this->instance->expects( 'get_post_types' )->once()->andReturn( [ 'post' ] );
 		$this->instance->expects( 'get_taxonomies_for_post_types' )->once()->with( [ 'post' ] )->andReturn( [ 'category' ] );
 
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'post', 'post', Indexing_Notification_Integration::REASON_HOME_URL_OPTION )->once();
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'post-type-archive', 'post', Indexing_Notification_Integration::REASON_HOME_URL_OPTION )->once();
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'term', 'category', Indexing_Notification_Integration::REASON_HOME_URL_OPTION )->once();
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'user', null, Indexing_Notification_Integration::REASON_HOME_URL_OPTION )->once();
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'home-page', null, Indexing_Notification_Integration::REASON_HOME_URL_OPTION )->once();
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'date-archive', null, Indexing_Notification_Integration::REASON_HOME_URL_OPTION )->once();
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'system-page', null, Indexing_Notification_Integration::REASON_HOME_URL_OPTION )->once();
+		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'post', 'post', Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
+		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'post-type-archive', 'post', Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
+		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'term', 'category', Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
+		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'user', null, Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
+		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'home-page', null, Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
+		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'date-archive', null, Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
+		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'system-page', null, Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
 
 		Monkey\Functions\expect( 'get_home_url' )
 			->once()
@@ -131,8 +131,8 @@ class Indexable_HomeUrl_Watcher_Test extends TestCase {
 	 * @covers ::reset_permalinks_post_type
 	 */
 	public function test_reset_permalinks_post_type() {
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'post', 'post', Indexing_Notification_Integration::REASON_HOME_URL_OPTION )->once();
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'post-type-archive', 'post', Indexing_Notification_Integration::REASON_HOME_URL_OPTION )->once();
+		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'post', 'post', Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
+		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'post-type-archive', 'post', Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
 
 		$this->instance->reset_permalinks_post_type( 'post' );
 	}

--- a/tests/unit/integrations/watchers/indexable-permalink-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-permalink-watcher-test.php
@@ -5,11 +5,11 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Watchers;
 use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
-use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Permalink_Watcher;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -155,7 +155,7 @@ class Indexable_Permalink_Watcher_Test extends TestCase {
 	public function test_reset_permalinks_term() {
 		$this->indexable_helper
 			->expects( 'reset_permalink_indexables' )
-			->with( 'term', 'category', Indexing_Notification_Integration::REASON_CATEGORY_BASE_PREFIX )
+			->with( 'term', 'category', Indexing_Reasons::REASON_CATEGORY_BASE_PREFIX )
 			->once();
 
 		$this->instance->reset_permalinks_term( null, null, 'category_base' );
@@ -169,7 +169,7 @@ class Indexable_Permalink_Watcher_Test extends TestCase {
 	public function test_reset_permalinks_for_term_tag() {
 		$this->indexable_helper
 			->expects( 'reset_permalink_indexables' )
-			->with( 'term', 'post_tag', Indexing_Notification_Integration::REASON_TAG_BASE_PREFIX )
+			->with( 'term', 'post_tag', Indexing_Reasons::REASON_TAG_BASE_PREFIX )
 			->once();
 
 		$this->instance->reset_permalinks_term( null, null, 'tag_base' );

--- a/tests/unit/routes/indexing-route-test.php
+++ b/tests/unit/routes/indexing-route-test.php
@@ -13,9 +13,9 @@ use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexing_Complete_Action;
 use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
+use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
 use Yoast\WP\SEO\Routes\Indexing_Route;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -451,7 +451,7 @@ class Indexing_Route_Test extends TestCase {
 	public function test_index_general_when_error_occurs() {
 		$this->general_indexation_action->expects( 'index' )->andThrow( new \Exception( 'An exception during indexing' ) );
 
-		$this->indexing_helper->expects( 'set_reason' )->with( Indexing_Notification_Integration::REASON_INDEXING_FAILED );
+		$this->indexing_helper->expects( 'set_reason' )->with( Indexing_Reasons::REASON_INDEXING_FAILED );
 
 		Mockery::mock( '\WP_Error' );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to separate the reasons from the integration

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* It just moves the constants to another class

## Relevant technical choices:

* I point the old constants to the new ones, just for BC

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Reset the permalink structure - A notice wil be given
* Do the same for the category base

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
