### PR TITLE
Add unit tests for the WooCommerce permalinks integration

### DIFF
--- a/src/integrations/third-party/woocommerce-permalinks.php
+++ b/src/integrations/third-party/woocommerce-permalinks.php
@@ -93,8 +93,6 @@ class Woocommerce_Permalinks implements Integration_Interface {
 	/**
 	 * Retrieves the taxonomies based on the attributes.
 	 *
-	 * @codeCoverageIgnore
-	 *
 	 * @return array The taxonomies.
 	 */
 	protected function get_attribute_taxonomies() {

--- a/tests/unit/integrations/third-party/woocommerce-permalinks-test.php
+++ b/tests/unit/integrations/third-party/woocommerce-permalinks-test.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
+use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
+use Yoast\WP\SEO\Integrations\Third_Party\Woocommerce_Permalinks;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class WooCommerce_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\Woocommerce_Permalinks
+ * @covers \Yoast\WP\SEO\Integrations\Third_Party\Woocommerce_Permalinks
+ *
+ * @group integrations
+ * @group woocommerce
+ */
+class WooCommerce_Permalinks_Test extends TestCase {
+
+	/**
+	 * The test instance.
+	 *
+	 * @var Woocommerce_Permalinks
+	 */
+	protected $instance;
+
+	/**
+	 * Represents the indexable helper.
+	 *
+	 * @var Mockery\MockInterface|Indexable_Helper
+	 */
+	protected $indexable_helper;
+
+	/**
+	 * Sets an instance for test purposes.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->indexable_helper = Mockery::mock( Indexable_Helper::class );
+		$this->instance = new Woocommerce_Permalinks( $this->indexable_helper );
+	}
+
+	/**
+	 * Tests if the expected conditionals are in place.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		static::assertEquals(
+			[ WooCommerce_Conditional::class, Migrations_Conditional::class ],
+			Woocommerce_Permalinks::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests if the constructor sets the right properties.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		static::assertAttributeInstanceOf( Indexable_Helper::class, 'indexable_helper', $this->instance );
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		static::assertNotFalse( Monkey\Filters\has( 'wpseo_post_types_reset_permalinks', [ $this->instance, 'filter_product_from_post_types' ] ) );
+		static::assertNotFalse( Monkey\Actions\has( 'update_option_woocommerce_permalinks', [ $this->instance, 'reset_woocommerce_permalinks' ] ) );
+	}
+
+	/**
+	 * Filters the product from the post types.
+	 *
+	 * @covers ::filter_product_from_post_types
+	 */
+	public function test_filter_product_from_post_types() {
+		$this->assertEquals(
+			[
+				'post' => 'post',
+				'page' => 'page',
+			],
+			$this->instance->filter_product_from_post_types(
+				[
+					'post'    => 'post',
+					'page'    => 'page',
+					'product' => 'product',
+				]
+			)
+		);
+	}
+
+	/**
+	 * Tests resetting the product on product_base change.
+	 *
+	 * @covers ::reset_woocommerce_permalinks
+	 */
+	public function test_reset_woocommerce_permalinks_product_base() {
+		$this->indexable_helper
+			->expects( 'reset_permalink_indexables' )
+			->once()
+			->with( 'post', 'product' );
+
+		$old = [
+			'product_base' => 'bar',
+		];
+		$new = [
+			'product_base' => 'foo',
+		];
+
+		$this->instance->reset_woocommerce_permalinks( $old, $new );
+	}
+
+	/**
+	 * Tests resetting the product on product_base change.
+	 *
+	 * @covers ::reset_woocommerce_permalinks
+	 */
+	public function test_reset_woocommerce_permalinks_attribute_base() {
+		$this->indexable_helper
+			->expects( 'reset_permalink_indexables' )
+			->once()
+			->with( 'term', 'my_attribute' );
+
+		$attribute = ( object ) [
+			'attribute_name' => 'my_attribute',
+		];
+
+		Monkey\Functions\expect( 'wc_get_attribute_taxonomies' )
+			->once()
+			->andReturn( [ $attribute ] );
+
+		Monkey\Functions\expect( 'wc_attribute_taxonomy_name' )
+			->once()
+			->with( 'my_attribute' )
+			->andReturn( 'my_attribute' );
+
+		$old = [
+			'attribute_base' => 'bar',
+		];
+		$new = [
+			'attribute_base' => 'foo',
+		];
+
+		$this->instance->reset_woocommerce_permalinks( $old, $new );
+	}
+
+	/**
+	 * Tests resetting the product on product_base change.
+	 *
+	 * @covers ::reset_woocommerce_permalinks
+	 */
+	public function test_reset_woocommerce_permalinks_terms_base() {
+		$this->indexable_helper
+			->expects( 'reset_permalink_indexables' )
+			->once()
+			->with( 'term', 'product_cat' );
+
+		$this->indexable_helper
+			->expects( 'reset_permalink_indexables' )
+			->once()
+			->with( 'term', 'product_tag' );
+
+		$old = [
+			'category_base' => 'bar',
+			'tag_base'      => 'bar',
+			'no_base'       => 'bar',
+		];
+		$new = [
+			'category_base' => 'foo',
+			'tag_base'      => 'foo',
+			'no_base'       => 'foo',
+		];
+
+		$this->instance->reset_woocommerce_permalinks( $old, $new );
+	}
+
+}

--- a/tests/unit/integrations/third-party/woocommerce-permalinks-test.php
+++ b/tests/unit/integrations/third-party/woocommerce-permalinks-test.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Integrations\Third_Party\Woocommerce_Permalinks;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class WooCommerce_Test.
+ * Class WooCommerce_Permalinks_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\Woocommerce_Permalinks
  * @covers \Yoast\WP\SEO\Integrations\Third_Party\Woocommerce_Permalinks
@@ -183,5 +183,4 @@ class WooCommerce_Permalinks_Test extends TestCase {
 
 		$this->instance->reset_woocommerce_permalinks( $old, $new );
 	}
-
 }


### PR DESCRIPTION
Moved from the WooCommerce SEO plugin

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* There aren't any tests for the WooCommerce permalink integration. I moved them from https://github.com/Yoast/wpseo-woocommerce/pull/644 to this repository.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* It just adds unit tests

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* If travis is happy, we are happy and can press the merge button.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
