### PR TITLE
Set the start time to null when changing the notification reason

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=795",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=767",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=258",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -102,12 +102,12 @@ class Indexing_Helper {
 	 *
 	 * @required
 	 *
-	 * @param Indexable_Post_Indexation_Action              $post_indexation                The post indexing action.
-	 * @param Indexable_Term_Indexation_Action              $term_indexation                The term indexing action.
-	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation   The posttype indexing action.
-	 * @param Indexable_General_Indexation_Action           $general_indexation             The general indexation (homepage etc) action.
-	 * @param Post_Link_Indexing_Action                     $post_link_indexing_action      The post crosslink indexation action.
-	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action      The term crossling indexation action.
+	 * @param Indexable_Post_Indexation_Action              $post_indexation              The post indexing action.
+	 * @param Indexable_Term_Indexation_Action              $term_indexation              The term indexing action.
+	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation The posttype indexing action.
+	 * @param Indexable_General_Indexation_Action           $general_indexation           The general indexing (homepage etc) action.
+	 * @param Post_Link_Indexing_Action                     $post_link_indexing_action    The post crosslink indexing action.
+	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action    The term crossling indexing action.
 	 */
 	public function set_indexing_actions(
 		Indexable_Post_Indexation_Action $post_indexation,

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -144,6 +144,16 @@ class Indexing_Helper {
 	}
 
 	/**
+	 * Sets appropriate flags when the indexing process fails.
+	 *
+	 * @return void
+	 */
+	public function indexing_failed() {
+		$this->set_reason( Indexing_Reasons::REASON_INDEXING_FAILED );
+		$this->set_started( null );
+	}
+
+	/**
 	 * Sets the indexing reason.
 	 *
 	 * @param string $reason The indexing reason.
@@ -160,8 +170,6 @@ class Indexing_Helper {
 		$this->notification_center->remove_notification_by_id(
 			Indexing_Notification_Integration::NOTIFICATION_ID
 		);
-
-		$this->set_started( null );
 	}
 
 	/**
@@ -170,7 +178,7 @@ class Indexing_Helper {
 	 * @return bool Whether an indexing reason has been set in the options.
 	 */
 	public function has_reason() {
-		$reason = $this->options_helper->get( 'indexing_reason', '' );
+		$reason = $this->get_reason();
 
 		return ! empty( $reason );
 	}
@@ -187,12 +195,12 @@ class Indexing_Helper {
 	/**
 	 * Sets the start time when the indexing process has started but not completed.
 	 *
-	 * @param int|bool $value The start time when the indexing process has started but not completed, false otherwise.
+	 * @param int|bool $timestamp The start time when the indexing process has started but not completed, false otherwise.
 	 *
 	 * @return void
 	 */
-	public function set_started( $value ) {
-		$this->options_helper->set( 'indexation_started', $value );
+	public function set_started( $timestamp ) {
+		$this->options_helper->set( 'indexation_started', $timestamp );
 	}
 
 	/**

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -141,6 +141,7 @@ class Indexing_Helper {
 	 */
 	public function finish() {
 		$this->set_reason( '' );
+		$this->set_started( null );
 	}
 
 	/**

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -140,7 +140,6 @@ class Indexing_Helper {
 	 * @return void
 	 */
 	public function finish() {
-		$this->set_started( null );
 		$this->set_reason( '' );
 	}
 
@@ -161,6 +160,8 @@ class Indexing_Helper {
 		$this->notification_center->remove_notification_by_id(
 			Indexing_Notification_Integration::NOTIFICATION_ID
 		);
+
+		$this->set_started( null );
 	}
 
 	/**

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -8,6 +8,7 @@ use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Type_Archive_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
+use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
 use Yoast_Notification_Center;
 

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -101,12 +101,12 @@ class Indexing_Helper {
 	 *
 	 * @required
 	 *
-	 * @param Indexable_Post_Indexation_Action              $post_indexation
-	 * @param Indexable_Term_Indexation_Action              $term_indexation
-	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation
-	 * @param Indexable_General_Indexation_Action           $general_indexation
-	 * @param Post_Link_Indexing_Action                     $post_link_indexing_action
-	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action
+	 * @param Indexable_Post_Indexation_Action              $post_indexation                The post indexing action.
+	 * @param Indexable_Term_Indexation_Action              $term_indexation                The term indexing action.
+	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation   The posttype indexing action.
+	 * @param Indexable_General_Indexation_Action           $general_indexation             The general indexation (homepage etc) action.
+	 * @param Post_Link_Indexing_Action                     $post_link_indexing_action      The post crosslink indexation action.
+	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action      The term crossling indexation action.
 	 */
 	public function set_indexing_actions(
 		Indexable_Post_Indexation_Action $post_indexation,

--- a/src/routes/indexing-route.php
+++ b/src/routes/indexing-route.php
@@ -419,7 +419,7 @@ class Indexing_Route extends Abstract_Indexation_Route {
 		try {
 			return parent::run_indexation_action( $indexation_action, $url );
 		} catch ( \Exception $exception ) {
-			$this->indexing_helper->set_reason( Indexing_Reasons::REASON_INDEXING_FAILED );
+			$this->indexing_helper->indexing_failed();
 
 			return new WP_Error( 'wpseo_error_indexing', $exception->getMessage() );
 		}

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -227,6 +227,11 @@ class Indexing_Helper_Test extends TestCase {
 			->once()
 			->with( Indexing_Notification_Integration::NOTIFICATION_ID );
 
+		$this->options_helper
+			->expects( 'set' )
+			->once()
+			->with( 'indexation_started', null );
+
 		$this->instance->set_reason( $reason );
 	}
 

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -227,11 +227,6 @@ class Indexing_Helper_Test extends TestCase {
 			->once()
 			->with( Indexing_Notification_Integration::NOTIFICATION_ID );
 
-		$this->options_helper
-			->expects( 'set' )
-			->once()
-			->with( 'indexation_started', null );
-
 		$this->instance->set_reason( $reason );
 	}
 

--- a/tests/unit/routes/indexing-route-test.php
+++ b/tests/unit/routes/indexing-route-test.php
@@ -451,7 +451,7 @@ class Indexing_Route_Test extends TestCase {
 	public function test_index_general_when_error_occurs() {
 		$this->general_indexation_action->expects( 'index' )->andThrow( new \Exception( 'An exception during indexing' ) );
 
-		$this->indexing_helper->expects( 'set_reason' )->with( Indexing_Reasons::REASON_INDEXING_FAILED );
+		$this->indexing_helper->expects( 'indexing_failed' )->withNoArgs();
 
 		Mockery::mock( '\WP_Error' );
 


### PR DESCRIPTION
If the start time would still be set to the time when indexing started, the notification is not shown

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where no notification to reindex your site would be shown when the indexing process failed.

## Relevant technical choices:

* In the `indexing-notifation-integration`, in `should-show-notification`, it is checked whether the `indexing_started` option has a value `> 0`. If so, we never show a notification.
* However, when the indexing reason changes, we do want to always show a notification.
* Therefore, the `indexing_started` option needs to be set to `null`.
* We were only setting `indexing_started` to `null` in the `finish` method, but if the indexing process fails, we never make it to the finish method. We always want to set `indexing_started` to `null` when the indexing reason changes.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

**Reproduce the bug**
* On `trunk`, reset the indexables.
* See you have a notification telling you that you should index.
* Throw an error in the indexing process.
* For example, add `throw new \Exception( 'test' );` to the `index()` method of `indexable-post-indexation-action`.
* Run the indexing process and see it fail.
* Go to the SEO dashboard and see there is **no** notification telling you to reindex.

**Test the fix**
* On this branch, reset the indexables.
* See you have a notification telling you that you should index.
* Throw an error in the indexing process.
* For example, add `throw new \Exception( 'test' );` to the `index()` method of `indexable-post-indexation-action`.
* Run the indexing process and see it fail.
* Go to the SEO dashboard and see there is a notification telling you to reindex.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-486
