### PR TITLE
Rename unreleased wpseo_image_get_data filter to wpseo_image_data

### DIFF
--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -117,7 +117,7 @@ class WPSEO_Image_Utils {
 		}
 
 		/**
-		 * Filter: 'wpseo_image_get_data' - Filter image data.
+		 * Filter: 'wpseo_image_data' - Filter image data.
 		 *
 		 * Elements with keys not listed in the section will be discarded.
 		 *
@@ -137,7 +137,7 @@ class WPSEO_Image_Utils {
 		 * }
 		 * @api int  Attachment ID.
 		 */
-		$image = apply_filters( 'wpseo_image_get_data', $image, $attachment_id );
+		$image = apply_filters( 'wpseo_image_data', $image, $attachment_id );
 
 		// Keep only the keys we need, and nothing else.
 		return array_intersect_key( $image, array_flip( [ 'id', 'alt', 'path', 'width', 'height', 'pixels', 'type', 'size', 'url', 'filesize' ] ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The filter name wpseo_image_get_data filter was not logical and not consistent with the name structure of other filters. The filter was introduced in https://github.com/Yoast/wordpress-seo/pull/16177 and is not released yet.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Renames the unreleased wpseo_image_get_data filter to wpseo_image_data.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
