### PR TITLE
P3-168 Add configuration and Slot for the Zapier text

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -42,6 +42,7 @@ class WPSEO_Admin_Init {
 		add_action( 'admin_init', [ $this, 'show_hook_deprecation_warnings' ] );
 		add_action( 'admin_init', [ 'WPSEO_Plugin_Conflict', 'hook_check_for_plugin_conflicts' ] );
 		add_action( 'admin_notices', [ $this, 'permalink_settings_notice' ] );
+		add_action( 'post_submitbox_misc_actions', [ $this, 'add_publish_box_section' ] );
 
 		/*
 		 * The `admin_notices` hook fires on single site admin pages vs.
@@ -552,6 +553,23 @@ class WPSEO_Admin_Init {
 			esc_js( wp_create_nonce( 'wpseo-ignore' ) ),
 			esc_html__( 'I don\'t want this site to show in the search results.', 'wordpress-seo' )
 		);
+	}
+
+	/**
+	 * Adds a custom Yoast section within the Classic Editor publish box.
+	 *
+	 * @return void
+	 */
+	public function add_publish_box_section() {
+		if ( in_array( $this->pagenow, [ 'post.php', 'post-new.php' ], true ) ) {
+			?>
+			<div id="yoast-seo-publishbox-section"></div>
+			<?php
+			/**
+			 * Fires after the post time/date setting in the Publish meta box.
+			 */
+			do_action( 'wpseo_publishbox_misc_actions' );
+		}
 	}
 
 	/* ********************* DEPRECATED METHODS ********************* */

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -167,6 +167,8 @@ class WPSEO_Metabox_Formatter {
 			],
 			'markdownEnabled'           => $this->is_markdown_enabled(),
 			'analysisHeadingTitle'      => __( 'Analysis', 'wordpress-seo' ),
+			'zapierIntegrationActive'   => WPSEO_Options::get( 'zapier_integration_active', false ) ? 1 : 0,
+			'zapierConnectedStatus'     => ! empty( WPSEO_Options::get( 'zapier_subscription', [] ) ) ? 1 : 0,
 		];
 	}
 

--- a/js/src/analysis/isZapierConnected.js
+++ b/js/src/analysis/isZapierConnected.js
@@ -1,0 +1,16 @@
+/* External dependencies */
+import { get } from "lodash-es";
+
+/* Internal dependencies */
+import getL10nObject from "./getL10nObject";
+
+/**
+ * Returns whether the Zapier integration is connected.
+ *
+ * @returns {boolean} Whether the Zapier integration is connected.
+ */
+export default function isZapierConnected() {
+	const l10nObject = getL10nObject();
+
+	return get( l10nObject, "zapierConnectedStatus", 0 ) === 1;
+}

--- a/js/src/analysis/isZapierIntegrationActive.js
+++ b/js/src/analysis/isZapierIntegrationActive.js
@@ -1,0 +1,16 @@
+/* External dependencies */
+import { get } from "lodash-es";
+
+/* Internal dependencies */
+import getL10nObject from "./getL10nObject";
+
+/**
+ * Returns whether the Zapier integration is active.
+ *
+ * @returns {boolean} Whether the Zapier integration is active.
+ */
+export default function isZapierIntegrationActive() {
+	const l10nObject = getL10nObject();
+
+	return get( l10nObject, "zapierIntegrationActive", 0 ) === 1;
+}

--- a/js/src/initializers/block-editor-integration.js
+++ b/js/src/initializers/block-editor-integration.js
@@ -95,9 +95,7 @@ function registerFills( store ) {
 	};
 	const preferences = store.getState().preferences;
 	const analysesEnabled = preferences.isKeywordAnalysisActive || preferences.isContentAnalysisActive;
-	const zapierEnabled = preferences.isZapierIntegrationActive;
-	const zapierConnected = preferences.isZapierConnected;
-	const showZapierPanel = zapierEnabled && zapierConnected;
+	const showZapierPanel = preferences.isZapierIntegrationActive && preferences.isZapierConnected;
 	initiallyOpenDocumentSettings();
 
 	/**

--- a/js/src/initializers/block-editor-integration.js
+++ b/js/src/initializers/block-editor-integration.js
@@ -13,6 +13,7 @@ import { select, dispatch } from "@wordpress/data";
 import { __, sprintf } from "@wordpress/i18n";
 import { registerFormatType } from "@wordpress/rich-text";
 import { get } from "lodash-es";
+import { Slot } from "@wordpress/components";
 
 
 /* Internal dependencies */
@@ -82,7 +83,8 @@ function initiallyOpenDocumentSettings() {
  */
 function registerFills( store ) {
 	const localizedData = getL10nObject();
-	const pluginTitle = localizedData.isPremium ? "Yoast SEO Premium" : "Yoast SEO";
+	const isPremium = localizedData.isPremium;
+	const pluginTitle = isPremium ? "Yoast SEO Premium" : "Yoast SEO";
 
 	const icon = <YoastIcon />;
 	updateCategory( "yoast-structured-data-blocks", { icon } );
@@ -93,6 +95,9 @@ function registerFills( store ) {
 	};
 	const preferences = store.getState().preferences;
 	const analysesEnabled = preferences.isKeywordAnalysisActive || preferences.isContentAnalysisActive;
+	const zapierEnabled = preferences.isZapierIntegrationActive;
+	const zapierConnected = preferences.isZapierConnected;
+	const showZapierPanel = zapierEnabled && zapierConnected;
 	initiallyOpenDocumentSettings();
 
 	/**
@@ -125,6 +130,14 @@ function registerFills( store ) {
 				icon={ <Fragment /> }
 			>
 				<PrePublish />
+			</PluginPrePublishPanel> }
+			{ isPremium && showZapierPanel && <PluginPrePublishPanel
+				className="yoast-seo-sidebar-panel"
+				title="Zapier"
+				initialOpen={ true }
+				icon={ <Fragment /> }
+			>
+				<Slot name="YoastZapierPrePublish" />
 			</PluginPrePublishPanel> }
 			<PluginPostPublishPanel
 				className="yoast-seo-sidebar-panel"

--- a/js/src/initializers/block-editor-integration.js
+++ b/js/src/initializers/block-editor-integration.js
@@ -95,7 +95,7 @@ function registerFills( store ) {
 	};
 	const preferences = store.getState().preferences;
 	const analysesEnabled = preferences.isKeywordAnalysisActive || preferences.isContentAnalysisActive;
-	const showZapierPanel = preferences.isZapierIntegrationActive && preferences.isZapierConnected;
+	const showZapierPanel = preferences.isZapierIntegrationActive && ! preferences.isZapierConnected;
 	initiallyOpenDocumentSettings();
 
 	/**

--- a/js/src/redux/reducers/preferences.js
+++ b/js/src/redux/reducers/preferences.js
@@ -4,6 +4,8 @@ import isKeywordAnalysisActive from "../../analysis/isKeywordAnalysisActive";
 import isCornerstoneActive from "../../analysis/isCornerstoneContentActive";
 import isWordFormRecognitionActive from "../../analysis/isWordFormRecognitionActive";
 import isSEMrushIntegrationActive from "../../analysis/isSEMrushIntegrationActive";
+import isZapierIntegrationActive from "../../analysis/isZapierIntegrationActive";
+import isZapierConnected from "../../analysis/isZapierConnected";
 
 /**
  * Gets the default state.
@@ -27,6 +29,8 @@ function getDefaultState() {
 		displaySchemaSettingsFooter: window.wpseoScriptData.metabox.schema.displayFooter,
 		displayFacebook: window.wpseoScriptData.metabox.showSocial.facebook,
 		displayTwitter: window.wpseoScriptData.metabox.showSocial.twitter,
+		isZapierIntegrationActive: isZapierIntegrationActive(),
+		isZapierConnected: isZapierConnected(),
 	};
 }
 

--- a/js/src/ui/publishBox.js
+++ b/js/src/ui/publishBox.js
@@ -67,7 +67,7 @@ function createScoresInPublishBox( type, status ) {
 		.attr( "class", imageScoreClass + " na" );
 
 	publishSection.append( imgElem ).append( spanElem );
-	$( "#misc-publishing-actions" ).append( publishSection );
+	$( "#yoast-seo-publishbox-section" ).prepend( publishSection );
 }
 
 /**
@@ -112,12 +112,12 @@ function scrollToCollapsible( id ) {
 export function initialize() {
 	var notAvailableStatus = "na";
 
-	if ( wpseoScriptData.metabox.contentAnalysisActive ) {
-		createScoresInPublishBox( "content", notAvailableStatus );
-	}
-
 	if ( wpseoScriptData.metabox.keywordAnalysisActive ) {
 		createScoresInPublishBox( "keyword", notAvailableStatus );
+	}
+
+	if ( wpseoScriptData.metabox.contentAnalysisActive ) {
+		createScoresInPublishBox( "content", notAvailableStatus );
 	}
 
 	// Target only the link and use event delegation, as this link doesn't exist on dom ready yet.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This is a companion PR for the related PR on Premium. For the test instructions, please refer to the Premium PR: https://github.com/Yoast/wordpress-seo-premium/pull/3063

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds configuration and layout for the Zapier text to be displayed in the Classic Editor publish box and the block editor pre-publish panel.

## Relevant technical choices:

- adds custom hook into the Classic Editor publish box to make sure the scores _and_ the Zapier text will always be displayed close each other (other plugins may add content here, via the WP hook and with non-predictable priority)
- adds flags for when the Zapier integration is active and connected, and makes these values available for JS (this part needs to be on Free since the related options are on Free)
- adds a Slot to the block editor pre-publish panel: this Slot will be filled with content from Premium: the trouble I had here is that it seems the `PluginPrePublishPanel` component needs to be on Free as it can't be added via Slot/Fill (actually, PluginPrePublishPanel is a Slot/Fill implementation itself)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Please refer to the test instructions on the related Premium PR: https://github.com/Yoast/wordpress-seo-premium/pull/3063

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

See [P3-168]
