### PR TITLE
Add extra post meta field and meta helper method to easily set values

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -214,6 +214,10 @@ class WPSEO_Meta {
 				'type'          => null,
 				'default_value' => '0',
 			],
+			'zapier_trigger_sent' => [
+				'type'          => null,
+				'default_value' => '0',
+			],
 		],
 	];
 

--- a/src/helpers/meta-helper.php
+++ b/src/helpers/meta-helper.php
@@ -51,4 +51,17 @@ class Meta_Helper {
 	public function get_term_value( $term, $taxonomy, $meta = null ) {
 		return WPSEO_Taxonomy_Meta::get_term_meta( $term, $taxonomy, $meta );
 	}
+
+	/**
+	 * Set a custom post meta value.
+	 *
+	 * @param string $key        Internal key of the value to set (without prefix).
+	 * @param mixed  $meta_value The value to set the meta value to.
+	 * @param int    $post_id    Post ID of the post to set the value for.
+	 *
+	 * @return bool Whether the value was changed.
+	 */
+	public function set_value( $key, $meta_value, $post_id ) {
+		return WPSEO_Meta::set_value( $key, $meta_value, $post_id );
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds extra post meta field for the Zapier trigger call.
* Adds meta helper method to easily set values.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds extra post meta field for the Zapier trigger call.
* Adds meta helper method to easily set values.

## Relevant technical choices:

* This PR is necessary to ensure we don't trigger calls to Zapier when a post has already been published.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Please test this with https://github.com/Yoast/wordpress-seo-premium/pull/3062

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
