### PR TITLE
Composer: update YoastCS + Composer Installers

### DIFF
--- a/admin/class-yoast-columns.php
+++ b/admin/class-yoast-columns.php
@@ -51,7 +51,7 @@ class WPSEO_Yoast_Columns implements WPSEO_WordPress_Integration {
 				'<em>',
 				'</em>'
 			);
-		};
+		}
 
 		$screen = get_current_screen();
 		$screen->add_help_tab(

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	},
 	"require": {
 		"php": "^5.6.20||^7.0",
-		"composer/installers": "~1.0",
+		"composer/installers": "^1.9.0",
 		"yoast/i18n-module": "^3.1.1",
 		"pimple/pimple": "^3.2",
 		"psr/log": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -81,8 +81,8 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=768",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=250",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=757",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=249",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs-summary": [

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	},
 	"require-dev": {
 		"yoast/php-development-environment": "^1.0",
-		"yoast/yoastcs": "^2.0.0",
+		"yoast/yoastcs": "^2.1.0",
 		"humbug/php-scoper": "^0.12.0",
 		"brain/monkey": "^2.4",
 		"phpunit/phpunit": "^5.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1177529eda603084e4cd921bbede0da",
+    "content-hash": "051d356d752270df95f6ea501e5ebb38",
     "packages": [
         {
             "name": "composer/installers",
@@ -934,22 +934,22 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.6.2",
+            "version": "v0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a"
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/8001af8eb107fbfcedc31a8b51e20b07d85b457a",
-                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e8d808670b8f882188368faaf1144448c169c0b7",
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "^2|^3"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2 || ^3 || 4.0.x-dev"
             },
             "require-dev": {
                 "composer/composer": "*",
@@ -996,7 +996,7 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2020-01-29T20:22:20+00:00"
+            "time": "2020-06-25T14:57:39+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -2863,16 +2863,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.6",
+            "version": "3.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
@@ -2910,7 +2910,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-08-10T04:50:15+00:00"
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "symfony/config",
@@ -3611,28 +3611,28 @@
         },
         {
             "name": "yoast/yoastcs",
-            "version": "2.0.2",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "0f6d2a18545e4b0751d7966a61f0cfc95a9f8d72"
+                "reference": "8cc5cb79b950588f05a45d68c3849ccfcfef6298"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/0f6d2a18545e4b0751d7966a61f0cfc95a9f8d72",
-                "reference": "0f6d2a18545e4b0751d7966a61f0cfc95a9f8d72",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/8cc5cb79b950588f05a45d68c3849ccfcfef6298",
+                "reference": "8cc5cb79b950588f05a45d68c3849ccfcfef6298",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6.2 || ^0.7",
                 "php": ">=5.4",
                 "phpcompatibility/phpcompatibility-wp": "^2.1.0",
                 "squizlabs/php_codesniffer": "^3.5.0",
                 "wp-coding-standards/wpcs": "^2.2.0"
             },
             "require-dev": {
-                "jakub-onderka/php-console-highlighter": "^0.4",
-                "jakub-onderka/php-parallel-lint": "^1.0",
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpcompatibility/php-compatibility": "^9.2.0",
                 "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
@@ -3658,7 +3658,7 @@
                 "wordpress",
                 "yoast"
             ],
-            "time": "2020-04-02T17:16:18+00:00"
+            "time": "2020-10-27T09:51:49+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,32 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "051d356d752270df95f6ea501e5ebb38",
+    "content-hash": "cff11dd8c5e68d1de323e65103a96f98",
     "packages": [
         {
             "name": "composer/installers",
-            "version": "v1.6.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b"
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/cfcca6b1b60bc4974324efb5783c13dca6932b5b",
-                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b",
+                "url": "https://api.github.com/repos/composer/installers/zipball/b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0"
+                "composer-plugin-api": "^1.0 || ^2.0"
             },
             "replace": {
                 "roundcube/plugin-installer": "*",
                 "shama/baton": "*"
             },
             "require-dev": {
-                "composer/composer": "1.0.*@dev",
-                "phpunit/phpunit": "^4.8.36"
+                "composer/composer": "1.6.* || 2.0.*@dev",
+                "composer/semver": "1.0.* || 2.0.*@dev",
+                "phpunit/phpunit": "^4.8.36",
+                "sebastian/comparator": "^1.2.4",
+                "symfony/process": "^2.3"
             },
             "type": "composer-plugin",
             "extra": {
@@ -65,6 +68,7 @@
                 "Kanboard",
                 "Lan Management System",
                 "MODX Evo",
+                "MantisBT",
                 "Mautic",
                 "Maya",
                 "OXID",
@@ -73,6 +77,7 @@
                 "RadPHP",
                 "SMF",
                 "Thelia",
+                "Whmcs",
                 "WolfCMS",
                 "agl",
                 "aimeos",
@@ -95,6 +100,7 @@
                 "installer",
                 "itop",
                 "joomla",
+                "known",
                 "kohana",
                 "laravel",
                 "lavalite",
@@ -117,6 +123,7 @@
                 "shopware",
                 "silverstripe",
                 "sydes",
+                "sylius",
                 "symfony",
                 "typo3",
                 "wordpress",
@@ -124,7 +131,17 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2018-08-27T06:10:37+00:00"
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-07T06:57:05+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/config/dependency-injection/interface-injection-pass.php
+++ b/config/dependency-injection/interface-injection-pass.php
@@ -49,7 +49,7 @@ class Interface_Injection_Pass implements CompilerPassInterface {
 
 				/*
 				 * The constructor needs to be called with a comma separated enumeration of objects.
-				 * example:				 function __construct( Fruit ...$allFruit )
+				 * example:              function __construct( Fruit ...$allFruit )
 				 * actually expands to:  function __construct( Fruit $f1, Fruit $f2, Fruit $f3, Fruit $fn )
 				 * We have to start this array at the position of the splat argument, and inject the next
 				 * matching type on the next position, and so on, until all matching types have been injected.

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -154,16 +154,16 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	/**
 	 * Meta_Tags_Context constructor.
 	 *
-	 * @param Options_Helper       $options                  The options helper.
-	 * @param Url_Helper           $url                      The url helper.
-	 * @param Image_Helper         $image                    The image helper.
-	 * @param ID_Helper            $id_helper                The schema id helper.
-	 * @param WPSEO_Replace_Vars   $replace_vars             The replace vars helper.
-	 * @param Site_Helper          $site                     The site helper.
-	 * @param User_Helper          $user                     The user helper.
-	 * @param Permalink_Helper     $permalink_helper         The permalink helper.
-	 * @param Indexable_Helper     $indexable_helper         The indexable helper.
-	 * @param Indexable_Repository $indexable_repository     The indexable repository.
+	 * @param Options_Helper       $options              The options helper.
+	 * @param Url_Helper           $url                  The url helper.
+	 * @param Image_Helper         $image                The image helper.
+	 * @param ID_Helper            $id_helper            The schema id helper.
+	 * @param WPSEO_Replace_Vars   $replace_vars         The replace vars helper.
+	 * @param Site_Helper          $site                 The site helper.
+	 * @param User_Helper          $user                 The user helper.
+	 * @param Permalink_Helper     $permalink_helper     The permalink helper.
+	 * @param Indexable_Helper     $indexable_helper     The indexable helper.
+	 * @param Indexable_Repository $indexable_repository The indexable repository.
 	 */
 	public function __construct(
 		Options_Helper $options,

--- a/src/deprecated/src/integrations/admin/indexation-integration.php
+++ b/src/deprecated/src/integrations/admin/indexation-integration.php
@@ -47,7 +47,7 @@ class Indexation_Integration implements Integration_Interface {
 	 * @param Indexable_Term_Indexation_Action              $term_indexation              The term indexation action.
 	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation The archive indexation action.
 	 * @param Indexable_General_Indexation_Action           $general_indexation           The general indexation action.
-	 * @param Indexable_Indexing_Complete_Action            $complete_indexation_action The complete indexation action.
+	 * @param Indexable_Indexing_Complete_Action            $complete_indexation_action   The complete indexation action.
 	 * @param Options_Helper                                $options_helper               The options helper.
 	 * @param WPSEO_Admin_Asset_Manager                     $asset_manager                The admin asset manager.
 	 * @param Yoast_Tools_Page_Conditional                  $yoast_tools_page_conditional The Yoast tools page conditional.

--- a/src/exceptions/oauth/authentication-failed-exception.php
+++ b/src/exceptions/oauth/authentication-failed-exception.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\WP\SEO\Exceptions\OAuth
- */
 
 namespace Yoast\WP\SEO\Exceptions\OAuth;
 

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -107,12 +107,12 @@ class Indexing_Notification_Integration implements Integration_Interface {
 	/**
 	 * Indexing_Notification_Integration constructor.
 	 *
-	 * @param Yoast_Notification_Center $notification_center  The notification center.
-	 * @param Product_Helper            $product_helper       The product helper.
-	 * @param Current_Page_Helper       $page_helper          The current page helper.
-	 * @param Short_Link_Helper         $short_link_helper    The short link helper.
-	 * @param Notification_Helper       $notification_helper  The notification helper.
-	 * @param Indexing_Helper           $indexing_helper      The indexing helper.
+	 * @param Yoast_Notification_Center $notification_center The notification center.
+	 * @param Product_Helper            $product_helper      The product helper.
+	 * @param Current_Page_Helper       $page_helper         The current page helper.
+	 * @param Short_Link_Helper         $short_link_helper   The short link helper.
+	 * @param Notification_Helper       $notification_helper The notification helper.
+	 * @param Indexing_Helper           $indexing_helper     The indexing helper.
 	 */
 	public function __construct(
 		Yoast_Notification_Center $notification_center,

--- a/tests/unit/actions/indexing/indexable-post-type-archive-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-type-archive-indexation-action-test.php
@@ -51,6 +51,9 @@ class Indexable_Post_Type_Archive_Indexation_Action_Test extends TestCase {
 	 */
 	protected $instance;
 
+	/**
+	 * Set up the mocks before each test.
+	 */
 	public function setUp() {
 		$this->repository = Mockery::mock( Indexable_Repository::class );
 		$this->builder    = Mockery::mock( Indexable_Builder::class );

--- a/tests/unit/actions/semrush/semrush-options-action-test.php
+++ b/tests/unit/actions/semrush/semrush-options-action-test.php
@@ -28,7 +28,6 @@ class SEMrush_Options_Action_Test extends TestCase {
 	protected $instance;
 
 	/**
-	 *
 	 * The options helper.
 	 *
 	 * @var Mockery\MockInterface|Options_Helper

--- a/tests/unit/helpers/schema/html-helper-test.php
+++ b/tests/unit/helpers/schema/html-helper-test.php
@@ -20,6 +20,9 @@ class HTML_Helper_Test extends TestCase {
 	 */
 	private $instance;
 
+	/**
+	 * Set up a new instance of the class under test before each test.
+	 */
 	public function setUp() {
 		parent::setUp();
 

--- a/tests/unit/inc/health-check-ryte-test.php
+++ b/tests/unit/inc/health-check-ryte-test.php
@@ -27,6 +27,9 @@ class Health_Check_Ryte_Test extends TestCase {
 	 */
 	private $health_check;
 
+	/**
+	 * Set up the mock classes.
+	 */
 	public function setUp() {
 		parent::setUp();
 

--- a/tests/unit/integrations/admin/cron-integration-test.php
+++ b/tests/unit/integrations/admin/cron-integration-test.php
@@ -27,8 +27,16 @@ class Cron_Integration_Test extends TestCase {
 	 */
 	protected $instance;
 
+	/**
+	 * Date Helper class mock.
+	 *
+	 * @var Date_Helper
+	 */
 	protected $date_helper;
 
+	/**
+	 * Set up the fixtures for the tests.
+	 */
 	public function setUp() {
 		parent::setUp();
 

--- a/tests/unit/presenters/admin/indexing-failed-notification-presenter-test.php
+++ b/tests/unit/presenters/admin/indexing-failed-notification-presenter-test.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace Yoast\WP\SEO\Tests\Unit\Presenters\Admin;
+
 use Brain\Monkey;
+use Mockery;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Presenters\Admin\Indexing_Failed_Notification_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;

--- a/tests/unit/presenters/admin/indexing-list-item-presenter-test.php
+++ b/tests/unit/presenters/admin/indexing-list-item-presenter-test.php
@@ -1,6 +1,8 @@
 <?php
 
+namespace Yoast\WP\SEO\Tests\Unit\Presenters\Admin;
 
+use Mockery;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Presenters\Admin\Indexing_List_Item_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;


### PR DESCRIPTION
## Context

* Updated dev dependencies

## Summary

This PR can be summarized in the following changelog entry:

* Updated dev dependencies

## Relevant technical choices:

### Composer: update YoastCS to v 2.1.0

* Updated YoastCS from `2.0.2` to `2.1.0`.
* Updated PHP_CodeSniffer from `3.5.5` to `3.5.8`.
* Updated the DealerDirect Composer plugin from `0.6.2` to `0.7.0` (which is  compatible with Composer 2.0).

Relevant changes in YoastCS:
* The minimum supported WP version has changed to `5.4`.
* A new check for test doubles being named as such.
* A few bugfixes.
* Various sniffs now provide metrics.

Relevant changes in PHPCS:
* PHPCS will now _run_ without problems on PHP 8.
    Note: it will not necessarily handle all code using PHP 8 syntax correctly  yet, though it does contain preliminary support for various syntaxes.
* Lots of bugfixes.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/2.1.0
* https://github.com/squizlabs/php_codesniffer/releases

### Composer: update the Composer installers dependency

Update the Composer Installers dependency from `1.6.0` to `1.9.0` to fix  compatibility with Composer 2.0.

Based on the changelog, this shouldn't have any other impact.

Ref: https://github.com/composer/installers/releases


### CS: various minor fixes

### QA: add missing namespace statements (tests)

.. and missing `use` statement.

### CS: update the thresholds 

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ Verify if the Travis build passes.