### PR TITLE
More utils cleanup

### DIFF
--- a/admin/class-yoast-plugin-conflict.php
+++ b/admin/class-yoast-plugin-conflict.php
@@ -311,7 +311,7 @@ class Yoast_Plugin_Conflict {
 	 *
 	 * @param string $plugin Plugin path relative to plugins directory.
 	 *
-	 * @return string|bool
+	 * @return string|bool Plugin name or false when no name is set.
 	 */
 	protected function get_plugin_name( $plugin ) {
 		$plugin_details = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );

--- a/admin/class-yoast-plugin-conflict.php
+++ b/admin/class-yoast-plugin-conflict.php
@@ -126,7 +126,7 @@ class Yoast_Plugin_Conflict {
 
 		$plugin_names = [];
 		foreach ( $plugins as $plugin ) {
-			$name = WPSEO_Utils::get_plugin_name( $plugin );
+			$name = $this->get_plugin_name( $plugin );
 			if ( ! empty( $name ) ) {
 				$plugin_names[] = '<em>' . $name . '</em>';
 			}
@@ -195,7 +195,7 @@ class Yoast_Plugin_Conflict {
 
 		foreach ( $this->active_plugins[ $plugin_section ] as $plugin_file ) {
 
-			$plugin_name = WPSEO_Utils::get_plugin_name( $plugin_file );
+			$plugin_name = $this->get_plugin_name( $plugin_file );
 
 			$error_message = '';
 			/* translators: %1$s: 'Facebook & Open Graph' plugin name(s) of possibly conflicting plugin(s), %2$s to Yoast SEO */
@@ -203,7 +203,7 @@ class Yoast_Plugin_Conflict {
 			$error_message .= '<p>' . sprintf( $readable_plugin_section, 'Yoast SEO', $plugin_name ) . '</p>';
 
 			/* translators: %s: 'Facebook' plugin name of possibly conflicting plugin */
-			$error_message .= '<a class="button button-primary" href="' . wp_nonce_url( 'plugins.php?action=deactivate&amp;plugin=' . $plugin_file . '&amp;plugin_status=all', 'deactivate-plugin_' . $plugin_file ) . '">' . sprintf( __( 'Deactivate %s', 'wordpress-seo' ), WPSEO_Utils::get_plugin_name( $plugin_file ) ) . '</a> ';
+			$error_message .= '<a class="button button-primary" href="' . wp_nonce_url( 'plugins.php?action=deactivate&amp;plugin=' . $plugin_file . '&amp;plugin_status=all', 'deactivate-plugin_' . $plugin_file ) . '">' . sprintf( __( 'Deactivate %s', 'wordpress-seo' ), $this->get_plugin_name( $plugin_file ) ) . '</a> ';
 
 			$identifier = $this->get_notification_identifier( $plugin_file );
 
@@ -304,6 +304,23 @@ class Yoast_Plugin_Conflict {
 				return $plugin_section;
 			}
 		}
+	}
+
+	/**
+	 * Get plugin name from file.
+	 *
+	 * @param string $plugin Plugin path relative to plugins directory.
+	 *
+	 * @return string|bool
+	 */
+	protected function get_plugin_name( $plugin ) {
+		$plugin_details = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
+
+		if ( $plugin_details['Name'] !== '' ) {
+			return $plugin_details['Name'];
+		}
+
+		return false;
 	}
 
 	/**

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -39,7 +39,7 @@ class WPSEO_Admin_Menu extends WPSEO_Base_Menu {
 				$this->get_manage_capability(),
 				$this->get_page_identifier(),
 				$this->get_admin_page_callback(),
-				WPSEO_Utils::get_icon_svg(),
+				$this->get_icon_svg(),
 				'99.31337'
 			);
 

--- a/admin/menu/class-base-menu.php
+++ b/admin/menu/class-base-menu.php
@@ -275,7 +275,7 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 	 *
 	 * @param bool $base64 Whether or not to return base64'd output.
 	 *
-	 * @return string
+	 * @return string SVG icon.
 	 */
 	public function get_icon_svg( $base64 = true ) {
 		$svg = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="100%" height="100%" style="fill:#82878c" viewBox="0 0 512 512" role="img" aria-hidden="true" focusable="false"><g><g><g><g><path d="M203.6,395c6.8-17.4,6.8-36.6,0-54l-79.4-204h70.9l47.7,149.4l74.8-207.6H116.4c-41.8,0-76,34.2-76,76V357c0,41.8,34.2,76,76,76H173C189,424.1,197.6,410.3,203.6,395z"/></g><g><path d="M471.6,154.8c0-41.8-34.2-76-76-76h-3L285.7,365c-9.6,26.7-19.4,49.3-30.3,68h216.2V154.8z"/></g></g><path stroke-width="2.974" stroke-miterlimit="10" d="M338,1.3l-93.3,259.1l-42.1-131.9h-89.1l83.8,215.2c6,15.5,6,32.5,0,48c-7.4,19-19,37.3-53,41.9l-7.2,1v76h8.3c81.7,0,118.9-57.2,149.6-142.9L431.6,1.3H338z M279.4,362c-32.9,92-67.6,128.7-125.7,131.8v-45c37.5-7.5,51.3-31,59.1-51.1c7.5-19.3,7.5-40.7,0-60l-75-192.7h52.8l53.3,166.8l105.9-294h58.1L279.4,362z"/></g></g></svg>';

--- a/admin/menu/class-base-menu.php
+++ b/admin/menu/class-base-menu.php
@@ -136,7 +136,7 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 			$submenu_page[3],
 			$submenu_page[4],
 			$submenu_page[5],
-			WPSEO_Utils::get_icon_svg(),
+			$this->get_icon_svg(),
 			'99.31337'
 		);
 
@@ -268,5 +268,22 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 		}
 
 		return $title;
+	}
+
+	/**
+	 * Returns a base64 URL for the svg for use in the menu.
+	 *
+	 * @param bool $base64 Whether or not to return base64'd output.
+	 *
+	 * @return string
+	 */
+	public function get_icon_svg( $base64 = true ) {
+		$svg = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="100%" height="100%" style="fill:#82878c" viewBox="0 0 512 512" role="img" aria-hidden="true" focusable="false"><g><g><g><g><path d="M203.6,395c6.8-17.4,6.8-36.6,0-54l-79.4-204h70.9l47.7,149.4l74.8-207.6H116.4c-41.8,0-76,34.2-76,76V357c0,41.8,34.2,76,76,76H173C189,424.1,197.6,410.3,203.6,395z"/></g><g><path d="M471.6,154.8c0-41.8-34.2-76-76-76h-3L285.7,365c-9.6,26.7-19.4,49.3-30.3,68h216.2V154.8z"/></g></g><path stroke-width="2.974" stroke-miterlimit="10" d="M338,1.3l-93.3,259.1l-42.1-131.9h-89.1l83.8,215.2c6,15.5,6,32.5,0,48c-7.4,19-19,37.3-53,41.9l-7.2,1v76h8.3c81.7,0,118.9-57.2,149.6-142.9L431.6,1.3H338z M279.4,362c-32.9,92-67.6,128.7-125.7,131.8v-45c37.5-7.5,51.3-31,59.1-51.1c7.5-19.3,7.5-40.7,0-60l-75-192.7h52.8l53.3,166.8l105.9-294h58.1L279.4,362z"/></g></g></svg>';
+
+		if ( $base64 ) {
+			return 'data:image/svg+xml;base64,' . base64_encode( $svg );
+		}
+
+		return $svg;
 	}
 }

--- a/admin/menu/class-network-admin-menu.php
+++ b/admin/menu/class-network-admin-menu.php
@@ -36,7 +36,7 @@ class WPSEO_Network_Admin_Menu extends WPSEO_Base_Menu {
 			$this->get_manage_capability(),
 			$this->get_page_identifier(),
 			[ $this, 'network_config_page' ],
-			WPSEO_Utils::get_icon_svg()
+			$this->get_icon_svg()
 		);
 
 		$submenu_pages = $this->get_submenu_pages();

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -812,58 +812,6 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Returns the SVG for the traffic light in the metabox.
-	 *
-	 * @return string
-	 */
-	public static function traffic_light_svg() {
-		return <<<'SVG'
-<svg class="yst-traffic-light init" version="1.1" xmlns="http://www.w3.org/2000/svg"
-	 role="img" aria-hidden="true" focusable="false"
-	 x="0px" y="0px" viewBox="0 0 30 47" enable-background="new 0 0 30 47" xml:space="preserve">
-<g id="BG_1_">
-</g>
-<g id="traffic_light">
-	<g>
-		<g>
-			<g>
-				<path fill="#5B2942" d="M22,0H8C3.6,0,0,3.6,0,7.9v31.1C0,43.4,3.6,47,8,47h14c4.4,0,8-3.6,8-7.9V7.9C30,3.6,26.4,0,22,0z
-					 M27.5,38.8c0,3.1-2.6,5.7-5.8,5.7H8.3c-3.2,0-5.8-2.5-5.8-5.7V8.3c0-1.5,0.6-2.9,1.7-4c1.1-1,2.5-1.6,4.1-1.6h13.4
-					c1.5,0,3,0.6,4.1,1.6c1.1,1.1,1.7,2.5,1.7,4V38.8z"/>
-			</g>
-			<g class="traffic-light-color traffic-light-red">
-				<ellipse fill="#C8C8C8" cx="15" cy="23.5" rx="5.7" ry="5.6"/>
-				<ellipse fill="#DC3232" cx="15" cy="10.9" rx="5.7" ry="5.6"/>
-				<ellipse fill="#C8C8C8" cx="15" cy="36.1" rx="5.7" ry="5.6"/>
-			</g>
-			<g class="traffic-light-color traffic-light-orange">
-				<ellipse fill="#F49A00" cx="15" cy="23.5" rx="5.7" ry="5.6"/>
-				<ellipse fill="#C8C8C8" cx="15" cy="10.9" rx="5.7" ry="5.6"/>
-				<ellipse fill="#C8C8C8" cx="15" cy="36.1" rx="5.7" ry="5.6"/>
-			</g>
-			<g class="traffic-light-color traffic-light-green">
-				<ellipse fill="#C8C8C8" cx="15" cy="23.5" rx="5.7" ry="5.6"/>
-				<ellipse fill="#C8C8C8" cx="15" cy="10.9" rx="5.7" ry="5.6"/>
-				<ellipse fill="#63B22B" cx="15" cy="36.1" rx="5.7" ry="5.6"/>
-			</g>
-			<g class="traffic-light-color traffic-light-empty">
-				<ellipse fill="#C8C8C8" cx="15" cy="23.5" rx="5.7" ry="5.6"/>
-				<ellipse fill="#C8C8C8" cx="15" cy="10.9" rx="5.7" ry="5.6"/>
-				<ellipse fill="#C8C8C8" cx="15" cy="36.1" rx="5.7" ry="5.6"/>
-			</g>
-			<g class="traffic-light-color traffic-light-init">
-				<ellipse fill="#C8C8C8" cx="15" cy="23.5" rx="5.7" ry="5.6"/>
-				<ellipse fill="#C8C8C8" cx="15" cy="10.9" rx="5.7" ry="5.6"/>
-				<ellipse fill="#C8C8C8" cx="15" cy="36.1" rx="5.7" ry="5.6"/>
-			</g>
-		</g>
-	</g>
-</g>
-</svg>
-SVG;
-	}
-
-	/**
 	 * Checks if the WP-REST-API is available.
 	 *
 	 * @since 3.6
@@ -1449,5 +1397,62 @@ SVG;
 			'@graph'   => $graph,
 		];
 		return "<script type='application/ld+json' class='" . esc_attr( $class ) . "'>" . self::format_json_encode( $output ) . '</script>' . "\n";
+	}
+
+	/**
+	 * Returns the SVG for the traffic light in the metabox.
+	 *
+	 * @deprecated 15.4
+	 * @codeCoverageIgnore
+	 *
+	 * @return string
+	 */
+	public static function traffic_light_svg() {
+		_deprecated_function( __METHOD__, 'WPSEO 15.4' );
+
+		return <<<'SVG'
+<svg class="yst-traffic-light init" version="1.1" xmlns="http://www.w3.org/2000/svg"
+	 role="img" aria-hidden="true" focusable="false"
+	 x="0px" y="0px" viewBox="0 0 30 47" enable-background="new 0 0 30 47" xml:space="preserve">
+<g id="BG_1_">
+</g>
+<g id="traffic_light">
+	<g>
+		<g>
+			<g>
+				<path fill="#5B2942" d="M22,0H8C3.6,0,0,3.6,0,7.9v31.1C0,43.4,3.6,47,8,47h14c4.4,0,8-3.6,8-7.9V7.9C30,3.6,26.4,0,22,0z
+					 M27.5,38.8c0,3.1-2.6,5.7-5.8,5.7H8.3c-3.2,0-5.8-2.5-5.8-5.7V8.3c0-1.5,0.6-2.9,1.7-4c1.1-1,2.5-1.6,4.1-1.6h13.4
+					c1.5,0,3,0.6,4.1,1.6c1.1,1.1,1.7,2.5,1.7,4V38.8z"/>
+			</g>
+			<g class="traffic-light-color traffic-light-red">
+				<ellipse fill="#C8C8C8" cx="15" cy="23.5" rx="5.7" ry="5.6"/>
+				<ellipse fill="#DC3232" cx="15" cy="10.9" rx="5.7" ry="5.6"/>
+				<ellipse fill="#C8C8C8" cx="15" cy="36.1" rx="5.7" ry="5.6"/>
+			</g>
+			<g class="traffic-light-color traffic-light-orange">
+				<ellipse fill="#F49A00" cx="15" cy="23.5" rx="5.7" ry="5.6"/>
+				<ellipse fill="#C8C8C8" cx="15" cy="10.9" rx="5.7" ry="5.6"/>
+				<ellipse fill="#C8C8C8" cx="15" cy="36.1" rx="5.7" ry="5.6"/>
+			</g>
+			<g class="traffic-light-color traffic-light-green">
+				<ellipse fill="#C8C8C8" cx="15" cy="23.5" rx="5.7" ry="5.6"/>
+				<ellipse fill="#C8C8C8" cx="15" cy="10.9" rx="5.7" ry="5.6"/>
+				<ellipse fill="#63B22B" cx="15" cy="36.1" rx="5.7" ry="5.6"/>
+			</g>
+			<g class="traffic-light-color traffic-light-empty">
+				<ellipse fill="#C8C8C8" cx="15" cy="23.5" rx="5.7" ry="5.6"/>
+				<ellipse fill="#C8C8C8" cx="15" cy="10.9" rx="5.7" ry="5.6"/>
+				<ellipse fill="#C8C8C8" cx="15" cy="36.1" rx="5.7" ry="5.6"/>
+			</g>
+			<g class="traffic-light-color traffic-light-init">
+				<ellipse fill="#C8C8C8" cx="15" cy="23.5" rx="5.7" ry="5.6"/>
+				<ellipse fill="#C8C8C8" cx="15" cy="10.9" rx="5.7" ry="5.6"/>
+				<ellipse fill="#C8C8C8" cx="15" cy="36.1" rx="5.7" ry="5.6"/>
+			</g>
+		</g>
+	</g>
+</g>
+</svg>
+SVG;
 	}
 }

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1062,15 +1062,6 @@ SVG;
 	 * In case of a multisite setup we return the network_home_url.
 	 *
 	 * @return string The home url.
-	 */
-
-	/**
-	 * Returns the unfiltered home URL.
-	 *
-	 * In case WPML is installed, returns the original home_url and not the WPML version.
-	 * In case of a multisite setup we return the network_home_url.
-	 *
-	 * @return string The home url.
 	 *
 	 * @codeCoverageIgnore
 	 */

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -22,28 +22,6 @@ class WPSEO_Utils {
 	public static $has_filters;
 
 	/**
-	 * Check whether the current user is allowed to access the configuration.
-	 *
-	 * @since 1.8.0
-	 *
-	 * @return boolean
-	 */
-	public static function grant_access() {
-		// @todo Add deprecation warning.
-		if ( ! is_multisite() ) {
-			return true;
-		}
-
-		$options = get_site_option( 'wpseo_ms' );
-
-		if ( empty( $options['access'] ) || $options['access'] === 'admin' ) {
-			return current_user_can( 'wpseo_manage_options' );
-		}
-
-		return is_super_admin();
-	}
-
-	/**
 	 * Check whether file editing is allowed for the .htaccess and robots.txt files.
 	 *
 	 * {@internal current_user_can() checks internally whether a user is on wp-ms and adjusts accordingly.}}
@@ -1464,5 +1442,31 @@ SVG;
 		}
 
 		return $svg;
+	}
+
+	/**
+	 * Check whether the current user is allowed to access the configuration.
+	 *
+	 * @deprecated 15.4
+	 * @codeCoverageIgnore
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return boolean
+	 */
+	public static function grant_access() {
+		_deprecated_function( __METHOD__, 'WPSEO 15.4' );
+
+		if ( ! is_multisite() ) {
+			return true;
+		}
+
+		$options = get_site_option( 'wpseo_ms' );
+
+		if ( empty( $options['access'] ) || $options['access'] === 'admin' ) {
+			return current_user_can( 'wpseo_manage_options' );
+		}
+
+		return is_super_admin();
 	}
 }

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -674,25 +674,6 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Get plugin name from file.
-	 *
-	 * @since 2.3.3
-	 *
-	 * @param string $plugin Plugin path relative to plugins directory.
-	 *
-	 * @return string|bool
-	 */
-	public static function get_plugin_name( $plugin ) {
-		$plugin_details = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
-
-		if ( $plugin_details['Name'] !== '' ) {
-			return $plugin_details['Name'];
-		}
-
-		return false;
-	}
-
-	/**
 	 * Retrieves the sitename.
 	 *
 	 * @since 3.0.0
@@ -1454,5 +1435,29 @@ class WPSEO_Utils {
 </g>
 </svg>
 SVG;
+	}
+
+	/**
+	 * Get plugin name from file.
+	 *
+	 * @deprecated 15.4
+	 * @codeCoverageIgnore
+	 *
+	 * @since 2.3.3
+	 *
+	 * @param string $plugin Plugin path relative to plugins directory.
+	 *
+	 * @return string|bool
+	 */
+	public static function get_plugin_name( $plugin ) {
+		_deprecated_function( __METHOD__, 'WPSEO 15.4' );
+
+		$plugin_details = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
+
+		if ( $plugin_details['Name'] !== '' ) {
+			return $plugin_details['Name'];
+		}
+
+		return false;
 	}
 }

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1129,44 +1129,6 @@ SVG;
 	}
 
 	/**
-	 * Output a Schema blob.
-	 *
-	 * @param array  $graph The Schema graph array to output.
-	 * @param string $class The (optional) class to add to the script tag.
-	 *
-	 * @return bool
-	 */
-	public static function schema_output( $graph, $class = 'yoast-schema-graph' ) {
-		if ( ! is_array( $graph ) || empty( $graph ) ) {
-			return false;
-		}
-
-		// phpcs:ignore WordPress.Security.EscapeOutput -- Escaping happens in WPSEO_Utils::schema_tag, which should be whitelisted.
-		echo self::schema_tag( $graph, $class );
-		return true;
-	}
-
-	/**
-	 * Returns a script tag with Schema blob.
-	 *
-	 * @param array  $graph The Schema graph array to output.
-	 * @param string $class The (optional) class to add to the script tag.
-	 *
-	 * @return false|string A schema blob with script tags.
-	 */
-	public static function schema_tag( $graph, $class = 'yoast-schema-graph' ) {
-		if ( ! is_array( $graph ) || empty( $graph ) ) {
-			return false;
-		}
-
-		$output = [
-			'@context' => 'https://schema.org',
-			'@graph'   => $graph,
-		];
-		return "<script type='application/ld+json' class='" . esc_attr( $class ) . "'>" . self::format_json_encode( $output ) . '</script>' . "\n";
-	}
-
-	/**
 	 * Extends the allowed post tags with accessibility-related attributes.
 	 *
 	 * @param array $allowed_post_tags The allowed post tags.
@@ -1448,5 +1410,53 @@ SVG;
 		_deprecated_function( __METHOD__, 'WPSEO 15.3' );
 
 		return YoastSEO()->helpers->woocommerce->is_active();
+	}
+
+	/**
+	 * Output a Schema blob.
+	 *
+	 * @deprecated 15.4
+	 * @codeCoverageIgnore
+	 *
+	 * @param array  $graph The Schema graph array to output.
+	 * @param string $class The (optional) class to add to the script tag.
+	 *
+	 * @return bool
+	 */
+	public static function schema_output( $graph, $class = 'yoast-schema-graph' ) {
+		_deprecated_function( __METHOD__, 'WPSEO 15.4' );
+
+		if ( ! is_array( $graph ) || empty( $graph ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.Security.EscapeOutput -- Escaping happens in WPSEO_Utils::schema_tag, which should be whitelisted.
+		echo self::schema_tag( $graph, $class );
+		return true;
+	}
+
+	/**
+	 * Returns a script tag with Schema blob.
+	 *
+	 * @deprecated 15.4
+	 * @codeCoverageIgnore
+	 *
+	 * @param array  $graph The Schema graph array to output.
+	 * @param string $class The (optional) class to add to the script tag.
+	 *
+	 * @return false|string A schema blob with script tags.
+	 */
+	public static function schema_tag( $graph, $class = 'yoast-schema-graph' ) {
+		_deprecated_function( __METHOD__, 'WPSEO 15.4' );
+
+		if ( ! is_array( $graph ) || empty( $graph ) ) {
+			return false;
+		}
+
+		$output = [
+			'@context' => 'https://schema.org',
+			'@graph'   => $graph,
+		];
+		return "<script type='application/ld+json' class='" . esc_attr( $class ) . "'>" . self::format_json_encode( $output ) . '</script>' . "\n";
 	}
 }

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1292,9 +1292,9 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Output a Schema blob.
+	 * Outputs a Schema blob.
 	 *
-	 * @deprecated 15.4
+	 * @deprecated 15.5
 	 * @codeCoverageIgnore
 	 *
 	 * @param array  $graph The Schema graph array to output.
@@ -1303,7 +1303,7 @@ class WPSEO_Utils {
 	 * @return bool
 	 */
 	public static function schema_output( $graph, $class = 'yoast-schema-graph' ) {
-		_deprecated_function( __METHOD__, 'WPSEO 15.4' );
+		_deprecated_function( __METHOD__, 'WPSEO 15.5' );
 
 		if ( ! is_array( $graph ) || empty( $graph ) ) {
 			return false;
@@ -1317,7 +1317,7 @@ class WPSEO_Utils {
 	/**
 	 * Returns a script tag with Schema blob.
 	 *
-	 * @deprecated 15.4
+	 * @deprecated 15.5
 	 * @codeCoverageIgnore
 	 *
 	 * @param array  $graph The Schema graph array to output.
@@ -1326,7 +1326,7 @@ class WPSEO_Utils {
 	 * @return false|string A schema blob with script tags.
 	 */
 	public static function schema_tag( $graph, $class = 'yoast-schema-graph' ) {
-		_deprecated_function( __METHOD__, 'WPSEO 15.4' );
+		_deprecated_function( __METHOD__, 'WPSEO 15.5' );
 
 		if ( ! is_array( $graph ) || empty( $graph ) ) {
 			return false;
@@ -1342,13 +1342,13 @@ class WPSEO_Utils {
 	/**
 	 * Returns the SVG for the traffic light in the metabox.
 	 *
-	 * @deprecated 15.4
+	 * @deprecated 15.5
 	 * @codeCoverageIgnore
 	 *
 	 * @return string
 	 */
 	public static function traffic_light_svg() {
-		_deprecated_function( __METHOD__, 'WPSEO 15.4' );
+		_deprecated_function( __METHOD__, 'WPSEO 15.5' );
 
 		return <<<'SVG'
 <svg class="yst-traffic-light init" version="1.1" xmlns="http://www.w3.org/2000/svg"
@@ -1397,9 +1397,9 @@ SVG;
 	}
 
 	/**
-	 * Get plugin name from file.
+	 * Gets the plugin name from file.
 	 *
-	 * @deprecated 15.4
+	 * @deprecated 15.5
 	 * @codeCoverageIgnore
 	 *
 	 * @since 2.3.3
@@ -1409,7 +1409,7 @@ SVG;
 	 * @return string|bool
 	 */
 	public static function get_plugin_name( $plugin ) {
-		_deprecated_function( __METHOD__, 'WPSEO 15.4' );
+		_deprecated_function( __METHOD__, 'WPSEO 15.5' );
 
 		$plugin_details = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
 
@@ -1423,7 +1423,7 @@ SVG;
 	/**
 	 * Returns a base64 URL for the svg for use in the menu.
 	 *
-	 * @deprecated 15.4
+	 * @deprecated 15.5
 	 * @codeCoverageIgnore
 	 *
 	 * @since 3.3.0
@@ -1433,7 +1433,7 @@ SVG;
 	 * @return string
 	 */
 	public static function get_icon_svg( $base64 = true ) {
-		_deprecated_function( __METHOD__, 'WPSEO 15.4' );
+		_deprecated_function( __METHOD__, 'WPSEO 15.5' );
 
 		$svg = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="100%" height="100%" style="fill:#82878c" viewBox="0 0 512 512" role="img" aria-hidden="true" focusable="false"><g><g><g><g><path d="M203.6,395c6.8-17.4,6.8-36.6,0-54l-79.4-204h70.9l47.7,149.4l74.8-207.6H116.4c-41.8,0-76,34.2-76,76V357c0,41.8,34.2,76,76,76H173C189,424.1,197.6,410.3,203.6,395z"/></g><g><path d="M471.6,154.8c0-41.8-34.2-76-76-76h-3L285.7,365c-9.6,26.7-19.4,49.3-30.3,68h216.2V154.8z"/></g></g><path stroke-width="2.974" stroke-miterlimit="10" d="M338,1.3l-93.3,259.1l-42.1-131.9h-89.1l83.8,215.2c6,15.5,6,32.5,0,48c-7.4,19-19,37.3-53,41.9l-7.2,1v76h8.3c81.7,0,118.9-57.2,149.6-142.9L431.6,1.3H338z M279.4,362c-32.9,92-67.6,128.7-125.7,131.8v-45c37.5-7.5,51.3-31,59.1-51.1c7.5-19.3,7.5-40.7,0-60l-75-192.7h52.8l53.3,166.8l105.9-294h58.1L279.4,362z"/></g></g></svg>';
 
@@ -1445,9 +1445,9 @@ SVG;
 	}
 
 	/**
-	 * Check whether the current user is allowed to access the configuration.
+	 * Checks whether the current user is allowed to access the configuration.
 	 *
-	 * @deprecated 15.4
+	 * @deprecated 15.5
 	 * @codeCoverageIgnore
 	 *
 	 * @since 1.8.0
@@ -1455,7 +1455,7 @@ SVG;
 	 * @return boolean
 	 */
 	public static function grant_access() {
-		_deprecated_function( __METHOD__, 'WPSEO 15.4' );
+		_deprecated_function( __METHOD__, 'WPSEO 15.5' );
 
 		if ( ! is_multisite() ) {
 			return true;

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -774,25 +774,6 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Returns a base64 URL for the svg for use in the menu.
-	 *
-	 * @since 3.3.0
-	 *
-	 * @param bool $base64 Whether or not to return base64'd output.
-	 *
-	 * @return string
-	 */
-	public static function get_icon_svg( $base64 = true ) {
-		$svg = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="100%" height="100%" style="fill:#82878c" viewBox="0 0 512 512" role="img" aria-hidden="true" focusable="false"><g><g><g><g><path d="M203.6,395c6.8-17.4,6.8-36.6,0-54l-79.4-204h70.9l47.7,149.4l74.8-207.6H116.4c-41.8,0-76,34.2-76,76V357c0,41.8,34.2,76,76,76H173C189,424.1,197.6,410.3,203.6,395z"/></g><g><path d="M471.6,154.8c0-41.8-34.2-76-76-76h-3L285.7,365c-9.6,26.7-19.4,49.3-30.3,68h216.2V154.8z"/></g></g><path stroke-width="2.974" stroke-miterlimit="10" d="M338,1.3l-93.3,259.1l-42.1-131.9h-89.1l83.8,215.2c6,15.5,6,32.5,0,48c-7.4,19-19,37.3-53,41.9l-7.2,1v76h8.3c81.7,0,118.9-57.2,149.6-142.9L431.6,1.3H338z M279.4,362c-32.9,92-67.6,128.7-125.7,131.8v-45c37.5-7.5,51.3-31,59.1-51.1c7.5-19.3,7.5-40.7,0-60l-75-192.7h52.8l53.3,166.8l105.9-294h58.1L279.4,362z"/></g></g></svg>';
-
-		if ( $base64 ) {
-			return 'data:image/svg+xml;base64,' . base64_encode( $svg );
-		}
-
-		return $svg;
-	}
-
-	/**
 	 * Checks if the WP-REST-API is available.
 	 *
 	 * @since 3.6
@@ -1459,5 +1440,29 @@ SVG;
 		}
 
 		return false;
+	}
+
+	/**
+	 * Returns a base64 URL for the svg for use in the menu.
+	 *
+	 * @deprecated 15.4
+	 * @codeCoverageIgnore
+	 *
+	 * @since 3.3.0
+	 *
+	 * @param bool $base64 Whether or not to return base64'd output.
+	 *
+	 * @return string
+	 */
+	public static function get_icon_svg( $base64 = true ) {
+		_deprecated_function( __METHOD__, 'WPSEO 15.4' );
+
+		$svg = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="100%" height="100%" style="fill:#82878c" viewBox="0 0 512 512" role="img" aria-hidden="true" focusable="false"><g><g><g><g><path d="M203.6,395c6.8-17.4,6.8-36.6,0-54l-79.4-204h70.9l47.7,149.4l74.8-207.6H116.4c-41.8,0-76,34.2-76,76V357c0,41.8,34.2,76,76,76H173C189,424.1,197.6,410.3,203.6,395z"/></g><g><path d="M471.6,154.8c0-41.8-34.2-76-76-76h-3L285.7,365c-9.6,26.7-19.4,49.3-30.3,68h216.2V154.8z"/></g></g><path stroke-width="2.974" stroke-miterlimit="10" d="M338,1.3l-93.3,259.1l-42.1-131.9h-89.1l83.8,215.2c6,15.5,6,32.5,0,48c-7.4,19-19,37.3-53,41.9l-7.2,1v76h8.3c81.7,0,118.9-57.2,149.6-142.9L431.6,1.3H338z M279.4,362c-32.9,92-67.6,128.7-125.7,131.8v-45c37.5-7.5,51.3-31,59.1-51.1c7.5-19.3,7.5-40.7,0-60l-75-192.7h52.8l53.3,166.8l105.9-294h58.1L279.4,362z"/></g></g></svg>';
+
+		if ( $base64 ) {
+			return 'data:image/svg+xml;base64,' . base64_encode( $svg );
+		}
+
+		return $svg;
 	}
 }

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1029,20 +1029,6 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Checks if the current installation supports MyYoast access tokens.
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @return bool True if access_tokens are supported.
-	 *
-	 * @deprecated 15.0
-	 */
-	public static function has_access_token_support() {
-		_deprecated_function( __METHOD__, 'WPSEO 15.0' );
-		return false;
-	}
-
-	/**
 	 * Prepares data for outputting as JSON.
 	 *
 	 * @param array $data The data to format.
@@ -1251,6 +1237,20 @@ class WPSEO_Utils {
 		$roles = $wp_roles->get_names();
 
 		return $roles;
+	}
+
+	/**
+	 * Checks if the current installation supports MyYoast access tokens.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return bool True if access_tokens are supported.
+	 *
+	 * @deprecated 15.0
+	 */
+	public static function has_access_token_support() {
+		_deprecated_function( __METHOD__, 'WPSEO 15.0' );
+		return false;
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -117,24 +117,6 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * List all the available user roles.
-	 *
-	 * @since 1.8.0
-	 * @deprecated 15.0
-	 * @codeCoverageIgnore
-	 *
-	 * @return array $roles
-	 */
-	public static function get_roles() {
-		_deprecated_function( __METHOD__, '15.0', 'wp_roles()->get_names()' );
-		$wp_roles = wp_roles();
-
-		$roles = $wp_roles->get_names();
-
-		return $roles;
-	}
-
-	/**
 	 * Recursively trim whitespace round a string value or of string values within an array.
 	 * Only trims strings to avoid typecasting a variable (to string).
 	 *
@@ -1348,6 +1330,26 @@ SVG;
 		$enabled_features = apply_filters( 'wpseo_enable_feature', $enabled_features );
 
 		return $enabled_features;
+	}
+
+	/* ********************* DEPRECATED METHODS ********************* */
+
+	/**
+	 * List all the available user roles.
+	 *
+	 * @since 1.8.0
+	 * @deprecated 15.0
+	 * @codeCoverageIgnore
+	 *
+	 * @return array $roles
+	 */
+	public static function get_roles() {
+		_deprecated_function( __METHOD__, '15.0', 'wp_roles()->get_names()' );
+		$wp_roles = wp_roles();
+
+		$roles = $wp_roles->get_names();
+
+		return $roles;
 	}
 
 	/**

--- a/src/exceptions/oauth/authentication-failed-exception.php
+++ b/src/exceptions/oauth/authentication-failed-exception.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO plugin file.
- *
- * @package Yoast\WP\SEO\Exceptions\OAuth
- */
 
 namespace Yoast\WP\SEO\Exceptions\OAuth;
 

--- a/tests/integration/test-class-wpseo-utils.php
+++ b/tests/integration/test-class-wpseo-utils.php
@@ -11,38 +11,6 @@
 class WPSEO_Utils_Test extends WPSEO_UnitTestCase {
 
 	/**
-	 * Tests whether a user is allowed to access the SEO configuration in various situations.
-	 *
-	 * @covers WPSEO_Utils::grant_access
-	 */
-	public function test_grant_access() {
-
-		if ( ! is_multisite() ) { // Should be true when not running multisite.
-			$this->assertTrue( WPSEO_Utils::grant_access() );
-			return;
-		}
-
-		// Admin required by default/option.
-		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
-		wp_set_current_user( $user_id );
-		$this->assertTrue( WPSEO_Utils::grant_access() );
-
-		// Super Admin required by option.
-		$options           = get_site_option( 'wpseo_ms' );
-		$options['access'] = 'superadmin';
-		update_site_option( 'wpseo_ms', $options );
-		$this->assertFalse( WPSEO_Utils::grant_access() );
-
-		grant_super_admin( $user_id );
-		$this->assertTrue( WPSEO_Utils::grant_access() );
-
-		// Below admin not allowed.
-		$user_id = $this->factory->user->create( [ 'role' => 'editor' ] );
-		wp_set_current_user( $user_id );
-		$this->assertFalse( WPSEO_Utils::grant_access() );
-	}
-
-	/**
 	 * Tests whether is_apache correctly returns if the site runs on apache.
 	 *
 	 * @covers WPSEO_Utils::is_apache


### PR DESCRIPTION
# Attention please 🚨 
I've deprecated some methods, when you are merging this and the next release is higher than `15.4` please change the version numbers instead of pushing it back to me, otherwise it would take up some time where I keep increasing the version number. Thanks!

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to replace the static utils by helper methods. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* It just replaces, deprecates and moves existing logic.

## Relevant technical choices:

* I did a search for all methods and couldn't find any occurrences of them. This makes it safe enough for me to move / deprecate the functionality.
* The methods `grant_access`,`traffic_light_svg`, `schema_tag` and `schema_output` aren't used anymore. Safe enough to remove them.
* I moved the methods `has_access_token_support` and `get_roles` to the bottom of the class. And added a line to mark the starting of the deprecated methods.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Do the review commit by commit, this makes it easier to proces.
* There is no functional change being made. 
* You can just build the plugin and do a smoke test.
   * Make sure the admin bar shows the yoast logo. -> This will test the move of `WPSEO_Utils::get_icon_svg`
   * Install a conflicting plugin like `All in One SEO` and see if the plugin conflict notification still shows the right plugin name. This will test the move of `WPSEO_Utils::get_plugin_name`
 
### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
