### PR TITLE
Inverses the dependency

### DIFF
--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -25,13 +25,6 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	private $permalink;
 
 	/**
-	 * The date helper.
-	 *
-	 * @var WPSEO_Date_Helper
-	 */
-	protected $date;
-
-	/**
 	 * Constructor.
 	 *
 	 * @param WP_Post|array $post      Post object.
@@ -41,7 +34,6 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	public function __construct( $post, array $options, $structure ) {
 		$this->post      = $post;
 		$this->permalink = $structure;
-		$this->date      = new WPSEO_Date_Helper();
 	}
 
 	/**
@@ -227,6 +219,6 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string
 	 */
 	private function get_metadesc_date() {
-		return $this->date->format_translated( $this->post->post_date, 'M j, Y' );
+		return YoastSEO()->helpers->date->format_translated( $this->post->post_date, 'M j, Y' );
 	}
 }

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -48,13 +48,6 @@ class WPSEO_Replace_Vars {
 	protected $args;
 
 	/**
-	 * The date helper.
-	 *
-	 * @var WPSEO_Date_Helper
-	 */
-	protected $date;
-
-	/**
 	 * Help texts for use in WPSEO -> Search appearance tabs.
 	 *
 	 * @var array
@@ -67,13 +60,6 @@ class WPSEO_Replace_Vars {
 	 * @var array
 	 */
 	protected static $external_replacements = [];
-
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->date = new WPSEO_Date_Helper();
-	}
 
 	/**
 	 * Setup the help texts and external replacements as statics so they will be available to all instances.
@@ -319,7 +305,7 @@ class WPSEO_Replace_Vars {
 
 		if ( $this->args->post_date !== '' ) {
 			// Returns a string.
-			$replacement = $this->date->format_translated( $this->args->post_date, get_option( 'date_format' ) );
+			$replacement = YoastSEO()->helpers->date->format_translated( $this->args->post_date, get_option( 'date_format' ) );
 		}
 		else {
 			if ( get_query_var( 'day' ) && get_query_var( 'day' ) !== '' ) {
@@ -943,7 +929,7 @@ class WPSEO_Replace_Vars {
 		$replacement = null;
 
 		if ( ! empty( $this->args->post_modified ) ) {
-			$replacement = $this->date->format_translated( $this->args->post_modified, get_option( 'date_format' ) );
+			$replacement = YoastSEO()->helpers->date->format_translated( $this->args->post_modified, get_option( 'date_format' ) );
 		}
 
 		return $replacement;

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -650,13 +650,7 @@ class WPSEO_Utils {
 	 * @return bool
 	 */
 	public static function is_valid_datetime( $datetime ) {
-		static $date_helper;
-
-		if ( ! $date_helper ) {
-			$date_helper = new WPSEO_Date_Helper();
-		}
-
-		return $date_helper->is_valid_datetime( $datetime );
+		return YoastSEO()->helpers->date->is_valid_datetime( $datetime );
 	}
 
 	/**

--- a/inc/date-helper.php
+++ b/inc/date-helper.php
@@ -21,13 +21,7 @@ class WPSEO_Date_Helper {
 	 * @return string The formatted date.
 	 */
 	public function format( $date, $format = DATE_W3C ) {
-		$immutable_date = date_create_immutable_from_format( 'Y-m-d H:i:s', $date, new DateTimeZone( 'UTC' ) );
-
-		if ( ! $immutable_date ) {
-			return $date;
-		}
-
-		return $immutable_date->format( $format );
+		return YoastSEO()->helpers->date->format( $date, $format );
 	}
 
 	/**
@@ -39,13 +33,7 @@ class WPSEO_Date_Helper {
 	 * @return string The formatted date.
 	 */
 	public function format_timestamp( $timestamp, $format = DATE_W3C ) {
-		$immutable_date = date_create_immutable_from_format( 'U', $timestamp, new DateTimeZone( 'UTC' ) );
-
-		if ( ! $immutable_date ) {
-			return $timestamp;
-		}
-
-		return $immutable_date->format( $format );
+		return YoastSEO()->helpers->date->format_timestamp( $timestamp, $format );
 	}
 
 	/**
@@ -57,7 +45,7 @@ class WPSEO_Date_Helper {
 	 * @return string The formatted and translated date.
 	 */
 	public function format_translated( $date, $format = DATE_W3C ) {
-		return date_i18n( $format, $this->format( $date, 'U' ) );
+		return YoastSEO()->helpers->date->format_translated( $date, $format );
 	}
 
 	/**
@@ -68,14 +56,6 @@ class WPSEO_Date_Helper {
 	 * @return bool True when datatime is valid.
 	 */
 	public function is_valid_datetime( $datetime ) {
-		if ( substr( $datetime, 0, 1 ) === '-' ) {
-			return false;
-		}
-
-		try {
-			return new DateTime( $datetime ) !== false;
-		} catch ( Exception $exception ) {
-			return false;
-		}
+		return YoastSEO()->helpers->date->is_valid_datetime( $datetime );
 	}
 }

--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -13,20 +13,6 @@ use Yoast\WP\SEO\Helpers\Author_Archive_Helper;
 class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 	/**
-	 * The date helper.
-	 *
-	 * @var WPSEO_Date_Helper
-	 */
-	protected $date;
-
-	/**
-	 * WPSEO_Author_Sitemap_Provider constructor.
-	 */
-	public function __construct() {
-		$this->date = new WPSEO_Date_Helper();
-	}
-
-	/**
 	 * Check if provider supports given item type.
 	 *
 	 * @param string $type Type string to check for.
@@ -91,7 +77,7 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			$user    = get_user_by( 'id', $user_id );
 			$index[] = [
 				'loc'     => WPSEO_Sitemaps_Router::get_base_url( 'author-sitemap' . $page . '.xml' ),
-				'lastmod' => ( $user->_yoast_wpseo_profile_updated ) ? $this->date->format_timestamp( $user->_yoast_wpseo_profile_updated ) : null,
+				'lastmod' => ( $user->_yoast_wpseo_profile_updated ) ? YoastSEO()->helpers->date->format_timestamp( $user->_yoast_wpseo_profile_updated ) : null,
 			];
 
 			++$page;

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -39,13 +39,6 @@ class WPSEO_Sitemaps_Renderer {
 	protected $needs_conversion = false;
 
 	/**
-	 * The date helper.
-	 *
-	 * @var WPSEO_Date_Helper
-	 */
-	protected $date;
-
-	/**
 	 * Set up object properties.
 	 */
 	public function __construct() {
@@ -53,7 +46,6 @@ class WPSEO_Sitemaps_Renderer {
 		$this->stylesheet     = '<?xml-stylesheet type="text/xsl" href="' . esc_url( $stylesheet_url ) . '"?>';
 		$this->charset        = get_bloginfo( 'charset' );
 		$this->output_charset = $this->charset;
-		$this->date           = new WPSEO_Date_Helper();
 
 		if (
 			$this->charset !== 'UTF-8'
@@ -192,7 +184,7 @@ class WPSEO_Sitemaps_Renderer {
 		$date = null;
 
 		if ( ! empty( $url['lastmod'] ) ) {
-			$date = $this->date->format( $url['lastmod'] );
+			$date = YoastSEO()->helpers->date->format( $url['lastmod'] );
 		}
 
 		$url['loc'] = htmlspecialchars( $url['loc'], ENT_COMPAT, $this->output_charset, false );
@@ -221,7 +213,7 @@ class WPSEO_Sitemaps_Renderer {
 
 		if ( ! empty( $url['mod'] ) ) {
 			// Create a DateTime object date in the correct timezone.
-			$date = $this->date->format( $url['mod'] );
+			$date = YoastSEO()->helpers->date->format( $url['mod'] );
 		}
 
 		$url['loc'] = htmlspecialchars( $url['loc'], ENT_COMPAT, $this->output_charset, false );

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -92,13 +92,6 @@ class WPSEO_Sitemaps {
 	public $providers;
 
 	/**
-	 * The date helper.
-	 *
-	 * @var WPSEO_Date_Helper
-	 */
-	protected $date;
-
-	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
@@ -112,7 +105,6 @@ class WPSEO_Sitemaps {
 		$this->router   = new WPSEO_Sitemaps_Router();
 		$this->renderer = new WPSEO_Sitemaps_Renderer();
 		$this->cache    = new WPSEO_Sitemaps_Cache();
-		$this->date     = new WPSEO_Date_Helper();
 
 		if ( ! empty( $_SERVER['SERVER_PROTOCOL'] ) ) {
 			$this->http_protocol = sanitize_text_field( wp_unslash( $_SERVER['SERVER_PROTOCOL'] ) );
@@ -440,7 +432,7 @@ class WPSEO_Sitemaps {
 		$expires = YEAR_IN_SECONDS;
 		header( 'Pragma: public' );
 		header( 'Cache-Control: max-age=' . $expires );
-		header( 'Expires: ' . $this->date->format_timestamp( ( time() + $expires ), 'D, d M Y H:i:s' ) . ' GMT' );
+		header( 'Expires: ' . YoastSEO()->helpers->date->format_timestamp( ( time() + $expires ), 'D, d M Y H:i:s' ) . ' GMT' );
 
 		// Don't use WP_Filesystem() here because that's not initialized yet. See https://yoast.atlassian.net/browse/QAK-2043.
 		readfile( WPSEO_PATH . 'css/main-sitemap.xsl' );
@@ -538,7 +530,7 @@ class WPSEO_Sitemaps {
 	 * @return string
 	 */
 	public function get_last_modified( $post_types ) {
-		return $this->date->format( self::get_last_modified_gmt( $post_types ) );
+		return YoastSEO()->helpers->date->format( self::get_last_modified_gmt( $post_types ) );
 	}
 
 	/**

--- a/src/deprecated/inc/sitemaps/class-sitemap-timezone.php
+++ b/src/deprecated/inc/sitemaps/class-sitemap-timezone.php
@@ -27,9 +27,7 @@ class WPSEO_Sitemap_Timezone {
 	public function format_date( $datetime_string, $format = 'c' ) {
 		_deprecated_function( __METHOD__, 'WPSEO 12.8', 'Date_Helper::format' );
 
-		$date_helper = new WPSEO_Date_Helper();
-
-		return $date_helper->format( $format );
+		return YoastSEO()->helpers->date->format( $format );
 	}
 
 	/**

--- a/src/helpers/date-helper.php
+++ b/src/helpers/date-helper.php
@@ -2,28 +2,10 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
-use WPSEO_Date_Helper;
-
 /**
  * A helper object for dates.
  */
 class Date_Helper {
-
-	/**
-	 * The date helper.
-	 *
-	 * @var WPSEO_Date_Helper
-	 */
-	protected $date;
-
-	/**
-	 * Date_Helper constructor.
-	 *
-	 * @codeCoverageIgnore It only sets dependencies.
-	 */
-	public function __construct() {
-		$this->date = new WPSEO_Date_Helper();
-	}
 
 	/**
 	 * Convert given date string to the W3C format.
@@ -33,8 +15,6 @@ class Date_Helper {
 	 *
 	 * @param string $date      Date string to convert.
 	 * @param bool   $translate Whether the return date should be translated. Default false.
-	 *
-	 * @codeCoverageIgnore It just wraps an external function.
 	 *
 	 * @return string Formatted date string.
 	 */
@@ -48,12 +28,46 @@ class Date_Helper {
 	 * @param string $date   String representing the date / time.
 	 * @param string $format The format that the passed date should be in.
 	 *
-	 * @codeCoverageIgnore - We have to write test when this method contains own code.
-	 *
 	 * @return string The formatted date.
 	 */
 	public function format( $date, $format = \DATE_W3C ) {
-		return $this->date->format( $date, $format );
+		$immutable_date = \date_create_immutable_from_format( 'Y-m-d H:i:s', $date, new \DateTimeZone( 'UTC' ) );
+
+		if ( ! $immutable_date ) {
+			return $date;
+		}
+
+		return $immutable_date->format( $format );
+	}
+
+	/**
+	 * Formats the given timestamp to the needed format.
+	 *
+	 * @param int    $timestamp The timestamp to use for the formatting.
+	 * @param string $format    The format that the passed date should be in.
+	 *
+	 * @return string The formatted date.
+	 */
+	public function format_timestamp( $timestamp, $format = DATE_W3C ) {
+		$immutable_date = \date_create_immutable_from_format( 'U', $timestamp, new \DateTimeZone( 'UTC' ) );
+
+		if ( ! $immutable_date ) {
+			return $timestamp;
+		}
+
+		return $immutable_date->format( $format );
+	}
+
+	/**
+	 * Formats a given date in UTC TimeZone format and translate it to the set language.
+	 *
+	 * @param string $date   String representing the date / time.
+	 * @param string $format The format that the passed date should be in.
+	 *
+	 * @return string The formatted and translated date.
+	 */
+	public function format_translated( $date, $format = DATE_W3C ) {
+		return \date_i18n( $format, $this->format( $date, 'U' ) );
 	}
 
 	/**
@@ -63,5 +77,24 @@ class Date_Helper {
 	 */
 	public function current_time() {
 		return \time();
+	}
+
+	/**
+	 * Check if a string is a valid datetime.
+	 *
+	 * @param string $datetime String input to check as valid input for DateTime class.
+	 *
+	 * @return bool True when datatime is valid.
+	 */
+	public function is_valid_datetime( $datetime ) {
+		if ( \substr( $datetime, 0, 1 ) === '-' ) {
+			return false;
+		}
+
+		try {
+			return new \DateTime( $datetime ) !== false;
+		} catch ( \Exception $exception ) {
+			return false;
+		}
 	}
 }

--- a/tests/unit/helpers/date-helper-test.php
+++ b/tests/unit/helpers/date-helper-test.php
@@ -3,13 +3,13 @@
 namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 
 use Brain\Monkey;
-use WPSEO_Date_Helper;
+use Yoast\WP\SEO\Helpers\Date_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
  * Unit Test Class.
  *
- * @coversDefaultClass \WPSEO_Date_Helper
+ * @coversDefaultClass \Yoast\WP\SEO\Helpers\Date_Helper
  *
  * @group helpers
  */
@@ -18,7 +18,7 @@ class Date_Helper_Test extends TestCase {
 	/**
 	 * The date helper instance.
 	 *
-	 * @var WPSEO_Date_Helper
+	 * @var Date_Helper
 	 */
 	protected $instance;
 
@@ -28,7 +28,7 @@ class Date_Helper_Test extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->instance = new WPSEO_Date_Helper();
+		$this->instance = new Date_Helper();
 	}
 
 	/**
@@ -44,7 +44,7 @@ class Date_Helper_Test extends TestCase {
 	 * @covers ::format
 	 */
 	public function test_format( $date, $format, $expected, $message ) {
-		$this->assertEquals( $expected, $this->instance->format( $date, $format ), $message );
+		static::assertEquals( $expected, $this->instance->format( $date, $format ), $message );
 	}
 
 	/**
@@ -118,7 +118,7 @@ class Date_Helper_Test extends TestCase {
 	 * @covers ::format_timestamp
 	 */
 	public function test_format_timestamp( $timestamp, $format, $expected, $message ) {
-		$this->assertEquals( $expected, $this->instance->format_timestamp( $timestamp, $format ), $message );
+		static::assertEquals( $expected, $this->instance->format_timestamp( $timestamp, $format ), $message );
 	}
 
 	/**
@@ -160,7 +160,7 @@ class Date_Helper_Test extends TestCase {
 			->with( \DATE_W3C, '1609421820' )
 			->andReturn( '2020-12-31' );
 
-		$this->assertEquals(
+		static::assertEquals(
 			'2020-12-31',
 			$this->instance->format_translated( '2020-12-31 13:37:00' )
 		);
@@ -172,7 +172,7 @@ class Date_Helper_Test extends TestCase {
 	 * @covers ::is_valid_datetime
 	 */
 	public function test_is_valid_datetime_WITH_valid_datetime() {
-		$this->assertTrue( $this->instance->is_valid_datetime( '2015-02-25T04:44:44+00:00' ) );
+		static::assertTrue( $this->instance->is_valid_datetime( '2015-02-25T04:44:44+00:00' ) );
 	}
 
 	/**
@@ -181,6 +181,6 @@ class Date_Helper_Test extends TestCase {
 	 * @covers ::is_valid_datetime
 	 */
 	public function test_is_valid_datetime_WITH_invalid_datetime() {
-		$this->assertFalse( $this->instance->is_valid_datetime( '-0001-11-30T00:00:00+00:00' ) );
+		static::assertFalse( $this->instance->is_valid_datetime( '-0001-11-30T00:00:00+00:00' ) );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to use modern helpers instead of the old ones.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* No functional change, it just inverses the dependencies.

## Relevant technical choices:

* I just removed the `WPSEO_Date_Helper` dependency on the date helper in the `src` directory. And just called the 'modern' date helper in the old `WPSEO_Date_Helper`. All locations where we have `WPSEO_Date_Helper` as dependency are replaced by calling methods from `YoastSEO()->helpers->date`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* I would suggest to do a smoke test by:
   * visiting the sitemaps and see if the dates are rendered right
   * make sure the `%%date%%` replacevar is still correct.
   * make sure the `%%modified%%` replace var is still right.
   * And the date that is shown in the preview is right. I hope there is still one, it occurs in the metadescription code for the metabox.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Sitemaps (all dates given
* The date shown in the preview (metadescription) in the metabox 
* The replacement variables.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
