### PR TITLE
Clean up permalink code

### DIFF
--- a/src/integrations/watchers/indexable-homeurl-watcher.php
+++ b/src/integrations/watchers/indexable-homeurl-watcher.php
@@ -79,33 +79,10 @@ class Indexable_HomeUrl_Watcher implements Integration_Interface {
 	 * @return void
 	 */
 	public function reset_permalinks() {
-		$post_types = $this->get_post_types();
-		foreach ( $post_types as $post_type ) {
-			$this->reset_permalinks_post_type( $post_type );
-		}
-
-		$taxonomies = $this->get_taxonomies_for_post_types( $post_types );
-		foreach ( $taxonomies as $taxonomy ) {
-			$this->indexable_helper->reset_permalink_indexables( 'term', $taxonomy, Indexing_Reasons::REASON_HOME_URL_OPTION );
-		}
-
-		$this->indexable_helper->reset_permalink_indexables( 'home-page', null, Indexing_Reasons::REASON_HOME_URL_OPTION );
-		$this->indexable_helper->reset_permalink_indexables( 'user', null, Indexing_Reasons::REASON_HOME_URL_OPTION );
-		$this->indexable_helper->reset_permalink_indexables( 'date-archive', null, Indexing_Reasons::REASON_HOME_URL_OPTION );
-		$this->indexable_helper->reset_permalink_indexables( 'system-page', null, Indexing_Reasons::REASON_HOME_URL_OPTION );
+		$this->indexable_helper->reset_permalink_indexables( null, null, Indexing_Reasons::REASON_HOME_URL_OPTION );
 
 		// Reset the home_url option.
 		$this->options_helper->set( 'home_url', get_home_url() );
-	}
-
-	/**
-	 * Resets the permalink for the given post type.
-	 *
-	 * @param string $post_type The post type to reset.
-	 */
-	public function reset_permalinks_post_type( $post_type ) {
-		$this->indexable_helper->reset_permalink_indexables( 'post', $post_type, Indexing_Reasons::REASON_HOME_URL_OPTION );
-		$this->indexable_helper->reset_permalink_indexables( 'post-type-archive', $post_type, Indexing_Reasons::REASON_HOME_URL_OPTION );
 	}
 
 	/**
@@ -134,40 +111,5 @@ class Indexable_HomeUrl_Watcher implements Integration_Interface {
 	 */
 	public function should_reset_permalinks() {
 		return \get_home_url() !== $this->options_helper->get( 'home_url' );
-	}
-
-	/**
-	 * Retrieves a list with the public post types.
-	 *
-	 * @return array The post types.
-	 */
-	protected function get_post_types() {
-		/**
-		 * Filter: Gives the possibility to filter out post types.
-		 *
-		 * @param array $post_types The post type names.
-		 *
-		 * @return array The post types.
-		 */
-		return \apply_filters( 'wpseo_post_types_reset_permalinks', $this->post_type->get_public_post_types() );
-	}
-
-	/**
-	 * Retrieves the taxonomies that belongs to the public post types.
-	 *
-	 * @param array $post_types The post types to get taxonomies for.
-	 *
-	 * @return array The retrieved taxonomies.
-	 */
-	protected function get_taxonomies_for_post_types( $post_types ) {
-		$taxonomies = [];
-		foreach ( $post_types as $post_type ) {
-			$taxonomies[] = \get_object_taxonomies( $post_type, 'names' );
-		}
-
-		$taxonomies = \array_merge( [], ...$taxonomies );
-		$taxonomies = \array_unique( $taxonomies );
-
-		return $taxonomies;
 	}
 }

--- a/src/integrations/watchers/indexable-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-permalink-watcher.php
@@ -81,6 +81,7 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 		\add_action( 'update_option_category_base', [ $this, 'reset_permalinks_term' ], 10, 3 );
 		\add_action( 'update_option_tag_base', [ $this, 'reset_permalinks_term' ], 10, 3 );
 		\add_action( 'wpseo_permalink_structure_check', [ $this, 'force_reset_permalinks' ] );
+		\add_action( 'wpseo_deactivate', [ $this, 'unschedule_cron' ] );
 	}
 
 	/**
@@ -255,6 +256,19 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 		}
 
 		\wp_schedule_event( time(), 'daily', 'wpseo_permalink_structure_check' );
+	}
+
+	/**
+	 * Unschedules the WP-Cron job to check the permalink_structure status.
+	 *
+	 * @return void
+	 */
+	public function unschedule_cron() {
+		if ( ! \wp_next_scheduled( 'wpseo_permalink_structure_check' ) ) {
+			return;
+		}
+
+		\wp_clear_scheduled_hook( 'wpseo_permalink_structure_check' );
 	}
 
 	/* ********************* DEPRECATED METHODS ********************* */

--- a/tests/unit/integrations/watchers/indexable-homeurl-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-homeurl-watcher-test.php
@@ -102,16 +102,7 @@ class Indexable_HomeUrl_Watcher_Test extends TestCase {
 	 * @covers ::reset_permalinks
 	 */
 	public function test_reset_permalinks() {
-		$this->instance->expects( 'get_post_types' )->once()->andReturn( [ 'post' ] );
-		$this->instance->expects( 'get_taxonomies_for_post_types' )->once()->with( [ 'post' ] )->andReturn( [ 'category' ] );
-
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'post', 'post', Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'post-type-archive', 'post', Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'term', 'category', Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'user', null, Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'home-page', null, Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'date-archive', null, Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'system-page', null, Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
+		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( null, null, Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
 
 		Monkey\Functions\expect( 'get_home_url' )
 			->once()
@@ -123,18 +114,6 @@ class Indexable_HomeUrl_Watcher_Test extends TestCase {
 			->once();
 
 		$this->instance->reset_permalinks();
-	}
-
-	/**
-	 * Test resetting the permalinks for a post type.
-	 *
-	 * @covers ::reset_permalinks_post_type
-	 */
-	public function test_reset_permalinks_post_type() {
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'post', 'post', Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
-		$this->indexable_helper->expects( 'reset_permalink_indexables' )->with( 'post-type-archive', 'post', Indexing_Reasons::REASON_HOME_URL_OPTION )->once();
-
-		$this->instance->reset_permalinks_post_type( 'post' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Cleans up some of the code that exists for the watchers related to permalinks by removing unnecessary complexity.
* Introduces a new method called `unschedule_cron` that gets called when the plugin is deactivated to ensure the cron is deactivated.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Cleans up some of the code that exists for the watchers related to permalinks by removing unnecessary complexity.
* Introduces a new method called `unschedule_cron` that gets called when the plugin is deactivated to ensure the cron is deactivated.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Testing that behavior hasn't changed
* Prior to checking out this branch, run the steps described in https://github.com/Yoast/wordpress-seo/pull/16078 and/or https://github.com/Yoast/wordpress-seo/pull/16079. **Please note that the `wpseo_home_url_check` mentioned in the first PR no longer exists and all occurrences should be replaced with `wpseo_permalink_structure_check` (i.e. in crons etc)**
* Please take note of the changes that were made in your database so you can compare these later.
* After running one or both the previous test scenarios, checkout this PR and build as per usual.
* Ensure you have re-indexed your site.
* Re-run one or both of the aforementioned scenarios to clear the indexables table (`wp_yoast_indexable`).
* Ensure the resulting changes in the table are the same as the changes that were made prior to checking out this branch.

### Testing unscheduling of cron
* In your Docker installation, run `./wp.sh cron event list`. Notice that `wpseo_permalink_structure_check` is listed.
* Deactivate the plugin and rerun the previous command. Notice that the `wpseo_permalink_structure_check` is no longer listed.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-183]