### PR TITLE
Problem in canonical single page CPTs #16281

### DIFF
--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -74,7 +74,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 			return $this->model->canonical;
 		}
 
-		$permalink = $this->get_permalink();
+		$permalink = ( get_the_permalink() != $this->get_permalink() ) ? get_the_permalink() : $this->get_permalink();
 
 		// Fix paginated pages canonical, but only if the page is truly paginated.
 		$current_page = $this->pagination->get_current_post_page_number();

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -74,7 +74,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 			return $this->model->canonical;
 		}
 
-		$permalink = ( get_the_permalink() != $this->get_permalink() ) ? get_the_permalink() : $this->get_permalink();
+		$permalink = ( \get_the_permalink() != $this->get_permalink() ) ? \get_the_permalink() : $this->get_permalink();
 
 		// Fix paginated pages canonical, but only if the page is truly paginated.
 		$current_page = $this->pagination->get_current_post_page_number();


### PR DESCRIPTION
When a post (including CPT) is edited, Yoast saves it's permalink in the `wp_yoast_indexable` table. In this case, when the rewrite rules of that post type change, Yoast still receives permalink from the database.

This problem is resolved when posts whose their rewrite rule has been changed are updated, because Yoast changes them in the database. But doing so is really hard. Editing all posts is time consuming.

I fixed this problem with the following code:
Function: `generate_canonical` in File: `wordpress-seo/src/presentations/indexable-post-type-presentation.php` Line 72

Current code is:
```php

	public function generate_canonical() {
		if ( $this->model->canonical ) {
			return $this->model->canonical;
		}

		$permalink = $this->get_permalink();

		// Fix paginated pages canonical, but only if the page is truly paginated.
		$current_page = $this->pagination->get_current_post_page_number();
		if ( $current_page > 1 ) {
			$number_of_pages = $this->model->number_of_pages;
			if ( $number_of_pages && $current_page <= $number_of_pages ) {
				$permalink = $this->get_paginated_url( $permalink, $current_page );
			}
		}

		return $this->url->ensure_absolute_url( $permalink );
	}
```

It should be like this:

```php
	public function generate_canonical() {
		if ( $this->model->canonical ) {
			if( $permalink === $this->model->canonical ) {
				return $this->model->canonical;
			}
		}

		$permalink = ( get_the_permalink() != $this->get_permalink() ) ? get_the_permalink() : $this->get_permalink();

		// Fix paginated pages canonical, but only if the page is truly paginated.
		$current_page = $this->pagination->get_current_post_page_number();
		if ( $current_page > 1 ) {
			$number_of_pages = $this->model->number_of_pages;
			if ( $number_of_pages && $current_page <= $number_of_pages ) {
				$permalink = $this->get_paginated_url( $permalink, $current_page );
			}
		}

		return $this->url->ensure_absolute_url( $permalink );
	}
```


Screenshots:

Before update CPT post - after rewrite rules (there is no post id in permalink):

![before-update-cpt](https://user-images.githubusercontent.com/40775953/97818066-79059780-1cb5-11eb-8c53-b7e4fe1102c2.png)



After update CPT post - after rewrite rules (post id added to permalink):

![after-update-cpt](https://user-images.githubusercontent.com/40775953/97818081-86bb1d00-1cb5-11eb-8ca0-595529f5a57c.png)
