### PR TITLE
P1 209 upsell modals styling

### DIFF
--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -57,6 +57,9 @@
 
 .yoast a.dashicons {
 	color: var(--yoast-color-inactive-text);
+	height: 24px;
+	width: 24px;
+	vertical-align: middle;
 }
 
 .button-link {
@@ -74,6 +77,37 @@
 	border: none;
 	box-shadow: none;
 	background: none;
+}
+
+.yoast-gutenberg-modal input[type="radio"] {
+	appearance: none;
+	border-radius: 50%;
+	border: 2px solid #6c7781;
+	margin-right: 12px;
+	transition: none;
+	box-shadow: 0 0 0 transparent;
+	height: 1rem;
+	padding: 0;
+	vertical-align: middle;
+	width: 1rem;
+	min-width: 1rem;
+}
+
+.yoast-gutenberg-modal input[type="radio"]:checked {
+	background: #11a0d2;
+	border-color: #11a0d2;
+}
+
+input[type="radio"]:checked::before {
+	content: "";
+	float: left;
+	vertical-align: middle;
+	border-radius: 50%;
+	line-height: 1.14285714;
+	width: 6px;
+	height: 6px;
+	margin: 3px 0 0 3px;
+	background-color: #fff;
 }
 
 /* Upsell modal close-button tooltips */
@@ -98,6 +132,34 @@
 
 .yoast-gutenberg-modal .components-modal__header .components-tooltip::before, .yoast-gutenberg-modal .components-modal__header .components-tooltip::after {
 	top: 0;
+}
+
+/* Tab-focus styling */
+.yoast div:focus {
+	outline: 0;
+}
+
+.yoast a:focus, .yoast .button-link:focus {
+	color: #124964;
+	box-shadow: 0 0 0 1px #5b9dd9, 0 0 2px 1px rgba(30, 140, 190, 0.8);
+	outline: 1px solid transparent;
+}
+
+.yoast a.dashicons:focus {
+	color: #1e8cbe;
+}
+
+.yoast input[type="radio"]:checked:focus {
+	box-shadow: 0 0 0 2px #555d66;
+}
+
+.yoast input[type="radio"]:focus {
+	box-shadow: 0 0 0 1px #6c7781;
+}
+
+.yoast .yoast-button-upsell:focus {
+	color: #000;
+	box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.2), 0 0 0 1px #5b9dd9, 0 0 2px 1px rgba(30, 140, 190, 0.8);
 }
 
 /* All hover effects */

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -71,6 +71,7 @@
 }
 
 .yoast-elementor-panel__fills .UpsellLinkButton, .yoast .yoast-button-upsell {
+	line-height: 1.4em;
 	color: var(--yoast-color-label);
 	text-decoration: none;
 }

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -44,7 +44,7 @@
 	-webkit-font-smoothing: subpixel-antialiased;
 }
 
-.yoast li, .yoast p, .yoast small, .button-link {
+.yoast li, .yoast p, .yoast small {
 	margin-bottom: 6px;
 	line-height: 1.5;
 	color: var(--yoast-elementor-color-paragraph);
@@ -66,6 +66,7 @@
 	border: none;
 	background: none;
 	cursor: pointer;
+	line-height: 1.5;
 }
 
 .yoast-elementor-panel__fills .UpsellLinkButton, .yoast .yoast-button-upsell {

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -12,7 +12,9 @@
 }
 
 .yoast h2 {
-	color: var(--yoast-color-font-default);
+	color: var(--yoast-color-dark);
+	font-size: 1.3em;
+	font-weight: var(--yoast-font-weight-bold);
 	margin-bottom: 1em;
 }
 

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -59,7 +59,7 @@
 	color: var(--yoast-color-inactive-text);
 	height: 24px;
 	width: 24px;
-	vertical-align: middle;
+	vertical-align: text-bottom;
 }
 
 .button-link {

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -74,6 +74,30 @@
 	background: none;
 }
 
+/* Upsell modal close-button tooltips */
+.yoast-gutenberg-modal {
+	overflow: visible;
+}
+
+.yoast-gutenberg-modal .components-modal__header .components-button {
+	overflow: visible;
+}
+
+.yoast-gutenberg-modal .components-modal__header .components-button > span {
+	width: 0;
+	height: 0;
+}
+
+.yoast-gutenberg-modal .components-modal__header .components-button .components-tooltip {
+	position: absolute;
+	top: 0 !important;
+	left: 20px !important;
+}
+
+.yoast-gutenberg-modal .components-modal__header .components-tooltip::before, .yoast-gutenberg-modal .components-modal__header .components-tooltip::after {
+	top: 0;
+}
+
 /* All hover effects */
 @media(hover:hover) {
 	

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -66,6 +66,7 @@
 	border: none;
 	background: none;
 	cursor: pointer;
+	font-size: 1em;
 	line-height: 1.5;
 }
 

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -98,6 +98,10 @@
 	border-color: #11a0d2;
 }
 
+.yoast-post-settings-modal .yoast-notice-container {
+	bottom: auto;
+}
+
 input[type="radio"]:checked::before {
 	content: "";
 	float: left;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Modal close button hover/active tooltip was broken within the Elementor integration. Also :focus styling of the modal wasn't the same as in Gutenberg. At last radio button styling was off in the Google preview modal.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes styling of modals within the Elementor integration.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check whether modals' close buttons tooltips look the same as in the Block editor
* Check whether the radio-button in the Google preview modal looks the same as in the Block editor
* Check whether the :active state of all elements looks the same as in the Block editor

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
P1-209 && P1-208