### PR TITLE
P3-248 hide zapier in non public post types

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -558,17 +558,21 @@ class WPSEO_Admin_Init {
 	/**
 	 * Adds a custom Yoast section within the Classic Editor publish box.
 	 *
+	 * @param \WP_Post $post The current post object.
+	 *
 	 * @return void
 	 */
-	public function add_publish_box_section() {
+	public function add_publish_box_section( $post ) {
 		if ( in_array( $this->pagenow, [ 'post.php', 'post-new.php' ], true ) ) {
 			?>
 			<div id="yoast-seo-publishbox-section"></div>
 			<?php
 			/**
 			 * Fires after the post time/date setting in the Publish meta box.
+			 *
+			 * @api \WP_Post The current post object.
 			 */
-			do_action( 'wpseo_publishbox_misc_actions' );
+			do_action( 'wpseo_publishbox_misc_actions', $post );
 		}
 	}
 

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -73,7 +73,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'tag_base_url'                             => '',
 		'custom_taxonomy_slugs'                    => [],
 		'enable_enhanced_slack_sharing'            => true,
-		'zapier_integration_active'                => true,
+		'zapier_integration_active'                => false,
 		'zapier_subscription'                      => [],
 		'zapier_api_key'                           => '',
 	];

--- a/src/integrations/duplicate-post-integration.php
+++ b/src/integrations/duplicate-post-integration.php
@@ -7,7 +7,7 @@ use Yoast\WP\SEO\Conditionals\No_Conditionals;
 /**
  * Class to manage the integration with Yoast Duplicate Post.
  */
-class Duplicate_Post implements Integration_Interface {
+class Duplicate_Post_Integration implements Integration_Interface {
 
 	use No_Conditionals;
 
@@ -19,7 +19,7 @@ class Duplicate_Post implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_action( 'duplicate_post_excludelist_filter', [ $this, 'exclude_zapier_meta' ] );
+		\add_filter( 'duplicate_post_excludelist_filter', [ $this, 'exclude_zapier_meta' ] );
 	}
 
 	/**

--- a/src/integrations/duplicate-post.php
+++ b/src/integrations/duplicate-post.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations;
+
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+
+/**
+ * Class to manage the integration with Yoast Duplicate Post.
+ */
+class Duplicate_Post implements Integration_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * This is the place to register hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'duplicate_post_excludelist_filter', [ $this, 'exclude_zapier_meta' ] );
+	}
+
+	/**
+	 * Filters out the Zapier meta when you copy a post with Yoast Duplicate Post.
+	 *
+	 * @param array $meta_excludelist The current excludelist of meta fields.
+	 *
+	 * @return array The updated excludelist.
+	 */
+	public function exclude_zapier_meta( $meta_excludelist ) {
+		$meta_excludelist[] = 'zapier_trigger_sent';
+		return $meta_excludelist;
+	}
+}

--- a/tests/integration/inc/options/test-class-wpseo-option-wpseo.php
+++ b/tests/integration/inc/options/test-class-wpseo-option-wpseo.php
@@ -38,8 +38,9 @@ class WPSEO_Option_WPSEO_Test extends WPSEO_UnitTestCase {
 	public function test_verify_features_against_network() {
 		$this->skipWithoutMultisite();
 
-		$options  = WPSEO_Options::get_option( 'wpseo' );
-		$expected = array_fill_keys( $this->feature_vars, true );
+		$options                               = WPSEO_Options::get_option( 'wpseo' );
+		$expected                              = array_fill_keys( $this->feature_vars, true );
+		$expected['zapier_integration_active'] = false;
 		$this->assertEqualSets( $expected, array_intersect_key( $options, $expected ) );
 
 		// Ensure the variables are disabled via the network.

--- a/tests/unit/integrations/duplicate-post-integration-test.php
+++ b/tests/unit/integrations/duplicate-post-integration-test.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Integrations\Duplicate_Post_Integration;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Duplicate_Post_Integration_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Duplicate_Post_Integration
+ *
+ * @group integrations
+ */
+class Duplicate_Post_Integration_Test extends TestCase {
+
+	/**
+	 * Represents the instance we are testing.
+	 *
+	 * @var Mockery\MockInterface|Duplicate_Post_Integration
+	 */
+	private $instance;
+
+	/**
+	 * Sets an instance for test purposes.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->instance = new Duplicate_Post_Integration();
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertNotFalse( Monkey\Filters\has( 'duplicate_post_excludelist_filter', [ $this->instance, 'exclude_zapier_meta' ] ), 'Does not have expected duplicate_post_excludelist_filter filter' );
+	}
+
+	/**
+	 * Tests calling exclude_zapier_meta.
+	 *
+	 * @covers ::exclude_zapier_meta
+	 */
+	public function test_exclude_zapier_meta() {
+		$meta_excludelist = [
+			'_edit_lock',
+			'_edit_last',
+		];
+		$this->assertSame(
+			[
+				'_edit_lock',
+				'_edit_last',
+				'zapier_trigger_sent',
+			],
+			$this->instance->exclude_zapier_meta( $meta_excludelist )
+		);
+	}
+}


### PR DESCRIPTION
**Note that the branch has a wrong issue number**

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We need to restrict the Zapier integration to supported post types, disable it by default and make sure it's compatible with Yoast Duplicate Post. We need to apply some changes in the Free plugin even if the Zapier integration is a Premium feature.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the Zapier integration by default, and adds a Duplicate Post integration to filter out meta fields while copying.

## Relevant technical choices:

* The Duplicate Post integration has been added in Free so it can be used in the future for any other need.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This needs to be tested together with the companion Premium RC :https://github.com/Yoast/wordpress-seo-premium/pull/3072. refer to that for the testing instructions.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-248]
