### PR TITLE
PHP 8.0: fix fatal ArgumentCountError

### DIFF
--- a/admin/class-admin-editor-specific-replace-vars.php
+++ b/admin/class-admin-editor-specific-replace-vars.php
@@ -59,7 +59,7 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars {
 		/**
 		 * Filter: Adds the possibility to add extra editor specific replacement variables.
 		 *
-		 * @api array $replacement_variables Empty array to add the editor specific replace vars to.
+		 * @api array $replacement_variables Array of editor specific replace vars.
 		 */
 		$replacement_variables = apply_filters(
 			'wpseo_editor_specific_replace_vars',
@@ -220,7 +220,7 @@ class WPSEO_Admin_Editor_Specific_Replace_Vars {
 	 * @return array The list of unique editor specific replacement variables.
 	 */
 	protected function get_unique_replacement_variables() {
-		$merged_replacement_variables = call_user_func_array( 'array_merge', $this->get() );
+		$merged_replacement_variables = call_user_func_array( 'array_merge', array_values( $this->get() ) );
 
 		return array_unique( $merged_replacement_variables );
 	}


### PR DESCRIPTION
## Context

* Improved compatibility with PHP 8.0

## Summary

This PR can be summarized in the following changelog entry:

* Improved compatibility with PHP 8.0

## Relevant technical choices:

### Setting the scene

`array_merge()` expects to be passed one or more arrays to be merged. As the `$arrays` parameter is variadic, PHP 8.0 named parameters is not supported.

`call_user_func_array()` expects a function name and an array of parameters to be unpacked and passed on to the function.

In PHP 8, when `call_user_func_array()` receives an array of parameters with string keys, the keys will be interpreted as parameter names.

Refs:
* https://www.php.net/manual/en/function.array-merge.php
* https://www.php.net/manual/en/function.call-user-func-array
* https://wiki.php.net/rfc/named_params#call_user_func_and_friends

### The cause of the error

The base `$replacement_variables` array has string keys and is used as the base for the array of parameters to be passed to `call_user_func_array()` and subsequently to `array_merge()`.

The array in `$replacement_variables` having keys is a useful and sensible choice for the following reasons:
* Human comprehension of what the various entries in the array signify.
* Making it easier to filter the array in the `get()` method.

Having said that, the keys will need to be removed before the array is passed to `call_user_func_array()`.

Simply wrapping the parameter within an `array_values()` when passing it to `call_user_func_array()` maintains the usefullness of the keys in the other parts of the code, while preventing the fatal error in PHP 8.0.

As an alternative, the function call could be changed to a call to `call_user_func()` in combination with unpacking the array using the spread operator, however, the spread operator does not accept arrays with string keys either, so that would still need the call to `array_values()` as well.

For a behavioural comparison of the code on various PHP versions which proofs that this fix does not constitute a behavioural change, see https://3v4l.org/WhghT

### Other notes

I've verified and confirmed that this error would have been caught once the tests will be run on PHP 8.0. The existing `WPSEO_Admin_Editor_Specific_Replace_Vars_Test::test_get_shared_replace_vars_filters_editor_specific_replace_vars()` integration test covers this code and would trigger the fatal error on PHP 8.0 without the fix in this PR.

Includes minor fix to an incorrect filter parameter description.



Fixes #16241



## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* First on `trunk`, execute the "How can we reproduce this behavior?" steps as described in https://github.com/Yoast/wordpress-seo/issues/16241 to see the error.
* Next, switch to this branch, rinse & repeat to see that the fatal error no longer appears and that the admin editor variable replacement still works, same as before.


### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

