### PR TITLE
Enforce post objects to WP_Post in class WPSEO_Post_Type_Sitemap_Provider

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -546,13 +546,12 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		$post_ids = [];
 
-		foreach ( $posts as $post ) {
-			$post->post_type   = $post_type;
-			$post->filter      = 'sample';
-			$post->ID          = (int) $post->ID;
-			$post->post_parent = (int) $post->post_parent;
-			$post->post_author = (int) $post->post_author;
-			$post_ids[]        = $post->ID;
+		foreach ( $posts as $post_index => $post ) {
+			$post->post_type      = $post_type;
+			$sanitized_post       = sanitize_post( $post, 'raw' );
+			$posts[ $post_index ] = new WP_Post( $sanitized_post );
+
+			$post_ids[] = $sanitized_post->ID;
 		}
 
 		update_meta_cache( 'post', $post_ids );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* To improve compatibility with [get_permalink](https://developer.wordpress.org/reference/functions/get_permalink/).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where post-sitemap.xml causes a fatal error when the filter post_link requires WP_Post object.

## Relevant technical choices:

* Use [sanitize_post](https://developer.wordpress.org/reference/functions/sanitize_post/) instead of casting to int and enforce [WP_Post](https://developer.wordpress.org/reference/classes/wp_post/) object instead of default stdClass.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->
1. Add following PHP code:
```php
add_filter( 'post_link', function( $permalink, WP_Post $post ){ 
    return $permalink;
}, 10, 2 );
```
2. Check _post-sitemap.xml_. It should work without PHP fatal error.

* [x] QA should use the same steps as above.
## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* It affects all post_type sitemaps (post, page, CPTs).

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #16308
