### PR TITLE
P1-221 Fix analysis bullets reflecting score

### DIFF
--- a/js/src/analysis/PostDataCollector.js
+++ b/js/src/analysis/PostDataCollector.js
@@ -390,10 +390,6 @@ PostDataCollector.prototype.saveScores = function( score, keyword ) {
 			"js-text-analysis",
 			"Enter a focus keyphrase to calculate the SEO score"
 		);
-		indicator.fullText = i18n.dgettext(
-			"js-text-analysis",
-			"Content optimization: Enter a focus keyphrase to calculate the SEO score"
-		);
 	}
 
 	updateTrafficLight( indicator );

--- a/js/src/analysis/getIndicatorForScore.js
+++ b/js/src/analysis/getIndicatorForScore.js
@@ -1,68 +1,60 @@
-/* global YoastSEO */
-
+import { __ } from "@wordpress/i18n";
 import { helpers } from "yoastseo";
-const { scoreToRating } = helpers;
-import {
-	isUndefined,
-	isNil,
-} from "lodash-es";
+import { isNil } from "lodash";
 
 /**
- * Returns whether or not the current page has presenters.
+ * Gets a score indicator for a given rating.
  *
- * @returns {boolean} Whether or not the page has presenters.
- */
-var hasPresenter = function() {
-	var app = YoastSEO.app || {};
-
-	return ( ! isUndefined( app.seoAssessorPresenter ) || ! isUndefined( app.contentAssessorPresenter ) );
-};
-
-/**
- * Returns the presenter that is currently present on the page. Prevent errors if one of the analyses is disabled.
+ * @param {string} rating The rating.
  *
- * @returns {AssessorPresenter} An active assessor presenter.
+ * @returns {Object} The score indicator for the given rating.
  */
-var getPresenter = function() {
-	var app = YoastSEO.app;
-
-	if ( ! isUndefined( app.seoAssessorPresenter ) ) {
-		return app.seoAssessorPresenter;
+function getIndicatorForRating( rating ) {
+	switch ( rating ) {
+		case "feedback":
+			return {
+				className: "na",
+				screenReaderText: __( "Feedback", "wordpress-seo" ),
+				screenReaderReadabilityText: "",
+			};
+		case "bad":
+			return {
+				className: "bad",
+				screenReaderText: __( "Needs improvement", "wordpress-seo" ),
+				screenReaderReadabilityText: __( "Needs improvement", "wordpress-seo" ),
+			};
+		case "ok":
+			return {
+				className: "ok",
+				screenReaderText: __( "OK SEO score", "wordpress-seo" ),
+				screenReaderReadabilityText: __( "OK", "wordpress-seo" ),
+			};
+		case "good":
+			return {
+				className: "good",
+				screenReaderText: __( "Good SEO score", "wordpress-seo" ),
+				screenReaderReadabilityText: __( "Good", "wordpress-seo" ),
+			};
+		default:
+			return {
+				className: "loading",
+				screenReaderText: "",
+				screenReaderReadabilityText: "",
+			};
 	}
-
-	if ( ! isUndefined( app.contentAssessorPresenter ) ) {
-		return app.contentAssessorPresenter;
-	}
-};
+}
 
 /**
- * Simple helper function that returns the indicator for a given total score
+ * Gets an indicator for a given total score.
  *
  * @param {number} score The score from 0 to 100.
  * @returns {Object} The indicator for the given score.
  */
 export default function getIndicatorForScore( score ) {
-	var indicator = {
-		className: "",
-		screenReaderText: "",
-		fullText: "",
-		screenReaderReadabilityText: "",
-	};
-
-	if ( ! hasPresenter() ) {
-		return indicator;
+	if ( ! isNil( score ) ) {
+		// Scale because scoreToRating works from 0 to 10.
+		score /= 10;
 	}
 
-	if ( isNil( score ) ) {
-		indicator.className = "loading";
-
-		return indicator;
-	}
-
-	// Scale because scoreToRating works from 0 to 10.
-	score /= 10;
-
-	var presenter = getPresenter();
-
-	return presenter.getIndicator( scoreToRating( score ) );
+	return getIndicatorForRating( helpers.scoreToRating( score ) );
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the analysis bullets reflecting the score again in Elementor.

## Relevant technical choices:

* Since we do not have the yoastseo app anymore in Elementor, I pulled the indicator translations out of yoastseo into the helper.
  * **Positive**:
    * One more step away from the old app.
    * Less usage of Jed, in favor of `@wordpress/i18n`.
  * **Cost**:
    * Influences all the score indication being done, requiring more testing.
    * The translations are now moved to the `wordpress-seo` domain, requiring it to be translated again.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post/page in Elementor.
* Open our sidebar (settings bottom-left -> Yoast SEO tab at the top).
* Verify the readability and SEO analysis collapsible have icons.
* Adapt the post to change the score. Verify the overall bullets adapt to the score.
* See the list of locations under the impact check. You could verify adaptations cause changes in those locations.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Influences all the score indicators that are produced via JS. In code that is: PostDataCollector, TermDataCollector, ReadabilityAnalysis, SeoAnalysis, DocumentSidebar, PluginIcon, PrePublish, post-scraper, term-scraper. Resulting in the following locations:
  * Traffic light: for posts/pages and terms
  * Admin bar: for posts/pages and terms
  * Classic editor: publish section image
  * Readability analysis collapsible bullet
  * SEO analysis collapsible bullet
  * Readability analysis tab bullet
  * SEO analysis tab bullet
  * Yoast SEO in the document sidebar (block-editor)
  * Yoast SEO plugin icon at the top of the the block-editor sidebar
  * Yoast SEO section in the pre-publish flow/check

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-221
