### PR TITLE
P3-235 Add filter to deactivate the PreviouslyUsedKeyword assessment.

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -169,6 +169,7 @@ class WPSEO_Metabox_Formatter {
 			'analysisHeadingTitle'        => __( 'Analysis', 'wordpress-seo' ),
 			'zapierIntegrationActive'     => WPSEO_Options::get( 'zapier_integration_active', false ) ? 1 : 0,
 			'zapierConnectedStatus'       => ! empty( WPSEO_Options::get( 'zapier_subscription', [] ) ) ? 1 : 0,
+
 			/**
 			 * Filter to determine whether the PreviouslyUsedKeyword assessment should run.
 			 *

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -55,53 +55,53 @@ class WPSEO_Metabox_Formatter {
 		$schema_types         = new Schema_Types();
 
 		return [
-			'author_name'               => get_the_author_meta( 'display_name' ),
-			'site_name'                 => get_bloginfo( 'name' ),
-			'sitewide_social_image'     => WPSEO_Options::get( 'og_default_image' ),
-			'language'                  => WPSEO_Language_Utils::get_site_language_name(),
-			'settings_link'             => $this->get_settings_link(),
-			'search_url'                => '',
-			'post_edit_url'             => '',
-			'base_url'                  => '',
-			'contentTab'                => __( 'Readability', 'wordpress-seo' ),
-			'keywordTab'                => __( 'Keyphrase:', 'wordpress-seo' ),
-			'removeKeyword'             => __( 'Remove keyphrase', 'wordpress-seo' ),
-			'contentLocale'             => get_locale(),
-			'userLocale'                => WPSEO_Language_Utils::get_user_locale(),
-			'translations'              => $this->get_translations(),
-			'keyword_usage'             => [],
-			'title_template'            => '',
-			'metadesc_template'         => '',
-			'contentAnalysisActive'     => $analysis_readability->is_enabled() ? 1 : 0,
-			'keywordAnalysisActive'     => $analysis_seo->is_enabled() ? 1 : 0,
-			'cornerstoneActive'         => WPSEO_Options::get( 'enable_cornerstone_content', false ) ? 1 : 0,
-			'semrushIntegrationActive'  => WPSEO_Options::get( 'semrush_integration_active', true ) ? 1 : 0,
-			'intl'                      => $this->get_content_analysis_component_translations(),
-			'isRtl'                     => is_rtl(),
-			'isPremium'                 => WPSEO_Utils::is_yoast_seo_premium(),
-			'addKeywordUpsell'          => $this->get_add_keyword_upsell_translations(),
-			'wordFormRecognitionActive' => YoastSEO()->helpers->language->is_word_form_recognition_active( WPSEO_Language_Utils::get_language( get_locale() ) ),
-			'siteIconUrl'               => get_site_icon_url(),
-			'countryCode'               => WPSEO_Options::get( 'semrush_country_code', false ),
-			'SEMrushLoginStatus'        => WPSEO_Options::get( 'semrush_integration_active', true ) ? $this->get_semrush_login_status() : false,
-			'showSocial'                => [
+			'author_name'                 => get_the_author_meta( 'display_name' ),
+			'site_name'                   => get_bloginfo( 'name' ),
+			'sitewide_social_image'       => WPSEO_Options::get( 'og_default_image' ),
+			'language'                    => WPSEO_Language_Utils::get_site_language_name(),
+			'settings_link'               => $this->get_settings_link(),
+			'search_url'                  => '',
+			'post_edit_url'               => '',
+			'base_url'                    => '',
+			'contentTab'                  => __( 'Readability', 'wordpress-seo' ),
+			'keywordTab'                  => __( 'Keyphrase:', 'wordpress-seo' ),
+			'removeKeyword'               => __( 'Remove keyphrase', 'wordpress-seo' ),
+			'contentLocale'               => get_locale(),
+			'userLocale'                  => WPSEO_Language_Utils::get_user_locale(),
+			'translations'                => $this->get_translations(),
+			'keyword_usage'               => [],
+			'title_template'              => '',
+			'metadesc_template'           => '',
+			'contentAnalysisActive'       => $analysis_readability->is_enabled() ? 1 : 0,
+			'keywordAnalysisActive'       => $analysis_seo->is_enabled() ? 1 : 0,
+			'cornerstoneActive'           => WPSEO_Options::get( 'enable_cornerstone_content', false ) ? 1 : 0,
+			'semrushIntegrationActive'    => WPSEO_Options::get( 'semrush_integration_active', true ) ? 1 : 0,
+			'intl'                        => $this->get_content_analysis_component_translations(),
+			'isRtl'                       => is_rtl(),
+			'isPremium'                   => WPSEO_Utils::is_yoast_seo_premium(),
+			'addKeywordUpsell'            => $this->get_add_keyword_upsell_translations(),
+			'wordFormRecognitionActive'   => YoastSEO()->helpers->language->is_word_form_recognition_active( WPSEO_Language_Utils::get_language( get_locale() ) ),
+			'siteIconUrl'                 => get_site_icon_url(),
+			'countryCode'                 => WPSEO_Options::get( 'semrush_country_code', false ),
+			'SEMrushLoginStatus'          => WPSEO_Options::get( 'semrush_integration_active', true ) ? $this->get_semrush_login_status() : false,
+			'showSocial'                  => [
 				'facebook' => WPSEO_Options::get( 'opengraph', false ),
 				'twitter'  => WPSEO_Options::get( 'twitter', false ),
 			],
-			'schema'                    => [
+			'schema'                      => [
 				'displayFooter'      => WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ),
 				'pageTypeOptions'    => $schema_types->get_page_type_options(),
 				'articleTypeOptions' => $schema_types->get_article_type_options(),
 			],
-			'twitterCardType'           => YoastSEO()->helpers->options->get( 'twitter_card_type' ),
+			'twitterCardType'             => YoastSEO()->helpers->options->get( 'twitter_card_type' ),
 
 			/**
 			 * Filter to determine if the markers should be enabled or not.
 			 *
 			 * @param bool $showMarkers Should the markers being enabled. Default = true.
 			 */
-			'show_markers'              => apply_filters( 'wpseo_enable_assessment_markers', true ),
-			'publish_box'               => [
+			'show_markers'                => apply_filters( 'wpseo_enable_assessment_markers', true ),
+			'publish_box'                 => [
 				'labels' => [
 					'content' => [
 						'na'   => sprintf(
@@ -165,10 +165,16 @@ class WPSEO_Metabox_Formatter {
 					],
 				],
 			],
-			'markdownEnabled'           => $this->is_markdown_enabled(),
-			'analysisHeadingTitle'      => __( 'Analysis', 'wordpress-seo' ),
-			'zapierIntegrationActive'   => WPSEO_Options::get( 'zapier_integration_active', false ) ? 1 : 0,
-			'zapierConnectedStatus'     => ! empty( WPSEO_Options::get( 'zapier_subscription', [] ) ) ? 1 : 0,
+			'markdownEnabled'             => $this->is_markdown_enabled(),
+			'analysisHeadingTitle'        => __( 'Analysis', 'wordpress-seo' ),
+			'zapierIntegrationActive'     => WPSEO_Options::get( 'zapier_integration_active', false ) ? 1 : 0,
+			'zapierConnectedStatus'       => ! empty( WPSEO_Options::get( 'zapier_subscription', [] ) ) ? 1 : 0,
+			/**
+			 * Filter to determine whether the PreviouslyUsedKeyword assessment should run.
+			 *
+			 * @param bool $previouslyUsedKeywordActive Whether the PreviouslyUsedKeyword assessment should run.
+			 */
+			'previouslyUsedKeywordActive' => apply_filters( 'wpseo_previously_used_keyword_active', true ),
 		];
 	}
 

--- a/js/src/initializers/used-keywords-assessment.js
+++ b/js/src/initializers/used-keywords-assessment.js
@@ -14,7 +14,12 @@ import UsedKeywords from "../analysis/usedKeywords";
  */
 export default function initializeUsedKeywords( refreshAnalysis, ajaxAction, store ) {
 	const localizedData = getL10nObject();
-	const scriptUrl     = get(
+
+	if ( ! localizedData.previouslyUsedKeywordActive ) {
+		return;
+	}
+
+	const scriptUrl = get(
 		window,
 		[ "wpseoScriptData", "analysis", "worker", "keywords_assessment_url" ],
 		"used-keywords-assessment.js"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the duplicate posts for Rewrite & Republish to skip the Previously Used Keyword analysis assessment so that they can share the same keyphrase without affecting the analysis. These posts are temporary copies and will be deleted when "Republishing" so the assessment result would be misleading.

Note: this is a companion PR for the main PR on Duplicate Post, see https://github.com/Yoast/duplicate-post/pull/56

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a filter to deactivate the Previously Used Keyword analysis assessment.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- this PR needs to be tested together with the main PR on Duplicate Post, please refer to the test instructions there.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

 -N/A as it was decided the Rewrite & Republish feature should be tested as a whole when the implementation will be complete.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-235]
