### PR TITLE
Remove query parameter

### DIFF
--- a/js/src/components/Indexation.js
+++ b/js/src/components/Indexation.js
@@ -4,6 +4,7 @@ import { __ } from "@wordpress/i18n";
 import { ProgressBar, NewButton, Alert } from "@yoast/components";
 import { colors } from "@yoast/style-guide";
 import PropTypes from "prop-types";
+import { removeSearchParam, addHistoryState } from "../helpers/urlHelpers";
 
 /**
  * Indexes the site and shows a progress bar indicating the indexing process' progress.
@@ -191,10 +192,12 @@ export class Indexation extends Component {
 		const shouldStart = new URLSearchParams( window.location.search ).get( "start-indexation" ) === "true";
 
 		if ( shouldStart ) {
+			const currentURL = removeSearchParam( window.location.href, "start-indexation" );
+			addHistoryState( null, "", currentURL );
+
 			this.startIndexing();
 		}
 	}
-
 
 	/**
 	 * Renders a notice if it is the first time the indexation is performed.

--- a/js/src/helpers/urlHelpers.js
+++ b/js/src/helpers/urlHelpers.js
@@ -1,4 +1,3 @@
-
 /**
  * Removes the query parameter from the given url.
  *
@@ -8,11 +7,11 @@
  * @returns {string} The altered url object.
  */
 export function removeSearchParam( url, parameter ) {
-    let currentURL = new URL( url );
+	const currentURL = new URL( url );
 
-    currentURL.searchParams.delete( parameter );
+	currentURL.searchParams.delete( parameter );
 
-    return currentURL.href;
+	return currentURL.href;
 }
 
 /**
@@ -21,7 +20,9 @@ export function removeSearchParam( url, parameter ) {
  * @param {any}    data  The data to set.
  * @param {string} title The new title.
  * @param {string} url   The new url.
+ *
+ * @returns {void}
  */
 export function addHistoryState( data, title, url ) {
-    window.history.pushState( data, title, url );
+	window.history.pushState( data, title, url );
 }

--- a/js/src/helpers/urlHelpers.js
+++ b/js/src/helpers/urlHelpers.js
@@ -1,0 +1,27 @@
+
+/**
+ * Removes the query parameter from the given url.
+ *
+ * @param {string} url       The url to remove the parameter from
+ * @param {string} parameter The parameter to remove
+ *
+ * @returns {string} The altered url object.
+ */
+export function removeSearchParam( url, parameter ) {
+    let currentURL = new URL( url );
+
+    currentURL.searchParams.delete( parameter );
+
+    return currentURL.href;
+}
+
+/**
+ * Replaces the history state.
+ *
+ * @param {any}    data  The data to set.
+ * @param {string} title The new title.
+ * @param {string} url   The new url.
+ */
+export function addHistoryState( data, title, url ) {
+    window.history.pushState( data, title, url );
+}

--- a/js/tests/helpers/urlHelpers.test.js
+++ b/js/tests/helpers/urlHelpers.test.js
@@ -1,35 +1,35 @@
 import {
-    removeSearchParam,
-    addHistoryState
+	removeSearchParam,
+	addHistoryState,
 } from "../../src/helpers/urlHelpers";
 
 describe( "removeSearchParam", () => {
-    it( "removes the given parameter from url", () => {
-        const expected = "https://example.org/file.html?first=foo";
+	it( "removes the given parameter from url", () => {
+		const expected = "https://example.org/file.html?first=foo";
 
-        const actual = removeSearchParam( "https://example.org/file.html?first=foo&second=bar", "second" );
+		const actual = removeSearchParam( "https://example.org/file.html?first=foo&second=bar", "second" );
 
-        expect( actual ).toEqual( expected );
-    } );
+		expect( actual ).toEqual( expected );
+	} );
 
-    it( "removes the given non present parameter from url", () => {
-        const expected = "https://example.org/file.html?first=foo&second=bar";
+	it( "removes the given non present parameter from url", () => {
+		const expected = "https://example.org/file.html?first=foo&second=bar";
 
-        const actual = removeSearchParam( "https://example.org/file.html?first=foo&second=bar", "third" );
+		const actual = removeSearchParam( "https://example.org/file.html?first=foo&second=bar", "third" );
 
-        expect( actual ).toEqual( expected );
-    } );
+		expect( actual ).toEqual( expected );
+	} );
 } );
 
 describe( "addHistoryState", () => {
-    it( "adds a new state to the history.", () => {
-        const currentURL = window.location.href;
+	it( "adds a new state to the history.", () => {
+		const currentURL = window.location.href;
 
-        addHistoryState( null, "", "http://localhost/file.html?first=foo" );
+		addHistoryState( null, "", "http://localhost/file.html?first=foo" );
 
-        const actual = window.location.href;
+		const actual = window.location.href;
 
-        expect( currentURL ).toEqual( "http://localhost/" );
-        expect( actual ).toEqual( "http://localhost/file.html?first=foo" );
-    } );
+		expect( currentURL ).toEqual( "http://localhost/" );
+		expect( actual ).toEqual( "http://localhost/file.html?first=foo" );
+	} );
 } );

--- a/js/tests/helpers/urlHelpers.test.js
+++ b/js/tests/helpers/urlHelpers.test.js
@@ -1,0 +1,35 @@
+import {
+    removeSearchParam,
+    addHistoryState
+} from "../../src/helpers/urlHelpers";
+
+describe( "removeSearchParam", () => {
+    it( "removes the given parameter from url", () => {
+        const expected = "https://example.org/file.html?first=foo";
+
+        const actual = removeSearchParam( "https://example.org/file.html?first=foo&second=bar", "second" );
+
+        expect( actual ).toEqual( expected );
+    } );
+
+    it( "removes the given non present parameter from url", () => {
+        const expected = "https://example.org/file.html?first=foo&second=bar";
+
+        const actual = removeSearchParam( "https://example.org/file.html?first=foo&second=bar", "third" );
+
+        expect( actual ).toEqual( expected );
+    } );
+} );
+
+describe( "addHistoryState", () => {
+    it( "adds a new state to the history.", () => {
+        const currentURL = window.location.href;
+
+        addHistoryState( null, "", "http://localhost/file.html?first=foo" );
+
+        const actual = window.location.href;
+
+        expect( currentURL ).toEqual( "http://localhost/" );
+        expect( actual ).toEqual( "http://localhost/file.html?first=foo" );
+    } );
+} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When the indexing is started we don't want to start it again after page reload. If a user refreshes the page he has to press the index button again.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents the indexing to restart automatically when the page is reloaded during indexing.

## Relevant technical choices:

* Decided to push the url state instead of replacing it, this allows the user to go back (also to the case where the indexation is started automatically). 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Reset the indexables with the test helper.
* Go the the yoast dashboard and press the index button in the notification you get about the indexing.
* During indexing refresh the page. Indexing shouldn't start again.
   * You can verify this also by checking if the url is altered when the indexing starts. A query parameter named `start-indexation=true` will be removed from the url. 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Indexation button on the tools page.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
