### PR TITLE
P1 212 used keywords assessment elementor

### DIFF
--- a/js/src/elementor.js
+++ b/js/src/elementor.js
@@ -41,7 +41,7 @@ domReady( () => {
 	};
 
 	// Initialize the Used Keywords Assessment.
-	initializeUsedKeywords( dispatch( "yoast-seo/editor" ).refreshAnalysisDataTimestamp, "get_focus_keyword_usage" );
+	initializeUsedKeywords();
 } );
 
 // Initialize the editor integration.

--- a/js/src/elementor.js
+++ b/js/src/elementor.js
@@ -4,6 +4,7 @@ import { pluginReady, pluginReloaded, registerPlugin, registerModification } fro
 import initAnalysis from "./initializers/analysis";
 import initElementorEditorIntegration from "./initializers/elementor-editor-integration";
 import initEditorStore from "./elementor/initializers/editor-store";
+import initializeUsedKeywords from "./elementor/initializers/used-keywords-assessment";
 import initElementorWatcher from "./watchers/elementorWatcher";
 import initReplaceVarPlugin, { addReplacement, ReplaceVar } from "./elementor/replaceVars/elementor-replacevar-plugin";
 
@@ -38,6 +39,9 @@ domReady( () => {
 		addReplacement,
 		ReplaceVar,
 	};
+
+	// Initialize the Used Keywords Assessment.
+	initializeUsedKeywords( dispatch( "yoast-seo/editor" ).refreshAnalysisDataTimestamp, "get_focus_keyword_usage" );
 } );
 
 // Initialize the editor integration.

--- a/js/src/elementor/initializers/used-keywords-assessment.js
+++ b/js/src/elementor/initializers/used-keywords-assessment.js
@@ -1,5 +1,5 @@
 import { get } from "lodash-es";
-import { subscribe, select } from "@wordpress/data";
+import { subscribe, select, dispatch } from "@wordpress/data";
 
 import getL10nObject from "../../analysis/getL10nObject";
 import UsedKeywords from "../../analysis/usedKeywords";
@@ -7,12 +7,9 @@ import UsedKeywords from "../../analysis/usedKeywords";
 /**
  * Initialize used keyword analysis.
  *
- * @param {Function} refreshAnalysis Function that triggers a refresh of the analysis.
- * @param {string}   ajaxAction      The ajax action to use when retrieving the used keywords data.
- *
  * @returns {void}
  */
-export default function initializeUsedKeywords( refreshAnalysis, ajaxAction ) {
+export default function initializeUsedKeywords() {
 	const localizedData = getL10nObject();
 	const scriptUrl     = get(
 		window,
@@ -21,9 +18,9 @@ export default function initializeUsedKeywords( refreshAnalysis, ajaxAction ) {
 	);
 
 	const usedKeywords = new UsedKeywords(
-		ajaxAction,
+		"get_focus_keyword_usage",
 		localizedData,
-		refreshAnalysis,
+		dispatch( "yoast-seo/editor" ).refreshAnalysisDataTimestamp,
 		scriptUrl
 	);
 	usedKeywords.init();

--- a/js/src/elementor/initializers/used-keywords-assessment.js
+++ b/js/src/elementor/initializers/used-keywords-assessment.js
@@ -1,0 +1,40 @@
+import { get } from "lodash-es";
+import { subscribe, select } from "@wordpress/data";
+
+import getL10nObject from "../../analysis/getL10nObject";
+import UsedKeywords from "../../analysis/usedKeywords";
+
+/**
+ * Initialize used keyword analysis.
+ *
+ * @param {Function} refreshAnalysis Function that triggers a refresh of the analysis.
+ * @param {string}   ajaxAction      The ajax action to use when retrieving the used keywords data.
+ *
+ * @returns {void}
+ */
+export default function initializeUsedKeywords( refreshAnalysis, ajaxAction ) {
+	const localizedData = getL10nObject();
+	const scriptUrl     = get(
+		window,
+		[ "wpseoScriptData", "analysis", "worker", "keywords_assessment_url" ],
+		"used-keywords-assessment.js"
+	);
+
+	const usedKeywords = new UsedKeywords(
+		ajaxAction,
+		localizedData,
+		refreshAnalysis,
+		scriptUrl
+	);
+	usedKeywords.init();
+
+	let lastFocusKeyphrase = "";
+	subscribe( () => {
+		const focusKeyphrase = select( "yoast-seo/editor" ).getFocusKeyphrase();
+		if ( focusKeyphrase === lastFocusKeyphrase ) {
+			return;
+		}
+		lastFocusKeyphrase = focusKeyphrase;
+		usedKeywords.setKeyword( focusKeyphrase );
+	} );
+}

--- a/js/src/watchers/elementorWatcher.js
+++ b/js/src/watchers/elementorWatcher.js
@@ -1,6 +1,5 @@
 import { dispatch } from "@wordpress/data";
 import { get, debounce } from "lodash";
-import { refreshDelay } from "../analysis/constants";
 import firstImageUrlInContent from "../helpers/firstImageUrlInContent";
 import registerElementorHook from "../helpers/elementorHook";
 

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -399,7 +399,7 @@ class Elementor implements Integration_Interface {
 	protected function render_hidden_fields() {
 		// Wrap in a form with an action and post_id for the submit.
 		printf(
-			'<form id="yoast-form" method="post" action="%1$s"><input type="hidden" name="action" value="wpseo_elementor_save" /><input type="hidden" name="post_id" value="%2$s" />',
+			'<form id="yoast-form" method="post" action="%1$s"><input type="hidden" name="action" value="wpseo_elementor_save" /><input type="hidden" id="post_ID" name="post_id" value="%2$s" />',
 			\esc_url( \admin_url( 'admin-ajax.php' ) ),
 			\esc_attr( $this->get_metabox_post()->ID )
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the used keywords assessment to run in the Elementor integration too.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* The Used Keyword assessment is now initialized in our Elementor integration.

## Relevant technical choices:

* Added our new refresh analysis function and passed it to the used-keywords-assessment.
* Removed references to the old store, and use `subscribe`, `dispatch` and `select` from `@wordpress/data` instead.
	* We get the focusKeyphrase via a selector now.
* Had to add an id to the post_id hidden field (`usedKeywords.js` uses a jQuery search to find the post id hidden field, in order to pass it on in an AJAX request).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open three posts in Elementor.
* Add `&yoastdebug` to the URL (make sure this bit is in your `basic-wordpress-config.php`:
```
if ( isset( $_GET['yoastdebug'] )) {
	define( 'WPSEO_DEBUG', true );
	define( 'YOAST_SEO_DEBUG', true );
	define( 'YOAST_SEO_DEBUG_ANALYSIS_WORKER', 'TRACE' );
}
```
* Open the console on each page.
* Give the posts an identical keyphrase.
* Notice that you are getting custom messages from the worker with one "used-keywords-assessment-initialize" on load, and several "used-keywords-assessment-updateKeywordUsage" as you change the keyphrases. Within that log, there should be a data object with all your used keywords from this session, and the id's of the posts those already occur in.
* Open the SEO analysis collapsible, and find that the Used Keyword assessment is working.
If you have three posts with identical keywords, you should get a red bullet with:
```
Previously used keyphrase: You've used this keyphrase 2 times before. Do not use your keyphrase more than once.
```
If you have two posts with identical keywords, you should get an orange bullet with
```
Previously used keyphrase: You've used this keyphrase once before. Do not use your keyphrase more than once.
```
If the keyword is unique, it should be a green bullet with:
```
Previously used keyphrase: You've not used this keyphrase before, very good.
```

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Open three posts in Elementor.
* Give the posts an identical keyphrase.
* Open the SEO analysis collapsible, and find that the Used Keyword assessment is working.
If you have three posts with identical keywords, you should get a red bullet with:
```
Previously used keyphrase: You've used this keyphrase 2 times before. Do not use your keyphrase more than once.
```
If you have two posts with identical keywords, you should get an orange bullet with
```
Previously used keyphrase: You've used this keyphrase once before. Do not use your keyphrase more than once.
```
If the keyword is unique, it should be a green bullet with:
```
Previously used keyphrase: You've not used this keyphrase before, very good.
```

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-212
