### PR TITLE
Fix the save button being enabled on page load

### DIFF
--- a/js/src/initializers/elementor-editor-integration.js
+++ b/js/src/initializers/elementor-editor-integration.js
@@ -41,7 +41,14 @@ const storeValueAsOldValue = ( input ) => {
  * @returns {void}
  */
 const detectChange = input => {
-	if ( input.value !== input.oldValue ) {
+	let value = input.value;
+
+	// We don't store linkdex values below 0 so treat them as 0 for the purpose of changes.
+	if ( input.name === "yoast_wpseo_linkdex" && parseInt( input.value, 10 ) < 0 ) {
+		value = "0";
+	}
+
+	if ( value !== input.oldValue ) {
 		activateSaveButton();
 		storeValueAsOldValue( input );
 	}

--- a/js/src/initializers/elementor-editor-integration.js
+++ b/js/src/initializers/elementor-editor-integration.js
@@ -41,14 +41,12 @@ const storeValueAsOldValue = ( input ) => {
  * @returns {void}
  */
 const detectChange = input => {
-	let value = input.value;
-
-	// We don't store linkdex values below 0 so treat them as 0 for the purpose of changes.
-	if ( input.name === "yoast_wpseo_linkdex" && parseInt( input.value, 10 ) < 0 ) {
-		value = "0";
+	// The SEO score and the content score changing do not require a new save.
+	if ( input.name === "yoast_wpseo_linkdex" || input.name === "yoast_wpseo_content_score" ) {
+		return;
 	}
 
-	if ( value !== input.oldValue ) {
+	if ( input.value !== input.oldValue ) {
 		activateSaveButton();
 		storeValueAsOldValue( input );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The update button should be disabled if no changes have been made. With Yoast SEO it's enabled immediately if your SEO score is negative.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the update button being enabled in Elementor even if no changes have been made.

## Relevant technical choices:

* Linkdex values below 0 aren't saved by the plugin. So when watching for changes we treat values below 0 as the default ( which is 0 ).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open a post in elementor.
* The update button should be disabled.
* Make a change in the post.
* The button should enable.
* Save your post.
* The button should be disabled again.
* Change any SEO setting
* The button should enable.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Detecting changes in SEO settings inside the elementor integration.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-230
