### PR TITLE
P1-233 Fix SEO setting for post type

### DIFF
--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -398,7 +398,7 @@ class Elementor implements Integration_Interface {
 			'isElementorEditor' => true,
 		];
 
-		if ( post_type_supports( get_post_type(), 'thumbnail' ) ) {
+		if ( \post_type_supports( $this->get_metabox_post()->post_type, 'thumbnail' ) ) {
 			$this->asset_manager->enqueue_style( 'featured-image' );
 
 			$script_data['featuredImage'] = [

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -125,6 +125,10 @@ class Elementor implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
+		if ( ! $this->display_metabox( $this->get_metabox_post()->post_type ) ) {
+			return;
+		}
+
 		\add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'init' ] );
 
 		// We are too late for elementor/init. We should see if we can be on time, or else this workaround works (we do always get the "else" though).
@@ -181,6 +185,20 @@ class Elementor implements Integration_Interface {
 	}
 
 	// Below is mostly copied from `class-metabox.php`. That constructor has side-effects we do not need.
+
+	/**
+	 * Determines whether the metabox should be shown for the passed identifier.
+	 *
+	 * By default the check is done for post types, but can also be used for taxonomies.
+	 *
+	 * @param string|null $identifier The identifier to check.
+	 * @param string      $type       The type of object to check. Defaults to post_type.
+	 *
+	 * @return bool Whether or not the metabox should be displayed.
+	 */
+	public function display_metabox( $identifier = null, $type = 'post_type' ) {
+		return WPSEO_Utils::is_metabox_active( $identifier, $type );
+	}
 
 	/**
 	 * Saves the WP SEO metadata for posts.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When a user disables the SEO settings for a post type, we should not display our sidebar.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the SEO setting for post type in Elementor.

## Relevant technical choices:

* Copied the `display_metabox` from `class-metabox.php` and added the check in register hooks. Had to pass the post-type as the `get_post_type` does not work in that moment of time.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Disable the SEO settings for posts: SEO -> Search appearance -> Content types -> post type -> Show SEO settings for Posts -> Hide
* Edit a post in Elementor.
* Verify our Elementor integration is not active for that post.
* Edit a page in Elementor.
* Verify our Elementor integration is still active for that page.
* Feel free to play around with combinations here 😉 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-233
