### PR TITLE
Moved Yoast SEO button location in hamburger menu from "style" to "more"

### DIFF
--- a/js/src/initializers/elementor-editor-integration.js
+++ b/js/src/initializers/elementor-editor-integration.js
@@ -117,7 +117,7 @@ export default function initElementEditorIntegration() {
 					window.$e.routes.run( "panel/page-settings/yoast-tab" );
 				}
 			},
-		}, "style" );
+		}, "more" );
 	} );
 
 	const yoastInputs = document.querySelectorAll( "input[name^='yoast']" );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Authors don't see the "settings" part of the hamburger menu due to Elementor's restrictions. We now register the button under "more".

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* The location of the Yoast SEO button in Elementor has shifted from "settings" to "more".

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have the Yoast test helper (or log in as a user with the author role).
* Follow the steps to reproduce in issue [P1-237](https://yoast.atlassian.net/browse/P1-237).
* Switch to an author, and verify that you can still access Yoast SEO via the hamburger menu (top left three horizontal stripes).


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Be logged in as an author (not admin).
* Verify that you can still access the Yoast SEO sidebar via the route: hamburger menu (top left three horizontal stripes) > Yoast SEO.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-237
