### PR TITLE
Travis: fix `lint` command for Premium on PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,7 +145,13 @@ install:
     fi
   - |
     if [[ $TRAVIS_PHP_VERSION == "nightly" && "$PHPLINT" == "1" ]]; then
-      composer install --no-interaction --ignore-platform-reqs --no-scripts --no-suggest
+      if [[ "$IS_PREMIUM" == "1" ]]; then
+        cd premium
+        composer install --no-interaction --ignore-platform-reqs --no-scripts --no-suggest
+        cd -
+      else
+        composer install --no-interaction --ignore-platform-reqs --no-scripts --no-suggest
+      fi
     elif [[ "$PHPUNIT" == "1" || "$COVERAGE" == "1" || "$PHPCS" == "1" || "$PHPLINT" == "1" ]]; then
       # Run composer update as we have dev dependencies locked at PHP ^7.0 versions.
       composer update


### PR DESCRIPTION
## Context

* Fix broken CI check

## Summary

This PR can be summarized in the following changelog entry:

* Fix broken CI check

## Relevant technical choices:

The `composer install` within the `premium` subdirectory was not being run for PHP 8, which was the reason the PHP `nightly` builds were failing on Premium as the linting tooling could not be found.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_

Once Free has been merged back into Premium, check the output of the Travis build for `nightly`. It should be passing and running the PHP linting correctly, while previously it was failing.