### PR TITLE
PHPCS: ruleset update and add select ignore annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,8 +81,8 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=746",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=239",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=559",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=229",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs-summary": [

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -162,6 +162,16 @@
 		<exclude-pattern>/config/composer/*</exclude-pattern>
 	</rule>
 
+	<!-- Exclude the "lib" folder from select naming conventions.
+		 The intention is to extract this to a separate package, so the names are
+		 based on the "future" package. -->
+	<rule ref="Yoast.NamingConventions.NamespaceName">
+		<exclude-pattern>/lib/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound">
+		<exclude-pattern>/lib/*</exclude-pattern>
+	</rule>
+
 	<!-- Exclude php-codeshift from being checked too roughly. -->
 	<rule ref="Yoast.NamingConventions.ObjectNameDepth">
 		<exclude-pattern>/config/php-codeshift/*</exclude-pattern>
@@ -198,6 +208,17 @@
 		<exclude-pattern>/inc/wpseo-functions-deprecated\.php$</exclude-pattern>
 	</rule>
 
+	<!-- Exclude deprecated code from select sniffs regarding naming conventions.
+		 These classes are still available to prevent BC-breaks and renaming them would
+		 create a BC-break. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<exclude-pattern>/src/deprecated/*</exclude-pattern>
+	</rule>
+	<rule ref="Yoast.Files.FileName">
+		<exclude-pattern>/src/deprecated/*</exclude-pattern>
+	</rule>
+
+
 	<!-- TEST CODE -->
 
 	<!-- Valid usage: For testing purposes, some non-prefixed globals are being created, which is fine. -->
@@ -218,6 +239,11 @@
 	<!-- Changing the cron interval to test things, is fine. -->
 	<rule ref="WordPress.WP.CronInterval">
 		<exclude-pattern>/tests/*</exclude-pattern>
+	</rule>
+
+	<!-- The unit tests are not run within the context of a WP install, so overwritting globals is fine. -->
+	<rule ref="WordPress.WP.GlobalVariablesOverride">
+		<exclude-pattern>/tests/unit/*</exclude-pattern>
 	</rule>
 
 	<!-- Allow for the double/mock classes to override methods just to change the visibility. -->

--- a/tests/unit/builders/indexable-post-builder-test.php
+++ b/tests/unit/builders/indexable-post-builder-test.php
@@ -300,6 +300,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$this->indexable->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$this->indexable->orm->expects( 'set' )
+			// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encodeWithAdditionalParams -- Test code, mocking WP.
 			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES ) ) );
 
 		// We expect the twitter image and its source to be set.

--- a/tests/unit/builders/indexable-social-image-trait-test.php
+++ b/tests/unit/builders/indexable-social-image-trait-test.php
@@ -142,6 +142,7 @@ class Indexable_Social_Image_Trait_Test extends TestCase {
 		$this->indexable->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$this->indexable->orm->expects( 'set' )
+			// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encodeWithAdditionalParams -- Test code, mocking WP.
 			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES ) ) );
 
 		// We expect twitter image meta to be set.
@@ -193,6 +194,7 @@ class Indexable_Social_Image_Trait_Test extends TestCase {
 		$this->indexable->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$this->indexable->orm->expects( 'set' )
+			// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encodeWithAdditionalParams -- Test code, mocking WP.
 			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES ) ) );
 
 		$alternative_image = [
@@ -308,6 +310,7 @@ class Indexable_Social_Image_Trait_Test extends TestCase {
 		$this->indexable->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$this->indexable->orm->expects( 'set' )
+			// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encodeWithAdditionalParams -- Test code, mocking WP.
 			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES ) ) );
 
 		$alternative_image = [

--- a/tests/unit/builders/indexable-term-builder-test.php
+++ b/tests/unit/builders/indexable-term-builder-test.php
@@ -270,6 +270,7 @@ class Indexable_Term_Builder_Test extends TestCase {
 		$indexable_mock->orm->expects( 'set' )
 			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
 		$indexable_mock->orm->expects( 'set' )
+			// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encodeWithAdditionalParams -- Test code, mocking WP.
 			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES ) ) );
 
 		// We expect the twitter image and its source to be set.


### PR DESCRIPTION
## Context

* Code consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

### PHPCS ruleset: minor tweaks

* Ignore overwriting WordPress global variables for the unit tests, as for those, the WordPress environment is not loaded, so it won't influence other tests.
* Exclude the `lib` directory from select naming conventions sniffs as the intention is to move this code to a separate package.
* Exclude the `src/deprecated` directory from select naming conventions sniffs as renaming classes and such would be a BC-break, while these files remain in place to _prevent_ BC-breaks.

### Build/PHPCS: add select ignore annotations in the tests 

### Composer: update the CS thresholds

... to take these changes and the other changes of today into account.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the Travis build passes, we're good.