### PR TITLE
P1 238 elementor modal styling issues

### DIFF
--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -18,6 +18,10 @@
 	margin-bottom: 1em;
 }
 
+.yoast.components-panel__body .yoast-title {
+	font-weight: var(--yoast-font-weight-bold);
+}
+
 .elementor-panel .elementor-tab-control-yoast-tab a:before, .yoast-element-menu-icon:before {
 	mask-image: var(--yoast-svg-icon-yoast);
 	-webkit-mask-image: var(--yoast-svg-icon-yoast);

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -57,6 +57,9 @@
 .yoast li, .yoast p, .yoast small {
 	margin-bottom: 6px;
 	line-height: 1.5;
+}
+
+.yoast ul[role='list'] li, .yoast p, .yoast small {
 	color: var(--yoast-elementor-color-paragraph);
 }
 

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -105,38 +105,42 @@
 }
 
 .yoast-gutenberg-modal input[type="radio"] {
-	appearance: none;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	width: 18px;
+	height: 18px;
+	padding: 2px;
+	margin: 0 8px 0 0;
+	vertical-align: text-bottom;
 	border-radius: 50%;
-	border: 2px solid #6c7781;
-	margin-right: 12px;
-	transition: none;
-	box-shadow: 0 0 0 transparent;
-	height: 1rem;
-	padding: 0;
-	vertical-align: middle;
-	width: 1rem;
-	min-width: 1rem;
+	transition: all 150ms ease-out 0s;
+	border: var(--yoast-border-default);
+	box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+	position: relative;
+	overflow: hidden;
+	cursor: pointer;
 }
 
 .yoast-gutenberg-modal input[type="radio"]:checked {
-	background: #11a0d2;
-	border-color: #11a0d2;
+	border-color: var(--yoast-color-primary);
+	background-color: inherit;
+}
+
+.yoast-gutenberg-modal input[type='radio']:checked:after {
+	background: var(--yoast-color-primary);
+	width: 10px;
+	height: 10px;
+	background: var(--yoast-color-primary);
+	position: absolute;
+	left: 3px;
+	top: 3px;
+	content: "";
+	display: block;
+	border-radius: 50%;
 }
 
 .yoast-post-settings-modal .yoast-notice-container {
 	bottom: auto;
-}
-
-input[type="radio"]:checked::before {
-	content: "";
-	float: left;
-	vertical-align: middle;
-	border-radius: 50%;
-	line-height: 1.14285714;
-	width: 6px;
-	height: 6px;
-	margin: 3px 0 0 3px;
-	background-color: #fff;
 }
 
 /* Tab-focus styling */
@@ -155,11 +159,8 @@ input[type="radio"]:checked::before {
 }
 
 .yoast input[type="radio"]:checked:focus {
-	box-shadow: 0 0 0 2px #555d66;
-}
-
-.yoast input[type="radio"]:focus {
-	box-shadow: 0 0 0 1px #6c7781;
+	box-shadow: var(--yoast-color-focus);
+	border-color: #fff;
 }
 
 .yoast .yoast-button-upsell:focus {

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -7,8 +7,8 @@
 	--yoast-elementor-color-paragraph: #555D66;
 }
 
-.yoast {
-	font-family: var(--yoast-font-family);
+.yoast, .yoast h2, .yoast h3 {
+	font-family: var(--yoast-font-family) !important;
 }
 
 .yoast h2 {
@@ -19,7 +19,11 @@
 }
 
 .yoast.components-panel__body .yoast-title {
-	font-weight: var(--yoast-font-weight-bold);
+	font-weight: 500;
+}
+
+.yoast h3 span > span {
+	font-weight: 400;
 }
 
 .elementor-panel .elementor-tab-control-yoast-tab a:before, .yoast-element-menu-icon:before {

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -127,30 +127,6 @@ input[type="radio"]:checked::before {
 	background-color: #fff;
 }
 
-/* Upsell modal close-button tooltips */
-.yoast-gutenberg-modal {
-	overflow: visible;
-}
-
-.yoast-gutenberg-modal .components-modal__header .components-button {
-	overflow: visible;
-}
-
-.yoast-gutenberg-modal .components-modal__header .components-button > span {
-	width: 0;
-	height: 0;
-}
-
-.yoast-gutenberg-modal .components-modal__header .components-button .components-tooltip {
-	position: absolute;
-	top: 0 !important;
-	left: 20px !important;
-}
-
-.yoast-gutenberg-modal .components-modal__header .components-tooltip::before, .yoast-gutenberg-modal .components-modal__header .components-tooltip::after {
-	top: 0;
-}
-
 /* Tab-focus styling */
 .yoast div:focus {
 	outline: 0;

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -99,6 +99,11 @@
 	background: none;
 }
 
+.yoast-gutenberg-modal .yoast-notice-container > hr {
+	border-top-color: #ddd;
+	border-top-style: solid;
+}
+
 .yoast-gutenberg-modal input[type="radio"] {
 	appearance: none;
 	border-radius: 50%;

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -128,7 +128,7 @@ input[type="radio"]:checked::before {
 }
 
 /* Tab-focus styling */
-.yoast div:focus {
+.yoast div:focus, div.yoast:focus {
 	outline: 0;
 }
 

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -143,6 +143,13 @@
 	bottom: auto;
 }
 
+.yoast-gutenberg-modal .components-popover.components-tooltip {
+	position: relative;
+	left: unset !important;
+	top: 15px !important;
+	right: 40px;
+}
+
 /* Tab-focus styling */
 .yoast div:focus, div.yoast:focus {
 	outline: 0;

--- a/js/src/elementor/containers/SnippetEditor.js
+++ b/js/src/elementor/containers/SnippetEditor.js
@@ -67,7 +67,7 @@ const mapEditorDataToPreview = ( data, context ) => {
  *
  * @returns {wp.Element} The component.
  */
-const SnippetEditorWrapper = ( {  isLoading, onLoad, hasPaperStyle, location, ...restProps } ) => {
+const SnippetEditorWrapper = ( {  isLoading, onLoad, location, ...restProps } ) => {
 	useEffect( () => {
 		setTimeout( () => {
 			if ( isLoading ) {
@@ -83,7 +83,7 @@ const SnippetEditorWrapper = ( {  isLoading, onLoad, hasPaperStyle, location, ..
 	return (
 		<SnippetPreviewSection
 			icon="eye"
-			hasPaperStyle={ hasPaperStyle }
+			hasPaperStyle={ restProps.hasPaperStyle }
 		>
 			<SnippetEditor
 				{ ...restProps }


### PR DESCRIPTION
## Context
QA discovered some issues with styling of the Elementor integration. Especially with the overflow of modals. This PR fixes those issues.
*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->

## Relevant technical choices:

* Nothing special

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check whether modals show a vertical scrollbar when the content doesn't fit the screen instead of content overflowing
* Check whether styling of the Elementor integration looks the same as that of the Block editor sidebar apart from link hover color and the radio buttons in the Google Preview. Those are delibaretely different as decided together with Kai.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Check that styling is the same as in te Block editor sidebar apart from link hover color and the radio buttons in the Google Preview. Those are delibaretely different as decided together with Kai. 
* Please note that text and link colors can be slightly different color(codes) as we're following Yoast standards instead of Block editor standards there. Almost invisible to the human eye.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
P1-238