### PR TITLE
Fix semrush modal closing immediately

### DIFF
--- a/js/src/components/SEMrushRelatedKeyphrasesModal.js
+++ b/js/src/components/SEMrushRelatedKeyphrasesModal.js
@@ -12,6 +12,7 @@ import { NewButton, ButtonStyledLink } from "@yoast/components";
 import { ModalContainer } from "./modals/Container";
 import Modal from "./modals/Modal";
 import YoastIcon from "../../../images/Yoast_icon_kader.svg";
+import { isCloseEvent } from "./modals/editorModals/EditorModal.js";
 
 /**
  * Redux container for the RelatedKeyPhrasesModal modal.
@@ -50,9 +51,15 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 	/**
 	 * Handles the close event for the modal.
 	 *
+	 * @param {Event} event The event passed to the onRequestClose.
+	 *
 	 * @returns {void}
 	 */
-	onModalClose() {
+	onModalClose( event ) {
+		if ( ! isCloseEvent( event ) ) {
+			return;
+		}
+
 		this.props.onClose();
 	}
 

--- a/js/src/components/modals/editorModals/EditorModal.js
+++ b/js/src/components/modals/editorModals/EditorModal.js
@@ -13,7 +13,7 @@ import { LocationProvider } from "../../contexts/location";
  *
  * @returns {boolean} False when this event should not lead to closing to modal. True otherwise.
  */
-const isCloseEvent = ( event ) => {
+export const isCloseEvent = ( event ) => {
 	if ( event.type === "blur" ) {
 		// The blur event type should only close the modal when the screen overlay is clicked.
 		if ( event.relatedTarget && event.relatedTarget.querySelector( ".components-modal__screen-overlay" ) ) {

--- a/js/src/initializers/elementor-editor-integration.js
+++ b/js/src/initializers/elementor-editor-integration.js
@@ -87,7 +87,7 @@ export default function initElementEditorIntegration() {
 		window.$e.routes.on( "run:after", function( component, route ) {
 			if ( route === "panel/page-settings/yoast-tab" ) {
 				renderReactRoot( window.YoastSEO.store, "elementor-panel-page-settings-controls", (
-					<StyleSheetManager target={ window.document.body }>
+					<StyleSheetManager target={ document.getElementById( "elementor-panel-page-settings-controls" ) }>
 						<div className="yoast yoast-elementor-panel__fills">
 							<ElementorSlot />
 							<ElementorFill />


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* SEMRush modal was not accessible when our sidebar was closed and then opened again.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug in the Elementor integration where the SEMrush modal was closing immediately upon opening, after the Yoast SEO sidebar had been closed an opened again.

## Relevant technical choices:

* Moved the stylesheet from the bottom of the body to our own integration, because it kept duplicating on every close and open. Now it is removed on close, and added again on open.
* Filter the blur event to check whether it is caused by clicking outside of the modal (not all blur events should lead to a close).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the SEO sidebar in Elementor. Open the Semrush modal. It should open.
* Go to any other location in the sidebar (closing the YoastSEO sidebar).
* Go back to the Yoast SEO sidebar. Open the semrush modal. This should work. If not on this branch, it does not work.



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* SEMrush modal in block editor.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-241
