### PR TITLE
Dependency Injection: fix custom loader on Windows

### DIFF
--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -38,12 +38,11 @@ class Custom_Loader extends PhpFileLoader {
 		if ( ! $class_map ) {
 			$class_map = require __DIR__ . '/../../vendor/composer/autoload_classmap.php';
 			$class_map = \array_map( [ $this, 'normalize_slashes' ], $class_map );
+			$class_map = \array_flip( $class_map );
 		}
 
-		foreach ( $class_map as $class => $class_path ) {
-			if ( $path === $class_path ) {
-				return $class;
-			}
+		if ( isset( $class_map[ $path ] ) ) {
+			return $class_map[ $path ];
 		}
 
 		return false;

--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -193,11 +193,11 @@ class Custom_Loader extends PhpFileLoader {
 	}
 
 	/**
-	 * Normalize all slashes in a file path to forward slashes.
+	 * Normalizes all slashes in a file path to forward slashes.
 	 *
 	 * @param string $path File path.
 	 *
-	 * @return string
+	 * @return string The file path with normalized slashes.
 	 */
 	private function normalize_slashes( $path ) {
 		return \str_replace( '\\', '/', $path );

--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -37,6 +37,7 @@ class Custom_Loader extends PhpFileLoader {
 
 		if ( ! $class_map ) {
 			$class_map = require __DIR__ . '/../../vendor/composer/autoload_classmap.php';
+			$class_map = \array_map( [ $this, 'normalize_slashes' ], $class_map );
 		}
 
 		foreach ( $class_map as $class => $class_path ) {
@@ -124,7 +125,8 @@ class Custom_Loader extends PhpFileLoader {
 				}
 
 				// Normalize Windows slashes.
-				$exclude_paths[ \str_replace( '\\', '/', $path ) ] = true;
+				$path                   = $this->normalize_slashes( $path );
+				$exclude_paths[ $path ] = true;
 			}
 		}
 
@@ -141,7 +143,10 @@ class Custom_Loader extends PhpFileLoader {
 				}
 			}
 
-			if ( isset( $exclude_paths[ \str_replace( '\\', '/', $path ) ] ) ) {
+			// Normalize Windows slashes.
+			$path = $this->normalize_slashes( $path );
+
+			if ( isset( $exclude_paths[ $path ] ) ) {
 				continue;
 			}
 
@@ -186,5 +191,16 @@ class Custom_Loader extends PhpFileLoader {
 		}
 
 		return $classes;
+	}
+
+	/**
+	 * Normalize all slashes in a file path to forward slashes.
+	 *
+	 * @param string $path File path.
+	 *
+	 * @return string
+	 */
+	private function normalize_slashes( $path ) {
+		return \str_replace( '\\', '/', $path );
 	}
 }


### PR DESCRIPTION
## Context

* Fixed Dependency Injection Compile command on Windows

## Summary

This PR can be summarized in the following changelog entry:

* Fixed Dependency Injection Compile command on Windows

## Relevant technical choices:

### Compile-DI: fix custom loader on Windows

Both the returned value from `glob` as well as the classmap generated by Composer contain file paths with a mix of forward and backward slashes when run on Windows.

This was breaking the `compile-di` command.

Previously it was _silently_ broken - it wouldn't work, but without throwing an error.
Since the addition of the `Schema_Blocks` it would fail with an exception.

This commit fixes this by:
1. Adding a `normalize_slashes()` method.
2. Calling that method in the relevant places in the script to make sure that paths are normalized before they are compared based on their string value.

### Custom_Loader::getClassFromClassMap(): efficiency fix

The `Custom_Loader::getClassFromClassMap()` would do a loop through all classes registered in the classmap via a foreach for _each_ class requested (which could be many).

By flipping the array and using `isset()` instead, the functionality remains the same, but is infinitely faster.



## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

This should be tested on the three OS-es used by devs: Linux, MacOS and Windows.
* On `trunk`, run `composer install`.
    On Linux and Mac this should be successful already, on Windows it will fail with an exception during the `compile-di` step.
* After running the command, verify that the `src/generated` folder contains both the `container.php` and the `container.php.meta` file and that those are not empty.
* Switch to this branch, rinse & repeat.
    If all is good, the command should now finish successfully on all three OSes.

