### PR TITLE
Only add the patch number in the readme if we're actually doing a patch

### DIFF
--- a/config/grunt/custom-tasks/update-readme.js
+++ b/config/grunt/custom-tasks/update-readme.js
@@ -3,7 +3,7 @@ const parseVersion = require( "../lib/parse-version" );
 const _isEmpty = require( "lodash/isEmpty" );
 
 /**
- * ...
+ * A task to remove old changelog entries and add new ones in readme.txt.
  *
  * @param {Object} grunt The grunt helper object.
  * @returns {void}
@@ -84,7 +84,12 @@ module.exports = function( grunt ) {
 				} );
 			} else {
 				// If the current version is not in the changelog, allow the user to enter new changelog items.
-				const changelogVersionNumber = versionNumber.major + "." + versionNumber.minor + "." + versionNumber.patch;
+				let changelogVersionNumber = versionNumber.major + "." + versionNumber.minor;
+
+				// Only add the patch number if we're actually doing a patch.
+				if ( versionNumber.patch !== 0 ) {
+					changelogVersionNumber += "." + versionNumber.patch;
+				}
 
 				// Present the user with only the version number.
 				getUserInput( { initialContent: `= ${changelogVersionNumber} =` } ).then( newChangelog => {

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -40,7 +40,7 @@ class Schema_Blocks_Test extends TestCase {
 	public function test_get_conditionals() {
 		static::assertSame(
 			[
-				Schema_Blocks_Conditional::class
+				Schema_Blocks_Conditional::class,
 			],
 			Schema_Blocks::get_conditionals()
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The pop-up that lets you enter the new changelog entries already fills in the version number for the new release. However, it currently always fills in a number like `15.4.0`, even though we never use the `0` in our versioning. I added a check that only adds the patch number if it is unequal to zero.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the RC automatization by checking whether the plugin version number should contain a patch number.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**To reproduce**
* Create a new test branch from `trunk` (because the test will add a commit to your branch).
* In the terminal, run `grunt update-readme --plugin-version=15.5` (the version number should be higher than what we currently have in `readme.txt`).
* See a window pop up that lets you enter the new changelog.
* See that it says `= 15.5.0 =` as the version number.

**To test the fix**
* Checkout this branch, and create a new test branch from it (or use this branch, but make sure you don't push the commits that will result from testing).
* In the terminal, run `grunt update-readme --plugin-version=15.5` (the version number should be higher than what we currently have in `readme.txt`).
* See a window pop up that lets you enter the new changelog.
* See that it says `= 15.5 =` as the version number.
* In the terminal, run `grunt update-readme --plugin-version=15.5.1`.
* See a window pop up that lets you enter the new changelog.
* See that it says `= 15.5.1 =` as the version number.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* No QA test needed.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The RC automatization.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
