### PR TITLE
Elementor: ignore prominent words change

### DIFF
--- a/js/src/initializers/elementor-editor-integration.js
+++ b/js/src/initializers/elementor-editor-integration.js
@@ -46,6 +46,11 @@ const detectChange = input => {
 		return;
 	}
 
+	// The prominent words do not require a new save (based on the content anyway).
+	if ( input.name === "yoast_wpseo_words_for_linking" ) {
+		return;
+	}
+
 	if ( input.value !== input.oldValue ) {
 		activateSaveButton();
 		storeValueAsOldValue( input );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Elementor update button would be active on page load right away.

## Relevant technical choices:

The prominent words are not loaded in the hidden field correctly. This always starts as an empty string (not only in the Elementor editor). The actual values are then calculated in JS.
In Elementor this is a problem because we rely on the hidden input values for the "dirty" check.
But since the prominent words are based on the content, title and description (ty Marijn 😄  and Herre for confirming) I felt it is save to ignore changes in that data.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is a free change that impacts premium only. So developers: create a branch (from release/15.4 on premium and merge this into it).
* On Premium: edit a post in the Elementor editor.
* Save the post.
* Reload the page.
* It should no longer have the `update` button highlighted right away.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* On Premium: edit a post in the Elementor editor.
* It should no longer have the `update` button highlighted right away.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-245
