### PR TITLE
Don't fire HTTP requests when the Yoast dashboard widget has been hidden

### DIFF
--- a/js/src/dashboard-widget.js
+++ b/js/src/dashboard-widget.js
@@ -64,7 +64,7 @@ class DashboardWidget extends Component {
 	 * @returns {string} The color to use for this score. Defaults to grey if no such color exists.
 	 */
 	static getColorFromScore( score ) {
-		return colors[ `$color_${ score }` ] || colors.$color_grey;
+		return colors[ `$color_${score}` ] || colors.$color_grey;
 	}
 
 	/**
@@ -80,14 +80,16 @@ class DashboardWidget extends Component {
 				return;
 			}
 
-			statistics.seoScores = response.seo_scores.map( ( score ) => ( {
-				value: parseInt( score.count, 10 ),
-				color: DashboardWidget.getColorFromScore( score.seo_rank ),
-				html: `<a href="${ score.link }">${ score.label }</a>`,
-			} ) );
+			statistics.seoScores = response.seo_scores.map( ( score ) => (
+				{
+					value: parseInt( score.count, 10 ),
+					color: DashboardWidget.getColorFromScore( score.seo_rank ),
+					html: `<a href="${score.link}">${score.label}</a>`,
+				}
+			) );
 
 			// Wrap in a div and get the text to HTML decode.
-			statistics.header = jQuery( `<div>${ response.header }</div>` ).text();
+			statistics.header = jQuery( `<div>${response.header}</div>` ).text();
 
 			this.setState( { statistics } );
 		} );
@@ -103,12 +105,12 @@ class DashboardWidget extends Component {
 		getPostFeed(
 			"https://yoast.com/feed/widget/?wp_version=" + wpseoDashboardWidgetL10n.wp_version +
 			"&php_version=" + wpseoDashboardWidgetL10n.php_version,
-			2
+			2,
 		)
 			.then( ( feed ) => {
 				feed.items = feed.items.map( ( item ) => {
-					item.description = jQuery( `<div>${ item.description }</div>` ).text();
-					item.description = item.description.replace( `The post ${ item.title } appeared first on Yoast.`, "" ).trim();
+					item.description = jQuery( `<div>${item.description}</div>` ).text();
+					item.description = item.description.replace( `The post ${item.title} appeared first on Yoast.`, "" ).trim();
 
 					return item;
 				} );
@@ -131,8 +133,8 @@ class DashboardWidget extends Component {
 
 		return <SeoAssessment
 			key="yoast-seo-posts-assessment"
-			seoAssessmentText={ this.state.statistics.header }
-			seoAssessmentItems={ this.state.statistics.seoScores }
+			seoAssessmentText={this.state.statistics.header}
+			seoAssessmentItems={this.state.statistics.seoScores}
 		/>;
 	}
 
@@ -149,9 +151,9 @@ class DashboardWidget extends Component {
 		return <WordpressFeed
 			className="wordpress-feed"
 			key="yoast-seo-blog-feed"
-			title={ wpseoDashboardWidgetL10n.feed_header }
-			feed={ this.state.feed }
-			footerLinkText={ wpseoDashboardWidgetL10n.feed_footer }
+			title={wpseoDashboardWidgetL10n.feed_header}
+			feed={this.state.feed}
+			footerLinkText={wpseoDashboardWidgetL10n.feed_footer}
 		/>;
 	}
 
@@ -170,7 +172,7 @@ class DashboardWidget extends Component {
 			return null;
 		}
 
-		return <div>{ contents }</div>;
+		return <div>{contents}</div>;
 	}
 }
 
@@ -179,5 +181,5 @@ const element = document.getElementById( "yoast-seo-dashboard-widget" );
 if ( element ) {
 	setYoastComponentsL10n();
 
-	render( <DashboardWidget />, element );
+	render( <DashboardWidget/>, element );
 }

--- a/js/src/dashboard-widget.js
+++ b/js/src/dashboard-widget.js
@@ -10,7 +10,7 @@ import { getPostFeed } from "@yoast/helpers";
 import { setYoastComponentsL10n } from "./helpers/i18n";
 
 /**
- * The Yoast dashboardwidget component used on the WordPress admin dashboard.
+ * The Yoast dashboard widget component used on the WordPress admin dashboard.
  */
 class DashboardWidget extends Component {
 	/**
@@ -22,10 +22,38 @@ class DashboardWidget extends Component {
 		this.state = {
 			statistics: null,
 			feed: null,
+			isDataFetched: false,
 		};
+
+		const widgetCheckbox = jQuery( "#wpseo-dashboard-overview-hide" );
+
+		// Only fetch the data if the Yoast SEO dashboard widget is checked in the Screen Options.
+		if ( widgetCheckbox.is( ":checked" ) ) {
+			this.fetchData();
+		}
+
+		// Whenever the checkbox gets clicked, fetch the data if needed.
+		widgetCheckbox.on( "click", () => {
+			this.fetchData();
+		} );
+	}
+
+	/**
+	 * Fetches the relevant data, if they haven't been fetched before.
+	 *
+	 * @returns {void}
+	 */
+	fetchData() {
+		if ( this.state.isDataFetched ) {
+			return;
+		}
 
 		this.getStatistics();
 		this.getFeed();
+
+		this.setState( {
+			isDataFetched: true,
+		} );
 	}
 
 	/**

--- a/js/src/dashboard-widget.js
+++ b/js/src/dashboard-widget.js
@@ -64,7 +64,7 @@ class DashboardWidget extends Component {
 	 * @returns {string} The color to use for this score. Defaults to grey if no such color exists.
 	 */
 	static getColorFromScore( score ) {
-		return colors[ `$color_${score}` ] || colors.$color_grey;
+		return colors[ `$color_${ score }` ] || colors.$color_grey;
 	}
 
 	/**
@@ -80,16 +80,14 @@ class DashboardWidget extends Component {
 				return;
 			}
 
-			statistics.seoScores = response.seo_scores.map( ( score ) => (
-				{
-					value: parseInt( score.count, 10 ),
-					color: DashboardWidget.getColorFromScore( score.seo_rank ),
-					html: `<a href="${score.link}">${score.label}</a>`,
-				}
-			) );
+			statistics.seoScores = response.seo_scores.map( ( score ) => ( {
+				value: parseInt( score.count, 10 ),
+				color: DashboardWidget.getColorFromScore( score.seo_rank ),
+				html: `<a href="${ score.link }">${ score.label }</a>`,
+			} ) );
 
 			// Wrap in a div and get the text to HTML decode.
-			statistics.header = jQuery( `<div>${response.header}</div>` ).text();
+			statistics.header = jQuery( `<div>${ response.header }</div>` ).text();
 
 			this.setState( { statistics } );
 		} );
@@ -105,12 +103,12 @@ class DashboardWidget extends Component {
 		getPostFeed(
 			"https://yoast.com/feed/widget/?wp_version=" + wpseoDashboardWidgetL10n.wp_version +
 			"&php_version=" + wpseoDashboardWidgetL10n.php_version,
-			2,
+			2
 		)
 			.then( ( feed ) => {
 				feed.items = feed.items.map( ( item ) => {
-					item.description = jQuery( `<div>${item.description}</div>` ).text();
-					item.description = item.description.replace( `The post ${item.title} appeared first on Yoast.`, "" ).trim();
+					item.description = jQuery( `<div>${ item.description }</div>` ).text();
+					item.description = item.description.replace( `The post ${ item.title } appeared first on Yoast.`, "" ).trim();
 
 					return item;
 				} );
@@ -133,8 +131,8 @@ class DashboardWidget extends Component {
 
 		return <SeoAssessment
 			key="yoast-seo-posts-assessment"
-			seoAssessmentText={this.state.statistics.header}
-			seoAssessmentItems={this.state.statistics.seoScores}
+			seoAssessmentText={ this.state.statistics.header }
+			seoAssessmentItems={ this.state.statistics.seoScores }
 		/>;
 	}
 
@@ -151,9 +149,9 @@ class DashboardWidget extends Component {
 		return <WordpressFeed
 			className="wordpress-feed"
 			key="yoast-seo-blog-feed"
-			title={wpseoDashboardWidgetL10n.feed_header}
-			feed={this.state.feed}
-			footerLinkText={wpseoDashboardWidgetL10n.feed_footer}
+			title={ wpseoDashboardWidgetL10n.feed_header }
+			feed={ this.state.feed }
+			footerLinkText={ wpseoDashboardWidgetL10n.feed_footer }
 		/>;
 	}
 
@@ -172,7 +170,7 @@ class DashboardWidget extends Component {
 			return null;
 		}
 
-		return <div>{contents}</div>;
+		return <div>{ contents }</div>;
 	}
 }
 
@@ -181,5 +179,5 @@ const element = document.getElementById( "yoast-seo-dashboard-widget" );
 if ( element ) {
 	setYoastComponentsL10n();
 
-	render( <DashboardWidget/>, element );
+	render( <DashboardWidget />, element );
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When a user chooses to hide the Yoast SEO dashboard widget by unchecking the corresponding box in the screen options on the dashboard, we want to prevent this widget from still fetching data.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Yoast SEO dashboard widget would still fetch data even when it was hidden.

## Relevant technical choices:

* We only want to fetch the data when the box is checked.
* We only want to fetch the data once. If a user keeps checking and unchecking the box, the data don't need to be fetched every time. Therefore, we introduced `isDataFetched` in the state.
* Please note that this PR tackles the situation where the widget is _hidden_. It's also possible to completely [remove the widget with a filter](https://yoast.com/help/how-to-hide-the-seo-dashboard-widget/). In that situation, HTTP requests are not fired. Therefore, that situation doesn't require a fix.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**To reproduce the bug**: run the following steps without this PR.
* Open your network tab.
* Go to WordPress dashboard.
* No matter whether or not the Yoast SEO Posts Overview checkbox in the Screen options is checked, you will see the following requests being done:
    * `/wp-json/yoast/v1/statistics` (filter on "statistics" for easier readability)
    * `https://yoast.com/feed/widget/` (filter on "feed" for easier readability)

**To test the fix**: use the code from this PR.
* Open your network tab.
* Go to WordPress dashboard.
* Check the Yoast SEO Posts Overview checkbox in the Screen options, if it isn't checked yet.
* Refresh the dashboard, see the statistics and feed requests in your network tab.
* Uncheck the box, see the widget disappear.
* Check the box again, and see the widget reappear.
* See that no _additional_ statistics and feed requests are being done, each time you check and uncheck the box.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above. Use the RC containing this code to test the fix, use an earlier RC to reproduce the bug.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The Yoast SEO dashboard widget.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/12359
