### PR TITLE
Only attempt loading Social data if the platform is enabled

### DIFF
--- a/js/src/elementor/initializers/editor-store.js
+++ b/js/src/elementor/initializers/editor-store.js
@@ -37,9 +37,14 @@ const populateStore = store => {
 		} )
 	);
 
-	// Initialize the Social Preview data
-	store.dispatch( actions.loadFacebookPreviewData() );
-	store.dispatch( actions.loadTwitterPreviewData() );
+	// Initialize the Social Preview data depending on which platform should be present
+	const { facebook: showFacebook, twitter: showTwitter } = window.wpseoScriptData.metabox.showSocial;
+	if ( showFacebook ) {
+		store.dispatch( actions.loadFacebookPreviewData() );
+	}
+	if ( showTwitter ) {
+		store.dispatch( actions.loadTwitterPreviewData() );
+	}
 
 	store.dispatch( actions.setSEMrushChangeCountry( window.wpseoScriptData.metabox.countryCode ) );
 	store.dispatch( actions.setSEMrushLoginStatus( window.wpseoScriptData.metabox.SEMrushLoginStatus ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* An error occurred in Elementor when opening the sidebar without having `opengraph` enabled. Or `twitter`.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the Yoast SEO sidebar would crash in Elementor if "opengraph" or "twitter" were disabled.

## Relevant technical choices:

* Only initialize data we actually have on the page.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Disable `opengraph`, go to an Elementor page and open our sidebar. No crashing should occur. Twitter should be visible populated with the right data.
* Disable `opengraph` and `twitter`, go to an Elementor page and open our sidebar. No crashing should occur. No social fields should be visible.
* Disable `twitter` (enable `opengraph`), go to an Elementor page and open our sidebar. No crashing should occur. Facebook should be visible and populated with the right data.
* Enable both `opengraph` and `twitter`, go to an Elementor page and open our sidebar. No crashing should occur and both Social collapsibles should be visible and populated with the right data.



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-253
