### PR TITLE
Restore old Snippet Editor fields functionality

### DIFF
--- a/js/src/elementor/redux/actions/snippetEditor.js
+++ b/js/src/elementor/redux/actions/snippetEditor.js
@@ -42,7 +42,7 @@ export const loadSnippetEditorData = () => {
 	return {
 		type: LOAD_SNIPPET_EDITOR_DATA,
 		data: {
-			title: SearchMetadataFields.title,
+			title: SearchMetadataFields.title || get( window, "wpseoScriptData.metabox.title_template", "" ),
 			description: SearchMetadataFields.description,
 			slug: SearchMetadataFields.slug,
 		},

--- a/js/src/elementor/redux/actions/snippetEditor.js
+++ b/js/src/elementor/redux/actions/snippetEditor.js
@@ -18,10 +18,21 @@ export function updateData( data ) {
 	 * Using a truthy check (e.g. `data.title`) does not work, as it would be false when the string is empty.
 	 */
 	if ( data.hasOwnProperty( "title" ) ) {
-		SearchMetadataFields.title = data.title;
+		let titleToBeSaved = data.title;
+		// Test whether this is actually the template, which we don't want to save.
+		if ( data.title === get( window, "wpseoScriptData.metabox.title_template", "" ) ) {
+			titleToBeSaved = "";
+		}
+
+		SearchMetadataFields.title = titleToBeSaved;
 	}
 	if ( data.hasOwnProperty( "description" ) ) {
-		SearchMetadataFields.description = data.description;
+		let metaDescToBeSaved = data.description;
+		// Test whether this is actually the template, which we don't want to save.
+		if ( data.description === get( window, "wpseoScriptData.metabox.metadesc_template", "" ) ) {
+			metaDescToBeSaved = "";
+		}
+		SearchMetadataFields.description = metaDescToBeSaved;
 	}
 	if ( data.hasOwnProperty( "slug" ) ) {
 		SearchMetadataFields.slug = data.slug;
@@ -39,15 +50,16 @@ export function updateData( data ) {
  * @returns {Object} The load cornerstone content action.
  */
 export const loadSnippetEditorData = () => {
+	const titleTemplate = get( window, "wpseoScriptData.metabox.title_template", "" );
 	return {
 		type: LOAD_SNIPPET_EDITOR_DATA,
 		data: {
-			title: SearchMetadataFields.title || get( window, "wpseoScriptData.metabox.title_template", "" ),
+			title: SearchMetadataFields.title || titleTemplate,
 			description: SearchMetadataFields.description,
 			slug: SearchMetadataFields.slug,
 		},
 		templates: {
-			title: get( window, "wpseoScriptData.metabox.title_template", "" ),
+			title: titleTemplate,
 			description: get( window, "wpseoScriptData.metabox.metadesc_template", "" ),
 		},
 	};

--- a/js/src/elementor/redux/actions/snippetEditor.js
+++ b/js/src/elementor/redux/actions/snippetEditor.js
@@ -51,16 +51,18 @@ export function updateData( data ) {
  */
 export const loadSnippetEditorData = () => {
 	const titleTemplate = get( window, "wpseoScriptData.metabox.title_template", "" );
+	const descriptionTemplate = get( window, "wpseoScriptData.metabox.metadesc_template", "" );
+
 	return {
 		type: LOAD_SNIPPET_EDITOR_DATA,
 		data: {
 			title: SearchMetadataFields.title || titleTemplate,
-			description: SearchMetadataFields.description,
+			description: SearchMetadataFields.description || descriptionTemplate,
 			slug: SearchMetadataFields.slug,
 		},
 		templates: {
 			title: titleTemplate,
-			description: get( window, "wpseoScriptData.metabox.metadesc_template", "" ),
+			description: descriptionTemplate,
 		},
 	};
 };

--- a/js/src/elementor/redux/selectors/analysis.js
+++ b/js/src/elementor/redux/selectors/analysis.js
@@ -5,9 +5,9 @@ import {
 	getContentLocale,
 	getEditorDataContent,
 	getFocusKeyphrase,
-	getSnippetEditorDescriptionForAnalysis,
+	getSnippetEditorDescriptionWithTemplate,
 	getSnippetEditorSlug,
-	getSnippetEditorTitle,
+	getSnippetEditorTitleWithTemplate,
 } from "../../../redux/selectors";
 import { applyModifications } from "../../initializers/pluggable";
 
@@ -19,8 +19,8 @@ import { applyModifications } from "../../initializers/pluggable";
  * @returns {Object} The analysis results.
  */
 export const getAnalysisData = ( state ) => {
-	let title = getSnippetEditorTitle( state );
-	let description = getSnippetEditorDescriptionForAnalysis( state );
+	let title = getSnippetEditorTitleWithTemplate( state );
+	let description = getSnippetEditorDescriptionWithTemplate( state );
 	let slug = getSnippetEditorSlug( state );
 	let baseUrl = getBaseUrlFromSettings( state );
 

--- a/js/src/elementor/redux/selectors/analysis.js
+++ b/js/src/elementor/redux/selectors/analysis.js
@@ -5,7 +5,7 @@ import {
 	getContentLocale,
 	getEditorDataContent,
 	getFocusKeyphrase,
-	getSnippetEditorDescription,
+	getSnippetEditorDescriptionForAnalysis,
 	getSnippetEditorSlug,
 	getSnippetEditorTitle,
 } from "../../../redux/selectors";
@@ -20,7 +20,7 @@ import { applyModifications } from "../../initializers/pluggable";
  */
 export const getAnalysisData = ( state ) => {
 	let title = getSnippetEditorTitle( state );
-	let description = getSnippetEditorDescription( state );
+	let description = getSnippetEditorDescriptionForAnalysis( state );
 	let slug = getSnippetEditorSlug( state );
 	let baseUrl = getBaseUrlFromSettings( state );
 

--- a/js/src/redux/selectors/snippetEditor.js
+++ b/js/src/redux/selectors/snippetEditor.js
@@ -31,13 +31,22 @@ export const getSnippetEditorTemplates = state => get( state, "snippetEditor.tem
 export const getSnippetEditorMode = state => get( state, "snippetEditor.mode", "mobile" );
 
 /**
- * Gets the snippet editor title. Falls back to the title template.
+ * Gets the snippet editor title.
  *
  * @param {Object} state The state object.
  *
  * @returns {string} The snippet editor title.
  */
-export const getSnippetEditorTitle = state => get( state, "snippetEditor.data.title", "" ) || getSnippetEditorTemplates( state ).title;
+export const getSnippetEditorTitle = state => get( state, "snippetEditor.data.title", "" );
+
+/**
+ * Gets the snippet editor title and the template. Falls back to the title template.
+ *
+ * @param {Object} state The state object.
+ *
+ * @returns {string} The snippet editor title.
+ */
+export const getSnippetEditorTitleWithTemplate = state => get( state, "snippetEditor.data.title", "" ) || getSnippetEditorTemplates( state ).title;
 
 /**
  * Gets the snippet editor description.
@@ -49,13 +58,15 @@ export const getSnippetEditorTitle = state => get( state, "snippetEditor.data.ti
 export const getSnippetEditorDescription = state => get( state, "snippetEditor.data.description", "" );
 
 /**
- * Gets the snippet editor for analysis. If description is empty, falls back to template.
+ * Gets the snippet editor and the template. If description is empty, falls back to template.
  *
  * @param {Object} state The state object.
  *
  * @returns {string} The snippet editor description.
  */
-export const getSnippetEditorDescriptionForAnalysis = state => getSnippetEditorDescription( state ) || getSnippetEditorTemplates( state ).description;
+export const getSnippetEditorDescriptionWithTemplate = state => {
+	return getSnippetEditorDescription( state ) || getSnippetEditorTemplates( state ).description;
+};
 
 /**
  * Gets the snippet editor slug.

--- a/js/src/redux/selectors/snippetEditor.js
+++ b/js/src/redux/selectors/snippetEditor.js
@@ -37,7 +37,7 @@ export const getSnippetEditorMode = state => get( state, "snippetEditor.mode", "
  *
  * @returns {string} The snippet editor title.
  */
-export const getSnippetEditorTitle = state => get( state, "snippetEditor.data.title", getSnippetEditorTemplates( state ).title );
+export const getSnippetEditorTitle = state => get( state, "snippetEditor.data.title", "" ) || getSnippetEditorTemplates( state ).title;
 
 /**
  * Gets the snippet editor description.

--- a/js/src/redux/selectors/snippetEditor.js
+++ b/js/src/redux/selectors/snippetEditor.js
@@ -10,6 +10,18 @@ import { get } from "lodash";
 export const getReplaceVars = state => get( state, "snippetEditor.replacementVariables", [] );
 
 /**
+ * Gets the snippet editor templates.
+ *
+ * @param {Object} state The state object.
+ *
+ * @returns {string} The snippet editor templates.
+ */
+export const getSnippetEditorTemplates = state => get( state, "snippetEditor.templates", {
+	title: "",
+	description: "",
+} );
+
+/**
  * Gets the snippet editor mode.
  *
  * @param {Object} state The state object.
@@ -19,13 +31,13 @@ export const getReplaceVars = state => get( state, "snippetEditor.replacementVar
 export const getSnippetEditorMode = state => get( state, "snippetEditor.mode", "mobile" );
 
 /**
- * Gets the snippet editor title.
+ * Gets the snippet editor title. Falls back to the title template.
  *
  * @param {Object} state The state object.
  *
  * @returns {string} The snippet editor title.
  */
-export const getSnippetEditorTitle = state => get( state, "snippetEditor.data.title", "" );
+export const getSnippetEditorTitle = state => get( state, "snippetEditor.data.title", getSnippetEditorTemplates( state ).title );
 
 /**
  * Gets the snippet editor description.
@@ -35,6 +47,15 @@ export const getSnippetEditorTitle = state => get( state, "snippetEditor.data.ti
  * @returns {string} The snippet editor description.
  */
 export const getSnippetEditorDescription = state => get( state, "snippetEditor.data.description", "" );
+
+/**
+ * Gets the snippet editor for analysis. If description is empty, falls back to template.
+ *
+ * @param {Object} state The state object.
+ *
+ * @returns {string} The snippet editor description.
+ */
+export const getSnippetEditorDescriptionForAnalysis = state => getSnippetEditorDescription( state ) || getSnippetEditorTemplates( state ).description;
 
 /**
  * Gets the snippet editor slug.
@@ -56,18 +77,6 @@ export const getSnippetEditorData = state => get( state, "snippetEditor.data", {
 	title: getSnippetEditorTitle( state ),
 	description: getSnippetEditorDescription( state ),
 	slug: getSnippetEditorSlug( state ),
-} );
-
-/**
- * Gets the snippet editor templates.
- *
- * @param {Object} state The state object.
- *
- * @returns {string} The snippet editor templates.
- */
-export const getSnippetEditorTemplates = state => get( state, "snippetEditor.templates", {
-	title: "",
-	description: "",
 } );
 
 /**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to change the way the snippet editor fields behave simultaneously with the new integration, because it is slightly confusing. For MVP, we will revert back to the old behavior.
* Also fixes incorrect Keyword in Title and metadescription assessments.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the confusing cases where the title input field was empty, yet the title length bar showed a non-zero length.
* Fixes an unreleased bug where the meta description and keyword in title assessments were not getting accurate data.

## Relevant technical choices:

* I had a hard time restoring old functionality in a nice way, so I went with a pragmatic way.
The SnippetEditor selectors need some work, since they don't play nicely with the templates. It's hard to select whether you want:
• whether the input field is empty or not
• what the input field should show (IF it is empty, it should still show a template)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify what your site-wide default seo title is. Add at least the `%%title%%` replacevar. Do the same for the metadescription
* Go to a post. Enter a keyphrase and enter the keyphrase in the title.
* Verify that the seo title input field in the snippet editor is filled with the site-wide default.
* Verify that the seo title as it is (with the site-wide default) is reflected in the SEO analysis:
    * Keyphrase in title check
    * SEO title lenght check
	* Metadescription check (should not be empty).
* Update the post. Change your keyphrase in the Keyphrase input field and the post title.
* Analysis should still work.
* Update and reload.
* Change something to your site-wide default. (add another `%%sep%%` or change some order). Save.
* Go back to post, refresh if needed, and verify that SEO title now reflects the new site-wide default.
* Override the site-wide default by editing the SEO title in the snippet editor.
* See that preview and analysis change.
* Update and reload. SEO title should still be the override you just wrote.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-256
Fixes P1-260
Fixes P1-254