### PR TITLE
Output schema templates later

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -179,6 +179,17 @@ class WPSEO_Admin_Asset_Manager {
 	}
 
 	/**
+	 * Checks if the given script is enqueued.
+	 *
+	 * @param string $script The script to check.
+	 *
+	 * @return bool True when the script is enqueued.
+	 */
+	public function is_script_enqueued( $script ) {
+		return \wp_script_is( $this->prefix . $script );
+	}
+
+	/**
 	 * Returns the scripts that need to be registered.
 	 *
 	 * @todo Data format is not self-documenting. Needs explanation inline. R.

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=465",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=463",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=228",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/integrations/schema-blocks.php
+++ b/src/integrations/schema-blocks.php
@@ -18,6 +18,13 @@ class Schema_Blocks implements Integration_Interface {
 	protected $templates = [];
 
 	/**
+	 * Contains the asset manager.
+	 *
+	 * @var WPSEO_Admin_Asset_Manager
+	 */
+	protected $asset_manager;
+
+	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
 	 * @return array
@@ -29,6 +36,15 @@ class Schema_Blocks implements Integration_Interface {
 	}
 
 	/**
+	 * Schema_Blocks constructor.
+	 *
+	 * @param WPSEO_Admin_Asset_Manager $asset_manager The asset manager.
+	 */
+	public function __construct( WPSEO_Admin_Asset_Manager $asset_manager ) {
+		$this->asset_manager = $asset_manager;
+	}
+
+	/**
 	 * Initializes the integration.
 	 *
 	 * This is the place to register hooks and filters.
@@ -37,6 +53,7 @@ class Schema_Blocks implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'enqueue_block_editor_assets', [ $this, 'load' ] );
+		\add_action( 'admin_enqueue_scripts', [ $this, 'output' ] );
 	}
 
 	/**
@@ -62,6 +79,18 @@ class Schema_Blocks implements Integration_Interface {
 	 * @return void
 	 */
 	public function load() {
+		$this->asset_manager->enqueue_script( 'schema-blocks' );
+		$this->asset_manager->enqueue_style( 'schema-blocks' );
+	}
+
+	/**
+	 * Outputs the set templates.
+	 */
+	public function output() {
+		if ( ! $this->asset_manager->is_script_enqueued( 'schema-blocks' ) ) {
+			return;
+		}
+
 		/**
 		 * Filter: 'wpseo_schema_templates' - Allow adding additional schema templates.
 		 *
@@ -81,9 +110,5 @@ class Schema_Blocks implements Integration_Interface {
 			include $template;
 			echo '</script>';
 		}
-
-		$asset_manager = new WPSEO_Admin_Asset_Manager();
-		$asset_manager->enqueue_script( 'schema-blocks' );
-		$asset_manager->enqueue_style( 'schema-blocks' );
 	}
 }

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -172,4 +172,18 @@ abstract class TestCase extends BaseTestCase {
 			$this->assertTrue( $found === false, \sprintf( 'Expected "%s" to be found in "%s" but couldn\'t find it.', $needle, $output ) );
 		}
 	}
+
+	/**
+	 * Tests for expected empty output.
+	 *
+	 * @param string $description Explanation why this result is expected.
+	 */
+	protected function expectEmptyOutput( $description = '' ) {
+		$output = \ob_get_contents();
+		\ob_clean();
+
+		$output = \preg_replace( '|\R|', "\r\n", $output );
+
+		$this->assertEmpty( $output, $description );
+	}
 }

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -134,7 +134,7 @@ class Schema_Blocks_Test extends TestCase {
 	public function test_output() {
 		$this->asset_manager
 			->expects( 'is_script_enqueued' )
-			->with('schema-blocks')
+			->with( 'schema-blocks' )
 			->once()
 			->andReturnTrue();
 
@@ -152,7 +152,7 @@ class Schema_Blocks_Test extends TestCase {
 	public function test_output_with_scripts_not_enqueued() {
 		$this->asset_manager
 			->expects( 'is_script_enqueued' )
-			->with('schema-blocks')
+			->with( 'schema-blocks' )
 			->once()
 			->andReturnFalse();
 
@@ -170,7 +170,7 @@ class Schema_Blocks_Test extends TestCase {
 	public function test_load_with_filter() {
 		$this->asset_manager
 			->expects( 'is_script_enqueued' )
-			->with('schema-blocks')
+			->with( 'schema-blocks' )
 			->once()
 			->andReturnTrue();
 
@@ -191,7 +191,7 @@ class Schema_Blocks_Test extends TestCase {
 	public function test_load_with_filter_returning_faulty_value() {
 		$this->asset_manager
 			->expects( 'is_script_enqueued' )
-			->with('schema-blocks')
+			->with( 'schema-blocks' )
 			->once()
 			->andReturnTrue();
 
@@ -212,7 +212,7 @@ class Schema_Blocks_Test extends TestCase {
 	public function test_output_with_non_existing_template() {
 		$this->asset_manager
 			->expects( 'is_script_enqueued' )
-			->with('schema-blocks')
+			->with( 'schema-blocks' )
 			->once()
 			->andReturnTrue();
 
@@ -231,7 +231,7 @@ class Schema_Blocks_Test extends TestCase {
 	public function test_output_with_having_no_templates_set() {
 		$this->asset_manager
 			->expects( 'is_script_enqueued' )
-			->with('schema-blocks')
+			->with( 'schema-blocks' )
 			->once()
 			->andReturnTrue();
 

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations;
 
 use Brain\Monkey;
 use Mockery;
+use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Schema_Blocks_Conditional;
 use Yoast\WP\SEO\Integrations\Schema_Blocks;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -15,7 +16,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  *
  * @group integrations
  * @group schema
- * @group test
  */
 class Schema_Blocks_Test extends TestCase {
 
@@ -26,10 +26,30 @@ class Schema_Blocks_Test extends TestCase {
 	 */
 	protected $instance;
 
+	/**
+	 * Represents the asset manager.
+	 *
+	 * @var Mockery\MockInterface|WPSEO_Admin_Asset_Manager
+	 */
+	protected $asset_manager;
+
+	/**
+	 * Runs the setup to prepare the needed instance.
+	 */
 	public function setUp() {
 		parent::setUp();
 
-		$this->instance = new Schema_Blocks();
+		$this->asset_manager = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
+		$this->instance      = new Schema_Blocks( $this->asset_manager );
+	}
+
+	/**
+	 * Tests the constructor by checking the set attributes.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		static::assertAttributeInstanceOf( WPSEO_Admin_Asset_Manager::class, 'asset_manager', $this );
 	}
 
 	/**
@@ -89,32 +109,76 @@ class Schema_Blocks_Test extends TestCase {
 
 	/**
 	 * Tests the loading of all schema block templates.
+	 *
+	 * @covers ::load
 	 */
 	public function test_load() {
-		$this->instance->register_template( WPSEO_PATH . '/src/schema-templates/recipe.block.php' );
+		$this->asset_manager
+			->expects( 'enqueue_script' )
+			->with( 'schema-blocks' )
+			->once();
 
-		Monkey\Functions\expect( 'wp_enqueue_script' )->once();
-		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
+		$this->asset_manager
+			->expects( 'enqueue_style' )
+			->with( 'schema-blocks' )
+			->once();
 
 		$this->instance->load();
+	}
+
+	/**
+	 * Tests the outputting of a template.
+	 *
+	 * @covers ::output
+	 */
+	public function test_output() {
+		$this->asset_manager
+			->expects( 'is_script_enqueued' )
+			->with('schema-blocks')
+			->once()
+			->andReturnTrue();
+
+		$this->instance->register_template( WPSEO_PATH . '/src/schema-templates/recipe.block.php' );
+		$this->instance->output();
 
 		$this->expectOutputContains( '<script type="text/block-template">' );
 	}
 
 	/**
+	 * Tests the outputting of the templates without having the needed scripts enqueued.
+	 *
+	 * @covers ::output
+	 */
+	public function test_output_with_scripts_not_enqueued() {
+		$this->asset_manager
+			->expects( 'is_script_enqueued' )
+			->with('schema-blocks')
+			->once()
+			->andReturnFalse();
+
+		$this->instance->output();
+
+		$this->instance->register_template( WPSEO_PATH . '/src/schema-templates/recipe.block.php' );
+		$this->expectOutputNotContains( '<script type="text/block-template">' );
+	}
+
+	/**
 	 * Tests the loading of schema block templates by using the filter.
 	 *
-	 * @covers ::load
+	 * @covers ::output
 	 */
 	public function test_load_with_filter() {
+		$this->asset_manager
+			->expects( 'is_script_enqueued' )
+			->with('schema-blocks')
+			->once()
+			->andReturnTrue();
+
 		// First add a template.
 		Monkey\Filters\expectApplied( 'wpseo_load_schema_templates' )
 			->andReturn( [ WPSEO_PATH . '/src/schema-templates/recipe.block.php' ] );
 
-		Monkey\Functions\expect( 'wp_enqueue_script' )->once();
-		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
-
-		$this->instance->load();
+		$this->instance->output();
 
 		$this->expectOutputContains( '<script type="text/block-template">' );
 	}
@@ -122,46 +186,59 @@ class Schema_Blocks_Test extends TestCase {
 	/**
 	 * Tests the loading of schema block templates by using the filter that returns a faulty value.
 	 *
-	 * @covers ::load
+	 * @covers ::output
 	 */
 	public function test_load_with_filter_returning_faulty_value() {
+		$this->asset_manager
+			->expects( 'is_script_enqueued' )
+			->with('schema-blocks')
+			->once()
+			->andReturnTrue();
+
 		// First add a template.
 		Monkey\Filters\expectApplied( 'wpseo_load_schema_templates' )
 			->andReturnFalse();
 
-		Monkey\Functions\expect( 'wp_enqueue_script' )->never();
-		Monkey\Functions\expect( 'wp_enqueue_style' )->never();
+		$this->instance->output();
 
-		$this->instance->load();
+		$this->expectEmptyOutput();
 	}
 
 	/**
-	 * Tests the loading of a schema block template that doesn't exists.
+	 * Tests the outputting of a schema block template that doesn't exists.
 	 *
-	 * @covers ::load
+	 * @covers ::output
 	 */
-	public function test_load_with_non_existing_template() {
+	public function test_output_with_non_existing_template() {
+		$this->asset_manager
+			->expects( 'is_script_enqueued' )
+			->with('schema-blocks')
+			->once()
+			->andReturnTrue();
+
 		$this->instance->register_template( WPSEO_PATH . '/src/schema-templates/nonexisting.block.php' );
 
-		Monkey\Functions\expect( 'wp_enqueue_script' )->once();
-		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
+		$this->instance->output();
 
-		$this->instance->load();
-
-		$this->expectOutput( '' );
+		$this->expectEmptyOutput();
 	}
 
 	/**
-	 * Tests the loading of schema block templates with no templates being set.
+	 * Tests the outputting of schema block templates with no templates being set.
 	 *
-	 * @covers ::load
+	 * @covers ::output
 	 */
-	public function test_load_with_having_no_templates_set() {
+	public function test_output_with_having_no_templates_set() {
+		$this->asset_manager
+			->expects( 'is_script_enqueued' )
+			->with('schema-blocks')
+			->once()
+			->andReturnTrue();
+
 		Monkey\Filters\expectApplied( 'wpseo_load_schema_templates' );
 
-		Monkey\Functions\expect( 'wp_enqueue_script' )->never();
-		Monkey\Functions\expect( 'wp_enqueue_style' )->never();
+		$this->instance->output();
 
-		$this->instance->load();
+		$this->expectEmptyOutput();
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The templated are shown before the `<html>`-tag which resulted in wrong parsed templates. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the templates aren't parsed correctly

## Relevant technical choices:

* Added a wrapper for `is_script_enqueued` to the `WPSEO_Admin_Asset_Manger` to check if a script is enqueued.
* Passed the `WPSEO_Admin_Asset_Manger` as dependency to the constructor
* Added an `expectEmptyOutput` to the testcase just to have a proper assertion when testing early returns

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check this together with https://github.com/Yoast/javascript/pull/944


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*  

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
