### PR TITLE
Enqueue an existing script instead of one that isn't used anymore

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -222,20 +222,6 @@ class WPSEO_Admin_Asset_Manager {
 				],
 			],
 			[
-				'name' => 'search-appearance',
-				'src'  => 'search-appearance-' . $flat_version,
-				'deps' => [
-					'lodash',
-					'wp-api',
-					'wp-element',
-					'wp-i18n',
-					self::PREFIX . 'styled-components',
-					self::PREFIX . 'yoast-components',
-					self::PREFIX . 'replacement-variable-editor',
-					self::PREFIX . 'commons',
-				],
-			],
-			[
 				'name' => 'schema-blocks',
 				'src'  => 'schema-blocks-' . $flat_version,
 				'deps' => [

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -132,6 +132,17 @@ class WPSEO_Admin_Asset_Manager {
 	}
 
 	/**
+	 * Localizes the script.
+	 *
+	 * @param string $handle      The script handle.
+	 * @param string $object_name The object name.
+	 * @param array  $data        The l10n data.
+	 */
+	public function localize_script( $handle, $object_name, $data ) {
+		\wp_localize_script( $this->prefix . $handle, $object_name, $data );
+	}
+
+	/**
 	 * A list of styles that shouldn't be registered but are needed in other locations in the plugin.
 	 *
 	 * @return array

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -253,8 +253,7 @@ class WPSEO_Admin {
 	public function config_page_scripts() {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$asset_manager->enqueue_script( 'admin-global-script' );
-
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-global-script', 'wpseoAdminGlobalL10n', $this->localize_admin_global_script() );
+		$asset_manager->localize_script( 'admin-global-script', 'wpseoAdminGlobalL10n', $this->localize_admin_global_script() );
 	}
 
 	/**

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -108,7 +108,7 @@ class WPSEO_Admin_Pages {
 			remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 
 			$yoast_components_l10n = new WPSEO_Admin_Asset_Yoast_Components_L10n();
-			$yoast_components_l10n->localize_script( 'search-appearance' );
+			$yoast_components_l10n->localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'settings' );
 		}
 
 		if ( in_array( $page, [ 'wpseo_social', WPSEO_Admin::PAGE_IDENTIFIER, 'wpseo_titles' ], true ) ) {

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -123,7 +123,7 @@ class WPSEO_Admin_Pages {
 			$this->enqueue_tools_scripts();
 		}
 
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'settings', 'wpseoScriptData', $script_data );
+		$this->asset_manager->localize_script( 'settings', 'wpseoScriptData', $script_data );
 	}
 
 	/**

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -130,8 +130,9 @@ class WPSEO_Primary_Term_Admin implements WPSEO_WordPress_Integration {
 		$data = [
 			'taxonomies' => $mapped_taxonomies,
 		];
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'post-edit', 'wpseoPrimaryCategoryL10n', $data );
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'post-edit-classic', 'wpseoPrimaryCategoryL10n', $data );
+
+		$asset_manager->localize_script( 'post-edit', 'wpseoPrimaryCategoryL10n', $data );
+		$asset_manager->localize_script( 'post-edit-classic', 'wpseoPrimaryCategoryL10n', $data );
 	}
 
 	/**

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -104,7 +104,7 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 			return;
 		}
 
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'dashboard-widget', 'wpseoDashboardWidgetL10n', $this->localize_dashboard_script() );
+		$this->asset_manager->localize_script( 'dashboard-widget', 'wpseoDashboardWidgetL10n', $this->localize_dashboard_script() );
 		$yoast_components_l10n = new WPSEO_Admin_Asset_Yoast_Components_L10n();
 		$yoast_components_l10n->localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'dashboard-widget' );
 		$this->asset_manager->enqueue_script( 'dashboard-widget' );

--- a/admin/class-yoast-network-admin.php
+++ b/admin/class-yoast-network-admin.php
@@ -197,8 +197,8 @@ class Yoast_Network_Admin implements WPSEO_WordPress_Integration, WPSEO_WordPres
 			/* translators: %s: error message */
 			'error_prefix'   => __( 'Error: %s', 'wordpress-seo' ),
 		];
-		wp_localize_script(
-			WPSEO_Admin_Asset_Manager::PREFIX . 'network-admin-script',
+		$asset_manager->localize_script(
+			'network-admin-script',
 			'wpseoNetworkAdminGlobalL10n',
 			$translations
 		);

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -90,7 +90,7 @@ class WPSEO_Configuration_Page {
 
 		$config = $this->get_config();
 
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'configuration-wizard', 'yoastWizardConfig', $config );
+		$asset_manager->localize_script( 'configuration-wizard', 'yoastWizardConfig', $config );
 
 		$yoast_components_l10n = new WPSEO_Admin_Asset_Yoast_Components_L10n();
 		$yoast_components_l10n->localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'configuration-wizard' );

--- a/admin/filters/class-abstract-post-filter.php
+++ b/admin/filters/class-abstract-post-filter.php
@@ -84,8 +84,8 @@ abstract class WPSEO_Abstract_Post_Filter implements WPSEO_WordPress_Integration
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$asset_manager->enqueue_script( 'filter-explanation' );
 		$asset_manager->enqueue_style( 'filter-explanation' );
-		wp_localize_script(
-			WPSEO_Admin_Asset_Manager::PREFIX . 'filter-explanation',
+		$asset_manager->localize_script(
+			'filter-explanation',
 			'yoastFilterExplanation',
 			[ 'text' => $this->get_explanation() ]
 		);

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -843,8 +843,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		 */
 		remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . $post_edit_handle, 'wpseoAdminL10n', WPSEO_Utils::get_admin_l10n() );
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . $post_edit_handle, 'wpseoFeaturesL10n', WPSEO_Utils::retrieve_enabled_features() );
+		$asset_manager->localize_script( $post_edit_handle, 'wpseoAdminL10n', WPSEO_Utils::get_admin_l10n() );
+		$asset_manager->localize_script( $post_edit_handle, 'wpseoFeaturesL10n', WPSEO_Utils::retrieve_enabled_features() );
 
 		$analysis_worker_location          = new WPSEO_Admin_Asset_Analysis_Worker_Location( $asset_manager->flatten_version( WPSEO_VERSION ) );
 		$used_keywords_assessment_location = new WPSEO_Admin_Asset_Analysis_Worker_Location( $asset_manager->flatten_version( WPSEO_VERSION ), 'used-keywords-assessment' );
@@ -891,7 +891,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			];
 		}
 
-		wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . $post_edit_handle, 'wpseoScriptData', $script_data );
+		$asset_manager->localize_script( $post_edit_handle, 'wpseoScriptData', $script_data );
 	}
 
 	/**

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -150,8 +150,8 @@ class WPSEO_Taxonomy {
 			 */
 			remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'term-edit', 'wpseoAdminL10n', WPSEO_Utils::get_admin_l10n() );
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'term-edit', 'wpseoFeaturesL10n', WPSEO_Utils::retrieve_enabled_features() );
+			$asset_manager->localize_script( 'term-edit', 'wpseoAdminL10n', WPSEO_Utils::get_admin_l10n() );
+			$asset_manager->localize_script( 'term-edit', 'wpseoFeaturesL10n', WPSEO_Utils::retrieve_enabled_features() );
 
 			$script_data = [
 				'analysis'         => [
@@ -183,7 +183,7 @@ class WPSEO_Taxonomy {
 				'userLanguageCode' => WPSEO_Language_Utils::get_language( WPSEO_Language_Utils::get_user_locale() ),
 				'isTerm'           => true,
 			];
-			wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'term-edit', 'wpseoScriptData', $script_data );
+			$asset_manager->localize_script( 'term-edit', 'wpseoScriptData', $script_data );
 		}
 
 		if ( self::is_term_overview( $pagenow ) ) {

--- a/src/integrations/admin/indexing-tool-integration.php
+++ b/src/integrations/admin/indexing-tool-integration.php
@@ -117,7 +117,7 @@ class Indexing_Tool_Integration implements Integration_Interface {
 		 */
 		$data = \apply_filters( 'wpseo_indexing_data', $data );
 
-		\wp_localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'indexation', 'yoastIndexingData', $data );
+		$this->asset_manager->localize_script( 'indexation', 'yoastIndexingData', $data );
 	}
 
 	/**

--- a/tests/unit/integrations/admin/indexing-tool-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-tool-integration-test.php
@@ -179,8 +179,9 @@ class Indexing_Tool_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'rest_url' )
 			->andReturn( 'https://example.org/wp-ajax/' );
 
-		Monkey\Functions\expect( 'wp_localize_script' )
-			->with( 'yoast-seo-indexation', 'yoastIndexingData', $injected_data );
+		$this->asset_manager
+			->expects( 'localize_script' )
+			->with( 'indexation', 'yoastIndexingData', $injected_data );
 
 		Monkey\Filters\expectApplied( 'wpseo_indexing_data' )
 			->with( $injected_data );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the page isn't translated right

## Relevant technical choices:

* Removed the declaration of the `search-appearence` script
* Localized `settings` because that script will be loaded on that page.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* On trunk
* Set your site in a non-English language. For example Dutch
* Go to the search appearance page and visit the post types tab or the taxonomies tab
* See that the text is a mix of English and the set language.
* Checkout this branch 
* There might be untranslated element, but the mostly of the page should be translated. There is a `Insert Variable` button that keeps English, but that is another issue.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
