### PR TITLE
Do action for premium elementor to get access to redirect headers

### DIFF
--- a/js/src/initializers/elementor-editor-integration.js
+++ b/js/src/initializers/elementor-editor-integration.js
@@ -2,6 +2,7 @@
 /* global jQuery, window */
 import domReady from "@wordpress/dom-ready";
 import { dispatch } from "@wordpress/data";
+import { doAction } from "@wordpress/hooks";
 import { get } from "lodash";
 import { registerReactComponent, renderReactRoot } from "../helpers/reactRoot";
 import ElementorSlot from "../elementor/components/slots/ElementorSlot";
@@ -64,11 +65,13 @@ const sendFormData = ( form ) => {
 		return result;
 	}, {} );
 
-	jQuery.post( form.getAttribute( "action" ), data, ( { success, data: responseData } ) => {
+	jQuery.post( form.getAttribute( "action" ), data, ( { success, data: responseData }, status, xhr ) => {
 		if ( ! success ) {
 			// Something went wrong while saving.
 			return;
 		}
+
+		doAction( "yoast.elementor.save.success", xhr );
 
 		// Update the slug in our store if WP changed it.
 		if ( responseData.slug && responseData.slug !== data.slug ) {

--- a/js/src/initializers/elementor-editor-integration.js
+++ b/js/src/initializers/elementor-editor-integration.js
@@ -2,7 +2,6 @@
 import domReady from "@wordpress/dom-ready";
 import { dispatch } from "@wordpress/data";
 import { doAction } from "@wordpress/hooks";
-import { get } from "lodash";
 import { registerElementorDataHookAfter } from "../helpers/elementorHook";
 import { registerReactComponent, renderReactRoot } from "../helpers/reactRoot";
 import ElementorSlot from "../elementor/components/slots/ElementorSlot";

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -15,7 +15,6 @@ use WPSEO_Metabox_Analysis_Readability;
 use WPSEO_Metabox_Analysis_SEO;
 use WPSEO_Metabox_Formatter;
 use WPSEO_Post_Metabox_Formatter;
-use WPSEO_Post_Watcher;
 use WPSEO_Utils;
 use Yoast\WP\SEO\Conditionals\Admin\Elementor_Edit_Conditional;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
@@ -87,13 +86,6 @@ class Elementor implements Integration_Interface {
 	protected $readability_analysis;
 
 	/**
-	 * Holds the post watcher instance.
-	 *
-	 * @var WPSEO_Post_Watcher
-	 */
-	protected $post_watcher;
-
-	/**
 	 * The identifier for the elementor tab.
 	 */
 	const YOAST_TAB = 'yoast-tab';
@@ -121,7 +113,6 @@ class Elementor implements Integration_Interface {
 
 		$this->seo_analysis                 = new WPSEO_Metabox_Analysis_SEO();
 		$this->readability_analysis         = new WPSEO_Metabox_Analysis_Readability();
-		$this->post_watcher                 = new WPSEO_Post_Watcher();
 		$this->social_is_enabled            = $this->options->get( 'opengraph', false ) || $this->options->get( 'twitter', false );
 		$this->is_advanced_metadata_enabled = $this->capability->current_user_can( 'wpseo_edit_advanced_metadata' ) || $this->options->get( 'disableadvanced_meta' ) === false;
 	}
@@ -135,8 +126,6 @@ class Elementor implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'wp_ajax_wpseo_elementor_save', [ $this, 'save_postdata' ] );
-
-		\add_action( 'post_updated', [ $this->post_watcher, 'detect_slug_change' ], 12, 3 );
 
 		if ( ! $this->display_metabox( $this->get_metabox_post()->post_type ) ) {
 			return;

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -15,6 +15,7 @@ use WPSEO_Metabox_Analysis_Readability;
 use WPSEO_Metabox_Analysis_SEO;
 use WPSEO_Metabox_Formatter;
 use WPSEO_Post_Metabox_Formatter;
+use WPSEO_Post_Watcher;
 use WPSEO_Utils;
 use Yoast\WP\SEO\Conditionals\Admin\Elementor_Edit_Conditional;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
@@ -86,6 +87,13 @@ class Elementor implements Integration_Interface {
 	protected $readability_analysis;
 
 	/**
+	 * Holds the post watcher instance.
+	 *
+	 * @var WPSEO_Post_Watcher
+	 */
+	protected $post_watcher;
+
+	/**
 	 * The identifier for the elementor tab.
 	 */
 	const YOAST_TAB = 'yoast-tab';
@@ -113,6 +121,7 @@ class Elementor implements Integration_Interface {
 
 		$this->seo_analysis                 = new WPSEO_Metabox_Analysis_SEO();
 		$this->readability_analysis         = new WPSEO_Metabox_Analysis_Readability();
+		$this->post_watcher                 = new WPSEO_Post_Watcher();
 		$this->social_is_enabled            = $this->options->get( 'opengraph', false ) || $this->options->get( 'twitter', false );
 		$this->is_advanced_metadata_enabled = $this->capability->current_user_can( 'wpseo_edit_advanced_metadata' ) || $this->options->get( 'disableadvanced_meta' ) === false;
 	}
@@ -126,6 +135,8 @@ class Elementor implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'wp_ajax_wpseo_elementor_save', [ $this, 'save_postdata' ] );
+
+		\add_action( 'post_updated', [ $this->post_watcher, 'detect_slug_change' ], 12, 3 );
 
 		if ( ! $this->display_metabox( $this->get_metabox_post()->post_type ) ) {
 			return;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Saving takes place in free code in Elementor via an Ajax request, but in Premium we need to check the headers for whether a redirect has taken place.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an action to hook into the save functionality of our Elementor integration.

## Relevant technical choices:

* Needed for https://github.com/Yoast/wordpress-seo-premium/pull/3097

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See https://github.com/Yoast/wordpress-seo-premium/pull/3097


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-258
