### PR TITLE
P1-269 Delay loading our Elementor JS

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -745,9 +745,9 @@ class WPSEO_Admin_Asset_Manager {
 				'src'  => 'draft-js-' . $flat_version,
 			],
 			[
-				'name' => 'elementor',
-				'src'  => 'elementor-' . $flat_version,
-				'deps' => [
+				'name'   => 'elementor',
+				'src'    => 'elementor-' . $flat_version,
+				'deps'   => [
 					'jquery',
 					'lodash',
 					'wp-data',
@@ -765,6 +765,7 @@ class WPSEO_Admin_Asset_Manager {
 					self::PREFIX . 'select2',
 					self::PREFIX . 'select2-translations',
 				],
+				'footer' => true,
 			],
 		];
 	}

--- a/js/src/elementor.js
+++ b/js/src/elementor.js
@@ -1,4 +1,5 @@
 import { dispatch } from "@wordpress/data";
+import { doAction } from "@wordpress/hooks";
 import { applyModifications, pluginReady, pluginReloaded, registerPlugin, registerModification } from "./elementor/initializers/pluggable";
 import initAnalysis, { collectData } from "./initializers/analysis";
 import initElementorEditorIntegration from "./initializers/elementor-editor-integration";
@@ -59,6 +60,9 @@ function initialize() {
 
 	// Initialize the editor integration.
 	initElementorEditorIntegration();
+
+	// Offer an action after our load.
+	doAction( "yoast.elementor.loaded" );
 }
 
 // Wait on `window.elementor`.

--- a/js/src/elementor.js
+++ b/js/src/elementor.js
@@ -1,5 +1,4 @@
 import { dispatch } from "@wordpress/data";
-import domReady from "@wordpress/dom-ready";
 import { applyModifications, pluginReady, pluginReloaded, registerPlugin, registerModification } from "./elementor/initializers/pluggable";
 import initAnalysis, { collectData } from "./initializers/analysis";
 import initElementorEditorIntegration from "./initializers/elementor-editor-integration";
@@ -10,7 +9,12 @@ import initHighlightFocusKeyphraseForms from "./elementor/initializers/highlight
 import initReplaceVarPlugin, { addReplacement, ReplaceVar } from "./elementor/replaceVars/elementor-replacevar-plugin";
 import initializeIntroduction from "./elementor/initializers/introduction";
 
-domReady( () => {
+/**
+ * Initializes Yoast SEO for Elementor.
+ *
+ * @returns {void}
+ */
+function initialize() {
 	// Initialize the editor store and set it on the window.
 	window.YoastSEO = window.YoastSEO || {};
 	window.YoastSEO.store = initEditorStore();
@@ -52,7 +56,15 @@ domReady( () => {
 
 	// Initialize the introduction.
 	initializeIntroduction();
-} );
 
-// Initialize the editor integration.
-initElementorEditorIntegration();
+	// Initialize the editor integration.
+	initElementorEditorIntegration();
+}
+
+// Wait on `window.elementor`.
+jQuery( window ).on( "elementor:init", () => {
+	// Wait on Elementor app to have started.
+	window.elementor.on( "panel:init", () => {
+		setTimeout( initialize );
+	} );
+} );

--- a/js/src/initializers/elementor-editor-integration.js
+++ b/js/src/initializers/elementor-editor-integration.js
@@ -1,6 +1,5 @@
 /* eslint-disable require-jsdoc */
 /* global jQuery, window */
-import domReady from "@wordpress/dom-ready";
 import { dispatch } from "@wordpress/data";
 import { get } from "lodash";
 import { registerReactComponent, renderReactRoot } from "../helpers/reactRoot";
@@ -87,43 +86,41 @@ export default function initElementEditorIntegration() {
 	window.YoastSEO = window.YoastSEO || {};
 	window.YoastSEO._registerReactComponent = registerReactComponent;
 
-	domReady( () => {
-		// Check whether the route to our tab is active. If so, render our React root.
-		window.$e.routes.on( "run:after", function( component, route ) {
-			if ( route === "panel/page-settings/yoast-tab" ) {
-				renderReactRoot( window.YoastSEO.store, "elementor-panel-page-settings-controls", (
-					<StyleSheetManager target={ document.getElementById( "elementor-panel-page-settings-controls" ) }>
-						<div className="yoast yoast-elementor-panel__fills">
-							<ElementorSlot />
-							<ElementorFill />
-						</div>
-					</StyleSheetManager>
-				) );
-			}
-		} );
-
-		// Hook into the save.
-		const handleSave = sendFormData.bind( null, document.getElementById( "yoast-form" ) );
-		window.elementor.saver.on( "after:save", handleSave );
-
-		// Register with the menu.
-		const menu = window.elementor.modules.layouts.panel.pages.menu.Menu;
-		menu.addItem( {
-			name: "yoast",
-			icon: "yoast yoast-element-menu-icon",
-			title: "Yoast SEO",
-			type: "page",
-			callback: () => {
-				try {
-					window.$e.routes.run( "panel/page-settings/yoast-tab" );
-				} catch ( error ) {
-					// The yoast tab is only available if the page settings have been visited.
-					window.$e.routes.run( "panel/page-settings/settings" );
-					window.$e.routes.run( "panel/page-settings/yoast-tab" );
-				}
-			},
-		}, "more" );
+	// Check whether the route to our tab is active. If so, render our React root.
+	window.$e.routes.on( "run:after", function( component, route ) {
+		if ( route === "panel/page-settings/yoast-tab" ) {
+			renderReactRoot( window.YoastSEO.store, "elementor-panel-page-settings-controls", (
+				<StyleSheetManager target={ document.getElementById( "elementor-panel-page-settings-controls" ) }>
+					<div className="yoast yoast-elementor-panel__fills">
+						<ElementorSlot />
+						<ElementorFill />
+					</div>
+				</StyleSheetManager>
+			) );
+		}
 	} );
+
+	// Hook into the save.
+	const handleSave = sendFormData.bind( null, document.getElementById( "yoast-form" ) );
+	window.elementor.saver.on( "after:save", handleSave );
+
+	// Register with the menu.
+	const menu = window.elementor.modules.layouts.panel.pages.menu.Menu;
+	menu.addItem( {
+		name: "yoast",
+		icon: "yoast yoast-element-menu-icon",
+		title: "Yoast SEO",
+		type: "page",
+		callback: () => {
+			try {
+				window.$e.routes.run( "panel/page-settings/yoast-tab" );
+			} catch ( error ) {
+				// The yoast tab is only available if the page settings have been visited.
+				window.$e.routes.run( "panel/page-settings/settings" );
+				window.$e.routes.run( "panel/page-settings/yoast-tab" );
+			}
+		},
+	}, "more" );
 
 	const yoastInputs = document.querySelectorAll( "input[name^='yoast']" );
 	yoastInputs.forEach( input => storeValueAsOldValue( input ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The goal is to speed up the Elementor editor loading, or rather the interactivity. Keep in mind this PR is written with a time constraint too.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Loads our Elementor JS at a later time, making the interactivity earlier.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to an Elementor edit page.
* Compare the moment of interactivity of this version and a previous version (previous RC?).
* To get some more measurements you can open the network tab in the inspector.
* The elementor JS script is loaded in later.
* The initialize in that script is run later, which results in the analysis-worker script to be loaded in later.
* Verify the action works by testing the Premium PR that uses it: https://github.com/Yoast/wordpress-seo-premium/pull/3099

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-269
