### PR TITLE
Unit Tests: make the testsuite compatible with PHPUnit 9 and test against PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ premium/node_modules/
 phpcs.xml
 .phpcs.xml
 phpunit.xml
+.phpunit.result.cache
 
 ############
 ## OSes

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,41 +132,41 @@ install:
       # So we temporarily switch PHP versions, do a full install and then remove the package.
       # Then switch back to the PHP version we want to test and delete the vendor directory.
       phpenv local 7.1
-      composer install --no-interaction --ignore-platform-reqs
-      composer remove humbug/php-scoper --dev --ignore-platform-reqs
-      composer remove atanamo/php-codeshift --dev --ignore-platform-reqs
+      travis_retry composer install --no-interaction --ignore-platform-reqs
+      travis_retry composer remove humbug/php-scoper --dev --ignore-platform-reqs
+      travis_retry composer remove atanamo/php-codeshift --dev --ignore-platform-reqs
       phpenv local --unset
       rm -rf vendor/*
     fi
   - |
     if [[ "$COVERAGE" == "1" ]]; then
       # Install phpcov so we can combine the coverage results of unit and integration tests.
-      composer require phpunit/phpcov ^3.1
+      travis_retry composer require phpunit/phpcov ^3.1
     fi
   - |
-    if [[ $TRAVIS_PHP_VERSION == "nightly" && "$PHPLINT" == "1" ]]; then
+    if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
       if [[ "$IS_PREMIUM" == "1" ]]; then
         cd premium
-        composer install --no-interaction --ignore-platform-reqs --no-scripts --no-suggest
+        travis_retry composer install --no-interaction --ignore-platform-reqs --no-scripts --no-suggest
         cd -
       else
-        composer install --no-interaction --ignore-platform-reqs --no-scripts --no-suggest
+        travis_retry composer install --no-interaction --ignore-platform-reqs --no-scripts --no-suggest
       fi
     elif [[ "$PHPUNIT" == "1" || "$COVERAGE" == "1" || "$PHPCS" == "1" || "$PHPLINT" == "1" ]]; then
       # Run composer update as we have dev dependencies locked at PHP ^7.0 versions.
-      composer update
-      composer install --no-interaction
+      travis_retry composer update
+      travis_retry composer install --no-interaction
       composer du
       if [[ "$IS_PREMIUM" == "1" ]]; then
         if [[ "$PHPCS" == "1" || "$PHPLINT" == "1" ]]; then
           cd premium
-          composer install --no-interaction
+          travis_retry composer install --no-interaction
           cd -
         fi
       fi
     elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "🚀 deployment" ]]; then
-      composer update
-      composer install --no-dev --no-interaction
+      travis_retry composer update
+      travis_retry composer install --no-dev --no-interaction
       composer du
     fi
   - |
@@ -288,6 +288,14 @@ script:
       vendor/bin/phpunit
       travis_time_finish && travis_fold end "PHP.tests"
     fi;
+  - |
+    if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+      travis_fold start "PHP.tests" && travis_time_start
+      composer require --dev phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs &&
+      composer update yoast/wp-test-utils --with-all-dependencies --ignore-platform-reqs &&
+      vendor/bin/phpunit
+      travis_time_finish && travis_fold end "PHP.tests"
+    fi
   - |
     if [[ "$COVERAGE" == "1" ]]; then
       travis_fold start "PHP.coverage" && travis_time_start

--- a/composer.json
+++ b/composer.json
@@ -34,12 +34,12 @@
 		"yoast/php-development-environment": "^1.0",
 		"yoast/yoastcs": "^2.1.0",
 		"humbug/php-scoper": "^0.13.4",
-		"brain/monkey": "^2.5.0",
 		"phpunit/phpunit": "^5.7",
 		"atanamo/php-codeshift": "^1.0",
 		"symfony/config": "^3.4",
 		"php-parallel-lint/php-parallel-lint": "^1.2.0",
-		"php-parallel-lint/php-console-highlighter": "^0.5"
+		"php-parallel-lint/php-console-highlighter": "^0.5",
+		"yoast/wp-test-utils": "^0.1.1"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0dfd4abfeaf86831946b9d1f06ac2f18",
+    "content-hash": "4086f1ca0fa58866e06eaee474ecc5e2",
     "packages": [
         {
             "name": "composer/installers",
@@ -3799,6 +3799,127 @@
                 "wordpress"
             ],
             "time": "2016-06-16T10:12:26+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/c48e4cf0c44b2d892540846aff19fb0468627bab",
+                "reference": "c48e4cf0c44b2d892540846aff19fb0468627bab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "time": "2020-11-25T02:59:57+00:00"
+        },
+        {
+            "name": "yoast/wp-test-utils",
+            "version": "0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/wp-test-utils.git",
+                "reference": "206df89cfefe4d2cbdf354e4a6212869de8bd942"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/206df89cfefe4d2cbdf354e4a6212869de8bd942",
+                "reference": "206df89cfefe4d2cbdf354e4a6212869de8bd942",
+                "shasum": ""
+            },
+            "require": {
+                "brain/monkey": "^2.5.0",
+                "php": ">=5.6",
+                "yoast/phpunit-polyfills": "^0.2.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/wp-test-utils/graphs/contributors"
+                }
+            ],
+            "description": "PHPUnit cross-version compatibility layer for testing plugins and themes build for WordPress",
+            "homepage": "https://github.com/Yoast/wp-test-utils/",
+            "keywords": [
+                "brainmonkey",
+                "integration-testing",
+                "phpunit",
+                "unit-testing",
+                "wordpress"
+            ],
+            "time": "2020-11-25T12:40:18+00:00"
         },
         {
             "name": "yoast/yoastcs",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
+	forceCoversAnnotation="true"
 	processIsolation="false"
 	stopOnError="false"
 	stopOnFailure="false"
@@ -15,20 +16,20 @@
 	verbose="true"
 	>
 	<testsuites>
-		<testsuite name="main">
+		<testsuite name="yoastseo">
 			<directory suffix="-test.php">./tests/unit/</directory>
 		</testsuite>
 	</testsuites>
 
 	<filter>
 		<whitelist>
-			<directory>./inc</directory>
-			<directory>./frontend</directory>
+			<file>./wp-seo.php</file>
+			<file>./wp-seo-main.php</file>
 			<directory>./admin</directory>
+			<directory>./inc</directory>
 			<directory>./src</directory>
 			<exclude>
-				<directory suffix=".php">./deprecated</directory>
-				<directory suffix=".php">./config/composer</directory>
+				<directory suffix=".php">./src/deprecated</directory>
 				<file>./inc/wpseo-functions-deprecated.php</file>
 			</exclude>
 		</whitelist>

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -24,9 +24,6 @@ abstract class TestCase extends YoastTestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->stubEscapeFunctions();
-		$this->stubTranslationFunctions();
-
 		Monkey\Functions\stubs(
 			[
 				// Null makes it so the function returns its first argument.

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -3,13 +3,13 @@
 namespace Yoast\WP\SEO\Tests\Unit;
 
 use Brain\Monkey;
-use PHPUnit\Framework\TestCase as BaseTestCase;
 use WPSEO_Options;
+use Yoast\WPTestUtils\BrainMonkey\YoastTestCase;
 
 /**
  * TestCase base class.
  */
-abstract class TestCase extends BaseTestCase {
+abstract class TestCase extends YoastTestCase {
 
 	/**
 	 * Options being mocked.
@@ -21,79 +21,16 @@ abstract class TestCase extends BaseTestCase {
 	/**
 	 * Set up the test fixtures.
 	 */
-	protected function setUp() {
-		parent::setUp();
-		Monkey\setUp();
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
 
 		Monkey\Functions\stubs(
 			[
 				// Null makes it so the function returns its first argument.
-				'esc_attr'             => null,
-				'esc_html'             => null,
-				'esc_textarea'         => null,
-				'__'                   => null,
-				'_n'                   => function( $single, $plural, $number ) {
-					if ( $number === 1 ) {
-						return $single;
-					}
-
-					return $plural;
-				},
-				'_x'                   => null,
-				'esc_html__'           => null,
-				'esc_html_x'           => null,
-				'esc_attr__'           => null,
-				'esc_attr_x'           => null,
-				'esc_url'              => null,
-				'esc_url_raw'          => null,
-				'esc_js'               => null,
-				'sanitize_text_field'  => null,
 				'is_admin'             => false,
-				'is_multisite'         => false,
-				'wp_kses_post'         => null,
-				'site_url'             => 'https://www.example.org',
-				'wp_json_encode'       => function( $data, $options = 0, $depth = 512 ) {
-					// phpcs:ignore Yoast.Yoast.AlternativeFunctions.json_encode_json_encodeWithAdditionalParams -- Usage in tests is fine.
-					return \json_encode( $data, $options, $depth );
-				},
-				'wp_slash'             => null,
-				'wp_unslash'           => function( $value ) {
-					return \is_string( $value ) ? \stripslashes( $value ) : $value;
-				},
-				'absint'               => function( $value ) {
-					return \abs( \intval( $value ) );
-				},
-				'mysql2date'           => function( $format, $date ) {
-					return $date;
-				},
-				'number_format_i18n'   => null,
-				'wp_parse_args'        => function( $settings, $defaults ) {
-					return \array_merge( $defaults, $settings );
-				},
-				'user_trailingslashit' => function( $string ) {
-					return \trailingslashit( $string );
-				},
-				'wp_strip_all_tags'    => function( $string, $remove_breaks = false ) {
-					$string = \preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $string );
-					// phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags -- We are stubbing the wp_strip_all_tags.
-					$string = \strip_tags( $string );
-
-					if ( $remove_breaks ) {
-						$string = \preg_replace( '/[\r\n\t ]+/', ' ', $string );
-					}
-
-					return \trim( $string );
-				},
-				'get_bloginfo'         => function( $show ) {
-					switch ( $show ) {
-						case 'charset':
-							return 'UTF-8';
-						case 'language':
-							return 'English';
-					}
-
-					return $show;
-				},
 			]
 		);
 
@@ -109,14 +46,6 @@ abstract class TestCase extends BaseTestCase {
 
 		// This is required to ensure backfill and other statics are set.
 		WPSEO_Options::get_instance();
-	}
-
-	/**
-	 * Tear down the test fixtures.
-	 */
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
 	}
 
 	/**

--- a/tests/unit/actions/indexables/indexable-head-action-test.php
+++ b/tests/unit/actions/indexables/indexable-head-action-test.php
@@ -34,8 +34,8 @@ class Indexable_Head_Action_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->meta_surface = Mockery::mock( Meta_Surface::class );
 		$this->instance     = new Indexable_Head_Action( $this->meta_surface );

--- a/tests/unit/actions/indexables/indexable-head-action-test.php
+++ b/tests/unit/actions/indexables/indexable-head-action-test.php
@@ -47,7 +47,10 @@ class Indexable_Head_Action_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Meta_Surface::class, 'meta_surface', $this->instance );
+		$this->assertInstanceOf(
+			Meta_Surface::class,
+			$this->getPropertyValue( $this->instance, 'meta_surface' )
+		);
 	}
 
 	/**

--- a/tests/unit/actions/indexing/abstract-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/abstract-link-indexing-action-test.php
@@ -59,8 +59,8 @@ class Abstract_Link_Indexing_Action_Test extends TestCase {
 	/**
 	 * Does the setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		global $wpdb;
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the Abstract_Link_Indexing_Action.

--- a/tests/unit/actions/indexing/abstract-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/abstract-link-indexing-action-test.php
@@ -87,9 +87,18 @@ class Abstract_Link_Indexing_Action_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		static::assertAttributeInstanceOf( Indexable_Link_Builder::class, 'link_builder', $this->instance );
-		static::assertAttributeInstanceOf( Indexable_Repository::class, 'repository', $this->instance );
-		static::assertAttributeInstanceOf( 'wpdb', 'wpdb', $this->instance );
+		static::assertInstanceOf(
+			Indexable_Link_Builder::class,
+			$this->getPropertyValue( $this->instance, 'link_builder' )
+		);
+		static::assertInstanceOf(
+			Indexable_Repository::class,
+			$this->getPropertyValue( $this->instance, 'repository' )
+		);
+		static::assertInstanceOf(
+			'wpdb',
+			$this->getPropertyValue( $this->instance, 'wpdb' )
+		);
 	}
 
 	/**

--- a/tests/unit/actions/indexing/indexable-complete-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-complete-indexation-action-test.php
@@ -34,8 +34,8 @@ class Indexable_Indexing_Complete_Action_Test extends TestCase {
 	/**
 	 * Setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->indexable_helper = Mockery::mock( Indexable_Helper::class );
 

--- a/tests/unit/actions/indexing/indexable-complete-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-complete-indexation-action-test.php
@@ -50,7 +50,10 @@ class Indexable_Indexing_Complete_Action_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Indexable_Helper::class, 'indexable_helper', $this->instance );
+		$this->assertInstanceOf(
+			Indexable_Helper::class,
+			$this->getPropertyValue( $this->instance, 'indexable_helper' )
+		);
 	}
 
 	/**

--- a/tests/unit/actions/indexing/indexable-general-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-general-indexation-action-test.php
@@ -35,8 +35,8 @@ class Indexable_General_Indexation_Action_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->indexable_repository = Mockery::mock( Indexable_Repository::class );
 		$this->instance             = new Indexable_General_Indexation_Action( $this->indexable_repository );

--- a/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
@@ -52,7 +52,9 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		global $wpdb;
 		$wpdb = (object) [ 'prefix' => 'wp_' ];
 

--- a/tests/unit/actions/indexing/indexable-post-type-archive-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-type-archive-indexation-action-test.php
@@ -54,7 +54,9 @@ class Indexable_Post_Type_Archive_Indexation_Action_Test extends TestCase {
 	/**
 	 * Set up the mocks before each test.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->repository = Mockery::mock( Indexable_Repository::class );
 		$this->builder    = Mockery::mock( Indexable_Builder::class );
 		$this->post_type  = Mockery::mock( Post_Type_Helper::class );

--- a/tests/unit/actions/indexing/indexable-post-type-archive-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-type-archive-indexation-action-test.php
@@ -80,9 +80,9 @@ class Indexable_Post_Type_Archive_Indexation_Action_Test extends TestCase {
 			$this->post_type
 		);
 
-		$this->assertAttributeEquals( $this->repository, 'repository', $instance );
-		$this->assertAttributeEquals( $this->builder, 'builder', $instance );
-		$this->assertAttributeEquals( $this->post_type, 'post_type', $instance );
+		$this->assertEquals( $this->repository, $this->getPropertyValue( $instance, 'repository' ) );
+		$this->assertEquals( $this->builder, $this->getPropertyValue( $instance, 'builder' ) );
+		$this->assertEquals( $this->post_type, $this->getPropertyValue( $instance, 'post_type' ) );
 	}
 
 	/**

--- a/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
@@ -52,7 +52,9 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		global $wpdb;
 		$wpdb = (object) [ 'prefix' => 'wp_' ];
 

--- a/tests/unit/actions/indexing/indexing-complete-action-test.php
+++ b/tests/unit/actions/indexing/indexing-complete-action-test.php
@@ -34,8 +34,8 @@ class Indexing_Complete_Action_Test extends TestCase {
 	/**
 	 * Runs the setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->indexing = Mockery::mock( Indexing_Helper::class );
 		$this->instance = new Indexing_Complete_Action( $this->indexing );

--- a/tests/unit/actions/indexing/indexing-complete-action-test.php
+++ b/tests/unit/actions/indexing/indexing-complete-action-test.php
@@ -47,7 +47,10 @@ class Indexing_Complete_Action_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		self::assertAttributeInstanceOf( Indexing_Helper::class, 'indexing_helper', $this->instance );
+		self::assertInstanceOf(
+			Indexing_Helper::class,
+			$this->getPropertyValue( $this->instance, 'indexing_helper' )
+		);
 	}
 
 	/**

--- a/tests/unit/actions/indexing/indexing-prepare-action-test.php
+++ b/tests/unit/actions/indexing/indexing-prepare-action-test.php
@@ -43,8 +43,8 @@ class Indexing_Prepare_Action_Test extends TestCase {
 	/**
 	 * Set up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 		$this->indexing            = Mockery::mock( Indexing_Helper::class );
 		$this->notification_center = Mockery::mock( Yoast_Notification_Center::class );
 

--- a/tests/unit/actions/indexing/indexing-prepare-action-test.php
+++ b/tests/unit/actions/indexing/indexing-prepare-action-test.php
@@ -60,8 +60,8 @@ class Indexing_Prepare_Action_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeEquals( $this->indexing, 'indexing_helper', $this->instance );
-		$this->assertAttributeEquals( $this->notification_center, 'notification_center', $this->instance );
+		$this->assertEquals( $this->indexing, $this->getPropertyValue( $this->instance, 'indexing_helper' ) );
+		$this->assertEquals( $this->notification_center, $this->getPropertyValue( $this->instance, 'notification_center' ) );
 	}
 
 	/**

--- a/tests/unit/actions/indexing/post-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/post-link-indexing-action-test.php
@@ -90,7 +90,10 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 	public function test_set_helper() {
 		$this->instance->set_helper( Mockery::mock( Post_Type_Helper::class ) );
 
-		static::assertAttributeInstanceOf( Post_Type_Helper::class, 'post_type_helper', $this->instance );
+		static::assertInstanceOf(
+			Post_Type_Helper::class,
+			$this->getPropertyValue( $this->instance, 'post_type_helper' )
+		);
 	}
 
 	/**

--- a/tests/unit/actions/indexing/post-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/post-link-indexing-action-test.php
@@ -61,8 +61,8 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		global $wpdb;
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the Abstract_Link_Indexing_Action.

--- a/tests/unit/actions/indexing/term-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/term-link-indexing-action-test.php
@@ -61,8 +61,8 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 	/**
 	 * Set up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		global $wpdb;
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended, to be able to test the Abstract_Link_Indexing_Action.

--- a/tests/unit/actions/indexing/term-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/term-link-indexing-action-test.php
@@ -90,7 +90,10 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 	public function test_set_helper() {
 		$this->instance->set_helper( Mockery::mock( Taxonomy_Helper::class ) );
 
-		static::assertAttributeInstanceOf( Taxonomy_Helper::class, 'taxonomy_helper', $this->instance );
+		static::assertInstanceOf(
+			Taxonomy_Helper::class,
+			$this->getPropertyValue( $this->instance, 'taxonomy_helper' )
+		);
 	}
 
 	/**

--- a/tests/unit/actions/semrush/semrush-login-action-test.php
+++ b/tests/unit/actions/semrush/semrush-login-action-test.php
@@ -49,7 +49,10 @@ class SEMrush_Login_Action_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( SEMrush_Client::class, 'client', $this->instance );
+		$this->assertInstanceOf(
+			SEMrush_Client::class,
+			$this->getPropertyValue( $this->instance, 'client' )
+		);
 	}
 
 	/**

--- a/tests/unit/actions/semrush/semrush-login-action-test.php
+++ b/tests/unit/actions/semrush/semrush-login-action-test.php
@@ -36,8 +36,8 @@ class SEMrush_Login_Action_Test extends TestCase {
 	/**
 	 * Set up the test fixtures.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->client_instance = Mockery::mock( SEMrush_Client::class );
 		$this->instance        = new SEMrush_Login_Action( $this->client_instance );

--- a/tests/unit/actions/semrush/semrush-options-action-test.php
+++ b/tests/unit/actions/semrush/semrush-options-action-test.php
@@ -46,7 +46,10 @@ class SEMrush_Options_Action_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Options_Helper::class, 'options_helper', $this->instance );
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $this->instance, 'options_helper' )
+		);
 	}
 
 	/**

--- a/tests/unit/actions/semrush/semrush-options-action-test.php
+++ b/tests/unit/actions/semrush/semrush-options-action-test.php
@@ -33,8 +33,8 @@ class SEMrush_Options_Action_Test extends TestCase {
 	/**
 	 * Set up the test fixtures.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options_helper = Mockery::mock( Options_Helper::class );
 		$this->instance       = new SEMrush_Options_Action( $this->options_helper );

--- a/tests/unit/actions/semrush/semrush-phrases-action-test.php
+++ b/tests/unit/actions/semrush/semrush-phrases-action-test.php
@@ -34,8 +34,8 @@ class SEMrush_Phrases_Action_Test extends TestCase {
 	/**
 	 * Set up the test fixtures.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->client_instance = Mockery::mock( SEMrush_Client::class );
 		$this->instance        = new SEMrush_Phrases_Action( $this->client_instance );

--- a/tests/unit/actions/semrush/semrush-phrases-action-test.php
+++ b/tests/unit/actions/semrush/semrush-phrases-action-test.php
@@ -47,7 +47,10 @@ class SEMrush_Phrases_Action_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( SEMrush_Client::class, 'client', $this->instance );
+		$this->assertInstanceOf(
+			SEMrush_Client::class,
+			$this->getPropertyValue( $this->instance, 'client' )
+		);
 	}
 
 	/**

--- a/tests/unit/admin/admin-features-test.php
+++ b/tests/unit/admin/admin-features-test.php
@@ -50,6 +50,8 @@ class Admin_Features_Test extends TestCase {
 	 * Sets up the YoastSEO function with the right expectations.
 	 */
 	private function setup_yoastseo_with_expectations() {
+		$this->stubTranslationFunctions();
+
 		$current_page_helper = Mockery::mock( Current_Page_Helper::class );
 		$current_page_helper->expects( 'is_yoast_seo_page' )->twice()->andReturn( true );
 

--- a/tests/unit/admin/capabilities/capabilities-utils-test.php
+++ b/tests/unit/admin/capabilities/capabilities-utils-test.php
@@ -26,8 +26,8 @@ final class Capabilities_Utils_Test extends TestCase {
 	/**
 	 * Does the setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->roles = Mockery::mock();
 

--- a/tests/unit/admin/formatter/post-metabox-formatter-test.php
+++ b/tests/unit/admin/formatter/post-metabox-formatter-test.php
@@ -34,8 +34,8 @@ class Post_Metabox_Formatter_Test extends TestCase {
 	/**
 	 * Set up the class which will be tested.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->mock_post               = Mockery::mock( '\WP_Post' )->makePartial();
 		$this->mock_post->ID           = 1;

--- a/tests/unit/admin/formatter/term-metabox-formatter-test.php
+++ b/tests/unit/admin/formatter/term-metabox-formatter-test.php
@@ -42,8 +42,8 @@ class Term_Metabox_Formatter_Test extends TestCase {
 	/**
 	 * Set up the class which will be tested.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->taxonomy           = (object) [];
 		$this->mock_term          = Mockery::mock( '\WP_Term' )->makePartial();

--- a/tests/unit/admin/input-validation-test.php
+++ b/tests/unit/admin/input-validation-test.php
@@ -14,6 +14,17 @@ use Yoast_Input_Validation;
 class Input_Validation_Test extends TestCase {
 
 	/**
+	 * Set up the class which will be tested.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		Monkey\Functions\stubs( [ 'add_settings_error' => null ] );
+	}
+
+	/**
 	 * Tests the document title is updated when there's an error.
 	 *
 	 * @covers Yoast_Input_Validation::add_yoast_admin_document_title_errors
@@ -21,8 +32,6 @@ class Input_Validation_Test extends TestCase {
 	 */
 	public function test_document_title_updated_with_error() {
 		$admin_title = 'Original title';
-
-		Monkey\Functions\stubs( [ 'add_settings_error' => null ] );
 
 		Monkey\Functions\expect( 'get_settings_errors' )
 			->once()
@@ -50,8 +59,6 @@ class Input_Validation_Test extends TestCase {
 	 */
 	public function test_document_title_updated_with_errors() {
 		$admin_title = 'Original title';
-
-		Monkey\Functions\stubs( [ 'add_settings_error' => null ] );
 
 		Monkey\Functions\expect( 'get_settings_errors' )
 			->once()
@@ -86,8 +93,6 @@ class Input_Validation_Test extends TestCase {
 	public function test_document_title_not_updated_with_non_yoast_errors() {
 		$admin_title = 'Original title';
 
-		Monkey\Functions\stubs( [ 'add_settings_error' => null ] );
-
 		Monkey\Functions\expect( 'get_settings_errors' )
 			->once()
 			->andReturn(
@@ -114,8 +119,6 @@ class Input_Validation_Test extends TestCase {
 	 */
 	public function test_document_title_not_updated_with_settings_updated_error() {
 		$admin_title = 'Original title';
-
-		Monkey\Functions\stubs( [ 'add_settings_error' => null ] );
 
 		Monkey\Functions\expect( 'get_settings_errors' )
 			->once()
@@ -150,8 +153,6 @@ class Input_Validation_Test extends TestCase {
 				'type'    => 'error',
 			],
 		];
-
-		Monkey\Functions\stubs( [ 'add_settings_error' => null ] );
 
 		Monkey\Functions\expect( 'get_settings_errors' )
 			->once()
@@ -190,8 +191,6 @@ class Input_Validation_Test extends TestCase {
 				'type'    => 'error',
 			],
 		];
-
-		Monkey\Functions\stubs( [ 'add_settings_error' => null ] );
 
 		Monkey\Functions\expect( 'get_settings_errors' )
 			->once()

--- a/tests/unit/admin/input-validation-test.php
+++ b/tests/unit/admin/input-validation-test.php
@@ -21,6 +21,9 @@ class Input_Validation_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		Monkey\Functions\stubs( [ 'add_settings_error' => null ] );
 	}
 

--- a/tests/unit/admin/metabox/metabox-collapsibles-section-test.php
+++ b/tests/unit/admin/metabox/metabox-collapsibles-section-test.php
@@ -15,6 +15,18 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 class Metabox_Collapsibles_Section_Test extends TestCase {
 
 	/**
+	 * Set up function stubs.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+	}
+
+	/**
 	 * Tests the output of \WPSEO_Metabox_Collapsibles_Section::display_content.
 	 *
 	 * @covers WPSEO_Metabox_Collapsibles_Sections::__construct
@@ -26,8 +38,6 @@ class Metabox_Collapsibles_Section_Test extends TestCase {
 	 * @covers WPSEO_Metabox_Collapsible::link
 	 */
 	public function test_display_content_with_collapsible() {
-		$this->stubTranslationFunctions();
-
 		$collapsibles = [];
 
 		$collapsibles[] = new WPSEO_Metabox_Collapsible(

--- a/tests/unit/admin/metabox/metabox-collapsibles-section-test.php
+++ b/tests/unit/admin/metabox/metabox-collapsibles-section-test.php
@@ -26,7 +26,7 @@ class Metabox_Collapsibles_Section_Test extends TestCase {
 	 * @covers WPSEO_Metabox_Collapsible::link
 	 */
 	public function test_display_content_with_collapsible() {
-		Monkey\Functions\stubs( [ 'esc_attr_e' ] );
+		$this->stubTranslationFunctions();
 
 		$collapsibles = [];
 

--- a/tests/unit/admin/metabox/metabox-editor-test.php
+++ b/tests/unit/admin/metabox/metabox-editor-test.php
@@ -24,8 +24,8 @@ class Metabox_Editor_Test extends TestCase {
 	/**
 	 * Set up the class which will be tested.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 		$this->subject = new WPSEO_Metabox_Editor();
 	}
 

--- a/tests/unit/admin/metabox/metabox-section-additional-test.php
+++ b/tests/unit/admin/metabox/metabox-section-additional-test.php
@@ -13,6 +13,17 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 class Metabox_Section_Additional_Test extends TestCase {
 
 	/**
+	 * Set up function stubs.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubEscapeFunctions();
+	}
+
+	/**
 	 * Tests the output of \WPSEO_Metabox_Section_Additional::display_content.
 	 *
 	 * @covers WPSEO_Metabox_Section_Additional::__construct

--- a/tests/unit/admin/metabox/metabox-test.php
+++ b/tests/unit/admin/metabox/metabox-test.php
@@ -26,8 +26,8 @@ class Metabox_Test extends TestCase {
 	/**
 	 * Set up the class which will be tested.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		global $_SERVER;
 		$_SERVER['HTTP_USER_AGENT'] = 'User Agent';

--- a/tests/unit/admin/myyoast-proxy-test.php
+++ b/tests/unit/admin/myyoast-proxy-test.php
@@ -107,14 +107,12 @@ class MyYoast_Proxy_Test extends TestCase {
 			->will( $this->returnValue( '1.0' ) );
 
 		$instance
-			->expects( $this->at( 2 ) )
+			->expects( $this->exactly( 2 ) )
 			->method( 'set_header' )
-			->with( 'Content-Type: text/javascript; charset=UTF-8' );
-
-		$instance
-			->expects( $this->at( 3 ) )
-			->method( 'set_header' )
-			->with( 'Cache-Control: max-age=' . WPSEO_MyYoast_Proxy::CACHE_CONTROL_MAX_AGE );
+			->withConsecutive(
+				[ 'Content-Type: text/javascript; charset=UTF-8' ],
+				[ 'Cache-Control: max-age=' . WPSEO_MyYoast_Proxy::CACHE_CONTROL_MAX_AGE ]
+			);
 
 		$instance
 			->expects( $this->once() )
@@ -163,29 +161,15 @@ class MyYoast_Proxy_Test extends TestCase {
 			->will( $this->returnValue( '1.0' ) );
 
 		$instance
-			->expects( $this->at( 2 ) )
+			->expects( $this->exactly( 5 ) )
 			->method( 'set_header' )
-			->with( 'Content-Type: text/javascript; charset=UTF-8' );
-
-		$instance
-			->expects( $this->at( 3 ) )
-			->method( 'set_header' )
-			->with( 'Cache-Control: max-age=' . WPSEO_MyYoast_Proxy::CACHE_CONTROL_MAX_AGE );
-
-		$instance
-			->expects( $this->at( 4 ) )
-			->method( 'set_header' )
-			->with( 'Content-Type: text/plain' );
-
-		$instance
-			->expects( $this->at( 5 ) )
-			->method( 'set_header' )
-			->with( 'Cache-Control: max-age=0' );
-
-		$instance
-			->expects( $this->at( 6 ) )
-			->method( 'set_header' )
-			->with( 'HTTP/1.0 500 Received unexpected response from MyYoast' );
+			->withConsecutive(
+				[ 'Content-Type: text/javascript; charset=UTF-8' ],
+				[ 'Cache-Control: max-age=' . WPSEO_MyYoast_Proxy::CACHE_CONTROL_MAX_AGE ],
+				[ 'Content-Type: text/plain' ],
+				[ 'Cache-Control: max-age=0' ],
+				[ 'HTTP/1.0 500 Received unexpected response from MyYoast' ]
+			);
 
 		$instance->render_proxy_page();
 

--- a/tests/unit/admin/paper-presenter-test.php
+++ b/tests/unit/admin/paper-presenter-test.php
@@ -20,7 +20,7 @@ class Paper_Presenter_Test extends TestCase {
 	 * @covers WPSEO_Paper_Presenter::collapsible_config
 	 */
 	public function test_get_paper_presenter_output_without_view_file() {
-		Monkey\Functions\stubs( [ 'esc_attr_e' ] );
+		$this->stubTranslationFunctions();
 
 		$paper_presenter = new WPSEO_Paper_Presenter( 'paper', null, [ 'content' => 'This is some content' ] );
 		$output          = $paper_presenter->get_output();

--- a/tests/unit/admin/paper-presenter-test.php
+++ b/tests/unit/admin/paper-presenter-test.php
@@ -26,6 +26,6 @@ class Paper_Presenter_Test extends TestCase {
 		$paper_presenter = new WPSEO_Paper_Presenter( 'paper', null, [ 'content' => 'This is some content' ] );
 		$output          = $paper_presenter->get_output();
 
-		$this->assertContains( 'This is some content', $output );
+		$this->assertStringContainsString( 'This is some content', $output );
 	}
 }

--- a/tests/unit/admin/paper-presenter-test.php
+++ b/tests/unit/admin/paper-presenter-test.php
@@ -20,6 +20,7 @@ class Paper_Presenter_Test extends TestCase {
 	 * @covers WPSEO_Paper_Presenter::collapsible_config
 	 */
 	public function test_get_paper_presenter_output_without_view_file() {
+		$this->stubEscapeFunctions();
 		$this->stubTranslationFunctions();
 
 		$paper_presenter = new WPSEO_Paper_Presenter( 'paper', null, [ 'content' => 'This is some content' ] );

--- a/tests/unit/admin/tracking/tracking-test.php
+++ b/tests/unit/admin/tracking/tracking-test.php
@@ -19,8 +19,8 @@ class WPSEO_Tracking_Test extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 	}
 
 	/**

--- a/tests/unit/admin/tracking/tracking-test.php
+++ b/tests/unit/admin/tracking/tracking-test.php
@@ -39,9 +39,9 @@ class WPSEO_Tracking_Test extends TestCase {
 
 		$instance = new WPSEO_Tracking( 'https://tracking.yoast.com/stats', ( \WEEK_IN_SECONDS * 2 ) );
 
-		$this->assertAttributeEquals( 0, 'threshold', $instance );
-		$this->assertAttributeEquals( '', 'endpoint', $instance );
-		$this->assertAttributeEquals( null, 'current_time', $instance );
+		$this->assertEquals( 0, $this->getPropertyValue( $instance, 'threshold' ) );
+		$this->assertEquals( '', $this->getPropertyValue( $instance, 'endpoint' ) );
+		$this->assertEquals( null, $this->getPropertyValue( $instance, 'current_time' ) );
 
 		WPSEO_Options::clear_cache();
 	}
@@ -61,9 +61,9 @@ class WPSEO_Tracking_Test extends TestCase {
 
 		$instance = new WPSEO_Tracking( 'https://tracking.yoast.com/stats', ( \WEEK_IN_SECONDS * 2 ) );
 
-		$this->assertAttributeEquals( ( \WEEK_IN_SECONDS * 2 ), 'threshold', $instance );
-		$this->assertAttributeEquals( 'https://tracking.yoast.com/stats', 'endpoint', $instance );
-		$this->assertAttributeEquals( \time(), 'current_time', $instance );
+		$this->assertEquals( ( \WEEK_IN_SECONDS * 2 ), $this->getPropertyValue( $instance, 'threshold' ) );
+		$this->assertEquals( 'https://tracking.yoast.com/stats', $this->getPropertyValue( $instance, 'endpoint' ) );
+		$this->assertEquals( \time(), $this->getPropertyValue( $instance, 'current_time' ) );
 
 		WPSEO_Options::clear_cache();
 	}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -5,22 +5,10 @@
  * @package Yoast\WP\SEO
  */
 
-define( 'ABSPATH', true );
 define( 'WPSEO_INDEXABLES', true );
-
-define( 'MINUTE_IN_SECONDS', 60 );
-define( 'HOUR_IN_SECONDS', 3600 );
-define( 'DAY_IN_SECONDS', 86400 );
-define( 'WEEK_IN_SECONDS', 604800 );
-define( 'MONTH_IN_SECONDS', 2592000 );
-define( 'YEAR_IN_SECONDS', 31536000 );
-
 define( 'EP_DATE', 1 );
 
-if ( function_exists( 'opcache_reset' ) ) {
-	opcache_reset();
-}
-
+require_once __DIR__ . '/../../vendor/yoast/wp-test-utils/src/BrainMonkey/bootstrap.php';
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 if ( file_exists( __DIR__ . '/../../wp-seo-premium.php' ) ) {

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -38,8 +38,8 @@ class Indexable_Author_Builder_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->indexable_mock      = Mockery::mock( Indexable::class );
 		$this->indexable_mock->orm = Mockery::mock( ORM::class );

--- a/tests/unit/builders/indexable-builder-test.php
+++ b/tests/unit/builders/indexable-builder-test.php
@@ -124,8 +124,8 @@ class Indexable_Builder_Test extends TestCase {
 	/**
 	 * Sets up the test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->author_builder            = Mockery::mock( Indexable_Author_Builder::class );
 		$this->post_builder              = Mockery::mock( Indexable_Post_Builder::class );

--- a/tests/unit/builders/indexable-hierarchy-builder-test.php
+++ b/tests/unit/builders/indexable-hierarchy-builder-test.php
@@ -73,7 +73,9 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 	/**
 	 * Runs the setup steps.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->indexable_hierarchy_repository = Mockery::mock( Indexable_Hierarchy_Repository::class );
 		$this->primary_term_repository        = Mockery::mock( Primary_Term_Repository::class );
 		$this->options                        = Mockery::mock( Options_Helper::class );
@@ -87,8 +89,6 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 			$this->post
 		);
 		$this->instance->set_indexable_repository( $this->indexable_repository );
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/builders/indexable-home-page-builder-test.php
+++ b/tests/unit/builders/indexable-home-page-builder-test.php
@@ -88,8 +88,8 @@ class Indexable_Home_Page_Builder_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Setup the options mock.
 		$this->options_mock = Mockery::mock( Options_Helper::class );

--- a/tests/unit/builders/indexable-link-builder-test.php
+++ b/tests/unit/builders/indexable-link-builder-test.php
@@ -64,8 +64,8 @@ class Indexable_Link_Builder_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->seo_links_repository = Mockery::mock( SEO_Links_Repository::class );
 		$this->url_helper           = Mockery::mock( Url_Helper::class );

--- a/tests/unit/builders/indexable-post-builder-test.php
+++ b/tests/unit/builders/indexable-post-builder-test.php
@@ -78,7 +78,9 @@ class Indexable_Post_Builder_Test extends TestCase {
 	/**
 	 * Initializes the test mocks.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->indexable            = Mockery::mock();
 		$this->indexable_repository = Mockery::mock( Indexable_Repository::class );
 		$this->image                = Mockery::mock( Image_Helper::class );
@@ -96,8 +98,6 @@ class Indexable_Post_Builder_Test extends TestCase {
 			$this->open_graph_image,
 			$this->twitter_image
 		);
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/builders/indexable-post-builder-test.php
+++ b/tests/unit/builders/indexable-post-builder-test.php
@@ -163,7 +163,10 @@ class Indexable_Post_Builder_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Post_Helper::class, 'post', $this->instance );
+		$this->assertInstanceOf(
+			Post_Helper::class,
+			$this->getPropertyValue( $this->instance, 'post' )
+		);
 	}
 
 	/**
@@ -173,7 +176,11 @@ class Indexable_Post_Builder_Test extends TestCase {
 	 */
 	public function test_set_indexable_repository() {
 		$this->instance->set_indexable_repository( $this->indexable_repository );
-		$this->assertAttributeInstanceOf( Indexable_Repository::class, 'indexable_repository', $this->instance );
+
+		$this->assertInstanceOf(
+			Indexable_Repository::class,
+			$this->getPropertyValue( $this->instance, 'indexable_repository' )
+		);
 	}
 
 	/**

--- a/tests/unit/builders/indexable-social-image-trait-test.php
+++ b/tests/unit/builders/indexable-social-image-trait-test.php
@@ -60,8 +60,8 @@ class Indexable_Social_Image_Trait_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Indexable_Social_Image_Trait_Double::class );
 

--- a/tests/unit/builders/indexable-social-image-trait-test.php
+++ b/tests/unit/builders/indexable-social-image-trait-test.php
@@ -80,9 +80,18 @@ class Indexable_Social_Image_Trait_Test extends TestCase {
 	public function test_set_social_image_helpers() {
 		$this->instance->set_social_image_helpers( $this->image, $this->open_graph_image, $this->twitter_image );
 
-		self::assertAttributeInstanceOf( Twitter\Image_Helper::class, 'twitter_image', $this->instance );
-		self::assertAttributeInstanceOf( Open_Graph\Image_Helper::class, 'open_graph_image', $this->instance );
-		self::assertAttributeInstanceOf( Image_Helper::class, 'image', $this->instance );
+		self::assertInstanceOf(
+			Twitter\Image_Helper::class,
+			$this->getPropertyValue( $this->instance, 'twitter_image' )
+		);
+		self::assertInstanceOf(
+			Open_Graph\Image_Helper::class,
+			$this->getPropertyValue( $this->instance, 'open_graph_image' )
+		);
+		self::assertInstanceOf(
+			Image_Helper::class,
+			$this->getPropertyValue( $this->instance, 'image' )
+		);
 	}
 
 	/**

--- a/tests/unit/builders/indexable-term-builder-test.php
+++ b/tests/unit/builders/indexable-term-builder-test.php
@@ -71,8 +71,8 @@ class Indexable_Term_Builder_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->taxonomy = Mockery::mock( Taxonomy_Helper::class );
 

--- a/tests/unit/builders/indexable-term-builder-test.php
+++ b/tests/unit/builders/indexable-term-builder-test.php
@@ -157,7 +157,12 @@ class Indexable_Term_Builder_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Taxonomy_Helper::class, 'taxonomy', $this->instance );
+		$instance = new Indexable_Term_Builder( $this->taxonomy );
+
+		$this->assertInstanceOf(
+			Taxonomy_Helper::class,
+			$this->getPropertyValue( $instance, 'taxonomy' )
+		);
 	}
 
 	/**

--- a/tests/unit/builders/primary-term-builder-test.php
+++ b/tests/unit/builders/primary-term-builder-test.php
@@ -52,8 +52,8 @@ class Primary_Term_Builder_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->repository   = Mockery::mock( Primary_Term_Repository::class );
 		$this->primary_term = Mockery::mock( Primary_Term_Helper::class );

--- a/tests/unit/builders/primary-term-builder-test.php
+++ b/tests/unit/builders/primary-term-builder-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Builders;
 
 use Brain\Monkey\Functions;
 use Mockery;
+use Yoast\WP\SEO\Builders\Primary_Term_Builder;
 use Yoast\WP\SEO\Helpers\Meta_Helper;
 use Yoast\WP\SEO\Helpers\Primary_Term_Helper;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
@@ -72,28 +73,25 @@ class Primary_Term_Builder_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_successfully_creates_primary_term_builder() {
-		$primary_term_builder = new Primary_Term_Builder_Double(
+		$primary_term_builder = new Primary_Term_Builder(
 			$this->repository,
 			$this->primary_term,
 			$this->meta
 		);
 
-		$this->assertAttributeInstanceOf(
+		$this->assertInstanceOf(
 			Primary_Term_Repository::class,
-			'repository',
-			$primary_term_builder
+			$this->getPropertyValue( $primary_term_builder, 'repository' )
 		);
 
-		$this->assertAttributeInstanceOf(
+		$this->assertInstanceOf(
 			Primary_Term_Helper::class,
-			'primary_term',
-			$primary_term_builder
+			$this->getPropertyValue( $primary_term_builder, 'primary_term' )
 		);
 
-		$this->assertAttributeInstanceOf(
+		$this->assertInstanceOf(
 			Meta_Helper::class,
-			'meta',
-			$primary_term_builder
+			$this->getPropertyValue( $primary_term_builder, 'meta' )
 		);
 	}
 

--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -76,7 +76,9 @@ class Index_Command_Test extends TestCase {
 	/**
 	 * Prepares the test by setting up the needed properties.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->post_indexation_action              = Mockery::mock( Indexable_Post_Indexation_Action::class );
 		$this->term_indexation_action              = Mockery::mock( Indexable_Term_Indexation_Action::class );
 		$this->post_type_archive_indexation_action = Mockery::mock( Indexable_Post_Type_Archive_Indexation_Action::class );

--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -102,10 +102,22 @@ class Index_Command_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeInstanceOf( Indexable_Post_Indexation_Action::class, 'post_indexation_action', $this->instance );
-		$this->assertAttributeInstanceOf( Indexable_Term_Indexation_Action::class, 'term_indexation_action', $this->instance );
-		$this->assertAttributeInstanceOf( Indexable_Post_Type_Archive_Indexation_Action::class, 'post_type_archive_indexation_action', $this->instance );
-		$this->assertAttributeInstanceOf( Indexable_General_Indexation_Action::class, 'general_indexation_action', $this->instance );
+		$this->assertInstanceOf(
+			Indexable_Post_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'post_indexation_action' )
+		);
+		$this->assertInstanceOf(
+			Indexable_Term_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'term_indexation_action' )
+		);
+		$this->assertInstanceOf(
+			Indexable_Post_Type_Archive_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'post_type_archive_indexation_action' )
+		);
+		$this->assertInstanceOf(
+			Indexable_General_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'general_indexation_action' )
+		);
 	}
 
 	/**

--- a/tests/unit/conditionals/breadcrumbs-enabled-conditional-test.php
+++ b/tests/unit/conditionals/breadcrumbs-enabled-conditional-test.php
@@ -33,8 +33,8 @@ class Breadcrumbs_Enabled_Conditional_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options = Mockery::mock( Options_Helper::class );
 

--- a/tests/unit/conditionals/get-request-conditional-test.php
+++ b/tests/unit/conditionals/get-request-conditional-test.php
@@ -25,7 +25,9 @@ class Get_Request_Conditional_Test extends TestCase {
 	/**
 	 * Set up the test fixtures.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance = new Get_Request_Conditional();
 	}
 

--- a/tests/unit/conditionals/headless-rest-endpoints-enabled-conditional-test.php
+++ b/tests/unit/conditionals/headless-rest-endpoints-enabled-conditional-test.php
@@ -46,7 +46,10 @@ class Headless_Rest_Endpoints_Enabled_Conditional_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeInstanceOf( Options_Helper::class, 'options', $this->instance );
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $this->instance, 'options' )
+		);
 	}
 
 	/**

--- a/tests/unit/conditionals/headless-rest-endpoints-enabled-conditional-test.php
+++ b/tests/unit/conditionals/headless-rest-endpoints-enabled-conditional-test.php
@@ -33,8 +33,8 @@ class Headless_Rest_Endpoints_Enabled_Conditional_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options  = Mockery::mock( Options_Helper::class );
 		$this->instance = new Headless_Rest_Endpoints_Enabled_Conditional( $this->options );

--- a/tests/unit/conditionals/jetpack-conditional-test.php
+++ b/tests/unit/conditionals/jetpack-conditional-test.php
@@ -25,8 +25,8 @@ class Jetpack_Conditional_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Jetpack_Conditional();
 	}

--- a/tests/unit/conditionals/no-tool-selected-conditional-test.php
+++ b/tests/unit/conditionals/no-tool-selected-conditional-test.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group indexables
  * @group conditionals
  *
- * @coversDefaultClass \Yoast\WP\SEO\Conditionals\No_Tool_Selected_Conditional()
+ * @coversDefaultClass \Yoast\WP\SEO\Conditionals\No_Tool_Selected_Conditional
  */
 class No_Tool_Selected_Conditional_Test extends TestCase {
 

--- a/tests/unit/conditionals/no-tool-selected-conditional-test.php
+++ b/tests/unit/conditionals/no-tool-selected-conditional-test.php
@@ -25,7 +25,9 @@ class No_Tool_Selected_Conditional_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance = new No_Tool_Selected_Conditional();
 	}
 

--- a/tests/unit/conditionals/posts-overview-or-ajax-conditional-test.php
+++ b/tests/unit/conditionals/posts-overview-or-ajax-conditional-test.php
@@ -25,8 +25,8 @@ class Posts_Overview_Or_Ajax_Conditional_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Posts_Overview_Or_Ajax_Conditional();
 	}

--- a/tests/unit/conditionals/schema-blocks-conditional-test.php
+++ b/tests/unit/conditionals/schema-blocks-conditional-test.php
@@ -24,8 +24,8 @@ class Schema_Blocks_Conditional_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Schema_Blocks_Conditional();
 	}

--- a/tests/unit/conditionals/schema-blocks-conditional-test.php
+++ b/tests/unit/conditionals/schema-blocks-conditional-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  *
  * @group conditionals
  *
- * @coversDefaultClass Y\oast\WP\SEO\Conditionals\Schema_Blocks_Conditional
+ * @coversDefaultClass \Yoast\WP\SEO\Conditionals\Schema_Blocks_Conditional
  */
 class Schema_Blocks_Conditional_Test extends TestCase {
 

--- a/tests/unit/conditionals/should-index-links-conditional-test.php
+++ b/tests/unit/conditionals/should-index-links-conditional-test.php
@@ -47,7 +47,10 @@ class Should_Index_Links_Conditional_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeInstanceOf( Options_Helper::class, 'options_helper', $this->instance );
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $this->instance, 'options_helper' )
+		);
 	}
 
 	/**

--- a/tests/unit/conditionals/should-index-links-conditional-test.php
+++ b/tests/unit/conditionals/should-index-links-conditional-test.php
@@ -34,8 +34,8 @@ class Should_Index_Links_Conditional_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options  = Mockery::mock( Options_Helper::class );
 		$this->instance = new Should_Index_Links_Conditional( $this->options );

--- a/tests/unit/conditionals/web-stories-conditional-test.php
+++ b/tests/unit/conditionals/web-stories-conditional-test.php
@@ -25,8 +25,8 @@ class Web_Stories_Conditional_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Web_Stories_Conditional();
 	}

--- a/tests/unit/conditionals/wpml-wpseo-conditional-test.php
+++ b/tests/unit/conditionals/wpml-wpseo-conditional-test.php
@@ -26,8 +26,8 @@ class WPML_WPSEO_Conditional_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->instance = new WPML_WPSEO_Conditional();
 	}
 

--- a/tests/unit/conditionals/yoast-admin-and-dashboard-conditional-test.php
+++ b/tests/unit/conditionals/yoast-admin-and-dashboard-conditional-test.php
@@ -26,7 +26,9 @@ class Yoast_Admin_And_Dashboard_Conditional_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance = new Yoast_Admin_And_Dashboard_Conditional();
 	}
 

--- a/tests/unit/conditionals/yoast-tools-page-conditional-test.php
+++ b/tests/unit/conditionals/yoast-tools-page-conditional-test.php
@@ -25,7 +25,9 @@ class Yoast_Admin_Tools_Page_Conditional_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance = new Yoast_Tools_Page_Conditional();
 	}
 

--- a/tests/unit/config/semrush-client-test.php
+++ b/tests/unit/config/semrush-client-test.php
@@ -89,8 +89,14 @@ class SEMrush_Client_Test extends TestCase {
 			Mockery::mock( WP_Remote_Handler::class )
 		);
 
-		$this->assertAttributeInstanceOf( GenericProvider::class, 'provider', $instance );
-		$this->assertAttributeInstanceOf( Options_Helper::class, 'options_helper', $instance );
+		$this->assertInstanceOf(
+			GenericProvider::class,
+			$this->getPropertyValue( $instance, 'provider' )
+		);
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $instance, 'options_helper' )
+		);
 	}
 
 	/**
@@ -118,9 +124,18 @@ class SEMrush_Client_Test extends TestCase {
 			Mockery::mock( WP_Remote_Handler::class )
 		);
 
-		$this->assertAttributeInstanceOf( GenericProvider::class, 'provider', $instance );
-		$this->assertAttributeInstanceOf( Options_Helper::class, 'options_helper', $instance );
-		$this->assertAttributeInstanceOf( SEMrush_Token::class, 'token', $instance );
+		$this->assertInstanceOf(
+			GenericProvider::class,
+			$this->getPropertyValue( $instance, 'provider' )
+		);
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $instance, 'options_helper' )
+		);
+		$this->assertInstanceOf(
+			SEMrush_Token::class,
+			$this->getPropertyValue( $instance, 'token' )
+		);
 	}
 
 	/**

--- a/tests/unit/config/semrush-client-test.php
+++ b/tests/unit/config/semrush-client-test.php
@@ -5,6 +5,8 @@ namespace Yoast\WP\SEO\Tests\Unit\Config;
 use Mockery;
 use Mockery\LegacyMockInterface;
 use Mockery\MockInterface;
+use Yoast\WP\SEO\Exceptions\OAuth\Authentication_Failed_Exception;
+use Yoast\WP\SEO\Exceptions\SEMrush\Tokens\Failed_Storage_Exception;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Config\SEMrush_Client_Double;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -176,10 +178,10 @@ class SEMrush_Client_Test extends TestCase {
 	 * Tests the scenario where no code is passed along to the OAuth client.
 	 *
 	 * @covers ::request_tokens
-	 *
-	 * @expectedException Yoast\WP\SEO\Exceptions\OAuth\Authentication_Failed_Exception
 	 */
 	public function test_invalid_request_tokens_when_no_code_is_set() {
+		$this->expectException( Authentication_Failed_Exception::class );
+
 		$this->provider
 			->expects( 'getAccessToken' )
 			->once()
@@ -205,10 +207,9 @@ class SEMrush_Client_Test extends TestCase {
 	 * Tests the scenario where the token storing fails.
 	 *
 	 * @covers ::store_token
-	 *
-	 * @expectedException Yoast\WP\SEO\Exceptions\SEMrush\Tokens\Failed_Storage_Exception
 	 */
 	public function test_storing_token_failure() {
+		$this->expectException( Failed_Storage_Exception::class );
 
 		$this->token->expects( 'to_array' )->once()->andReturns(
 			[

--- a/tests/unit/config/semrush-client-test.php
+++ b/tests/unit/config/semrush-client-test.php
@@ -61,8 +61,8 @@ class SEMrush_Client_Test extends TestCase {
 	/**
 	 * Set up the test fixtures.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->response       = Mockery::mock( AccessTokenInterface::class );
 		$this->token          = Mockery::mock( SEMrush_Token::class );

--- a/tests/unit/context/meta-tags-context-test.php
+++ b/tests/unit/context/meta-tags-context-test.php
@@ -107,8 +107,8 @@ class Meta_Tags_Context_Test extends TestCase {
 	/**
 	 * Set up the test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options              = Mockery::mock( Options_Helper::class );
 		$this->url                  = Mockery::mock( Url_Helper::class );

--- a/tests/unit/database/migration-runner-test.php
+++ b/tests/unit/database/migration-runner-test.php
@@ -24,8 +24,8 @@ class Migration_Runner_Test extends TestCase {
 	/**
 	 * Setup the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		global $wpdb;
 		$wpdb = $this->get_wpdb_mock();

--- a/tests/unit/database/migration-runner-test.php
+++ b/tests/unit/database/migration-runner-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Database;
 
+use Exception;
 use Mockery;
 use wpdb;
 use Yoast\WP\Lib\Migrations\Adapter;
@@ -146,11 +147,11 @@ class Migration_Runner_Test extends TestCase {
 	 * Tests the initializing when everything goes wrong.
 	 *
 	 * @covers ::run_migrations
-	 *
-	 * @expectedException \Exception
-	 * @expectedExceptionMessage Migration error
 	 */
 	public function test_migration_error() {
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Migration error' );
+
 		$status_mock  = Mockery::mock( Migration_Status::class );
 		$loader_mock  = Mockery::mock( Loader::class );
 		$adapter_mock = Mockery::mock( Adapter::class );

--- a/tests/unit/dependency-injection/schema-templates-loader-test.php
+++ b/tests/unit/dependency-injection/schema-templates-loader-test.php
@@ -24,8 +24,8 @@ class Schema_Templates_Loader_Test extends TestCase {
 	/**
 	 * Sets the instances to test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->instance = new Schema_Templates_Loader();
 	}

--- a/tests/unit/dependency-injection/schema-templates-pass-test.php
+++ b/tests/unit/dependency-injection/schema-templates-pass-test.php
@@ -42,8 +42,8 @@ class Schema_Templates_Pass_Test extends TestCase {
 	/**
 	 * Sets the instances to test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->container_builder = Mockery::mock( ContainerBuilder::class );
 		$this->templates_loader  = Mockery::mock( Schema_Templates_Loader::class );

--- a/tests/unit/generators/breadcrumbs-generator-test.php
+++ b/tests/unit/generators/breadcrumbs-generator-test.php
@@ -323,6 +323,8 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	 * @covers ::add_paged_crumb
 	 */
 	public function test_with_date_archive( $scenario, $is_paged, $current_page, $expected ) {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
 		$this->setup_expectations_for_date_archive( $scenario, $is_paged, $current_page );
 
 		$this->assertEquals(

--- a/tests/unit/generators/breadcrumbs-generator-test.php
+++ b/tests/unit/generators/breadcrumbs-generator-test.php
@@ -91,8 +91,8 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->repository        = Mockery::mock( Indexable_Repository::class );
 		$this->options           = Mockery::mock( Options_Helper::class );

--- a/tests/unit/generators/open-graph-image-generator-test.php
+++ b/tests/unit/generators/open-graph-image-generator-test.php
@@ -70,8 +70,8 @@ class Open_Graph_Image_Generator_Test extends TestCase {
 	/**
 	 * Setup the test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->image            = Mockery::mock( Image_Helper::class );
 		$this->url              = Mockery::mock( Url_Helper::class );

--- a/tests/unit/generators/open-graph-locale-generator-test.php
+++ b/tests/unit/generators/open-graph-locale-generator-test.php
@@ -35,8 +35,8 @@ class Open_Graph_Locale_Generator_Test extends TestCase {
 	/**
 	 * Setup the test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Open_Graph_Locale_Generator();
 		$this->context  = Mockery::mock( Meta_Tags_Context_Mock::class );

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -84,8 +84,8 @@ class Schema_Generator_Test extends TestCase {
 	/**
 	 * Sets up the test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->id           = Mockery::mock( ID_Helper::class );
 		$this->current_page = Mockery::mock( Current_Page_Helper::class );

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -244,6 +244,8 @@ class Schema_Generator_Test extends TestCase {
 	 * @covers ::get_graph_pieces
 	 */
 	public function test_generate_with_blocks() {
+		$this->stubEscapeFunctions();
+
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
 			->withNoArgs()
@@ -288,6 +290,8 @@ class Schema_Generator_Test extends TestCase {
 	 * @covers ::get_graph_pieces
 	 */
 	public function test_generate_with_generator_have_identifier() {
+		$this->stubEscapeFunctions();
+
 		$piece             = new FAQ();
 		$piece->identifier = 'faq_block';
 		$this->instance
@@ -312,6 +316,8 @@ class Schema_Generator_Test extends TestCase {
 	 * @covers ::get_graph_pieces
 	 */
 	public function test_generate_with_block_not_having_generated_output() {
+		$this->stubEscapeFunctions();
+
 		Monkey\Functions\expect( 'is_single' )
 			->once()
 			->withNoArgs()

--- a/tests/unit/generators/schema/article-test.php
+++ b/tests/unit/generators/schema/article-test.php
@@ -87,7 +87,9 @@ class Article_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->id                      = Mockery::mock( ID_Helper::class );
 		$this->article                 = Mockery::mock( Article_Helper::class );
 		$this->date                    = Mockery::mock( Date_Helper::class );
@@ -113,8 +115,6 @@ class Article_Test extends TestCase {
 				'language' => $this->language,
 			],
 		];
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/generators/schema/article-test.php
+++ b/tests/unit/generators/schema/article-test.php
@@ -287,6 +287,8 @@ class Article_Test extends TestCase {
 	 * @covers ::add_terms
 	 */
 	public function test_add_terms_happy_path() {
+		$this->stubTranslationFunctions();
+
 		$terms = [
 			(object) [ 'name' => 'Tag1' ],
 			(object) [ 'name' => 'Tag2' ],

--- a/tests/unit/generators/schema/author-test.php
+++ b/tests/unit/generators/schema/author-test.php
@@ -102,8 +102,8 @@ class Author_Test extends TestCase {
 	/**
 	 * Sets up the test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->article      = Mockery::mock( Article_Helper::class );
 		$this->image        = Mockery::mock( Image_Helper::class );

--- a/tests/unit/generators/schema/breadcrumb-test.php
+++ b/tests/unit/generators/schema/breadcrumb-test.php
@@ -61,8 +61,8 @@ class Breadcrumb_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->current_page = Mockery::mock( Current_Page_Helper::class );
 		$this->id           = Mockery::mock( ID_Helper::class );

--- a/tests/unit/generators/schema/faq-test.php
+++ b/tests/unit/generators/schema/faq-test.php
@@ -43,7 +43,9 @@ class FAQ_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->html     = Mockery::mock( HTML_Helper::class );
 		$this->language = Mockery::mock( Language_Helper::class );
 
@@ -55,7 +57,6 @@ class FAQ_Test extends TestCase {
 				'html'     => $this->html,
 			],
 		];
-		parent::setUp();
 	}
 
 	/**

--- a/tests/unit/generators/schema/faq-test.php
+++ b/tests/unit/generators/schema/faq-test.php
@@ -67,6 +67,8 @@ class FAQ_Test extends TestCase {
 	 * @covers ::add_accepted_answer_property
 	 */
 	public function test_generate() {
+		$this->stubEscapeFunctions();
+
 		$blocks = [
 			'yoast/faq-block' => [
 				[
@@ -165,6 +167,8 @@ class FAQ_Test extends TestCase {
 	 * @covers ::add_accepted_answer_property
 	 */
 	public function test_generate_does_not_output_questions_with_no_answer() {
+		$this->stubEscapeFunctions();
+
 		$blocks = [
 			'yoast/faq-block' => [
 				[

--- a/tests/unit/generators/schema/howto-test.php
+++ b/tests/unit/generators/schema/howto-test.php
@@ -138,8 +138,8 @@ class HowTo_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$id = 1234;
 

--- a/tests/unit/generators/schema/howto-test.php
+++ b/tests/unit/generators/schema/howto-test.php
@@ -141,6 +141,8 @@ class HowTo_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$id = 1234;
 
 		$this->meta_tags_context = Mockery::mock( Meta_Tags_Context_Mock::class );

--- a/tests/unit/generators/schema/main-image-test.php
+++ b/tests/unit/generators/schema/main-image-test.php
@@ -60,8 +60,8 @@ class Main_Image_Test extends TestCase {
 	/**
 	 * Setup the test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->schema_image = Mockery::mock( Schema\Image_Helper::class );
 		$this->image        = Mockery::mock( Image_Helper::class );

--- a/tests/unit/generators/schema/organization-test.php
+++ b/tests/unit/generators/schema/organization-test.php
@@ -68,8 +68,8 @@ class Organization_Test extends TestCase {
 	/**
 	 * Initializes the test environment.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->image    = Mockery::mock( Image_Helper::class );
 		$this->options  = Mockery::mock( Options_Helper::class );

--- a/tests/unit/generators/schema/person-test.php
+++ b/tests/unit/generators/schema/person-test.php
@@ -54,8 +54,8 @@ class Person_Test extends TestCase {
 	/**
 	 * Initializes the test environment.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance                     = new Person();
 		$this->instance->context            = new Meta_Tags_Context_Mock();

--- a/tests/unit/generators/schema/webpage-test.php
+++ b/tests/unit/generators/schema/webpage-test.php
@@ -75,8 +75,8 @@ class WebPage_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->current_page      = Mockery::mock( Current_Page_Helper::class );
 		$this->html              = Mockery::mock( HTML_Helper::class );

--- a/tests/unit/generators/schema/website-test.php
+++ b/tests/unit/generators/schema/website-test.php
@@ -60,8 +60,8 @@ class Website_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options  = Mockery::mock( Options_Helper::class );
 		$this->html     = Mockery::mock( HTML_Helper::class );

--- a/tests/unit/generators/twitter-image-generator-test.php
+++ b/tests/unit/generators/twitter-image-generator-test.php
@@ -61,8 +61,8 @@ class Twitter_Image_Generator_Test extends TestCase {
 	/**
 	 * Setup the test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->image           = Mockery::mock( Image_Helper::class );
 		$this->url             = Mockery::mock( Url_Helper::class );

--- a/tests/unit/helpers/author-archive-helper-test.php
+++ b/tests/unit/helpers/author-archive-helper-test.php
@@ -28,8 +28,8 @@ class Author_Archive_Helper_Test extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Author_Archive_Helper::class )
 			->shouldAllowMockingProtectedMethods()

--- a/tests/unit/helpers/blocks-helper-test.php
+++ b/tests/unit/helpers/blocks-helper-test.php
@@ -34,8 +34,8 @@ class Blocks_Helper_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->post = Mockery::mock( Post_Helper::class );
 

--- a/tests/unit/helpers/capability-helper-test.php
+++ b/tests/unit/helpers/capability-helper-test.php
@@ -28,8 +28,8 @@ class Capability_Helper_Test extends TestCase {
 	/**
 	 * Set up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Capability_Helper();
 	}

--- a/tests/unit/helpers/current-page-helper-test.php
+++ b/tests/unit/helpers/current-page-helper-test.php
@@ -41,8 +41,8 @@ class Current_Page_Helper_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->wp_query_wrapper = Mockery::mock( WP_Query_Wrapper::class );
 		$this->wp_query         = Mockery::mock();

--- a/tests/unit/helpers/date-helper-test.php
+++ b/tests/unit/helpers/date-helper-test.php
@@ -25,8 +25,8 @@ class Date_Helper_Test extends TestCase {
 	/**
 	 * Performs the setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Date_Helper();
 	}

--- a/tests/unit/helpers/home-url-helper-test.php
+++ b/tests/unit/helpers/home-url-helper-test.php
@@ -25,8 +25,8 @@ class Home_Url_Helper_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Home_Url_Helper();
 	}

--- a/tests/unit/helpers/image-helper-test.php
+++ b/tests/unit/helpers/image-helper-test.php
@@ -26,12 +26,12 @@ class Image_Helper_Test extends TestCase {
 	/**
 	 * Setup.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance = Mockery::mock( Image_Helper::class )
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
-
-		parent::setUp();
 	}
 
 	/**

--- a/tests/unit/helpers/indexable-helper-test.php
+++ b/tests/unit/helpers/indexable-helper-test.php
@@ -60,8 +60,8 @@ class Indexable_Helper_Test extends TestCase {
 	/**
 	 * Sets up the class under test and mock objects.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options            = Mockery::mock( Options_Helper::class );
 		$this->repository         = Mockery::mock( Indexable_Repository::class );

--- a/tests/unit/helpers/indexable-helper-test.php
+++ b/tests/unit/helpers/indexable-helper-test.php
@@ -77,9 +77,18 @@ class Indexable_Helper_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeInstanceOf( Options_Helper::class, 'options_helper', $this->instance );
-		$this->assertAttributeInstanceOf( Environment_Helper::class, 'environment_helper', $this->instance );
-		$this->assertAttributeInstanceOf( Indexing_Helper::class, 'indexing_helper', $this->instance );
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $this->instance, 'options_helper' )
+		);
+		$this->assertInstanceOf(
+			Environment_Helper::class,
+			$this->getPropertyValue( $this->instance, 'environment_helper' )
+		);
+		$this->assertInstanceOf(
+			Indexing_Helper::class,
+			$this->getPropertyValue( $this->instance, 'indexing_helper' )
+		);
 	}
 
 	/**

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -136,8 +136,14 @@ class Indexing_Helper_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeInstanceOf( Options_Helper::class, 'options_helper', $this->instance );
-		$this->assertAttributeInstanceOf( Date_Helper::class, 'date_helper', $this->instance );
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $this->instance, 'options_helper' )
+		);
+		$this->assertInstanceOf(
+			Date_Helper::class,
+			$this->getPropertyValue( $this->instance, 'date_helper' )
+		);
 	}
 
 	/**
@@ -146,12 +152,30 @@ class Indexing_Helper_Test extends TestCase {
 	 * @covers ::set_indexing_actions
 	 */
 	public function test_set_indexing_actions() {
-		static::assertAttributeInstanceOf( Indexable_Post_Indexation_Action::class, 'post_indexation', $this->instance );
-		static::assertAttributeInstanceOf( Indexable_Term_Indexation_Action::class, 'term_indexation', $this->instance );
-		static::assertAttributeInstanceOf( Indexable_Post_Type_Archive_Indexation_Action::class, 'post_type_archive_indexation', $this->instance );
-		static::assertAttributeInstanceOf( Indexable_General_Indexation_Action::class, 'general_indexation', $this->instance );
-		static::assertAttributeInstanceOf( Post_Link_Indexing_Action::class, 'post_link_indexing_action', $this->instance );
-		static::assertAttributeInstanceOf( Term_Link_Indexing_Action::class, 'term_link_indexing_action', $this->instance );
+		static::assertInstanceOf(
+			Indexable_Post_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'post_indexation' )
+		);
+		static::assertInstanceOf(
+			Indexable_Term_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'term_indexation' )
+		);
+		static::assertInstanceOf(
+			Indexable_Post_Type_Archive_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'post_type_archive_indexation' )
+		);
+		static::assertInstanceOf(
+			Indexable_General_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'general_indexation' )
+		);
+		static::assertInstanceOf(
+			Post_Link_Indexing_Action::class,
+			$this->getPropertyValue( $this->instance, 'post_link_indexing_action' )
+		);
+		static::assertInstanceOf(
+			Term_Link_Indexing_Action::class,
+			$this->getPropertyValue( $this->instance, 'term_link_indexing_action' )
+		);
 	}
 
 	/**

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -102,8 +102,8 @@ class Indexing_Helper_Test extends TestCase {
 	/**
 	 * Sets up the class under test and mock objects.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options_helper      = Mockery::mock( Options_Helper::class );
 		$this->date_helper         = Mockery::mock( Date_Helper::class );

--- a/tests/unit/helpers/language-helper-test.php
+++ b/tests/unit/helpers/language-helper-test.php
@@ -24,8 +24,8 @@ class Language_Helper_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 		$this->instance = new Language_Helper();
 	}
 

--- a/tests/unit/helpers/open-graph/image-helper-test.php
+++ b/tests/unit/helpers/open-graph/image-helper-test.php
@@ -42,8 +42,8 @@ class Image_Helper_Test extends TestCase {
 	/**
 	 * Setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->url   = Mockery::mock( Url_Helper::class )->makePartial();
 		$this->image = Mockery::mock( Base_Image_Helper::class )->makePartial();

--- a/tests/unit/helpers/options-helper-test.php
+++ b/tests/unit/helpers/options-helper-test.php
@@ -25,8 +25,8 @@ class Options_Helper_Test extends TestCase {
 	/**
 	 * Prepares the test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Options_Helper::class )
 			->shouldAllowMockingProtectedMethods()

--- a/tests/unit/helpers/pagination-helper-test.php
+++ b/tests/unit/helpers/pagination-helper-test.php
@@ -38,8 +38,8 @@ class Pagination_Helper_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->wp_rewrite_wrapper = Mockery::mock( WP_Rewrite_Wrapper::class );
 		$this->wp_query_wrapper   = Mockery::mock( WP_Query_Wrapper::class );

--- a/tests/unit/helpers/pagination-helper-test.php
+++ b/tests/unit/helpers/pagination-helper-test.php
@@ -53,8 +53,14 @@ class Pagination_Helper_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( WP_Rewrite_Wrapper::class, 'wp_rewrite_wrapper', $this->instance );
-		$this->assertAttributeInstanceOf( WP_Query_Wrapper::class, 'wp_query_wrapper', $this->instance );
+		$this->assertInstanceOf(
+			WP_Rewrite_Wrapper::class,
+			$this->getPropertyValue( $this->instance, 'wp_rewrite_wrapper' )
+		);
+		$this->assertInstanceOf(
+			WP_Query_Wrapper::class,
+			$this->getPropertyValue( $this->instance, 'wp_query_wrapper' )
+		);
 	}
 
 	/**

--- a/tests/unit/helpers/permalink-helper-test.php
+++ b/tests/unit/helpers/permalink-helper-test.php
@@ -27,8 +27,8 @@ class Permalink_Helper_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Permalink_Helper();
 	}

--- a/tests/unit/helpers/post-helper-test.php
+++ b/tests/unit/helpers/post-helper-test.php
@@ -37,6 +37,8 @@ class Post_Helper_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubTranslationFunctions();
+
 		$this->string   = Mockery::mock( String_Helper::class );
 		$this->instance = new Post_Helper( $this->string );
 	}

--- a/tests/unit/helpers/post-helper-test.php
+++ b/tests/unit/helpers/post-helper-test.php
@@ -34,8 +34,8 @@ class Post_Helper_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->string   = Mockery::mock( String_Helper::class );
 		$this->instance = new Post_Helper( $this->string );

--- a/tests/unit/helpers/primary-term-helper-test.php
+++ b/tests/unit/helpers/primary-term-helper-test.php
@@ -24,8 +24,8 @@ class Primary_Term_Helper_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Primary_Term_Helper::class )
 			->shouldAllowMockingProtectedMethods()

--- a/tests/unit/helpers/product-helper-test.php
+++ b/tests/unit/helpers/product-helper-test.php
@@ -25,8 +25,8 @@ class Product_Helper_Test extends TestCase {
 	/**
 	 * Prepares the test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Product_Helper::class )
 			->makePartial()

--- a/tests/unit/helpers/robots-helper-test.php
+++ b/tests/unit/helpers/robots-helper-test.php
@@ -25,8 +25,8 @@ class Robots_Helper_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Robots_Helper();
 	}

--- a/tests/unit/helpers/schema/article-helper-test.php
+++ b/tests/unit/helpers/schema/article-helper-test.php
@@ -26,8 +26,8 @@ class Article_Helper_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Article_Helper();
 	}

--- a/tests/unit/helpers/schema/html-helper-test.php
+++ b/tests/unit/helpers/schema/html-helper-test.php
@@ -23,8 +23,8 @@ class HTML_Helper_Test extends TestCase {
 	/**
 	 * Set up a new instance of the class under test before each test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new HTML_Helper();
 	}

--- a/tests/unit/helpers/schema/id-helper-test.php
+++ b/tests/unit/helpers/schema/id-helper-test.php
@@ -27,8 +27,8 @@ class ID_Helper_Test extends TestCase {
 	/**
 	 * Sets up the test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( ID_Helper::class )->makePartial();
 	}

--- a/tests/unit/helpers/schema/image-helper-test.php
+++ b/tests/unit/helpers/schema/image-helper-test.php
@@ -50,8 +50,8 @@ class Image_Helper_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->html     = Mockery::mock( HTML_Helper::class );
 		$this->language = Mockery::mock( Language_Helper::class );

--- a/tests/unit/helpers/string-helper-test.php
+++ b/tests/unit/helpers/string-helper-test.php
@@ -25,8 +25,8 @@ class String_Helper_Test extends TestCase {
 	/**
 	 * Setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new String_Helper();
 	}

--- a/tests/unit/helpers/taxonomy-helper-test.php
+++ b/tests/unit/helpers/taxonomy-helper-test.php
@@ -42,8 +42,8 @@ class Taxonomy_Helper_Test extends TestCase {
 	/**
 	 * Prepares the test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options  = Mockery::mock( Options_Helper::class );
 		$this->string   = Mockery::mock( String_Helper::class );

--- a/tests/unit/helpers/twitter/image-helper-test.php
+++ b/tests/unit/helpers/twitter/image-helper-test.php
@@ -24,8 +24,8 @@ class Image_Helper_Test extends TestCase {
 	/**
 	 * Setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Image_Helper::class )->makePartial();
 	}

--- a/tests/unit/helpers/url-helper-test.php
+++ b/tests/unit/helpers/url-helper-test.php
@@ -27,8 +27,8 @@ class Url_Helper_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Url_Helper::class )->makePartial();
 	}

--- a/tests/unit/helpers/user-helper-test.php
+++ b/tests/unit/helpers/user-helper-test.php
@@ -25,8 +25,8 @@ class User_Helper_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new User_Helper();
 	}

--- a/tests/unit/helpers/woocommerce-helper-test.php
+++ b/tests/unit/helpers/woocommerce-helper-test.php
@@ -27,8 +27,8 @@ class Woocommerce_Helper_Test extends TestCase {
 	/**
 	 * Sets the instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Woocommerce_Helper();
 	}

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -309,6 +309,8 @@ class Addon_Manager_Test extends TestCase {
 	 * @param string $message  The message when test fails.
 	 */
 	public function test_get_plugin_information( $action, $args, $expected, $message ) {
+		$this->stubTranslationFunctions();
+
 		$this->instance
 			->shouldReceive( 'get_subscriptions' )
 			->atMost()
@@ -399,6 +401,8 @@ class Addon_Manager_Test extends TestCase {
 	 * @param string $message  Message to show when test fails.
 	 */
 	public function test_check_for_updates( $addons, $data, $expected, $message ) {
+		$this->stubTranslationFunctions();
+
 		$this->instance
 			->shouldReceive( 'get_installed_addons' )
 			->atMost()
@@ -451,6 +455,8 @@ class Addon_Manager_Test extends TestCase {
 	 * @covers ::convert_subscription_to_plugin
 	 */
 	public function test_convert_subscription_to_plugin() {
+		$this->stubTranslationFunctions();
+
 		$this->assertEquals(
 			(object) [
 				'new_version'   => '10.0',

--- a/tests/unit/inc/addon-manager-test.php
+++ b/tests/unit/inc/addon-manager-test.php
@@ -42,12 +42,12 @@ class Addon_Manager_Test extends TestCase {
 	/**
 	 * Setup the tests.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance = Mockery::mock( Addon_Manager_Double::class )
 				->shouldAllowMockingProtectedMethods()
 					->makePartial();
-
-		parent::setUp();
 	}
 
 	/**

--- a/tests/unit/inc/content-images-test.php
+++ b/tests/unit/inc/content-images-test.php
@@ -25,8 +25,8 @@ class Content_Images_Test extends TestCase {
 	/**
 	 * Set up the class which will be tested.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new WPSEO_Content_Images();
 	}

--- a/tests/unit/inc/health-check-curl-version-test.php
+++ b/tests/unit/inc/health-check-curl-version-test.php
@@ -49,7 +49,7 @@ class Health_Check_Curl_Version_Test extends TestCase {
 		$this->instance->run();
 
 		// We just want to verify that the label is empty because the health check test didn't run.
-		$this->assertAttributeEquals( '', 'label', $this->instance );
+		$this->assertEquals( '', $this->getPropertyValue( $this->instance, 'label' ) );
 	}
 
 	/**
@@ -80,9 +80,13 @@ class Health_Check_Curl_Version_Test extends TestCase {
 		$this->instance->run();
 
 		// We want to verify that the label attribute is the "not passed" message.
-		$this->assertAttributeEquals( 'Your site can not connect to my.yoast.com', 'label', $this->instance );
+		$this->assertEquals(
+			'Your site can not connect to my.yoast.com',
+			$this->getPropertyValue( $this->instance, 'label' )
+		);
+
 		// We want to verify that the status attribute is "critical".
-		$this->assertAttributeEquals( 'critical', 'status', $this->instance );
+		$this->assertEquals( 'critical', $this->getPropertyValue( $this->instance, 'status' ) );
 	}
 
 	/**
@@ -113,9 +117,13 @@ class Health_Check_Curl_Version_Test extends TestCase {
 		$this->instance->run();
 
 		// We want to verify that the label attribute is the "not passed" message.
-		$this->assertAttributeEquals( 'Your site can not connect to my.yoast.com', 'label', $this->instance );
+		$this->assertEquals(
+			'Your site can not connect to my.yoast.com',
+			$this->getPropertyValue( $this->instance, 'label' )
+		);
+
 		// We want to verify that the status attribute is "critical".
-		$this->assertAttributeEquals( 'critical', 'status', $this->instance );
+		$this->assertEquals( 'critical', $this->getPropertyValue( $this->instance, 'status' ) );
 	}
 
 	/**
@@ -137,6 +145,9 @@ class Health_Check_Curl_Version_Test extends TestCase {
 		$this->instance->run();
 
 		// We just want to verify that the label attribute is the "passed" message.
-		$this->assertAttributeEquals( 'Your site can connect to my.yoast.com', 'label', $this->instance );
+		$this->assertEquals(
+			'Your site can connect to my.yoast.com',
+			$this->getPropertyValue( $this->instance, 'label' )
+		);
 	}
 }

--- a/tests/unit/inc/health-check-curl-version-test.php
+++ b/tests/unit/inc/health-check-curl-version-test.php
@@ -27,6 +27,9 @@ class Health_Check_Curl_Version_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$this->instance = Mockery::mock( WPSEO_Health_Check_Curl_Version::class )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();

--- a/tests/unit/inc/health-check-curl-version-test.php
+++ b/tests/unit/inc/health-check-curl-version-test.php
@@ -24,8 +24,8 @@ class Health_Check_Curl_Version_Test extends TestCase {
 	/**
 	 * Set up the class which will be tested.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( WPSEO_Health_Check_Curl_Version::class )
 			->shouldAllowMockingProtectedMethods()

--- a/tests/unit/inc/health-check-default-tagline-test.php
+++ b/tests/unit/inc/health-check-default-tagline-test.php
@@ -49,7 +49,10 @@ class Health_Check_Default_Tagline_Test extends TestCase {
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "not passed" message.
-		$this->assertAttributeEquals( 'You should change the default WordPress tagline', 'label', $health_check );
+		$this->assertEquals(
+			'You should change the default WordPress tagline',
+			$this->getPropertyValue( $health_check, 'label' )
+		);
 	}
 
 	/**
@@ -68,7 +71,10 @@ class Health_Check_Default_Tagline_Test extends TestCase {
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "passed" message.
-		$this->assertAttributeEquals( 'You changed the default WordPress tagline', 'label', $health_check );
+		$this->assertEquals(
+			'You changed the default WordPress tagline',
+			$this->getPropertyValue( $health_check, 'label' )
+		);
 	}
 
 	/**
@@ -87,6 +93,9 @@ class Health_Check_Default_Tagline_Test extends TestCase {
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "passed" message.
-		$this->assertAttributeEquals( 'You changed the default WordPress tagline', 'label', $health_check );
+		$this->assertEquals(
+			'You changed the default WordPress tagline',
+			$this->getPropertyValue( $health_check, 'label' )
+		);
 	}
 }

--- a/tests/unit/inc/health-check-default-tagline-test.php
+++ b/tests/unit/inc/health-check-default-tagline-test.php
@@ -14,6 +14,18 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 class Health_Check_Default_Tagline_Test extends TestCase {
 
 	/**
+	 * Set up function stubs.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+	}
+
+	/**
 	 * Tests the run method when the WordPress tagline is the default one.
 	 *
 	 * @covers WPSEO_Health_Check_Default_Tagline::run

--- a/tests/unit/inc/health-check-link-table-not-accessible-test.php
+++ b/tests/unit/inc/health-check-link-table-not-accessible-test.php
@@ -25,8 +25,8 @@ class Health_Check_Link_Table_Not_Accessible_Test extends TestCase {
 	/**
 	 * Set up the class which will be tested.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( WPSEO_Health_Check_Link_Table_Not_Accessible::class )
 			->shouldAllowMockingProtectedMethods()

--- a/tests/unit/inc/health-check-link-table-not-accessible-test.php
+++ b/tests/unit/inc/health-check-link-table-not-accessible-test.php
@@ -28,6 +28,8 @@ class Health_Check_Link_Table_Not_Accessible_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubTranslationFunctions();
+
 		$this->instance = Mockery::mock( WPSEO_Health_Check_Link_Table_Not_Accessible::class )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();

--- a/tests/unit/inc/health-check-link-table-not-accessible-test.php
+++ b/tests/unit/inc/health-check-link-table-not-accessible-test.php
@@ -49,7 +49,7 @@ class Health_Check_Link_Table_Not_Accessible_Test extends TestCase {
 		$this->instance->run();
 
 		// We just want to verify that the label is empty because the health check test didn't run.
-		$this->assertAttributeEquals( '', 'label', $this->instance );
+		$this->assertEquals( '', $this->getPropertyValue( $this->instance, 'label' ) );
 	}
 
 	/**
@@ -76,9 +76,13 @@ class Health_Check_Link_Table_Not_Accessible_Test extends TestCase {
 		$this->instance->run();
 
 		// We want to verify that the label attribute is the "passed" message.
-		$this->assertAttributeEquals( 'The text link counter is working as expected', 'label', $this->instance );
+		$this->assertEquals(
+			'The text link counter is working as expected',
+			$this->getPropertyValue( $this->instance, 'label' )
+		);
+
 		// We want to verify that the status attribute is "good".
-		$this->assertAttributeEquals( 'good', 'status', $this->instance );
+		$this->assertEquals( 'good', $this->getPropertyValue( $this->instance, 'status' ) );
 	}
 
 	/**
@@ -105,8 +109,12 @@ class Health_Check_Link_Table_Not_Accessible_Test extends TestCase {
 		$this->instance->run();
 
 		// We want to verify that the label attribute is the "not passed" message.
-		$this->assertAttributeEquals( 'The text link counter feature is not working as expected', 'label', $this->instance );
+		$this->assertEquals(
+			'The text link counter feature is not working as expected',
+			$this->getPropertyValue( $this->instance, 'label' )
+		);
+
 		// We want to verify that the status attribute is "recommended".
-		$this->assertAttributeEquals( 'recommended', 'status', $this->instance );
+		$this->assertEquals( 'recommended', $this->getPropertyValue( $this->instance, 'status' ) );
 	}
 }

--- a/tests/unit/inc/health-check-page-comments-test.php
+++ b/tests/unit/inc/health-check-page-comments-test.php
@@ -41,7 +41,10 @@ class Health_Check_Page_Comments_Test extends TestCase {
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "passed" message.
-		$this->assertAttributeEquals( 'Comments are displayed on a single page', 'label', $health_check );
+		$this->assertEquals(
+			'Comments are displayed on a single page',
+			$this->getPropertyValue( $health_check, 'label' )
+		);
 	}
 
 	/**
@@ -62,6 +65,9 @@ class Health_Check_Page_Comments_Test extends TestCase {
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "not passed" message.
-		$this->assertAttributeEquals( 'Comments break into multiple pages', 'label', $health_check );
+		$this->assertEquals(
+			'Comments break into multiple pages',
+			$this->getPropertyValue( $health_check, 'label' )
+		);
 	}
 }

--- a/tests/unit/inc/health-check-page-comments-test.php
+++ b/tests/unit/inc/health-check-page-comments-test.php
@@ -14,6 +14,18 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 class Health_Check_Page_Comments_Test extends TestCase {
 
 	/**
+	 * Set up function stubs.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+	}
+
+	/**
 	 * Tests the run method when page_comments are disabled.
 	 *
 	 * @covers WPSEO_Health_Check_Page_Comments::run

--- a/tests/unit/inc/health-check-postname-permalink-test.php
+++ b/tests/unit/inc/health-check-postname-permalink-test.php
@@ -40,7 +40,10 @@ class Health_Check_Postname_Permalink_Test extends TestCase {
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "passed" message.
-		$this->assertAttributeEquals( 'Your permalink structure includes the post name', 'label', $health_check );
+		$this->assertEquals(
+			'Your permalink structure includes the post name',
+			$this->getPropertyValue( $health_check, 'label' )
+		);
 	}
 
 	/**
@@ -59,7 +62,10 @@ class Health_Check_Postname_Permalink_Test extends TestCase {
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "passed" message.
-		$this->assertAttributeEquals( 'Your permalink structure includes the post name', 'label', $health_check );
+		$this->assertEquals(
+			'Your permalink structure includes the post name',
+			$this->getPropertyValue( $health_check, 'label' )
+		);
 	}
 
 	/**
@@ -80,6 +86,9 @@ class Health_Check_Postname_Permalink_Test extends TestCase {
 		$health_check->run();
 
 		// We just want to verify that the label attribute is the "not passed" message.
-		$this->assertAttributeEquals( 'You do not have your postname in the URL of your posts and pages', 'label', $health_check );
+		$this->assertEquals(
+			'You do not have your postname in the URL of your posts and pages',
+			$this->getPropertyValue( $health_check, 'label' )
+		);
 	}
 }

--- a/tests/unit/inc/health-check-postname-permalink-test.php
+++ b/tests/unit/inc/health-check-postname-permalink-test.php
@@ -14,6 +14,17 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 class Health_Check_Postname_Permalink_Test extends TestCase {
 
 	/**
+	 * Set up function stubs.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubTranslationFunctions();
+	}
+
+	/**
 	 * Tests the run method when the permalink structure is set to "Post name".
 	 *
 	 * @covers WPSEO_Health_Check_Postname_Permalink::run

--- a/tests/unit/inc/health-check-ryte-test.php
+++ b/tests/unit/inc/health-check-ryte-test.php
@@ -291,6 +291,8 @@ class Health_Check_Ryte_Test extends TestCase {
 	 * @throws Monkey\Expectation\Exception\ExpectationArgsRequired
 	 */
 	private function ryte_enabled_and_blog_public() {
+		$this->stubTranslationFunctions();
+
 		Monkey\Functions\expect( 'get_option' )
 			->once()
 			->with( 'blog_public' )

--- a/tests/unit/inc/health-check-ryte-test.php
+++ b/tests/unit/inc/health-check-ryte-test.php
@@ -67,7 +67,7 @@ class Health_Check_Ryte_Test extends TestCase {
 		$this->health_check->run();
 
 		// We just want to verify that the label attribute hasn't been set.
-		$this->assertAttributeEquals( '', 'label', $this->health_check );
+		$this->assertEquals( '', $this->getPropertyValue( $this->health_check, 'label' ) );
 	}
 
 	/**
@@ -100,7 +100,7 @@ class Health_Check_Ryte_Test extends TestCase {
 		$this->health_check->run();
 
 		// We just want to verify that the label attribute hasn't been set.
-		$this->assertAttributeEquals( '', 'label', $this->health_check );
+		$this->assertEquals( '', $this->getPropertyValue( $this->health_check, 'label' ) );
 	}
 
 	/**
@@ -138,7 +138,7 @@ class Health_Check_Ryte_Test extends TestCase {
 		$this->health_check->run();
 
 		// We just want to verify that the label attribute hasn't been set.
-		$this->assertAttributeEquals( '', 'label', $this->health_check );
+		$this->assertEquals( '', $this->getPropertyValue( $this->health_check, 'label' ) );
 	}
 
 	/**
@@ -174,8 +174,11 @@ class Health_Check_Ryte_Test extends TestCase {
 
 		$this->health_check->run();
 
-		$this->assertAttributeEquals( 'Your site cannot be found by search engines', 'label', $this->health_check );
-		$this->assertAttributeEquals( 'critical', 'status', $this->health_check );
+		$this->assertEquals(
+			'Your site cannot be found by search engines',
+			$this->getPropertyValue( $this->health_check, 'label' )
+		);
+		$this->assertEquals( 'critical', $this->getPropertyValue( $this->health_check, 'status' ) );
 	}
 
 	/**
@@ -213,8 +216,11 @@ class Health_Check_Ryte_Test extends TestCase {
 		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( '' );
 
 		$this->health_check->run();
-		$this->assertAttributeEquals( 'Ryte cannot determine whether your site can be found by search engines', 'label', $this->health_check );
-		$this->assertAttributeEquals( 'recommended', 'status', $this->health_check );
+		$this->assertEquals(
+			'Ryte cannot determine whether your site can be found by search engines',
+			$this->getPropertyValue( $this->health_check, 'label' )
+		);
+		$this->assertEquals( 'recommended', $this->getPropertyValue( $this->health_check, 'status' ) );
 	}
 
 	/**
@@ -249,8 +255,11 @@ class Health_Check_Ryte_Test extends TestCase {
 		Monkey\Functions\expect( 'update_option' )->andReturn( true );
 
 		$this->health_check->run();
-		$this->assertAttributeEquals( 'Your site can be found by search engines', 'label', $this->health_check );
-		$this->assertAttributeEquals( 'good', 'status', $this->health_check );
+		$this->assertEquals(
+			'Your site can be found by search engines',
+			$this->getPropertyValue( $this->health_check, 'label' )
+		);
+		$this->assertEquals( 'good', $this->getPropertyValue( $this->health_check, 'status' ) );
 	}
 
 	/**
@@ -281,8 +290,11 @@ class Health_Check_Ryte_Test extends TestCase {
 		Monkey\Functions\expect( 'update_option' )->andReturn( true );
 
 		$this->health_check->run();
-		$this->assertAttributeEquals( 'An error occurred while checking whether your site can be found by search engines', 'label', $this->health_check );
-		$this->assertAttributeEquals( 'recommended', 'status', $this->health_check );
+		$this->assertEquals(
+			'An error occurred while checking whether your site can be found by search engines',
+			$this->getPropertyValue( $this->health_check, 'label' )
+		);
+		$this->assertEquals( 'recommended', $this->getPropertyValue( $this->health_check, 'status' ) );
 	}
 
 	/**
@@ -328,6 +340,6 @@ class Health_Check_Ryte_Test extends TestCase {
 		$this->health_check->run();
 
 		// We just want to verify that the label attribute hasn't been set.
-		$this->assertAttributeEquals( '', 'label', $this->health_check );
+		$this->assertEquals( '', $this->getPropertyValue( $this->health_check, 'label' ) );
 	}
 }

--- a/tests/unit/inc/health-check-ryte-test.php
+++ b/tests/unit/inc/health-check-ryte-test.php
@@ -30,8 +30,8 @@ class Health_Check_Ryte_Test extends TestCase {
 	/**
 	 * Set up the mock classes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->ryte_option = Mockery::mock( WPSEO_Ryte_Option::class )
 			->shouldAllowMockingProtectedMethods()

--- a/tests/unit/inc/health-check-test.php
+++ b/tests/unit/inc/health-check-test.php
@@ -110,6 +110,9 @@ class Health_Check_Test extends TestCase {
 	 * @covers WPSEO_Health_Check::get_test_result
 	 */
 	public function test_get_test_result() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$this->instance->shouldReceive( 'run' )->once();
 
 		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( '' );

--- a/tests/unit/inc/health-check-test.php
+++ b/tests/unit/inc/health-check-test.php
@@ -26,12 +26,12 @@ class Health_Check_Test extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance = Mockery::mock( WPSEO_Health_Check::class )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
-
-		parent::setUp();
 	}
 
 	/**

--- a/tests/unit/inc/image-utils-test.php
+++ b/tests/unit/inc/image-utils-test.php
@@ -25,8 +25,8 @@ class Image_Utils_Test extends TestCase {
 	/**
 	 * Set up the class which will be tested.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Image_Utils_Double();
 	}

--- a/tests/unit/inc/language-utils-test.php
+++ b/tests/unit/inc/language-utils-test.php
@@ -61,6 +61,9 @@ class Language_Utils_Test extends TestCase {
 	 * @covers WPSEO_Language_Utils::get_knowledge_graph_company_info_missing_l10n
 	 */
 	public function test_get_knowledge_graph_company_info_missing_l10n() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$shortlinker = new Shortlinker_Double();
 
 		Monkey\Functions\expect( 'add_query_arg' )

--- a/tests/unit/inc/options/option-social-test.php
+++ b/tests/unit/inc/options/option-social-test.php
@@ -16,6 +16,18 @@ use Yoast_Input_Validation;
 class Option_Social_Test extends TestCase {
 
 	/**
+	 * Set up function stubs.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+	}
+
+	/**
 	 * Tests validate_option with valid data.
 	 *
 	 * @param string $expected The expected value.

--- a/tests/unit/inc/options/option-social-test.php
+++ b/tests/unit/inc/options/option-social-test.php
@@ -188,13 +188,8 @@ class Option_Social_Test extends TestCase {
 				'wp_remote_retrieve_response_code' => function () {
 					return 200;
 				},
-			]
-		);
-
-		// Return an invalid Facebook API response from `http://graph.facebook.com/<APP_ID>` with an invalid ID.
-		Monkey\Functions\stubs(
-			[
-				'wp_remote_retrieve_body' => function () {
+				// Return an invalid Facebook API response from `http://graph.facebook.com/<APP_ID>` with an invalid ID.
+				'wp_remote_retrieve_body'          => function () {
 					return WPSEO_Utils::format_json_encode(
 						[
 							'error' => [
@@ -250,13 +245,8 @@ class Option_Social_Test extends TestCase {
 				'wp_remote_retrieve_response_code' => function () use ( $response_code ) {
 					return $response_code;
 				},
-			]
-		);
-
-		// Return an invalid Facebook API response from `http://graph.facebook.com/<APP_ID>` with an invalid ID.
-		Monkey\Functions\stubs(
-			[
-				'wp_remote_retrieve_body' => function () {
+				// Return an invalid Facebook API response from `http://graph.facebook.com/<APP_ID>` with an invalid ID.
+				'wp_remote_retrieve_body'          => function () {
 					return WPSEO_Utils::format_json_encode(
 						[
 							'category' => 'Just For Fun',
@@ -302,13 +292,8 @@ class Option_Social_Test extends TestCase {
 				'wp_remote_retrieve_response_code' => function () {
 					return 200;
 				},
-			]
-		);
-
-		// Return an invalid Facebook API response from `http://graph.facebook.com/<APP_ID>` with an invalid ID.
-		Monkey\Functions\stubs(
-			[
-				'wp_remote_retrieve_body' => function () {
+				// Return an invalid Facebook API response from `http://graph.facebook.com/<APP_ID>` with an invalid ID.
+				'wp_remote_retrieve_body'          => function () {
 					return WPSEO_Utils::format_json_encode(
 						[
 							'error' => [

--- a/tests/unit/inc/sitemaps/sitemaps-admin-test.php
+++ b/tests/unit/inc/sitemaps/sitemaps-admin-test.php
@@ -42,8 +42,8 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance             = Mockery::mock( WPSEO_Sitemaps_Admin::class )->makePartial();
 		$this->options_mock         = Mockery::mock( WPSEO_Options::class )->shouldAllowMockingProtectedMethods();

--- a/tests/unit/initializers/disable-core-sitemaps-test.php
+++ b/tests/unit/initializers/disable-core-sitemaps-test.php
@@ -42,8 +42,8 @@ class Disable_Core_Sitemaps_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options  = Mockery::mock( Options_Helper::class );
 		$this->redirect = Mockery::mock( Redirect_Helper::class );

--- a/tests/unit/integrations/admin/admin-columns-cache-integration-test.php
+++ b/tests/unit/integrations/admin/admin-columns-cache-integration-test.php
@@ -37,7 +37,9 @@ class Admin_Columns_Cache_Integration_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->indexable_repository = Mockery::mock( Indexable_Repository::class );
 		$this->instance             = new Admin_Columns_Cache_Integration( $this->indexable_repository );
 	}

--- a/tests/unit/integrations/admin/background-indexing-integration-test.php
+++ b/tests/unit/integrations/admin/background-indexing-integration-test.php
@@ -95,8 +95,8 @@ class Background_Indexing_Integration_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->post_indexation              = Mockery::mock( Indexable_Post_Indexation_Action::class );
 		$this->term_indexation              = Mockery::mock( Indexable_Term_Indexation_Action::class );

--- a/tests/unit/integrations/admin/background-indexing-integration-test.php
+++ b/tests/unit/integrations/admin/background-indexing-integration-test.php
@@ -141,12 +141,30 @@ class Background_Indexing_Integration_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		static::assertAttributeInstanceOf( Indexable_Post_Indexation_Action::class, 'post_indexation', $this->instance );
-		static::assertAttributeInstanceOf( Indexable_Term_Indexation_Action::class, 'term_indexation', $this->instance );
-		static::assertAttributeInstanceOf( Indexable_Post_Type_Archive_Indexation_Action::class, 'post_type_archive_indexation', $this->instance );
-		static::assertAttributeInstanceOf( Indexable_General_Indexation_Action::class, 'general_indexation', $this->instance );
-		static::assertAttributeInstanceOf( Indexable_Indexing_Complete_Action::class, 'complete_indexation_action', $this->instance );
-		static::assertAttributeInstanceOf( Indexing_Helper::class, 'indexing_helper', $this->instance );
+		static::assertInstanceOf(
+			Indexable_Post_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'post_indexation' )
+		);
+		static::assertInstanceOf(
+			Indexable_Term_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'term_indexation' )
+		);
+		static::assertInstanceOf(
+			Indexable_Post_Type_Archive_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'post_type_archive_indexation' )
+		);
+		static::assertInstanceOf(
+			Indexable_General_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'general_indexation' )
+		);
+		static::assertInstanceOf(
+			Indexable_Indexing_Complete_Action::class,
+			$this->getPropertyValue( $this->instance, 'complete_indexation_action' )
+		);
+		static::assertInstanceOf(
+			Indexing_Helper::class,
+			$this->getPropertyValue( $this->instance, 'indexing_helper' )
+		);
 	}
 
 	/**

--- a/tests/unit/integrations/admin/cron-integration-test.php
+++ b/tests/unit/integrations/admin/cron-integration-test.php
@@ -37,8 +37,8 @@ class Cron_Integration_Test extends TestCase {
 	/**
 	 * Set up the fixtures for the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->date_helper = Mockery::mock( Date_Helper::class );
 		$this->instance    = new Cron_Integration( $this->date_helper );

--- a/tests/unit/integrations/admin/cron-integration-test.php
+++ b/tests/unit/integrations/admin/cron-integration-test.php
@@ -64,7 +64,10 @@ class Cron_Integration_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		static::assertAttributeInstanceOf( Date_Helper::class, 'date_helper', $this->instance );
+		static::assertInstanceOf(
+			Date_Helper::class,
+			$this->getPropertyValue( $this->instance, 'date_helper' )
+		);
 	}
 
 	/**

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -86,8 +86,8 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->notification_center = Mockery::mock( Yoast_Notification_Center::class );
 		$this->product_helper      = Mockery::mock( Product_Helper::class );

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -112,35 +112,29 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf(
+		$this->assertInstanceOf(
 			Yoast_Notification_Center::class,
-			'notification_center',
-			$this->instance
+			$this->getPropertyValue( $this->instance, 'notification_center' )
 		);
-		$this->assertAttributeInstanceOf(
+		$this->assertInstanceOf(
 			Product_Helper::class,
-			'product_helper',
-			$this->instance
+			$this->getPropertyValue( $this->instance, 'product_helper' )
 		);
-		$this->assertAttributeInstanceOf(
+		$this->assertInstanceOf(
 			Current_Page_Helper::class,
-			'page_helper',
-			$this->instance
+			$this->getPropertyValue( $this->instance, 'page_helper' )
 		);
-		$this->assertAttributeInstanceOf(
+		$this->assertInstanceOf(
 			Short_Link_Helper::class,
-			'short_link_helper',
-			$this->instance
+			$this->getPropertyValue( $this->instance, 'short_link_helper' )
 		);
-		$this->assertAttributeInstanceOf(
+		$this->assertInstanceOf(
 			Notification_Helper::class,
-			'notification_helper',
-			$this->instance
+			$this->getPropertyValue( $this->instance, 'notification_helper' )
 		);
-		$this->assertAttributeInstanceOf(
+		$this->assertInstanceOf(
 			Indexing_Helper::class,
-			'indexing_helper',
-			$this->instance
+			$this->getPropertyValue( $this->instance, 'indexing_helper' )
 		);
 	}
 

--- a/tests/unit/integrations/admin/indexing-tool-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-tool-integration-test.php
@@ -62,8 +62,8 @@ class Indexing_Tool_Integration_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->asset_manager     = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
 		$this->indexable_helper  = Mockery::mock( Indexable_Helper::class );

--- a/tests/unit/integrations/admin/indexing-tool-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-tool-integration-test.php
@@ -87,10 +87,22 @@ class Indexing_Tool_Integration_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		static::assertAttributeInstanceOf( WPSEO_Admin_Asset_Manager::class, 'asset_manager', $this->instance );
-		static::assertAttributeInstanceOf( Indexable_Helper::class, 'indexable_helper', $this->instance );
-		static::assertAttributeInstanceOf( Short_Link_Helper::class, 'short_link_helper', $this->instance );
-		static::assertAttributeInstanceOf( Indexing_Helper::class, 'indexing_helper', $this->instance );
+		static::assertInstanceOf(
+			WPSEO_Admin_Asset_Manager::class,
+			$this->getPropertyValue( $this->instance, 'asset_manager' )
+		);
+		static::assertInstanceOf(
+			Indexable_Helper::class,
+			$this->getPropertyValue( $this->instance, 'indexable_helper' )
+		);
+		static::assertInstanceOf(
+			Short_Link_Helper::class,
+			$this->getPropertyValue( $this->instance, 'short_link_helper' )
+		);
+		static::assertInstanceOf(
+			Indexing_Helper::class,
+			$this->getPropertyValue( $this->instance, 'indexing_helper' )
+		);
 	}
 
 	/**

--- a/tests/unit/integrations/admin/indexing-tool-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-tool-integration-test.php
@@ -65,6 +65,9 @@ class Indexing_Tool_Integration_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
 		$this->asset_manager     = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
 		$this->indexable_helper  = Mockery::mock( Indexable_Helper::class );
 		$this->short_link_helper = Mockery::mock( Short_Link_Helper::class );

--- a/tests/unit/integrations/admin/migration-error-integration-test.php
+++ b/tests/unit/integrations/admin/migration-error-integration-test.php
@@ -37,8 +37,8 @@ class Migration_Error_Integration_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->migration_status = Mockery::mock( Migration_Status::class );
 		$this->instance         = new Migration_Error_Integration( $this->migration_status );

--- a/tests/unit/integrations/admin/migration-error-integration-test.php
+++ b/tests/unit/integrations/admin/migration-error-integration-test.php
@@ -40,6 +40,9 @@ class Migration_Error_Integration_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
 		$this->migration_status = Mockery::mock( Migration_Status::class );
 		$this->instance         = new Migration_Error_Integration( $this->migration_status );
 	}

--- a/tests/unit/integrations/admin/migration-error-integration-test.php
+++ b/tests/unit/integrations/admin/migration-error-integration-test.php
@@ -53,7 +53,10 @@ class Migration_Error_Integration_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeInstanceOf( Migration_Status::class, 'migration_status', $this->instance );
+		$this->assertInstanceOf(
+			Migration_Status::class,
+			$this->getPropertyValue( $this->instance, 'migration_status' )
+		);
 	}
 
 	/**

--- a/tests/unit/integrations/breadcrumbs-integration-test.php
+++ b/tests/unit/integrations/breadcrumbs-integration-test.php
@@ -45,8 +45,8 @@ class Breadcrumbs_Integration_Test extends TestCase {
 	/**
 	 * Set up the class which will be tested.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->context_memoizer = Mockery::mock( Meta_Tags_Context_Memoizer::class );
 		$this->instance         = new Breadcrumbs_Integration(

--- a/tests/unit/integrations/duplicate-post-integration-test.php
+++ b/tests/unit/integrations/duplicate-post-integration-test.php
@@ -26,8 +26,8 @@ class Duplicate_Post_Integration_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Duplicate_Post_Integration();
 	}

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -55,8 +55,8 @@ class Front_End_Integration_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->context_memoizer = Mockery::mock( Meta_Tags_Context_Memoizer::class );
 		$this->container        = Mockery::mock( ContainerInterface::class );

--- a/tests/unit/integrations/front-end/category-term-description-test.php
+++ b/tests/unit/integrations/front-end/category-term-description-test.php
@@ -28,8 +28,8 @@ class Category_Term_Description_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Category_Term_Description();
 	}

--- a/tests/unit/integrations/front-end/comment-link-fixer-test.php
+++ b/tests/unit/integrations/front-end/comment-link-fixer-test.php
@@ -45,8 +45,8 @@ class Comment_Link_Fixer_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->redirect = Mockery::mock( Redirect_Helper::class );
 		$this->robots   = Mockery::mock( Robots_Helper::class );

--- a/tests/unit/integrations/front-end/force-rewrite-title-test.php
+++ b/tests/unit/integrations/front-end/force-rewrite-title-test.php
@@ -45,8 +45,8 @@ class Force_Rewrite_Title_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options  = Mockery::mock( Options_Helper::class );
 		$this->wp_query = Mockery::mock( WP_Query_Wrapper::class );

--- a/tests/unit/integrations/front-end/handle-404-test.php
+++ b/tests/unit/integrations/front-end/handle-404-test.php
@@ -37,8 +37,8 @@ class Handle_404_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->query_wrapper = Mockery::mock( WP_Query_Wrapper::class )->makePartial();
 		$this->instance      = Mockery::mock( Handle_404::class, [ $this->query_wrapper ] )

--- a/tests/unit/integrations/front-end/indexing-controls-test.php
+++ b/tests/unit/integrations/front-end/indexing-controls-test.php
@@ -37,8 +37,8 @@ class Indexing_Controls_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->robots   = Mockery::mock( Robots_Helper::class );
 		$this->instance = Mockery::mock( Indexing_Controls::class )->makePartial()->shouldAllowMockingProtectedMethods();

--- a/tests/unit/integrations/front-end/open-graph-oembed-test.php
+++ b/tests/unit/integrations/front-end/open-graph-oembed-test.php
@@ -65,7 +65,7 @@ class Open_Graph_OEmbed_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeEquals( $this->meta, 'meta', $this->instance );
+		$this->assertEquals( $this->meta, $this->getPropertyValue( $this->instance, 'meta' ) );
 	}
 
 	/**

--- a/tests/unit/integrations/front-end/open-graph-oembed-test.php
+++ b/tests/unit/integrations/front-end/open-graph-oembed-test.php
@@ -37,8 +37,8 @@ class Open_Graph_OEmbed_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->meta = Mockery::mock( Meta_Surface::class )
 			->makePartial()

--- a/tests/unit/integrations/front-end/redirects-test.php
+++ b/tests/unit/integrations/front-end/redirects-test.php
@@ -61,8 +61,8 @@ class Redirects_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options      = Mockery::mock( Options_Helper::class );
 		$this->meta         = Mockery::mock( Meta_Helper::class );

--- a/tests/unit/integrations/front-end/rss-footer-embed-test.php
+++ b/tests/unit/integrations/front-end/rss-footer-embed-test.php
@@ -37,13 +37,13 @@ class RSS_Footer_Embed_Test extends TestCase {
 	/**
 	 * Setup the class instance.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->options  = Mockery::mock( Options_Helper::class );
 		$this->instance = Mockery::mock( RSS_Footer_Embed::class, [ $this->options ] )
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
-
-		parent::setUp();
 	}
 
 	/**

--- a/tests/unit/integrations/front-end/theme-titles-test.php
+++ b/tests/unit/integrations/front-end/theme-titles-test.php
@@ -64,6 +64,8 @@ class Theme_Titles_Test extends TestCase {
 	 * @covers ::title
 	 */
 	public function test_title() {
+		$this->stubTranslationFunctions();
+
 		Monkey\Functions\expect( '_deprecated_function' )
 			->once()
 			->with(

--- a/tests/unit/integrations/front-end/theme-titles-test.php
+++ b/tests/unit/integrations/front-end/theme-titles-test.php
@@ -28,8 +28,8 @@ class Theme_Titles_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Theme_Titles();
 	}

--- a/tests/unit/integrations/primary-category-test.php
+++ b/tests/unit/integrations/primary-category-test.php
@@ -26,8 +26,8 @@ class Primary_Category_Test extends TestCase {
 	/**
 	 * Set up the class which will be tested.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Primary_Category::class )
 			->makePartial()

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -132,6 +132,9 @@ class Schema_Blocks_Test extends TestCase {
 	 * @covers ::output
 	 */
 	public function test_output() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$this->asset_manager
 			->expects( 'is_script_enqueued' )
 			->with( 'schema-blocks' )
@@ -168,6 +171,9 @@ class Schema_Blocks_Test extends TestCase {
 	 * @covers ::output
 	 */
 	public function test_load_with_filter() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$this->asset_manager
 			->expects( 'is_script_enqueued' )
 			->with( 'schema-blocks' )

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -85,10 +85,9 @@ class Schema_Blocks_Test extends TestCase {
 	public function test_register_template_not_starting_with_slash() {
 		$this->instance->register_template( 'template.php' );
 
-		static::assertAttributeEquals(
+		static::assertEquals(
 			[ WPSEO_PATH . '/template.php' ],
-			'templates',
-			$this->instance
+			$this->getPropertyValue( $this->instance, 'templates' )
 		);
 	}
 
@@ -100,10 +99,9 @@ class Schema_Blocks_Test extends TestCase {
 	public function test_register_template() {
 		$this->instance->register_template( '/template.php' );
 
-		static::assertAttributeEquals(
+		static::assertEquals(
 			[ '/template.php' ],
-			'templates',
-			$this->instance
+			$this->getPropertyValue( $this->instance, 'templates' )
 		);
 	}
 

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -49,7 +49,7 @@ class Schema_Blocks_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		static::assertAttributeInstanceOf( WPSEO_Admin_Asset_Manager::class, 'asset_manager', $this );
+		static::assertInstanceOf( WPSEO_Admin_Asset_Manager::class, $this->getPropertyValue( $this, 'asset_manager' ) );
 	}
 
 	/**

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -36,8 +36,8 @@ class Schema_Blocks_Test extends TestCase {
 	/**
 	 * Runs the setup to prepare the needed instance.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->asset_manager = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
 		$this->instance      = new Schema_Blocks( $this->asset_manager );

--- a/tests/unit/integrations/third-party/amp-test.php
+++ b/tests/unit/integrations/third-party/amp-test.php
@@ -36,8 +36,8 @@ class AMP_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->front_end = Mockery::mock( Front_End_Integration::class );
 		$this->instance  = new AMP( $this->front_end );

--- a/tests/unit/integrations/third-party/bbpress-test.php
+++ b/tests/unit/integrations/third-party/bbpress-test.php
@@ -36,8 +36,8 @@ class BbPress_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options  = Mockery::mock( Options_Helper::class );
 		$this->instance = new BbPress( $this->options );

--- a/tests/unit/integrations/third-party/jetpack-test.php
+++ b/tests/unit/integrations/third-party/jetpack-test.php
@@ -29,8 +29,8 @@ class Jetpack_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 		$this->instance = new Jetpack();
 	}
 

--- a/tests/unit/integrations/third-party/web-stories-test.php
+++ b/tests/unit/integrations/third-party/web-stories-test.php
@@ -38,8 +38,8 @@ class Web_Stories_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->front_end = Mockery::mock( Front_End_Integration::class );
 		$this->instance  = new Web_Stories( $this->front_end );

--- a/tests/unit/integrations/third-party/woocommerce-permalinks-test.php
+++ b/tests/unit/integrations/third-party/woocommerce-permalinks-test.php
@@ -38,8 +38,8 @@ class WooCommerce_Permalinks_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->indexable_helper = Mockery::mock( Indexable_Helper::class );
 		$this->instance         = new Woocommerce_Permalinks( $this->indexable_helper );

--- a/tests/unit/integrations/third-party/woocommerce-permalinks-test.php
+++ b/tests/unit/integrations/third-party/woocommerce-permalinks-test.php
@@ -63,7 +63,10 @@ class WooCommerce_Permalinks_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		static::assertAttributeInstanceOf( Indexable_Helper::class, 'indexable_helper', $this->instance );
+		static::assertInstanceOf(
+			Indexable_Helper::class,
+			$this->getPropertyValue( $this->instance, 'indexable_helper' )
+		);
 	}
 
 	/**

--- a/tests/unit/integrations/third-party/woocommerce-test.php
+++ b/tests/unit/integrations/third-party/woocommerce-test.php
@@ -112,8 +112,16 @@ class WooCommerce_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Options_Helper::class, 'options', $this->instance );
-		$this->assertAttributeInstanceOf( WPSEO_Replace_Vars::class, 'replace_vars', $this->instance );
+		$instance = new WooCommerce( $this->options, $this->replace_vars, $this->context_memoizer, $this->repository );
+
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $instance, 'options' )
+		);
+		$this->assertInstanceOf(
+			WPSEO_Replace_Vars::class,
+			$this->getPropertyValue( $instance, 'replace_vars' )
+		);
 	}
 
 	/**

--- a/tests/unit/integrations/third-party/woocommerce-test.php
+++ b/tests/unit/integrations/third-party/woocommerce-test.php
@@ -78,8 +78,8 @@ class WooCommerce_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->options          = Mockery::mock( Options_Helper::class );
 		$this->replace_vars     = Mockery::mock( WPSEO_Replace_Vars::class );

--- a/tests/unit/integrations/third-party/wpml-test.php
+++ b/tests/unit/integrations/third-party/wpml-test.php
@@ -27,8 +27,8 @@ class WPML_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new WPML();
 	}

--- a/tests/unit/integrations/third-party/wpml-wpseo-notification-test.php
+++ b/tests/unit/integrations/third-party/wpml-wpseo-notification-test.php
@@ -52,8 +52,9 @@ class WPML_WPSEO_Notification_Test extends TestCase {
 	/**
 	 * Sets up the class under test and mock objects.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
+
 		$this->short_link_helper      = Mockery::mock( Short_Link_Helper::class );
 		$this->notification_center    = Mockery::mock( Yoast_Notification_Center::class );
 		$this->wpml_wpseo_conditional = Mockery::mock( WPML_WPSEO_Conditional::class );

--- a/tests/unit/integrations/third-party/wpml-wpseo-notification-test.php
+++ b/tests/unit/integrations/third-party/wpml-wpseo-notification-test.php
@@ -120,6 +120,9 @@ class WPML_WPSEO_Notification_Test extends TestCase {
 	 * @covers ::notification
 	 */
 	public function test_notifies_when_not_installed() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		// Mock that the Yoast SEO Multilingual plugin is not installed and activated.
 		$this->wpml_wpseo_conditional->expects( 'is_met' )->andReturnFalse();
 

--- a/tests/unit/integrations/third-party/wpml-wpseo-notification-test.php
+++ b/tests/unit/integrations/third-party/wpml-wpseo-notification-test.php
@@ -71,20 +71,17 @@ class WPML_WPSEO_Notification_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		self::assertAttributeInstanceOf(
+		self::assertInstanceOf(
 			Yoast_Notification_Center::class,
-			'notification_center',
-			$this->instance
+			$this->getPropertyValue( $this->instance, 'notification_center' )
 		);
-		self::assertAttributeInstanceOf(
+		self::assertInstanceOf(
 			WPML_WPSEO_Conditional::class,
-			'wpml_wpseo_conditional',
-			$this->instance
+			$this->getPropertyValue( $this->instance, 'wpml_wpseo_conditional' )
 		);
-		self::assertAttributeInstanceOf(
+		self::assertInstanceOf(
 			Short_Link_Helper::class,
-			'short_link_helper',
-			$this->instance
+			$this->getPropertyValue( $this->instance, 'short_link_helper' )
 		);
 	}
 

--- a/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
@@ -77,8 +77,8 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->indexable_repository           = Mockery::mock( Indexable_Repository::class );
 		$this->indexable_hierarchy_builder    = Mockery::mock( Indexable_Hierarchy_Builder::class );

--- a/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
@@ -132,9 +132,18 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeInstanceOf( Indexable_Repository::class, 'indexable_repository', $this->instance );
-		$this->assertAttributeInstanceOf( Indexable_Hierarchy_Builder::class, 'indexable_hierarchy_builder', $this->instance );
-		$this->assertAttributeInstanceOf( Permalink_Helper::class, 'permalink_helper', $this->instance );
+		$this->assertInstanceOf(
+			Indexable_Repository::class,
+			$this->getPropertyValue( $this->instance, 'indexable_repository' )
+		);
+		$this->assertInstanceOf(
+			Indexable_Hierarchy_Builder::class,
+			$this->getPropertyValue( $this->instance, 'indexable_hierarchy_builder' )
+		);
+		$this->assertInstanceOf(
+			Permalink_Helper::class,
+			$this->getPropertyValue( $this->instance, 'permalink_helper' )
+		);
 	}
 
 	/**

--- a/tests/unit/integrations/watchers/indexable-author-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-author-watcher-test.php
@@ -46,8 +46,8 @@ class Indexable_Author_Watcher_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->repository = Mockery::mock( Indexable_Repository::class );
 		$this->builder    = Mockery::mock( Indexable_Builder::class );

--- a/tests/unit/integrations/watchers/indexable-category-permalink-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-category-permalink-watcher-test.php
@@ -62,7 +62,9 @@ class Indexable_Category_Permalink_Watcher_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		Monkey\Functions\stubs(
 			[
 				'wp_next_scheduled' => false,
@@ -81,8 +83,6 @@ class Indexable_Category_Permalink_Watcher_Test extends TestCase {
 			$this->indexable_helper,
 			$this->taxonomy_helper
 		);
-
-		parent::setUp();
 	}
 
 	/**

--- a/tests/unit/integrations/watchers/indexable-date-archive-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-date-archive-watcher-test.php
@@ -44,8 +44,8 @@ class Indexable_Date_Archive_Watcher_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->repository = Mockery::mock( Indexable_Repository::class );
 		$this->builder    = Mockery::mock( Indexable_Builder::class );

--- a/tests/unit/integrations/watchers/indexable-home-page-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-home-page-watcher-test.php
@@ -46,8 +46,8 @@ class Indexable_Home_Page_Watcher_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->repository = Mockery::mock( Indexable_Repository::class );
 		$this->builder    = Mockery::mock( Indexable_Builder::class );

--- a/tests/unit/integrations/watchers/indexable-homeurl-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-homeurl-watcher-test.php
@@ -54,8 +54,8 @@ class Indexable_HomeUrl_Watcher_Test extends TestCase {
 	/**
 	 * Does the setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		Monkey\Functions\stubs(
 			[

--- a/tests/unit/integrations/watchers/indexable-permalink-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-permalink-watcher-test.php
@@ -62,8 +62,8 @@ class Indexable_Permalink_Watcher_Test extends TestCase {
 	/**
 	 * Does the setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		Monkey\Functions\stubs(
 			[

--- a/tests/unit/integrations/watchers/indexable-post-meta-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-meta-watcher-test.php
@@ -37,8 +37,8 @@ class Indexable_Post_Meta_Watcher_Test extends TestCase {
 	/**
 	 * Initializes the test mocks.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 		$this->post_watcher = Mockery::mock( Indexable_Post_Watcher::class );
 		$this->instance     = new Indexable_Post_Meta_Watcher( $this->post_watcher );
 	}

--- a/tests/unit/integrations/watchers/indexable-post-type-archive-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-type-archive-watcher-test.php
@@ -46,8 +46,8 @@ class Indexable_Post_Type_Archive_Watcher_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->repository = Mockery::mock( Indexable_Repository::class );
 		$this->builder    = Mockery::mock( Indexable_Builder::class );

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -89,7 +89,9 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	/**
 	 * Initializes the test mocks.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->repository           = Mockery::mock( Indexable_Repository::class );
 		$this->builder              = Mockery::mock( Indexable_Builder::class );
 		$this->hierarchy_repository = Mockery::mock( Indexable_Hierarchy_Repository::class );
@@ -111,8 +113,6 @@ class Indexable_Post_Watcher_Test extends TestCase {
 		)
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/integrations/watchers/indexable-static-home-page-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-static-home-page-watcher-test.php
@@ -39,8 +39,8 @@ class Indexable_Static_Home_Page_Watcher_Test extends TestCase {
 	/**
 	 * Sets an instance for test purposes.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->repository = Mockery::mock( Indexable_Repository::class );
 		$this->instance   = new Indexable_Static_Home_Page_Watcher( $this->repository );

--- a/tests/unit/integrations/watchers/indexable-system-page-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-system-page-watcher-test.php
@@ -46,8 +46,8 @@ class Indexable_System_Page_Watcher_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->repository = Mockery::mock( Indexable_Repository::class );
 		$this->builder    = Mockery::mock( Indexable_Builder::class );

--- a/tests/unit/integrations/watchers/indexable-term-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-term-watcher-test.php
@@ -63,8 +63,8 @@ class Indexable_Term_Watcher_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->repository   = Mockery::mock( Indexable_Repository::class );
 		$this->builder      = Mockery::mock( Indexable_Builder::class );

--- a/tests/unit/integrations/watchers/option-titles-watcher-test.php
+++ b/tests/unit/integrations/watchers/option-titles-watcher-test.php
@@ -29,8 +29,8 @@ class Option_Titles_Watcher_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Option_Titles_Watcher();
 	}

--- a/tests/unit/integrations/watchers/option-wpseo-watcher-test.php
+++ b/tests/unit/integrations/watchers/option-wpseo-watcher-test.php
@@ -27,8 +27,8 @@ class Option_Wpseo_Watcher_Test extends TestCase {
 	/**
 	 * Does the setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Option_Wpseo_Watcher();
 	}

--- a/tests/unit/integrations/watchers/primary-term-watcher-test.php
+++ b/tests/unit/integrations/watchers/primary-term-watcher-test.php
@@ -61,8 +61,8 @@ class Primary_Term_Watcher_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->repository           = Mockery::mock( Primary_Term_Repository::class );
 		$this->site                 = Mockery::mock( Site_Helper::class );

--- a/tests/unit/integrations/xmlrpc-test.php
+++ b/tests/unit/integrations/xmlrpc-test.php
@@ -24,8 +24,8 @@ class XMLRPC_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new XMLRPC();
 	}

--- a/tests/unit/memoizers/meta-tags-context-memoizer-test.php
+++ b/tests/unit/memoizers/meta-tags-context-memoizer-test.php
@@ -121,11 +121,26 @@ class Meta_Tags_Context_Memoizer_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Blocks_Helper::class, 'blocks', $this->instance );
-		$this->assertAttributeInstanceOf( Current_Page_Helper::class, 'current_page', $this->instance );
-		$this->assertAttributeInstanceOf( Indexable_Repository::class, 'repository', $this->instance );
-		$this->assertAttributeInstanceOf( Meta_Tags_Context::class, 'context_prototype', $this->instance );
-		$this->assertAttributeInstanceOf( Presentation_Memoizer::class, 'presentation_memoizer', $this->instance );
+		$this->assertInstanceOf(
+			Blocks_Helper::class,
+			$this->getPropertyValue( $this->instance, 'blocks' )
+		);
+		$this->assertInstanceOf(
+			Current_Page_Helper::class,
+			$this->getPropertyValue( $this->instance, 'current_page' )
+		);
+		$this->assertInstanceOf(
+			Indexable_Repository::class,
+			$this->getPropertyValue( $this->instance, 'repository' )
+		);
+		$this->assertInstanceOf(
+			Meta_Tags_Context::class,
+			$this->getPropertyValue( $this->instance, 'context_prototype' )
+		);
+		$this->assertInstanceOf(
+			Presentation_Memoizer::class,
+			$this->getPropertyValue( $this->instance, 'presentation_memoizer' )
+		);
 	}
 
 	/**

--- a/tests/unit/memoizers/meta-tags-context-memoizer-test.php
+++ b/tests/unit/memoizers/meta-tags-context-memoizer-test.php
@@ -90,8 +90,8 @@ class Meta_Tags_Context_Memoizer_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->blocks                = Mockery::mock( Blocks_Helper::class );
 		$this->current_page          = Mockery::mock( Current_Page_Helper::class );

--- a/tests/unit/memoizers/presentation-memoizer-test.php
+++ b/tests/unit/memoizers/presentation-memoizer-test.php
@@ -81,7 +81,10 @@ class Presentation_Memoizer_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( ContainerInterface::class, 'container', $this->instance );
+		$this->assertInstanceOf(
+			ContainerInterface::class,
+			$this->getPropertyValue( $this->instance, 'container' )
+		);
 	}
 
 	/**

--- a/tests/unit/memoizers/presentation-memoizer-test.php
+++ b/tests/unit/memoizers/presentation-memoizer-test.php
@@ -57,8 +57,8 @@ class Presentation_Memoizer_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		// Mock classes.
 		$this->container              = Mockery::mock( ContainerInterface::class );

--- a/tests/unit/models/indexable-test.php
+++ b/tests/unit/models/indexable-test.php
@@ -28,8 +28,8 @@ class Indexable_Test extends TestCase {
 	/**
 	 * Sets up the class which will be tested.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance      = new Indexable_Double();
 		$this->instance->orm = Mockery::mock( ORM::class );

--- a/tests/unit/presentations/abstract-presentation-test.php
+++ b/tests/unit/presentations/abstract-presentation-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Presentations;
 
+use Exception;
 use Mockery;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Presentations\Abstract_Presentation_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -50,10 +51,11 @@ class Abstract_Presentation_Test extends TestCase {
 	/**
 	 * Tests whether the`of`-method throws an exception when called on a prototype.
 	 *
-	 * @expectedException \Exception
 	 * @covers ::of
 	 */
 	public function test_of_throws_exception_on_prototype() {
+		$this->expectException( Exception::class );
+
 		$this->instance
 			->expects( 'is_prototype' )
 			->andReturnFalse();
@@ -70,10 +72,11 @@ class Abstract_Presentation_Test extends TestCase {
 	 * Tests whether an exception is thrown when trying to access a property
 	 * with no generator method.
 	 *
-	 * @expectedException \Exception
 	 * @covers ::__get
 	 */
 	public function test_get_throws_exception_when_accessing_property_with_no_generator() {
+		$this->expectException( Exception::class );
+
 		$this->instance
 			->expects( 'is_prototype' )
 			->andReturnTrue();
@@ -85,10 +88,11 @@ class Abstract_Presentation_Test extends TestCase {
 	 * Tests whether an exception is thrown when trying to access a property
 	 * with no generator method.
 	 *
-	 * @expectedException \Exception
 	 * @covers ::__get
 	 */
 	public function test_get_throws_exception_when_accessing_property_on_prototype() {
+		$this->expectException( Exception::class );
+
 		$this->instance->expects( 'is_prototype' )
 			->andReturnFalse();
 

--- a/tests/unit/presentations/abstract-presentation-test.php
+++ b/tests/unit/presentations/abstract-presentation-test.php
@@ -24,8 +24,8 @@ class Abstract_Presentation_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Abstract_Presentation_Mock::class )->makePartial();
 	}

--- a/tests/unit/presentations/archive-adjacent-test.php
+++ b/tests/unit/presentations/archive-adjacent-test.php
@@ -28,8 +28,8 @@ class Archive_Adjacent_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->pagination = Mockery::mock( Pagination_Helper::class );
 

--- a/tests/unit/presentations/indexable-author-archive-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/canonical-test.php
@@ -18,8 +18,8 @@ class Canonical_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-author-archive-presentation/meta-description-test.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/meta-description-test.php
@@ -18,8 +18,8 @@ class Meta_Description_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-author-archive-presentation/open-graph-type-test.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/open-graph-type-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Type_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-author-archive-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/robots-test.php
@@ -19,8 +19,8 @@ class Robots_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-author-archive-presentation/source-test.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/source-test.php
@@ -17,8 +17,8 @@ class Source_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-author-archive-presentation/title-test.php
+++ b/tests/unit/presentations/indexable-author-archive-presentation/title-test.php
@@ -18,8 +18,8 @@ class Title_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-date-archive-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-date-archive-presentation/canonical-test.php
@@ -18,8 +18,8 @@ class Canonical_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-date-archive-presentation/open-graph-url-test.php
+++ b/tests/unit/presentations/indexable-date-archive-presentation/open-graph-url-test.php
@@ -19,8 +19,8 @@ class Open_Graph_URL_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-date-archive-presentation/rel-next-test.php
+++ b/tests/unit/presentations/indexable-date-archive-presentation/rel-next-test.php
@@ -18,8 +18,8 @@ class Rel_Next_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-date-archive-presentation/rel-prev-test.php
+++ b/tests/unit/presentations/indexable-date-archive-presentation/rel-prev-test.php
@@ -18,8 +18,8 @@ class Rel_Prev_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-date-archive-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-date-archive-presentation/robots-test.php
@@ -16,8 +16,8 @@ class Robots_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-date-archive-presentation/title-test.php
+++ b/tests/unit/presentations/indexable-date-archive-presentation/title-test.php
@@ -18,8 +18,8 @@ class Title_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-error-page-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-error-page-presentation/robots-test.php
@@ -18,8 +18,8 @@ class Robots_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-error-page-presentation/title-test.php
+++ b/tests/unit/presentations/indexable-error-page-presentation/title-test.php
@@ -18,8 +18,8 @@ class Title_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-home-page-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-home-page-presentation/canonical-test.php
@@ -18,8 +18,8 @@ class Canonical_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-home-page-presentation/meta-description-test.php
+++ b/tests/unit/presentations/indexable-home-page-presentation/meta-description-test.php
@@ -18,10 +18,10 @@ class Meta_Description_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		$this->set_instance();
+	protected function set_up() {
+		parent::set_up();
 
-		return parent::setUp();
+		$this->set_instance();
 	}
 
 	/**

--- a/tests/unit/presentations/indexable-home-page-presentation/title-test.php
+++ b/tests/unit/presentations/indexable-home-page-presentation/title-test.php
@@ -18,10 +18,10 @@ class Title_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		$this->set_instance();
+	protected function set_up() {
+		parent::set_up();
 
-		parent::setUp();
+		$this->set_instance();
 	}
 
 	/**

--- a/tests/unit/presentations/indexable-post-type-archive-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-post-type-archive-presentation/canonical-test.php
@@ -18,8 +18,8 @@ class Canonical_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-post-type-archive-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-post-type-archive-presentation/robots-test.php
@@ -18,8 +18,8 @@ class Robots_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-post-type-archive-presentation/source-test.php
+++ b/tests/unit/presentations/indexable-post-type-archive-presentation/source-test.php
@@ -17,8 +17,8 @@ class Source_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-post-type-archive-presentation/title-test.php
+++ b/tests/unit/presentations/indexable-post-type-archive-presentation/title-test.php
@@ -18,10 +18,10 @@ class Title_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		$this->set_instance();
+	protected function set_up() {
+		parent::set_up();
 
-		parent::setUp();
+		$this->set_instance();
 	}
 
 	/**

--- a/tests/unit/presentations/indexable-post-type-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/canonical-test.php
@@ -18,8 +18,8 @@ class Canonical_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-post-type-presentation/meta-description-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/meta-description-test.php
@@ -18,8 +18,8 @@ class Meta_Description_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-post-type-presentation/open-graph-article-author-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/open-graph-article-author-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Article_Author_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 		$this->indexable->object_id = 1;

--- a/tests/unit/presentations/indexable-post-type-presentation/open-graph-article-modified-time-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/open-graph-article-modified-time-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Article_Modified_Time_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-post-type-presentation/open-graph-article-published-time-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/open-graph-article-published-time-test.php
@@ -19,8 +19,8 @@ class Open_Graph_Article_Published_Time_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-post-type-presentation/open-graph-article-publisher-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/open-graph-article-publisher-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Article_Publisher_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-post-type-presentation/open-graph-description-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/open-graph-description-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Description_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 		$this->indexable->object_id = 1;

--- a/tests/unit/presentations/indexable-post-type-presentation/open-graph-images-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/open-graph-images-test.php
@@ -20,8 +20,8 @@ class Open_Graph_Images_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-post-type-presentation/open-graph-type-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/open-graph-type-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Type_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-post-type-presentation/rel-next-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/rel-next-test.php
@@ -18,8 +18,8 @@ class Rel_Next_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-post-type-presentation/rel-prev-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/rel-prev-test.php
@@ -18,8 +18,8 @@ class Rel_Prev_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-post-type-presentation/replace-vars-object-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/replace-vars-object-test.php
@@ -18,8 +18,8 @@ class Replace_Vars_Object_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 		$this->indexable->object_id = 11;

--- a/tests/unit/presentations/indexable-post-type-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/robots-test.php
@@ -19,8 +19,8 @@ class Robots_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-post-type-presentation/title-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/title-test.php
@@ -18,8 +18,8 @@ class Title_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-post-type-presentation/twitter-creator-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/twitter-creator-test.php
@@ -20,13 +20,13 @@ class Twitter_Creator_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->set_instance();
 
 		$source = (object) [ 'post_author' => 1337 ];
 		$this->instance->expects( 'generate_source' )->once()->andReturn( $source );
-
-		parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presentations/indexable-post-type-presentation/twitter-description-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/twitter-description-test.php
@@ -19,8 +19,8 @@ class Twitter_Description_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 		$this->indexable->object_id = 1;

--- a/tests/unit/presentations/indexable-post-type-presentation/twitter-image-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/twitter-image-test.php
@@ -21,8 +21,8 @@ class Twitter_Image_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-presentation/canonical-test.php
@@ -18,8 +18,8 @@ class Canonical_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/debug-info-test.php
+++ b/tests/unit/presentations/indexable-presentation/debug-info-test.php
@@ -17,8 +17,8 @@ class Debug_Info_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/meta-description-test.php
+++ b/tests/unit/presentations/indexable-presentation/meta-description-test.php
@@ -17,8 +17,8 @@ class Meta_Description_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/open-graph-article-author-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-article-author-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Article_Author_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/open-graph-article-modified-time-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-article-modified-time-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Article_Modified_Time_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/open-graph-article-published-time-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-article-published-time-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Article_Published_Time_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/open-graph-article-publisher-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-article-publisher-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Article_Publisher_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/open-graph-description-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-description-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Description_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/open-graph-fb-app-id-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-fb-app-id-test.php
@@ -18,8 +18,8 @@ class Open_Graph_FB_App_ID_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/open-graph-images-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-images-test.php
@@ -19,10 +19,10 @@ class Open_Graph_Images_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		$this->set_instance();
+	protected function set_up() {
+		parent::set_up();
 
-		parent::setUp();
+		$this->set_instance();
 	}
 
 	/**

--- a/tests/unit/presentations/indexable-presentation/open-graph-locale-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-locale-test.php
@@ -19,8 +19,8 @@ class Open_Graph_Locale_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/open-graph-site-name-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-site-name-test.php
@@ -18,10 +18,10 @@ class Open_Graph_Site_Name_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		$this->set_instance();
+	protected function set_up() {
+		parent::set_up();
 
-		return parent::setUp();
+		$this->set_instance();
 	}
 
 	/**

--- a/tests/unit/presentations/indexable-presentation/open-graph-title-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-title-test.php
@@ -19,8 +19,8 @@ class Open_Graph_Title_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/open-graph-type-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-type-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Type_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/open-graph-url-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-url-test.php
@@ -18,8 +18,8 @@ class Open_Graph_URL_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/permalink-test.php
+++ b/tests/unit/presentations/indexable-presentation/permalink-test.php
@@ -17,8 +17,8 @@ class Permalink_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/rel-next-test.php
+++ b/tests/unit/presentations/indexable-presentation/rel-next-test.php
@@ -17,8 +17,8 @@ class Rel_Next_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/rel-prev-test.php
+++ b/tests/unit/presentations/indexable-presentation/rel-prev-test.php
@@ -17,8 +17,8 @@ class Rel_Prev_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/replace-vars-object-test.php
+++ b/tests/unit/presentations/indexable-presentation/replace-vars-object-test.php
@@ -17,8 +17,8 @@ class Replace_Vars_Object_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-presentation/robots-test.php
@@ -19,8 +19,8 @@ class Robots_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/title-test.php
+++ b/tests/unit/presentations/indexable-presentation/title-test.php
@@ -18,10 +18,10 @@ class Title_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		$this->set_instance();
+	protected function set_up() {
+		parent::set_up();
 
-		return parent::setUp();
+		$this->set_instance();
 	}
 
 	/**

--- a/tests/unit/presentations/indexable-presentation/twitter-card-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-card-test.php
@@ -19,8 +19,8 @@ class Twitter_Card_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/twitter-creator-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-creator-test.php
@@ -18,8 +18,8 @@ class Twitter_Creator_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/twitter-description-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-description-test.php
@@ -20,8 +20,8 @@ class Twitter_Description_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/twitter-image-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-image-test.php
@@ -19,8 +19,8 @@ class Twitter_Image_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/twitter-site-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-site-test.php
@@ -18,8 +18,8 @@ class Twitter_Site_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-presentation/twitter-title-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-title-test.php
@@ -20,8 +20,8 @@ class Twitter_Title_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-search-result-page-presentation/open-graph-type-test.php
+++ b/tests/unit/presentations/indexable-search-result-page-presentation/open-graph-type-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Type_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-search-result-page-presentation/open-graph-url-test.php
+++ b/tests/unit/presentations/indexable-search-result-page-presentation/open-graph-url-test.php
@@ -19,8 +19,8 @@ class Open_Graph_URL_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-search-result-page-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-search-result-page-presentation/robots-test.php
@@ -18,8 +18,8 @@ class Robots_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-search-result-page-presentation/title-test.php
+++ b/tests/unit/presentations/indexable-search-result-page-presentation/title-test.php
@@ -18,8 +18,8 @@ class Title_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-search-result-page-presentation/twitter-title-test.php
+++ b/tests/unit/presentations/indexable-search-result-page-presentation/twitter-title-test.php
@@ -18,8 +18,8 @@ class Twitter_Title_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-static-home-page-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-static-home-page-presentation/canonical-test.php
@@ -18,8 +18,8 @@ class Canonical_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-static-home-page-presentation/open-graph-type-test.php
+++ b/tests/unit/presentations/indexable-static-home-page-presentation/open-graph-type-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Type_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-static-posts-page-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-static-posts-page-presentation/canonical-test.php
@@ -18,8 +18,8 @@ class Canonical_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-static-posts-page-presentation/open-graph-url-test.php
+++ b/tests/unit/presentations/indexable-static-posts-page-presentation/open-graph-url-test.php
@@ -17,8 +17,8 @@ class Open_Graph_URL_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-term-archive-presentation/canonical-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/canonical-test.php
@@ -19,8 +19,8 @@ class Canonical_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-term-archive-presentation/meta-description-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/meta-description-test.php
@@ -18,10 +18,10 @@ class Meta_Description_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		$this->set_instance();
+	protected function set_up() {
+		parent::set_up();
 
-		return parent::setUp();
+		$this->set_instance();
 	}
 
 	/**

--- a/tests/unit/presentations/indexable-term-archive-presentation/open-graph-description-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/open-graph-description-test.php
@@ -19,8 +19,8 @@ class Open_Graph_Description_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 		$this->indexable->object_id = 1;

--- a/tests/unit/presentations/indexable-term-archive-presentation/open-graph-type-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/open-graph-type-test.php
@@ -18,8 +18,8 @@ class Open_Graph_Type_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-term-archive-presentation/replace-vars-object-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/replace-vars-object-test.php
@@ -18,8 +18,8 @@ class Replace_Vars_Object_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 		$this->indexable->object_id       = 11;

--- a/tests/unit/presentations/indexable-term-archive-presentation/robots-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/robots-test.php
@@ -19,8 +19,8 @@ class Robots_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 	}

--- a/tests/unit/presentations/indexable-term-archive-presentation/title-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/title-test.php
@@ -18,10 +18,10 @@ class Title_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		$this->set_instance();
+	protected function set_up() {
+		parent::set_up();
 
-		parent::setUp();
+		$this->set_instance();
 	}
 
 	/**

--- a/tests/unit/presentations/indexable-term-archive-presentation/twitter-description-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/twitter-description-test.php
@@ -19,8 +19,8 @@ class Twitter_Description_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->set_instance();
 		$this->indexable->object_id = 1;

--- a/tests/unit/presenters/admin/alert-presenter-test.php
+++ b/tests/unit/presenters/admin/alert-presenter-test.php
@@ -40,7 +40,10 @@ class Alert_Presenter_Test extends TestCase {
 		$this->assertAttributeSame( 'content', 'content', $test );
 		$this->assertAttributeSame( 'error', 'type', $test );
 
-		$this->assertAttributeInstanceOf( WPSEO_Admin_Asset_Manager::class, 'asset_manager', $test );
+		$this->assertInstanceOf(
+			WPSEO_Admin_Asset_Manager::class,
+			$this->getPropertyValue( $test, 'asset_manager' )
+		);
 	}
 
 	/**

--- a/tests/unit/presenters/admin/alert-presenter-test.php
+++ b/tests/unit/presenters/admin/alert-presenter-test.php
@@ -17,6 +17,17 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 class Alert_Presenter_Test extends TestCase {
 
 	/**
+	 * Set up function stubs.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubEscapeFunctions();
+	}
+
+	/**
 	 * Test constructor
 	 *
 	 * @covers ::__construct

--- a/tests/unit/presenters/admin/alert-presenter-test.php
+++ b/tests/unit/presenters/admin/alert-presenter-test.php
@@ -37,8 +37,8 @@ class Alert_Presenter_Test extends TestCase {
 
 		$test = new Alert_Presenter( 'content', 'error' );
 
-		$this->assertAttributeSame( 'content', 'content', $test );
-		$this->assertAttributeSame( 'error', 'type', $test );
+		$this->assertSame( 'content', $this->getPropertyValue( $test, 'content' ) );
+		$this->assertSame( 'error', $this->getPropertyValue( $test, 'type' ) );
 
 		$this->assertInstanceOf(
 			WPSEO_Admin_Asset_Manager::class,

--- a/tests/unit/presenters/admin/indexing-failed-notification-presenter-test.php
+++ b/tests/unit/presenters/admin/indexing-failed-notification-presenter-test.php
@@ -17,6 +17,17 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 class Indexing_Failed_Notification_Presenter_Test extends TestCase {
 
 	/**
+	 * Set up function stubs.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubTranslationFunctions();
+	}
+
+	/**
 	 * Tests the present method when not in Premium.
 	 *
 	 * @covers ::__construct

--- a/tests/unit/presenters/admin/indexing-list-item-presenter-test.php
+++ b/tests/unit/presenters/admin/indexing-list-item-presenter-test.php
@@ -27,6 +27,10 @@ class Indexing_List_Item_Presenter_Test extends TestCase {
 	 */
 	protected function set_up() {
 		parent::set_up();
+
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$this->short_link_helper = Mockery::mock( Short_Link_Helper::class );
 	}
 

--- a/tests/unit/presenters/admin/indexing-list-item-presenter-test.php
+++ b/tests/unit/presenters/admin/indexing-list-item-presenter-test.php
@@ -25,8 +25,8 @@ class Indexing_List_Item_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 		$this->short_link_helper = Mockery::mock( Short_Link_Helper::class );
 	}
 

--- a/tests/unit/presenters/admin/indexing-notification-presenter-test.php
+++ b/tests/unit/presenters/admin/indexing-notification-presenter-test.php
@@ -29,6 +29,9 @@ class Indexing_Notification_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$this->short_link_helper = Mockery::mock( Short_Link_Helper::class );
 	}
 

--- a/tests/unit/presenters/admin/indexing-notification-presenter-test.php
+++ b/tests/unit/presenters/admin/indexing-notification-presenter-test.php
@@ -26,8 +26,8 @@ class Indexing_Notification_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->short_link_helper = Mockery::mock( Short_Link_Helper::class );
 	}

--- a/tests/unit/presenters/admin/migration-error-presenter-test.php
+++ b/tests/unit/presenters/admin/migration-error-presenter-test.php
@@ -22,6 +22,9 @@ class Migration_Error_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$migration_error = [ 'message' => 'test error' ];
 
 		Monkey\Functions\expect( 'add_query_arg' )

--- a/tests/unit/presenters/breadcrumbs-presenter-test.php
+++ b/tests/unit/presenters/breadcrumbs-presenter-test.php
@@ -46,6 +46,8 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->options = Mockery::mock( Options_Helper::class );
 
 		$this->instance = Mockery::mock( Breadcrumbs_Presenter::class )

--- a/tests/unit/presenters/breadcrumbs-presenter-test.php
+++ b/tests/unit/presenters/breadcrumbs-presenter-test.php
@@ -43,7 +43,9 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->options = Mockery::mock( Options_Helper::class );
 
 		$this->instance = Mockery::mock( Breadcrumbs_Presenter::class )
@@ -56,8 +58,6 @@ class Breadcrumbs_Presenter_Test extends TestCase {
 
 		$this->instance->presentation = new Indexable_Presentation();
 		$this->presentation           = $this->instance->presentation;
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presenters/canonical-presenter-test.php
+++ b/tests/unit/presenters/canonical-presenter-test.php
@@ -18,6 +18,17 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 class Canonical_Presenter_Test extends TestCase {
 
 	/**
+	 * Set up function stubs.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubEscapeFunctions();
+	}
+
+	/**
 	 * Tests the presenter of the canonical.
 	 *
 	 * @covers ::present

--- a/tests/unit/presenters/debug/marker-close-presenter-test.php
+++ b/tests/unit/presenters/debug/marker-close-presenter-test.php
@@ -24,6 +24,8 @@ class Marker_Close_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present() {
+		$this->stubEscapeFunctions();
+
 		$product = Mockery::mock( Product_Helper::class );
 		$product->expects( 'get_name' )->andReturn( 'Yoast SEO plugin' );
 

--- a/tests/unit/presenters/debug/marker-open-presenter-test.php
+++ b/tests/unit/presenters/debug/marker-open-presenter-test.php
@@ -24,6 +24,8 @@ class Marker_Open_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present() {
+		$this->stubEscapeFunctions();
+
 		$product_mock = Mockery::mock( Product_Helper::class );
 		$product_mock->expects( 'get_name' )->andReturn( 'Yoast SEO plugin' );
 

--- a/tests/unit/presenters/meta-description-presenter-test.php
+++ b/tests/unit/presenters/meta-description-presenter-test.php
@@ -55,6 +55,9 @@ class Meta_Description_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
 		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
 		$this->string       = Mockery::mock( String_Helper::class );
 

--- a/tests/unit/presenters/meta-description-presenter-test.php
+++ b/tests/unit/presenters/meta-description-presenter-test.php
@@ -52,7 +52,9 @@ class Meta_Description_Presenter_Test extends TestCase {
 	/**
 	 * Setup of the tests.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
 		$this->string       = Mockery::mock( String_Helper::class );
 
@@ -66,8 +68,6 @@ class Meta_Description_Presenter_Test extends TestCase {
 		$this->indexable_presentation->source = [];
 
 		$this->instance->presentation = $this->indexable_presentation;
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presenters/open-graph/article-author-presenter-test.php
+++ b/tests/unit/presenters/open-graph/article-author-presenter-test.php
@@ -37,6 +37,8 @@ class Article_Author_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance     = new Article_Author_Presenter();
 		$this->presentation = new Indexable_Presentation();
 

--- a/tests/unit/presenters/open-graph/article-author-presenter-test.php
+++ b/tests/unit/presenters/open-graph/article-author-presenter-test.php
@@ -34,13 +34,13 @@ class Article_Author_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance     = new Article_Author_Presenter();
 		$this->presentation = new Indexable_Presentation();
 
 		$this->instance->presentation = $this->presentation;
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presenters/open-graph/article-modified-time-presenter-test.php
+++ b/tests/unit/presenters/open-graph/article-modified-time-presenter-test.php
@@ -48,6 +48,8 @@ class Article_Modified_Time_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present() {
+		$this->stubEscapeFunctions();
+
 		$this->presentation->open_graph_article_modified_time = '2019-10-08T12:26:31+00:00';
 
 		$expected = '<meta property="article:modified_time" content="2019-10-08T12:26:31+00:00" />';

--- a/tests/unit/presenters/open-graph/article-modified-time-presenter-test.php
+++ b/tests/unit/presenters/open-graph/article-modified-time-presenter-test.php
@@ -33,13 +33,13 @@ class Article_Modified_Time_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance     = new Article_Modified_Time_Presenter();
 		$this->presentation = new Indexable_Presentation();
 
 		$this->instance->presentation = $this->presentation;
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presenters/open-graph/article-published-time-presenter-test.php
+++ b/tests/unit/presenters/open-graph/article-published-time-presenter-test.php
@@ -33,13 +33,13 @@ class Article_Published_Time_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance     = new Article_Published_Time_Presenter();
 		$this->presentation = new Indexable_Presentation();
 
 		$this->instance->presentation = $this->presentation;
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presenters/open-graph/article-published-time-presenter-test.php
+++ b/tests/unit/presenters/open-graph/article-published-time-presenter-test.php
@@ -48,6 +48,8 @@ class Article_Published_Time_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present() {
+		$this->stubEscapeFunctions();
+
 		$this->presentation->open_graph_article_published_time = '2019-10-08T12:26:31+00:00';
 
 		$expected = '<meta property="article:published_time" content="2019-10-08T12:26:31+00:00" />';

--- a/tests/unit/presenters/open-graph/article-publisher-presenter-test.php
+++ b/tests/unit/presenters/open-graph/article-publisher-presenter-test.php
@@ -34,13 +34,13 @@ class Article_Publisher_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance     = new Article_Publisher_Presenter();
 		$this->presentation = new Indexable_Presentation();
 
 		$this->instance->presentation = $this->presentation;
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presenters/open-graph/article-publisher-presenter-test.php
+++ b/tests/unit/presenters/open-graph/article-publisher-presenter-test.php
@@ -37,6 +37,8 @@ class Article_Publisher_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance     = new Article_Publisher_Presenter();
 		$this->presentation = new Indexable_Presentation();
 

--- a/tests/unit/presenters/open-graph/description-presenter-test.php
+++ b/tests/unit/presenters/open-graph/description-presenter-test.php
@@ -43,8 +43,8 @@ class Description_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance     = new Description_Presenter();
 		$this->presentation = new Indexable_Presentation();

--- a/tests/unit/presenters/open-graph/description-presenter-test.php
+++ b/tests/unit/presenters/open-graph/description-presenter-test.php
@@ -46,6 +46,8 @@ class Description_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance     = new Description_Presenter();
 		$this->presentation = new Indexable_Presentation();
 		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );

--- a/tests/unit/presenters/open-graph/fb-app-id-presenter-test.php
+++ b/tests/unit/presenters/open-graph/fb-app-id-presenter-test.php
@@ -48,6 +48,8 @@ class FB_App_ID_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present() {
+		$this->stubEscapeFunctions();
+
 		$this->presentation->open_graph_fb_app_id = '12345';
 
 		$expected = '<meta property="fb:app_id" content="12345" />';

--- a/tests/unit/presenters/open-graph/fb-app-id-presenter-test.php
+++ b/tests/unit/presenters/open-graph/fb-app-id-presenter-test.php
@@ -33,13 +33,13 @@ class FB_App_ID_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance     = new FB_App_ID_Presenter();
 		$this->presentation = new Indexable_Presentation();
 
 		$this->instance->presentation = $this->presentation;
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presenters/open-graph/image-presenter-test.php
+++ b/tests/unit/presenters/open-graph/image-presenter-test.php
@@ -62,6 +62,8 @@ class Image_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present_with_a_set_image() {
+		$this->stubEscapeFunctions();
+
 		$image = [
 			'url'    => 'https://example.com/image.jpg',
 			'width'  => 100,

--- a/tests/unit/presenters/open-graph/image-presenter-test.php
+++ b/tests/unit/presenters/open-graph/image-presenter-test.php
@@ -36,8 +36,8 @@ class Image_Presenter_Test extends TestCase {
 	/**
 	 * Setup some mocks.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance     = Mockery::mock( Image_Presenter::class )->makePartial();
 		$this->presentation = new Indexable_Presentation();

--- a/tests/unit/presenters/open-graph/locale-presenter-test.php
+++ b/tests/unit/presenters/open-graph/locale-presenter-test.php
@@ -34,13 +34,13 @@ class Locale_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance     = new Locale_Presenter();
 		$this->presentation = new Indexable_Presentation();
 
 		$this->instance->presentation = $this->presentation;
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presenters/open-graph/locale-presenter-test.php
+++ b/tests/unit/presenters/open-graph/locale-presenter-test.php
@@ -37,6 +37,8 @@ class Locale_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance     = new Locale_Presenter();
 		$this->presentation = new Indexable_Presentation();
 

--- a/tests/unit/presenters/open-graph/site-name-presenter-test.php
+++ b/tests/unit/presenters/open-graph/site-name-presenter-test.php
@@ -34,13 +34,13 @@ class Site_Name_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance     = new Site_Name_Presenter();
 		$this->presentation = new Indexable_Presentation();
 
 		$this->instance->presentation = $this->presentation;
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presenters/open-graph/site-name-presenter-test.php
+++ b/tests/unit/presenters/open-graph/site-name-presenter-test.php
@@ -37,6 +37,8 @@ class Site_Name_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance     = new Site_Name_Presenter();
 		$this->presentation = new Indexable_Presentation();
 

--- a/tests/unit/presenters/open-graph/title-presenter-test.php
+++ b/tests/unit/presenters/open-graph/title-presenter-test.php
@@ -51,8 +51,8 @@ class Title_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
 		$this->string       = Mockery::mock( String_Helper::class );

--- a/tests/unit/presenters/open-graph/title-presenter-test.php
+++ b/tests/unit/presenters/open-graph/title-presenter-test.php
@@ -54,6 +54,8 @@ class Title_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
 		$this->string       = Mockery::mock( String_Helper::class );
 

--- a/tests/unit/presenters/open-graph/type-presenter-test.php
+++ b/tests/unit/presenters/open-graph/type-presenter-test.php
@@ -35,13 +35,13 @@ class Type_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance     = new Type_Presenter();
 		$this->presentation = new Indexable_Presentation();
 
 		$this->instance->presentation = $this->presentation;
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presenters/open-graph/type-presenter-test.php
+++ b/tests/unit/presenters/open-graph/type-presenter-test.php
@@ -38,6 +38,8 @@ class Type_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance     = new Type_Presenter();
 		$this->presentation = new Indexable_Presentation();
 

--- a/tests/unit/presenters/open-graph/url-presenter-test.php
+++ b/tests/unit/presenters/open-graph/url-presenter-test.php
@@ -34,13 +34,13 @@ class Url_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance     = new Url_Presenter();
 		$this->presentation = new Indexable_Presentation();
 
 		$this->instance->presentation = $this->presentation;
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presenters/open-graph/url-presenter-test.php
+++ b/tests/unit/presenters/open-graph/url-presenter-test.php
@@ -37,6 +37,8 @@ class Url_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance     = new Url_Presenter();
 		$this->presentation = new Indexable_Presentation();
 

--- a/tests/unit/presenters/rel-next-presenter-test.php
+++ b/tests/unit/presenters/rel-next-presenter-test.php
@@ -31,6 +31,8 @@ class Rel_Next_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance = new Rel_Next_Presenter();
 	}
 

--- a/tests/unit/presenters/rel-next-presenter-test.php
+++ b/tests/unit/presenters/rel-next-presenter-test.php
@@ -28,8 +28,8 @@ class Rel_Next_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Rel_Next_Presenter();
 	}

--- a/tests/unit/presenters/rel-prev-presenter-test.php
+++ b/tests/unit/presenters/rel-prev-presenter-test.php
@@ -31,6 +31,8 @@ class Rel_Prev_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance = new Rel_Prev_Presenter();
 	}
 

--- a/tests/unit/presenters/rel-prev-presenter-test.php
+++ b/tests/unit/presenters/rel-prev-presenter-test.php
@@ -28,8 +28,8 @@ class Rel_Prev_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Rel_Prev_Presenter();
 	}

--- a/tests/unit/presenters/robots-presenter-test.php
+++ b/tests/unit/presenters/robots-presenter-test.php
@@ -51,6 +51,8 @@ class Robots_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present() {
+		$this->stubEscapeFunctions();
+
 		$this->presentation->robots = [
 			'index'  => 'index',
 			'follow' => 'nofollow',

--- a/tests/unit/presenters/robots-presenter-test.php
+++ b/tests/unit/presenters/robots-presenter-test.php
@@ -33,8 +33,8 @@ class Robots_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->presentation = new Indexable_Presentation();
 		$this->instance     = Mockery::mock( Robots_Presenter::class )

--- a/tests/unit/presenters/schema-presenter-test.php
+++ b/tests/unit/presenters/schema-presenter-test.php
@@ -35,13 +35,13 @@ class Schema_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance     = Mockery::mock( Schema_Presenter::class )->makePartial();
 		$this->presentation = new Indexable_Presentation();
 
 		$this->instance->presentation = $this->presentation;
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presenters/slack/enhanced-data-presenter-test.php
+++ b/tests/unit/presenters/slack/enhanced-data-presenter-test.php
@@ -39,6 +39,8 @@ class Enhanced_Data_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubTranslationFunctions();
+
 		$this->instance                       = new Enhanced_Data_Presenter();
 		$this->instance->presentation         = Mockery::mock( Indexable_Presentation::class );
 		$this->instance->presentation->source = Mockery::mock( WP_Post::class );

--- a/tests/unit/presenters/slack/enhanced-data-presenter-test.php
+++ b/tests/unit/presenters/slack/enhanced-data-presenter-test.php
@@ -36,8 +36,8 @@ class Enhanced_Data_Presenter_Test extends TestCase {
 	/**
 	 * Setup of the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance                       = new Enhanced_Data_Presenter();
 		$this->instance->presentation         = Mockery::mock( Indexable_Presentation::class );

--- a/tests/unit/presenters/title-presenter-test.php
+++ b/tests/unit/presenters/title-presenter-test.php
@@ -51,8 +51,8 @@ class Title_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
 		$this->string       = Mockery::mock( String_Helper::class );

--- a/tests/unit/presenters/title-presenter-test.php
+++ b/tests/unit/presenters/title-presenter-test.php
@@ -54,6 +54,8 @@ class Title_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
 		$this->string       = Mockery::mock( String_Helper::class );
 

--- a/tests/unit/presenters/twitter/card-presenter-test.php
+++ b/tests/unit/presenters/twitter/card-presenter-test.php
@@ -27,8 +27,8 @@ class Card_Presenter_Test extends TestCase {
 	/**
 	 * Setup of the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Card_Presenter();
 	}

--- a/tests/unit/presenters/twitter/card-presenter-test.php
+++ b/tests/unit/presenters/twitter/card-presenter-test.php
@@ -30,6 +30,8 @@ class Card_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance = new Card_Presenter();
 	}
 

--- a/tests/unit/presenters/twitter/creator-presenter-test.php
+++ b/tests/unit/presenters/twitter/creator-presenter-test.php
@@ -34,8 +34,8 @@ class Creator_Presenter_Test extends TestCase {
 	/**
 	 * Setup of the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->presentation = new Indexable_Presentation();
 		$this->instance     = new Creator_Presenter();

--- a/tests/unit/presenters/twitter/creator-presenter-test.php
+++ b/tests/unit/presenters/twitter/creator-presenter-test.php
@@ -49,6 +49,8 @@ class Creator_Presenter_Test extends TestCase {
 	 * @covers ::present
 	 */
 	public function test_present() {
+		$this->stubEscapeFunctions();
+
 		$this->presentation->twitter_creator = '@TwitterHandle';
 
 		$this->assertEquals(

--- a/tests/unit/presenters/twitter/description-presenter-test.php
+++ b/tests/unit/presenters/twitter/description-presenter-test.php
@@ -39,6 +39,8 @@ class Description_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
 
 		$this->instance               = new Description_Presenter();

--- a/tests/unit/presenters/twitter/description-presenter-test.php
+++ b/tests/unit/presenters/twitter/description-presenter-test.php
@@ -36,13 +36,13 @@ class Description_Presenter_Test extends TestCase {
 	/**
 	 * Setup of the tests.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
 
 		$this->instance               = new Description_Presenter();
 		$this->instance->replace_vars = $this->replace_vars;
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presenters/twitter/image-presenter-test.php
+++ b/tests/unit/presenters/twitter/image-presenter-test.php
@@ -35,12 +35,12 @@ class Image_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance               = new Image_Presenter();
 		$this->instance->presentation = new Indexable_Presentation();
 		$this->presentation           = $this->instance->presentation;
-
-		parent::setUp();
 
 		Monkey\Functions\expect( 'post_password_required' )->andReturn( false );
 	}

--- a/tests/unit/presenters/twitter/image-presenter-test.php
+++ b/tests/unit/presenters/twitter/image-presenter-test.php
@@ -38,6 +38,8 @@ class Image_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance               = new Image_Presenter();
 		$this->instance->presentation = new Indexable_Presentation();
 		$this->presentation           = $this->instance->presentation;

--- a/tests/unit/presenters/twitter/site-presenter-test.php
+++ b/tests/unit/presenters/twitter/site-presenter-test.php
@@ -35,8 +35,8 @@ class Site_Presenter_Test extends TestCase {
 	/**
 	 * Setup of the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->presentation = new Indexable_Presentation();
 		$this->instance     = new Site_Presenter();

--- a/tests/unit/presenters/twitter/site-presenter-test.php
+++ b/tests/unit/presenters/twitter/site-presenter-test.php
@@ -38,6 +38,8 @@ class Site_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->presentation = new Indexable_Presentation();
 		$this->instance     = new Site_Presenter();
 

--- a/tests/unit/presenters/twitter/title-presenter-test.php
+++ b/tests/unit/presenters/twitter/title-presenter-test.php
@@ -43,7 +43,9 @@ class Title_Presenter_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->instance               = new Title_Presenter();
 		$this->instance->presentation = new Indexable_Presentation();
 		$this->indexable_presentation = $this->instance->presentation;
@@ -51,8 +53,6 @@ class Title_Presenter_Test extends TestCase {
 
 		$this->instance->replace_vars         = $this->replace_vars;
 		$this->indexable_presentation->source = [];
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit/presenters/twitter/title-presenter-test.php
+++ b/tests/unit/presenters/twitter/title-presenter-test.php
@@ -46,6 +46,8 @@ class Title_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance               = new Title_Presenter();
 		$this->instance->presentation = new Indexable_Presentation();
 		$this->indexable_presentation = $this->instance->presentation;

--- a/tests/unit/presenters/webmaster/baidu-presenter-test.php
+++ b/tests/unit/presenters/webmaster/baidu-presenter-test.php
@@ -44,6 +44,8 @@ class Baidu_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance = new Baidu_Presenter();
 
 		$this->options = Mockery::mock( Options_Helper::class );

--- a/tests/unit/presenters/webmaster/baidu-presenter-test.php
+++ b/tests/unit/presenters/webmaster/baidu-presenter-test.php
@@ -41,8 +41,8 @@ class Baidu_Presenter_Test extends TestCase {
 	/**
 	 * Setup of the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Baidu_Presenter();
 

--- a/tests/unit/presenters/webmaster/bing-presenter-test.php
+++ b/tests/unit/presenters/webmaster/bing-presenter-test.php
@@ -44,6 +44,8 @@ class Bing_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance = new Bing_Presenter();
 
 		$this->options = Mockery::mock( Options_Helper::class );

--- a/tests/unit/presenters/webmaster/bing-presenter-test.php
+++ b/tests/unit/presenters/webmaster/bing-presenter-test.php
@@ -41,8 +41,8 @@ class Bing_Presenter_Test extends TestCase {
 	/**
 	 * Setup of the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Bing_Presenter();
 

--- a/tests/unit/presenters/webmaster/google-presenter-test.php
+++ b/tests/unit/presenters/webmaster/google-presenter-test.php
@@ -41,8 +41,8 @@ class Google_Presenter_Test extends TestCase {
 	/**
 	 * Setup of the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Google_Presenter();
 

--- a/tests/unit/presenters/webmaster/google-presenter-test.php
+++ b/tests/unit/presenters/webmaster/google-presenter-test.php
@@ -44,6 +44,8 @@ class Google_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance = new Google_Presenter();
 
 		$this->options = Mockery::mock( Options_Helper::class );

--- a/tests/unit/presenters/webmaster/pinterest-presenter-test.php
+++ b/tests/unit/presenters/webmaster/pinterest-presenter-test.php
@@ -41,8 +41,8 @@ class Pinterest_Presenter_Test extends TestCase {
 	/**
 	 * Setup of the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Pinterest_Presenter();
 

--- a/tests/unit/presenters/webmaster/pinterest-presenter-test.php
+++ b/tests/unit/presenters/webmaster/pinterest-presenter-test.php
@@ -44,6 +44,8 @@ class Pinterest_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance = new Pinterest_Presenter();
 
 		$this->options = Mockery::mock( Options_Helper::class );

--- a/tests/unit/presenters/webmaster/yandex-presenter-test.php
+++ b/tests/unit/presenters/webmaster/yandex-presenter-test.php
@@ -41,8 +41,8 @@ class Yandex_Presenter_Test extends TestCase {
 	/**
 	 * Setup of the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = new Yandex_Presenter();
 

--- a/tests/unit/presenters/webmaster/yandex-presenter-test.php
+++ b/tests/unit/presenters/webmaster/yandex-presenter-test.php
@@ -44,6 +44,8 @@ class Yandex_Presenter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		$this->stubEscapeFunctions();
+
 		$this->instance = new Yandex_Presenter();
 
 		$this->options = Mockery::mock( Options_Helper::class );

--- a/tests/unit/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/unit/repositories/indexable-hierarchy-repository-test.php
@@ -37,8 +37,8 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->instance = Mockery::mock( Indexable_Hierarchy_Repository::class )->makePartial();
 		$this->builder  = Mockery::mock( Indexable_Hierarchy_Builder::class );

--- a/tests/unit/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/unit/repositories/indexable-hierarchy-repository-test.php
@@ -52,7 +52,10 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 	public function test_set_builder() {
 		$this->instance->set_builder( $this->builder );
 
-		$this->assertAttributeInstanceOf( Indexable_Hierarchy_Builder::class, 'builder', $this->instance );
+		$this->assertInstanceOf(
+			Indexable_Hierarchy_Builder::class,
+			$this->getPropertyValue( $this->instance, 'builder' )
+		);
 	}
 
 	/**

--- a/tests/unit/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/unit/repositories/indexable-hierarchy-repository-test.php
@@ -231,7 +231,7 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 
 		$query = $this->instance->query();
 
-		$this->assertAttributeEquals( '\Yoast\WP\SEO\Models\Indexable_Hierarchy', 'class_name', $query );
+		$this->assertEquals( '\Yoast\WP\SEO\Models\Indexable_Hierarchy', $this->getPropertyValue( $query, 'class_name' ) );
 		$this->assertInstanceOf( ORM::class, $query );
 	}
 

--- a/tests/unit/repositories/indexable-repository-test.php
+++ b/tests/unit/repositories/indexable-repository-test.php
@@ -315,7 +315,7 @@ class Indexable_Repository_Test extends TestCase {
 
 		$query = $this->instance->query();
 
-		$this->assertAttributeEquals( '\Yoast\WP\SEO\Models\Indexable', 'class_name', $query );
+		$this->assertEquals( '\Yoast\WP\SEO\Models\Indexable', $this->getPropertyValue( $query, 'class_name' ) );
 		$this->assertInstanceOf( ORM::class, $query );
 	}
 

--- a/tests/unit/repositories/indexable-repository-test.php
+++ b/tests/unit/repositories/indexable-repository-test.php
@@ -76,8 +76,8 @@ class Indexable_Repository_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->builder              = Mockery::mock( Indexable_Builder::class );
 		$this->current_page         = Mockery::mock( Current_Page_Helper::class );

--- a/tests/unit/routes/indexables-head-route-test.php
+++ b/tests/unit/routes/indexables-head-route-test.php
@@ -49,7 +49,10 @@ class Indexables_Head_Route_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeInstanceOf( Indexable_Head_Action::class, 'head_action', $this->instance );
+		$this->assertInstanceOf(
+			Indexable_Head_Action::class,
+			$this->getPropertyValue( $this->instance, 'head_action' )
+		);
 	}
 
 	/**

--- a/tests/unit/routes/indexables-head-route-test.php
+++ b/tests/unit/routes/indexables-head-route-test.php
@@ -36,8 +36,8 @@ class Indexables_Head_Route_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->head_action = Mockery::mock( Indexable_Head_Action::class );
 		$this->instance    = new Indexables_Head_Route( $this->head_action );

--- a/tests/unit/routes/indexables-head-route-test.php
+++ b/tests/unit/routes/indexables-head-route-test.php
@@ -98,6 +98,8 @@ class Indexables_Head_Route_Test extends TestCase {
 	 * @covers ::get_head
 	 */
 	public function test_get_head() {
+		$this->stubEscapeFunctions();
+
 		$request = Mockery::mock( 'WP_REST_Request', 'ArrayAccess' );
 		$request
 			->expects( 'offsetGet' )

--- a/tests/unit/routes/indexing-route-test.php
+++ b/tests/unit/routes/indexing-route-test.php
@@ -154,17 +154,50 @@ class Indexing_Route_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Indexable_Post_Indexation_Action::class, 'post_indexation_action', $this->instance );
-		$this->assertAttributeInstanceOf( Indexable_Term_Indexation_Action::class, 'term_indexation_action', $this->instance );
-		$this->assertAttributeInstanceOf( Indexable_Post_Type_Archive_Indexation_Action::class, 'post_type_archive_indexation_action', $this->instance );
-		$this->assertAttributeInstanceOf( Indexable_General_Indexation_Action::class, 'general_indexation_action', $this->instance );
-		$this->assertAttributeInstanceOf( Indexable_Indexing_Complete_Action::class, 'indexable_indexing_complete_action', $this->instance );
-		$this->assertAttributeInstanceOf( Indexing_Complete_Action::class, 'indexing_complete_action', $this->instance );
-		$this->assertAttributeInstanceOf( Indexable_Prepare_Indexation_Action::class, 'prepare_indexation_action', $this->instance );
-		$this->assertAttributeInstanceOf( Post_Link_Indexing_Action::class, 'post_link_indexing_action', $this->instance );
-		$this->assertAttributeInstanceOf( Term_Link_Indexing_Action::class, 'term_link_indexing_action', $this->instance );
-		$this->assertAttributeInstanceOf( Options_Helper::class, 'options_helper', $this->instance );
-		$this->assertAttributeInstanceOf( Indexing_Helper::class, 'indexing_helper', $this->instance );
+		$this->assertInstanceOf(
+			Indexable_Post_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'post_indexation_action' )
+		);
+		$this->assertInstanceOf(
+			Indexable_Term_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'term_indexation_action' )
+		);
+		$this->assertInstanceOf(
+			Indexable_Post_Type_Archive_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'post_type_archive_indexation_action' )
+		);
+		$this->assertInstanceOf(
+			Indexable_General_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'general_indexation_action' )
+		);
+		$this->assertInstanceOf(
+			Indexable_Indexing_Complete_Action::class,
+			$this->getPropertyValue( $this->instance, 'indexable_indexing_complete_action' )
+		);
+		$this->assertInstanceOf(
+			Indexing_Complete_Action::class,
+			$this->getPropertyValue( $this->instance, 'indexing_complete_action' )
+		);
+		$this->assertInstanceOf(
+			Indexable_Prepare_Indexation_Action::class,
+			$this->getPropertyValue( $this->instance, 'prepare_indexation_action' )
+		);
+		$this->assertInstanceOf(
+			Post_Link_Indexing_Action::class,
+			$this->getPropertyValue( $this->instance, 'post_link_indexing_action' )
+		);
+		$this->assertInstanceOf(
+			Term_Link_Indexing_Action::class,
+			$this->getPropertyValue( $this->instance, 'term_link_indexing_action' )
+		);
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $this->instance, 'options_helper' )
+		);
+		$this->assertInstanceOf(
+			Indexing_Helper::class,
+			$this->getPropertyValue( $this->instance, 'indexing_helper' )
+		);
 	}
 
 	/**

--- a/tests/unit/routes/indexing-route-test.php
+++ b/tests/unit/routes/indexing-route-test.php
@@ -116,8 +116,8 @@ class Indexing_Route_Test extends TestCase {
 	/**
 	 * Sets up the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->post_indexation_action              = Mockery::mock( Indexable_Post_Indexation_Action::class );
 		$this->term_indexation_action              = Mockery::mock( Indexable_Term_Indexation_Action::class );

--- a/tests/unit/routes/semrush-route-test.php
+++ b/tests/unit/routes/semrush-route-test.php
@@ -67,9 +67,18 @@ class SEMrush_Route_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertAttributeInstanceOf( SEMrush_Login_Action::class, 'login_action', $this->instance );
-		$this->assertAttributeInstanceOf( SEMrush_Options_Action::class, 'options_action', $this->instance );
-		$this->assertAttributeInstanceOf( SEMrush_Phrases_Action::class, 'phrases_action', $this->instance );
+		$this->assertInstanceOf(
+			SEMrush_Login_Action::class,
+			$this->getPropertyValue( $this->instance, 'login_action' )
+		);
+		$this->assertInstanceOf(
+			SEMrush_Options_Action::class,
+			$this->getPropertyValue( $this->instance, 'options_action' )
+		);
+		$this->assertInstanceOf(
+			SEMrush_Phrases_Action::class,
+			$this->getPropertyValue( $this->instance, 'phrases_action' )
+		);
 	}
 
 	/**

--- a/tests/unit/routes/semrush-route-test.php
+++ b/tests/unit/routes/semrush-route-test.php
@@ -52,8 +52,8 @@ class SEMrush_Route_Test extends TestCase {
 	/**
 	 * Set up the test fixtures.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->login_action   = Mockery::mock( SEMrush_Login_Action::class );
 		$this->options_action = Mockery::mock( SEMrush_Options_Action::class );

--- a/tests/unit/routes/yoast-head-rest-field-test.php
+++ b/tests/unit/routes/yoast-head-rest-field-test.php
@@ -81,9 +81,18 @@ class Yoast_Head_REST_Field_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_constructor() {
-		$this->assertAttributeInstanceOf( Post_Type_Helper::class, 'post_type_helper', $this->instance );
-		$this->assertAttributeInstanceOf( Taxonomy_Helper::class, 'taxonomy_helper', $this->instance );
-		$this->assertAttributeInstanceOf( Indexable_Head_Action::class, 'head_action', $this->instance );
+		$this->assertInstanceOf(
+			Post_Type_Helper::class,
+			$this->getPropertyValue( $this->instance, 'post_type_helper' )
+		);
+		$this->assertInstanceOf(
+			Taxonomy_Helper::class,
+			$this->getPropertyValue( $this->instance, 'taxonomy_helper' )
+		);
+		$this->assertInstanceOf(
+			Indexable_Head_Action::class,
+			$this->getPropertyValue( $this->instance, 'head_action' )
+		);
 	}
 
 	/**

--- a/tests/unit/routes/yoast-head-rest-field-test.php
+++ b/tests/unit/routes/yoast-head-rest-field-test.php
@@ -52,7 +52,9 @@ class Yoast_Head_REST_Field_Test extends TestCase {
 	/**
 	 * @inheritDoc
 	 */
-	public function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->post_type_helper = Mockery::mock( Post_Type_Helper::class );
 		$this->taxonomy_helper  = Mockery::mock( Taxonomy_Helper::class );
 		$this->head_action      = Mockery::mock( Indexable_Head_Action::class );

--- a/tests/unit/surfaces/meta-surface-test.php
+++ b/tests/unit/surfaces/meta-surface-test.php
@@ -83,7 +83,9 @@ class Meta_Surface_Test extends TestCase {
 	 *
 	 * @return void
 	 */
-	protected function setUp() {
+	protected function set_up() {
+		parent::set_up();
+
 		$this->container          = Mockery::mock( ContainerInterface::class );
 		$this->context_memoizer   = Mockery::mock( Meta_Tags_Context_Memoizer::class );
 		$this->repository         = Mockery::mock( Indexable_Repository::class );
@@ -101,8 +103,6 @@ class Meta_Surface_Test extends TestCase {
 		);
 
 		$this->context->presentation = (object) [ 'test' => 'succeeds' ];
-
-		parent::setUp();
 	}
 
 	/**

--- a/tests/unit/values/images-test.php
+++ b/tests/unit/values/images-test.php
@@ -41,8 +41,8 @@ class Images_Test extends TestCase {
 	/**
 	 * Setup the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->image    = Mockery::mock( Image_Helper::class );
 		$this->url      = Mockery::mock( Url_Helper::class );

--- a/tests/unit/values/open-graph/images-test.php
+++ b/tests/unit/values/open-graph/images-test.php
@@ -51,8 +51,8 @@ class Images_Test extends TestCase {
 	/**
 	 * Setup the tests.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->image            = Mockery::mock( Image_Helper::class )->makePartial();
 		$this->url              = Mockery::mock( Url_Helper::class )->makePartial();

--- a/tests/unit/values/semrush/semrush-token-test.php
+++ b/tests/unit/values/semrush/semrush-token-test.php
@@ -117,10 +117,10 @@ class SEMrush_Token_Test extends TestCase {
 		$instance = SEMrush_Token::from_response( $response );
 
 		$this->assertInstanceOf( SEMrush_Token::class, $instance );
-		$this->assertAttributeEquals( '000000', 'access_token', $instance );
-		$this->assertAttributeEquals( '000001', 'refresh_token', $instance );
-		$this->assertAttributeEquals( 604800, 'expires', $instance );
-		$this->assertAttributeEquals( false, 'has_expired', $instance );
-		$this->assertAttributeEquals( $this->created_at, 'created_at', $instance );
+		$this->assertEquals( '000000', $this->getPropertyValue( $instance, 'access_token' ) );
+		$this->assertEquals( '000001', $this->getPropertyValue( $instance, 'refresh_token' ) );
+		$this->assertEquals( 604800, $this->getPropertyValue( $instance, 'expires' ) );
+		$this->assertEquals( false, $this->getPropertyValue( $instance, 'has_expired' ) );
+		$this->assertEquals( $this->created_at, $this->getPropertyValue( $instance, 'created_at' ) );
 	}
 }

--- a/tests/unit/values/semrush/semrush-token-test.php
+++ b/tests/unit/values/semrush/semrush-token-test.php
@@ -27,8 +27,8 @@ class SEMrush_Token_Test extends TestCase {
 	/**
 	 * Set up the test fixtures.
 	 */
-	public function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->created_at = \time();
 	}

--- a/tests/unit/values/semrush/semrush-token-test.php
+++ b/tests/unit/values/semrush/semrush-token-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Values\SEMrush;
 
 use Mockery;
+use Yoast\WP\SEO\Exceptions\SEMrush\Tokens\Empty_Property_Exception;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Values\SEMrush\SEMrush_Token;
 use YoastSEO_Vendor\League\OAuth2\Client\Token\AccessTokenInterface;
@@ -48,9 +49,10 @@ class SEMrush_Token_Test extends TestCase {
 	 * Test creating a new instance with an empty property.
 	 *
 	 * @covers ::__construct
-	 * @expectedException Yoast\WP\SEO\Exceptions\SEMrush\Tokens\Empty_Property_Exception
 	 */
 	public function test_creating_new_instance_empty_property() {
+		$this->expectException( Empty_Property_Exception::class );
+
 		$instance = new SEMrush_Token( '', '000001', 604800, true, $this->created_at );
 	}
 


### PR DESCRIPTION
## Context

* Preparation for compatibility with PHP 8

## Summary

This PR can be summarized in the following changelog entry:

* Preparation for compatibility with PHP 8

## Relevant technical choices:

Note: this PR will be easiest to review by reviewing the individual commits in the order I've placed them in.


### Composer: require Yoast/wp-test-utils

* Adds a dev dependency to the `yoast/wp-test-utils` package, which will also  make the PHPUnit Polyfills available.
* As that package already requires and manages the installable versions for  BrainMonkey and PHPUnit, remove the BrainMonkey package as explicit requirements from `require- dev` in favour of letting the WP Test Utils package manage the versions.
    As YoastSEO Free does not have `platform:php` configuration set within the `composer.json`, the more limited constraint for the PHPUnit dependency is left in place for now.

This new package adds the following features:
* Polyfills for various PHPUnit cross-version changes.
* Basic test cases for use by the plugins.

Refs:
* https://github.com/Yoast/wp-test-utils
* https://github.com/Yoast/PHPUnit-Polyfills/

### Tests: use the bootstrap file from WP Test Utils

... and remove everything which  is already done within that file.

### Tests: switch over to the Yoast\WPTestUtils\BrainMonkey\YoastTestCase

All test classes for the BrainMonkey based unit tests in the YoastSEO test suite have a YoastSEO native `TestCase` as a parent class.

This switches the parent of that `TestCase` from the PHPUnit native TestCase to the `Yoast\WPTestUtils \BrainMonkey\YoastTestCase`.

The `YoastTestCase`:
* Inherits PHPUnit cross-version compatibility from the PHPUnit Polyfills TestCase.
* Inherits the  BrainMonkey set up and teardown and Mockery expectation counting as assertions from the BrainMonkey TestCase.
* And natively adds a number of stubs for commonly used WP functions.

This switch over includes:
* Removing the addition of  function stubs which are already added via the `YoastTestCase` class.
* Removing  the `tearDown()` method. This will be inherited from the `YoastTestCase` now.
* Renaming the `setUp()` method to `set_up()` for PHPUnit  cross-version compatibility.

### Tests: rename setUp() to set_up() for cross-version compat [1]

All test classes for the BrainMonkey based unit tests have the YoastSEO native `TestCase` as a parent class.

The parent of that `TestCase` has been switched over to the `Yoast\WPTestUtils\BrainMonkey\YoastTestCase` which offers PHPUnit cross-version compatibility by using snake-case `set_up()` and tear_down()` methods.

This commit:
* Renames the `setUp()` method to `set_up()` in various test classes for PHPUnit cross-version compatibility and compliance with the updated parent class.
* Makes the `set_up()` methods `protected` to match the visibility in PHPUnit itself.

### Tests: rename setUp() to set_up() + call parent first [2]

All test classes for the BrainMonkey based unit tests have the YoastSEO native `TestCase` as a parent class.

The parent of that `TestCase` has been switched over to the `Yoast\WPTestUtils\BrainMonkey\YoastTestCase` which offers PHPUnit cross-version compatibility by using snake-case `set_up()` and tear_down()` methods.

This commit:
* Renames the `setUp()` method to `set_up()` in various test classes for PHPUnit cross-version compatibility and compliance with the updated parent class.
* Makes the `set_up()` methods `protected` to match the visibility in PHPUnit itself.
* **Moves the call to `parent::set_up()` up to the very top of the function**, to make sure that BrainMonkey, Mockery and the default stubs are available before any other set up is done.

### Tests: rename setUp() to set_up(), call parent first + no return [3]

All test classes for the BrainMonkey based unit tests have the YoastSEO native `TestCase` as a parent class.

The parent of that `TestCase` has been switched over to the `Yoast\WPTestUtils\BrainMonkey\YoastTestCase` which offers PHPUnit cross-version compatibility by using snake-case `set_up()` and tear_down()` methods.

This commit:
* Renames the `setUp()` method to `set_up()` in various test classes for PHPUnit cross-version compatibility and compliance with the updated parent class.
* Makes the `set_up()` methods `protected` to match the visibility in PHPUnit itself.
* **Moves the call to `parent::set_up()` up to the very top of the function**, to make sure that BrainMonkey, Mockery and the default stubs are available before any other set up is done.
* **Removes the `return`.**
    PHPUnit `setUp()` (`set_up()`) methods are explicitly `void` methods, so should never `return` anything.

### Tests: rename setUp() to set_up() + add missing calls to parent [4]

All test classes for the BrainMonkey based unit tests have the YoastSEO native `TestCase` as a parent class.

The parent of that `TestCase` has been switched over to the `Yoast\WPTestUtils\BrainMonkey\YoastTestCase` which offers PHPUnit cross-version compatibility by using snake-case `set_up()` and tear_down()` methods.

This commit:
* Renames the `setUp()` method to `set_up()` in various test classes for PHPUnit cross-version compatibility and compliance with the updated parent class.
* Makes the `set_up()` methods `protected` to match the visibility in PHPUnit itself.
* **Adds a call to `parent::set_up()` up to make sure that BrainMonkey, Mockery and the default stubs are available before any other set up is done.**
    While these tests may not strictly _need_ the stubs, the BrainMonkey and Mockery instantiation should still be executed.
    For consistency across the test suite, I've elected to call the normal parent `set_up()` method which _does_ include setting up the function stubs.
    Alternatively, the "grandparent" `set_up()` could be called to still set up BrainMonkey and Mockery, but without setting up the stubs.

### Admin\Input_Validation_Test: move repeated stubbing to set_up()

If all test methods in a class need a stub, create it via `set_up()` instead of repeatedly doing the same stubbing.

### Options\Option_Social_Test: merge stub function calls

No need to call `Monkey\Functions\stubs()` twice when one call will suffice.

### Tests: replace stubbing of translation functions with wholesale stubbing

BrainMonkey offers a `stubTranslationFunctions()` function which stubs all nearly translation functions and includes escaping for the "translate and escape" functions.

The WP Test Utils base class for BrainMonkey offers an alternative implementation which doesn't do the escaping, but will always return the original value unchanged.

Instead of stubbing translation/escaping functions ourselves, either one of these wholesale stubbing functions should be used.

### TestCase: remove the generic stubbing of the translation and escaping functions

Only a very limited number of tests - 127 out of 1576 - need these stubs, so we may as well only load them if and when needed.

BrainMonkey offers a `stubTranslationFunctions()` function which stubs all nearly translation functions and includes escaping for the "translate and escape" functions.
Similarly, it contains a `stubEscapeFunctions()` function.

The WP Test Utils base class for BrainMonkey offers an alternative implementation for both of these, which doesn't do any escaping, but will always return the original value unchanged.

For each of the 127 tests which actually need either the translation functions or the escaping functions, or both, a call to one or both of the wholesale stubbing functions has been put in place.

As a rule of thumb, these function calls have been added to a test `set_up()` method if more than half the tests in the class need these functions.

Otherwise, the function call(s) have been added to the individual test.

### Tests: modernize used assertions

The PHPUnit Polyfills allows for using PHPUnit   9.x assertions, even when the tests are being run on older PHPUnit versions.

This updates select assertions to the modern PHPUnit syntax, most notably, it switches out the following assertions:
* `assertContains()` with string haystacks for `assertStringContainsString()`.

### Tests: remove use of `@expectException*` annotations

Setting expectations for exception via annotations is deprecated in PHPUnit 8 and removed in PHPUnit 9.

This replaces the few instances in which annotations were used with the use of the `expectException*()` methods.

### Tests: remove use of `assertAttributeInstanceOf()` assertions [1]

The `assertAttribute*()` assertion methods were deprecated in PHPUnit 8.x and removed in PHPUnit 9.

The reasoning for that was that `protected` and `private` properties are implementation details and should not be tested directly, but via the methods in the class.

For now, I've elected to maintain the existing test behaviour, while making it work in a PHPUnit cross-version compatible manner.

This is done by:
1. Using a test helper method introduced provided via PHPUnit Polyfills (0.2.0) to get the value of a non-public property.
2. Changing the assertions for the tests from `assertAttribute*()` to `assert*()`

At a later point in time, it should be re-examined whether these implementation details should be tested in this way, if at all.

### Tests: remove use of `assertAttributeInstanceOf()` assertions [2]

The `assertAttribute*()` assertion methods were deprecated in PHPUnit 8.x and removed in PHPUnit 9.

The reasoning for that was that `protected` and `private` properties are implementation details and should not be tested directly, but via the methods in the class.

For now, I've elected to maintain the existing test behaviour, while making it work in a PHPUnit cross-version compatible manner.

This is done by:
1. Using a test helper method introduced provided via PHPUnit Polyfills (0.2.0) to get the value of a non-public property.
2. Changing the assertions for the tests from `assertAttribute*()` to `assert*()`
3. **Testing the class under test directly.**
    In these three cases, either a Mock or a Double of the class was used in combination with testing the value of a `private` property. This will no longer work as the private property is set in the parent class and inaccessible from the mock/double child class. Overloading the visibility of the property in the mock/double is also not a solution.
    Opting for the simplest of solutions now, by using a local instance of the original class to still test the constructor.

At a later point in time, it should be re-examined whether these implementation details should be tested in this way, if at all.

### Tests: remove use of `assertAttributeEquals/Same()` assertions

The `assertAttribute*()` assertion methods were deprecated in PHPUnit 8.x and removed in PHPUnit 9.

The reasoning for that was that `protected` and `private` properties are implementation details and should not be tested directly, but via the methods in the class.

For now, I've elected to maintain the existing test behaviour, while making it work in a PHPUnit cross-version compatible manner.

This is done by:
1. Using a test helper method introduced provided via PHPUnit Polyfills (0.2.0) to get the value of a non-public property.
2. Changing the assertions for the tests from `assertAttribute*()` to `assert*()`

At a later point in time, it should be re-examined whether these implementation details should be tested in this way, if at all.

### Admin\MyYoast_Proxy_Test: refactor tests using `at()`

The `at()` matcher has been deprecated in PHPUnit 9 and will be removed in PHPUnit 10. It is strongly recommended not to rely on the order in which methods are invoked.

Replacing the expectations create with the `at()` matcher, by a slightly different expectation which still tests that the `set_header()` function is called 1) the expected number of times and 2) with specific arguments and 3) in a certain order.

This stabilizes these tests for the future.

### QA: fix broken `@coversDefaultClass` tags

The individual tests did have method `@covers` tags, but the class level `@coversDefaultClass` tags were incorrect, which meant that code coverage wouldn't be recorded for these tests.

Fixed now.

### PHPUnit config: minor tweaks

* Rename the testsuite to use a more descriptive name.
* Improve the code coverage configuration:
    - Allow for code coverage to record coverage of code in the `wp-seo.php` and `wp-seo-main.php` files.
    - Remove the reference to the no longer existing `/frontend` directory.
    - Fix code coverage exclusions:
        - The `deprecated` folder is now `src/deprecated`.
        - The `config/composer` directory does not need to be excluded as the `config` directory is not whitelisted, so code coverage would never be sought for this directory anyhow.
    - Add `addUncoveredFilesFromWhitelist` and `processUncoveredFilesFromWhitelist` directives with sensible values.
    - Add the `forceCoversAnnotation` attribute to only record code coverage for the method under test as annotated via a `@covers` annotation.

Based on this configuration, the strict code coverage for this testsuite is currently **29.13%**, with 71.35% of the code in the `/src` directory covered.

### Travis: run the unit tests against PHP 8/nightly

Now the BrainMonkey based tests are fully compatible with PHPUnit 9, the test suite can be run on PHP 8.

However, as the integration tests are not (yet) compatible with PHPUnit > 5.7, we need to add a separate condition block to the `script` section.

In this block, we run a `composer update` for just and only the test dependencies on PHP 8 to make sure that the test dependencies available are compatible with PHP 8.

Includes:
* Adding `travis_retry` to `composer install`-like commands to get round builds stalling on the connection with Packagist, especially on older PHP versions.
* Adding the PHPUnit cache file which is generated when using PHPUnit 8/9 to `.gitignore`.



## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the output of all builds for this PR, making sure that 1) the installation via Composer works without issues, 2) the tests are being run and 3) the tests pass.

To test locally, it will be simplest to:
1. Run `composer install`.
2. Run `composer test` on any PHP version below 8.0 and see the tests pass, including a more accurate assertion count (8679 compared to 1610 previously, due to Mockery expectations now being counted).
    This confirms that the changes to the `TestCase` work correctly cross-version as the PHPUnit version installed based on the `composer.lock` file will be PHPUnit 5.7.27.
3. Switch to PHP 8.
4. Run `composer require --dev phpunit/phpunit:"^9.0" --update-with-dependencies`
5. Run `composer update yoast/wp-test-utils --with-all-dependencies`
6. Run `composer test` to see the tests running and passing on PHP 8 in combination with PHPUnit 9.x.
    This confirms that the tests can now run cross-version on all PHPUnit versions between PHPUnit 5.7 and PHPUnit 9.x and that the tests run and pass on PHP 8.

Note: this doesn't confirm full PHP 8 compatibility yet as the test code coverage based on the BrainMonkey based tests alone, as noted above, is only ~29%.
