### PR TITLE
updates headings in sidebar to wp5.5 colorscheme

### DIFF
--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -36,6 +36,10 @@
 	font-weight: 500;
 }
 
+.yoast-field-group__title b {
+	font-weight: var(--yoast-font-weight-bold);
+}
+
 .yoast h3 span > span {
 	font-weight: 400;
 }

--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -25,11 +25,7 @@
 }
 
 .yoast label {
-	color: var(--yoast-color-label-help);
-}
-
-label[for="focus-keyword-input-sidebar"], .yoast-field-group__title > label {
-	color: var(--yoast-color-font-default);
+	color: var(--yoast-color-label);
 }
 
 .yoast input[disabled] {
@@ -75,7 +71,7 @@ label[for="focus-keyword-input-sidebar"], .yoast-field-group__title > label {
 .yoast-elementor-panel__fills {
 	margin-top: 10px;
 	padding: 5px 5px 0 5px;
-	color: var(--yoast-color-font-default);
+	color: var(--yoast-color-dark);
 	background-color: var(--yoast-color-white);
 	-webkit-font-smoothing: subpixel-antialiased;
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Headings in our sidebar in Elementor where mimicing the color scheme our plugin has in the Block editor on WP5.3. That needed to be updated to look just like in the Block editor on WP5.5.3 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Colors of our headings in the Elementor sidebar are now universal in color and mostly slightly darker, like in the newest Block editor

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open our Elementor integration and verify that the headings look comparable to our sidebar in the Block editor on WP5.5.3. Please be aware that color-codes can sligthly differ, as the Elementor integration uses the Yoast color scheme instead of the WP color scheme. But the general look should be the same.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
P1-262 [Elementor] Styling differences