### PR TITLE
Fix console error .find of undefined on document switching

### DIFF
--- a/js/src/watchers/elementorWatcher.js
+++ b/js/src/watchers/elementorWatcher.js
@@ -14,12 +14,14 @@ const editorData = {
 /**
  * Gets the post content.
  *
+ * @param {Document} editorDocument The current document.
+ *
  * @returns {string} The post's content.
  */
-function getContent() {
+function getContent( editorDocument ) {
 	const content = [];
 
-	window.elementor.documents.getCurrent().$element.find( ".elementor-widget-container" ).each( ( index, element ) => {
+	editorDocument.$element.find( ".elementor-widget-container" ).each( ( index, element ) => {
 		content.push( element.innerHTML.trim() );
 	} );
 
@@ -47,10 +49,12 @@ function getImageUrl( content ) {
 /**
  * Gets the data that is specific to this editor.
  *
+ * @param {Document} editorDocument The current document.
+ *
  * @returns {Object} The editorData object.
  */
-function getEditorData() {
-	const content = getContent();
+function getEditorData( editorDocument ) {
+	const content = getContent( editorDocument );
 
 	return {
 		content,
@@ -66,7 +70,17 @@ function getEditorData() {
  * @returns {void}
  */
 function handleEditorChange() {
-	const data = getEditorData();
+	const currentDocument = window.elementor.documents.getCurrent();
+
+	/*
+	Quit early if the change was caused by switching out of the wp-post/page document.
+	This can happen when users go to Site Settings, for example.
+	*/
+	if ( ! [ "wp-post", "wp-page" ].includes( currentDocument.config.type ) ) {
+		return;
+	}
+
+	const data = getEditorData( currentDocument );
 
 	if ( data.content !== editorData.content ) {
 		editorData.content = data.content;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where a console error would appear when switching to site settings in Elementor.

## Relevant technical choices:

* Chose to skip analysis dispatches entirely when the document is not a "wp-post" or "wp-page".

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* On release/15.4, the bug would occur if you go to site settings (hamburger menu > site settings).
* With this branch checked out and built, open a post, a custom post, and a page.
* On each, make some changes and verify that the analysis runs (for example remove your focus keyphrase from the title) and verify that that assessment changes. Or check the logs / redux if you have access.
* Then switch to site settings on each, and verify that there is no console error, and no analysis being run.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-275
