### PR TITLE
P1-272 add warning

### DIFF
--- a/js/src/redux/actions/index.js
+++ b/js/src/redux/actions/index.js
@@ -20,6 +20,7 @@ export * from "./settings";
 export * from "./snippetEditor";
 export * from "./twitterEditor";
 export * from "./facebookEditor";
+export * from "./warning";
 
 /**
  * A wrapper function so that we can wrap the field helper to the monorepo action.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a warning when there are SEO setting changes on a non-draft post.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new post/page and switch to the Elementor editor.
* Verify there is no warning at the top of our sidebar.
* Change some SEO settings.
* This should never make the warning appear.
* Publish the post/page.
* Verify there is no warning (yet).
* Change an SEO setting.
* Verify the warning appeared at the top of our sidebar:
![Screen Shot 2020-11-26 at 10 13 05](https://user-images.githubusercontent.com/35524806/100331147-1790ca00-2fd0-11eb-99b1-2c9706c7c5f0.png)
* Check the text is the same as in the issue.
* Change the post status back to draft (Settings (the tab next to the Yoast SEO tab) -> General Settings -> Status).
* Verify the warning disappears.
* Play around with this 😄 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-272
