### PR TITLE
Add Hungarian to lists of languages with morphology and function words

### DIFF
--- a/src/helpers/language-helper.php
+++ b/src/helpers/language-helper.php
@@ -15,7 +15,7 @@ class Language_Helper {
 	 * @return boolean Whether word form recognition is active for the used language.
 	 */
 	public function is_word_form_recognition_active( $language ) {
-		$supported_languages = [ 'de', 'en', 'es', 'fr', 'it', 'nl', 'ru', 'id', 'pt', 'pl', 'ar', 'sv', 'he' ];
+		$supported_languages = [ 'de', 'en', 'es', 'fr', 'it', 'nl', 'ru', 'id', 'pt', 'pl', 'ar', 'sv', 'he', 'hu' ];
 
 		return \in_array( $language, $supported_languages, true );
 	}
@@ -29,7 +29,7 @@ class Language_Helper {
 	 * @return bool Whether the language has function word support.
 	 */
 	public function has_function_word_support( $language ) {
-		$supported_languages = [ 'en', 'de', 'nl', 'fr', 'es', 'it', 'pt', 'ru', 'pl', 'sv', 'id', 'he', 'ar' ];
+		$supported_languages = [ 'en', 'de', 'nl', 'fr', 'es', 'it', 'pt', 'ru', 'pl', 'sv', 'id', 'he', 'ar', 'hu' ];
 
 		return \in_array( $language, $supported_languages, true );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Let Free users see an upsell notification that promotes Premium word form recognition. Reduce the limit of prominent words that are saved so that it matches the limit of other languages with function word support (languages with no function words get a higher limit to increase the chances of content words showing up in the prominent words).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Activate word form recognition upsell banner for Hungarian users, and reduce the maximum number of prominent words that are saved for Hungarian users to match that of other languages with function word support.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
* Set the language of your website to Hungarian.
* Check that you are seeing a morphology upsell in Free. (See [this PR](https://github.com/Yoast/wordpress-seo/pull/15322) for what the upsell looks like.)
* To test the prominent words limit:
     * Test in Premium
     * Open a post with sufficient and diverse content, around 1000 words.
         * Tip: copy a blog article from yoast.com.
     * Check the network tab in your browser's development tools.
     * It should contain a request to the `link_suggestions` endpoint.
     * Count the number of prominent words that show up, in the form of query string arguments:
      <img width="500" alt="Screenshot_2020-08-27_at_10_37_53" src="https://user-images.githubusercontent.com/10195175/91417879-b54def00-e851-11ea-9d5f-d90c3f18f5e1.png">
     * Change the site language to a language with no function word support (e.g. Afrikaans).
     * Make sure that the number of prominent word suggestions increases (by about 33 %).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-548
