### PR TITLE
Localize an existing script

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -222,20 +222,6 @@ class WPSEO_Admin_Asset_Manager {
 				],
 			],
 			[
-				'name' => 'search-appearance',
-				'src'  => 'search-appearance-' . $flat_version,
-				'deps' => [
-					'lodash',
-					'wp-api',
-					'wp-element',
-					'wp-i18n',
-					self::PREFIX . 'styled-components',
-					self::PREFIX . 'yoast-components',
-					self::PREFIX . 'replacement-variable-editor',
-					self::PREFIX . 'commons',
-				],
-			],
-			[
 				'name' => 'schema-blocks',
 				'src'  => 'schema-blocks-' . $flat_version,
 				'deps' => [

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -108,7 +108,7 @@ class WPSEO_Admin_Pages {
 			remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 
 			$yoast_components_l10n = new WPSEO_Admin_Asset_Yoast_Components_L10n();
-			$yoast_components_l10n->localize_script( 'search-appearance' );
+			$yoast_components_l10n->localize_script( WPSEO_Admin_Asset_Manager::PREFIX . 'settings' );
 		}
 
 		if ( in_array( $page, [ 'wpseo_social', WPSEO_Admin::PAGE_IDENTIFIER, 'wpseo_titles' ], true ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR replaces https://github.com/Yoast/wordpress-seo/pull/16400/commits/b9b1cd86f3ee41000b448ad3f26f50533b9cbf3d. That PR was created off of a wrong branch (i.e., not `trunk`), taking along with it the commits of that wrong branch.
* In this PR, I cherry-picked the only commit from https://github.com/Yoast/wordpress-seo/pull/16400/commits/b9b1cd86f3ee41000b448ad3f26f50533b9cbf3d which was actually meant to be present in the PR.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the translations on Search Appearance pages would be broken.

## Relevant technical choices:

* Removed the declaration of the `search-appearence` script
* Localized `settings` because that script will be loaded on that page.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* On trunk
* Set your site in a non-English language. For example Dutch
* Go to the search appearance page and visit the post types tab or the taxonomies tab
* See that the text is a mix of English and the set language.
* Checkout this branch 
* There might be untranslated element, but the mostly of the page should be translated. There is a `Insert Variable` button that keeps English, but that is another issue.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-542
