### PR TITLE
Trying with a new component

### DIFF
--- a/js/src/elementor/components/fills/ElementorFill.js
+++ b/js/src/elementor/components/fills/ElementorFill.js
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 
 // Internal dependencies.
 import CollapsibleCornerstone from "../../../containers/CollapsibleCornerstone";
-import Warning from "../../../containers/Warning";
+import Alert from "../../containers/Alert";
 import KeywordInput from "../../../components/contentAnalysis/KeywordInput";
 import ReadabilityAnalysis from "../../../components/contentAnalysis/ReadabilityAnalysis";
 import SeoAnalysis from "../../../components/contentAnalysis/SeoAnalysis";
@@ -45,7 +45,7 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 	return (
 		<Fill name="YoastElementor">
 			<SidebarItem renderPriority={ 1 }>
-				<Warning />
+				<Alert />
 			</SidebarItem>
 			{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
 				<KeywordInput

--- a/js/src/elementor/containers/Alert.js
+++ b/js/src/elementor/containers/Alert.js
@@ -1,0 +1,18 @@
+import { Alert } from "@yoast/components";
+import { withSelect } from "@wordpress/data";
+
+function WrappedAlert( props ) {
+	return ( props.message.length === 0 ? null : <Alert type={ props.type }>{ props.message }</Alert> );
+}
+
+export default withSelect( select => {
+	const {
+		getWarningMessage,
+	} = select( "yoast-seo/editor" );
+
+	return {
+		message: getWarningMessage(),
+		type: "warning",
+	};
+} )( WrappedAlert );
+

--- a/js/src/elementor/containers/Alert.js
+++ b/js/src/elementor/containers/Alert.js
@@ -1,6 +1,15 @@
 import { Alert } from "@yoast/components";
 import { withSelect } from "@wordpress/data";
 
+/**
+ * Wraps the Alert as a quick fix for the way it is used in Elementor.
+ * Message is sometimes an empty array or an empty string,
+ * in which case the Alert should not be shown.
+ *
+ * @param {Object} props The props.
+ *
+ * @returns {ReactElement|Null} The Alert or Null.
+ */
 function WrappedAlert( props ) {
 	return ( props.message.length === 0 ? null : <Alert type={ props.type }>{ props.message }</Alert> );
 }

--- a/js/src/elementor/containers/Alert.js
+++ b/js/src/elementor/containers/Alert.js
@@ -1,5 +1,6 @@
 import { Alert } from "@yoast/components";
 import { withSelect } from "@wordpress/data";
+import PropTypes from "prop-types";
 
 /**
  * Wraps the Alert as a quick fix for the way it is used in Elementor.
@@ -13,6 +14,11 @@ import { withSelect } from "@wordpress/data";
 function WrappedAlert( props ) {
 	return ( props.message.length === 0 ? null : <Alert type={ props.type }>{ props.message }</Alert> );
 }
+
+WrappedAlert.propTypes = {
+	message: PropTypes.oneOfType( [ PropTypes.array, PropTypes.string ] ).isRequired,
+	type: PropTypes.string.isRequired,
+};
 
 export default withSelect( select => {
 	const {

--- a/js/src/elementor/containers/Alert.js
+++ b/js/src/elementor/containers/Alert.js
@@ -12,7 +12,7 @@ export default withSelect( select => {
 
 	return {
 		message: getWarningMessage(),
-		type: "warning",
+		type: "info",
 	};
 } )( WrappedAlert );
 

--- a/js/src/initializers/elementor-editor-integration.js
+++ b/js/src/initializers/elementor-editor-integration.js
@@ -171,7 +171,7 @@ export default function initElementEditorIntegration() {
 	window.$e.routes.on( "run:after", function( component, route ) {
 		if ( route === "panel/page-settings/yoast-tab" ) {
 			renderReactRoot( window.YoastSEO.store, "elementor-panel-page-settings-controls", (
-				<StyleSheetManager target={ document.getElementById( "elementor-panel-page-settings-controls" ) }>
+				<StyleSheetManager target={ document.getElementById( "elementor-panel-inner" ) }>
 					<div className="yoast yoast-elementor-panel__fills">
 						<ElementorSlot />
 						<ElementorFill />

--- a/js/src/redux/selectors/index.js
+++ b/js/src/redux/selectors/index.js
@@ -16,3 +16,4 @@ export * from "./SEMrushRequest";
 export * from "./settings";
 export * from "./snippetEditor";
 export * from "./twitterEditor";
+export * from "./warning";

--- a/js/src/redux/selectors/warning.js
+++ b/js/src/redux/selectors/warning.js
@@ -1,0 +1,12 @@
+import { get } from "lodash";
+
+/**
+ * Selects the warning messages.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {Array} The warning message or an empty string.
+ */
+export function getWarningMessage( state ) {
+	return get( state, "warning.message", [] );
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix a console error that appeared in some cases, mostly around the draft warning in Elementor.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where a console error would appear when the draft warning rendered.
* Changes the draft warning to a draft info box which is less threatening.

## Relevant technical choices:

* Using a more applicable component, `Alert.js` which accepts strings rather than an array of html. Had to create a quick container to translate [] => string though.
* Shifted to using an "info" alert rather than a "warning" alert, as per the spec.
* Moved the StyleSheetManager up one level, because it was misbehaving.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* `yarn unlink-monorepo`!!!!! Build all the things, and finally run `grunt webpack:buildProd`
          * Alternatively, create a zip based on this branch (without linked monorepo) and try that. If you are QA, use the RC zip.
* Make sure you have the console open
* Create a new post/page and switch to the Elementor editor
* Change some SEO settings5. Publish the post/page*
* Change the status back to draft (Settings (the tab next to the Yoast SEO tab) -> General Settings -> Status)
* Change the status to Private
* Observe that there is no longer an error.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-278
