### PR TITLE
Add translation around replacevar labels

### DIFF
--- a/js/src/elementor/replaceVars/blockEditor/parentTitle.js
+++ b/js/src/elementor/replaceVars/blockEditor/parentTitle.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get, isUndefined } from "lodash";
 
 /**
@@ -25,7 +26,7 @@ function getReplacement() {
  */
 export default {
 	name: "parent_title",
-	label: "Category",
+	label: __( "Parent title", "wordpress-seo" ),
 	placeholder: "%%parent_title%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/classicEditor/parentTitle.js
+++ b/js/src/elementor/replaceVars/classicEditor/parentTitle.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get, isUndefined } from "lodash";
 
 /**
@@ -25,7 +26,7 @@ function getReplacement() {
  */
 export default {
 	name: "parent_title",
-	label: "Category",
+	label: __( "Parent title", "wordpress-seo" ),
 	placeholder: "%%parent_title%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/general/category.js
+++ b/js/src/elementor/replaceVars/general/category.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "category",
-	label: "Category",
+	label: __( "Category", "wordpress-seo" ),
 	placeholder: "%%category%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/general/currentYear.js
+++ b/js/src/elementor/replaceVars/general/currentYear.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "currentyear",
-	label: "Current year",
+	label: __( "Current year", "wordpress-seo" ),
 	placeholder: "%%currentyear%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/general/date.js
+++ b/js/src/elementor/replaceVars/general/date.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "date",
-	label: "Date",
+	label: __( "Date", "wordpress-seo" ),
 	placeholder: "%%date%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/general/excerpt.js
+++ b/js/src/elementor/replaceVars/general/excerpt.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { select } from "@wordpress/data";
 import { excerptFromContent } from "../../../helpers/replacementVariableHelpers";
 
@@ -28,7 +29,7 @@ function getReplacement() {
  */
 export default {
 	name: "excerpt",
-	label: "Excerpt",
+	label: __( "Excerpt", "wordpress-seo" ),
 	placeholder: "%%excerpt%%",
 	aliases: [
 		{

--- a/js/src/elementor/replaceVars/general/focusKeyphrase.js
+++ b/js/src/elementor/replaceVars/general/focusKeyphrase.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { select } from "@wordpress/data";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "focuskw",
-	label: "Focus keyphrase",
+	label: __( "Focus keyphrase", "wordpress-seo" ),
 	placeholder: "%%focuskw%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/general/id.js
+++ b/js/src/elementor/replaceVars/general/id.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "id",
-	label: "ID",
+	label: __( "ID", "wordpress-seo" ),
 	placeholder: "%%id%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/general/page.js
+++ b/js/src/elementor/replaceVars/general/page.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "page",
-	label: "Page",
+	label: __( "Page", "wordpress-seo" ),
 	placeholder: "%%page%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/general/primaryCategory.js
+++ b/js/src/elementor/replaceVars/general/primaryCategory.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "primary_category",
-	label: "Primary category",
+	label: __( "Primary category", "wordpress-seo" ),
 	placeholder: "%%primary_category%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/general/searchPhrase.js
+++ b/js/src/elementor/replaceVars/general/searchPhrase.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "searchphrase",
-	label: "Search phrase",
+	label: __( "Search phrase", "wordpress-seo" ),
 	placeholder: "%%searchphrase%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/general/separator.js
+++ b/js/src/elementor/replaceVars/general/separator.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "sep",
-	label: "Separator",
+	label: __( "Separator", "wordpress-seo" ),
 	placeholder: "%%sep%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/general/siteDescription.js
+++ b/js/src/elementor/replaceVars/general/siteDescription.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "sitedesc",
-	label: "Tagline",
+	label: __( "Tagline", "wordpress-seo" ),
 	placeholder: "%%sitedesc%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/general/siteName.js
+++ b/js/src/elementor/replaceVars/general/siteName.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "sitename",
-	label: "Site title",
+	label: __( "Site title", "wordpress-seo" ),
 	placeholder: "%%sitename%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/general/termDescription.js
+++ b/js/src/elementor/replaceVars/general/termDescription.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "term_description",
-	label: "Term description",
+	label: __( "Term description", "wordpress-seo" ),
 	placeholder: "%%term_description%%",
 	aliases: [
 		{

--- a/js/src/elementor/replaceVars/general/termHierarchy.js
+++ b/js/src/elementor/replaceVars/general/termHierarchy.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "term_hierarchy",
-	label: "Term hierarchy",
+	label: __( "Term hierarchy", "wordpress-seo" ),
 	placeholder: "%%term_hierarchy%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/general/termTitle.js
+++ b/js/src/elementor/replaceVars/general/termTitle.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "term_title",
-	label: "Term title",
+	label: __( "Term title", "wordpress-seo" ),
 	placeholder: "%%term_title%%",
 	aliases: [],
 	getReplacement,

--- a/js/src/elementor/replaceVars/general/title.js
+++ b/js/src/elementor/replaceVars/general/title.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { select } from "@wordpress/data";
 
 /**
@@ -16,7 +17,7 @@ function getReplacement() {
  */
 export default {
 	name: "title",
-	label: "Title",
+	label: __( "Title", "wordpress-seo" ),
 	placeholder: "%%title%%",
 	aliases: [],
 	getReplacement,


### PR DESCRIPTION
Used in Elementor only right now

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Google, Facebook and Twitter variables would not be translated in our Elementor integration.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Change the site language to something non-English.
* Open a post in the Elementor editor.
* Go to the Google, Facebook or Twitter preview.
* Insert a variable.
* The name of the replacement variables should still work.
* The name should be in the language that you set your site to, but it can still be English if there are no translations yet.
  You can check in the block editor if it works there.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
