### PR TITLE
P3-241 Ensure the AreaChart max values are at least 1 to avoid a division by zero

### DIFF
--- a/js/src/components/AreaChart.js
+++ b/js/src/components/AreaChart.js
@@ -35,8 +35,10 @@ const AreaChart = ( {
 	dataTableHeaderLabels,
 	isDataTableVisuallyHidden,
 } ) => {
-	const maximumXFromData = Math.max( ...data.map( point => point.x ) );
-	const maximumYFromData = Math.max( ...data.map( point => point.y ) );
+	// When all the x values are zero, make sure the maximumX value is at least 1 to avoid a division by zero later.
+	const maximumXFromData = Math.max( 1, Math.max( ...data.map( point => point.x ) ) );
+	// When all the y values are zero, make sure the maximumY value is at least 1 to avoid a division by zero later.
+	const maximumYFromData = Math.max( 1, Math.max( ...data.map( point => point.y ) ) );
 
 	// Reserve some vertical spacing to prevent the SVG stroke from being cut-off.
 	const chartHeight = height - strokeWidth;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid an error in the SEMrush modal when the trend values are all zero and also display a horizontal blue line when that's the case.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the SEMrush modal triggers errors and doesn't display a chart when all the Trend values are zero.

## Relevant technical choices:

- the AreaChart component used in the SEMrush modal works in a way that needs to get the maximum value for the X and y coordinates used for the chart
- in some edge cases, SEMrush may return a value of zero for all the previous 12 months displayed in the modal for a given keyphrase suggestion
- when this happens, the data returned for X and Y are like the ones in the screenshot below, where `y` is always `0`:

<img width="551" alt="Screenshot 2020-12-02 at 16 35 18" src="https://user-images.githubusercontent.com/1682452/100897898-7cf92500-34c0-11eb-95ce-c62a2fbc5d41.png">

- this triggers a division by zero later in the AreaChart code
- in order to fix this, we make sure the maximum value for Y (and also for X, just in case) is at least `1`
- by doing so, the chart will also display a horizontal line thus correctly representing the 12 months values
- note that this `1` value is used only for the chart
- the visually hidden table used as accessible alternative of the chart will still use a value of `0`, which is correct (you can check this by inspecting the source and checking the hidden tables after each chart)


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- switch to this branch and build the plugin
- edit a post 
- enter the focus keyphrase "testje"
- Open the SEMrush modal
- make sure the Country is set to "United States" 
- see the SEMrush table gets populated with data and the charts are generated
- in the last results in the table, you should see some suggested keyphrases that have a Trend value of `0`
- check these suggested keyphrases do show a chart which is a horizontal line, like in the screenshot below:

<img width="748" alt="Screenshot 2020-12-02 at 16 29 44" src="https://user-images.githubusercontent.com/1682452/100898891-8636c180-34c1-11eb-81c6-f8d3e5ac7c6d.png">

- check your browser's dev tools console and check there are no errors related to polygon and polyline, example of the previous errors:

```
Error: <polygon> attribute points: Expected number, "0,24 0,NaN 6,NaN 12,NaN…"
Error: <polyline> attribute points: Expected number, "0,NaN 6,NaN 12,NaN…"
```


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.
* except switching to this branch and building, as QA will likely test the RC zip

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-241]
