### PR TITLE
Improve performance for taxonomy sitemaps

### DIFF
--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -193,7 +193,15 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		$hide_empty = apply_filters( 'wpseo_sitemap_exclude_empty_terms', true, [ $taxonomy->name ] );
 		/** This filter is documented in inc/sitemaps/class-taxonomy-sitemap-provider.php */
 		$hide_empty_tax = apply_filters( 'wpseo_sitemap_exclude_empty_terms_taxonomy', $hide_empty, $taxonomy->name );
-		$terms          = get_terms( $taxonomy->name, [ 'hide_empty' => $hide_empty_tax, 'update_term_meta_cache' => false, 'offset' => $offset, 'number' => $steps ] );
+		$terms          = get_terms(
+			[
+				'taxonomy'               => $taxonomy->name,
+				'hide_empty'             => $hide_empty_tax,
+				'update_term_meta_cache' => false,
+				'offset'                 => $offset,
+				'number'                 => $steps,
+			]
+		);
 
 		// If there are no terms fetched for this range, we are on an invalid page.
 		if ( empty( $terms ) ) {

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -193,16 +193,11 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		$hide_empty = apply_filters( 'wpseo_sitemap_exclude_empty_terms', true, [ $taxonomy->name ] );
 		/** This filter is documented in inc/sitemaps/class-taxonomy-sitemap-provider.php */
 		$hide_empty_tax = apply_filters( 'wpseo_sitemap_exclude_empty_terms_taxonomy', $hide_empty, $taxonomy->name );
-		$terms          = get_terms( $taxonomy->name, [ 'hide_empty' => $hide_empty_tax ] );
+		$terms          = get_terms( $taxonomy->name, [ 'hide_empty' => $hide_empty_tax, 'update_term_meta_cache' => false, 'offset' => $offset, 'number' => $steps ] );
 
-		// If the total term count is lower than the offset, we are on an invalid page.
-		if ( count( $terms ) < $offset ) {
-			throw new OutOfBoundsException( 'Invalid sitemap page requested' );
-		}
-
-		$terms = array_splice( $terms, $offset, $steps );
+		// If there are no terms fetched for this range, we are on an invalid page.
 		if ( empty( $terms ) ) {
-			return $links;
+			throw new OutOfBoundsException( 'Invalid sitemap page requested' );
 		}
 
 		$post_statuses = array_map( 'esc_sql', WPSEO_Sitemaps::get_post_statuses() );


### PR DESCRIPTION
Hi folks!  👋 

`get_terms` in `wordpress-seo/inc/sitemaps/class-taxonomy-sitemap-provider.php` can be very taxing on a site with thousands of terms.  I'm adding some arguments here so that we don’t have to grab all the terms every time each single taxonomy sitemap is built.

## Context
* I've noticed degraded performance for some sites on WordPress VIP when taxonomy sitemaps are active.   We would like to help customers be able to keep these while not significantly degrading their applications.
* The main issues are in **when** the sitemap generation happens and **how** the links are built for taxonomies
* This PR hopes to address a small first step which is improving the performance of the `get_terms()` called
* Related issue: https://github.com/Yoast/wordpress-seo/issues/6761



## Note
I think there are more improvements that need to happen for sitemap generation, specifically what I was thinking:
* Yoast shouldn't regenerate sitemaps on request, **it should at least have the option to offload to CRON** 
* I would suggest setting stricter limits.  I've seen sitemaps with 1000 items which can quickly break memcached usage and cause eviction stampedes.   I'd say having a hard limit would make this more fault-tolerant

## Summary
This PR can be summarized in the following changelog entry:

*  Improves taxonomy sitemap generation performance. Props to [mikeyarce](https://github.com/mikeyarce).

## Relevant technical choices:

* We don't really need to grab all the term objects for every single taxonomy sitemap, we only need the ones necessary to build the current sitemap being requested.
* I'm adding some arguments to `get_terms()` to improve performance:

`
$terms          = get_terms( $taxonomy->name, [ 'hide_empty' => $hide_empty_tax, 'update_term_meta_cache' => false, 'offset' => $offset, 'number' => $steps ] );
`
* In my testing where I had taxonomy sitemaps at 50 items max, on a site with over `30000` terms, the response times went from around 40+ seconds to around 10 seconds.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure Taxonomy Sitemaps are enabled
* It's useful to have a site with many many terms and many items in each term to notice the difference.  
* Try setting a few different max items per sitemap
* Load many different taxonomy sitemap pages to make sure you get the expected items


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.



## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* Taxonomy Sitemaps

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/6761 (partly)
