### PR TITLE
P2-558 Register replacevars in the schema-blocks integration.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=463",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=460",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=228",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -212,6 +212,19 @@ class WPSEO_Replace_Vars {
 	}
 
 	/**
+	 * Checks whether the given replacement variable has already been registered or not.
+	 *
+	 * @param string $replacement_variable The replacement variable to check, including the variable delimiter (e.g. `%%var%%`).
+	 *
+	 * @return bool `true` if the replacement variable has already been registered.
+	 */
+	public function has_been_registered( $replacement_variable ) {
+		$replacement_variable = self::remove_var_delimiter( $replacement_variable );
+
+		return isset( self::$external_replacements[ $replacement_variable ] );
+	}
+
+	/**
 	 * Retrieve the replacements for the variables found.
 	 *
 	 * @param array $matches Variables found in the original string - regex result.

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -119,8 +119,6 @@ class Schema_Generator implements Generator_Interface {
 			}
 		}
 
-		$this->register_replace_vars( $context );
-
 		foreach ( $context->blocks as $block_type => $blocks ) {
 			foreach ( $blocks as $block ) {
 				/**
@@ -217,29 +215,6 @@ class Schema_Generator implements Generator_Interface {
 		 * @api array $pieces The schema pieces.
 		 */
 		return \apply_filters( 'wpseo_schema_graph_pieces', $schema_pieces, $context );
-	}
-
-	/**
-	 * Registers the Schema related replace vars.
-	 *
-	 * @param Meta_Tags_Context $context The meta tags context.
-	 *
-	 * @return void
-	 */
-	protected function register_replace_vars( Meta_Tags_Context $context ) {
-		WPSEO_Replace_Vars::register_replacement(
-			'%%main_schema_id%%',
-			static function() use ( $context ) {
-				return $context->main_schema_id;
-			}
-		);
-
-		WPSEO_Replace_Vars::register_replacement(
-			'%%author_id%%',
-			function() use ( $context ) {
-				return $this->helpers->schema->id->get_user_schema_id( $context->indexable->author_id, $context );
-			}
-		);
 	}
 
 	/**

--- a/src/integrations/schema-blocks.php
+++ b/src/integrations/schema-blocks.php
@@ -3,7 +3,11 @@
 namespace Yoast\WP\SEO\Integrations;
 
 use WPSEO_Admin_Asset_Manager;
+use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Schema_Blocks_Conditional;
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
+use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 
 /**
  * Loads schema block templates into Gutenberg.
@@ -25,6 +29,20 @@ class Schema_Blocks implements Integration_Interface {
 	protected $asset_manager;
 
 	/**
+	 * The meta tags context memoizer.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	protected $meta_tags_context_memoizer;
+
+	/**
+	 * The ID helper.
+	 *
+	 * @var ID_Helper
+	 */
+	protected $id_helper;
+
+	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
 	 * @return array
@@ -38,10 +56,18 @@ class Schema_Blocks implements Integration_Interface {
 	/**
 	 * Schema_Blocks constructor.
 	 *
-	 * @param WPSEO_Admin_Asset_Manager $asset_manager The asset manager.
+	 * @param WPSEO_Admin_Asset_Manager  $asset_manager              The asset manager.
+	 * @param Meta_Tags_Context_Memoizer $meta_tags_context_memoizer The meta tags context memoizer.
+	 * @param ID_Helper                  $id_helper                  The ID helper.
 	 */
-	public function __construct( WPSEO_Admin_Asset_Manager $asset_manager ) {
-		$this->asset_manager = $asset_manager;
+	public function __construct(
+		WPSEO_Admin_Asset_Manager $asset_manager,
+		Meta_Tags_Context_Memoizer $meta_tags_context_memoizer,
+		ID_Helper $id_helper
+	) {
+		$this->asset_manager              = $asset_manager;
+		$this->meta_tags_context_memoizer = $meta_tags_context_memoizer;
+		$this->id_helper                  = $id_helper;
 	}
 
 	/**
@@ -54,6 +80,7 @@ class Schema_Blocks implements Integration_Interface {
 	public function register_hooks() {
 		\add_action( 'enqueue_block_editor_assets', [ $this, 'load' ] );
 		\add_action( 'admin_enqueue_scripts', [ $this, 'output' ] );
+		\add_action( 'wpseo_json_ld', [ $this, 'register_replace_vars' ] );
 	}
 
 	/**
@@ -81,6 +108,29 @@ class Schema_Blocks implements Integration_Interface {
 	public function load() {
 		$this->asset_manager->enqueue_script( 'schema-blocks' );
 		$this->asset_manager->enqueue_style( 'schema-blocks' );
+	}
+
+	/**
+	 * Registers the Schema related replace vars.
+	 *
+	 * @return void
+	 */
+	public function register_replace_vars() {
+		$context = $this->meta_tags_context_memoizer->for_current_page();
+
+		WPSEO_Replace_Vars::register_replacement(
+			'%%main_schema_id%%',
+			static function() use ( $context ) {
+				return $context->main_schema_id;
+			}
+		);
+
+		WPSEO_Replace_Vars::register_replacement(
+			'%%author_id%%',
+			function() use ( $context ) {
+				return $this->id_helper->get_user_schema_id( $context->indexable->author_id, $context );
+			}
+		);
 	}
 
 	/**

--- a/src/integrations/schema-blocks.php
+++ b/src/integrations/schema-blocks.php
@@ -43,6 +43,13 @@ class Schema_Blocks implements Integration_Interface {
 	protected $id_helper;
 
 	/**
+	 * The replace vars helper.
+	 *
+	 * @var WPSEO_Replace_Vars
+	 */
+	protected $replace_vars;
+
+	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
 	 * @return array
@@ -58,15 +65,18 @@ class Schema_Blocks implements Integration_Interface {
 	 *
 	 * @param WPSEO_Admin_Asset_Manager  $asset_manager              The asset manager.
 	 * @param Meta_Tags_Context_Memoizer $meta_tags_context_memoizer The meta tags context memoizer.
+	 * @param WPSEO_Replace_Vars         $replace_vars               The replace vars helper.
 	 * @param ID_Helper                  $id_helper                  The ID helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
 		Meta_Tags_Context_Memoizer $meta_tags_context_memoizer,
+		WPSEO_Replace_Vars $replace_vars,
 		ID_Helper $id_helper
 	) {
 		$this->asset_manager              = $asset_manager;
 		$this->meta_tags_context_memoizer = $meta_tags_context_memoizer;
+		$this->replace_vars               = $replace_vars;
 		$this->id_helper                  = $id_helper;
 	}
 
@@ -118,19 +128,23 @@ class Schema_Blocks implements Integration_Interface {
 	public function register_replace_vars() {
 		$context = $this->meta_tags_context_memoizer->for_current_page();
 
-		WPSEO_Replace_Vars::register_replacement(
-			'%%main_schema_id%%',
-			static function() use ( $context ) {
-				return $context->main_schema_id;
-			}
-		);
+		if ( ! $this->replace_vars->has_been_registered( '%%main_schema_id%%' ) ) {
+			WPSEO_Replace_Vars::register_replacement(
+				'%%main_schema_id%%',
+				static function() use ( $context ) {
+					return $context->main_schema_id;
+				}
+			);
+		}
 
-		WPSEO_Replace_Vars::register_replacement(
-			'%%author_id%%',
-			function() use ( $context ) {
-				return $this->id_helper->get_user_schema_id( $context->indexable->author_id, $context );
-			}
-		);
+		if ( ! $this->replace_vars->has_been_registered( '%%author_id%%' ) ) {
+			WPSEO_Replace_Vars::register_replacement(
+				'%%author_id%%',
+				function() use ( $context ) {
+					return $this->id_helper->get_user_schema_id( $context->indexable->author_id, $context );
+				}
+			);
+		}
 	}
 
 	/**

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -168,11 +168,6 @@ class Schema_Generator_Test extends TestCase {
 	 */
 	public function test_generate_with_no_graph() {
 		$this->instance
-			->expects( 'register_replace_vars' )
-			->with( $this->context )
-			->once();
-
-		$this->instance
 			->expects( 'get_graph_pieces' )
 			->once()
 			->andReturn( [] );
@@ -193,11 +188,6 @@ class Schema_Generator_Test extends TestCase {
 	 * @covers ::get_graph_pieces
 	 */
 	public function test_generate_with_no_blocks() {
-		$this->instance
-			->expects( 'register_replace_vars' )
-			->with( $this->context )
-			->once();
-
 		$this->context->indexable->object_sub_type = 'super-custom-post-type';
 
 		Monkey\Functions\expect( 'is_single' )
@@ -268,11 +258,6 @@ class Schema_Generator_Test extends TestCase {
 	 */
 	public function test_generate_with_blocks() {
 		$this->stubEscapeFunctions();
-
-		$this->instance
-			->expects( 'register_replace_vars' )
-			->with( $this->context )
-			->once();
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
@@ -417,11 +402,6 @@ class Schema_Generator_Test extends TestCase {
 	public function test_generate_with_generator_have_identifier() {
 		$this->stubEscapeFunctions();
 
-		$this->instance
-			->expects( 'register_replace_vars' )
-			->with( $this->context )
-			->once();
-
 		$piece             = new FAQ();
 		$piece->identifier = 'faq_block';
 		$this->instance
@@ -447,11 +427,6 @@ class Schema_Generator_Test extends TestCase {
 	 */
 	public function test_generate_with_block_not_having_generated_output() {
 		$this->stubEscapeFunctions();
-
-		$this->instance
-			->expects( 'register_replace_vars' )
-			->with( $this->context )
-			->once();
 
 		Monkey\Functions\expect( 'is_single' )
 			->once()
@@ -492,11 +467,6 @@ class Schema_Generator_Test extends TestCase {
 	 * @covers ::validate_type
 	 */
 	public function test_validate_type_singular_array() {
-		$this->instance
-			->expects( 'register_replace_vars' )
-			->with( $this->context )
-			->once();
-
 		$this->context->blocks = [];
 
 		Monkey\Functions\expect( 'is_single' )
@@ -567,11 +537,6 @@ class Schema_Generator_Test extends TestCase {
 	 * @covers ::validate_type
 	 */
 	public function test_validate_type_unique_array() {
-		$this->instance
-			->expects( 'register_replace_vars' )
-			->with( $this->context )
-			->once();
-
 		$this->context->blocks = [];
 
 		Monkey\Functions\expect( 'is_single' )
@@ -640,11 +605,6 @@ class Schema_Generator_Test extends TestCase {
 	 * @covers ::get_graph_pieces
 	 */
 	public function test_get_graph_pieces_on_single_post_with_password_required() {
-		$this->instance
-			->expects( 'register_replace_vars' )
-			->with( $this->context )
-			->once();
-
 		Monkey\Functions\expect( 'is_single' )
 			->once()
 			->withNoArgs()

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -6,7 +6,9 @@ use Brain\Monkey;
 use Mockery;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Schema_Blocks_Conditional;
+use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Integrations\Schema_Blocks;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -34,13 +36,34 @@ class Schema_Blocks_Test extends TestCase {
 	protected $asset_manager;
 
 	/**
+	 * The meta tags context memoizer.
+	 *
+	 * @var Mockery\MockInterface|Meta_Tags_Context_Memoizer
+	 */
+	protected $meta_tags_context_memoizer;
+
+	/**
+	 * The ID helper.
+	 *
+	 * @var Mockery\MockInterface|ID_Helper
+	 */
+	protected $id_helper;
+
+	/**
 	 * Runs the setup to prepare the needed instance.
 	 */
 	public function set_up() {
 		parent::set_up();
 
-		$this->asset_manager = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
-		$this->instance      = new Schema_Blocks( $this->asset_manager );
+		$this->asset_manager              = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
+		$this->meta_tags_context_memoizer = Mockery::mock( Meta_Tags_Context_Memoizer::class );
+		$this->id_helper                  = Mockery::mock( ID_Helper::class );
+
+		$this->instance = new Schema_Blocks(
+			$this->asset_manager,
+			$this->meta_tags_context_memoizer,
+			$this->id_helper
+		);
 	}
 
 	/**

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -57,11 +57,13 @@ class Schema_Blocks_Test extends TestCase {
 
 		$this->asset_manager              = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
 		$this->meta_tags_context_memoizer = Mockery::mock( Meta_Tags_Context_Memoizer::class );
+		$this->replace_vars               = Mockery::mock( \WPSEO_Replace_Vars::class );
 		$this->id_helper                  = Mockery::mock( ID_Helper::class );
 
 		$this->instance = new Schema_Blocks(
 			$this->asset_manager,
 			$this->meta_tags_context_memoizer,
+			$this->replace_vars,
 			$this->id_helper
 		);
 	}
@@ -74,6 +76,7 @@ class Schema_Blocks_Test extends TestCase {
 	public function test_constructor() {
 		static::assertInstanceOf( WPSEO_Admin_Asset_Manager::class, $this->getPropertyValue( $this, 'asset_manager' ) );
 		static::assertInstanceOf( Meta_Tags_Context_Memoizer::class, $this->getPropertyValue( $this, 'meta_tags_context_memoizer' ) );
+		static::assertInstanceOf( \WPSEO_Replace_Vars::class, $this->getPropertyValue( $this, 'replace_vars' ) );
 		static::assertInstanceOf( ID_Helper::class, $this->getPropertyValue( $this, 'id_helper' ) );
 	}
 

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -73,6 +73,8 @@ class Schema_Blocks_Test extends TestCase {
 	 */
 	public function test_constructor() {
 		static::assertInstanceOf( WPSEO_Admin_Asset_Manager::class, $this->getPropertyValue( $this, 'asset_manager' ) );
+		static::assertInstanceOf( Meta_Tags_Context_Memoizer::class, $this->getPropertyValue( $this, 'meta_tags_context_memoizer' ) );
+		static::assertInstanceOf( ID_Helper::class, $this->getPropertyValue( $this, 'id_helper' ) );
 	}
 
 	/**
@@ -98,6 +100,7 @@ class Schema_Blocks_Test extends TestCase {
 		$this->instance->register_hooks();
 
 		Monkey\Actions\has( 'enqueue_block_editor_assets', [ $this->instance, 'load' ] );
+		Monkey\Actions\has( 'wpseo_json_ld', [ $this->instance, 'register_replace_vars' ] );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The `generate` code in the schema blocks generator is called multiple times, which means that we tried to register some replacement variables multiple times, leading to a PHP warning in the post editor.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where warnings about replacement variables were shown in the post editor.

## Relevant technical choices:

* Decided to move the registration of the replacement variables to the `Schema_Blocks_Integration`, 
  * To make sure that it is only called when the schema blocks feature flag is enabled.
* Hooked into the `wpseo_json_ld` action for registering the replace vars.
  * Since we need the replace vars to be registered before the schema output, and this hook triggers right before generating and outputting the schema, it seemed like the most appropriate hook. I am open for other suggestions, though. (`wpseo_head`?).
* Retrieving the meta tags context through the memoizer should make sure that it does not have a performance impact, since the context is memoized. If it was generated before, we use that.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Reproducing the bug
* Go to a post in the post editor.
* You should see PHP warning messages at the top of the page or in the admin sidebar.
  * Either as this:
    ![PHP warnings](https://user-images.githubusercontent.com/10195175/100992357-61d7f500-3554-11eb-8f1e-1ad7b026992a.jpg)
  * Or as this (in the admin sidebar):
    <img width="300" alt="Screenshot 2020-12-03 at 10 46 45" src="https://user-images.githubusercontent.com/10195175/100992800-e75ba500-3554-11eb-9d2f-68154e61471a.png">

#### Checking if the bug is fixed
* Go to a post in the post editor.
* You should not see any PHP warning messages.

#### Regression testing
* Make sure that the schema blocks feature flag is enabled.
  * E.g. make sure that you have this line in your WordPress config PHP file:
    ```php
    define( 'YOAST_SEO_SCHEMA_BLOCKS', true );
    ```
* Create a new post.
* Add a Recipe block to the post.
* Save the post.
* View the post on the frontend.
* Check the schema output.
  * It should contain this schema piece:
    ```json
    {
	   "@type": "Recipe",
	   "@id": "http://basic.wordpress.test/hello-world/#/schema/yoast-recipe-1",
	   "mainEntityOfPage": {
	        "@id": "http://basic.wordpress.test/hello-world/#webpage"
	    },
	    "name": "A Recipe",
	    "author": {
	         "@id": "http://basic.wordpress.test/#/schema/person/a00dc884baa6bd52ebacc06cfd5aab21"
	    }
	}
    ```
  * In the schema piece, check whether:
     * The ID of the `author` is the same the ID of the author schema piece.
     * The ID of the `mainEntityOfPage` is the same as the ID of the webpage schema piece.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
