### PR TITLE
P1-286 Fix socials translations

### DIFF
--- a/js/src/components/social/SocialUpsell.js
+++ b/js/src/components/social/SocialUpsell.js
@@ -32,7 +32,7 @@ const SocialUpsell = ( props ) => {
 	const previewText = sprintf(
 		/* Translators: %s expands to the social medium name, which is either Twitter or Facebook. %s expands to Yoast SEO Premium */
 		__(
-			"Do you want to preview what it will look like if people share this post on %s? You can, with %s.", "yoast-components"
+			"Do you want to preview what it will look like if people share this post on %s? You can, with %s.", "wordpress-seo"
 		), props.socialMediumName, " {{strong}}Yoast SEO Premium{{/strong}}"
 	);
 

--- a/js/src/components/social/SocialUpsell.js
+++ b/js/src/components/social/SocialUpsell.js
@@ -14,13 +14,6 @@ const PremiumInfoText = styled( Alert )`
 
 const YoastShortLink = makeOutboundLink();
 
-const upgradeText = sprintf(
-	/* Translators: %s expands to Yoast SEO Premium */
-	__(
-		"Find out why you should upgrade to %s", "yoast-components"
-	), "Yoast SEO Premium"
-);
-
 /**
  *
  * @param {Object} props The properties passed to this component.
@@ -34,6 +27,12 @@ const SocialUpsell = ( props ) => {
 		__(
 			"Do you want to preview what it will look like if people share this post on %s? You can, with %s.", "wordpress-seo"
 		), props.socialMediumName, " {{strong}}Yoast SEO Premium{{/strong}}"
+	);
+	const upgradeText = sprintf(
+		/* Translators: %s expands to Yoast SEO Premium */
+		__(
+			"Find out why you should upgrade to %s", "wordpress-seo"
+		), "Yoast SEO Premium"
 	);
 
 	return (

--- a/js/src/containers/FacebookEditor.js
+++ b/js/src/containers/FacebookEditor.js
@@ -11,20 +11,6 @@ import withLocation from "../helpers/withLocation";
 
 const socialMediumName = "Facebook";
 
-/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-const titleInputPlaceholder  = sprintf(
-	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-	__( "Modify your %s title by editing it right here...", "wordpress-seo" ),
-	socialMediumName
-);
-
-/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-const descriptionInputPlaceholder  = sprintf(
-	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-	__( "Modify your %s description by editing it right here...", "wordpress-seo" ),
-	socialMediumName
-);
-
 /**
  * The cached instance of the media object.
  *
@@ -83,6 +69,20 @@ export default compose( [
 			getSiteUrl,
 			getAuthorName,
 		} = select( "yoast-seo/editor" );
+
+		/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+		const titleInputPlaceholder  = sprintf(
+			/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+			__( "Modify your %s title by editing it right here...", "wordpress-seo" ),
+			socialMediumName
+		);
+
+		/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+		const descriptionInputPlaceholder  = sprintf(
+			/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+			__( "Modify your %s description by editing it right here...", "wordpress-seo" ),
+			socialMediumName
+		);
 
 		return {
 			imageUrl: getFacebookImageUrl(),

--- a/js/src/containers/FacebookEditor.js
+++ b/js/src/containers/FacebookEditor.js
@@ -14,14 +14,14 @@ const socialMediumName = "Facebook";
 /* Translators: %s expands to the social medium name, i.e. Faceboook. */
 const titleInputPlaceholder  = sprintf(
 	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-	__( "Modify your %s title by editing it right here...", "yoast-components" ),
+	__( "Modify your %s title by editing it right here...", "wordpress-seo" ),
 	socialMediumName
 );
 
 /* Translators: %s expands to the social medium name, i.e. Faceboook. */
 const descriptionInputPlaceholder  = sprintf(
 	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-	__( "Modify your %s description by editing it right here...", "yoast-components" ),
+	__( "Modify your %s description by editing it right here...", "wordpress-seo" ),
 	socialMediumName
 );
 

--- a/js/src/containers/TwitterEditor.js
+++ b/js/src/containers/TwitterEditor.js
@@ -11,20 +11,6 @@ import withLocation from "../helpers/withLocation";
 
 const socialMediumName = "Twitter";
 
-/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-const titleInputPlaceholder  = sprintf(
-	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-	__( "Modify your %s title by editing it right here...", "wordpress-seo" ),
-	socialMediumName
-);
-
-/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-const descriptionInputPlaceholder  = sprintf(
-	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-	__( "Modify your %s description by editing it right here...", "wordpress-seo" ),
-	socialMediumName
-);
-
 /**
  * The cached instance of the media object.
  *
@@ -88,6 +74,21 @@ export default compose( [
 			getSiteUrl,
 			getAuthorName,
 		} = select( "yoast-seo/editor" );
+
+		/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+		const titleInputPlaceholder  = sprintf(
+			/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+			__( "Modify your %s title by editing it right here...", "wordpress-seo" ),
+			socialMediumName
+		);
+
+		/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+		const descriptionInputPlaceholder  = sprintf(
+			/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+			__( "Modify your %s description by editing it right here...", "wordpress-seo" ),
+			socialMediumName
+		);
+
 		return {
 			imageUrl: getTwitterImageUrl(),
 			imageFallbackUrl: getFacebookImageUrl() || getImageFallback(),

--- a/js/src/containers/TwitterEditor.js
+++ b/js/src/containers/TwitterEditor.js
@@ -14,14 +14,14 @@ const socialMediumName = "Twitter";
 /* Translators: %s expands to the social medium name, i.e. Faceboook. */
 const titleInputPlaceholder  = sprintf(
 	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-	__( "Modify your %s title by editing it right here...", "yoast-components" ),
+	__( "Modify your %s title by editing it right here...", "wordpress-seo" ),
 	socialMediumName
 );
 
 /* Translators: %s expands to the social medium name, i.e. Faceboook. */
 const descriptionInputPlaceholder  = sprintf(
 	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-	__( "Modify your %s description by editing it right here...", "yoast-components" ),
+	__( "Modify your %s description by editing it right here...", "wordpress-seo" ),
 	socialMediumName
 );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We had some mistakes with translations. There are more mistakes, but this covers the social previews placeholders and info text only. The social preview labels for example should be covered by this issue: https://yoast.atlassian.net/browse/QAK-2529

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the social preview placeholders and info text where not translated.

## Relevant technical choices:

1. Use the correct text domain in the plugin itself: `wordpress-seo`.
1. If a file is imported before we pass the translations to `@wordpress/i18n` (see the i18n helpers), the translations won't work. This is now prevented by moving them to the function in which they are used.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Switch the site language to non-English
* Edit a post
* Open the social previews: Facebook and Twitter
* Verify the upsell text is now translated (when available in the language you selected I check with Dutch).
* Verify the placeholders are now translated.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
