### PR TITLE
Only set the state after the component has mounted

### DIFF
--- a/js/src/dashboard-widget.js
+++ b/js/src/dashboard-widget.js
@@ -24,7 +24,14 @@ class DashboardWidget extends Component {
 			feed: null,
 			isDataFetched: false,
 		};
+	}
 
+	/**
+	 * Watches whether the data for the widget should be fetched.
+	 *
+	 * @returns {void}
+	 */
+	componentDidMount() {
 		const widgetCheckbox = jQuery( "#wpseo-dashboard-overview-hide" );
 
 		// Only fetch the data if the Yoast SEO dashboard widget is checked in the Screen Options.

--- a/js/src/dashboard-widget.js
+++ b/js/src/dashboard-widget.js
@@ -5,7 +5,6 @@ import { ArticleList as WordpressFeed } from "@yoast/components";
 import { colors } from "@yoast/style-guide";
 import { SiteSEOReport as SeoAssessment } from "@yoast/analysis-report";
 import { getPostFeed } from "@yoast/helpers";
-import domReady from "@wordpress/dom-ready";
 
 // Internal dependencies.
 import { setYoastComponentsL10n } from "./helpers/i18n";
@@ -52,10 +51,8 @@ class DashboardWidget extends Component {
 		this.getStatistics();
 		this.getFeed();
 
-		domReady( () => {
-			this.setState( {
-				isDataFetched: true,
-			} );
+		this.setState( {
+			isDataFetched: true,
 		} );
 	}
 

--- a/js/src/dashboard-widget.js
+++ b/js/src/dashboard-widget.js
@@ -5,6 +5,7 @@ import { ArticleList as WordpressFeed } from "@yoast/components";
 import { colors } from "@yoast/style-guide";
 import { SiteSEOReport as SeoAssessment } from "@yoast/analysis-report";
 import { getPostFeed } from "@yoast/helpers";
+import domReady from "@wordpress/dom-ready";
 
 // Internal dependencies.
 import { setYoastComponentsL10n } from "./helpers/i18n";
@@ -51,8 +52,10 @@ class DashboardWidget extends Component {
 		this.getStatistics();
 		this.getFeed();
 
-		this.setState( {
-			isDataFetched: true,
+		domReady( () => {
+			this.setState( {
+				isDataFetched: true,
+			} );
 		} );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This prevents a console warning.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where a console warning would be output on the WordPress dashboard when the Yoast SEO widget was enabled.

## Relevant technical choices:

* Because the warning said that `setState` cannot be called on a component that is not yet mounted, I'm now first checking whether the DOM is ready.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Please make sure that https://github.com/Yoast/wordpress-seo/pull/16383 still works as expected.
* In addition, you should _not_ see a console warning about the Yoast dashboard widget when you're on the WordPress dashboard and have the Yoast dashboard widget enabled.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-559
