### PR TITLE
Remove about page remnants.

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -315,27 +315,10 @@ class WPSEO_Admin {
 				'<code>%s</code>',
 				'HelpScout beacon'
 			),
-			'dismiss_about_url'       => $this->get_dismiss_url( 'wpseo-dismiss-about' ),
 			/* translators: %s: expends to Yoast SEO */
 			'help_video_iframe_title' => sprintf( __( '%s video tutorial', 'wordpress-seo' ), 'Yoast SEO' ),
 			'scrollable_table_hint'   => __( 'Scroll to see the table content.', 'wordpress-seo' ),
 		];
-	}
-
-	/**
-	 * Extending the current page URL with two params to be able to ignore the notice.
-	 *
-	 * @param string $dismiss_param The param used to dismiss the notification.
-	 *
-	 * @return string
-	 */
-	private function get_dismiss_url( $dismiss_param ) {
-		$arr_params = [
-			$dismiss_param => '1',
-			'nonce'        => wp_create_nonce( $dismiss_param ),
-		];
-
-		return esc_url( add_query_arg( $arr_params ) );
 	}
 
 	/**

--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -11,13 +11,6 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
-if ( filter_input( INPUT_GET, 'intro' ) ) {
-	update_user_meta( get_current_user_id(), 'wpseo_seen_about_version', WPSEO_VERSION );
-	require WPSEO_PATH . 'admin/views/about.php';
-
-	return;
-}
-
 if ( isset( $_GET['allow_tracking'] ) && check_admin_referer( 'wpseo_activate_tracking', 'nonce' ) ) {
 	WPSEO_Options::set( 'yoast_tracking', ( $_GET['allow_tracking'] === 'yes' ) );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Picked up from the WPSEO CS Cleanup spreadsheet. This tiny PR seeks to remove remnants related to the old "about" page.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes unused code related to the old About page.

## Relevant technical choices:

- Yoast SEO used to have an "About" page accessible at the URL `wp-admin/admin.php?page=wpseo_dashboard&intro=1`
- That page was removed starting from #5504 and following changes.
- Right now, trying to access that URL (which users might have bookmarked, for example), makes WordPress print out the following error message on the page: "There has been a critical error on your website. Please check your site admin email inbox for instructions."
- This PR removes the unused code related to the About page.
- It does _not_ remove the user meta `wpseo_seen_about_version` that might still be stored in the users database. I guess removing this meta would require an upgrade routine, which seems a bit overkill. A decision should be made on this point.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- build the plugin
- from any page in WordPress, try to access the URL `wp-admin/admin.php?page=wpseo_dashboard&intro=1` by manually changing the URL in your browser's address bar and by pressing Enter
- observe you're brought to the SEO > Genera page
- check there are no errors


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #14374 
