### PR TITLE
Disable the Usage tracking feature toggle on multisite subsites

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -760,6 +760,11 @@ class Yoast_Form {
 	 * @return mixed|null The retrieved value.
 	 */
 	protected function get_field_value( $field_name, $default_value = null ) {
+		// On multisite subsites, the Usage tracking feature should always be set to Off.
+		if ( $this->is_tracking_on_subsite( $field_name ) ) {
+			return false;
+		}
+
 		return WPSEO_Options::get( $field_name, $default_value );
 	}
 
@@ -773,6 +778,11 @@ class Yoast_Form {
 	protected function is_control_disabled( $var ) {
 		if ( $this->option_instance === null ) {
 			return false;
+		}
+
+		// Disable the Usage tracking feature for multisite subsites.
+		if ( $this->is_tracking_on_subsite( $var ) ) {
+			return true;
 		}
 
 		return $this->option_instance->is_disabled( $var );
@@ -790,6 +800,24 @@ class Yoast_Form {
 			return '';
 		}
 
-		return '<p class="disabled-note">' . esc_html__( 'This feature has been disabled by the network admin.', 'wordpress-seo' ) . '</p>';
+		$disabled_message = esc_html__( 'This feature has been disabled by the network admin.', 'wordpress-seo' );
+
+		// The explanation to show when disabling the Usage tracking feature for multisite subsites.
+		if ( $this->is_tracking_on_subsite( $var ) ) {
+			$disabled_message = esc_html__( 'This feature has been disabled since subsites never send tracking data.', 'wordpress-seo' );
+		}
+		return '<p class="disabled-note">' . $disabled_message . '</p>';
+	}
+
+	/**
+	 * Determines whether we are dealing with the Usage tracking feature on a multisite subsite.
+	 * This feature requires specific behavior for the toggle switch.
+	 *
+	 * @param string $feature_setting The feature setting.
+	 *
+	 * @return boolean True if we are dealing with the Usage tracking feature on a multisite subsite.
+	 */
+	protected function is_tracking_on_subsite( $feature_setting ) {
+		return ( $feature_setting === 'tracking' && ! is_network_admin() && ! is_main_site() );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Subsites in a multisite network never send tracking data. Therefore, we don't want to confuse the user by showing a toggle for this feature, suggesting that they have control over it. In this PR, the toggle for the tracking feature is always disabled on multisite subsites.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where subsites in a multisite network could have an enabled feature toggle for the `Usage tracking` feature, even though subsites never send tracking data.

## Relevant technical choices:

* I couldn't find a specific function to check if a site is a subsite, therefore I used `! is_network_admin() && ! is_main_site()`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Get a multisite environment running (in Docker, you can use `./start.sh multisite-wordpress`).
* Test in the backend of three websites:
    * The network admin (`http://multisite.wordpress.test/wp-admin/network`).
    * The main site (`http://multisite.wordpress.test/wp-admin`).
    * A sub site (for example, `http://multisite.wordpress.test/site2/wp-admin`).
* In SEO > General > Features:
    * In the network admin, make sure that `Usage tracking` is set to `Allow control`.
    * In the main site, check that the `Usage tracking` feature toggle is still enabled.
    * In the subsite, check that the `Usage tracking` feature toggle is disabled, with the toggle set to `Off`, and accompanied by this message: "This feature has been disabled since subsites never send tracking data." The button should look like this:

<img width="449" alt="Screenshot 2020-12-04 at 16 01 48" src="https://user-images.githubusercontent.com/20280513/101326894-3748ad80-386e-11eb-9568-182f1b8c2b30.png">


* In SEO > General > Features:
    * In the network admin, set `Usage tracking` to `Disable`.
    * In the main site, check that the `Usage tracking` feature toggle is now disabled, and accompanied by this message: "This feature has been disabled by the network admin."
    * In the subsite, nothing should have changed.

* Without this PR, the behavior of the feature toggle on the subsite was identical to that of the main site, except that the tracking would never work regardless of whether it was `On` or `Off`.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The features page. Note that although this PR is about tracking, the actual tracking class (`class-tracking.php`) has not been touched, and therefore no functionality change is expected there.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-552
