### PR TITLE
Create job title block

### DIFF
--- a/src/schema-templates/job-title.block.php
+++ b/src/schema-templates/job-title.block.php
@@ -1,0 +1,5 @@
+<?php // phpcs:ignore Internal.NoCodeFound ?>
+{{block name="yoast/job-title" title="Job title" category="common" parent=[ "yoast/job-posting" ] }}
+<div class={{class-name}}>
+	{{variable-tag-rich-text name="title" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="Enter job title"}}
+</div>

--- a/src/schema-templates/job-title.schema.php
+++ b/src/schema-templates/job-title.schema.php
@@ -1,0 +1,5 @@
+<?php // phpcs:ignore Internal.NoCodeFound ?>
+{{schema name="yoast/job-title" only-nested=true}}
+{
+	"name": {{html name="title"}},
+}

--- a/src/schema-templates/job-title.schema.php
+++ b/src/schema-templates/job-title.schema.php
@@ -1,5 +1,5 @@
 <?php // phpcs:ignore Internal.NoCodeFound ?>
 {{schema name="yoast/job-title" only-nested=true}}
 {
-	"name": {{html name="title"}},
+	"name": {{html name="title"}}
 }

--- a/tests/unit/dependency-injection/schema-templates-loader-test.php
+++ b/tests/unit/dependency-injection/schema-templates-loader-test.php
@@ -36,7 +36,7 @@ class Schema_Templates_Loader_Test extends TestCase {
 	 * @covers ::get_templates
 	 */
 	public function test_get_templates() {
-		$schema_directory = dirname( WPSEO_FILE ) . '/src/schema-templates/';
+		$schema_directory = \dirname( WPSEO_FILE ) . '/src/schema-templates/';
 
 		$expected_schema_blocks = [
 			$schema_directory . 'address.block.php',
@@ -44,6 +44,8 @@ class Schema_Templates_Loader_Test extends TestCase {
 			$schema_directory . 'image.schema.php',
 			$schema_directory . 'ingredients.block.php',
 			$schema_directory . 'ingredients.schema.php',
+			$schema_directory . 'job-title.block.php',
+			$schema_directory . 'job-title.schema.php',
 			$schema_directory . 'recipe.block.php',
 			$schema_directory . 'recipe.schema.php',
 			$schema_directory . 'step.block.php',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Creates the block and schema template for the job title.

## Relevant technical choices:

* I used `recipe.block.php` as an example for the block template. That template has headers "h1" up until "h6", but I used "h2" as the biggest header for the job title block, because the job title block will always be nested within the job posting block.
* I used `recipe.schema.php` and `ingredients.schema.php` as an example for the schema template.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Turn on the feature flag and link the monorepo.
* Remove ` parent=[ "yoast/job-posting" ] ` from `job-title.block.php`. Otherwise the job title block won't be visible.
* Create a new post and add the job title block.
* See it appear with a placeholder:

<img width="270" alt="Screenshot 2020-12-08 at 10 02 02" src="https://user-images.githubusercontent.com/20280513/101462347-6d546300-393c-11eb-88b6-5fefa6fb3030.png">

* I don't think the Schema output can yet be tested, since it doesn't have a `@type`.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* No need for QA to test this PR, it is just a building stone in the Schema blocks feature.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The structured data blocks.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-253
