### PR TITLE
P1-223 Add advanced replacement variables in Elementor

### DIFF
--- a/js/src/elementor/replaceVars/elementor-replacevar-plugin.js
+++ b/js/src/elementor/replaceVars/elementor-replacevar-plugin.js
@@ -52,12 +52,19 @@ const getReplacements = ( scope = "" ) => {
 				"excerpt",
 				"id",
 				"focusKeyphrase",
+				"modified",
+				"name",
 				"page",
+				"pageNumber",
+				"pageTotal",
+				"postTypeNamePlural",
+				"postTypeNameSingular",
 				"searchPhrase",
 				"separator",
 				"siteDescription",
 				"siteName",
 				"title",
+				"userDescription",
 			];
 		case "page":
 			return [
@@ -67,12 +74,19 @@ const getReplacements = ( scope = "" ) => {
 				"excerpt",
 				"id",
 				"focusKeyphrase",
+				"modified",
+				"name",
 				"page",
+				"pageNumber",
+				"pageTotal",
+				"postTypeNamePlural",
+				"postTypeNameSingular",
 				"searchPhrase",
 				"separator",
 				"siteDescription",
 				"siteName",
 				"title",
+				"userDescription",
 			];
 	}
 

--- a/js/src/elementor/replaceVars/general/excerpt.js
+++ b/js/src/elementor/replaceVars/general/excerpt.js
@@ -43,5 +43,5 @@ export default {
 		},
 	],
 	getReplacement,
-	regexp: new RegExp( "%%excerpt%%|%%excerpt_only%%|%%caption", "g" ),
+	regexp: new RegExp( "%%excerpt%%|%%excerpt_only%%|%%caption%%", "g" ),
 };

--- a/js/src/elementor/replaceVars/general/excerpt.js
+++ b/js/src/elementor/replaceVars/general/excerpt.js
@@ -36,12 +36,7 @@ export default {
 			label: "Excerpt only",
 			placeholder: "%%excerpt_only%%",
 		},
-		{
-			name: "caption",
-			label: "Caption",
-			placeholder: "%%caption%%",
-		},
 	],
 	getReplacement,
-	regexp: new RegExp( "%%excerpt%%|%%excerpt_only%%|%%caption%%", "g" ),
+	regexp: new RegExp( "%%excerpt%%|%%excerpt_only%%", "g" ),
 };

--- a/js/src/elementor/replaceVars/general/excerpt.js
+++ b/js/src/elementor/replaceVars/general/excerpt.js
@@ -36,7 +36,12 @@ export default {
 			label: "Excerpt only",
 			placeholder: "%%excerpt_only%%",
 		},
+		{
+			name: "caption",
+			label: "Caption",
+			placeholder: "%%caption%%",
+		},
 	],
 	getReplacement,
-	regexp: new RegExp( "%%excerpt%%|%%excerpt_only%%", "g" ),
+	regexp: new RegExp( "%%excerpt%%|%%excerpt_only%%|%%caption", "g" ),
 };

--- a/js/src/elementor/replaceVars/general/index.js
+++ b/js/src/elementor/replaceVars/general/index.js
@@ -4,16 +4,24 @@ export { default as date } from "./date";
 export { default as excerpt } from "./excerpt";
 export { default as focusKeyphrase } from "./focusKeyphrase";
 export { default as id } from "./id";
+export { default as modified } from "./modified";
+export { default as name } from "./name";
 export { default as page } from "./page";
+export { default as pageNumber } from "./pageNumber";
+export { default as pageTotal } from "./pageTotal";
+export { default as postTypeNamePlural } from "./postTypeNamePlural";
+export { default as postTypeNameSingular } from "./postTypeNameSingular";
 export { default as primaryCategory } from "./primaryCategory";
 export { default as searchPhrase } from "./searchPhrase";
 export { default as separator } from "./separator";
 export { default as siteDescription } from "./siteDescription";
 export { default as siteName } from "./siteName";
+export { default as term404 } from "./term404";
 export { default as termDescription } from "./termDescription";
 export { default as termHierarchy } from "./termHierarchy";
 export { default as termTitle } from "./termTitle";
 export { default as title } from "./title";
+export { default as userDescription } from "./userDescription";
 
 /*
  * Exports all the general replacement variables.

--- a/js/src/elementor/replaceVars/general/modified.js
+++ b/js/src/elementor/replaceVars/general/modified.js
@@ -1,0 +1,24 @@
+import { get } from "lodash";
+
+/**
+ * Returns the replacement for the %%modified%% variable.
+ *
+ * @returns {string} The modified time.
+ */
+function getReplacement() {
+	return get( window, "wpseoScriptData.analysis.plugins.replaceVars.replace_vars.modified", "" );
+}
+
+/**
+ * Represents the modified replacement variable.
+ *
+ * @returns {Object} The modified replacement variable.
+ */
+export default {
+	name: "modified",
+	label: "Modified",
+	placeholder: "%%modified%%",
+	aliases: [],
+	getReplacement,
+	regexp: new RegExp( "%%modified%%", "g" ),
+};

--- a/js/src/elementor/replaceVars/general/name.js
+++ b/js/src/elementor/replaceVars/general/name.js
@@ -1,0 +1,24 @@
+import { get } from "lodash";
+
+/**
+ * Returns the replacement for the %%name%% variable.
+ *
+ * @returns {string} The author's `nicename`.
+ */
+function getReplacement() {
+	return get( window, "wpseoScriptData.analysis.plugins.replaceVars.replace_vars.name", "" );
+}
+
+/**
+ * Represents the name replacement variable.
+ *
+ * @returns {Object} The name replacement variable.
+ */
+export default {
+	name: "name",
+	label: "Name",
+	placeholder: "%%name%%",
+	aliases: [],
+	getReplacement,
+	regexp: new RegExp( "%%name%%", "g" ),
+};

--- a/js/src/elementor/replaceVars/general/pageNumber.js
+++ b/js/src/elementor/replaceVars/general/pageNumber.js
@@ -1,0 +1,24 @@
+import { get } from "lodash";
+
+/**
+ * Returns the replacement for the %%pagenumber%% variable.
+ *
+ * @returns {string} The page number.
+ */
+function getReplacement() {
+	return get( window, "wpseoScriptData.analysis.plugins.replaceVars.replace_vars.pagenumber", "" );
+}
+
+/**
+ * Represents the page_number replacement variable.
+ *
+ * @returns {Object} The page number replacement variable.
+ */
+export default {
+	name: "pagenumber",
+	label: "Pagenumber",
+	placeholder: "%%pagenumber%%",
+	aliases: [],
+	getReplacement,
+	regexp: new RegExp( "%%pagenumber%%", "g" ),
+};

--- a/js/src/elementor/replaceVars/general/pageTotal.js
+++ b/js/src/elementor/replaceVars/general/pageTotal.js
@@ -1,0 +1,24 @@
+import { get } from "lodash";
+
+/**
+ * Returns the replacement for the %%pagetotal%% variable.
+ *
+ * @returns {string} The page total.
+ */
+function getReplacement() {
+	return get( window, "wpseoScriptData.analysis.plugins.replaceVars.replace_vars.pagetotal", "" );
+}
+
+/**
+ * Represents the page_total replacement variable.
+ *
+ * @returns {Object} The page total replacement variable.
+ */
+export default {
+	name: "pagetotal",
+	label: "Pagetotal",
+	placeholder: "%%pagetotal%%",
+	aliases: [],
+	getReplacement,
+	regexp: new RegExp( "%%pagetotal%%", "g" ),
+};

--- a/js/src/elementor/replaceVars/general/postTypeNamePlural.js
+++ b/js/src/elementor/replaceVars/general/postTypeNamePlural.js
@@ -1,0 +1,24 @@
+import { get } from "lodash";
+
+/**
+ * Returns the replacement for the %%pt_plural%% variable.
+ *
+ * @returns {string} The post type name plural.
+ */
+function getReplacement() {
+	return get( window, "wpseoScriptData.analysis.plugins.replaceVars.replace_vars.pt_plural", "" );
+}
+
+/**
+ * Represents the post type name singular replacement variable.
+ *
+ * @returns {Object} The post type name singular replacement variable.
+ */
+export default {
+	name: "pt_plural",
+	label: "Post type (plural)",
+	placeholder: "%%pt_plural%%",
+	aliases: [],
+	getReplacement,
+	regexp: new RegExp( "%%pt_plural%%", "g" ),
+};

--- a/js/src/elementor/replaceVars/general/postTypeNameSingular.js
+++ b/js/src/elementor/replaceVars/general/postTypeNameSingular.js
@@ -1,0 +1,24 @@
+import { get } from "lodash";
+
+/**
+ * Returns the replacement for the %%pt_single%% variable.
+ *
+ * @returns {string} The post type name singular.
+ */
+function getReplacement() {
+	return get( window, "wpseoScriptData.analysis.plugins.replaceVars.replace_vars.pt_single", "" );
+}
+
+/**
+ * Represents the post type name singular replacement variable.
+ *
+ * @returns {Object} The post type name singular replacement variable.
+ */
+export default {
+	name: "pt_single",
+	label: "Post type (singular)",
+	placeholder: "%%pt_single%%",
+	aliases: [],
+	getReplacement,
+	regexp: new RegExp( "%%pt_single%%", "g" ),
+};

--- a/js/src/elementor/replaceVars/general/term404.js
+++ b/js/src/elementor/replaceVars/general/term404.js
@@ -1,0 +1,24 @@
+import { get } from "lodash";
+
+/**
+ * Returns the replacement for the %%term404%% variable.
+ *
+ * @returns {string} The slug which caused the 404.
+ */
+function getReplacement() {
+	return get( window, "wpseoScriptData.analysis.plugins.replaceVars.replace_vars.term404", "" );
+}
+
+/**
+ * Represents the term404 replacement variable.
+ *
+ * @returns {Object} The term404 replacement variable.
+ */
+export default {
+	name: "term404",
+	label: "Term404",
+	placeholder: "%%term404%%",
+	aliases: [],
+	getReplacement,
+	regexp: new RegExp( "%%term404%%", "g" ),
+};

--- a/js/src/elementor/replaceVars/general/userDescription.js
+++ b/js/src/elementor/replaceVars/general/userDescription.js
@@ -1,0 +1,24 @@
+import { get } from "lodash";
+
+/**
+ * Returns the replacement for the %%user_description%% variable.
+ *
+ * @returns {string} The author's ‘Biographical Info’.
+ */
+function getReplacement() {
+	return get( window, "wpseoScriptData.analysis.plugins.replaceVars.replace_vars.user_description", "" );
+}
+
+/**
+ * Represents the name replacement variable.
+ *
+ * @returns {Object} The name replacement variable.
+ */
+export default {
+	name: "user_description",
+	label: "User description",
+	placeholder: "%%user_description%%",
+	aliases: [],
+	getReplacement,
+	regexp: new RegExp( "%%user_description%%", "g" ),
+};

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -526,6 +526,13 @@ class Elementor implements Integration_Interface {
 			'sep',
 			'page',
 			'currentyear',
+			'pt_single',
+			'pt_plural',
+			'modified',
+			'name',
+			'user_description',
+			'pagetotal',
+			'pagenumber',
 		];
 
 		foreach ( $vars_to_cache as $var ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds advanced snippet variables in the Google preview of our Elementor integration.

## Relevant technical choices:

* Use all added replacement variables, except term404,  on posts and pages
* Use wpseoScriptData to pass the replacement value from PHP to JS

### Known "issues"
* Only in the Google preview until https://yoast.atlassian.net/browse/P1-242 is done. Then also in the social previews.
* Translation of the labels not working. There is a separate issue for this: https://yoast.atlassian.net/browse/QAK-2530

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post in the Elementor editor.
* Open the Google preview.
* Try the replacement variables in the title or description:
  * Post type (singular) / `%%pt_single%%`: Replaced with the content type single label
  * Post type (plural) / `%%pt_plural%%`: Replaced with the content type plural label
  * Modified / `%%modified%%`: Replaced with the post/page modified time
  * Name / `%%name%%`: Replaced with the post/page author’s ‘nicename’
    * In the user profile you can fill in the nickname of the author and use that as display.
  * User description	/ `%%user_description%%`: Replaced with the post/page author’s ‘Biographical Info’
    * In the user profile you can fill the biographical info
  * Pagetotal / `%%pagetotal%%`: Replaced with the current page total
  * Pagenumber / `%%pagenumber%%`: Replaced with the current page number
    * To get another number than 1 you can add a post overview from Elementor Pro and switch page in the frontend. I don't know if/how you can do this in the backend.
  * _Note_ the missing Caption replacevar. I left that out as that is useful for attachments only.
  * _Note_ the missing Term404 replacevar. I left that out as Elementor is post/page only.
* They should change to the label when you enter the `%%` version in the input field.
* They should display the value in the preview.
* When you save the post and check the frontend, the value should be the same there.
  * _Note_ there might be an edge case like modified being different because you just saved. And these values (except caption) are only updated on page load.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Known missing
* Only in the Google preview until https://yoast.atlassian.net/browse/P1-242 is done.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-223
