### PR TITLE
Integration Tests: make the testsuite x-version compatible and test against PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,14 @@ jobs:
     - php: 7.3.24
       env: WP_VERSION=latest WP_MULTISITE=1 COVERAGE=1
     - php: 5.6
-      env: WP_VERSION=5.4 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
+      env: WP_VERSION=5.5 WP_MULTISITE=1 PHPLINT=1 PHPUNIT=1
       # Use 'trusty' to test against MySQL 5.6, 'xenial' contains 5.7 by default.
       dist: trusty
     - php: 7.3
       env: WP_VERSION=master PHPUNIT=1
     - php: 7.4
+      env: WP_VERSION=latest PHPUNIT=1 PHPLINT=1
+    - php: 8.0
       env: WP_VERSION=latest PHPUNIT=1 PHPLINT=1
     - php: "nightly"
       env: PHPLINT=1
@@ -144,7 +146,7 @@ install:
       travis_retry composer require phpunit/phpcov ^3.1
     fi
   - |
-    if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       if [[ "$IS_PREMIUM" == "1" ]]; then
         cd premium
         travis_retry composer install --no-interaction --ignore-platform-reqs --no-scripts --no-suggest
@@ -277,22 +279,29 @@ script:
     fi
   # PHP Unit
   - |
-    if [[ "$PHPUNIT" == "1" ]]; then
+    if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:1} != "8" && $TRAVIS_PHP_VERSION != "nightly" ]]; then
       travis_fold start "PHP.integration-tests" && travis_time_start
       vendor/bin/phpunit -c phpunit-integration.xml.dist
       travis_time_finish && travis_fold end "PHP.integration-tests"
     fi;
   - |
-    if [[ "$PHPUNIT" == "1" ]]; then
+    if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
+      travis_fold start "PHP.integration-tests" && travis_time_start
+      travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
+      vendor/bin/phpunit -c phpunit-integration.xml.dist
+      travis_time_finish && travis_fold end "PHP.integration-tests"
+    fi;
+  - |
+    if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:1} != "8" && $TRAVIS_PHP_VERSION != "nightly" ]]; then
       travis_fold start "PHP.tests" && travis_time_start
       vendor/bin/phpunit
       travis_time_finish && travis_fold end "PHP.tests"
     fi;
   - |
-    if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.tests" && travis_time_start
-      composer require --dev phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs &&
-      composer update yoast/wp-test-utils --with-all-dependencies --ignore-platform-reqs &&
+      composer require --dev phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
+      composer update yoast/wp-test-utils --with-all-dependencies --ignore-platform-reqs --no-interaction &&
       vendor/bin/phpunit
       travis_time_finish && travis_fold end "PHP.tests"
     fi

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 		"symfony/config": "^3.4",
 		"php-parallel-lint/php-parallel-lint": "^1.2.0",
 		"php-parallel-lint/php-console-highlighter": "^0.5",
-		"yoast/wp-test-utils": "^0.1.1"
+		"yoast/wp-test-utils": "^0.2.1"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4086f1ca0fa58866e06eaee474ecc5e2",
+    "content-hash": "cfb0b23edefd7f8b5ea05940dd1e6b49",
     "packages": [
         {
             "name": "composer/installers",
@@ -885,16 +885,16 @@
         },
         {
             "name": "brain/monkey",
-            "version": "2.5.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Brain-WP/BrainMonkey.git",
-                "reference": "f2295a57da59ff88621cd959dbdb4b288feefd19"
+                "reference": "7042140000b4b18034c0c0010d86274a00f25442"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/f2295a57da59ff88621cd959dbdb4b288feefd19",
-                "reference": "f2295a57da59ff88621cd959dbdb4b288feefd19",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/7042140000b4b18034c0c0010d86274a00f25442",
+                "reference": "7042140000b4b18034c0c0010d86274a00f25442",
                 "shasum": ""
             },
             "require": {
@@ -947,7 +947,7 @@
                 "test",
                 "testing"
             ],
-            "time": "2020-10-09T06:55:33+00:00"
+            "time": "2020-10-13T17:56:14+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",
@@ -3861,20 +3861,20 @@
         },
         {
             "name": "yoast/wp-test-utils",
-            "version": "0.1.1",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/wp-test-utils.git",
-                "reference": "206df89cfefe4d2cbdf354e4a6212869de8bd942"
+                "reference": "c5cdabd58f2aa6f2a93f734cf48125f880c90101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/206df89cfefe4d2cbdf354e4a6212869de8bd942",
-                "reference": "206df89cfefe4d2cbdf354e4a6212869de8bd942",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/c5cdabd58f2aa6f2a93f734cf48125f880c90101",
+                "reference": "c5cdabd58f2aa6f2a93f734cf48125f880c90101",
                 "shasum": ""
             },
             "require": {
-                "brain/monkey": "^2.5.0",
+                "brain/monkey": "^2.6.0",
                 "php": ">=5.6",
                 "yoast/phpunit-polyfills": "^0.2.0"
             },
@@ -3919,7 +3919,7 @@
                 "unit-testing",
                 "wordpress"
             ],
-            "time": "2020-11-25T12:40:18+00:00"
+            "time": "2020-12-09T15:26:02+00:00"
         },
         {
             "name": "yoast/yoastcs",

--- a/phpunit-integration.xml.dist
+++ b/phpunit-integration.xml.dist
@@ -1,38 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-	backupGlobals="false"
-	backupStaticAttributes="false"
-	bootstrap="tests/integration/bootstrap.php"
-	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
-	processIsolation="false"
-	stopOnError="false"
-	stopOnFailure="false"
-	stopOnIncomplete="false"
-	stopOnSkipped="false"
-	syntaxCheck="false"
-	verbose="true"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.5/phpunit.xsd"
+		backupGlobals="false"
+		backupStaticAttributes="false"
+		bootstrap="tests/integration/bootstrap.php"
+		colors="true"
+		convertErrorsToExceptions="true"
+		convertNoticesToExceptions="true"
+		convertWarningsToExceptions="true"
+		forceCoversAnnotation="true"
+		processIsolation="false"
+		stopOnError="false"
+		stopOnFailure="false"
+		stopOnIncomplete="false"
+		stopOnSkipped="false"
+		verbose="true"
 	>
 	<testsuites>
-		<testsuite name="php52">
+		<testsuite name="yoastseo">
 			<directory prefix="test-" suffix=".php">./tests/integration</directory>
-		</testsuite>
-
-		<!-- Test namespaced classes only for PHP 5.6.0 and above -->
-		<testsuite name="php56+">
-			<directory suffix="-test.php" phpVersion="5.6.0" phpVersionOperator=">=">./tests/integration/src/</directory>
 		</testsuite>
 	</testsuites>
 
 	<filter>
-		<whitelist>
-			<directory>./inc</directory>
-			<directory>./frontend</directory>
+		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
+			<file>./wp-seo.php</file>
+			<file>./wp-seo-main.php</file>
 			<directory>./admin</directory>
+			<directory>./inc</directory>
 			<directory>./src</directory>
 			<exclude>
-				<directory suffix=".php">./deprecated</directory>
+				<directory suffix=".php">./src/deprecated</directory>
 				<file>./inc/wpseo-functions-deprecated.php</file>
 			</exclude>
 		</whitelist>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-	backupGlobals="false"
-	backupStaticAttributes="false"
-	bootstrap="tests/unit/bootstrap.php"
-	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
-	forceCoversAnnotation="true"
-	processIsolation="false"
-	stopOnError="false"
-	stopOnFailure="false"
-	stopOnIncomplete="false"
-	stopOnSkipped="false"
-	syntaxCheck="false"
-	verbose="true"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.5/phpunit.xsd"
+		backupGlobals="false"
+		backupStaticAttributes="false"
+		bootstrap="tests/unit/bootstrap.php"
+		colors="true"
+		convertErrorsToExceptions="true"
+		convertNoticesToExceptions="true"
+		convertWarningsToExceptions="true"
+		forceCoversAnnotation="true"
+		processIsolation="false"
+		stopOnError="false"
+		stopOnFailure="false"
+		stopOnIncomplete="false"
+		stopOnSkipped="false"
+		verbose="true"
 	>
 	<testsuites>
 		<testsuite name="yoastseo">
@@ -22,7 +24,7 @@
 	</testsuites>
 
 	<filter>
-		<whitelist>
+		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
 			<file>./wp-seo.php</file>
 			<file>./wp-seo-main.php</file>
 			<directory>./admin</directory>

--- a/tests/integration/admin/import/test-class-import-premium-seo-pack.php
+++ b/tests/integration/admin/import/test-class-import-premium-seo-pack.php
@@ -93,9 +93,9 @@ class WPSEO_Import_Premium_SEO_Pack_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @covers WPSEO_Import_Premium_SEO_Pack::run_import
 	 * @covers WPSEO_Import_Premium_SEO_Pack::import
-	 * @covers WPSEO_Import_Premium_SEO_Pack::import_post_values
-	 * @covers WPSEO_Import_Premium_SEO_Pack::retrieve_post_data
-	 * @covers WPSEO_Import_Premium_SEO_Pack::maybe_add_focus_kw
+	 * @covers WPSEO_Import_Squirrly::import_post_values
+	 * @covers WPSEO_Import_Squirrly::retrieve_post_data
+	 * @covers WPSEO_Import_Squirrly::maybe_add_focus_kw
 	 * @covers WPSEO_Import_Premium_SEO_Pack::retrieve_posts_query
 	 * @covers WPSEO_Import_Premium_SEO_Pack::retrieve_posts
 	 */
@@ -127,9 +127,9 @@ class WPSEO_Import_Premium_SEO_Pack_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Import_Premium_SEO_Pack::run_import
 	 * @covers WPSEO_Import_Premium_SEO_Pack::import
 	 * @covers WPSEO_Import_Premium_SEO_Pack::import_meta_helper
-	 * @covers WPSEO_Import_Premium_SEO_Pack::import_post_values
+	 * @covers WPSEO_Import_Squirrly::import_post_values
 	 * @covers WPSEO_Import_Premium_SEO_Pack::maybe_save_post_meta
-	 * @covers WPSEO_Import_Premium_SEO_Pack::retrieve_post_data
+	 * @covers WPSEO_Import_Squirrly::retrieve_post_data
 	 */
 	public function test_import_without_overwriting_data() {
 		$post_id = $this->setup_post( true );
@@ -157,8 +157,8 @@ class WPSEO_Import_Premium_SEO_Pack_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Import_Premium_SEO_Pack::run_import
 	 * @covers WPSEO_Import_Premium_SEO_Pack::import
 	 * @covers WPSEO_Import_Premium_SEO_Pack::import_meta_helper
-	 * @covers WPSEO_Import_Premium_SEO_Pack::import_post_values
-	 * @covers WPSEO_Import_Premium_SEO_Pack::retrieve_post_data
+	 * @covers WPSEO_Import_Squirrly::import_post_values
+	 * @covers WPSEO_Import_Squirrly::retrieve_post_data
 	 */
 	public function test_import_without_seo_column_in_db() {
 		$this->setup_post();

--- a/tests/integration/admin/services/test-class-file-size.php
+++ b/tests/integration/admin/services/test-class-file-size.php
@@ -42,7 +42,7 @@ class WPSEO_File_Size_Service_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_get_with_unknown_failure() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_File_Size_Service' )
@@ -72,7 +72,7 @@ class WPSEO_File_Size_Service_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_get_on_success() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$instance = $this
 			->getMockBuilder( 'WPSEO_File_Size_Service' )

--- a/tests/integration/admin/test-class-admin-asset-dev-server-location.php
+++ b/tests/integration/admin/test-class-admin-asset-dev-server-location.php
@@ -5,10 +5,12 @@
  * @package WPSEO\Tests\Admin
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Tests WPSEO_Admin_Asset_Dev_Server_Location.
  */
-final class Test_Admin_Asset_Dev_Server_Location extends PHPUnit_Framework_TestCase {
+final class Test_Admin_Asset_Dev_Server_Location extends TestCase {
 
 	/**
 	 * Default arguments to use for creating a new Admin_Asset.

--- a/tests/integration/admin/test-class-admin-asset-seo-location.php
+++ b/tests/integration/admin/test-class-admin-asset-seo-location.php
@@ -5,10 +5,12 @@
  * @package WPSEO\Tests\Admin
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Tests WPSEO_Admin_Asset.
  */
-final class Test_WPSEO_Admin_Asset_SEO_Location extends PHPUnit_Framework_TestCase {
+final class Test_WPSEO_Admin_Asset_SEO_Location extends TestCase {
 
 	/**
 	 * Tests the get_url function.

--- a/tests/integration/admin/test-class-plugin-suggestions.php
+++ b/tests/integration/admin/test-class-plugin-suggestions.php
@@ -36,7 +36,7 @@ class WPSEO_Plugin_Suggestions_Test extends WPSEO_UnitTestCase {
 
 		/*
 		 * Silencing errors for PHP 7.4 in combination with the Mock Builder.
-		 * See WPSEO_UnitTestCase::bypass_php74_mockbuilder_deprecation_warning() for context.
+		 * See {@see `Yoast_SEO_ReflectionToString_Deprecation_Handler`} for context.
 		 *
 		 * phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
 		 */

--- a/tests/integration/admin/test-class-yoast-input-select.php
+++ b/tests/integration/admin/test-class-yoast-input-select.php
@@ -126,7 +126,7 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 		$select->output_html();
 
 		// Because the output has empty values.
-		$this->expectOutput( "<select name=\"test-field\" id=\"test-id\">\n\t</select>\n" );
+		$this->expectOutputString( "<select name=\"test-field\" id=\"test-id\">\n\t</select>\n" );
 	}
 
 	/**

--- a/tests/integration/admin/test-class-yoast-input-select.php
+++ b/tests/integration/admin/test-class-yoast-input-select.php
@@ -31,9 +31,9 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 		);
 		$html   = $select->get_html();
 
-		$this->assertContains( '<select name="test-field" id="test-id">', $html );
-		$this->assertContains( '<option value="foo">bar</option>', $html );
-		$this->assertContains( '<option value="baz">foo</option>', $html );
+		$this->assertStringContainsString( '<select name="test-field" id="test-id">', $html );
+		$this->assertStringContainsString( '<option value="foo">bar</option>', $html );
+		$this->assertStringContainsString( '<option value="baz">foo</option>', $html );
 	}
 
 	/**
@@ -49,9 +49,9 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 		$select = new Yoast_Input_Select( 'test-id', 'test-field', [], false );
 		$html   = $select->get_html();
 
-		$this->assertContains( '<select name="test-field" id="test-id">', $html );
-		$this->assertNotContains( '<option', $html );
-		$this->assertNotContains( '</option>', $html );
+		$this->assertStringContainsString( '<select name="test-field" id="test-id">', $html );
+		$this->assertStringNotContainsString( '<option', $html );
+		$this->assertStringNotContainsString( '</option>', $html );
 	}
 
 	/**
@@ -74,9 +74,9 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 		);
 		$html   = $select->get_html();
 
-		$this->assertContains( '<select name="test-field" id="test-id">', $html );
-		$this->assertContains( '<option value="foo">bar</option>', $html );
-		$this->assertContains( '<option value="baz" selected=\'selected\'>foo</option>', $html );
+		$this->assertStringContainsString( '<select name="test-field" id="test-id">', $html );
+		$this->assertStringContainsString( '<option value="foo">bar</option>', $html );
+		$this->assertStringContainsString( '<option value="baz" selected=\'selected\'>foo</option>', $html );
 	}
 
 	/**
@@ -92,8 +92,8 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 		$select = new Yoast_Input_Select( 'test-id', 'test-field', [ '' => 'bar' ], false );
 		$html   = $select->get_html();
 
-		$this->assertContains( '<select name="test-field" id="test-id">', $html );
-		$this->assertContains( '<option value="" selected=\'selected\'>bar</option>', $html );
+		$this->assertStringContainsString( '<select name="test-field" id="test-id">', $html );
+		$this->assertStringContainsString( '<option value="" selected=\'selected\'>bar</option>', $html );
 	}
 
 	/**
@@ -109,8 +109,8 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 		$select = new Yoast_Input_Select( 'test-id', 'test-field', [ 'foo' => '' ], false );
 		$html   = $select->get_html();
 
-		$this->assertContains( '<select name="test-field" id="test-id">', $html );
-		$this->assertContains( '<option value="foo"></option>', $html );
+		$this->assertStringContainsString( '<select name="test-field" id="test-id">', $html );
+		$this->assertStringContainsString( '<option value="foo"></option>', $html );
 	}
 
 	/**
@@ -144,6 +144,6 @@ class Yoast_Input_Select_Test extends WPSEO_UnitTestCase {
 		$select->add_attribute( 'class', 'test' );
 		$html = $select->get_html();
 
-		$this->assertContains( '<select class="test" name="test-field" id="test-id">', $html );
+		$this->assertStringContainsString( '<select class="test" name="test-field" id="test-id">', $html );
 	}
 }

--- a/tests/integration/admin/test-class-yoast-network-admin.php
+++ b/tests/integration/admin/test-class-yoast-network-admin.php
@@ -201,8 +201,8 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 			->will( $this->returnValue( true ) );
 
 		$admin->register_hooks();
-		$this->assertInternalType( 'int', has_action( 'admin_action_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, [ $admin, 'handle_update_options_request' ] ) );
-		$this->assertInternalType( 'int', has_action( 'admin_action_' . Yoast_Network_Admin::RESTORE_SITE_ACTION, [ $admin, 'handle_restore_site_request' ] ) );
+		$this->assertIsInt( has_action( 'admin_action_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, [ $admin, 'handle_update_options_request' ] ) );
+		$this->assertIsInt( has_action( 'admin_action_' . Yoast_Network_Admin::RESTORE_SITE_ACTION, [ $admin, 'handle_restore_site_request' ] ) );
 	}
 
 	/**
@@ -214,8 +214,8 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		$admin = new Yoast_Network_Admin();
 
 		$admin->register_ajax_hooks();
-		$this->assertInternalType( 'int', has_action( 'wp_ajax_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, [ $admin, 'handle_update_options_request' ] ) );
-		$this->assertInternalType( 'int', has_action( 'wp_ajax_' . Yoast_Network_Admin::RESTORE_SITE_ACTION, [ $admin, 'handle_restore_site_request' ] ) );
+		$this->assertIsInt( has_action( 'wp_ajax_' . Yoast_Network_Admin::UPDATE_OPTIONS_ACTION, [ $admin, 'handle_update_options_request' ] ) );
+		$this->assertIsInt( has_action( 'wp_ajax_' . Yoast_Network_Admin::RESTORE_SITE_ACTION, [ $admin, 'handle_restore_site_request' ] ) );
 	}
 
 	/**

--- a/tests/integration/admin/test-class-yoast-network-admin.php
+++ b/tests/integration/admin/test-class-yoast-network-admin.php
@@ -398,15 +398,14 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		$this->expectException( 'WPDieException' );
 		$this->expectExceptionMessage( '' );
 
-		ob_start();
+		$this->expectOutputContains( 'success' );
 
 		try {
 			$admin->terminate_request();
 		} catch ( WPDieException $e ) {
-			$this->assertArrayHasKey( 'success', json_decode( ob_get_clean(), true ) );
+			$output_decoded = json_decode( $this->getActualOutput(), true );
+			$this->assertArrayHasKey( 'success', $output_decoded );
 			throw $e;
 		}
-
-		ob_get_clean();
 	}
 }

--- a/tests/integration/admin/test-class-yoast-network-admin.php
+++ b/tests/integration/admin/test-class-yoast-network-admin.php
@@ -246,7 +246,9 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 			$expected_message = 'Are you sure you want to do this?';
 		}
 
-		$this->setExpectedException( 'WPDieException', $expected_message );
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( $expected_message );
+
 		$admin->verify_request( 'my_action' );
 	}
 
@@ -261,7 +263,9 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 		$_REQUEST['_wp_http_referer'] = admin_url();
 		$_REQUEST['_wpnonce']         = wp_create_nonce( 'my_action' );
 
-		$this->setExpectedException( 'WPDieException', 'You are not allowed to perform this action.' );
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( 'You are not allowed to perform this action.' );
+
 		$admin->verify_request( 'my_action' );
 	}
 
@@ -302,7 +306,9 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 
 		$_REQUEST['_wpnonce'] = '';
 
-		$this->setExpectedException( 'WPDieException', '-1' );
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( '-1' );
+
 		$admin->verify_request( 'my_action' );
 	}
 
@@ -319,7 +325,9 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 
 		$_REQUEST['_wpnonce'] = wp_create_nonce( 'my_action' );
 
-		$this->setExpectedException( 'WPDieException', '-1' );
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( '-1' );
+
 		$admin->verify_request( 'my_action' );
 	}
 
@@ -387,7 +395,8 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 
 		$_REQUEST['_wpnonce'] = wp_create_nonce( 'my_action' );
 
-		$this->setExpectedException( 'WPDieException', '' );
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( '' );
 
 		ob_start();
 

--- a/tests/integration/admin/test-class-yoast-network-settings-api.php
+++ b/tests/integration/admin/test-class-yoast-network-settings-api.php
@@ -24,8 +24,8 @@ class Yoast_Network_Settings_API_Test extends WPSEO_UnitTestCase {
 		];
 		$api->register_setting( 'yst_ms_group', 'yst_ms_option', $setting_args );
 
-		$this->assertInternalType( 'int', has_filter( 'sanitize_option_yst_ms_option', [ $api, 'filter_sanitize_option' ] ) );
-		$this->assertInternalType( 'int', has_filter( 'default_site_option_yst_ms_option', [ $api, 'filter_default_option' ] ) );
+		$this->assertIsInt( has_filter( 'sanitize_option_yst_ms_option', [ $api, 'filter_sanitize_option' ] ) );
+		$this->assertIsInt( has_filter( 'default_site_option_yst_ms_option', [ $api, 'filter_default_option' ] ) );
 	}
 
 	/**

--- a/tests/integration/bootstrap.php
+++ b/tests/integration/bootstrap.php
@@ -5,18 +5,14 @@
  * @package Wordpress_Seo
  */
 
-// Determine the WP_TEST_DIR.
-if ( getenv( 'WP_TESTS_DIR' ) !== false ) {
-	$_tests_dir = getenv( 'WP_TESTS_DIR' );
-}
+use Yoast\WPTestUtils\WPIntegration;
 
-// Fall back on the WP_DEVELOP_DIR environment variable.
-if ( empty( $_tests_dir ) && getenv( 'WP_DEVELOP_DIR' ) !== false ) {
-	$_tests_dir = rtrim( getenv( 'WP_DEVELOP_DIR' ), '/' ) . '/tests/phpunit';
-}
+require_once dirname( dirname( __DIR__ ) ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
+
+$_tests_dir = WPIntegration\get_path_to_wp_test_dir();
 
 // Give access to tests_add_filter() function.
-require_once rtrim( $_tests_dir, '/' ) . '/includes/functions.php';
+require_once $_tests_dir . 'includes/functions.php';
 
 /**
  * Manually load the plugin being tested.
@@ -70,5 +66,4 @@ if ( defined( 'WPSEO_TESTS_PATH' ) && WPSEO_TESTS_PATH !== __DIR__ . '/' ) {
 }
 define( 'WPSEO_TESTS_PATH', __DIR__ . '/' );
 
-// Start up the WP testing environment.
-require $_tests_dir . '/includes/bootstrap.php';
+WPIntegration\bootstrap_it();

--- a/tests/integration/capabilities/test-class-capability-manager-factory.php
+++ b/tests/integration/capabilities/test-class-capability-manager-factory.php
@@ -5,10 +5,12 @@
  * @package WPSEO\Tests\Capabilities
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Unit Test Class.
  */
-class WPSEO_Capability_Manager_Factory_Tests extends PHPUnit_Framework_TestCase {
+class WPSEO_Capability_Manager_Factory_Tests extends TestCase {
 
 	/**
 	 * Tests whether the same factory instance is returned when the get function is called twice.

--- a/tests/integration/capabilities/test-class-capability-manager.php
+++ b/tests/integration/capabilities/test-class-capability-manager.php
@@ -5,10 +5,12 @@
  * @package WPSEO\Tests\Capabilities
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Unit Test Class.
  */
-class Capability_Manager_Tests extends PHPUnit_Framework_TestCase {
+class Capability_Manager_Tests extends TestCase {
 
 	/**
 	 * Tests whether capabilities are correctly registered.

--- a/tests/integration/capabilities/test-class-register-capabilities.php
+++ b/tests/integration/capabilities/test-class-register-capabilities.php
@@ -12,6 +12,8 @@ class WPSEO_Register_Capabilities_Tests extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests whether the list of registered capabilities contains the correct capabilities.
+	 *
+	 * @covers WPSEO_Register_Capabilities::register
 	 */
 	public function test_register() {
 		$manager = WPSEO_Capability_Manager_Factory::get();

--- a/tests/integration/config-ui/components/test-class-factory-post-type.php
+++ b/tests/integration/config-ui/components/test-class-factory-post-type.php
@@ -5,10 +5,12 @@
  * @package WPSEO\Tests\ConfigUI\Components
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Class WPSEO_Config_Component_Connect_Google_Search_Console_Test.
  */
-class WPSEO_Config_Factory_Post_Type_Test extends PHPUnit_Framework_TestCase {
+class WPSEO_Config_Factory_Post_Type_Test extends TestCase {
 
 	/**
 	 * Tests the retrieval of the fields for a post type.

--- a/tests/integration/config-ui/fields/test-class-config-field-choice.php
+++ b/tests/integration/config-ui/fields/test-class-config-field-choice.php
@@ -5,10 +5,12 @@
  * @package WPSEO\Tests\ConfigUI\Fields
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Class WPSEO_Config_Field_Choice_Test.
  */
-class WPSEO_Config_Field_Choice_Test extends PHPUnit_Framework_TestCase {
+class WPSEO_Config_Field_Choice_Test extends TestCase {
 
 	/**
 	 * Tests the retrieval of the set component.

--- a/tests/integration/config-ui/fields/test-class-config-field.php
+++ b/tests/integration/config-ui/fields/test-class-config-field.php
@@ -5,10 +5,12 @@
  * @package WPSEO\Tests\ConfigUI\Fields
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Class WPSEO_Config_Field_Test.
  */
-class WPSEO_Config_Field_Test extends PHPUnit_Framework_TestCase {
+class WPSEO_Config_Field_Test extends TestCase {
 
 	/**
 	 * Tests if the constructor works.

--- a/tests/integration/config-ui/fields/test-class-config-field.php
+++ b/tests/integration/config-ui/fields/test-class-config-field.php
@@ -98,7 +98,7 @@ class WPSEO_Config_Field_Test extends TestCase {
 
 		$result = $field->to_array();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'componentName', $result );
 	}
 

--- a/tests/integration/config-ui/test-class-configuration-components.php
+++ b/tests/integration/config-ui/test-class-configuration-components.php
@@ -12,6 +12,8 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
  */
 class WPSEO_Configuration_Components_Tests extends TestCase {
 
+	use Yoast_SEO_ReflectionToString_Deprecation_Handler;
+
 	/**
 	 * Holds the instance of the class being tested.
 	 *
@@ -80,7 +82,7 @@ class WPSEO_Configuration_Components_Tests extends TestCase {
 	 */
 	public function test_set_storage() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$storage = $this
 			->getMockBuilder( 'WPSEO_Configuration_Storage' )
@@ -107,7 +109,7 @@ class WPSEO_Configuration_Components_Tests extends TestCase {
 	 */
 	public function test_set_storage_on_field() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$component = $this
 			->getMockBuilder( 'WPSEO_Config_Component' )
@@ -145,20 +147,5 @@ class WPSEO_Configuration_Components_Tests extends TestCase {
 
 		$this->components->add_component( $component );
 		$this->components->set_storage( $storage );
-	}
-
-	/**
-	 * Bypass the PHP deprecation error which is thrown in PHP 7.4 for the PHPUnit mock builder
-	 * in select circumstances.
-	 *
-	 * @see WPSEO_UnitTestCase::bypass_php74_mockbuilder_deprecation_warning() For full explanation.
-	 *
-	 * @return void
-	 */
-	protected function bypass_php74_mockbuilder_deprecation_warning() {
-		if ( version_compare( PHP_VERSION_ID, 70399, '>' ) ) {
-			$this->expectException( 'PHPUnit_Framework_Error_Deprecated' );
-			$this->expectExceptionMessage( 'Function ReflectionType::__toString() is deprecated' );
-		}
 	}
 }

--- a/tests/integration/config-ui/test-class-configuration-components.php
+++ b/tests/integration/config-ui/test-class-configuration-components.php
@@ -5,10 +5,12 @@
  * @package WPSEO\Tests\ConfigUI
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Class WPSEO_Configuration_Components_Tests.
  */
-class WPSEO_Configuration_Components_Tests extends PHPUnit_Framework_TestCase {
+class WPSEO_Configuration_Components_Tests extends TestCase {
 
 	/**
 	 * Holds the instance of the class being tested.

--- a/tests/integration/config-ui/test-class-configuration-endpoint.php
+++ b/tests/integration/config-ui/test-class-configuration-endpoint.php
@@ -35,7 +35,7 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_set_service() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$service = $this->getMockBuilder( 'WPSEO_Configuration_Service' )->getMock();
 

--- a/tests/integration/config-ui/test-class-configuration-options-adapter.php
+++ b/tests/integration/config-ui/test-class-configuration-options-adapter.php
@@ -12,6 +12,8 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
  */
 class WPSEO_Configuration_Options_Adapter_Test extends TestCase {
 
+	use Yoast_SEO_ReflectionToString_Deprecation_Handler;
+
 	/**
 	 * Holds the instance of the class being tested.
 	 *
@@ -241,11 +243,7 @@ class WPSEO_Configuration_Options_Adapter_Test extends TestCase {
 	 */
 	public function test_get_unknown_type() {
 
-		// See WPSEO_UnitTestCase::bypass_php74_mockbuilder_deprecation_warning() for context.
-		if ( version_compare( PHP_VERSION_ID, 70399, '>' ) ) {
-			$this->expectException( 'PHPUnit_Framework_Error_Deprecated' );
-			$this->expectExceptionMessage( 'Function ReflectionType::__toString() is deprecated' );
-		}
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$field_name = 'field';
 

--- a/tests/integration/config-ui/test-class-configuration-options-adapter.php
+++ b/tests/integration/config-ui/test-class-configuration-options-adapter.php
@@ -5,10 +5,12 @@
  * @package WPSEO\Tests\ConfigUI
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Class WPSEO_Configuration_Options_Adapter_Test.
  */
-class WPSEO_Configuration_Options_Adapter_Test extends PHPUnit_Framework_TestCase {
+class WPSEO_Configuration_Options_Adapter_Test extends TestCase {
 
 	/**
 	 * Holds the instance of the class being tested.

--- a/tests/integration/config-ui/test-class-configuration-options-adapter.php
+++ b/tests/integration/config-ui/test-class-configuration-options-adapter.php
@@ -79,11 +79,11 @@ class WPSEO_Configuration_Options_Adapter_Test extends TestCase {
 	 * Tests adding a custom lookup with no get callable get argument given.
 	 *
 	 * @covers WPSEO_Configuration_Options_Adapter::add_custom_lookup
-	 *
-	 * @expectedException        InvalidArgumentException
-	 * @expectedExceptionMessage Custom option must be callable.
 	 */
 	public function test_add_custom_lookup_not_a_callback_get() {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Custom option must be callable.' );
+
 		$this->adapter->add_custom_lookup( 'stdClass', 'not_callable', '__return_true' );
 	}
 
@@ -91,11 +91,11 @@ class WPSEO_Configuration_Options_Adapter_Test extends TestCase {
 	 * Tests adding a custom lookup with no set callable argument given.
 	 *
 	 * @covers WPSEO_Configuration_Options_Adapter::add_custom_lookup
-	 *
-	 * @expectedException        InvalidArgumentException
-	 * @expectedExceptionMessage Custom option must be callable.
 	 */
 	public function test_add_custom_lookup_not_a_callback_set() {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Custom option must be callable.' );
+
 		$this->adapter->add_custom_lookup( 'stdClass', '__return_true', 'not_callable' );
 	}
 
@@ -143,11 +143,11 @@ class WPSEO_Configuration_Options_Adapter_Test extends TestCase {
 	 * Test adding a WordPress lookup for a non string. Resulting in an exception.
 	 *
 	 * @covers WPSEO_Configuration_Options_Adapter::add_wordpress_lookup
-	 *
-	 * @expectedException        InvalidArgumentException
-	 * @expectedExceptionMessage WordPress option must be a string.
 	 */
 	public function test_add_wordpress_lookup_option_non_string() {
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'WordPress option must be a string.' );
+
 		$this->adapter->add_wordpress_lookup( 'stdClass', [] );
 	}
 

--- a/tests/integration/config-ui/test-class-configuration-service.php
+++ b/tests/integration/config-ui/test-class-configuration-service.php
@@ -12,6 +12,8 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
  */
 class WPSEO_Configuration_Service_Test extends TestCase {
 
+	use Yoast_SEO_ReflectionToString_Deprecation_Handler;
+
 	/**
 	 * Instance.
 	 *
@@ -47,7 +49,7 @@ class WPSEO_Configuration_Service_Test extends TestCase {
 	 */
 	public function test_set_storage() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$service = new WPSEO_Configuration_Service_Mock();
 		$storage = $this->getMockBuilder( 'WPSEO_Configuration_Storage' )->getMock();
@@ -63,7 +65,7 @@ class WPSEO_Configuration_Service_Test extends TestCase {
 	 */
 	public function test_set_endpoint() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$service  = new WPSEO_Configuration_Service_Mock();
 		$endpoint = $this->getMockBuilder( 'WPSEO_Configuration_Endpoint' )->getMock();
@@ -79,7 +81,7 @@ class WPSEO_Configuration_Service_Test extends TestCase {
 	 */
 	public function test_set_options_adapter() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$service = new WPSEO_Configuration_Service_Mock();
 		$adapter = $this->getMockBuilder( 'WPSEO_Configuration_Options_Adapter' )->getMock();
@@ -95,7 +97,7 @@ class WPSEO_Configuration_Service_Test extends TestCase {
 	 */
 	public function test_set_components() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$service    = new WPSEO_Configuration_Service_Mock();
 		$components = $this->getMockBuilder( 'WPSEO_Configuration_Components' )->getMock();
@@ -211,21 +213,6 @@ class WPSEO_Configuration_Service_Test extends TestCase {
 
 		foreach ( $properties as $property ) {
 			$this->assertNotNull( $configuration_service->get( $property ) );
-		}
-	}
-
-	/**
-	 * Bypass the PHP deprecation error which is thrown in PHP 7.4 for the PHPUnit mock builder
-	 * in select circumstances.
-	 *
-	 * @see WPSEO_UnitTestCase::bypass_php74_mockbuilder_deprecation_warning() For full explanation.
-	 *
-	 * @return void
-	 */
-	protected function bypass_php74_mockbuilder_deprecation_warning() {
-		if ( version_compare( PHP_VERSION_ID, 70399, '>' ) ) {
-			$this->expectException( 'PHPUnit_Framework_Error_Deprecated' );
-			$this->expectExceptionMessage( 'Function ReflectionType::__toString() is deprecated' );
 		}
 	}
 }

--- a/tests/integration/config-ui/test-class-configuration-service.php
+++ b/tests/integration/config-ui/test-class-configuration-service.php
@@ -147,7 +147,7 @@ class WPSEO_Configuration_Service_Test extends TestCase {
 
 		$result = $this->configuration_service->get_configuration();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assertIsArray( $result );
 
 		$this->assertEquals(
 			[

--- a/tests/integration/config-ui/test-class-configuration-service.php
+++ b/tests/integration/config-ui/test-class-configuration-service.php
@@ -5,10 +5,12 @@
  * @package WPSEO\Tests\ConfigUI
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Class WPSEO_Configuration_Service_Test.
  */
-class WPSEO_Configuration_Service_Test extends PHPUnit_Framework_TestCase {
+class WPSEO_Configuration_Service_Test extends TestCase {
 
 	/**
 	 * Instance.

--- a/tests/integration/config-ui/test-class-configuration-storage.php
+++ b/tests/integration/config-ui/test-class-configuration-storage.php
@@ -12,6 +12,8 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
  */
 class WPSEO_Configuration_Storage_Test extends TestCase {
 
+	use Yoast_SEO_ReflectionToString_Deprecation_Handler;
+
 	/**
 	 * Holds the instance of the class being tested.
 	 *
@@ -35,7 +37,7 @@ class WPSEO_Configuration_Storage_Test extends TestCase {
 	 */
 	public function test_add_field() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$field = $this
 			->getMockBuilder( 'WPSEO_Config_Field' )
@@ -76,7 +78,7 @@ class WPSEO_Configuration_Storage_Test extends TestCase {
 	 */
 	public function test_get_field_data_null() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$data = null;
 
@@ -108,7 +110,7 @@ class WPSEO_Configuration_Storage_Test extends TestCase {
 	 */
 	public function test_get_field_data_field_default() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$data    = null;
 		$default = 'default';
@@ -146,7 +148,7 @@ class WPSEO_Configuration_Storage_Test extends TestCase {
 	 */
 	public function test_get_field_data_string() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$data = 'data';
 
@@ -178,7 +180,7 @@ class WPSEO_Configuration_Storage_Test extends TestCase {
 	 */
 	public function test_get_field_data_array() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$data    = [ 'a' => '1' ];
 		$default = [
@@ -337,20 +339,5 @@ class WPSEO_Configuration_Storage_Test extends TestCase {
 		];
 
 		$this->assertEquals( $expected, $result );
-	}
-
-	/**
-	 * Bypass the PHP deprecation error which is thrown in PHP 7.4 for the PHPUnit mock builder
-	 * in select circumstances.
-	 *
-	 * @see WPSEO_UnitTestCase::bypass_php74_mockbuilder_deprecation_warning() For full explanation.
-	 *
-	 * @return void
-	 */
-	protected function bypass_php74_mockbuilder_deprecation_warning() {
-		if ( version_compare( PHP_VERSION_ID, 70399, '>' ) ) {
-			$this->expectException( 'PHPUnit_Framework_Error_Deprecated' );
-			$this->expectExceptionMessage( 'Function ReflectionType::__toString() is deprecated' );
-		}
 	}
 }

--- a/tests/integration/config-ui/test-class-configuration-storage.php
+++ b/tests/integration/config-ui/test-class-configuration-storage.php
@@ -5,10 +5,12 @@
  * @package WPSEO\Tests\ConfigUI
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Class WPSEO_Configuration_Storage_Test.
  */
-class WPSEO_Configuration_Storage_Test extends PHPUnit_Framework_TestCase {
+class WPSEO_Configuration_Storage_Test extends TestCase {
 
 	/**
 	 * Holds the instance of the class being tested.

--- a/tests/integration/config-ui/test-class-configuration-structure.php
+++ b/tests/integration/config-ui/test-class-configuration-structure.php
@@ -5,10 +5,12 @@
  * @package WPSEO\Tests\ConfigUI
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Class WPSEO_Configuration_Structure_Test.
  */
-class WPSEO_Configuration_Structure_Test extends PHPUnit_Framework_TestCase {
+class WPSEO_Configuration_Structure_Test extends TestCase {
 
 	/**
 	 * Mock holder.

--- a/tests/integration/formatter/test-metabox-formatter.php
+++ b/tests/integration/formatter/test-metabox-formatter.php
@@ -78,7 +78,7 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	 * Test that wordFormRecognitionActive is true for English.
 	 *
 	 * @covers WPSEO_Metabox_Formatter::__construct
-	 * @covers WPSEO_Metabox_Formatter::is_word_form_recognition_active
+	 * @covers Yoast\WP\SEO\Helpers\Language_Helper::is_word_form_recognition_active
 	 */
 	public function test_word_form_recognition_is_active() {
 		add_filter(
@@ -106,7 +106,7 @@ class WPSEO_Metabox_Formatter_Test extends WPSEO_UnitTestCase {
 	 * Test that wordFormRecognitionActive is false for Afrikaans.
 	 *
 	 * @covers WPSEO_Metabox_Formatter::__construct
-	 * @covers WPSEO_Metabox_Formatter::is_word_form_recognition_active
+	 * @covers Yoast\WP\SEO\Helpers\Language_Helper::is_word_form_recognition_active
 	 */
 	public function test_word_form_recognition_is_not_active() {
 		add_filter(

--- a/tests/integration/framework/class-wpseo-unit-test-case.php
+++ b/tests/integration/framework/class-wpseo-unit-test-case.php
@@ -13,6 +13,8 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
  */
 abstract class WPSEO_UnitTestCase extends TestCase {
 
+	use Yoast_SEO_ReflectionToString_Deprecation_Handler;
+
 	/**
 	 * Make sure to do migrations before WP_UnitTestCase starts messing with the DB.
 	 *
@@ -58,31 +60,6 @@ abstract class WPSEO_UnitTestCase extends TestCase {
 		foreach ( $expected as $needle ) {
 			$found = strpos( $output, $needle );
 			$this->assertTrue( $found !== false, sprintf( 'Expected "%s" to be found in "%s" but couldn\'t find it.', $needle, $output ) );
-		}
-	}
-
-	/**
-	 * Bypass the PHP deprecation error which is thrown in PHP 7.4 for the PHPUnit mock builder
-	 * in select circumstances.
-	 *
-	 * In PHP 7.4+ a deprecation warning may be thrown about functionality in the PHPUnit mock builder.
-	 * Setting an expectation for this will allow the test to run on PHP 7.4 and report proper
-	 * results without the test failing on the deprecation warning.
-	 *
-	 * For tests which error out on PHP 7.4 because of this, a call to this function should be added
-	 * at the top of the test method.
-	 * Use selectively and with care !
-	 *
-	 * {@internal Note: The below way to set the expected exception in only supported in PHPUnit 5+.
-	 *            As this functionality will only be used with PHP 7.4, this is fine as that means that
-	 *            PHPUnit 5+ will be used anyway.}
-	 *
-	 * @return void
-	 */
-	protected function bypass_php74_mockbuilder_deprecation_warning() {
-		if ( version_compare( PHP_VERSION_ID, 70399, '>' ) ) {
-			$this->expectException( 'PHPUnit_Framework_Error_Deprecated' );
-			$this->expectExceptionMessage( 'Function ReflectionType::__toString() is deprecated' );
 		}
 	}
 }

--- a/tests/integration/framework/class-wpseo-unit-test-case.php
+++ b/tests/integration/framework/class-wpseo-unit-test-case.php
@@ -29,22 +29,6 @@ abstract class WPSEO_UnitTestCase extends TestCase {
 	}
 
 	/**
-	 * Tests for expected output.
-	 *
-	 * @param string $expected    Expected output.
-	 * @param string $description Explanation why this result is expected.
-	 */
-	protected function expectOutput( $expected, $description = '' ) {
-		$output = ob_get_contents();
-		ob_clean();
-
-		$output   = preg_replace( '|\R|', "\r\n", $output );
-		$expected = preg_replace( '|\R|', "\r\n", $expected );
-
-		$this->assertEquals( $expected, $output, $description );
-	}
-
-	/**
 	 * Tests whether the output contains the expected value.
 	 *
 	 * @param string|array $expected Expected output.

--- a/tests/integration/framework/class-wpseo-unit-test-case.php
+++ b/tests/integration/framework/class-wpseo-unit-test-case.php
@@ -6,11 +6,12 @@
  */
 
 use Yoast\WP\SEO\Initializers\Migration_Runner;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /**
  * TestCase base class for convenience methods.
  */
-abstract class WPSEO_UnitTestCase extends WP_UnitTestCase {
+abstract class WPSEO_UnitTestCase extends TestCase {
 
 	/**
 	 * Make sure to do migrations before WP_UnitTestCase starts messing with the DB.
@@ -23,33 +24,6 @@ abstract class WPSEO_UnitTestCase extends WP_UnitTestCase {
 		// Run migrations.
 		$migration_runner = YoastSEO()->classes->get( Migration_Runner::class );
 		$migration_runner->run_migrations( 'free' );
-	}
-
-	/**
-	 * Adds slashes to the value of $key in the $_POST array, and then updates the $_REQUEST array.
-	 *
-	 * @param string $key   Key to be used with PHP superglobals.
-	 * @param mixed  $value Value to assign to it.
-	 */
-	protected function set_post( $key, $value ) {
-		$_POST[ $key ]    = addslashes( $value );
-		$_REQUEST[ $key ] = $_POST[ $key ];
-	}
-
-	/**
-	 * Unsets a given variable in $_POST and $_REQUEST.
-	 *
-	 * @param string $key Key as used with PHP superglobal.
-	 */
-	protected function unset_post( $key ) {
-		unset( $_POST[ $key ], $_REQUEST[ $key ] );
-	}
-
-	/**
-	 * Fake a request to the WP front page.
-	 */
-	protected function go_to_home() {
-		$this->go_to( home_url( '/' ) );
 	}
 
 	/**

--- a/tests/integration/framework/class-wpseo-unit-test-case.php
+++ b/tests/integration/framework/class-wpseo-unit-test-case.php
@@ -27,23 +27,4 @@ abstract class WPSEO_UnitTestCase extends TestCase {
 		$migration_runner = YoastSEO()->classes->get( Migration_Runner::class );
 		$migration_runner->run_migrations( 'free' );
 	}
-
-	/**
-	 * Tests whether the output contains the expected value.
-	 *
-	 * @param string|array $expected Expected output.
-	 */
-	protected function expectOutputContains( $expected ) {
-		$output = preg_replace( '|\R|', "\r\n", ob_get_contents() );
-		ob_clean();
-
-		if ( ! is_array( $expected ) ) {
-			$expected = [ $expected ];
-		}
-
-		foreach ( $expected as $needle ) {
-			$found = strpos( $output, $needle );
-			$this->assertTrue( $found !== false, sprintf( 'Expected "%s" to be found in "%s" but couldn\'t find it.', $needle, $output ) );
-		}
-	}
 }

--- a/tests/integration/framework/reflectiontostring-deprecation-handler-trait.php
+++ b/tests/integration/framework/reflectiontostring-deprecation-handler-trait.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Framework
+ */
+
+/**
+ * Helper to set an expected exception for select tests.
+ */
+trait Yoast_SEO_ReflectionToString_Deprecation_Handler {
+
+	/**
+	 * Sets an expectation for a deprecation warning being thrown when the test in being run
+	 * on PHP >= 7.4 in combination with PHPUnit < 7.
+	 *
+	 * On PHP 7.4+ a deprecation warning may be thrown about functionality in the PHPUnit mock builder
+	 * in select circumstances.
+	 * Setting an expectation for this will allow the test to run on PHP 7.4 with PHPUnit 5 and 6,
+	 * and report proper results, without the test failing on the deprecation warning.
+	 *
+	 * For tests which error out on PHP 7.4 because of this warning, a call to this function
+	 * should be added at the top of the test method.
+	 * Use selectively and with care !
+	 *
+	 * {@internal Note: The below way to set the expected exception is specific to PHPUnit 5/6.
+	 *            As this functionality will only be used with PHP 7.4 and the PHPUnit version
+	 *            is locked via Composer to PHPUnit 5.7, this is fine.}
+	 *
+	 * @return void
+	 */
+	protected function expect_reflection_deprecation_warning_php74() {
+		$phpunit_version = tests_get_phpunit_version();
+		if ( PHP_VERSION_ID > 70399 && PHP_VERSION_ID < 80000
+			&& version_compare( $phpunit_version, '7.0.0', '<' )
+		) {
+			$exception = 'PHPUnit_Framework_Error_Deprecated';
+			if ( version_compare( $phpunit_version, '6.0.0', '>=' ) ) {
+				$exception = 'PHPUnit\Framework\Error\Deprecated';
+			}
+
+			$this->expectException( $exception );
+			$this->expectExceptionMessage( 'Function ReflectionType::__toString() is deprecated' );
+		}
+	}
+}

--- a/tests/integration/inc/test-class-myyoast-api-request.php
+++ b/tests/integration/inc/test-class-myyoast-api-request.php
@@ -206,11 +206,11 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 	 * Unit test to make sure this is fixed: https://github.com/Yoast/wordpress-seo/issues/12560
 	 *
 	 * @covers WPSEO_MyYoast_Api_Request::do_request
-	 *
-	 * @expectedException        WPSEO_MyYoast_Bad_Request_Exception
-	 * @expectedExceptionMessage Error
 	 */
 	public function test_exception_arguments() {
+		$this->expectException( WPSEO_MyYoast_Bad_Request_Exception::class );
+		$this->expectExceptionMessage( 'Error' );
+
 		add_filter( 'pre_http_request', [ $this, 'return_error_object' ] );
 
 		$instance = new WPSEO_MyYoast_Api_Request_Double( 'some_url', [] );

--- a/tests/integration/inc/test-class-myyoast-api-request.php
+++ b/tests/integration/inc/test-class-myyoast-api-request.php
@@ -62,7 +62,7 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 			->method( 'decode_response' );
 
 		$this->assertFalse( $instance->fire() );
-		$this->assertAttributeEquals( 'Request went wrong', 'error_message', $instance );
+		$this->assertEquals( 'Request went wrong', $this->getPropertyValue( $instance, 'error_message' ) );
 		$this->assertEquals( 'Request went wrong', $instance->get_error_message() );
 	}
 
@@ -89,7 +89,7 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 			->will( $this->returnValue( WPSEO_Utils::format_json_encode( $response ) ) );
 
 		$this->assertTrue( $instance->fire() );
-		$this->assertAttributeEquals( (object) $response, 'response', $instance );
+		$this->assertEquals( (object) $response, $this->getPropertyValue( $instance, 'response' ) );
 		$this->assertEquals( (object) $response, $instance->get_response() );
 	}
 
@@ -112,7 +112,7 @@ class WPSEO_MyYoast_Api_Request_Test extends WPSEO_UnitTestCase {
 			->will( $this->returnValue( 'raw_response' ) );
 
 		$this->assertFalse( $instance->fire() );
-		$this->assertAttributeEquals( 'No JSON object was returned.', 'error_message', $instance );
+		$this->assertEquals( 'No JSON object was returned.', $this->getPropertyValue( $instance, 'error_message' ) );
 	}
 
 	/**

--- a/tests/integration/inc/test-class-wpseo-admin-bar-menu.php
+++ b/tests/integration/inc/test-class-wpseo-admin-bar-menu.php
@@ -214,9 +214,9 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 			->will( $this->returnValue( true ) );
 
 		$admin_bar_menu->register_hooks();
-		$this->assertInternalType( 'int', has_action( 'admin_bar_menu', [ $admin_bar_menu, 'add_menu' ], 95 ) );
-		$this->assertInternalType( 'int', has_action( 'wp_enqueue_scripts', [ $admin_bar_menu, 'enqueue_assets' ] ) );
-		$this->assertInternalType( 'int', has_action( 'admin_enqueue_scripts', [ $admin_bar_menu, 'enqueue_assets' ] ) );
+		$this->assertIsInt( has_action( 'admin_bar_menu', [ $admin_bar_menu, 'add_menu' ], 95 ) );
+		$this->assertIsInt( has_action( 'wp_enqueue_scripts', [ $admin_bar_menu, 'enqueue_assets' ] ) );
+		$this->assertIsInt( has_action( 'admin_enqueue_scripts', [ $admin_bar_menu, 'enqueue_assets' ] ) );
 	}
 
 	/**

--- a/tests/integration/inc/test-class-wpseo-admin-bar-menu.php
+++ b/tests/integration/inc/test-class-wpseo-admin-bar-menu.php
@@ -74,7 +74,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_add_menu_lacking_capabilities() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$admin_bar_menu = $this
 			->getMockBuilder( 'WPSEO_Admin_Bar_Menu' )
@@ -112,7 +112,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_add_menu() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		wp_set_current_user( self::$wpseo_manager );
 

--- a/tests/integration/inc/test-class-wpseo-shortlinker.php
+++ b/tests/integration/inc/test-class-wpseo-shortlinker.php
@@ -47,18 +47,31 @@ class WPSEO_Shortlinker_Test extends TestCase {
 	/**
 	 * Tests getting a shortlink.
 	 *
+	 * @dataProvider data_show
+	 *
 	 * @covers WPSEO_Shortlinker::show
 	 * @covers WPSEO_Shortlinker::get_php_version
 	 * @covers WPSEO_Shortlinker::get_software
+	 *
+	 * @param string $expected_output Substring expected to be found in the actual output.
 	 */
-	public function test_show() {
-		ob_start();
+	public function test_show( $expected_output ) {
 		WPSEO_Shortlinker::show( 'http://yoa.st/blaat' );
-		$shortlink = ob_get_clean();
 
-		$this->assertContains( 'php_version', $shortlink );
-		$this->assertContains( 'platform_version', $shortlink );
-		$this->assertContains( 'software', $shortlink );
+		$this->expectOutputContains( $expected_output );
+	}
+
+	/**
+	 * Data provider for the `test_show()` test.
+	 *
+	 * @return array
+	 */
+	public function data_show() {
+		return [
+			[ 'php_version' ],
+			[ 'platform_version' ],
+			[ 'software' ],
+		];
 	}
 
 	/**

--- a/tests/integration/inc/test-class-wpseo-shortlinker.php
+++ b/tests/integration/inc/test-class-wpseo-shortlinker.php
@@ -5,10 +5,12 @@
  * @package WPSEO\Tests\Inc
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Unit Test Class.
  */
-class WPSEO_Shortlinker_Test extends PHPUnit_Framework_TestCase {
+class WPSEO_Shortlinker_Test extends TestCase {
 
 	/**
 	 * Tests building a shortlink.

--- a/tests/integration/inc/test-class-wpseo-shortlinker.php
+++ b/tests/integration/inc/test-class-wpseo-shortlinker.php
@@ -24,9 +24,9 @@ class WPSEO_Shortlinker_Test extends TestCase {
 
 		$shortlink = $shortlinks->build_shortlink( 'http://yoa.st/abcdefg' );
 
-		$this->assertContains( 'php_version', $shortlink );
-		$this->assertContains( 'platform_version', $shortlink );
-		$this->assertContains( 'software', $shortlink );
+		$this->assertStringContainsString( 'php_version', $shortlink );
+		$this->assertStringContainsString( 'platform_version', $shortlink );
+		$this->assertStringContainsString( 'software', $shortlink );
 	}
 
 	/**
@@ -39,9 +39,9 @@ class WPSEO_Shortlinker_Test extends TestCase {
 	public function test_get() {
 		$shortlink = WPSEO_Shortlinker::get( 'http://yoa.st/blaat' );
 
-		$this->assertContains( 'php_version', $shortlink );
-		$this->assertContains( 'platform_version', $shortlink );
-		$this->assertContains( 'software', $shortlink );
+		$this->assertStringContainsString( 'php_version', $shortlink );
+		$this->assertStringContainsString( 'platform_version', $shortlink );
+		$this->assertStringContainsString( 'software', $shortlink );
 	}
 
 	/**

--- a/tests/integration/inc/test-class-wpseo-upgrade-history.php
+++ b/tests/integration/inc/test-class-wpseo-upgrade-history.php
@@ -45,7 +45,7 @@ class WPSEO_Upgrade_History_Test extends WPSEO_UnitTestCase {
 	public function test_construct_with_default_option_name() {
 		$instance = new WPSEO_Upgrade_History();
 
-		$this->assertAttributeEquals( 'wpseo_upgrade_history', 'option_name', $instance );
+		$this->assertEquals( 'wpseo_upgrade_history', $this->getPropertyValue( $instance, 'option_name' ) );
 	}
 
 	/**
@@ -56,7 +56,7 @@ class WPSEO_Upgrade_History_Test extends WPSEO_UnitTestCase {
 	public function test_construct_with_given_option_name() {
 		$instance = new WPSEO_Upgrade_History( 'my_option_name' );
 
-		$this->assertAttributeEquals( 'my_option_name', 'option_name', $instance );
+		$this->assertEquals( 'my_option_name', $this->getPropertyValue( $instance, 'option_name' ) );
 	}
 
 	/**

--- a/tests/integration/inc/test-class-wpseo-upgrade-history.php
+++ b/tests/integration/inc/test-class-wpseo-upgrade-history.php
@@ -68,7 +68,7 @@ class WPSEO_Upgrade_History_Test extends WPSEO_UnitTestCase {
 		$upgrade_history = $this->get_instance();
 		$history         = $upgrade_history->get();
 
-		$this->assertInternalType( 'array', $history );
+		$this->assertIsArray( $history );
 		$this->assertEmpty( $history );
 	}
 
@@ -111,7 +111,7 @@ class WPSEO_Upgrade_History_Test extends WPSEO_UnitTestCase {
 		$history = $upgrade_history->get();
 		$entry   = current( $history );
 
-		$this->assertInternalType( 'array', $entry, 'There should be an entry added.' );
+		$this->assertIsArray( $entry, 'There should be an entry added.' );
 		$this->assertArrayHasKey( 'options', $entry );
 		$this->assertEmpty( $entry['options'], 'There should be no options.' );
 		$this->assertEquals( '1.0.0', $entry['old_version'] );
@@ -130,7 +130,7 @@ class WPSEO_Upgrade_History_Test extends WPSEO_UnitTestCase {
 		$history = $upgrade_history->get();
 		$entry   = current( $history );
 
-		$this->assertInternalType( 'array', $entry, 'There should be an entry added.' );
+		$this->assertIsArray( $entry, 'There should be an entry added.' );
 		$this->assertArrayHasKey( 'options', $entry );
 		$this->assertEmpty( $entry['options'], 'The non-existing option should not be returned.' );
 		$this->assertEquals( '1.0.0', $entry['old_version'] );

--- a/tests/integration/notifications/test-class-yoast-notification-center.php
+++ b/tests/integration/notifications/test-class-yoast-notification-center.php
@@ -201,7 +201,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$test = [ $notification->to_array() ];
 
-		$this->assertInternalType( 'array', $stored_notifications );
+		$this->assertIsArray( $stored_notifications );
 		$this->assertEquals( $test, $stored_notifications );
 	}
 
@@ -271,7 +271,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$sorted = $subject->get_sorted_notifications();
 
-		$this->assertInternalType( 'array', $sorted );
+		$this->assertIsArray( $sorted );
 		$this->assertEquals( [ $notification ], $sorted );
 	}
 
@@ -285,7 +285,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$sorted = $subject->get_sorted_notifications();
 
-		$this->assertInternalType( 'array', $sorted );
+		$this->assertIsArray( $sorted );
 		$this->assertEquals( [], $sorted );
 	}
 
@@ -461,7 +461,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$notifications = $notification_center->get_notifications();
 
-		$this->assertInternalType( 'array', $notifications );
+		$this->assertIsArray( $notifications );
 
 		$notification = array_shift( $notifications );
 
@@ -483,7 +483,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 
 		$new = $notification_center->get_new_notifications();
 
-		$this->assertInternalType( 'array', $new );
+		$this->assertIsArray( $new );
 		$this->assertContains( $notification, $new );
 	}
 

--- a/tests/integration/notifications/test-class-yoast-notification-center.php
+++ b/tests/integration/notifications/test-class-yoast-notification-center.php
@@ -371,7 +371,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$subject->add_notification( $notification );
 		$subject->display_notifications();
 
-		$this->expectOutput( 'a' );
+		$this->expectOutputString( 'a' );
 	}
 
 	/**
@@ -404,7 +404,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$subject->add_notification( $notification );
 		$subject->display_notifications();
 
-		$this->expectOutput( '' );
+		$this->expectOutputString( '' );
 	}
 
 	/**
@@ -433,7 +433,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$subject->display_notifications();
 
 		// It should not be displayed.
-		$this->expectOutput( '' );
+		$this->expectOutputString( '' );
 	}
 
 	/**

--- a/tests/integration/notifications/test-class-yoast-notification-center.php
+++ b/tests/integration/notifications/test-class-yoast-notification-center.php
@@ -728,7 +728,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_remove_notification_by_id_when_no_notification_is_found() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$notification_center = $this
 			->getMockBuilder( 'Yoast_Notification_Center' )
@@ -750,7 +750,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_remove_notification_by_id_when_notification_is_found() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$notification_center = $this
 			->getMockBuilder( 'Yoast_Notification_Center' )

--- a/tests/integration/notifications/test-class-yoast-notification.php
+++ b/tests/integration/notifications/test-class-yoast-notification.php
@@ -7,6 +7,8 @@
 
 /**
  * Class Test_Yoast_Notification.
+ *
+ * @covers Yoast_Notification
  */
 class Test_Yoast_Notification extends WPSEO_UnitTestCase {
 

--- a/tests/integration/notifiers/test-class-configuration-notifier.php
+++ b/tests/integration/notifiers/test-class-configuration-notifier.php
@@ -42,7 +42,9 @@ class WPSEO_Configuration_Notifier_Test extends WPSEO_UnitTestCase {
 	public function test_listen_when_notification_will_be_shown_and_dismissal_trigger_is_on() {
 		$notifier = $this
 			->getMockBuilder( 'WPSEO_Configuration_Notifier' )
-			->setConstructorArgs( [ 'show_onboarding_notice' => true ] )
+			->setConstructorArgs(
+				[ true ] // 'show_onboarding_notice'.
+			)
 			->setMethods( [ 'show_notification', 'dismissal_is_triggered', 'set_dismissed' ] )
 			->getMock();
 
@@ -71,7 +73,9 @@ class WPSEO_Configuration_Notifier_Test extends WPSEO_UnitTestCase {
 	public function test_listen_when_notification_is_not_shown() {
 		$notifier = $this
 			->getMockBuilder( 'WPSEO_Configuration_Notifier' )
-			->setConstructorArgs( [ 'show_onboarding_notice' => true ] )
+			->setConstructorArgs(
+				[ true ] // 'show_onboarding_notice'.
+			)
 			->setMethods( [ 'show_notification', 'dismissal_is_triggered', 'set_dismissed' ] )
 			->getMock();
 
@@ -99,7 +103,9 @@ class WPSEO_Configuration_Notifier_Test extends WPSEO_UnitTestCase {
 	public function test_listen_when_notification_is_show_but_trigger_is_not_on() {
 		$notifier = $this
 			->getMockBuilder( 'WPSEO_Configuration_Notifier' )
-			->setConstructorArgs( [ 'show_onboarding_notice' => true ] )
+			->setConstructorArgs(
+				[ true ] // 'show_onboarding_notice'.
+			)
 			->setMethods( [ 'show_notification', 'dismissal_is_triggered', 'set_dismissed' ] )
 			->getMock();
 

--- a/tests/integration/notifiers/test-class-dismissible-notification.php
+++ b/tests/integration/notifiers/test-class-dismissible-notification.php
@@ -61,7 +61,7 @@ class WPSEO_Dismissible_Notification_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_handle_where_situation_is_applicable() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$notification_center = $this
 			->getMockBuilder( 'Yoast_Notification_Center' )

--- a/tests/integration/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/integration/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -36,12 +36,12 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 *
 	 * Checks if an OutOfBoundsException is thrown, when there are no users in the sitemap.
 	 *
-	 * @expectedException        OutOfBoundsException
-	 * @expectedExceptionMessage Invalid sitemap page requested
-	 *
 	 * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
 	 */
 	public function test_author_excluded_from_sitemap_by_zero_posts() {
+		$this->expectException( OutOfBoundsException::class );
+		$this->expectExceptionMessage( 'Invalid sitemap page requested' );
+
 		// Removes authors with no posts.
 		WPSEO_Options::set( 'noindex-author-noposts-wpseo', true );
 
@@ -109,12 +109,12 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 *
 	 * Checks if an OutOfBoundsException is thrown, when there are no users in the sitemap.
 	 *
-	 * @expectedException        OutOfBoundsException
-	 * @expectedExceptionMessage Invalid sitemap page requested
-	 *
 	 * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
 	 */
 	public function test_author_exclusion() {
+		$this->expectException( OutOfBoundsException::class );
+		$this->expectExceptionMessage( 'Invalid sitemap page requested' );
+
 		// Creates a user with 3 posts.
 		$user_id = $this->factory->user->create( [ 'role' => 'author' ] );
 		$this->factory->post->create_many( 3, [ 'post_author' => $user_id ] );
@@ -207,12 +207,12 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 	 *
 	 * Checks if an OutOfBoundsException is thrown, when there are no users in the sitemap.
 	 *
-	 * @expectedException        OutOfBoundsException
-	 * @expectedExceptionMessage Invalid sitemap page requested
-	 *
 	 * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
 	 */
 	public function test_no_users_empty_author_sitemap() {
+		$this->expectException( OutOfBoundsException::class );
+		$this->expectExceptionMessage( 'Invalid sitemap page requested' );
+
 		// Checks which users are in the sitemap, there should be none.
 		self::$class_instance->get_sitemap_links( 'author', 10, 1 );
 	}

--- a/tests/integration/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/integration/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -149,7 +149,7 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 		$sitemaps->redirect( $GLOBALS['wp_the_query'] );
 
 		// Expects an empty page (404) to be returned.
-		$this->expectOutput( '' );
+		$this->expectOutputString( '' );
 	}
 
 	/**
@@ -172,7 +172,7 @@ class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
 		$sitemaps->redirect( $GLOBALS['wp_the_query'] );
 
 		// Expects an empty page (404) to be returned.
-		$this->expectOutput( '' );
+		$this->expectOutputString( '' );
 
 		// Cleanup.
 		WPSEO_Options::set( 'disable-author', false );

--- a/tests/integration/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/integration/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -131,7 +131,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$sitemaps->redirect( $GLOBALS['wp_the_query'] );
 
 		// Expect an empty page (404) to be returned.
-		$this->expectOutput( '' );
+		$this->expectOutputString( '' );
 	}
 
 	/**

--- a/tests/integration/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/integration/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -268,7 +268,7 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$post_object = $this->factory()->post->create_and_get();
 		$post_url    = $sitemap_provider->get_url( $post_object );
 
-		$this->assertContains( $current_home, $post_url['loc'] );
+		$this->assertStringContainsString( $current_home, $post_url['loc'] );
 
 		// Change home URL.
 		update_option( 'home', 'http://example.com' );

--- a/tests/integration/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
@@ -9,6 +9,8 @@
  * Class Test_WPSEO_Sitemap_Provider_Overlap.
  *
  * @group sitemaps
+ *
+ * @covers WPSEO_Sitemaps
  */
 class Test_WPSEO_Sitemap_Provider_Overlap extends WPSEO_UnitTestCase {
 

--- a/tests/integration/sitemaps/test-class-wpseo-sitemaps-cache-validator.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemaps-cache-validator.php
@@ -115,11 +115,10 @@ class WPSEO_Sitemaps_Cache_Validator_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Tests whether an exception is thrown when a non numeric value is passed.
 	 *
-	 * @expectedException InvalidArgumentException
-	 *
 	 * @covers ::convert_base10_to_base61
 	 */
 	public function test_base_10_to_base_61_non_integer() {
+		$this->expectException( InvalidArgumentException::class );
 
 		WPSEO_Sitemaps_Cache_Validator::convert_base10_to_base61( 'ab' );
 	}

--- a/tests/integration/sitemaps/test-class-wpseo-sitemaps-renderer.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemaps-renderer.php
@@ -45,8 +45,8 @@ class WPSEO_Sitemaps_Renderer_Test extends WPSEO_UnitTestCase {
 		];
 
 		$index = self::$class_instance->get_index( $links );
-		$this->assertContains( "<loc>{$loc}</loc>", $index );
-		$this->assertContains( "<lastmod>{$lastmod}</lastmod>", $index );
+		$this->assertStringContainsString( "<loc>{$loc}</loc>", $index );
+		$this->assertStringContainsString( "<lastmod>{$lastmod}</lastmod>", $index );
 	}
 
 	/**
@@ -78,11 +78,11 @@ class WPSEO_Sitemaps_Renderer_Test extends WPSEO_UnitTestCase {
 		];
 
 		$index = self::$class_instance->get_sitemap( $links, 'post', 0 );
-		$this->assertContains( "<loc>{$loc}</loc>", $index );
-		$this->assertContains( "<lastmod>{$mod}</lastmod>", $index );
-		$this->assertContains( "<image:loc>{$src}</image:loc>", $index );
-		$this->assertContains( "<image:title><![CDATA[{$title}]]></image:title>", $index );
-		$this->assertContains( "<image:caption><![CDATA[{$alt}]]></image:caption>", $index );
+		$this->assertStringContainsString( "<loc>{$loc}</loc>", $index );
+		$this->assertStringContainsString( "<lastmod>{$mod}</lastmod>", $index );
+		$this->assertStringContainsString( "<image:loc>{$src}</image:loc>", $index );
+		$this->assertStringContainsString( "<image:title><![CDATA[{$title}]]></image:title>", $index );
+		$this->assertStringContainsString( "<image:caption><![CDATA[{$alt}]]></image:caption>", $index );
 	}
 
 	/**

--- a/tests/integration/sitemaps/test-class-wpseo-sitemaps.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemaps.php
@@ -31,28 +31,44 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Test the nested sitemap generation.
 	 *
+	 * @dataProvider data_post_sitemap
+	 *
 	 * @covers WPSEO_Sitemaps::redirect
+	 *
+	 * @param string $expected_output Substring expected to be found in the actual output.
 	 */
-	public function test_post_sitemap() {
+	public function test_post_sitemap( $expected_output ) {
 		self::$class_instance->reset();
 
 		set_query_var( 'sitemap', 'post' );
 
 		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
 
-		$expected_contains = [
-			'<?xml',
-			'<urlset ',
+		$this->expectOutputContains( $expected_output );
+	}
+
+	/**
+	 * Data provider for the `test_post_sitemap()` test.
+	 *
+	 * @return array
+	 */
+	public function data_post_sitemap() {
+		return [
+			[ '<?xml' ],
+			[ '<urlset ' ],
 		];
-		$this->expectOutputContains( $expected_contains );
 	}
 
 	/**
 	 * Tests the main sitemap and also tests the transient cache.
 	 *
+	 * @dataProvider data_main_sitemap
+	 *
 	 * @covers WPSEO_Sitemaps::redirect
+	 *
+	 * @param string $expected_output Substring expected to be found in the actual output.
 	 */
-	public function test_main_sitemap() {
+	public function test_main_sitemap( $expected_output ) {
 
 		self::$class_instance->reset();
 
@@ -61,13 +77,22 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 		$this->factory->post->create();
 
 		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
-		$expected_contains = [
-			'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-			'<sitemap>',
-			'<lastmod>',
-			'</sitemapindex>',
+
+		$this->expectOutputContains( $expected_output );
+	}
+
+	/**
+	 * Data provider for the `test_main_sitemap()` test.
+	 *
+	 * @return array
+	 */
+	public function data_main_sitemap() {
+		return [
+			[ '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' ],
+			[ '<sitemap>' ],
+			[ '<lastmod>' ],
+			[ '</sitemapindex>' ],
 		];
-		$this->expectOutputContains( $expected_contains );
 	}
 
 	/**
@@ -95,10 +120,8 @@ class WPSEO_Sitemaps_Test extends WPSEO_UnitTestCase {
 		);
 
 		self::$class_instance->redirect( $GLOBALS['wp_the_query'] );
-		$expected_contains = [
-			'<loc>test-sitemap.xml</loc>',
-		];
-		$this->expectOutputContains( $expected_contains );
+
+		$this->expectOutputContains( '<loc>test-sitemap.xml</loc>' );
 	}
 
 	/**

--- a/tests/integration/sitemaps/test-class-wpseo-taxonomy-sitemap-provider.php
+++ b/tests/integration/sitemaps/test-class-wpseo-taxonomy-sitemap-provider.php
@@ -85,6 +85,6 @@ class WPSEO_Taxonomy_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$sitemaps->redirect( $GLOBALS['wp_the_query'] );
 
 		// Expect an empty page (404) to be returned.
-		$this->expectOutput( '' );
+		$this->expectOutputString( '' );
 	}
 }

--- a/tests/integration/taxonomy/test-class-taxonomy-presenter.php
+++ b/tests/integration/taxonomy/test-class-taxonomy-presenter.php
@@ -121,7 +121,10 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 			]
 		);
 
-		$this->assertContains( '<select name="wpseo_fieldname" id="wpseo_fieldname"><option  value="value">option_value</option></select>', $output );
+		$this->assertStringContainsString(
+			'<select name="wpseo_fieldname" id="wpseo_fieldname"><option  value="value">option_value</option></select>',
+			$output
+		);
 	}
 
 	/**
@@ -145,7 +148,10 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 			]
 		);
 
-		$this->assertContains( '<input name="wpseo_fieldname" id="wpseo_fieldname" type="checkbox" />', $output );
+		$this->assertStringContainsString(
+			'<input name="wpseo_fieldname" id="wpseo_fieldname" type="checkbox" />',
+			$output
+		);
 	}
 
 	/**
@@ -165,7 +171,10 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 			]
 		);
 
-		$this->assertContains( '<input name="wpseo_fieldname" id="hidden_wpseo_fieldname" type="hidden" value="" />', $output );
+		$this->assertStringContainsString(
+			'<input name="wpseo_fieldname" id="hidden_wpseo_fieldname" type="hidden" value="" />',
+			$output
+		);
 	}
 
 	/**
@@ -185,8 +194,11 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 			]
 		);
 
-		$this->assertContains( '<input id="wpseo_fieldname" type="text" size="36" name="wpseo_fieldname" value="" readonly="readonly" />', $output );
-		$this->assertContains(
+		$this->assertStringContainsString(
+			'<input id="wpseo_fieldname" type="text" size="36" name="wpseo_fieldname" value="" readonly="readonly" />',
+			$output
+		);
+		$this->assertStringContainsString(
 			'<input id="wpseo_fieldname_button" class="wpseo_image_upload_button button" data-target="wpseo_fieldname" data-target-id="hidden_wpseo_fieldname-id" type="button" value="Upload Image" />',
 			$output
 		);
@@ -209,6 +221,9 @@ class WPSEO_Taxonomy_Presenter_Test extends WPSEO_UnitTestCase {
 			]
 		);
 
-		$this->assertContains( '<p id="wpseo_fieldname-desc" class="yoast-metabox__description">description for the field</p>', $output );
+		$this->assertStringContainsString(
+			'<p id="wpseo_fieldname-desc" class="yoast-metabox__description">description for the field</p>',
+			$output
+		);
 	}
 }

--- a/tests/integration/taxonomy/test-class-taxonomy.php
+++ b/tests/integration/taxonomy/test-class-taxonomy.php
@@ -5,12 +5,14 @@
  * @package WPSEO\Tests\Taxonomy
  */
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Unit Test Class.
  *
  * @coversDefaultClass WPSEO_Taxonomy
  */
-class WPSEO_Taxonomy_Test extends PHPUnit_Framework_TestCase {
+class WPSEO_Taxonomy_Test extends TestCase {
 
 	/**
 	 * Make sure certain pages are marked as term edit.

--- a/tests/integration/test-class-admin-asset-manager.php
+++ b/tests/integration/test-class-admin-asset-manager.php
@@ -247,17 +247,11 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 			->getMock();
 
 		$class_instance
-			->expects( $this->at( 0 ) )
+			->expects( $this->exactly( 2 ) )
 			->method( 'register_script' )
-			->with(
-				$this->equalTo( new WPSEO_Admin_Asset( $asset_args[0] ) )
-			);
-
-		$class_instance
-			->expects( $this->at( 1 ) )
-			->method( 'register_script' )
-			->with(
-				$this->equalTo( new WPSEO_Admin_Asset( $asset_args[1] ) )
+			->withConsecutive(
+				[ $this->equalTo( new WPSEO_Admin_Asset( $asset_args[0] ) ) ],
+				[ $this->equalTo( new WPSEO_Admin_Asset( $asset_args[1] ) ) ]
 			);
 
 		$class_instance->register_scripts( $asset_args );
@@ -291,17 +285,11 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 			->getMock();
 
 		$class_instance
-			->expects( $this->at( 0 ) )
+			->expects( $this->exactly( 2 ) )
 			->method( 'register_style' )
-			->with(
-				$this->equalTo( new WPSEO_Admin_Asset( $asset_args[0] ) )
-			);
-
-		$class_instance
-			->expects( $this->at( 1 ) )
-			->method( 'register_style' )
-			->with(
-				$this->equalTo( new WPSEO_Admin_Asset( $asset_args[1] ) )
+			->withConsecutive(
+				[ $this->equalTo( new WPSEO_Admin_Asset( $asset_args[0] ) ) ],
+				[ $this->equalTo( new WPSEO_Admin_Asset( $asset_args[1] ) ) ]
 			);
 
 		$class_instance->register_styles( $asset_args );

--- a/tests/integration/test-class-admin-asset-manager.php
+++ b/tests/integration/test-class-admin-asset-manager.php
@@ -226,7 +226,7 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_register_scripts() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$asset_args = [
 			0 => [
@@ -270,7 +270,7 @@ class WPSEO_Admin_Asset_Manager_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_register_styles() {
 
-		$this->bypass_php74_mockbuilder_deprecation_warning();
+		$this->expect_reflection_deprecation_warning_php74();
 
 		$asset_args = [
 			0 => [

--- a/tests/integration/test-class-admin-asset.php
+++ b/tests/integration/test-class-admin-asset.php
@@ -14,10 +14,10 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 	 * Tests the constructor when no name and src are passed.
 	 *
 	 * @covers WPSEO_Admin_Asset::__construct
-	 *
-	 * @expectedException InvalidArgumentException
 	 */
 	public function test_constructor_missing_name() {
+		$this->expectException( InvalidArgumentException::class );
+
 		new WPSEO_Admin_Asset( [] );
 	}
 
@@ -25,10 +25,10 @@ class WPSEO_Admin_Asset_Test extends WPSEO_UnitTestCase {
 	 * Tests the constructor when no src is passed.
 	 *
 	 * @covers WPSEO_Admin_Asset::__construct
-	 *
-	 * @expectedException InvalidArgumentException
 	 */
 	public function test_constructor_missing_src() {
+		$this->expectException( InvalidArgumentException::class );
+
 		$asset_args = [
 			'name' => 'name',
 		];

--- a/tests/integration/test-wpseo-functions.php
+++ b/tests/integration/test-wpseo-functions.php
@@ -59,6 +59,6 @@ class WPSEO_Functions_Test extends WPSEO_UnitTestCase {
 	public function test_wpseo_get_capabilities() {
 		$capabilities = wpseo_get_capabilities();
 
-		$this->assertInternalType( 'array', $capabilities );
+		$this->assertIsArray( $capabilities );
 	}
 }

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -64,9 +64,11 @@ abstract class TestCase extends YoastTestCase {
 	/**
 	 * Tests if the output buffer contains the provided strings.
 	 *
-	 * @param string|array $expected Expected output.
+	 * @param string|array $expected        Expected output.
+	 * @param bool         $ignore_eol_diff Ignore. Temporary until this method has been removed
+	 *                                      in favour of the WP Test Utils `expectOutputContains()` method.
 	 */
-	protected function expectOutputContains( $expected ) {
+	public function expectOutputContains( $expected, $ignore_eol_diff = true ) {
 		$output = \preg_replace( '|\R|', "\r\n", \ob_get_contents() );
 		\ob_clean();
 

--- a/tests/unit/conditionals/post-conditional-test.php
+++ b/tests/unit/conditionals/post-conditional-test.php
@@ -24,8 +24,8 @@ class Post_Conditional_Test extends TestCase {
 	/**
 	 * Does the setup for testing.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->instance = new Post_Conditional();
 	}

--- a/tests/unit/helpers/input-helper-test.php
+++ b/tests/unit/helpers/input-helper-test.php
@@ -24,8 +24,8 @@ class Input_Helper_Test extends TestCase {
 	/**
 	 * Sets up the test class.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->instance = new Input_Helper();
 	}


### PR DESCRIPTION
## Context

* (Preparation for) compatibility with PHP 8

## Summary

This PR can be summarized in the following changelog entry:

* (Preparation for) compatibility with PHP 8

## Relevant technical choices:

:bulb: This PR will be easiest to review by going through the individual commits one by one.

### Composer: update Yoast/wp-test-utils to 0.2.1

A new version of the WP Test Utils package has been released which deals with the necessary work-arounds for the WP integration tests and adds utilities for this which individual plugins can use, like functions for the bootstrap and a `TestCase` which includes all the polyfills from the PHPUnit Polyfill repo.

As this repo does **not** have a `config.platform.php` set to PHP `5.6` in the `composer.json` file, as dev dependencies need a higher PHP version, the `require-dev` for PHPUnit needs to remain to keep it locked at PHPUnit 5.7.

The update to WP Test Utils `0.2.1` also updates BrainMonkey to version `2.6.0`.

Refs:
* https://github.com/Yoast/wp-test-utils/releases/tag/0.2.0
* https://github.com/Yoast/wp-test-utils/releases/tag/0.2.1

### Tests: use the bootstrap utilities from WP Test Utils

For integration tests, WP Test Utils contains a `bootstrap-functions.php` file with utility functions for a number of common patterns used in bootstrap files for WP integration tests.

As the order in which things get loaded is _**extremely**_ important for the integration tests, whenever possible, the `WPIntegration\bootstrap_it()` method should be used.

This method will:
- Verify that the Composer `autoload.php` file exists.
- Load WordPress.
    The location for WP can be configured by setting either the `WP_TESTS_DIR` or the `WP_DEVELOP_DIR` environment variable on an OS level or via a custom `phpunit.xml` file.
    If neither of these two environment variables is found, it is presumed that the plugin is installed in `src/wp-content/plugins/plugin-name`.
    _This is compatible with the old bootstrap setup and developers will not need to make any changes to their environment for this to work._
- While loading WordPress, the plugin will be loaded, including the Composer autoload file.
- And lastly, a custom autoloader will be added to handle the PHPUnit 7.x MockObject classes not being compatible with PHP 8.0.
    This custom autoloader will load the copies of the PHPUnit 9.x MockObject classes which are part of the WP native test suite as of WP 5.6 when PHP 8.x is detected, and will let the composer autoloader load the PHPUnit native versions when not on PHP 8.x.

If anything goes wrong during these steps, the WP Test Utils method will provide human readable error messages, similar to before.

### WPSEO_UnitTestCase: switch parent class

This switches the parent class of the `WPSEO_UnitTestCase` to the WP Test Utils `Yoast\WPTestUtils\WPIntegration\TestCase`.

Includes:
* Removing methods which were unused in this test suite.

### Tests: switch parent class for various test classes

Not all tests in the YoastSEO test suite use the `WPSEO_UnitTestCase` as a parent.

This commit switches out the parent class for the the test classes which don't. This will ensure that the PHPUnit polyfills are available everywhere.

### Improve handling of PHP 7.4 MockBuilder deprecation warning

Follow up on commit face1ff from last year.

The aforementioned commit introduced a `bypass_php74_mockbuilder_deprecation_warning()` method to get round a deprecation warning being thrown in PHP 7.4 when using the PHPUnit MockBuilder package which comes with PHPUnit 5.x.

Since then, this method has been copied over to various other test classes which don't extend the generic `WPSEO_UnitTestCase` class.

As the tests will now, selectively, be using PHPUnit 7.x, the method now needs adjusting as the MockBuilder code which ships with PHPUnit 7.x* does not trigger the warning anymore, which would cause tests to fail on an expected warning **_not_** being thrown.
_* Note: it has not been verified where exactly the cut-off point is between when the package would throw the warning and when it wouldn't. As the PHPUnit version is locked to PHPUnit 5.7.27 for most test runs and will use the latest version of PHPUnit 7 - 7.5.20 - as installed via Composer for others, the exact version is irrelevant._

This commit makes the necessary adjustments and cleans things up, by:
* Removing the function from the `WPSEO_UnitTestCase` as well as the various individual test classes in which it had been copied.
* Introducing a new `Yoast_SEO_ReflectionToString_Deprecation_Handler` trait which will be `use`d by all classes which previously contained a copy of the function.
* Now the function lives in a `trait` with a descriptive name, renaming the actual method to a better name `expect_reflection_deprecation_warning_php74()` too (previously: `bypass_php74_mockbuilder_deprecation_warning()`).
    Includes updating all calls to the method from within individual tests.
* Updating the code _within_ the function to ensure that the deprecation warning is **not** expected when PHPUnit 7.x or higher is used.
    This makes use of the WP Core `tests_get_phpunit_version()` function which, as this function is only used within the integration test suite, is available.
* Updating the code _within_ the function to expect the PHPUnit 6.x exception class when the tests would be run on PHPUnit 6.

### Tests: modernize used assertions / assertInternalType()

The PHPUnit Polyfills allows for using PHPUnit 9.x assertions, even when the tests are being run on older PHPUnit versions.

This updates select assertions to the modern PHPUnit syntax, most notably, it switches out the following assertions:
* `assertInternalType()` for calls to `assertIs[Type]()`.

Note: the method calls switched over are based on tests run on PHPUnit 8/9 (don't ask how I did that) and only those assertions which _need_ to be switched over to prevent issues in the future, have been.

### Tests: modernize used assertions / assertStringContainsString()

The PHPUnit Polyfills allows for using PHPUnit 9.x assertions, even when the tests are being run on older PHPUnit versions.

This updates select assertions to the modern PHPUnit syntax, most notably, it switches out the following assertions:
* `assertInternalType()` for calls to `assertIs[Type]()`.

Note: the method calls switched over are based on tests run on PHPUnit 8/9 (don't ask how I did that) and only those assertions which _need_ to be switched over to prevent issues in the future, have been.

### Tests: modernize used expectations / expectException*()

PHPUnit 5.2.0 introduced the `expectException()`, `expectExceptionMessage()`, `expectExceptionCode()` and the `expectExceptionMessageRegExp()` methods.

The `setExpectedException()` all-in-one method and the `setExpectedExceptionRegExp()` method were deprecated and removed in PHPUnit 6.0.0.

This commit updates those tests which were still using the old-school way of setting exception expectations.

### Tests: remove use of `@expectException*` annotations

Setting expectations for exception via annotations is deprecated in PHPUnit 8 and removed in PHPUnit 9.

This replaces the few instances in which annotations were used, with the use of the `expectException*()` methods.

### Tests: remove use of `assertAttribute*()` assertions

The `assertAttribute*()` assertion methods were deprecated in PHPUnit 8.x and removed in PHPUnit 9.

The reasoning for that was that `protected` and `private` properties are implementation details and should not be tested directly, but via the methods in the class.

For now, I've elected to maintain the existing test behaviour, while making it work in a PHPUnit cross-version compatible manner.

This is done by:
1. Using a test helper method introduced provided via PHPUnit Polyfills (0.2.0) to get the value of a non-public property.
2. Changing the assertion for the tests from `assertAttribute*()` to `assert*()`

At a later point in time, it should be re-examined whether these implementation details should be tested in this way.

Note: as these tests will only be run on PHPUnit 5-7, this change isn't _strictly_ necessary, however, it makes the use of the methods in tests consistent across the various plugins and should help devs to remember to use this pattern rather than the old `assertAttribute*()` methods.

### Tests: use `expectOutputString()`

PHPUnit contains a native `expectOutputString()` method to set expectations for generated output.

If needs be, this can be combined with a call to `setOutputCallback()` method to adjust the actual generated output before the expectation is tested, for instance, to normalize line endings.

With that in mind, there is no need for a custom `expectOutput()` method in the `WPSEO_UnitTestCase` class.

So, this commit switches out the custom code in this test suite in favour of using the PHPUnit native `expectOutputString()` method.

### Tests: use `expectOutputContains()`

WP Test Utils introduces a new `expectOutputContains()` method to complement the PHPUnit native `expectOutput*()` methods as it appears testing whether output contains a certain text string is a common pattern in the Yoast tests.

By default this method will ignore differences in line endings to improve the cross-OS compatibility of the tests.

This switches out the custom code to do the same in this test suite in favour of using the `expectOutputContains()` method instead.

**Important**: each test should only have one (1) output expectation. Subsequent expectations being set will overwrite the original expectation. In effect, that means that only the last set expectation will ever be tested.

This goes for both the PHPUnit native `expectOutput*()` methods as well as the WP Test Utils `expectOutputContains()` method.

To that end, when there were multiple expectations for one test, these tests have been refactored to be run multiple times in combination with a data provider. That way, each expectation will be tested separately.

### Tests: use `expectOutput*()`

PHPUnit contains a native `expectOutputString()` and a `expectOutputRegex()` method to set expectations for generated output and WP Test Utils introduces a new `expectOutputContains()` method to complement these.
PHPUnit also contains a `getActualOutput()` method to get access to the generated output if other handling would be needed.

Any tests generating output should use these methods to set expectations instead of using the PHP native `ob_*()` output buffering functions.

This switches out the custom code using the `ob_*()` functions in favour of using the PHPUnit native or the WP Test Utils `expectOutput*()` methods.

**Important**: each test should only have one (1) output expectation. Subsequent expectations being set will overwrite the original expectation. In effect, that means that only the last set expectation will ever be tested.

This goes for both the PHPUnit native `expectOutput*()` methods as well as the WP Test Utils `expectOutputContains()` method.

To that end, when there were multiple expectations for one test, these tests have been refactored to be run multiple times in combination with a data provider. That way, each expectation will be tested separately.

### WPSEO_Admin_Asset_Manager_Test: refactor tests using `MockBuilder->at()`

The `at()` matcher has been deprecated in PHPUnit 9 and will be removed in PHPUnit 10. It is strongly recommended not to rely on the order in which methods are invoked.

Replacing the expectations create with the `at()` matcher, by a slightly different expectation which still tests that the `register_(script|style)()` function is called 1) the expected number of times and 2) with specific arguments and 3) in a certain order.

This stabilizes these tests for the future.

### WPSEO_Configuration_Notifier_Test: fix PHP 8 bug (tests only)

When an array is passed to `MockBuilder::setConstructorArgs()`, it will internally in PHPUnit be called using `call_user_func_array()`.

As PHP 8 introduces named parameters, if the arguments passed to `MockBuilder::setConstructorArgs()` are an associative array instead of a numerically indexed array, the array keys will now be interpreted as parameter names.

To get round this, we just need to make sure that we're not passing an associative array.

### Test: fix a few missing and incorrect `@covers` tags

### PHPUnit config: improve code coverage configuration

* Add the schema annotation.
* Remove the `syntaxCheck` directive which hasn't been supported since forever.
* Rename the testsuite to use a more descriptive name.
* Remove the redundant `<testsuite name="php56+">` block.
    1. PHP 5.6 has been the minimum PHP version for quite a while now, so no need for a version check for tests.
    2. There are no tests with a filename ending on `-test.php` in the integration tests directory and the `tests/integration/src` directory doesn't exist.
* Improve the code coverage configuration:
    - Fix the code coverage configuration to include all relevant files and directories.
        This is now in sync with the same list in the `phpunit.xml.dist` file used for the BrainMonkey based tests.
    - Add `addUncoveredFilesFromWhitelist` and `processUncoveredFilesFromWhitelist` directives with sensible values.
    - Add the `forceCoversAnnotation` attribute to only record code coverage for the method under test as annotated via a `@covers` annotation.

Based on this configuration, the strict code coverage for this testsuite is currently 10.54%.

Includes minor tweaks to the `phpunit.xml.dist` file for the BrainMonkey based tests for the same.

### Travis: run the tests against PHP 8.0

Now the test setup has been made compatible for allowing to run the tests on PHP 8 using PHPUnit 7.x, the integration tests can be run on PHP 8.0 in the CI  runs.

However, there are still some things to take into account for running the tests on PHP 8.0:
1. The repo has a committed `composer.lock` file which locks  the PHPUnit version to PHPUnit 5.x.
2. The repo has a `require-dev` for PHPUnit set to PHPUnit `5.7.x`.
2. WP hard limits their test suite to PHPUnit 7.x (max), which means the plugin integration tests need to be run on PHPUnit 7.x as well.
    However, PHPUnit 7.x is also _required_ for running the tests on PHP 8.0, PHPUnit 5.x won't work.
3. The BrainMonkey based tests, however, should be run on PHPUnit 9.3+, which is the first PHPUnit version officially compatible with PHP 8.0.

Other relevant information:
* Since this Friday, Travis now has a PHP 8.0 image available.
* Any PHP 8 related fixes have gone into WP 5.6. Running the integration tests against earlier WP versions is futile.

So, keeping all of that in mind, this commit:
* Adds a new build against PHP 8.0, with `WP_VERSION` set to WP `latest` ( WP 5.6) as released on Tuesday, and the `PHPUNIT` flag set to `1` (= on).
* In the `install` section: makes sure that the `composer install` with `--ignore-platform-reqs` is used for PHP 8.x as otherwise the install would fail due  to PHPUnit 5.x (as per the lock file) not being allowed to be installed on PHP 8.
* In the `script` section:
    - Have a separate condition-based script for running the integration tests on PHP 8 (or `nightly`, though they currently won't be run against  `nightly`).
    - Within that script **hard** require PHPUnit 7..x.
    - As the `PHPUNIT` flag has been added, the conditions for the BrainMonkey based unit tests are also adjusted.
        These tests are no longer run against `nightly`, but are run against `8.0` when the `PHPUNIT` flag is enabled.

Includes updating the matrix for the release of WP 5.6.

### Unit tests: minor tweak

As the WP Test Utils now brings in a `expectOutputContains()` method with a slightly different method signature, we need to update the method signature of the method with the same name in the BrainMonkey base `TestCase` class.

This is a temporary fix. In the (near) future, this method will be removed in favour of the one in WP Test Utils. Same as is already done in this PR for the integration tests.

### Unit tests: fix fixture method names

Introduced in #16377. See PR #16409 for context.


## Test instructions


### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the output of all builds for this PR, making sure that 1) the installation via Composer works without issues, 2) the tests are being run, 3) the tests pass, 4) the BrainMonkey tests are being run and also pass.

To test locally, it will be simplest to:
1. Run `composer install`.
2. Run `composer integration-test` on any PHP version below 8.0 and see the tests pass.
    This confirms that the changes to the test bootstrap and the `TestCase` work correctly.
3. Switch to PHP 8.
4. Run `composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs`
5. Run `composer integration-test` to see the tests running and passing on PHP 8 in combination with PHPUnit 7.x.
    This confirms that the tests can now run cross-version on all PHPUnit versions between PHPUnit 5.7 and PHPUnit 7.x and that the tests run and pass on PHP 8.

Note: this doesn't confirm full PHP 8 compatibility yet as the test code coverage of the BrainMonkey + integration tests combined, is nowhere near 100%.


