### PR TITLE
Update README.md to use badge from travis-ci.com instead of travis-ci.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yoast SEO
 
-[![Build Status](https://api.travis-ci.org/Yoast/wordpress-seo.svg?branch=master)](https://travis-ci.org/Yoast/wordpress-seo)
+[![Build Status](https://api.travis-ci.com/Yoast/wordpress-seo.svg?branch=master)](https://travis-ci.com/Yoast/wordpress-seo)
 [![Stable Version](https://poser.pugx.org/yoast/wordpress-seo/v/stable.svg)](https://packagist.org/packages/yoast/wordpress-seo)
 [![License](https://poser.pugx.org/yoast/wordpress-seo/license.svg)](https://packagist.org/packages/yoast/wordpress-seo)
 


### PR DESCRIPTION
This PR simply replaces the URL that is used for the Travis badge that is displayed in the README.md file. I noticed that it is pointing to travis-ci.org and it seems that you migrated to travis-ci.com.