### PR TITLE
Unit tests: remove custom expectOutput*() methods and other improvements

### DIFF
--- a/tests/integration/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
@@ -24,6 +24,16 @@ class Test_WPSEO_Sitemap_Provider_Overlap extends WPSEO_UnitTestCase {
 	/**
 	 * Set up our double class.
 	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		// Make sure the author archives are enabled.
+		WPSEO_Options::set( 'disable-author', false );
+	}
+
+	/**
+	 * Set up our double class.
+	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -31,16 +41,6 @@ class Test_WPSEO_Sitemap_Provider_Overlap extends WPSEO_UnitTestCase {
 
 		// Reset the instance.
 		self::$class_instance->reset();
-	}
-
-	/**
-	 * Set up our double class.
-	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-
-		// Make sure the author archives are enabled.
-		WPSEO_Options::set( 'disable-author', false );
 	}
 
 	/**

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -46,27 +46,6 @@ abstract class TestCase extends YoastTestCase {
 	}
 
 	/**
-	 * Tests if the output buffer contains the provided strings.
-	 *
-	 * @param string|array $expected        Expected output.
-	 * @param bool         $ignore_eol_diff Ignore. Temporary until this method has been removed
-	 *                                      in favour of the WP Test Utils `expectOutputContains()` method.
-	 */
-	public function expectOutputContains( $expected, $ignore_eol_diff = true ) {
-		$output = \preg_replace( '|\R|', "\r\n", \ob_get_contents() );
-		\ob_clean();
-
-		if ( ! \is_array( $expected ) ) {
-			$expected = [ $expected ];
-		}
-
-		foreach ( $expected as $needle ) {
-			$found = \strpos( $output, $needle );
-			$this->assertTrue( $found !== false, \sprintf( 'Expected "%s" to be found in "%s" but couldn\'t find it.', $needle, $output ) );
-		}
-	}
-
-	/**
 	 * Tests if the output buffer doesn't contain the provided strings.
 	 *
 	 * @param string|array $needles Expected output.

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -44,23 +44,4 @@ abstract class TestCase extends YoastTestCase {
 		// This is required to ensure backfill and other statics are set.
 		WPSEO_Options::get_instance();
 	}
-
-	/**
-	 * Tests if the output buffer doesn't contain the provided strings.
-	 *
-	 * @param string|array $needles Expected output.
-	 */
-	protected function expectOutputNotContains( $needles ) {
-		$output = \preg_replace( '|\R|', "\r\n", \ob_get_contents() );
-		\ob_clean();
-
-		if ( ! \is_array( $needles ) ) {
-			$needles = [ $needles ];
-		}
-
-		foreach ( $needles as $needle ) {
-			$found = \strpos( $output, $needle );
-			$this->assertTrue( $found === false, \sprintf( 'Expected "%s" to be found in "%s" but couldn\'t find it.', $needle, $output ) );
-		}
-	}
 }

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -46,22 +46,6 @@ abstract class TestCase extends YoastTestCase {
 	}
 
 	/**
-	 * Tests for expected output.
-	 *
-	 * @param string $expected    Expected output.
-	 * @param string $description Explanation why this result is expected.
-	 */
-	protected function expectOutput( $expected, $description = '' ) {
-		$output = \ob_get_contents();
-		\ob_clean();
-
-		$output   = \preg_replace( '|\R|', "\r\n", $output );
-		$expected = \preg_replace( '|\R|', "\r\n", $expected );
-
-		$this->assertEquals( $expected, $output, $description );
-	}
-
-	/**
 	 * Tests if the output buffer contains the provided strings.
 	 *
 	 * @param string|array $expected        Expected output.
@@ -99,19 +83,5 @@ abstract class TestCase extends YoastTestCase {
 			$found = \strpos( $output, $needle );
 			$this->assertTrue( $found === false, \sprintf( 'Expected "%s" to be found in "%s" but couldn\'t find it.', $needle, $output ) );
 		}
-	}
-
-	/**
-	 * Tests for expected empty output.
-	 *
-	 * @param string $description Explanation why this result is expected.
-	 */
-	protected function expectEmptyOutput( $description = '' ) {
-		$output = \ob_get_contents();
-		\ob_clean();
-
-		$output = \preg_replace( '|\R|', "\r\n", $output );
-
-		$this->assertEmpty( $output, $description );
 	}
 }

--- a/tests/unit/admin/metabox/metabox-collapsibles-section-test.php
+++ b/tests/unit/admin/metabox/metabox-collapsibles-section-test.php
@@ -29,6 +29,8 @@ class Metabox_Collapsibles_Section_Test extends TestCase {
 	/**
 	 * Tests the output of \WPSEO_Metabox_Collapsibles_Section::display_content.
 	 *
+	 * @dataProvider data_display_content_with_collapsible
+	 *
 	 * @covers WPSEO_Metabox_Collapsibles_Sections::__construct
 	 * @covers WPSEO_Metabox_Collapsibles_Sections::display_content
 	 * @covers WPSEO_Metabox_Collapsibles_Sections::has_sections
@@ -36,8 +38,10 @@ class Metabox_Collapsibles_Section_Test extends TestCase {
 	 * @covers WPSEO_Metabox_Collapsible::__construct
 	 * @covers WPSEO_Metabox_Collapsible::content
 	 * @covers WPSEO_Metabox_Collapsible::link
+	 *
+	 * @param string $expected Substring expected to be found in the actual output.
 	 */
-	public function test_display_content_with_collapsible() {
+	public function test_display_content_with_collapsible( $expected ) {
 		$collapsibles = [];
 
 		$collapsibles[] = new WPSEO_Metabox_Collapsible(
@@ -54,13 +58,20 @@ class Metabox_Collapsibles_Section_Test extends TestCase {
 
 		$section->display_content();
 
-		$this->expectOutputContains(
-			[
-				'Collapsible 1 label',
-				'Collapsible 1 content',
-				'wpseo-meta-section-collapsibles-tab',
-			]
-		);
+		$this->expectOutputContains( $expected );
+	}
+
+	/**
+	 * Data provider for the `test_display_content_with_collapsible()` test.
+	 *
+	 * @return array
+	 */
+	public function data_display_content_with_collapsible() {
+		return [
+			[ 'Collapsible 1 label' ],
+			[ 'Collapsible 1 content' ],
+			[ 'wpseo-meta-section-collapsibles-tab' ],
+		];
 	}
 
 	/**
@@ -92,6 +103,6 @@ class Metabox_Collapsibles_Section_Test extends TestCase {
 
 		$section->display_link();
 
-		$this->expectOutputContains( [ 'Metabox Tab Title' ] );
+		$this->expectOutputContains( 'Metabox Tab Title' );
 	}
 }

--- a/tests/unit/admin/metabox/metabox-section-additional-test.php
+++ b/tests/unit/admin/metabox/metabox-section-additional-test.php
@@ -26,31 +26,46 @@ class Metabox_Section_Additional_Test extends TestCase {
 	/**
 	 * Tests the output of \WPSEO_Metabox_Section_Additional::display_content.
 	 *
+	 * @dataProvider data_display_content
+	 *
 	 * @covers WPSEO_Metabox_Section_Additional::__construct
 	 * @covers WPSEO_Metabox_Section_Additional::display_content
+	 *
+	 * @param string $expected Substring expected to be found in the actual output.
 	 */
-	public function test_display_content() {
+	public function test_display_content( $expected ) {
 		$section = new WPSEO_Metabox_Section_Additional( 'additional-tab', 'Additional Tab', 'Additional Content' );
 
 		$section->display_content();
 
-		$this->expectOutputContains(
-			[
-				'Additional Content',
-				'id="wpseo-meta-section-additional-tab"',
-				'aria-labelledby="wpseo-meta-tab-additional-tab"',
-			]
-		);
+		$this->expectOutputContains( $expected );
+	}
+
+	/**
+	 * Data provider for the `test_display_content()` test.
+	 *
+	 * @return array
+	 */
+	public function data_display_content() {
+		return [
+			[ 'Additional Content' ],
+			[ 'id="wpseo-meta-section-additional-tab"' ],
+			[ 'aria-labelledby="wpseo-meta-tab-additional-tab"' ],
+		];
 	}
 
 	/**
 	 * Tests the output of \WPSEO_Metabox_Section_Additional::display_link.
 	 *
+	 * @dataProvider data_display_link
+	 *
 	 * @covers WPSEO_Metabox_Section_Additional::__construct
 	 * @covers WPSEO_Metabox_Section_Additional::display_content
 	 * @covers WPSEO_Metabox_Section_Additional::display_link
+	 *
+	 * @param string $expected Substring expected to be found in the actual output.
 	 */
-	public function test_display_link() {
+	public function test_display_link( $expected ) {
 		$section = new WPSEO_Metabox_Section_Additional(
 			'additional-tab',
 			'Additional Tab',
@@ -63,16 +78,23 @@ class Metabox_Section_Additional_Test extends TestCase {
 
 		$section->display_link();
 
-		$this->expectOutputContains(
-			[
-				'Additional Tab',
-				'id="wpseo-meta-tab-additional-tab"',
-				'href="#wpseo-meta-section-additional-tab"',
-				'aria-controls="wpseo-meta-section-additional-tab"',
-				'additional-class',
-				'aria-label="additional-aria"',
-			]
-		);
+		$this->expectOutputContains( $expected );
+	}
+
+	/**
+	 * Data provider for the `test_display_link()` test.
+	 *
+	 * @return array
+	 */
+	public function data_display_link() {
+		return [
+			[ 'Additional Tab' ],
+			[ 'id="wpseo-meta-tab-additional-tab"' ],
+			[ 'href="#wpseo-meta-section-additional-tab"' ],
+			[ 'aria-controls="wpseo-meta-section-additional-tab"' ],
+			[ 'additional-class' ],
+			[ 'aria-label="additional-aria"' ],
+		];
 	}
 
 	/**

--- a/tests/unit/admin/metabox/metabox-section-additional-test.php
+++ b/tests/unit/admin/metabox/metabox-section-additional-test.php
@@ -104,10 +104,17 @@ class Metabox_Section_Additional_Test extends TestCase {
 	 * @covers WPSEO_Metabox_Section_Additional::display_link
 	 */
 	public function test_display_link_no_aria_label() {
-		$section = new WPSEO_Metabox_Section_Additional( 'additional-tab', 'Additional Tab', 'Additional Content', [ 'link_class' => 'additional-class' ] );
+		$section = new WPSEO_Metabox_Section_Additional(
+			'additional-tab',
+			'Additional Tab',
+			'Additional Content',
+			[ 'link_class' => 'additional-class' ]
+		);
 
 		$section->display_link();
 
-		$this->expectOutputNotContains( [ 'aria-label' ] );
+		$this->expectOutputContains( 'href="#wpseo-meta-section-additional-tab"' );
+
+		$this->assertStringNotContainsString( 'aria-label', $this->getActualOutput() );
 	}
 }

--- a/tests/unit/admin/myyoast-proxy-test.php
+++ b/tests/unit/admin/myyoast-proxy-test.php
@@ -121,7 +121,7 @@ class MyYoast_Proxy_Test extends TestCase {
 
 		$instance->render_proxy_page();
 
-		$this->expectOutput( '', 'Load URL succeeded, no output expected' );
+		$this->expectOutputString( '' );
 	}
 
 	/**
@@ -173,6 +173,6 @@ class MyYoast_Proxy_Test extends TestCase {
 
 		$instance->render_proxy_page();
 
-		$this->expectOutput( '', 'wp_remote_get failed, no output expected' );
+		$this->expectOutputString( '' );
 	}
 }

--- a/tests/unit/integrations/admin/indexing-tool-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-tool-integration-test.php
@@ -217,7 +217,7 @@ class Indexing_Tool_Integration_Test extends TestCase {
 		$this->instance->render_indexing_list_item();
 
 		// Assert.
-		$this->expectOutput( '' );
+		$this->expectOutputString( '' );
 	}
 
 	/**
@@ -234,6 +234,8 @@ class Indexing_Tool_Integration_Test extends TestCase {
 		$this->instance->render_indexing_list_item();
 
 		// Assert.
-		$this->expectOutput( '<li><strong>Optimize SEO Data</strong><br/>You can speed up your site and get insight into your internal linking structure by letting us perform a few optimizations to the way SEO data is stored. If you have a lot of content it might take a while, but trust us, it\'s worth it. <a href="https://yoast.com" target="_blank">Learn more about the benefits of optimized SEO data.</a><div id="yoast-seo-indexing-action" style="margin: 16px 0;"></div></li>' );
+		$this->expectOutputString(
+			'<li><strong>Optimize SEO Data</strong><br/>You can speed up your site and get insight into your internal linking structure by letting us perform a few optimizations to the way SEO data is stored. If you have a lot of content it might take a while, but trust us, it\'s worth it. <a href="https://yoast.com" target="_blank">Learn more about the benefits of optimized SEO data.</a><div id="yoast-seo-indexing-action" style="margin: 16px 0;"></div></li>'
+		);
 	}
 }

--- a/tests/unit/integrations/admin/migration-error-integration-test.php
+++ b/tests/unit/integrations/admin/migration-error-integration-test.php
@@ -123,6 +123,6 @@ class Migration_Error_Integration_Test extends TestCase {
 
 		$this->instance->render_migration_error();
 
-		$this->expectOutput( $expected );
+		$this->expectOutputString( $expected );
 	}
 }

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -149,7 +149,7 @@ class Front_End_Integration_Test extends TestCase {
 
 		$this->instance->present_head();
 
-		$this->expectOutput( \PHP_EOL . "\tOutput" . \PHP_EOL . \PHP_EOL . \PHP_EOL );
+		$this->expectOutputString( \PHP_EOL . "\tOutput" . \PHP_EOL . \PHP_EOL . \PHP_EOL );
 	}
 
 	/**

--- a/tests/unit/integrations/front-end/force-rewrite-title-test.php
+++ b/tests/unit/integrations/front-end/force-rewrite-title-test.php
@@ -133,7 +133,7 @@ class Force_Rewrite_Title_Test extends TestCase {
 
 		$this->instance->flush_cache();
 
-		$this->expectOutput( $expected_output );
+		$this->expectOutputString( $expected_output );
 	}
 
 	/**
@@ -175,7 +175,7 @@ class Force_Rewrite_Title_Test extends TestCase {
 		$expected_output .= '<meta rel="yoast" value="meta" />';
 		$expected_output .= '<!-- / Yoast SEO plugin. -->';
 
-		$this->expectOutput( $expected_output );
+		$this->expectOutputString( $expected_output );
 	}
 
 	/**
@@ -218,7 +218,7 @@ class Force_Rewrite_Title_Test extends TestCase {
 		$expected_output .= '<meta rel="yoast" value="meta" />';
 		$expected_output .= '<!-- / Yoast SEO plugin. -->';
 
-		$this->expectOutput( $expected_output );
+		$this->expectOutputString( $expected_output );
 	}
 
 	/**

--- a/tests/unit/integrations/front-end/force-rewrite-title-test.php
+++ b/tests/unit/integrations/front-end/force-rewrite-title-test.php
@@ -155,10 +155,10 @@ class Force_Rewrite_Title_Test extends TestCase {
 			->once()
 			->andReturn( [] );
 
-		$output  = '<title>This is an after title</title>';
-		$output .= '<!-- This site is optimized with the Yoast SEO plugin v1.0 -->';
+		$output  = '<!-- This site is optimized with the Yoast SEO plugin v1.0 -->';
 		$output .= '<meta rel="yoast" value="meta" />';
 		$output .= '<!-- / Yoast SEO plugin. -->';
+		$output .= '<title>This is an after title</title>';
 
 		$this->instance
 			->expects( 'get_buffered_output' )

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -234,7 +234,7 @@ class Schema_Blocks_Test extends TestCase {
 
 		$this->instance->output();
 
-		$this->expectEmptyOutput();
+		$this->expectOutputString( '' );
 	}
 
 	/**
@@ -253,7 +253,7 @@ class Schema_Blocks_Test extends TestCase {
 
 		$this->instance->output();
 
-		$this->expectEmptyOutput();
+		$this->expectOutputString( '' );
 	}
 
 	/**
@@ -272,6 +272,6 @@ class Schema_Blocks_Test extends TestCase {
 
 		$this->instance->output();
 
-		$this->expectEmptyOutput();
+		$this->expectOutputString( '' );
 	}
 }

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -168,7 +168,7 @@ class Schema_Blocks_Test extends TestCase {
 			->once()
 			->andReturnTrue();
 
-		$this->instance->register_template( WPSEO_PATH . '/src/schema-templates/recipe.block.php' );
+		$this->instance->register_template( 'src/schema-templates/recipe.block.php' );
 		$this->instance->output();
 
 		$this->expectOutputContains( '<script type="text/block-template">' );

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -188,8 +188,7 @@ class Schema_Blocks_Test extends TestCase {
 
 		$this->instance->output();
 
-		$this->instance->register_template( WPSEO_PATH . '/src/schema-templates/recipe.block.php' );
-		$this->expectOutputNotContains( '<script type="text/block-template">' );
+		$this->expectOutputString( '' );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Improve unit tests

## Summary

This PR can be summarized in the following changelog entry:

* Improve unit tests

## Relevant technical choices:

### Tests: change order of fixture method

Order fixture methods in the order they will executed fo lower cognitive load.

### Tests: use `expectOutputString()`

PHPUnit contains a native `expectOutputString()` method to set expectations for generated output.

If needs be, this can be combined with a call to `setOutputCallback()` method to adjust the actual generated output before the expectation is tested, for instance, to normalize line endings.

With that in mind, there is no need for a custom `expectOutput()` or `expectEmptyOutput()` methods in the `WPSEO_UnitTestCase` class.

So, this commit switches out the custom code in this test suite in favour of using the PHPUnit native `expectOutputString()` method.

### Tests: use `expectOutputContains()`

WP Test Utils 0.2.0 introduces a new `expectOutputContains()` method to complement the PHPUnit native `expectOutput*()` methods as it appears testing whether output contains a certain text string is a common pattern in the Yoast tests.

By default this method will ignore differences in line endings to improve the cross-OS compatibility of the tests.

This switches out the custom code to do the same in this test suite in favour of using the `expectOutputContains()` method instead.

**Important**: each test should only have one (1) output expectation. Subsequent expectations being set will overwrite the original expectation. In effect, that means that only the last set expectation will ever be tested.

This goes for both the PHPUnit native `expectOutput*()` methods as well as the WP Test Utils `expectOutputContains()` method.

To that end, when there were multiple expectations for one test, these tests have been refactored to be run multiple times in combination with a data provider. That way, each expectation will be tested separately.

### Tests: use `expectOutput*()`

PHPUnit contains a native `expectOutputString()` and a `expectOutputRegex()` method to set expectations for generated output and WP Test Utils introduces a new `expectOutputContains()` method to complement these.
PHPUnit also contains a `getActualOutput()` method to get access to the generated output if other handling would be needed.

Any tests generating output should use these methods to set expectations instead of using the PHP native `ob_*()` output buffering functions.

This switches out the last custom method `expectOutputNotContains()` using the `ob_*()` functions in favour of using the PHPUnit native or the WP Test Utils `expectOutput*()` methods in the tests themselves.

Includes minor changes to the test code to stabilize the tests.

### Force_Rewrite_Title_Test: fix incorrect test

The `test_flush_cache_with_replacing_the_titles_after()` test is supposed to test the removal of the `<title>` tag _after_ the debug marker.

In reality it was testing removing the tag _before_ the debug marker, making it a duplicate of the `test_flush_cache_with_replacing_the_titles_before()` test.

This fixes the test input to test correctly what the test intended to test.

### Schema_Blocks_Test: stabilize a test

The `Schema_Blocks::register_template()` expects either a relative or an absolute path and has a condition to handle relative paths.

This changes the `Schema_Blocks_Test::test_output()` to use a relative path instead of an absolute path, which makes sure the condition is tested, but also happens to stabilize the test on Windows as absolute paths on Windows, don't start with a `/` (but with a drive letter).


## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the tests pass, we're good.

Note: when making the test adjustments I have verified for each of these tests that they would correctly fail if the condition as now set, would not be met.