### PR TITLE
Expose the Yoast editormodules which are used outside of Yoast SEO.

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -592,6 +592,27 @@ class WPSEO_Admin_Asset_Manager {
 				],
 			],
 			[
+				/**
+				 * Asset exposing Yoast editor modules which are used in Yoast add-ons.
+				 */
+				'name' => 'editor-modules',
+				'src'  => false,
+				'deps' => [
+					'lodash',
+					'wp-compose',
+					'wp-data',
+					'wp-element',
+					'wp-i18n',
+					self::PREFIX . 'analysis',
+					self::PREFIX . 'analysis-report',
+					self::PREFIX . 'helpers',
+					self::PREFIX . 'legacy-components',
+					self::PREFIX . 'style-guide',
+					self::PREFIX . 'styled-components',
+					self::PREFIX . 'yoast-components',
+				],
+			],
+			[
 				// The `@yoast/components` package.
 				'name' => 'yoast-components',
 				'src'  => 'yoast/components-' . $flat_version,

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -596,7 +596,7 @@ class WPSEO_Admin_Asset_Manager {
 				 * Asset exposing Yoast editor modules which are used in Yoast add-ons.
 				 */
 				'name' => 'editor-modules',
-				'src'  => false,
+				'src'  => 'editor-modules-' . $flat_version,
 				'deps' => [
 					'lodash',
 					'wp-compose',

--- a/config/webpack/paths.js
+++ b/config/webpack/paths.js
@@ -16,6 +16,7 @@ const entry = {
 	"configuration-wizard": "./configuration-wizard.js",
 	"dashboard-widget": "./dashboard-widget.js",
 	"edit-page": "./edit-page.js",
+	"editor-modules": "./editor-modules.js",
 	"elementor": "./elementor.js",
 	"filter-explanation": "./filter-explanation.js",
 	"help-scout-beacon": "./help-scout-beacon.js",

--- a/js/src/editor-modules.js
+++ b/js/src/editor-modules.js
@@ -1,0 +1,54 @@
+import getL10nObject from "./analysis/getL10nObject";
+import getContentLocale from "./analysis/getContentLocale";
+import getIndicatorForScore from "./analysis/getIndicatorForScore";
+import * as constants from "./analysis/constants";
+import refreshAnalysis from "./analysis/refreshAnalysis";
+import HelpLink from "./components/HelpLink";
+import TopLevelProviders from "./components/TopLevelProviders";
+import * as i18n from "./helpers/i18n";
+import withYoastSidebarPriority from "./components/higherorder/withYoastSidebarPriority";
+import * as mapResults from "./components/contentAnalysis/mapResults";
+import MetaboxCollapsible from "./components/MetaboxCollapsible";
+import SEMrushRelatedKeyphrases from "./containers/SEMrushRelatedKeyphrases";
+import SidebarCollapsible from "./components/SidebarCollapsible";
+import Results from "./containers/Results";
+import createInterpolateElement from "./helpers/createInterpolateElement";
+import isBlockEditor from "./helpers/isBlockEditor";
+import * as replacementVariableHelpers from "./helpers/replacementVariableHelpers";
+import * as location from "./components/contexts/location";
+
+window.yoast = window.yoast || {};
+window.yoast.editorModules = {
+	analysis: {
+		getL10nObject,
+		getContentLocale,
+		getIndicatorForScore,
+		constants,
+		refreshAnalysis,
+	},
+	components: {
+		HelpLink,
+		TopLevelProviders,
+		higherorder: {
+			withYoastSidebarPriority,
+		},
+		contentAnalysis: {
+			mapResults,
+		},
+		contexts: {
+			location,
+		},
+		SidebarCollapsible,
+		MetaboxCollapsible,
+	},
+	containers: {
+		Results,
+		SEMrushRelatedKeyphrases,
+	},
+	helpers: {
+		createInterpolateElement,
+		isBlockEditor,
+		i18n,
+		replacementVariableHelpers,
+	},
+};


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Yoast SEO Premium is currently still a fork of Yoast SEO free. It relies directly on JavaScript modules in the free part of the code. This PR makes sure all Yoast editor modules which Premium relies on are exposed in a separate file, which can be depended on by Yoast SEO Premium, or any other plugin for that matter.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Exposes all Yoast editor modules which are relied on by Yoast SEO premium in a separate script.

## Relevant technical choices:

* Simply decided to expose all the modules in one big ugly object. The alternative would be to reorganize all of the JavaScript in Yoast SEO. That seemed like an easy trade off. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* enqueue the script. Notice no new JS errors.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* This PR adds a script which isn't used in Yoast SEO free. There is nothing to test in Yoast SEO free for QA. When we start using this in Yoast SEO Premium, this should be properly tested.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Nowhere

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
