### PR TITLE
Move Estimated Reading Time calculation and data flow to free

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -5,6 +5,9 @@
  * @package WPSEO\Admin
  */
 
+use Yoast\WP\SEO\Conditionals\Admin\Post_Conditional;
+use Yoast\WP\SEO\Conditionals\Estimated_Reading_Time_Conditional;
+use Yoast\WP\SEO\Helpers\Input_Helper;
 use Yoast\WP\SEO\Presenters\Admin\Alert_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Meta_Fields_Presenter;
 
@@ -56,6 +59,13 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	protected $is_advanced_metadata_enabled;
 
 	/**
+	 * Represents the estimated_reading_time_conditional.
+	 *
+	 * @var Estimated_Reading_Time_Conditional
+	 */
+	protected $estimated_reading_time_conditional;
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
@@ -76,6 +86,11 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		$this->social_is_enabled            = WPSEO_Options::get( 'opengraph', false ) || WPSEO_Options::get( 'twitter', false );
 		$this->is_advanced_metadata_enabled = WPSEO_Capability_Utils::current_user_can( 'wpseo_edit_advanced_metadata' ) || WPSEO_Options::get( 'disableadvanced_meta' ) === false;
+
+		$this->estimated_reading_time_conditional = new Estimated_Reading_Time_Conditional(
+			YoastSEO()->classes->get( Post_Conditional::class ),
+			YoastSEO()->classes->get( Input_Helper::class ),
+		);
 
 		$this->seo_analysis         = new WPSEO_Metabox_Analysis_SEO();
 		$this->readability_analysis = new WPSEO_Metabox_Analysis_Readability();
@@ -871,6 +886,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 					// We need to make the feature flags separately available inside of the analysis web worker.
 					'enabled_features'        => WPSEO_Utils::retrieve_enabled_features(),
 				],
+				'estimatedReadingTimeEnabled' => $this->estimated_reading_time_conditional->is_met(),
 			],
 			'media'            => [
 				// @todo replace this translation with JavaScript translations.

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -89,7 +89,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		$this->estimated_reading_time_conditional = new Estimated_Reading_Time_Conditional(
 			YoastSEO()->classes->get( Post_Conditional::class ),
-			YoastSEO()->classes->get( Input_Helper::class ),
+			YoastSEO()->classes->get( Input_Helper::class )
 		);
 
 		$this->seo_analysis         = new WPSEO_Metabox_Analysis_SEO();
@@ -865,7 +865,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$used_keywords_assessment_location = new WPSEO_Admin_Asset_Analysis_Worker_Location( $asset_manager->flatten_version( WPSEO_VERSION ), 'used-keywords-assessment' );
 
 		$script_data = [
-			'analysis'         => [
+			'analysis' => [
 				'plugins' => [
 					'replaceVars' => [
 						'no_parent_text'           => __( '(no parent)', 'wordpress-seo' ),

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -6,7 +6,7 @@
  */
 
 use Yoast\WP\SEO\Conditionals\Admin\Post_Conditional;
-use Yoast\WP\SEO\Conditionals\Estimated_Reading_Time_Conditional;
+use Yoast\WP\SEO\Conditionals\Admin\Estimated_Reading_Time_Conditional;
 use Yoast\WP\SEO\Helpers\Input_Helper;
 use Yoast\WP\SEO\Presenters\Admin\Alert_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Meta_Fields_Presenter;

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -88,8 +88,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$this->is_advanced_metadata_enabled = WPSEO_Capability_Utils::current_user_can( 'wpseo_edit_advanced_metadata' ) || WPSEO_Options::get( 'disableadvanced_meta' ) === false;
 
 		$this->estimated_reading_time_conditional = new Estimated_Reading_Time_Conditional(
-			YoastSEO()->classes->get( Post_Conditional::class ),
-			YoastSEO()->classes->get( Input_Helper::class )
+			new Post_Conditional(),
+			new Input_Helper()
 		);
 
 		$this->seo_analysis         = new WPSEO_Metabox_Analysis_SEO();

--- a/js/src/elementor.js
+++ b/js/src/elementor.js
@@ -4,6 +4,7 @@ import { applyModifications, pluginReady, pluginReloaded, registerPlugin, regist
 import { setWordPressSeoL10n, setYoastComponentsL10n } from "./helpers/i18n";
 import initAnalysis, { collectData } from "./initializers/analysis";
 import initElementorEditorIntegration from "./initializers/elementor-editor-integration";
+import initializeEstimatedReadingTime from "./initializers/estimated-reading-time";
 import initEditorStore from "./elementor/initializers/editor-store";
 import initializeUsedKeywords from "./elementor/initializers/used-keywords-assessment";
 import initElementorWatcher from "./watchers/elementorWatcher";
@@ -55,6 +56,11 @@ function initialize() {
 
 	// Initialize the Used Keywords Assessment.
 	initializeUsedKeywords();
+
+	console.time( "readingtime init" );
+	// Initialize Estimated Reading Time.
+	initializeEstimatedReadingTime();
+	console.timeEnd( "readingtime init" );
 
 	// Initialize focus keyphrase forms highlighting.
 	initHighlightFocusKeyphraseForms( window.YoastSEO.analysis.worker.runResearch );

--- a/js/src/elementor.js
+++ b/js/src/elementor.js
@@ -57,10 +57,8 @@ function initialize() {
 	// Initialize the Used Keywords Assessment.
 	initializeUsedKeywords();
 
-	console.time( "readingtime init" );
 	// Initialize Estimated Reading Time.
 	initializeEstimatedReadingTime();
-	console.timeEnd( "readingtime init" );
 
 	// Initialize focus keyphrase forms highlighting.
 	initHighlightFocusKeyphraseForms( window.YoastSEO.analysis.worker.runResearch );

--- a/js/src/helpers/fields/EstimatedReadingTimeFields.js
+++ b/js/src/helpers/fields/EstimatedReadingTimeFields.js
@@ -1,0 +1,34 @@
+/**
+ * This class is responsible for handling the interaction with the hidden fields for Estimated Reading Time (ert).
+ */
+export default class EstimatedReadingTimeFields {
+	/**
+	 * Getter for the estimated reading time element.
+	 *
+	 * @returns {HTMLElement} The estimatedReadingTimeElement.
+	 */
+	static get estimatedReadingTimeElement() {
+		return document.getElementById( "yoast_wpseo_estimated-reading-time-minutes" );
+	}
+
+	/**
+	 * Getter for the estimated reading time.
+	 *
+	 * @returns {string} The estimated reading time.
+	 */
+	static get estimatedReadingTime() {
+		return EstimatedReadingTimeFields.estimatedReadingTimeElement &&
+		EstimatedReadingTimeFields.estimatedReadingTimeElement.value || "";
+	}
+
+	/**
+	 * Setter for the estimated reading time.
+	 *
+	 * @param {string} value The value to set.
+	 *
+	 * @returns {void}
+	 */
+	static set estimatedReadingTime( value ) {
+		EstimatedReadingTimeFields.estimatedReadingTimeElement.value = value;
+	}
+}

--- a/js/src/initializers/estimated-reading-time.js
+++ b/js/src/initializers/estimated-reading-time.js
@@ -1,4 +1,3 @@
-/* global tinyMCE */
 import { dispatch, select, subscribe } from "@wordpress/data";
 import { debounce, get } from "lodash";
 import { Paper } from "yoastseo";

--- a/js/src/initializers/estimated-reading-time.js
+++ b/js/src/initializers/estimated-reading-time.js
@@ -27,11 +27,17 @@ const debouncedGetEstimatedReadingTime = debounce( getEstimatedReadingTime, 500 
 function initializeEstimatedReadingTimeClassic() {
 	const tmceEvents = [ "input", "change", "cut", "paste" ];
 	const editorHandle = get( window, "wpseoScriptData.isPost", "0" ) === "1" ? "content" : "description";
-	const tmceEditor = tinyMCE.get( editorHandle );
 
-	tmceEvents.forEach( function( eventName ) {
-		tmceEditor.on( eventName, () => {
-			debouncedGetEstimatedReadingTime( tmceEditor.getContent() );
+	// Once tinyMCE is initialized, add the listeners.
+	jQuery( document ).on( "tinymce-editor-init", ( event, editor ) => {
+		if ( editor.id !== editorHandle ) {
+			return;
+		}
+
+		tmceEvents.forEach( ( eventName ) => {
+			editor.on( eventName, () => {
+				debouncedGetEstimatedReadingTime( editor.getContent() );
+			} );
 		} );
 	} );
 }

--- a/js/src/initializers/estimated-reading-time.js
+++ b/js/src/initializers/estimated-reading-time.js
@@ -1,0 +1,94 @@
+/* global tinyMCE */
+import { dispatch, select, subscribe } from "@wordpress/data";
+import { debounce, get } from "lodash";
+import { Paper } from "yoastseo";
+
+/**
+ * Retrieves the estimated reading time.
+ *
+ * @param {string} content The content.
+ *
+ * @returns {void}
+ */
+function getEstimatedReadingTime( content ) {
+	window.YoastSEO.analysis.worker.runResearch( "readingTime", new Paper( content, {} ) )
+		.then( ( response ) => {
+			dispatch( "yoast-seo/editor" ).setEstimatedReadingTime( response.result );
+		} );
+}
+
+const debouncedGetEstimatedReadingTime = debounce( getEstimatedReadingTime, 500 );
+
+/**
+ * Initializes the estimated reading time for the classic editor.
+ *
+ * @returns {void}
+ */
+function initializeEstimatedReadingTimeClassic() {
+	const tmceEvents = [ "input", "change", "cut", "paste" ];
+	const editorHandle = get( window, "wpseoScriptData.isPost", "0" ) === "1" ? "content" : "description";
+	const tmceEditor = tinyMCE.get( editorHandle );
+
+	tmceEvents.forEach( function( eventName ) {
+		tmceEditor.on( eventName, () => {
+			debouncedGetEstimatedReadingTime( tmceEditor.getContent() );
+		} );
+	} );
+}
+
+/**
+ * Initializes the estimated reading time for the block editor.
+ *
+ * @returns {void}
+ */
+function initializeEstimatedReadingTimeBlockEditor() {
+	let previousContent = select( "core/editor" ).getEditedPostAttribute( "content" );
+
+	subscribe( () => {
+		const content = select( "core/editor" ).getEditedPostAttribute( "content" );
+
+		if ( content !== previousContent ) {
+			previousContent = content;
+			debouncedGetEstimatedReadingTime( content );
+		}
+	} );
+}
+
+/**
+ * Initializes the estimated reading time for the Elementor editor.
+ *
+ * @returns {void}
+ */
+function initializeEstimatedReadingTimeElementor() {
+	let previousContent = select( "yoast-seo/editor" ).getEditorDataContent();
+
+	subscribe( () => {
+		const content = select( "yoast-seo/editor" ).getEditorDataContent();
+
+		if ( content !== previousContent ) {
+			previousContent = content;
+			debouncedGetEstimatedReadingTime( content );
+		}
+	} );
+}
+
+/**
+ * Initializes the estimated reading time.
+ *
+ * @returns {void}
+ */
+export default function initializeEstimatedReadingTime() {
+	if ( get( window, "wpseoScriptData.analysis.estimatedReadingTimeEnabled", false ) === false ) {
+		return;
+	}
+
+	dispatch( "yoast-seo/editor" ).loadEstimatedReadingTime();
+
+	if ( window.wpseoScriptData.isElementorEditor === "1" ) {
+		initializeEstimatedReadingTimeElementor();
+	} else if ( window.wpseoScriptData.isBlockEditor === "1" ) {
+		initializeEstimatedReadingTimeBlockEditor();
+	} else {
+		initializeEstimatedReadingTimeClassic();
+	}
+}

--- a/js/src/post-edit.js
+++ b/js/src/post-edit.js
@@ -5,6 +5,7 @@ import initFeaturedImageIntegration from "./initializers/featured-image";
 import initAdminMedia from "./initializers/admin-media";
 import initAdmin from "./initializers/admin";
 import initEditorStore from "./initializers/editor-store";
+import initializeEstimatedReadingTime from "./initializers/estimated-reading-time";
 import domReady from "@wordpress/dom-ready";
 
 // Backwards compatibility globals.
@@ -43,4 +44,7 @@ domReady( () => {
 
 	// Initialize global admin scripts.
 	initAdmin( jQuery );
+
+	// Initialize the Estimated Reading Time
+	initializeEstimatedReadingTime();
 } );

--- a/js/src/redux/actions/estimatedReadingTime.js
+++ b/js/src/redux/actions/estimatedReadingTime.js
@@ -1,0 +1,31 @@
+import EstimatedReadingTimeFields from "../../helpers/fields/EstimatedReadingTimeFields";
+
+export const SET_ESTIMATED_READING_TIME = "SET_ESTIMATED_READING_TIME";
+export const LOAD_ESTIMATED_READING_TIME = "LOAD_ESTIMATED_READING_TIME";
+
+/**
+ * Sets the estimated reading time to the store
+ *
+ * @param {Object} estimatedReadingTime The estimated reading time from the researcher.
+ *
+ * @returns {Object} The SET_ESTIMATED_READING_TIME action.
+ */
+export function setEstimatedReadingTime( estimatedReadingTime ) {
+	EstimatedReadingTimeFields.estimatedReadingTime = estimatedReadingTime;
+	return {
+		type: SET_ESTIMATED_READING_TIME,
+		estimatedReadingTime,
+	};
+}
+
+/**
+ * Loads the Estimated Reading Time from the hidden field to the store.
+ *
+ * @returns {Object} The LOAD_ESTIMATED_READING_TIME action
+ */
+export function loadEstimatedReadingTime() {
+	return {
+		type: LOAD_ESTIMATED_READING_TIME,
+		estimatedReadingTime: EstimatedReadingTimeFields.estimatedReadingTime,
+	};
+}

--- a/js/src/redux/actions/index.js
+++ b/js/src/redux/actions/index.js
@@ -9,6 +9,7 @@ export * from "./advancedSettings";
 export * from "./analysis";
 export * from "./cornerstoneContent";
 export * from "./editorData";
+export * from "./estimatedReadingTime";
 export * from "./focusKeyword";
 export * from "./markerButtons";
 export * from "./markerPauseStatus";

--- a/js/src/redux/reducers/estimatedReadingTime.js
+++ b/js/src/redux/reducers/estimatedReadingTime.js
@@ -1,0 +1,32 @@
+import {
+	LOAD_ESTIMATED_READING_TIME,
+	SET_ESTIMATED_READING_TIME,
+} from "../actions/estimatedReadingTime";
+
+const INITIAL_STATE = {
+	estimatedReadingTime: 0,
+};
+
+/**
+ * A reducer for the estimatedReadingTime.
+ *
+ * @param {Object} state  The current state of the object.
+ * @param {Object} action The current action received.
+ *
+ * @returns {Object} The state.
+ */
+function estimatedReadingTimeReducer( state = INITIAL_STATE, action ) {
+	switch ( action.type ) {
+		case LOAD_ESTIMATED_READING_TIME:
+			// Fallthrough condition because format of LOAD_ and SET_ actions are the same.
+		case SET_ESTIMATED_READING_TIME:
+			return {
+				...state,
+				estimatedReadingTime: action.estimatedReadingTime,
+			};
+		default:
+			return state;
+	}
+}
+
+export default estimatedReadingTimeReducer;

--- a/js/src/redux/reducers/index.js
+++ b/js/src/redux/reducers/index.js
@@ -4,6 +4,7 @@ import advancedSettings from "./advancedSettings";
 import analysisData from "./analysisData";
 import editorContext from "./editorContext";
 import editorData from "./editorData";
+import estimatedReadingTime from "./estimatedReadingTime";
 import isCornerstone from "./cornerstoneContent";
 import isMarkerPaused from "./markerPauseStatus";
 import facebookEditor from "./facebookEditor";
@@ -26,6 +27,7 @@ export default {
 	analysisData,
 	editorContext,
 	editorData,
+	estimatedReadingTime,
 	isCornerstone,
 	facebookEditor,
 	focusKeyword,

--- a/js/src/redux/selectors/estimatedReadingTime.js
+++ b/js/src/redux/selectors/estimatedReadingTime.js
@@ -1,0 +1,12 @@
+import { get } from "lodash";
+
+/**
+ * Gets the Estimated Reading Time from the store.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {Number} The estimated reading time.
+ */
+export function getEstimatedReadingTime( state ) {
+	return get( state, "estimatedReadingTime.estimatedReadingTime", 0 ) || 0;
+}

--- a/js/src/redux/selectors/index.js
+++ b/js/src/redux/selectors/index.js
@@ -3,6 +3,7 @@ export * from "./analysis";
 export * from "./cornerstoneContent";
 export * from "./editorContext";
 export * from "./editorData";
+export * from "./estimatedReadingTime";
 export * from "./facebookEditor";
 export * from "./fallbacks";
 export * from "./focusKeyPhrase";

--- a/src/conditionals/admin/estimated-reading-time-conditional.php
+++ b/src/conditionals/admin/estimated-reading-time-conditional.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Yoast\WP\SEO\Conditionals;
+namespace Yoast\WP\SEO\Conditionals\Admin;
 
-use Yoast\WP\SEO\Conditionals\Admin\Post_Conditional;
+use Yoast\WP\SEO\Conditionals\Conditional;
 use Yoast\WP\SEO\Helpers\Input_Helper;
 
 /**

--- a/src/conditionals/admin/estimated-reading-time-conditional.php
+++ b/src/conditionals/admin/estimated-reading-time-conditional.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+use Yoast\WP\SEO\Conditionals\Admin\Post_Conditional;
+use Yoast\WP\SEO\Helpers\Input_Helper;
+
+/**
+ * Conditional that is only when we want the Estimated Reading Time.
+ */
+class Estimated_Reading_Time_Conditional implements Conditional {
+
+	/**
+	 * The Post Conditional.
+	 *
+	 * @var Post_Conditional
+	 */
+	protected $post_conditional;
+
+	/**
+	 * The Input Helper.
+	 *
+	 * @var Input_Helper
+	 */
+	protected $input_helper;
+
+	/**
+	 * Constructs the Estimated Reading Time Conditional.
+	 *
+	 * @param Post_Conditional $post_conditional The post conditional.
+	 * @param Input_Helper     $input_helper     The input helper.
+	 */
+	public function __construct( Post_Conditional $post_conditional, Input_Helper $input_helper ) {
+		$this->post_conditional = $post_conditional;
+		$this->input_helper     = $input_helper;
+	}
+
+	/**
+	 * Returns whether or not this conditional is met.
+	 *
+	 * @return boolean Whether or not the conditional is met.
+	 */
+	public function is_met() {
+		// Check if we are in our Elementor ajax request (for saving).
+		if ( \wp_doing_ajax() ) {
+			$post_action = $this->input_helper->filter( INPUT_POST, 'action', FILTER_SANITIZE_STRING );
+			if ( $post_action === 'wpseo_elementor_save' ) {
+				return true;
+			}
+		}
+
+		if ( ! $this->post_conditional->is_met() ) {
+			return false;
+		}
+
+		// We don't support Estimated Reading Time on the attachment post type.
+		$post_id = (int) $this->input_helper->filter( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
+		if ( \get_post_type( $post_id ) === 'attachment' ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/integrations/estimated-reading-time.php
+++ b/src/integrations/estimated-reading-time.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yoast\WP\SEO\Integrations\Admin;
+namespace Yoast\WP\SEO\Integrations;
 
 use Yoast\WP\SEO\Conditionals\Estimated_Reading_Time_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;

--- a/src/integrations/estimated-reading-time.php
+++ b/src/integrations/estimated-reading-time.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use Yoast\WP\SEO\Conditionals\Estimated_Reading_Time_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Estimated reading time class.
+ */
+class Estimated_Reading_Time implements Integration_Interface {
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * @return array
+	 */
+	public static function get_conditionals() {
+		return [ Estimated_Reading_Time_Conditional::class ];
+	}
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * This is the place to register hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_filter( 'wpseo_metabox_entries_general', [ $this, 'add_estimated_reading_time_hidden_fields' ] );
+	}
+
+	/**
+	 * Adds an estimated-reading-time hidden field.
+	 *
+	 * @param array $field_defs The $fields_defs.
+	 *
+	 * @return array
+	 */
+	public function add_estimated_reading_time_hidden_fields( $field_defs ) {
+		if ( \is_array( $field_defs ) ) {
+			$field_defs['estimated-reading-time-minutes'] = [
+				'type'  => 'hidden',
+				'title' => 'estimated-reading-time-minutes',
+			];
+		}
+
+		return $field_defs;
+	}
+}

--- a/src/integrations/estimated-reading-time.php
+++ b/src/integrations/estimated-reading-time.php
@@ -2,7 +2,7 @@
 
 namespace Yoast\WP\SEO\Integrations;
 
-use Yoast\WP\SEO\Conditionals\Estimated_Reading_Time_Conditional;
+use Yoast\WP\SEO\Conditionals\Admin\Estimated_Reading_Time_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -409,17 +409,17 @@ class Elementor implements Integration_Interface {
 		];
 
 		$script_data = [
-			'analysis'          => [
-				'plugins'                     => $plugins_script_data,
-				'worker'                      => $worker_script_data,
-				'estimatedReadingTimeEnabled' => $this->estimated_reading_time_conditional->is_met(),
-			],
 			'media'             => [ 'choose_image' => __( 'Use Image', 'wordpress-seo' ) ],
 			'metabox'           => $this->get_metabox_script_data(),
 			'userLanguageCode'  => WPSEO_Language_Utils::get_language( WPSEO_Language_Utils::get_user_locale() ),
 			'isPost'            => true,
 			'isBlockEditor'     => WP_Screen::get()->is_block_editor(),
 			'isElementorEditor' => true,
+			'analysis'          => [
+				'plugins'                     => $plugins_script_data,
+				'worker'                      => $worker_script_data,
+				'estimatedReadingTimeEnabled' => $this->estimated_reading_time_conditional->is_met(),
+			],
 		];
 
 		if ( \post_type_supports( $this->get_metabox_post()->post_type, 'thumbnail' ) ) {

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -386,33 +386,35 @@ class Elementor implements Integration_Interface {
 		$analysis_worker_location          = new WPSEO_Admin_Asset_Analysis_Worker_Location( $this->asset_manager->flatten_version( WPSEO_VERSION ) );
 		$used_keywords_assessment_location = new WPSEO_Admin_Asset_Analysis_Worker_Location( $this->asset_manager->flatten_version( WPSEO_VERSION ), 'used-keywords-assessment' );
 
+		$plugins_script_data = [
+			'replaceVars' => [
+				'no_parent_text'           => __( '(no parent)', 'wordpress-seo' ),
+				'replace_vars'             => $this->get_replace_vars(),
+				'recommended_replace_vars' => $this->get_recommended_replace_vars(),
+				'scope'                    => $this->determine_scope(),
+				'has_taxonomies'           => $this->current_post_type_has_taxonomies(),
+			],
+			'shortcodes'  => [
+				'wpseo_filter_shortcodes_nonce' => \wp_create_nonce( 'wpseo-filter-shortcodes' ),
+				'wpseo_shortcode_tags'          => $this->get_valid_shortcode_tags(),
+			],
+		];
+
+		$worker_script_data = [
+			'url'                     => $analysis_worker_location->get_url( $analysis_worker_location->get_asset(), WPSEO_Admin_Asset::TYPE_JS ),
+			'keywords_assessment_url' => $used_keywords_assessment_location->get_url( $used_keywords_assessment_location->get_asset(), WPSEO_Admin_Asset::TYPE_JS ),
+			'log_level'               => WPSEO_Utils::get_analysis_worker_log_level(),
+			// We need to make the feature flags separately available inside of the analysis web worker.
+			'enabled_features'        => WPSEO_Utils::retrieve_enabled_features(),
+		];
+
 		$script_data = [
 			'analysis'          => [
-				'plugins' => [
-					'replaceVars' => [
-						'no_parent_text'           => __( '(no parent)', 'wordpress-seo' ),
-						'replace_vars'             => $this->get_replace_vars(),
-						'recommended_replace_vars' => $this->get_recommended_replace_vars(),
-						'scope'                    => $this->determine_scope(),
-						'has_taxonomies'           => $this->current_post_type_has_taxonomies(),
-					],
-					'shortcodes'  => [
-						'wpseo_filter_shortcodes_nonce' => \wp_create_nonce( 'wpseo-filter-shortcodes' ),
-						'wpseo_shortcode_tags'          => $this->get_valid_shortcode_tags(),
-					],
-				],
-				'worker'  => [
-					'url'                     => $analysis_worker_location->get_url( $analysis_worker_location->get_asset(), WPSEO_Admin_Asset::TYPE_JS ),
-					'keywords_assessment_url' => $used_keywords_assessment_location->get_url( $used_keywords_assessment_location->get_asset(), WPSEO_Admin_Asset::TYPE_JS ),
-					'log_level'               => WPSEO_Utils::get_analysis_worker_log_level(),
-					// We need to make the feature flags separately available inside of the analysis web worker.
-					'enabled_features'        => WPSEO_Utils::retrieve_enabled_features(),
-				],
+				'plugins'                     => $plugins_script_data,
+				'worker'                      => $worker_script_data,
 				'estimatedReadingTimeEnabled' => $this->estimated_reading_time_conditional->is_met(),
 			],
-			'media'             => [
-				'choose_image' => __( 'Use Image', 'wordpress-seo' ),
-			],
+			'media'             => [ 'choose_image' => __( 'Use Image', 'wordpress-seo' ) ],
 			'metabox'           => $this->get_metabox_script_data(),
 			'userLanguageCode'  => WPSEO_Language_Utils::get_language( WPSEO_Language_Utils::get_user_locale() ),
 			'isPost'            => true,

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -23,6 +23,7 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Meta_Fields_Presenter;
 use Elementor\Controls_Manager;
 use Elementor\Core\DocumentTypes\PageBase;
+use Yoast\WP\SEO\Conditionals\Estimated_Reading_Time_Conditional;
 
 /**
  * Integrates the Yoast SEO metabox in the Elementor editor.
@@ -86,6 +87,13 @@ class Elementor implements Integration_Interface {
 	protected $readability_analysis;
 
 	/**
+	 * Represents the estimated_reading_time_conditional.
+	 *
+	 * @var Estimated_Reading_Time_Conditional
+	 */
+	protected $estimated_reading_time_conditional;
+
+	/**
 	 * The identifier for the elementor tab.
 	 */
 	const YOAST_TAB = 'yoast-tab';
@@ -102,19 +110,26 @@ class Elementor implements Integration_Interface {
 	/**
 	 * Constructor.
 	 *
-	 * @param WPSEO_Admin_Asset_Manager $asset_manager The asset manager.
-	 * @param Options_Helper            $options       The options helper.
-	 * @param Capability_Helper         $capability    The capability helper.
+	 * @param WPSEO_Admin_Asset_Manager          $asset_manager                      The asset manager.
+	 * @param Options_Helper                     $options                            The options helper.
+	 * @param Capability_Helper                  $capability                         The capability helper.
+	 * @param Estimated_Reading_Time_Conditional $estimated_reading_time_conditional The Estimated Reading Time conditional.
 	 */
-	public function __construct( WPSEO_Admin_Asset_Manager $asset_manager, Options_Helper $options, Capability_Helper $capability ) {
+	public function __construct(
+		WPSEO_Admin_Asset_Manager $asset_manager,
+		Options_Helper $options,
+		Capability_Helper $capability,
+		Estimated_Reading_Time_Conditional $estimated_reading_time_conditional
+	) {
 		$this->asset_manager = $asset_manager;
 		$this->options       = $options;
 		$this->capability    = $capability;
 
-		$this->seo_analysis                 = new WPSEO_Metabox_Analysis_SEO();
-		$this->readability_analysis         = new WPSEO_Metabox_Analysis_Readability();
-		$this->social_is_enabled            = $this->options->get( 'opengraph', false ) || $this->options->get( 'twitter', false );
-		$this->is_advanced_metadata_enabled = $this->capability->current_user_can( 'wpseo_edit_advanced_metadata' ) || $this->options->get( 'disableadvanced_meta' ) === false;
+		$this->seo_analysis                       = new WPSEO_Metabox_Analysis_SEO();
+		$this->readability_analysis               = new WPSEO_Metabox_Analysis_Readability();
+		$this->social_is_enabled                  = $this->options->get( 'opengraph', false ) || $this->options->get( 'twitter', false );
+		$this->is_advanced_metadata_enabled       = $this->capability->current_user_can( 'wpseo_edit_advanced_metadata' ) || $this->options->get( 'disableadvanced_meta' ) === false;
+		$this->estimated_reading_time_conditional = $estimated_reading_time_conditional;
 	}
 
 	/**
@@ -393,6 +408,7 @@ class Elementor implements Integration_Interface {
 					// We need to make the feature flags separately available inside of the analysis web worker.
 					'enabled_features'        => WPSEO_Utils::retrieve_enabled_features(),
 				],
+				'estimatedReadingTimeEnabled' => $this->estimated_reading_time_conditional->is_met(),
 			],
 			'media'             => [
 				'choose_image' => __( 'Use Image', 'wordpress-seo' ),

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -23,7 +23,7 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Meta_Fields_Presenter;
 use Elementor\Controls_Manager;
 use Elementor\Core\DocumentTypes\PageBase;
-use Yoast\WP\SEO\Conditionals\Estimated_Reading_Time_Conditional;
+use Yoast\WP\SEO\Conditionals\Admin\Estimated_Reading_Time_Conditional;
 
 /**
  * Integrates the Yoast SEO metabox in the Elementor editor.

--- a/tests/unit/conditionals/estimated-reading-time-conditional-test.php
+++ b/tests/unit/conditionals/estimated-reading-time-conditional-test.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Conditionals;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Admin\Post_Conditional;
+use Yoast\WP\SEO\Conditionals\Estimated_Reading_Time_Conditional;
+use Yoast\WP\SEO\Helpers\Input_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Estimated_Reading_Time_Conditional.
+ *
+ * @group conditionals
+ * @group estimated-reading-time
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Conditionals\Estimated_Reading_Time_Conditional
+ */
+class Estimated_Reading_Time_Conditional_Test extends TestCase {
+
+	/**
+	 * The estimated reading time conditional.
+	 *
+	 * @var Estimated_Reading_Time_Conditional
+	 */
+	protected $instance;
+
+	/**
+	 * Does the setup for testing.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->post_conditional = Mockery::mock( Post_Conditional::class );
+		$this->input_helper     = Mockery::mock( Input_Helper::class );
+
+		$this->instance = new Estimated_Reading_Time_Conditional(
+			$this->post_conditional,
+			$this->input_helper
+		);
+	}
+
+	/**
+	 * Tests that the conditional is met when we are saving for Elementor.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_ajax_elementor_save() {
+		// We are in an Ajax request.
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( true );
+
+		// We are saving in Elementor with Ajax.
+		$this->input_helper
+			->expects( 'filter' )
+			->with( INPUT_POST, 'action', FILTER_SANITIZE_STRING )
+			->andReturn( 'wpseo_elementor_save' );
+
+		$this->assertEquals( true, $this->instance->is_met() );
+	}
+
+	/**
+	 * Tests that the conditional is not met when we are not on a post, and also not in an Elementor save.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_not_post_not_elementor_save() {
+		// We are in an Ajax request.
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( true );
+
+		// The Ajax action is not for saving Elementor.
+		$this->input_helper
+			->expects( 'filter' )
+			->with( INPUT_POST, 'action', FILTER_SANITIZE_STRING )
+			->andReturn( 'some_other_value' );
+
+		// We are not on a post according to the post conditional.
+		$this->post_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( false );
+
+		$this->assertEquals( false, $this->instance->is_met() );
+	}
+
+	/**
+	 * Tests that the conditional is not met when we are not on a post, and also not in an Elementor save.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_post_is_attachment() {
+		// We are not in an Ajax request.
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+
+		// We are on a post according to the post conditional.
+		$this->post_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		// Returns the post id.
+		$this->input_helper
+			->expects( 'filter' )
+			->with( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT )
+			->andReturn( '1' );
+
+		// Returns the attachment post type.
+		Monkey\Functions\expect( 'get_post_type' )
+			->with( 1 )
+			->andReturn( 'attachment' );
+
+		$this->assertEquals( false, $this->instance->is_met() );
+	}
+
+	/**
+	 * Tests that the conditional is not met when we are not on a post, and also not in an Elementor save.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_post() {
+		// We are not in an Ajax request.
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+
+		// We are on a post according to the post conditional.
+		$this->post_conditional
+			->expects( 'is_met' )
+			->once()
+			->andReturn( true );
+
+		// Returns the post id.
+		$this->input_helper
+			->expects( 'filter' )
+			->with( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT )
+			->andReturn( '1' );
+
+		// Returns post type.
+		Monkey\Functions\expect( 'get_post_type' )
+			->with( 1 )
+			->andReturn( 'post' );
+
+		$this->assertEquals( true, $this->instance->is_met() );
+	}
+}

--- a/tests/unit/conditionals/estimated-reading-time-conditional-test.php
+++ b/tests/unit/conditionals/estimated-reading-time-conditional-test.php
@@ -16,7 +16,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group conditionals
  * @group estimated-reading-time
  *
- * @coversDefaultClass \Yoast\WP\SEO\Conditionals\Estimated_Reading_Time_Conditional
+ * @coversDefaultClass \Yoast\WP\SEO\Conditionals\Admin\Estimated_Reading_Time_Conditional
  */
 class Estimated_Reading_Time_Conditional_Test extends TestCase {
 

--- a/tests/unit/conditionals/estimated-reading-time-conditional-test.php
+++ b/tests/unit/conditionals/estimated-reading-time-conditional-test.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Conditionals;
 use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Conditionals\Admin\Post_Conditional;
-use Yoast\WP\SEO\Conditionals\Estimated_Reading_Time_Conditional;
+use Yoast\WP\SEO\Conditionals\Admin\Estimated_Reading_Time_Conditional;
 use Yoast\WP\SEO\Helpers\Input_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 

--- a/tests/unit/conditionals/estimated-reading-time-conditional-test.php
+++ b/tests/unit/conditionals/estimated-reading-time-conditional-test.php
@@ -9,6 +9,7 @@ use Yoast\WP\SEO\Conditionals\Admin\Estimated_Reading_Time_Conditional;
 use Yoast\WP\SEO\Helpers\Input_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
+// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
 /**
  * Class Estimated_Reading_Time_Conditional.
  *
@@ -141,3 +142,4 @@ class Estimated_Reading_Time_Conditional_Test extends TestCase {
 		$this->assertEquals( true, $this->instance->is_met() );
 	}
 }
+// phpcs:enable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded

--- a/tests/unit/integrations/estimated-reading-time-test.php
+++ b/tests/unit/integrations/estimated-reading-time-test.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Conditionals\Estimated_Reading_Time_Conditional;
+use Yoast\WP\SEO\Integrations\Estimated_Reading_Time;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Test class for testing the estimated reading time integration.
+ *
+ * @group estimated-reading-time
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Admin\Estimated_Reading_Time
+ */
+class Estimated_Reading_Time_Test extends TestCase {
+
+	/**
+	 * The class to test.
+	 *
+	 * @var Estimated_Reading_Time
+	 */
+	protected $instance;
+
+	/**
+	 * Setup.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->instance = new Estimated_Reading_Time();
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		Monkey\Filters\expectAdded( 'wpseo_metabox_entries_general' )
+			->with( [ $this->instance, 'add_estimated_reading_time_hidden_fields' ] );
+
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Tests the retrieval of the conditionals.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		static::assertEquals(
+			[ Estimated_Reading_Time_Conditional::class ],
+			Estimated_Reading_Time::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the adding of the hidden fields.
+	 *
+	 * @covers ::add_estimated_reading_time_hidden_fields
+	 */
+	public function test_add_estimated_reading_time_hidden_fields() {
+		$actual = $this->instance->add_estimated_reading_time_hidden_fields( [] );
+
+		$this->assertIsArray( $actual );
+		$this->assertArrayHasKey( 'estimated-reading-time-minutes', $actual );
+		$this->assertEquals(
+			[
+				'type'  => 'hidden',
+				'title' => 'estimated-reading-time-minutes',
+			],
+			$actual['estimated-reading-time-minutes']
+		);
+	}
+
+	/**
+	 * Tests only adding when the fields value is an array.
+	 *
+	 * @covers ::add_estimated_reading_time_hidden_fields
+	 */
+	public function test_add_estimated_reading_time_hidden_fields_only_when_array() {
+		$actual = $this->instance->add_estimated_reading_time_hidden_fields( 'not-an-array' );
+
+		$this->assertSame( 'not-an-array', $actual );
+	}
+}

--- a/tests/unit/integrations/estimated-reading-time-test.php
+++ b/tests/unit/integrations/estimated-reading-time-test.php
@@ -3,7 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Integrations;
 
 use Brain\Monkey;
-use Yoast\WP\SEO\Conditionals\Estimated_Reading_Time_Conditional;
+use Yoast\WP\SEO\Conditionals\Admin\Estimated_Reading_Time_Conditional;
 use Yoast\WP\SEO\Integrations\Estimated_Reading_Time;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In https://github.com/Yoast/wordpress-seo-premium/pull/3094 we added Estimated Reading Time to premium. But there are free features that also need the value. That's why the changes in Premium were removed in https://github.com/Yoast/wordpress-seo-premium/pull/3122, and added here.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds estimated reading time to the yoast-seo/editor store and relevant actions and selectors.
* Adds an estimated reading time hidden field, so the reading time can be persisted in post metadata.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* The easiest way to make sure everything in P1-288 went well, is to test in premium, with a `--no-commit` of this branch. Therefor, follow the test instructions here https://github.com/Yoast/wordpress-seo-premium/pull/3122 .
* However, also test whether the `estimated reading time` is available in free, without premium.
* That means that you should test all the steps in the premium PR, in free as well.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes P1-288
