### PR TITLE
Add filter for display_post_type_metabox

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -780,7 +780,7 @@ class WPSEO_Utils {
 			return false;
 		}
 
-		return apply_filters( 'wpseo_display_metabox_' . $post_type, WPSEO_Options::get( 'display-metabox-pt-' . $post_type ) );
+		return apply_filters( 'wpseo_enable_editor_features_' . $post_type, WPSEO_Options::get( 'display-metabox-pt-' . $post_type ) );
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -780,7 +780,7 @@ class WPSEO_Utils {
 			return false;
 		}
 
-		return WPSEO_Options::get( 'display-metabox-pt-' . $post_type );
+		return apply_filters( 'wpseo_display_metabox_' . $post_type, WPSEO_Options::get( 'display-metabox-pt-' . $post_type ) );
 	}
 
 	/**


### PR DESCRIPTION
Allow overriding of if the Yoast SEO metabox should show on a post type.
Useful when you need Yoast functionality on non-public post types.

## Context
I wrote this code so that in collaboration with the existing `wpseo_accessible_post_types` filter I can have the "Primary Category" functionality work on a non-public post type (I am using it with Sensei Question post type). 

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a filter that allows for showing the Yoast SEO metabox on non-public post types if these are accessible. Props to [jondcampbell](https://github.com/jondcampbell).

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add a new filter using `wpseo_display_metabox_{post_type}` that returns true or false to show or hide the box.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Install Sensei LMS
* Update the themes functions.php with the following snippet to make the questions post type accessible for Yoast SEO and the metabox enabled:
```
add_filter( 'wpseo_enable_editor_features_question', '__return_true' );

add_filter( 'wpseo_accessible_post_types', function($post_types) {
	$post_types[] = 'question';
	return $post_types;
});
```
* Add a new Question and make sure the Yoast SEO metabox is shown

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
