### PR TITLE
Web Stories: ensure that there’s always a meta description

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@wordpress/data": "^4.10.0",
     "@wordpress/dependency-extraction-webpack-plugin": "^2.8.0",
     "@wordpress/element": "^2.9.0",
-    "@yoast/grunt-plugin-tasks": "^1.7.2",
+    "@yoast/grunt-plugin-tasks": "^2.0.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-jest": "^18.0.0",

--- a/src/integrations/third-party/web-stories.php
+++ b/src/integrations/third-party/web-stories.php
@@ -113,7 +113,7 @@ class Web_Stories implements Integration_Interface {
 	/**
 	 * Filters the meta description for stories.
 	 *
-	 * @param string $description The description sentence.
+	 * @param string                 $description The description sentence.
 	 * @param Indexable_Presentation $presentation The presentation of an indexable.
 	 * @return string The description sentence.
 	 */

--- a/yarn.lock
+++ b/yarn.lock
@@ -820,10 +820,10 @@
   resolved "https://registry.yarnpkg.com/@yoast/feature-flag/-/feature-flag-0.5.2.tgz#ef4cd8ddb959c5857c5d68639ab09ab75c381508"
   integrity sha512-erHel5POEyPpt1B2fToLm8caZPruiOxBRZvn7X9nWqwb0lIbxbOkDp/XQnm168bcvVEL95Dg9JMaPgQwO3rA9w==
 
-"@yoast/grunt-plugin-tasks@^1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@yoast/grunt-plugin-tasks/-/grunt-plugin-tasks-1.7.2.tgz#c3314c1f0d0ec5de747dcdca65f3eb87bc16fdd0"
-  integrity sha512-QBVB370homhYin//kxvC0b4mNrLfHXUJ6DZF1JYVx1Y+qOQYqdjB6/0GxtYFOLhNHLrpWRXiT1DZR42HzmziZw==
+"@yoast/grunt-plugin-tasks@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@yoast/grunt-plugin-tasks/-/grunt-plugin-tasks-2.0.0.tgz#77c33c1b3fd8087075b611e49c4654b21e86ca15"
+  integrity sha512-RL2Rx0vJfITcKAYOQoMa8xa+AqBK9nW4N75ybkRMIxVcGjuHyeoWWiviy47BqLfketGWecJScVZBRg1spVBoaA==
   dependencies:
     "@yoast/browserslist-config" "^1.0.0"
     autoprefixer "^9.7.2"
@@ -6205,9 +6205,9 @@ grunt-git@^1.0.14:
   dependencies:
     flopmang "^1.0.0"
 
-"grunt-glotpress@https://github.com/Yoast/grunt-glotpress.git#master":
+"grunt-glotpress@git+https://github.com/Yoast/grunt-glotpress.git#master":
   version "0.3.0"
-  resolved "https://github.com/Yoast/grunt-glotpress.git#e6ccc69c2532d126f5d8a30397ffd012e55b6eec"
+  resolved "git+https://github.com/Yoast/grunt-glotpress.git#e6ccc69c2532d126f5d8a30397ffd012e55b6eec"
   dependencies:
     request "^2.88.0"
     request-promise-native "^1.0.7"


### PR DESCRIPTION
## Context

In order for Web Stories to be discoverable, it makes sense to always have a meta description.

Since Web Stories for WordPress does not _yet_ have support for the Yoast meta boxes, this seems like the easiest way to ensure meta descriptions being present, without the user having to change the Search Appearance settings.

If there's a better suited filter for this, please let me know.

## Summary

This PR can be summarized in the following changelog entry:

* Web Stories: ensure that there’s always a meta description. Props to [swissspidy](https://github.com/swissspidy)

## Relevant technical choices:

* Uses the `wpseo_metadesc` filter to fall back to displaying the post excerpt if there's no meta description present.

## Test instructions

This PR can be tested by following these steps:

1. Create a new web story
1. Add some excerpt in the document panel
1. Publish the story
1. Verify that the meta description is added on the frontend

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
