### PR TITLE
Added migration to transform ID columns in the indexable table to bigint.

### DIFF
--- a/src/config/migrations/20201216124002_ExpandIndexableIDColumnLengths.php
+++ b/src/config/migrations/20201216124002_ExpandIndexableIDColumnLengths.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\WP\SEO\Config\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 
@@ -55,14 +50,6 @@ class ExpandIndexableIDColumnLengths extends Migration {
 	 * @return void
 	 */
 	public function down() {
-		foreach ( self::$columns_to_change as $column ) {
-			$this->change_column(
-				$this->get_table_name(),
-				$column,
-				'integer',
-				[ 'limit' => 11 ]
-			);
-		}
 	}
 
 	/**

--- a/src/config/migrations/20201216124002_ExpandIndexableIDColumnLengths.php
+++ b/src/config/migrations/20201216124002_ExpandIndexableIDColumnLengths.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package Yoast\WP\SEO\Config\Migrations
+ */
+
+namespace Yoast\WP\SEO\Config\Migrations;
+
+use Yoast\WP\Lib\Migrations\Migration;
+use Yoast\WP\Lib\Model;
+
+/**
+ * ExpandIndexableIDColumnLengths class.
+ */
+class ExpandIndexableIDColumnLengths extends Migration {
+
+	/**
+	 * The plugin this migration belongs to.
+	 *
+	 * @var string
+	 */
+	public static $plugin = 'free';
+
+	/**
+	 * The columns to change the column type and length of.
+	 *
+	 * @var string[]
+	 */
+	protected static $columns_to_change = [
+		'object_id',
+		'author_id',
+		'post_parent',
+	];
+
+	/**
+	 * Migration up.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		foreach ( self::$columns_to_change as $column ) {
+			$this->change_column(
+				$this->get_table_name(),
+				$column,
+				'biginteger',
+				[ 'limit' => 20 ]
+			);
+		}
+	}
+
+	/**
+	 * Migration down.
+	 *
+	 * @return void
+	 */
+	public function down() {
+		foreach ( self::$columns_to_change as $column ) {
+			$this->change_column(
+				$this->get_table_name(),
+				$column,
+				'integer',
+				[ 'limit' => 11 ]
+			);
+		}
+	}
+
+	/**
+	 * Retrieves the table name to use for storing indexables.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Model::get_table_name( 'Indexable' );
+	}
+}

--- a/src/config/migrations/20201216141134_ExpandPrimaryTermIDColumnLengths.php
+++ b/src/config/migrations/20201216141134_ExpandPrimaryTermIDColumnLengths.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package Yoast\WP\SEO\Config\Migrations
+ */
+
+namespace Yoast\WP\SEO\Config\Migrations;
+
+use Yoast\WP\Lib\Migrations\Migration;
+use Yoast\WP\Lib\Model;
+
+/**
+ * ExpandPrimaryTermIDColumnLengths class.
+ */
+class ExpandPrimaryTermIDColumnLengths extends Migration {
+
+	/**
+	 * The plugin this migration belongs to.
+	 *
+	 * @var string
+	 */
+	public static $plugin = 'free';
+
+	/**
+	 * The columns to change the column type and length of.
+	 *
+	 * @var string[]
+	 */
+	protected static $columns_to_change = [
+		'post_id',
+		'term_id',
+	];
+
+	/**
+	 * Migration up.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		foreach ( self::$columns_to_change as $column ) {
+			$this->change_column(
+				$this->get_table_name(),
+				$column,
+				'biginteger',
+				[ 'limit' => 20 ]
+			);
+		}
+	}
+
+	/**
+	 * Migration down.
+	 *
+	 * @return void
+	 */
+	public function down() {
+		foreach ( self::$columns_to_change as $column ) {
+			$this->change_column(
+				$this->get_table_name(),
+				$column,
+				'integer',
+				[ 'limit' => 11 ]
+			);
+		}
+	}
+
+	/**
+	 * Retrieves the table name to use for storing indexables.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Model::get_table_name( 'Primary_Term' );
+	}
+}

--- a/src/config/migrations/20201216141134_ExpandPrimaryTermIDColumnLengths.php
+++ b/src/config/migrations/20201216141134_ExpandPrimaryTermIDColumnLengths.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Yoast SEO Plugin File.
- *
- * @package Yoast\WP\SEO\Config\Migrations
- */
 
 namespace Yoast\WP\SEO\Config\Migrations;
 
@@ -54,14 +49,6 @@ class ExpandPrimaryTermIDColumnLengths extends Migration {
 	 * @return void
 	 */
 	public function down() {
-		foreach ( self::$columns_to_change as $column ) {
-			$this->change_column(
-				$this->get_table_name(),
-				$column,
-				'integer',
-				[ 'limit' => 11 ]
-			);
-		}
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* On large WordPress installations, IDs like post IDs and author IDs can be large. Larger than our database tables (e.g. `wp_yoast_indexable` and `wp_yoast_primary_term`) currently allows. This PR migrates those columns to `bigint`s, such that they allow higher ID values.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the plugin would break on very large WordPress installations.

## Relevant technical choices:

* Decided to split the new database migrations into two, one for each database table.
  * This makes each migration responsible for one table, which makes it easier to read.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check the `indexable` table structure in your WordPress database.
	* The `object_id`, `author_id` and `post_parent` columns should have a datatype of `INT` and a length of 11.
* Check the `primary_term` table structure in your WordPress database.
	* The `post_id` and `term_id` columns should have a datatype of `INT` and a length of 11.
* Using the Yoast test helper, reset the indexables tables and migrations.
* Check the `indexable` table structure in your WordPress database.
	* The `object_id`, `author_id` and `post_parent` columns should have a datatype of `BIGINT` and a length of 20.
* Check the `primary_term` table structure in your WordPress database.
	* The `post_id` and `term_id` columns should have a datatype of `BIGINT` and a length of 20.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #16236
