### PR TITLE
Web Stories: Update metadata filters

### DIFF
--- a/src/integrations/third-party/web-stories.php
+++ b/src/integrations/third-party/web-stories.php
@@ -49,26 +49,16 @@ class Web_Stories implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_action( 'web_stories_story_head', [ $this, 'remove_web_stories_meta_output' ], 0 );
+		\add_action( 'web_stories_enable_metadata', '__return_false' );
+		\add_action( 'web_stories_enable_schemaorg_metadata', '__return_false' );
+		\add_action( 'web_stories_enable_open_graph_metadata', '__return_false' );
+		\add_action( 'web_stories_enable_twitter_metadata', '__return_false' );
+		\remove_action( 'web_stories_story_head', 'rel_canonical' );
 		\add_action( 'web_stories_story_head', [ $this->front_end, 'call_wpseo_head' ], 9 );
 		\add_filter( 'wpseo_schema_article_post_types', [ $this, 'filter_schema_article_post_types' ] );
 		\add_filter( 'wpseo_schema_article_type', [ $this, 'filter_schema_article_type' ], 10, 2 );
 		\add_action( 'admin_enqueue_scripts', [ $this, 'dequeue_admin_assets' ] );
 		\add_filter( 'wpseo_metadesc', [ $this, 'filter_meta_description' ], 10, 2 );
-	}
-
-	/**
-	 * Removes Web Stories meta output.
-	 *
-	 * @return void
-	 */
-	public function remove_web_stories_meta_output() {
-		$instance = Google_Web_Stories\get_plugin_instance()->discovery;
-		\remove_action( 'web_stories_story_head', [ $instance, 'print_metadata' ] );
-		\remove_action( 'web_stories_story_head', [ $instance, 'print_schemaorg_metadata' ] );
-		\remove_action( 'web_stories_story_head', [ $instance, 'print_open_graph_metadata' ] );
-		\remove_action( 'web_stories_story_head', [ $instance, 'print_twitter_metadata' ] );
-		\remove_action( 'web_stories_story_head', 'rel_canonical' );
 	}
 
 	/**

--- a/tests/unit/integrations/third-party/web-stories-test.php
+++ b/tests/unit/integrations/third-party/web-stories-test.php
@@ -66,38 +66,21 @@ class Web_Stories_Test extends TestCase {
 	public function test_register_hooks() {
 		$this->instance->register_hooks();
 
-		$this->assertNotFalse( \has_action( 'web_stories_story_head', [ $this->instance, 'remove_web_stories_meta_output' ] ), 'The remove Web Stories meta output function is registered.' );
+		\add_action( 'web_stories_enable_metadata', '__return_false' );
+		\add_action( 'web_stories_enable_schemaorg_metadata', '__return_false' );
+		\add_action( 'web_stories_enable_open_graph_metadata', '__return_false' );
+		\add_action( 'web_stories_enable_twitter_metadata', '__return_false' );
+
+		$this->assertNotFalse( \has_action( 'web_stories_enable_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
+		$this->assertNotFalse( \has_action( 'web_stories_enable_schemaorg_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
+		$this->assertNotFalse( \has_action( 'web_stories_enable_open_graph_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
+		$this->assertNotFalse( \has_action( 'web_stories_enable_twitter_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
+		$this->assertFalse( \has_action( 'web_stories_story_head', 'rel_canonical' ), 'The rel canonical action is not registered' );
 		$this->assertNotFalse( \has_action( 'web_stories_story_head', [ $this->front_end, 'call_wpseo_head' ] ), 'The wpseo head action is registered.' );
 		$this->assertNotFalse( \has_filter( 'wpseo_schema_article_post_types', [ $this->instance, 'filter_schema_article_post_types' ] ), 'The filter schema article post types function is registered.' );
 		$this->assertNotFalse( \has_filter( 'wpseo_schema_article_type', [ $this->instance, 'filter_schema_article_type' ] ), 'The filter schema article type function is registered.' );
 		$this->assertNotFalse( \has_action( 'admin_enqueue_scripts', [ $this->instance, 'dequeue_admin_assets' ] ), 'The admin_enqueue_scripts action is registered.' );
 		$this->assertNotFalse( \has_filter( 'wpseo_metadesc', [ $this->instance, 'filter_meta_description' ] ), 'The metadesc action is registered.' );
-	}
-
-	/**
-	 * Tests remove web stories meta output.
-	 *
-	 * @covers ::remove_web_stories_meta_output
-	 */
-	public function test_remove_web_stories_meta_output() {
-		$instance = Mockery::mock( '\Google\Web_Stories\Discovery' );
-		Monkey\Functions\expect( '\Google\Web_Stories\get_plugin_instance' )
-			->once()
-			->andReturn( (object) [ 'discovery' => $instance ] );
-
-		\add_action( 'web_stories_story_head', [ $instance, 'print_metadata' ] );
-		\add_action( 'web_stories_story_head', [ $instance, 'print_schemaorg_metadata' ] );
-		\add_action( 'web_stories_story_head', [ $instance, 'print_open_graph_metadata' ] );
-		\add_action( 'web_stories_story_head', [ $instance, 'print_twitter_metadata' ] );
-		\add_action( 'web_stories_story_head', 'rel_canonical' );
-
-		$this->instance->remove_web_stories_meta_output();
-
-		$this->assertFalse( \has_action( 'web_stories_story_head', [ $instance, 'print_metadata' ] ), 'The Web Stories print metadata action is not registered' );
-		$this->assertFalse( \has_action( 'web_stories_story_head', [ $instance, 'print_schemaorg_metadata' ] ), 'The Web Stories print schema metadata action is not registered' );
-		$this->assertFalse( \has_action( 'web_stories_story_head', [ $instance, 'print_open_graph_metadata' ] ), 'The Web Stories print open graph metadata action is not registered' );
-		$this->assertFalse( \has_action( 'web_stories_story_head', [ $instance, 'print_twitter_metadata' ] ), 'The Web Stories print twitter metadata action is not registered' );
-		$this->assertFalse( \has_action( 'web_stories_story_head', 'rel_canonical' ), 'The rel canonical action is not registered' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Simplifies the way default metadata output of Web Stories for WordPress is removed.

## Summary

In the Web Stories plugin we recently simplified how the plugin's default metadata output can be remove by plugins like Yoast SEO. There are now a few dedicated filters, see https://github.com/google/web-stories-wp/blob/0994fd1808777a2907e3369c5f93f85438cedb3a/includes/Discovery.php

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Make integration with Web Stories for WordPress more robust

## Relevant technical choices:

* Uses more appropriate filters to filter metadata output

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Create a new web story
2. View story on frontend
3. Ensure Yoast SEO metadata is present
4. Ensure default metadata added by Web Stories is present (i.e. there are no duplicates). 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Web Stories integration

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
