### PR TITLE
Add CSS for two columns in modal

### DIFF
--- a/css/src/modal.css
+++ b/css/src/modal.css
@@ -367,6 +367,7 @@
 .yoast-modal-content--columns {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
+	grid-gap: 24px;
 }
 
 .yoast-post-settings-modal__button-container {

--- a/css/src/modal.css
+++ b/css/src/modal.css
@@ -364,6 +364,11 @@
 	padding: 16px;
 }
 
+.yoast-modal-content--columns {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+}
+
 .yoast-post-settings-modal__button-container {
 	padding: 16px;
 	display: flex;

--- a/css/src/modal.css
+++ b/css/src/modal.css
@@ -364,10 +364,12 @@
 	padding: 16px;
 }
 
-.yoast-modal-content--columns {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	grid-gap: 24px;
+@media (min-width: 782px) {
+	.yoast-modal-content--columns {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		grid-gap: 24px;
+	}
 }
 
 .yoast-post-settings-modal__button-container {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In https://github.com/Yoast/wordpress-seo/pull/16484 we accidentally merged Estimated Reading Time changes to trunk, but they also have to be in release/15.6. Thus, this is a copy of that branch, rebased to release/15.6. For all further information, see the original PR.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds two columns to be used in the modal

