### PR TITLE
Create DI framework to be used by add-ons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ test.sh
 # Legacy, can be removed in the future.
 .recalibration.yaml
 /src/generated/
+/premium/src/generated/
 
 ############
 # Dist files

--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -121,7 +121,12 @@ class Actions {
 		$io->write( 'Compiling the dependency injection container...' );
 
 		// Pas true as debug to force a recheck of the container.
-		Container_Compiler::compile( true );
+		Container_Compiler::compile(
+			true,
+			__DIR__ . '/../../src/generated/container.php',
+			__DIR__ . '/../dependency-injection/services.php',
+			'Yoast\WP\SEO\Generated'
+		);
 
 		$io->write( 'The dependency injection container has been compiled.' );
 	}

--- a/config/dependency-injection/container-compiler.php
+++ b/config/dependency-injection/container-compiler.php
@@ -35,6 +35,7 @@ class Container_Compiler {
 
 		if ( ! $cache->isFresh() ) {
 			if ( ! \defined( 'WPSEO_VERSION' ) ) {
+				// @phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Constant is prefixed with old prefix.
 				\define( 'WPSEO_VERSION', 'COMPILING' );
 			}
 
@@ -51,8 +52,8 @@ class Container_Compiler {
 			$dumper = new PhpDumper( $container_builder );
 			$code   = $dumper->dump(
 				[
-					'class'      => 'Cached_Container',
-					'namespace'  => $namespace,
+					'class'     => 'Cached_Container',
+					'namespace' => $namespace,
 				]
 			);
 			$code   = \str_replace( 'Symfony\\Component\\DependencyInjection', 'YoastSEO_Vendor\\Symfony\\Component\\DependencyInjection', $code );

--- a/config/dependency-injection/schema-templates-pass.php
+++ b/config/dependency-injection/schema-templates-pass.php
@@ -33,6 +33,10 @@ class Schema_Templates_Pass implements CompilerPassInterface {
 	 * @param ContainerBuilder $container DI Container.
 	 */
 	public function process( ContainerBuilder $container ) {
+		if ( ! $container->hasDefinition( Schema_Blocks::class ) ) {
+			return;
+		}
+
 		$schema_blocks_definition = $container->getDefinition( Schema_Blocks::class );
 
 		foreach ( $this->schema_templates_loader->get_templates() as $template ) {

--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -66,7 +66,3 @@ $yoast_seo_base_definition
  * @var $loader \Yoast\WP\SEO\Dependency_Injection\Custom_Loader
  */
 $loader->registerClasses( $yoast_seo_base_definition, 'Yoast\\WP\\SEO\\', 'src/*', 'src/{' . $yoast_seo_excluded . '}' );
-
-if ( \file_exists( __DIR__ . '/../../premium/config/dependency-injection/services.php' ) ) {
-	include __DIR__ . '/../../premium/config/dependency-injection/services.php';
-}

--- a/lib/abstract-main.php
+++ b/lib/abstract-main.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Yoast\WP\Lib;
+
+use Exception;
+use Yoast\WP\Lib\Dependency_Injection\Container_Registry;
+use Yoast\WP\SEO\Loader;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Abstract class to extend for the main class in a plugin.
+ */
+abstract class Abstract_Main {
+
+	/**
+	 * The DI container.
+	 *
+	 * @var ContainerInterface|null
+	 */
+	private $container;
+
+	/**
+	 * Loads the plugin.
+	 *
+	 * @throws Exception If loading fails and YOAST_ENVIRONMENT is development.
+	 */
+	public function load() {
+		if ( $this->container ) {
+			return;
+		}
+
+		try {
+			$this->container = $this->get_container();
+			Container_Registry::register( $this->get_name(), $this->container );
+
+			if ( ! $this->container ) {
+				return;
+			}
+			if ( ! $this->container->has( Loader::class ) ) {
+				return;
+			}
+
+			$this->container->get( Loader::class )->load();
+		} catch ( Exception $e ) {
+			if ( $this->is_development() ) {
+				throw $e;
+			}
+			// Don't crash the entire site, simply don't load.
+		}
+	}
+
+	/**
+	 * Magic getter for retrieving a property.
+	 *
+	 * @param string $property The property to retrieve.
+	 *
+	 * @throws Exception When the property doesn't exist.
+	 *
+	 * @return string The value of the property.
+	 */
+	public function __get( $property ) {
+		$surfaces = $this->get_surfaces();
+
+		if ( isset( $surfaces[ $property ] ) ) {
+			$this->{$property} = $this->container->get( $surfaces[ $property ] );
+
+			return $this->{$property};
+		}
+		throw new Exception( "Property $property does not exist." );
+	}
+
+	/**
+	 * Checks if the given property exists as a surface.
+	 *
+	 * @param string $property The property to retrieve.
+	 *
+	 * @return bool True when property is set.
+	 */
+	public function __isset( $property ) {
+		return isset( $this->surfaces[ $property ] );
+	}
+
+	/**
+	 * Loads the DI container.
+	 *
+	 * @throws Exception If something goes wrong generating the DI container.
+	 *
+	 * @return null|ContainerInterface The DI container.
+	 */
+	abstract protected function get_container();
+
+	/**
+	 * Gets the name of the plugin.
+	 *
+	 * @return string The name.
+	 */
+	abstract protected function get_name();
+
+	/**
+	 * Gets the surfaces of this plugin.
+	 *
+	 * @return array A mapping of surface name to the responsible class.
+	 */
+	abstract protected function get_surfaces();
+
+	/**
+	 * Returns whether or not we're in an environment for Yoast development.
+	 *
+	 * @return bool Whether or not to load in development mode.
+	 */
+	protected function is_development() {
+		return \defined( 'YOAST_ENVIRONMENT' ) && \YOAST_ENVIRONMENT === 'development';
+	}
+}

--- a/lib/dependency-injection/container-registry.php
+++ b/lib/dependency-injection/container-registry.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Yoast\WP\Lib\Dependency_Injection;
+
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+/**
+ * Container_Registry class.
+ */
+class Container_Registry {
+
+	/**
+	 * The registered containers.
+	 *
+	 * @var ContainerInterface[]
+	 */
+	private static $containers = [];
+
+	/**
+	 * Register a container.
+	 *
+	 * @param string             $name      The name of the container.
+	 * @param ContainerInterface $container The container.
+	 *
+	 * @return void
+	 */
+	public static function register( $name, ContainerInterface $container ) {
+		self::$containers[ $name ] = $container;
+	}
+
+    // phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- PHPCS doesn't take into account exceptions thrown in called methods.
+
+	/**
+	 * Get an instance from a specific container.
+	 *
+	 * @param string $name              The name of the container.
+	 * @param string $id                The ID of the service.
+	 * @param int    $invalid_behaviour The behaviour when the service could not be found.
+	 *
+	 * @return object The service.
+	 *
+	 * @throws ServiceCircularReferenceException When a circular reference is detected.
+	 * @throws ServiceNotFoundException          When the service is not defined.
+	 */
+	public static function get( $name, $id, $invalid_behaviour = 1 ) {
+		if ( ! \array_key_exists( $name, self::$containers ) ) {
+			if ( $invalid_behaviour === ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE ) {
+				throw new ServiceNotFoundException( $id );
+			}
+			return null;
+		}
+		return self::$containers[ $name ]->get( $id, $invalid_behaviour );
+	}
+
+    // phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
+
+	/**
+	 * Attempts to find a given service ID in all registered containers.
+	 *
+	 * @param string $id The service ID.
+	 *
+	 * @return string|null The name of the container if the service was found.
+	 */
+	public static function find( $id ) {
+		foreach ( self::$containers as $name => $container ) {
+			if ( $container->has( $id ) ) {
+				return $name;
+			}
+		}
+	}
+}

--- a/src/main.php
+++ b/src/main.php
@@ -2,7 +2,7 @@
 
 namespace Yoast\WP\SEO;
 
-use Exception;
+use Yoast\WP\Lib\Abstract_Main;
 use Yoast\WP\SEO\Dependency_Injection\Container_Compiler;
 use Yoast\WP\SEO\Generated\Cached_Container;
 use Yoast\WP\SEO\Surfaces\Classes_Surface;
@@ -22,7 +22,7 @@ if ( ! \defined( 'WPSEO_VERSION' ) ) {
  * @property Meta_Surface    $meta         The meta surface.
  * @property Helpers_Surface $helpers      The helpers surface.
  */
-class Main {
+class Main extends Abstract_Main {
 
 	/**
 	 * The API namespace constant.
@@ -39,90 +39,17 @@ class Main {
 	const WP_CLI_NAMESPACE = 'yoast';
 
 	/**
-	 * The DI container.
-	 *
-	 * @var Cached_Container|null
+	 * @inheritDoc
 	 */
-	private $container;
-
-	/**
-	 * Surface classes that provide our external interface.
-	 *
-	 * @var string[]
-	 */
-	private $surfaces = [
-		'classes' => Classes_Surface::class,
-		'meta'    => Meta_Surface::class,
-		'helpers' => Helpers_Surface::class,
-	];
-
-	/**
-	 * Loads the plugin.
-	 *
-	 * @throws Exception If loading fails and YOAST_ENVIRONMENT is development.
-	 */
-	public function load() {
-		if ( $this->container ) {
-			return;
-		}
-
-		try {
-			$this->container = $this->get_container();
-
-			if ( ! $this->container ) {
-				return;
-			}
-
-			$this->container->get( Loader::class )->load();
-		} catch ( Exception $e ) {
-			if ( $this->is_development() ) {
-				throw $e;
-			}
-			// Don't crash the entire site, simply don't load.
-			// TODO: Add error notifications here.
-		}
-	}
-
-	/**
-	 * Magic getter for retrieving a property.
-	 *
-	 * @param string $property The property to retrieve.
-	 *
-	 * @throws Exception When the property doesn't exist.
-	 *
-	 * @return string The value of the property.
-	 */
-	public function __get( $property ) {
-		if ( isset( $this->{$property} ) ) {
-			$this->{$property} = $this->container->get( $this->surfaces[ $property ] );
-
-			return $this->{$property};
-		}
-		throw new Exception( "Property $property does not exist." );
-	}
-
-	/**
-	 * Checks if the given property exists as a surface.
-	 *
-	 * @param string $property The property to retrieve.
-	 *
-	 * @return bool True when property is set.
-	 */
-	public function __isset( $property ) {
-		return isset( $this->surfaces[ $property ] );
-	}
-
-	/**
-	 * Loads the DI container.
-	 *
-	 * @throws Exception If something goes wrong generating the DI container.
-	 *
-	 * @return null|Cached_Container The DI container.
-	 */
-	private function get_container() {
+	protected function get_container() {
 		if ( $this->is_development() && \class_exists( '\Yoast\WP\SEO\Dependency_Injection\Container_Compiler' ) ) {
 			// Exception here is unhandled as it will only occur in development.
-			Container_Compiler::compile( $this->is_development() );
+			Container_Compiler::compile(
+				$this->is_development(),
+				__DIR__ . '/generated/container.php',
+				__DIR__ . '/../config/dependency-injection/services.php',
+				'Yoast\WP\SEO\Generated'
+			);
 		}
 
 		if ( \file_exists( __DIR__ . '/generated/container.php' ) ) {
@@ -135,11 +62,20 @@ class Main {
 	}
 
 	/**
-	 * Returns whether or not we're in an environment for Yoast development.
-	 *
-	 * @return bool Whether or not to load in development mode.
+	 * @inheritDoc
 	 */
-	private function is_development() {
-		return \defined( 'YOAST_ENVIRONMENT' ) && \YOAST_ENVIRONMENT === 'development';
+	protected function get_name() {
+		return 'yoast-seo';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function get_surfaces() {
+		return [
+			'classes' => Classes_Surface::class,
+			'meta'    => Meta_Surface::class,
+			'helpers' => Helpers_Surface::class,
+		];
 	}
 }

--- a/src/main.php
+++ b/src/main.php
@@ -38,6 +38,8 @@ class Main extends Abstract_Main {
 	 */
 	const WP_CLI_NAMESPACE = 'yoast';
 
+	// @phpcs:disable Generic.Commenting.DocComment.MissingShort -- Description is included in the inherited comment.
+
 	/**
 	 * @inheritDoc
 	 */

--- a/tests/unit/dependency-injection/schema-templates-pass-test.php
+++ b/tests/unit/dependency-injection/schema-templates-pass-test.php
@@ -59,6 +59,12 @@ class Schema_Templates_Pass_Test extends TestCase {
 		$schema_blocks_definition = Mockery::mock();
 
 		$this->container_builder
+			->expects( 'hasDefinition' )
+			->once()
+			->with( Schema_Blocks::class )
+			->andReturn( true );
+
+		$this->container_builder
 			->expects( 'getDefinition' )
 			->once()
 			->with( Schema_Blocks::class )
@@ -76,6 +82,21 @@ class Schema_Templates_Pass_Test extends TestCase {
 			->expects( 'addMethodCall' )
 			->once()
 			->with( 'register_template', [ 'src/schema-templates/address.block.php' ] );
+
+		$this->instance->process( $this->container_builder );
+	}
+
+	/**
+	 * Tests the processing of the templates.
+	 *
+	 * @covers ::process
+	 */
+	public function test_process_without_definition() {
+		$this->container_builder
+			->expects( 'hasDefinition' )
+			->once()
+			->with( Schema_Blocks::class )
+			->andReturn( false );
 
 		$this->instance->process( $this->container_builder );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Creates the basic DI framework that can be used and expanded by our add-ons so they can implement their own DI containers that can inject classes from the free container.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

There are no effective changes, this only introduces framework to be used by add-ons. Functionally free stays identical.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Delete your generated container in `src/generated/container.php` as well as the meta file next to it.
* Run `composer compile-di`
* It should work
* Run the plugin, meta output should appear as normal on the front-end without warnings or errors.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Meta output should appear as normal on the front-end without warnings or errors.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The initial load of all our namespaced code. This essentially means every new feature starting with indexables. Note this is only the loading of those features, there have been no changes in how these features work or behave.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
