### PR TITLE
Fixed PHP notice on non-post pages.

### DIFF
--- a/src/helpers/schema/replace-vars-helper.php
+++ b/src/helpers/schema/replace-vars-helper.php
@@ -82,8 +82,12 @@ class Replace_Vars_Helper {
 			'webpage_id'       => $context->canonical . Schema_IDs::WEBPAGE_HASH,
 			'website_id'       => $context->site_url . Schema_IDs::WEBSITE_HASH,
 			'organization_id'  => $context->site_url . Schema_IDs::ORGANIZATION_HASH,
-			'post_date'        => $context->post->post_date,
 		];
+
+		if ( $context->post ) {
+			// Post does not always exist, e.g. on term pages.
+			$replace_vars['post_date'] = $context->post->post_date;
+		}
 
 		foreach ( $replace_vars as $var => $value ) {
 			$this->register_replacement( $var, $value );

--- a/tests/unit/helpers/schema/replace-vars-helper-test.php
+++ b/tests/unit/helpers/schema/replace-vars-helper-test.php
@@ -158,6 +158,58 @@ class Replace_Vars_Helper_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the registration of the Schema ID replace vars when on a non-post.
+	 * E.g. a term- or author archive page.
+	 *
+	 * @covers ::__construct
+	 * @covers ::register_replace_vars
+	 * @covers ::register_replacement
+	 */
+	public function test_registers_the_right_replace_vars_on_non_post() {
+		$replace_vars = [
+			'main_schema_id'   => 'https://basic.wordpress.test/schema-templates/#webpage',
+			'author_id'        => 'https://basic.wordpress.test#/schema/person/a00dc884baa6bd52ebacc06cfd5aab21',
+			'person_id'        => 'https://basic.wordpress.test#/schema/person/',
+			'primary_image_id' => 'https://basic.wordpress.test/schema-templates#primaryimage',
+			'webpage_id'       => 'https://basic.wordpress.test/schema-templates#webpage',
+			'website_id'       => 'https://basic.wordpress.test#website',
+			'organization_id'  => 'https://basic.wordpress.test#organization',
+		];
+
+		$indexable            = Mockery::mock( Indexable_Mock::class );
+		$indexable->author_id = 'author_id';
+
+		$meta_tags_context                 = Mockery::mock( Meta_Tags_Context_Mock::class );
+		$meta_tags_context->indexable      = $indexable;
+		$meta_tags_context->main_schema_id = 'https://basic.wordpress.test/schema-templates/#webpage';
+		$meta_tags_context->site_url       = 'https://basic.wordpress.test';
+		$meta_tags_context->canonical      = 'https://basic.wordpress.test/schema-templates';
+
+		$this->id_helper
+			->expects( 'get_user_schema_id' )
+			->andReturn( 'https://basic.wordpress.test#/schema/person/a00dc884baa6bd52ebacc06cfd5aab21' );
+
+		// Partial mock, to be able to spy on the `register_replacement` method.
+		$instance = Mockery::mock(
+			Replace_Vars_Helper::class,
+			[
+				$this->replace_vars,
+				$this->id_helper,
+			]
+		)
+			->shouldAllowMockingProtectedMethods()
+			->makePartial();
+
+		foreach ( $replace_vars as $var => $value ) {
+			$instance
+				->expects( 'register_replacement' )
+				->with( $var, $value );
+		}
+
+		$instance->register_replace_vars( $meta_tags_context );
+	}
+
+	/**
 	 * Tests the replace method.
 	 *
 	 * @covers ::__construct


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where a PHP notice was shown on non-post pages.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Steps to reproduce
1. Make sure that you have Query Monitor plugin installed.
2. Visit to a non-post page, like an author archive or term archive page. 
3. See the following PHP notice when you open the Query Monitor debug bar:
   ```
   Trying to get property 'post_date' of non-object
   ```

#### Steps to see that the bug is fixed
1. Make sure that you have Query Monitor plugin installed.
2. Visit to a non-post page, like an author archive or term archive page.
3. You should not see any PHP notices.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
