### PR TITLE
Update health-check-curl-version.php

### DIFF
--- a/inc/health-check-curl-version.php
+++ b/inc/health-check-curl-version.php
@@ -66,7 +66,7 @@ class WPSEO_Health_Check_Curl_Version extends WPSEO_Health_Check {
 				'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3u8' ) ) . '" target="_blank">',
 				WPSEO_Admin_Utils::get_new_tab_message() . '</a>',
 				'Yoast SEO',
-				'my.yoast.com'				
+				'my.yoast.com'
 			);
 			return;
 		}

--- a/inc/health-check-curl-version.php
+++ b/inc/health-check-curl-version.php
@@ -52,9 +52,9 @@ class WPSEO_Health_Check_Curl_Version extends WPSEO_Health_Check {
 		// Note: as of January 2020, the most recent cURL version is 7.67.0.
 		if ( ! $this->is_my_yoast_api_reachable() && ! $this->is_recent_curl_version() ) {
 			$this->label = sprintf(
-				/* translators: %1$s expands to 'my.yoast.com'. */
+				/* translators: %1$s expands to 'Yoast'. */
 				esc_html__( '%1$s premium plugins cannot update', 'wordpress-seo' ),
-				'my.yoast.com'
+				'Yoast'
 			);
 			$this->status         = self::STATUS_CRITICAL;
 			$this->badge['color'] = 'red';

--- a/inc/health-check-curl-version.php
+++ b/inc/health-check-curl-version.php
@@ -36,12 +36,14 @@ class WPSEO_Health_Check_Curl_Version extends WPSEO_Health_Check {
 			$this->status         = self::STATUS_CRITICAL;
 			$this->badge['color'] = 'red';
 			$this->description    = sprintf(
-				/* translators: %1$s Emphasis open tag, %2$s: Emphasis close tag, %3$s Link start tag to the Yoast knowledge base, %4$s Link closing tag. */
-				esc_html__( 'You can %1$snot%2$s activate your premium plugin(s) and receive updates. A common cause for not being able to connect is an out-of-date version of cURL, software used to connect to other servers. However, your cURL version seems fine. Please talk to your host and, if needed, the Yoast support team to figure out what is broken. %3$sRead more about cURL in our knowledge base%4$s.', 'wordpress-seo' ),
+				/* translators: %1$s Emphasis open tag, %2$s: Emphasis close tag, %3$s Link start tag to the Yoast knowledge base, %4$s Link closing tag, %5$s to Yoast SEO, %6$s to my.yoast.com. */
+				esc_html__( 'You can %1$snot%2$s activate your premium plugin(s) and receive updates because %5$s cannot connect to %6$s. A common cause for not being able to connect is an out-of-date version of cURL, software used to connect to other servers. However, your cURL version seems fine. Please talk to your host and, if needed, the Yoast support team to figure out what is broken. %3$sRead more about cURL in our knowledge base%4$s.', 'wordpress-seo' ),
 				'<em>',
 				'</em>',
 				'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3u8' ) ) . '" target="_blank">',
-				WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
+				WPSEO_Admin_Utils::get_new_tab_message() . '</a>',
+				'Yoast SEO',
+				'my.yoast.com'
 			);
 
 			return;
@@ -51,26 +53,28 @@ class WPSEO_Health_Check_Curl_Version extends WPSEO_Health_Check {
 		if ( ! $this->is_my_yoast_api_reachable() && ! $this->is_recent_curl_version() ) {
 			$this->label = sprintf(
 				/* translators: %1$s expands to 'my.yoast.com'. */
-				esc_html__( 'Your site can not connect to %1$s', 'wordpress-seo' ),
+				esc_html__( '%1$s premium plugins cannot update.', 'wordpress-seo' ),
 				'my.yoast.com'
 			);
 			$this->status         = self::STATUS_CRITICAL;
 			$this->badge['color'] = 'red';
 			$this->description    = sprintf(
-				/* translators: %1$s Emphasis open tag, %2$s: Emphasis close tag, %3$s Link start tag to the Yoast knowledge base, %4$s Link closing tag. */
-				esc_html__( 'You can %1$snot%2$s activate your premium plugin(s) and receive updates. The cause for this error is probably that the cURL software on your server is too old. Please contact your host and ask them to update it to at least version 7.34. %3$sRead more about cURL in our knowledge base%4$s.', 'wordpress-seo' ),
+				/* translators: %1$s Emphasis open tag, %2$s: Emphasis close tag, %3$s Link start tag to the Yoast knowledge base, %4$s Link closing tag, %5$s to Yoast SEO, %6$s to my.yoast.com. */
+				esc_html__( 'You can %1$snot%2$s activate your premium plugin(s) and receive updates because %5$s cannot connect to %6$s. The cause for this error is probably that the cURL software on your server is too old. Please contact your host and ask them to update it to at least version 7.34. %3$sRead more about cURL in our knowledge base%4$s.', 'wordpress-seo' ),
 				'<em>',
 				'</em>',
 				'<a href="' . esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/3u8' ) ) . '" target="_blank">',
-				WPSEO_Admin_Utils::get_new_tab_message() . '</a>'
+				WPSEO_Admin_Utils::get_new_tab_message() . '</a>',
+				'Yoast SEO',
+				'my.yoast.com'				
 			);
 			return;
 		}
 
 		$this->label = sprintf(
-			/* translators: %1$s expands to 'my.yoast.com'. */
-			esc_html__( 'Your site can connect to %1$s', 'wordpress-seo' ),
-			'my.yoast.com'
+			/* translators: %1$s expands to 'Yoast'. */
+			esc_html__( '%1$s premium plugin updates work fine', 'wordpress-seo' ),
+			'Yoast'
 		);
 		$this->status         = self::STATUS_GOOD;
 		$this->badge['color'] = 'blue';

--- a/inc/health-check-curl-version.php
+++ b/inc/health-check-curl-version.php
@@ -29,9 +29,9 @@ class WPSEO_Health_Check_Curl_Version extends WPSEO_Health_Check {
 
 		if ( ! $this->is_my_yoast_api_reachable() && $this->is_recent_curl_version() ) {
 			$this->label = sprintf(
-				/* translators: %1$s expands to 'my.yoast.com'. */
-				esc_html__( 'Your site can not connect to %1$s', 'wordpress-seo' ),
-				'my.yoast.com'
+				/* translators: %1$s expands to 'Yoast'. */
+				esc_html__( '%1$s premium plugins cannot update.', 'wordpress-seo' ),
+				'Yoast'
 			);
 			$this->status         = self::STATUS_CRITICAL;
 			$this->badge['color'] = 'red';

--- a/inc/health-check-curl-version.php
+++ b/inc/health-check-curl-version.php
@@ -30,7 +30,7 @@ class WPSEO_Health_Check_Curl_Version extends WPSEO_Health_Check {
 		if ( ! $this->is_my_yoast_api_reachable() && $this->is_recent_curl_version() ) {
 			$this->label = sprintf(
 				/* translators: %1$s expands to 'Yoast'. */
-				esc_html__( '%1$s premium plugins cannot update.', 'wordpress-seo' ),
+				esc_html__( '%1$s premium plugins cannot update', 'wordpress-seo' ),
 				'Yoast'
 			);
 			$this->status         = self::STATUS_CRITICAL;
@@ -53,7 +53,7 @@ class WPSEO_Health_Check_Curl_Version extends WPSEO_Health_Check {
 		if ( ! $this->is_my_yoast_api_reachable() && ! $this->is_recent_curl_version() ) {
 			$this->label = sprintf(
 				/* translators: %1$s expands to 'my.yoast.com'. */
-				esc_html__( '%1$s premium plugins cannot update.', 'wordpress-seo' ),
+				esc_html__( '%1$s premium plugins cannot update', 'wordpress-seo' ),
 				'my.yoast.com'
 			);
 			$this->status         = self::STATUS_CRITICAL;

--- a/tests/unit/inc/health-check-curl-version-test.php
+++ b/tests/unit/inc/health-check-curl-version-test.php
@@ -81,7 +81,7 @@ class Health_Check_Curl_Version_Test extends TestCase {
 
 		// We want to verify that the label attribute is the "not passed" message.
 		$this->assertEquals(
-			'Your site can not connect to my.yoast.com',
+			'Yoast premium plugins cannot update',
 			$this->getPropertyValue( $this->instance, 'label' )
 		);
 
@@ -118,7 +118,7 @@ class Health_Check_Curl_Version_Test extends TestCase {
 
 		// We want to verify that the label attribute is the "not passed" message.
 		$this->assertEquals(
-			'Your site can not connect to my.yoast.com',
+			'Yoast premium plugins cannot update',
 			$this->getPropertyValue( $this->instance, 'label' )
 		);
 
@@ -146,7 +146,7 @@ class Health_Check_Curl_Version_Test extends TestCase {
 
 		// We just want to verify that the label attribute is the "passed" message.
 		$this->assertEquals(
-			'Your site can connect to my.yoast.com',
+			'Yoast premium plugin updates work fine',
 			$this->getPropertyValue( $this->instance, 'label' )
 		);
 	}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changed the wording on the my.yoast.com connect error shown in Health Check when a Yoast premium plugin is enabled to lead with what the user's problem is.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
