### PR TITLE
P1 242 elementor social replacevars update

### DIFF
--- a/js/src/elementor/components/fills/ElementorFill.js
+++ b/js/src/elementor/components/fills/ElementorFill.js
@@ -12,8 +12,8 @@ import ReadabilityAnalysis from "../../../components/contentAnalysis/Readability
 import SeoAnalysis from "../../../components/contentAnalysis/SeoAnalysis";
 import SidebarItem from "../../../components/SidebarItem";
 import GooglePreviewModal from "../modals/editorModals/GooglePreviewModal";
-import TwitterPreviewModal from "../../../components/modals/editorModals/TwitterPreviewModal";
-import FacebookPreviewModal from "../../../components/modals/editorModals/FacebookPreviewModal";
+import TwitterPreviewModal from "../modals/editorModals/TwitterPreviewModal";
+import FacebookPreviewModal from "../modals/editorModals/FacebookPreviewModal";
 import SidebarCollapsible from "../../../components/SidebarCollapsible";
 import SchemaTabContainer from "../../../containers/SchemaTab";
 import AdvancedSettings from "../../../containers/AdvancedSettings";

--- a/js/src/elementor/components/modals/editorModals/FacebookPreviewModal.js
+++ b/js/src/elementor/components/modals/editorModals/FacebookPreviewModal.js
@@ -1,0 +1,21 @@
+/* External dependencies */
+import { __ } from "@wordpress/i18n";
+
+/* Internal dependencies */
+import EditorModal from "../../../../containers/EditorModal";
+import FacebookEditor from "../../../containers/FacebookEditor";
+
+/**
+ * The Facebook Preview Modal.
+ *
+ * @returns {React.Component} The Facebook Preview Modal.
+ */
+const FacebookPreviewModal = () => {
+	return (
+		<EditorModal title={ __( "Facebook preview", "wordpress-seo" ) }>
+			<FacebookEditor />
+		</EditorModal>
+	);
+};
+
+export default FacebookPreviewModal;

--- a/js/src/elementor/components/modals/editorModals/TwitterPreviewModal.js
+++ b/js/src/elementor/components/modals/editorModals/TwitterPreviewModal.js
@@ -1,0 +1,23 @@
+/* External dependencies */
+import { __ } from "@wordpress/i18n";
+
+/* Internal dependencies */
+import EditorModal from "../../../../containers/EditorModal";
+import TwitterEditor from "../../../containers/TwitterEditor";
+
+/**
+ * The Twitter Preview Modal.
+ *
+ * @returns {React.Component} The Twitter Preview Modal.
+ */
+const TwitterPreviewModal = () => {
+	return (
+		<EditorModal
+			title={ __( "Twitter preview", "wordpress-seo" ) }
+		>
+			<TwitterEditor />
+		</EditorModal>
+	);
+};
+
+export default TwitterPreviewModal;

--- a/js/src/elementor/containers/FacebookEditor.js
+++ b/js/src/elementor/containers/FacebookEditor.js
@@ -1,0 +1,124 @@
+/* External dependencies */
+import { compose } from "@wordpress/compose";
+import { withDispatch, withSelect, dispatch as wpDataDispatch } from "@wordpress/data";
+import { __, sprintf } from "@wordpress/i18n";
+import { validateFacebookImage } from "@yoast/helpers";
+
+/* Internal dependencies */
+import FacebookWrapper from "../../components/social/FacebookWrapper";
+import getL10nObject from "../../analysis/getL10nObject";
+import withLocation from "../../helpers/withLocation";
+import { getCurrentReplacementVariablesForEditor } from "../replaceVars/elementor-replacevar-plugin";
+
+const socialMediumName = "Facebook";
+
+/**
+ * The cached instance of the media object.
+ *
+ * @type {wp.media} The media object
+ */
+let media = null;
+
+/**
+ * Lazy function to get the media object and hook the right action dispatchers.
+ *
+ * @returns {void}
+ */
+const getMedia = () => {
+	if ( ! media ) {
+		media = window.wp.media();
+		// Listens for the selection of an image. Then gets the right data and dispatches the data to the store.
+		media.on( "select", () => {
+			const selected = media.state().get( "selection" ).first();
+			const image = {
+				type: selected.attributes.subtype,
+				width: selected.attributes.width,
+				height: selected.attributes.height,
+			};
+			wpDataDispatch( "yoast-seo/editor" ).setFacebookPreviewImage( {
+				url: selected.attributes.url,
+				id: selected.attributes.id,
+				warnings: validateFacebookImage( image ),
+			} );
+		} );
+	}
+
+	return media;
+};
+
+/**
+ * Lazy function to open the media instance.
+ *
+ * @returns {void}
+ */
+const openMedia = () => {
+	return getMedia().open();
+};
+
+export default compose( [
+	withSelect( select => {
+		const {
+			getFacebookDescription,
+			getDescriptionFallback,
+			getFacebookTitle,
+			getTitleFallback,
+			getFacebookImageUrl,
+			getImageFallback,
+			getFacebookWarnings,
+			getRecommendedReplaceVars,
+			getReplaceVars,
+			getSiteUrl,
+			getAuthorName,
+		} = select( "yoast-seo/editor" );
+
+		/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+		const titleInputPlaceholder  = sprintf(
+			/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+			__( "Modify your %s title by editing it right here...", "wordpress-seo" ),
+			socialMediumName
+		);
+
+		/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+		const descriptionInputPlaceholder  = sprintf(
+			/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+			__( "Modify your %s description by editing it right here...", "wordpress-seo" ),
+			socialMediumName
+		);
+
+		return {
+			imageUrl: getFacebookImageUrl(),
+			imageFallbackUrl: getImageFallback(),
+			recommendedReplacementVariables: getRecommendedReplaceVars(),
+			replacementVariables: getCurrentReplacementVariablesForEditor(),
+			description: getFacebookDescription(),
+			descriptionPreviewFallback: getDescriptionFallback() || descriptionInputPlaceholder,
+			title: getFacebookTitle(),
+			titlePreviewFallback: getTitleFallback() || titleInputPlaceholder,
+			imageWarnings: getFacebookWarnings(),
+			authorName: getAuthorName(),
+			siteUrl: getSiteUrl(),
+			isPremium: !! getL10nObject().isPremium,
+			titleInputPlaceholder,
+			descriptionInputPlaceholder,
+			socialMediumName,
+		};
+	} ),
+
+	withDispatch( dispatch => {
+		const {
+			setFacebookPreviewTitle,
+			setFacebookPreviewDescription,
+			clearFacebookPreviewImage,
+			loadFacebookPreviewData,
+		} = dispatch( "yoast-seo/editor" );
+		return {
+			onSelectImageClick: openMedia,
+			onRemoveImageClick: clearFacebookPreviewImage,
+			onDescriptionChange: setFacebookPreviewDescription,
+			onTitleChange: setFacebookPreviewTitle,
+			onLoad: loadFacebookPreviewData,
+		};
+	} ),
+
+	withLocation(),
+] )( FacebookWrapper );

--- a/js/src/elementor/containers/FacebookEditor.js
+++ b/js/src/elementor/containers/FacebookEditor.js
@@ -66,7 +66,6 @@ export default compose( [
 			getImageFallback,
 			getFacebookWarnings,
 			getRecommendedReplaceVars,
-			getReplaceVars,
 			getSiteUrl,
 			getAuthorName,
 		} = select( "yoast-seo/editor" );

--- a/js/src/elementor/containers/TwitterEditor.js
+++ b/js/src/elementor/containers/TwitterEditor.js
@@ -71,7 +71,6 @@ export default compose( [
 			getTwitterImageType,
 			getImageFallback,
 			getRecommendedReplaceVars,
-			getReplaceVars,
 			getSiteUrl,
 			getAuthorName,
 		} = select( "yoast-seo/editor" );

--- a/js/src/elementor/containers/TwitterEditor.js
+++ b/js/src/elementor/containers/TwitterEditor.js
@@ -1,0 +1,132 @@
+/* External dependencies */
+import { compose } from "@wordpress/compose";
+import { withDispatch, withSelect, dispatch as wpDataDispatch } from "@wordpress/data";
+import { __, sprintf } from "@wordpress/i18n";
+import { validateTwitterImage } from "@yoast/helpers";
+
+/* Internal dependencies */
+import TwitterWrapper from "../components/social/TwitterWrapper";
+import getL10nObject from "../analysis/getL10nObject";
+import withLocation from "../helpers/withLocation";
+import { getCurrentReplacementVariablesForEditor } from "../replaceVars/elementor-replacevar-plugin";
+
+const socialMediumName = "Twitter";
+
+/**
+ * The cached instance of the media object.
+ *
+ * @type {wp.media} The media object
+ */
+let media = null;
+
+/**
+ * Lazy function to get the media object and hook the right action dispatchers.
+ *
+ * @returns {void}
+ */
+const getMedia = () => {
+	if ( ! media ) {
+		media = window.wp.media();
+		// Listens for the selection of an image. Then gets the right data and dispatches the data to the store.
+		media.on( "select", () => {
+			const selected = media.state().get( "selection" ).first();
+			const image = {
+				type: selected.attributes.subtype,
+				width: selected.attributes.width,
+				height: selected.attributes.height,
+			};
+			wpDataDispatch( "yoast-seo/editor" ).setTwitterPreviewImage( {
+				url: selected.attributes.url,
+				id: selected.attributes.id,
+				warnings: validateTwitterImage( image ),
+			} );
+		} );
+	}
+
+	return media;
+};
+
+/**
+ * Lazy function to open the media instance.
+ *
+ * @returns {void}
+ */
+const openMedia = () => {
+	return getMedia().open();
+};
+
+/* eslint-disable complexity */
+export default compose( [
+	withSelect( select => {
+		const {
+			getTwitterDescription,
+			getTwitterTitle,
+			getTwitterImageUrl,
+			getFacebookImageUrl,
+			getFacebookTitle,
+			getFacebookDescription,
+			getDescriptionFallback,
+			getTitleFallback,
+			getTwitterWarnings,
+			getTwitterImageType,
+			getImageFallback,
+			getRecommendedReplaceVars,
+			getReplaceVars,
+			getSiteUrl,
+			getAuthorName,
+		} = select( "yoast-seo/editor" );
+
+		/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+		const titleInputPlaceholder  = sprintf(
+			/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+			__( "Modify your %s title by editing it right here...", "wordpress-seo" ),
+			socialMediumName
+		);
+
+		/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+		const descriptionInputPlaceholder  = sprintf(
+			/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+			__( "Modify your %s description by editing it right here...", "wordpress-seo" ),
+			socialMediumName
+		);
+
+		return {
+			imageUrl: getTwitterImageUrl(),
+			imageFallbackUrl: getFacebookImageUrl() || getImageFallback(),
+			recommendedReplacementVariables: getRecommendedReplaceVars(),
+			replacementVariables: getCurrentReplacementVariablesForEditor(),
+			description: getTwitterDescription(),
+			descriptionPreviewFallback: getFacebookDescription() || getDescriptionFallback() || descriptionInputPlaceholder,
+			title: getTwitterTitle(),
+			titlePreviewFallback: getFacebookTitle() || getTitleFallback() || titleInputPlaceholder,
+			imageWarnings: getTwitterWarnings(),
+			authorName: getAuthorName(),
+			siteUrl: getSiteUrl(),
+			isPremium: !! getL10nObject().isPremium,
+			isLarge: getTwitterImageType() !== "summary",
+			titleInputPlaceholder,
+			descriptionInputPlaceholder,
+			socialMediumName,
+		};
+	} ),
+
+	withDispatch( dispatch => {
+		const {
+			setTwitterPreviewTitle,
+			setTwitterPreviewDescription,
+			clearTwitterPreviewImage,
+			loadTwitterPreviewData,
+		} = dispatch( "yoast-seo/editor" );
+
+		return {
+			onSelectImageClick: openMedia,
+			onRemoveImageClick:	clearTwitterPreviewImage,
+			onDescriptionChange: setTwitterPreviewDescription,
+			onTitleChange: setTwitterPreviewTitle,
+			onLoad: loadTwitterPreviewData,
+		};
+	} ),
+
+	withLocation(),
+] )( TwitterWrapper );
+/* eslint-enable complexity */

--- a/js/src/elementor/containers/TwitterEditor.js
+++ b/js/src/elementor/containers/TwitterEditor.js
@@ -5,9 +5,9 @@ import { __, sprintf } from "@wordpress/i18n";
 import { validateTwitterImage } from "@yoast/helpers";
 
 /* Internal dependencies */
-import TwitterWrapper from "../components/social/TwitterWrapper";
-import getL10nObject from "../analysis/getL10nObject";
-import withLocation from "../helpers/withLocation";
+import TwitterWrapper from "../../components/social/TwitterWrapper";
+import getL10nObject from "../../analysis/getL10nObject";
+import withLocation from "../../helpers/withLocation";
 import { getCurrentReplacementVariablesForEditor } from "../replaceVars/elementor-replacevar-plugin";
 
 const socialMediumName = "Twitter";


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* A newer implementation of replacevars was used for the Google preview in Elementor. For consistency and future implementations this needs to be applied to the Social previews as well.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds advanced snippet variables in the Social previews of our Elementor integration.

## Relevant technical choices:

* Copied some files like done for the Google Preview modal. These copies can be removed whenever the new kind of Replacevar implementation is adapted to the Block and Classic editor as well.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post in the Elementor editor.
* Open the Facebook preview.
* Try the replacement variables in the title or description:
  * Post type (singular) / `%%pt_single%%`: Replaced with the content type single label
  * Post type (plural) / `%%pt_plural%%`: Replaced with the content type plural label
  * Modified / `%%modified%%`: Replaced with the post/page modified time
  * Name / `%%name%%`: Replaced with the post/page author’s ‘nicename’
    * In the user profile you can fill in the nickname of the author and use that as display.
  * User description	/ `%%user_description%%`: Replaced with the post/page author’s ‘Biographical Info’
    * In the user profile you can fill the biographical info
  * Pagetotal / `%%pagetotal%%`: Replaced with the current page total
  * Pagenumber / `%%pagenumber%%`: Replaced with the current page number
    * To get another number than 1 you can add a post overview from Elementor Pro and switch page in the frontend. I don't know if/how you can do this in the backend.
  * _Note_ the missing Caption replacevar. I left that out as that is useful for attachments only.
  * _Note_ the missing Term404 replacevar. I left that out as Elementor is post/page only.
* They should change to the label when you enter the `%%` version in the input field.
* They should display the value in the preview.
* When you save the post and check the frontend, the value should be the same there.
  * _Note_ there might be an edge case like modified being different because you just saved. And these values (except caption) are only updated on page load.
* Repeat above steps for the Twitter Preview
* Repeat above steps in Premium, and verify the preview shows the values correctly.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-242
