### PR TITLE
Fixes CS warnings on docs in the generator unit tests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=431",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=412",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=227",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/tests/unit/generators/breadcrumbs-generator-test.php
+++ b/tests/unit/generators/breadcrumbs-generator-test.php
@@ -89,7 +89,7 @@ class Breadcrumbs_Generator_Test extends TestCase {
 	private $pagination_helper;
 
 	/**
-	 * @inheritDoc
+	 * Method that is called before each individual test case.
 	 */
 	protected function set_up() {
 		parent::set_up();

--- a/tests/unit/generators/open-graph-image-generator-test.php
+++ b/tests/unit/generators/open-graph-image-generator-test.php
@@ -28,41 +28,57 @@ use Yoast\WP\SEO\Values\Open_Graph\Images;
 class Open_Graph_Image_Generator_Test extends TestCase {
 
 	/**
+	 * Open graph image helper mock.
+	 *
 	 * @var Open_Graph_Image_Helper|Mockery\MockInterface
 	 */
 	protected $open_graph_image;
 
 	/**
+	 * Image helper mock.
+	 *
 	 * @var Image_Helper|Mockery\MockInterface
 	 */
 	protected $image;
 
 	/**
+	 * Options helper mock.
+	 *
 	 * @var Options_Helper|Mockery\MockInterface
 	 */
 	protected $options;
 
 	/**
+	 * Instance under test.
+	 *
 	 * @var Open_Graph_Image_Generator|Mockery\MockInterface
 	 */
 	protected $instance;
 
 	/**
+	 * Indexable mock.
+	 *
 	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
 	/**
+	 * Images container mock.
+	 *
 	 * @var Mockery\MockInterface|Images
 	 */
 	protected $image_container;
 
 	/**
+	 * Meta tags context mock.
+	 *
 	 * @var Mockery\MockInterface|Meta_Tags_Context_Mock
 	 */
 	protected $context;
 
 	/**
+	 * URL helper mock.
+	 *
 	 * @var Mockery\MockInterface|Url_Helper
 	 */
 	protected $url;

--- a/tests/unit/generators/schema/article-test.php
+++ b/tests/unit/generators/schema/article-test.php
@@ -24,7 +24,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group schema
  *
  * @coversDefaultClass \Yoast\WP\SEO\Generators\Schema\Article
- * @covers ::<!public>
+ * @covers \Yoast\WP\SEO\Generators\Schema\Article
  */
 class Article_Test extends TestCase {
 

--- a/tests/unit/generators/schema/article-test.php
+++ b/tests/unit/generators/schema/article-test.php
@@ -24,7 +24,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group schema
  *
  * @coversDefaultClass \Yoast\WP\SEO\Generators\Schema\Article
- * @covers \Yoast\WP\SEO\Generators\Schema\Article
  */
 class Article_Test extends TestCase {
 

--- a/tests/unit/generators/schema/faq-test.php
+++ b/tests/unit/generators/schema/faq-test.php
@@ -41,7 +41,7 @@ class FAQ_Test extends TestCase {
 	private $instance;
 
 	/**
-	 * @inheritDoc
+	 * Setup the test.
 	 */
 	protected function set_up() {
 		parent::set_up();

--- a/tests/unit/generators/schema/howto-test.php
+++ b/tests/unit/generators/schema/howto-test.php
@@ -136,7 +136,7 @@ class HowTo_Test extends TestCase {
 	];
 
 	/**
-	 * @inheritDoc
+	 * Setup the test.
 	 */
 	protected function set_up() {
 		parent::set_up();

--- a/tests/unit/generators/twitter-image-generator-test.php
+++ b/tests/unit/generators/twitter-image-generator-test.php
@@ -24,36 +24,50 @@ use Yoast\WP\SEO\Values\Images;
 class Twitter_Image_Generator_Test extends TestCase {
 
 	/**
+	 * Twitter image generator mock.
+	 *
 	 * @var Twitter_Image_Generator|Mockery\MockInterface
 	 */
 	protected $twitter_image;
 
 	/**
+	 * Image helper mock.
+	 *
 	 * @var Image_Helper|Mockery\MockInterface
 	 */
 	protected $image;
 
 	/**
+	 * URL helper mock.
+	 *
 	 * @var Mockery\MockInterface|Url_Helper
 	 */
 	protected $url;
 
 	/**
+	 * Instance under test.
+	 *
 	 * @var Twitter_Image_Generator|Mockery\MockInterface
 	 */
 	protected $instance;
 
 	/**
+	 * Indexable mock.
+	 *
 	 * @var Indexable_Mock
 	 */
 	protected $indexable;
 
 	/**
+	 * Images container mock.
+	 *
 	 * @var Mockery\MockInterface|Images
 	 */
 	protected $image_container;
 
 	/**
+	 * Meta tags context mock.
+	 *
 	 * @var Mockery\MockInterface|Meta_Tags_Context_Mock
 	 */
 	protected $context;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds doc blocks to methods in the generator unit tests.
* Fixes an incorrect `@covers` annotation in a unit test.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check that Travis passes.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A, only applies documentation blocks to some unit tests.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A, only applies documentation blocks to some unit tests.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
