### PR TITLE
Make the class map path dynamic in the custom loader

### DIFF
--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -125,6 +125,7 @@ class Actions {
 			true,
 			__DIR__ . '/../../src/generated/container.php',
 			__DIR__ . '/../dependency-injection/services.php',
+			__DIR__ . '/../../vendor/composer/autoload_classmap.php',
 			'Yoast\WP\SEO\Generated'
 		);
 

--- a/config/dependency-injection/container-compiler.php
+++ b/config/dependency-injection/container-compiler.php
@@ -19,6 +19,7 @@ class Container_Compiler {
 	 * @param boolean $debug                    If false the container will only be re-compiled if it does not yet already exist.
 	 * @param string  $generated_container_path The path the generated container should be written to.
 	 * @param string  $services_path            The path of the services.php.
+	 * @param string  $class_map_path           The path of the class map.
 	 * @param string  $namespace                The namespace the generated container should be in.
 	 *
 	 * @throws Exception If compiling the container fails.
@@ -29,6 +30,7 @@ class Container_Compiler {
 		$debug,
 		$generated_container_path,
 		$services_path,
+		$class_map_path,
 		$namespace
 	) {
 		$cache = new ConfigCache( $generated_container_path, $debug );
@@ -45,7 +47,7 @@ class Container_Compiler {
 			$container_builder->addCompilerPass( new Interface_Injection_Pass() );
 			$container_builder->addCompilerPass( new AutowireRequiredMethodsPass() );
 			$container_builder->addCompilerPass( new Inject_From_Registry_Pass() );
-			$loader = new Custom_Loader( $container_builder );
+			$loader = new Custom_Loader( $container_builder, $class_map_path );
 			$loader->load( $services_path );
 			$container_builder->compile();
 

--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -17,11 +17,20 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 class Custom_Loader extends PhpFileLoader {
 
 	/**
+	 * The class map path.
+	 *
+	 * @var string;
+	 */
+	private $class_map_path;
+
+	/**
 	 * Custom_Loader constructor.
 	 *
-	 * @param ContainerBuilder $container The ContainerBuilder to load classes for.
+	 * @param ContainerBuilder $container      The ContainerBuilder to load classes for.
+	 * @param string           $class_map_path The class map path.
 	 */
-	public function __construct( ContainerBuilder $container ) {
+	public function __construct( ContainerBuilder $container, $class_map_path ) {
+		$this->class_map_path = $class_map_path;
 		parent::__construct( $container, new FileLocator( __DIR__ . '/../..' ) );
 	}
 
@@ -36,7 +45,7 @@ class Custom_Loader extends PhpFileLoader {
 		static $class_map;
 
 		if ( ! $class_map ) {
-			$class_map = require __DIR__ . '/../../vendor/composer/autoload_classmap.php';
+			$class_map = require $this->class_map_path;
 			$class_map = \array_map( [ $this, 'normalize_slashes' ], $class_map );
 			$class_map = \array_flip( $class_map );
 		}

--- a/src/main.php
+++ b/src/main.php
@@ -50,6 +50,7 @@ class Main extends Abstract_Main {
 				$this->is_development(),
 				__DIR__ . '/generated/container.php',
 				__DIR__ . '/../config/dependency-injection/services.php',
+				__DIR__ . '/../vendor/composer/autoload_classmap.php',
 				'Yoast\WP\SEO\Generated'
 			);
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This is preparation for using premium as an addon, a hardcoded class map path doesn't work when free is in the vendor directory itself.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes the class map path of the custom DI loader dynamic instead of hardcoded.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run `composer compile-di`. Your `src/generated/container.php` shouldn't change.
* Delete `src/generated/container.php` and load any page, it should automatically be regenerated.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Load any page which has Yoast SEO meta in the head. The fields should be present and unchanged.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This affects building the DI container. If it breaks literally everything in the `src` directory will be broken, as such checking the meta fields which are handled by presenters in the src directory validates that these are correctly loaded.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
