### PR TITLE
Add push after gutenberg compatibility version change

### DIFF
--- a/config/grunt/custom-tasks/sync-gutenberg-version.js
+++ b/config/grunt/custom-tasks/sync-gutenberg-version.js
@@ -29,6 +29,10 @@ module.exports = function( grunt ) {
 					files: { src: [targetFile] }
 				} );
 				grunt.task.run( "gitcommit:gutenbergFiles" );
+
+				// Push the commit to the branch.
+				grunt.config( "gitpush.gutenbergVersion.options", { remote: "origin", upstream: true, branch: grunt.config.data.branchForRC } );
+				grunt.task.run( "gitpush:gutenbergVersion" );
 			}
 
 			return done();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When creating the RC per grunt script, a change in the Gutenberg compatibility version is not pushed to the remote.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `sync-gutenberg-version` Grunt task would not push the changes.

## Relevant technical choices:

* Making use of https://github.com/rubenv/grunt-git as in the `bump-rc-version` task.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Switch to this branch.
* Run yarn install to ensure grunt dependencies are there.
* Open `admin/class-gutenberg-compatibility.php` and lower the version.
* Create a new branch (e.g. `test-sync-gutenberg`) and push it to the remote (so you can remove it instead of having to force push later).
* Commit this change (push does not matter).
* Run the grunt task: `grunt sync-gutenberg-version --branchForRC=test-sync-gutenberg`.
   * Note: the `branchForRC` part is passing the variable that is normally set in a previous task (`config/grunt/custom-tasks/ensure-pre-release-branch.js`). This is only for testing and you should change it to the same as your test branch you created above.
* It is expected that:
  * it detected a need to update the version like normal.
  * the commit is now pushed to the branch you specified on the remote.
* Verify that the branch contains the version bump commit.
* Clean up your test branch on the remote (and locally).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* No need to be tested by QA. This is development tooling.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
