### PR TITLE
Fix enhanced slack sharing bug when reading time is null

### DIFF
--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -683,8 +683,8 @@ class Indexable_Presentation extends Abstract_Presentation {
 
 		// 250 is the estimated words per minute, https://en.wikipedia.org/wiki/Speed_reading.
 		$words_per_minute = 250;
-		$word    = \str_word_count( \wp_strip_all_tags( $this->context->post->post_content ) );
-		return \round( $word / $words_per_minute );
+		$words            = \str_word_count( \wp_strip_all_tags( $this->context->post->post_content ) );
+		return \round( $words / $words_per_minute );
 	}
 
 	/**

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -684,7 +684,7 @@ class Indexable_Presentation extends Abstract_Presentation {
 		// 250 is the estimated words per minute, https://en.wikipedia.org/wiki/Speed_reading.
 		$words_per_minute = 250;
 		$words            = \str_word_count( \wp_strip_all_tags( $this->context->post->post_content ) );
-		return \round( $words / $words_per_minute );
+		return (int) \round( $words / $words_per_minute );
 	}
 
 	/**

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -49,6 +49,7 @@ use Yoast\WP\SEO\Models\Indexable;
  * @property string $twitter_site
  * @property array  $source
  * @property array  $breadcrumbs
+ * @property int    $estimated_reading_time_minutes
  */
 class Indexable_Presentation extends Abstract_Presentation {
 
@@ -672,7 +673,18 @@ class Indexable_Presentation extends Abstract_Presentation {
 	 * @codeCoverageIgnore Wrapper method.
 	 */
 	public function generate_estimated_reading_time_minutes() {
-		return $this->model->estimated_reading_time_minutes;
+		if ( $this->model->estimated_reading_time_minutes !== null ) {
+			return $this->model->estimated_reading_time_minutes;
+		};
+
+		if ( $this->context->post === null ) {
+			return null;
+		}
+
+		// 250 is the estimated words per minute, https://en.wikipedia.org/wiki/Speed_reading.
+		$words_per_minute = 250;
+		$word    = \str_word_count( \wp_strip_all_tags( $this->context->post->post_content ) );
+		return \round( $word / $words_per_minute );
 	}
 
 	/**

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -681,8 +681,8 @@ class Indexable_Presentation extends Abstract_Presentation {
 			return null;
 		}
 
-		// 250 is the estimated words per minute, https://en.wikipedia.org/wiki/Speed_reading.
-		$words_per_minute = 250;
+		// 200 is the approximate estimated words per minute across languages.
+		$words_per_minute = 200;
 		$words            = \str_word_count( \wp_strip_all_tags( $this->context->post->post_content ) );
 		return (int) \round( $words / $words_per_minute );
 	}

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -21,6 +21,7 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
  * @property string      $company_name                      The company name from the Knowledge graph settings.
  * @property int         $company_logo_id                   The attachment ID for the company logo.
  * @property string      $description                       The meta description for the current page, if set.
+ * @property int         $estimated_reading_time_minutes    The estimated reading time in minutes for posts.
  * @property string      $main_schema_id                    Schema ID that points to the main Schema thing on the page, usually the webpage or article Schema piece.
  * @property string      $meta_description                  The meta description for the current page, if set.
  * @property string      $open_graph_article_author         The article:author value.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Enhanced Slack Integration did not have access to Estimated Reading Time any longer, unless a post was recently saved/updated.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Enhanced Slack sharing integration did not show Estimated Reading Time for posts that were not recently created or updated.

## Relevant technical choices:

* Added the old estimated reading time to the generator in case the reading time is not set yet.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Clear the estimated_reading_time_minutes from the indexable for a post, or find one where the estimated_reading_time_minutes is NULL.
* Then view that post on the frontend (don't go to the editor for that post). Before this fix, enhanced slack integration would not display estimated reading time.
* Now it should.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Visit old posts on the frontend (that haven't been open in the editor yet on 15.6).
* Verify that the `twitter:data2` meta tag (estimated reading time) is populated and present.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Enhanced Slack sharing integration.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes N/A
