### PR TITLE
P2-252 - Added `@wordpress/date` as an external WP JavaScript package in WebPack.

### DIFF
--- a/config/webpack/externals.js
+++ b/config/webpack/externals.js
@@ -1,6 +1,6 @@
 const {
 	camelCaseDash,
-} = require( '@wordpress/dependency-extraction-webpack-plugin/lib/util' );
+} = require( "@wordpress/dependency-extraction-webpack-plugin/lib/util" );
 
 const externals = {
 	// This is necessary for Gutenberg to work.
@@ -49,10 +49,10 @@ const wordpressPackages = [
 /**
  * Yoast dependencies, declared as such in the package.json.
  */
-const { dependencies } = require( '../../package' );
-const legacyYoastPackages = [ 'yoast-components' ];
+const { dependencies } = require( "../../package" );
+const legacyYoastPackages = [ "yoast-components" ];
 
-const YOAST_PACKAGE_NAMESPACE = '@yoast/';
+const YOAST_PACKAGE_NAMESPACE = "@yoast/";
 
 // Fetch all packages from the dependencies list.
 const yoastPackages = Object.keys( dependencies )
@@ -67,14 +67,14 @@ const yoastPackages = Object.keys( dependencies )
  */
 // Yoast Packages.
 const yoastExternals = yoastPackages.reduce( ( memo, packageName ) => {
-	let useablePackageName = packageName.replace( YOAST_PACKAGE_NAMESPACE, '' );
+	let useablePackageName = packageName.replace( YOAST_PACKAGE_NAMESPACE, "" );
 
 	// Handle the difference between yoast-components and @yoast/components.
-	useablePackageName = ( useablePackageName === 'components' ) ? 'components-new' : useablePackageName;
-	useablePackageName = ( useablePackageName === 'yoast-components' ) ? 'components' : useablePackageName;
+	useablePackageName = ( useablePackageName === "components" ) ? "components-new" : useablePackageName;
+	useablePackageName = ( useablePackageName === "yoast-components" ) ? "components" : useablePackageName;
 
 	// Handle yoastseo as analysis reference.
-	useablePackageName = ( useablePackageName === 'yoastseo' ) ? 'analysis' : useablePackageName;
+	useablePackageName = ( useablePackageName === "yoastseo" ) ? "analysis" : useablePackageName;
 
 	memo[ packageName ] = `window.yoast.${ camelCaseDash( useablePackageName ) }`;
 	return memo;
@@ -82,7 +82,7 @@ const yoastExternals = yoastPackages.reduce( ( memo, packageName ) => {
 
 // WordPress packages.
 const wordpressExternals = wordpressPackages.reduce( ( memo, packageName ) => {
-	const name = camelCaseDash( packageName.replace( '@wordpress/', '' ) );
+	const name = camelCaseDash( packageName.replace( "@wordpress/", "" ) );
 
 	memo[ packageName ] = `window.wp.${ name }`;
 	return memo;
@@ -95,5 +95,5 @@ module.exports = {
 	externals,
 	yoastExternals,
 	wordpressExternals,
-	YOAST_PACKAGE_NAMESPACE
-}
+	YOAST_PACKAGE_NAMESPACE,
+};

--- a/config/webpack/externals.js
+++ b/config/webpack/externals.js
@@ -31,6 +31,7 @@ const wordpressPackages = [
 	"@wordpress/components",
 	"@wordpress/compose",
 	"@wordpress/data",
+	"@wordpress/date",
 	"@wordpress/dom",
 	"@wordpress/dom-ready",
 	"@wordpress/edit-post",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to be able to use the `@wordpress/date` package inside of the editor, which is set on the window under `window.wp.date`.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the `@wordpress/date` package as an external JS dependency to the plugin's WebPack configuration.

## Relevant technical choices:

* Fixed the code style of the `externals.js` config file to be in line with the JS code style. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Only a regression test is needed, see the test instruction under "Impact check".


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Test whether the block editor still works as expected, no new JavaScript errors are introduced.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
