### PR TITLE
P1-314 add alert dismissal

### DIFF
--- a/src/actions/alert-dismissal-action.php
+++ b/src/actions/alert-dismissal-action.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Yoast\WP\SEO\Actions;
+
+use Yoast\WP\SEO\Helpers\User_Helper;
+
+/**
+ * Class Alert_Dismissal_Action.
+ */
+class Alert_Dismissal_Action {
+
+	const USER_META_KEY = '_yoast_alerts_dismissed';
+
+	/**
+	 * Holds the user helper instance.
+	 *
+	 * @var User_Helper
+	 */
+	protected $user;
+
+	/**
+	 * Constructs Alert_Dismissal_Action.
+	 *
+	 * @param User_Helper $user User helper.
+	 */
+	public function __construct( User_Helper $user ) {
+		$this->user = $user;
+	}
+
+	/**
+	 * Dismisses an alert.
+	 *
+	 * @param string $alert_identifier Alert identifier.
+	 *
+	 * @return boolean Whether the dismiss was successful or not.
+	 */
+	public function dismiss( $alert_identifier ) {
+		$user_id = $this->user->get_current_user_id();
+		if ( $user_id === 0 ) {
+			return false;
+		}
+
+		$dismissed_alerts = $this->get_dismissed_alerts( $user_id );
+		if ( $dismissed_alerts === false ) {
+			return false;
+		}
+
+		if ( \array_key_exists( $alert_identifier, $dismissed_alerts ) === true ) {
+			// The alert is already dismissed.
+			return true;
+		}
+
+		// Add this alert to the dismissed alerts.
+		$dismissed_alerts[ $alert_identifier ] = true;
+
+		// Save.
+		return $this->user->update_meta( $user_id, static::USER_META_KEY, $dismissed_alerts ) !== false;
+	}
+
+	/**
+	 * Resets an alert.
+	 *
+	 * @param string $alert_identifier Alert identifier.
+	 *
+	 * @return boolean Whether the reset was successful or not.
+	 */
+	public function reset( $alert_identifier ) {
+		$user_id = $this->user->get_current_user_id();
+		if ( $user_id === 0 ) {
+			return false;
+		}
+
+		$dismissed_alerts = $this->get_dismissed_alerts( $user_id );
+		if ( $dismissed_alerts === false ) {
+			return false;
+		}
+
+		$amount_of_dismissed_alerts = \count( $dismissed_alerts );
+		if ( $amount_of_dismissed_alerts === 0 ) {
+			// No alerts: nothing to reset.
+			return true;
+		}
+
+		if ( \array_key_exists( $alert_identifier, $dismissed_alerts ) === false ) {
+			// Alert not found: nothing to reset.
+			return true;
+		}
+
+		if ( $amount_of_dismissed_alerts === 1 ) {
+			// The 1 remaining dismissed alert is the alert to reset: delete the alerts user meta row.
+			return $this->user->delete_meta( $user_id, static::USER_META_KEY, $dismissed_alerts );
+		}
+
+		// Remove this alert from the dismissed alerts.
+		unset( $dismissed_alerts[ $alert_identifier ] );
+
+		// Save.
+		return $this->user->update_meta( $user_id, static::USER_META_KEY, $dismissed_alerts ) !== false;
+	}
+
+	/**
+	 * Returns if an alert is dismissed or not.
+	 *
+	 * @param string $alert_identifier Alert identifier.
+	 *
+	 * @return bool Whether the alert has been dismissed.
+	 */
+	public function is_dismissed( $alert_identifier ) {
+		$user_id = $this->user->get_current_user_id();
+		if ( $user_id === 0 ) {
+			return false;
+		}
+
+		$dismissed_alerts = $this->get_dismissed_alerts( $user_id );
+		if ( $dismissed_alerts === false ) {
+			return false;
+		}
+
+		return \array_key_exists( $alert_identifier, $dismissed_alerts );
+	}
+
+	/**
+	 * Retrieves the dismissed alerts.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return string[]|false The dismissed alerts. False for an invalid $user_id.
+	 */
+	protected function get_dismissed_alerts( $user_id ) {
+		$dismissed_alerts = $this->user->get_meta( $user_id, static::USER_META_KEY, true );
+		if ( $dismissed_alerts === false ) {
+			// Invalid user ID.
+			return false;
+		}
+
+		if ( $dismissed_alerts === '' ) {
+			/*
+			 * When no database row exists yet, an empty string is returned because of the `single` parameter.
+			 * We do want a single result returned, but the default should be an empty array instead.
+			 */
+			return [];
+		}
+
+		return $dismissed_alerts;
+	}
+}

--- a/src/helpers/user-helper.php
+++ b/src/helpers/user-helper.php
@@ -14,8 +14,6 @@ class User_Helper {
 	 * @param string $key     Optional. The meta key to retrieve. By default, returns data for all keys.
 	 * @param bool   $single  Whether to return a single value.
 	 *
-	 * @codeCoverageIgnore It only wraps a WordPress function.
-	 *
 	 * @return mixed Will be an array if $single is false. Will be value of meta data field if $single is true.
 	 */
 	public function get_meta( $user_id, $key = '', $single = false ) {
@@ -29,8 +27,6 @@ class User_Helper {
 	 * @param array|string $post_type Optional. Single post type or array of post types to count the number of posts
 	 *                                for. Default 'post'.
 	 *
-	 * @codeCoverageIgnore It only wraps a WordPress function.
-	 *
 	 * @return int The number of posts the user has written in this post type.
 	 */
 	public function count_posts( $user_id, $post_type = 'post' ) {
@@ -43,11 +39,60 @@ class User_Helper {
 	 * @param string    $field   The user field to retrieve.
 	 * @param int|false $user_id User ID.
 	 *
-	 * @codeCoverageIgnore It only wraps a WordPress function.
-	 *
 	 * @return string The author's field from the current author's DB object.
 	 */
 	public function get_the_author_meta( $field, $user_id ) {
 		return \get_the_author_meta( $field, $user_id );
+	}
+
+	/**
+	 * Retrieves the current user ID.
+	 *
+	 * @return int The current user's ID, or 0 if no user is logged in.
+	 */
+	public function get_current_user_id() {
+		return \get_current_user_id();
+	}
+
+	/**
+	 * Updates user meta field for a user.
+	 *
+	 * Use the $prev_value parameter to differentiate between meta fields with the
+	 * same key and user ID.
+	 *
+	 * If the meta field for the user does not exist, it will be added.
+	 *
+	 * @param int    $user_id    User ID.
+	 * @param string $meta_key   Metadata key.
+	 * @param mixed  $meta_value Metadata value. Must be serializable if non-scalar.
+	 * @param mixed  $prev_value Optional. Previous value to check before updating.
+	 *                           If specified, only update existing metadata entries with
+	 *                           this value. Otherwise, update all entries. Default empty.
+	 *
+	 * @return int|bool Meta ID if the key didn't exist, true on successful update,
+	 *                  false on failure or if the value passed to the function
+	 *                  is the same as the one that is already in the database.
+	 */
+	public function update_meta( $user_id, $meta_key, $meta_value, $prev_value = '' ) {
+		return \update_user_meta( $user_id, $meta_key, $meta_value, $prev_value );
+	}
+
+	/**
+	 * Removes metadata matching criteria from a user.
+	 *
+	 * You can match based on the key, or key and value. Removing based on key and
+	 * value, will keep from removing duplicate metadata with the same key. It also
+	 * allows removing all metadata matching key, if needed.
+	 *
+	 * @param int    $user_id    User ID.
+	 * @param string $meta_key   Metadata name.
+	 * @param mixed  $meta_value Optional. Metadata value. If provided,
+	 *                           rows will only be removed that match the value.
+	 *                           Must be serializable if non-scalar. Default empty.
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	public function delete_meta( $user_id, $meta_key, $meta_value = '' ) {
+		return \delete_user_meta( $user_id, $meta_key, $meta_value );
 	}
 }

--- a/src/routes/alert-dismissal-route.php
+++ b/src/routes/alert-dismissal-route.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Yoast\WP\SEO\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\Actions\Alert_Dismissal_Action;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Main;
+
+/**
+ * Class Alert_Dismissal_Route.
+ */
+class Alert_Dismissal_Route implements Route_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * Represents the alerts route prefix.
+	 *
+	 * @var string
+	 */
+	const ROUTE_PREFIX = 'alerts';
+
+	/**
+	 * Represents the dismiss route.
+	 *
+	 * @var string
+	 */
+	const DISMISS_ROUTE = self::ROUTE_PREFIX . '/dismiss';
+
+	/**
+	 * Represents the full dismiss route.
+	 *
+	 * @var string
+	 */
+	const FULL_DISMISS_ROUTE = Main::API_V1_NAMESPACE . '/' . self::DISMISS_ROUTE;
+
+	/**
+	 * Represents the alert dismissal action.
+	 *
+	 * @var Alert_Dismissal_Action
+	 */
+	protected $alert_dismissal_action;
+
+	/**
+	 * Constructs Alert_Dismissal_Route.
+	 *
+	 * @param Alert_Dismissal_Action $alert_dismissal_action The alert dismissal action.
+	 */
+	public function __construct( Alert_Dismissal_Action $alert_dismissal_action ) {
+		$this->alert_dismissal_action = $alert_dismissal_action;
+	}
+
+	/**
+	 * Registers routes with WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		$dismiss_route_args = [
+			'methods'             => 'POST',
+			'callback'            => [ $this, 'dismiss' ],
+			'permission_callback' => [ $this, 'can_dismiss' ],
+			'args'                => [
+				'key' => [
+					'validate_callback' => [ $this, 'has_valid_key' ],
+					'required'          => true,
+				],
+			],
+		];
+
+		\register_rest_route( Main::API_V1_NAMESPACE, self::DISMISS_ROUTE, $dismiss_route_args );
+	}
+
+	/**
+	 * Dismisses an alert.
+	 *
+	 * @param WP_REST_Request $request The request. This request should have a key param set.
+	 *
+	 * @return WP_REST_Response The response.
+	 */
+	public function dismiss( WP_REST_Request $request ) {
+		$success = $this->alert_dismissal_action->dismiss( $request['key'] );
+		$status  = $success === ( true ) ? 200 : 400;
+
+		return new WP_REST_Response(
+			(object) [
+				'success' => $success,
+				'status'  => $status,
+			],
+			$status
+		);
+	}
+
+	/**
+	 * Checks if a valid key was returned.
+	 *
+	 * @param string $key The key to check.
+	 *
+	 * @return boolean Whether or not the key is valid.
+	 */
+	public function has_valid_key( $key ) {
+		return \is_string( $key ) && $key !== '';
+	}
+
+	/**
+	 * Whether or not the current user is allowed to dismiss alerts.
+	 *
+	 * @return boolean Whether or not the current user is allowed to dismiss alerts.
+	 */
+	public function can_dismiss() {
+		return \current_user_can( 'edit_posts' );
+	}
+}

--- a/tests/unit/actions/alert-dismissal-action-test.php
+++ b/tests/unit/actions/alert-dismissal-action-test.php
@@ -1,0 +1,553 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Actions;
+
+use Mockery;
+use Yoast\WP\SEO\Actions\Alert_Dismissal_Action;
+use Yoast\WP\SEO\Helpers\User_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Alert_Dismissal_Action_Test.
+ *
+ * @group actions
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Actions\Alert_Dismissal_Action
+ */
+class Alert_Dismissal_Action_Test extends TestCase {
+
+	/**
+	 * Holds the class instance.
+	 *
+	 * @var Alert_Dismissal_Action
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the user helper.
+	 *
+	 * @var Mockery\MockInterface|\Yoast\WP\SEO\Helpers\User_Helper
+	 */
+	protected $user;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->user     = Mockery::mock( User_Helper::class );
+		$this->instance = new Alert_Dismissal_Action( $this->user );
+	}
+
+	/**
+	 * Tests if the needed attributes are set correctly.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			User_Helper::class,
+			$this->getPropertyValue( $this->instance, 'user' )
+		);
+	}
+
+	/**
+	 * Tests dismissing an alert.
+	 *
+	 * @covers ::dismiss
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_dismiss_alert() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn( [ 'other alert' => true ] );
+
+		$this->user
+			->expects( 'update_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn(
+				[
+					'other alert' => true,
+					'test'        => true,
+				]
+			);
+
+		$this->assertTrue( $this->instance->dismiss( 'test' ) );
+	}
+
+	/**
+	 * Tests dismissing an alert that is already dismissed.
+	 *
+	 * @covers ::dismiss
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_dismiss_alert_already_dismissed() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn( [ 'already dismissed' => true ] );
+
+		$this->user
+			->expects( 'update_meta' )
+			->never();
+
+		$this->assertTrue( $this->instance->dismiss( 'already dismissed' ) );
+	}
+
+	/**
+	 * Tests dismissing an alert - retrieving the dismissed alerts goes wrong.
+	 *
+	 * @covers ::dismiss
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_dismiss_alert_wrong_dismissed_alerts() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn( false );
+
+		$this->user
+			->expects( 'update_meta' )
+			->never();
+
+		$this->assertFalse( $this->instance->dismiss( 'test' ) );
+	}
+
+	/**
+	 * Tests dismissing an alert - retrieving the current user ID goes wrong.
+	 *
+	 * @covers ::dismiss
+	 */
+	public function test_dismiss_alert_wrong_current_user_id() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 0 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->never();
+
+		$this->user
+			->expects( 'update_meta' )
+			->never();
+
+		$this->assertFalse( $this->instance->dismiss( 'test' ) );
+	}
+
+	/**
+	 * Tests dismissing an alert - but receiving an update failure.
+	 *
+	 * @covers ::dismiss
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_dismiss_alert_update_failure() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn( [ 'other alert' => true ] );
+
+		$this->user
+			->expects( 'update_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn( false );
+
+		$this->assertFalse( $this->instance->dismiss( 'test' ) );
+	}
+
+	/**
+	 * Tests resetting an alert.
+	 *
+	 * @covers ::reset
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_reset_alert() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn(
+				[
+					'some alert'  => true,
+					'test'        => true,
+					'other alert' => true,
+				]
+			);
+
+		$this->user
+			->expects( 'delete_meta' )
+			->never();
+
+		$this->user
+			->expects( 'update_meta' )
+			->with(
+				1,
+				Alert_Dismissal_Action::USER_META_KEY,
+				[
+					'some alert'  => true,
+					'other alert' => true,
+				]
+			)
+			->once()
+			->andReturn(
+				[
+					'some alert'  => true,
+					'other alert' => true,
+				]
+			);
+
+		$this->assertTrue( $this->instance->reset( 'test' ) );
+	}
+
+	/**
+	 * Tests resetting the only dismissed alert.
+	 *
+	 * @covers ::reset
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_reset_alert_last_remaining() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn( [ 'test' => true ] );
+
+		$this->user
+			->expects( 'delete_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, [ 'test' => true ] )
+			->andReturn( true );
+
+		$this->user
+			->expects( 'update_meta' )
+			->never();
+
+		$this->assertTrue( $this->instance->reset( 'test' ) );
+	}
+
+	/**
+	 * Tests resetting the only dismissed alert - but receiving a delete failure.
+	 *
+	 * @covers ::reset
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_reset_alert_last_remaining_delete_failure() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn( [ 'test' => true ] );
+
+		$this->user
+			->expects( 'delete_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, [ 'test' => true ] )
+			->andReturn( false );
+
+		$this->user
+			->expects( 'update_meta' )
+			->never();
+
+		$this->assertFalse( $this->instance->reset( 'test' ) );
+	}
+
+	/**
+	 * Tests resetting a non-dismissed alert.
+	 *
+	 * @covers ::reset
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_reset_alert_non_dismissed_alert() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn( [ 'other alert' => true ] );
+
+		$this->user
+			->expects( 'delete_meta' )
+			->never();
+
+		$this->user
+			->expects( 'update_meta' )
+			->never();
+
+		$this->assertTrue( $this->instance->reset( 'test' ) );
+	}
+
+	/**
+	 * Tests resetting an alert when the user has no dismissed alerts.
+	 *
+	 * @covers ::reset
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_reset_alert_no_dismissed_alerts() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn( [] );
+
+		$this->user
+			->expects( 'delete_meta' )
+			->never();
+
+		$this->user
+			->expects( 'update_meta' )
+			->never();
+
+		$this->assertTrue( $this->instance->reset( 'test' ) );
+	}
+
+	/**
+	 * Tests resetting an alert - retrieving the dismissed alerts goes wrong.
+	 *
+	 * @covers ::reset
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_reset_alert_wrong_dismissed_alerts() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn( false );
+
+		$this->user
+			->expects( 'delete_meta' )
+			->never();
+
+		$this->user
+			->expects( 'update_meta' )
+			->never();
+
+		$this->assertFalse( $this->instance->reset( 'test' ) );
+	}
+
+	/**
+	 * Tests resetting an alert - retrieving the current user ID goes wrong.
+	 *
+	 * @covers ::reset
+	 */
+	public function test_reset_alert_wrong_current_user_id() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 0 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->never();
+
+		$this->user
+			->expects( 'delete_meta' )
+			->never();
+
+		$this->user
+			->expects( 'update_meta' )
+			->never();
+
+		$this->assertFalse( $this->instance->reset( 'test' ) );
+	}
+
+	/**
+	 * Tests resetting an alert - but returning an update failure.
+	 *
+	 * @covers ::reset
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_reset_alert_update_failure() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn(
+				[
+					'some alert'  => true,
+					'test'        => true,
+					'other alert' => true,
+				]
+			);
+
+		$this->user
+			->expects( 'delete_meta' )
+			->never();
+
+		$this->user
+			->expects( 'update_meta' )
+			->with(
+				1,
+				Alert_Dismissal_Action::USER_META_KEY,
+				[
+					'some alert'  => true,
+					'other alert' => true,
+				]
+			)
+			->once()
+			->andReturn( false );
+
+		$this->assertFalse( $this->instance->reset( 'test' ) );
+	}
+
+	/**
+	 * Tests that the alert is dismissed.
+	 *
+	 * @covers ::is_dismissed
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_is_dismissed_true() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn( [ 'test' => true ] );
+
+		$this->assertTrue( $this->instance->is_dismissed( 'test' ) );
+	}
+
+	/**
+	 * Tests that the alert is not dismissed.
+	 *
+	 * @covers ::is_dismissed
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_is_dismissed_false() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn( [ 'other alert' => true ] );
+
+		$this->assertFalse( $this->instance->is_dismissed( 'test' ) );
+	}
+
+	/**
+	 * Tests that the alert is not dismissed - retrieving the dismissed alerts goes wrong.
+	 *
+	 * @covers ::is_dismissed
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_is_dismissed_wrong_dismissed_alerts() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn( false );
+
+		$this->assertFalse( $this->instance->is_dismissed( 'test' ) );
+	}
+
+	/**
+	 * Tests that the alert is not dismissed - retrieving the current user ID goes wrong.
+	 *
+	 * @covers ::is_dismissed
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_is_dismissed_wrong_current_user_id() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 0 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->never();
+
+		$this->assertFalse( $this->instance->is_dismissed( 'test' ) );
+	}
+
+	/**
+	 * Tests that get dismissed alerts returns an empty array when get_meta returns an empty string.
+	 *
+	 * @covers ::get_dismissed_alerts
+	 */
+	public function test_get_dismissed_alerts_empty_array() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->user
+			->expects( 'get_meta' )
+			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
+			->once()
+			->andReturn( '' );
+
+		$this->assertFalse( $this->instance->is_dismissed( 'test' ) );
+	}
+}

--- a/tests/unit/helpers/user-helper-test.php
+++ b/tests/unit/helpers/user-helper-test.php
@@ -32,6 +32,22 @@ class User_Helper_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that get_meta calls the global get_user_meta.
+	 *
+	 * And returns the return value of it.
+	 *
+	 * @covers ::get_meta
+	 */
+	public function test_get_meta() {
+		Functions\expect( 'get_user_meta' )
+			->with( 1, 'key', true )
+			->once()
+			->andReturn( 'value' );
+
+		$this->assertSame( 'value', $this->instance->get_meta( 1, 'key', true ) );
+	}
+
+	/**
 	 * Tests that `count_posts` converts a string to an integer.
 	 *
 	 * @covers ::count_posts
@@ -44,6 +60,69 @@ class User_Helper_Test extends TestCase {
 
 		$actual = $this->instance->count_posts( 1, 'post' );
 
-		$this->assertEquals( 0, $actual );
+		$this->assertSame( 0, $actual );
+	}
+
+	/**
+	 * Tests that get_the_author_meta calls the global get_the_author_meta.
+	 *
+	 * And returns the return value of it.
+	 *
+	 * @covers ::get_the_author_meta
+	 */
+	public function test_get_the_author_meta() {
+		Functions\expect( 'get_the_author_meta' )
+			->with( 'field', 1 )
+			->once()
+			->andReturn( 'author meta' );
+
+		$this->assertSame( 'author meta', $this->instance->get_the_author_meta( 'field', 1 ) );
+	}
+
+	/**
+	 * Tests that get_current_user_id calls the global get_current_user_id.
+	 *
+	 * And returns the return value of it.
+	 *
+	 * @covers ::get_current_user_id
+	 */
+	public function test_get_current_user_id() {
+		Functions\expect( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		$this->assertSame( 1, $this->instance->get_current_user_id() );
+	}
+
+	/**
+	 * Tests that update_meta calls the global update_user_meta.
+	 *
+	 * And returns the return value of it.
+	 *
+	 * @covers ::update_meta
+	 */
+	public function test_update_meta() {
+		Functions\expect( 'update_user_meta' )
+			->with( 1, 'key', 'value', 'previous' )
+			->once()
+			->andReturn( true );
+
+		$this->assertTrue( $this->instance->update_meta( 1, 'key', 'value', 'previous' ) );
+	}
+
+	/**
+	 * Tests that delete_meta calls the global delete_user_meta.
+	 *
+	 * And returns the return value of it.
+	 *
+	 * @covers ::delete_meta
+	 */
+	public function test_delete_meta() {
+		Functions\expect( 'delete_user_meta' )
+			->with( 1, 'key', 'value' )
+			->once()
+			->andReturn( true );
+
+		$this->assertTrue( $this->instance->delete_meta( 1, 'key', 'value' ) );
 	}
 }

--- a/tests/unit/routes/alert-dismissal-route-test.php
+++ b/tests/unit/routes/alert-dismissal-route-test.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Routes;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Actions\Alert_Dismissal_Action;
+use Yoast\WP\SEO\Routes\Alert_Dismissal_Route;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Alert_Dismissal_Route_Test.
+ *
+ * @group routes
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Routes\Alert_Dismissal_Route
+ */
+class Alert_Dismissal_Route_Test extends TestCase {
+
+	/**
+	 * Represents the alert dismissal action.
+	 *
+	 * @var Alert_Dismissal_Action
+	 */
+	protected $alert_dismissal_action;
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var \Yoast\WP\SEO\Routes\Alert_Dismissal_Route
+	 */
+	protected $instance;
+
+	/**
+	 * Set up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->alert_dismissal_action = Mockery::mock( Alert_Dismissal_Action::class );
+
+		$this->instance = new Alert_Dismissal_Route( $this->alert_dismissal_action );
+	}
+
+	/**
+	 * Tests if the needed attributes are set correctly.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct() {
+		$this->assertInstanceOf(
+			Alert_Dismissal_Action::class,
+			$this->getPropertyValue( $this->instance, 'alert_dismissal_action' )
+		);
+	}
+
+	/**
+	 * Tests the retrieval of the conditionals.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals(
+			[],
+			Alert_Dismissal_Route::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the registration of the routes.
+	 *
+	 * @covers ::register_routes
+	 */
+	public function test_register_routes() {
+		Monkey\Functions\expect( 'register_rest_route' )
+			->with(
+				'yoast/v1',
+				'alerts/dismiss',
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this->instance, 'dismiss' ],
+					'permission_callback' => [ $this->instance, 'can_dismiss' ],
+					'args'                => [
+						'code' => [
+							'validate_callback' => [ $this->instance, 'has_valid_key' ],
+							'required'          => true,
+						],
+					],
+				]
+			)
+			->once();
+
+		$this->instance->register_routes();
+	}
+
+	/**
+	 * Tests the dismiss route.
+	 *
+	 * @covers ::dismiss
+	 */
+	public function test_dismiss() {
+		$request = Mockery::mock( 'WP_REST_Request', 'ArrayAccess' );
+		$request
+			->expects( 'offsetGet' )
+			->with( 'key' )
+			->andReturn( 'alert_key' );
+
+		$this->alert_dismissal_action
+			->expects( 'dismiss' )
+			->with( 'alert_key' )
+			->andReturn( true );
+
+		Mockery::mock( 'overload:WP_REST_Response' );
+
+		$response = $this->instance->dismiss( $request );
+
+		$this->assertInstanceOf( 'WP_REST_Response', $response );
+	}
+
+	/**
+	 * Tests that the key is an invalid key.
+	 *
+	 * @covers ::has_valid_key
+	 */
+	public function test_is_valid_code_with_invalid_code_given() {
+		$this->assertFalse( $this->instance->has_valid_key( '' ) );
+	}
+
+	/**
+	 * Tests that the key is a valid key.
+	 *
+	 * @covers ::has_valid_key
+	 */
+	public function test_is_valid_key_with_valid_key_given() {
+		$this->assertTrue( $this->instance->has_valid_key( 'some_alert' ) );
+	}
+
+	/**
+	 * Tests that can dismiss calls `current_user_can` with `edit_posts`.
+	 *
+	 * And passes along the returned value.
+	 *
+	 * @covers ::can_dismiss
+	 */
+	public function test_can_dismiss() {
+		Monkey\Functions\expect( 'current_user_can' )
+			->with( 'edit_posts' )
+			->once()
+			->andReturn( true );
+
+		$this->assertTrue( $this->instance->can_dismiss() );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When adding dismissable alerts (not to be confused with the Yoast Notification Center notifications) we do not want to have to reinvent the wheel every time. This PR implements an action that handles that alert per user. Plus an endpoint that calls the dismiss action with a given key (for when the user dismisses an alert in JS).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds generic alert dismissal functionality.

## Relevant technical choices:

* Using the `edit_posts` permission as per feedback from Herre. Subscribers shouldn't be able to save data to the database. https://yoast.slack.com/archives/C01FYN1QGB1/p1610458141008200?thread_ts=1610457905.008100&cid=C01FYN1QGB1
* Not too sure about the return data of the route. But looked at the SEMRush and there we have an object that includes `success` and `status`, so applied that here too.
* Codescout: added a couple easy tests in the User_Helper to remove all `CodeCoverageIgnore` there.
* Put it as non-user-facing because it should be internal use.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### Dismiss alert endpoint
* To make Basic Auth work you need to install and activate this plugin first: https://github.com/WP-API/Basic-Auth
* In Postman (or a similar application), add a new POST request to `http://basic.wordpress.test/wp-json/yoast/v1/alerts/dismiss`.
  * In the authorization tab use Basic Auth with your WordPress' credentials (deciding what is seen as the current user).
  * In the body tab add a form-data with a key named `key` and a value that is the name of the alert you are dismissing. Note: using query params also works (instead of form-data).
* When sending the request, it should return an object with success: `true` and status: `200`.
* If something went wrong, like credentials not correct, or no `key` param. This will change.

### Alert actions
* Besides the dismiss, the actions are not used (yet).  So we have to find a place in the code to play with the actions. I can suggest the Yoast SEO dashboard: `wordpress-seo/admin/pages/dashboard.php`.
* Some code to help with some output (we don't have log level things in our PHP, right?):
```php
function _action() {
	static $action;

	if ( $action === null ) {
		$action = YoastSEO()->classes->get( \Yoast\WP\SEO\Actions\Alert_Dismissal_Action::class );
	};

	return $action;
}
function _dismiss( $key ) {
	echo 'dismissing ', $key, '...<br/>';
	_action()->dismiss( $key );
}
function _reset( $key ) {
	echo 'resetting ', $key, '...<br/>';
	_action()->reset( $key );
}
function _is_dismissed( $key ) {
	echo $key, ' is ', _action()->is_dismissed( $key ) ? '' : 'not ', 'dismissed<br/>';
}
```
* Then you can play around with some different scenarios like this:
```php
$key = 'test';
_is_dismissed( $key );
_dismiss( $key );
_is_dismissed( $key );
_reset( $key );
_is_dismissed( $key );
```
* The above should output:
```text
test is not dismissed
dismissing test...
test is dismissed
resetting test...
test is not dismissed
```
* You can check your database. In the `wp_usermeta` (the `wp_` prefix is the default) a row will be added to hold the dismissed alerts for each user that has dismissed at least 1 alert. The `meta_key` is `_yoast_alerts_dismissed`. This way you can track if the output makes sense to what is happening in the database.
* Important to test:
  * When you dismiss, it should be added in the DB entry.
  * When you reset, it should be removed from the DB entry.
  * When you check is_dismissed, it should return true when the key is present in the DB entry.
  * When the last key is removed, the whole row should be gone.

### Documentation
https://yoast.atlassian.net/wiki/spaces/PLUGIN/pages/1190461470/How+to+dismiss+an+Alert
* Does it make sense?

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

### Dismiss alert endpoint
* To make Basic Auth work you need to install and activate this plugin first: https://github.com/WP-API/Basic-Auth
* In Postman (or a similar application), add a new POST request to `http://basic.wordpress.test/wp-json/yoast/v1/alerts/dismiss`.
  * In the authorization tab use Basic Auth with your WordPress' credentials (deciding what is seen as the current user).
  * In the body tab add a form-data with a key named `key` and a value that is the name of the alert you are dismissing. Note: using query params also works (instead of form-data).
* When sending the request, it should return an object with success: `true` and status: `200`.
* If something went wrong, like credentials not correct, or no `key` param. This will change.
* You can check your database. In the `wp_usermeta` (the `wp_` prefix is the default) a row will be added to hold the dismissed alerts for each user that has dismissed at least 1 alert. The `meta_key` is `_yoast_alerts_dismissed`.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change.
* https://yoast.atlassian.net/wiki/spaces/PLUGIN/pages/1190461470/How+to+dismiss+an+Alert

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-314
