### PR TITLE
Replace filter_input( INPUT_SERVER, ... ) with  for fastcgi compat

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -661,9 +661,10 @@ class Yoast_Notification_Center {
 	private static function get_user_input( $key ) {
 
 		$filter_input_type = INPUT_GET;
-
 		// phcps:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Using filter_input on INPUT_SERVER doesn't work with fastcgi
-		if ( isset( $_SERVER['REQUEST_METHOD'] ) && strtoupper( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) === 'POST' ) {
+		$request_method = filter_var( $_SERVER['REQUEST_METHOD'] );
+
+		if ( isset( $_SERVER['REQUEST_METHOD'] ) && strtoupper( wp_unslash( $request_method ) ) === 'POST' ) {
 			$filter_input_type = INPUT_POST;
 		}
 

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -661,9 +661,9 @@ class Yoast_Notification_Center {
 	private static function get_user_input( $key ) {
 
 		$filter_input_type = INPUT_GET;
-		$request_method    = filter_input( INPUT_SERVER, 'REQUEST_METHOD' );
 
-		if ( isset( $_SERVER['REQUEST_METHOD'] ) && strtoupper( $request_method ) === 'POST' ) {
+		// phcps:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Using filter_input on INPUT_SERVER doesn't work with fastcgi
+		if ( isset( $_SERVER['REQUEST_METHOD'] ) && strtoupper( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) === 'POST' ) {
 			$filter_input_type = INPUT_POST;
 		}
 

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -662,9 +662,9 @@ class Yoast_Notification_Center {
 
 		$filter_input_type = INPUT_GET;
 		// phcps:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Using filter_input on INPUT_SERVER doesn't work with fastcgi
-		$request_method = filter_var( $_SERVER['REQUEST_METHOD'] );
+		$request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? filter_var( $_SERVER['REQUEST_METHOD'] ) : '';
 
-		if ( isset( $_SERVER['REQUEST_METHOD'] ) && strtoupper( wp_unslash( $request_method ) ) === 'POST' ) {
+		if ( strtoupper( wp_unslash( $request_method ) ) === 'POST' ) {
 			$filter_input_type = INPUT_POST;
 		}
 

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -661,10 +661,9 @@ class Yoast_Notification_Center {
 	private static function get_user_input( $key ) {
 
 		$filter_input_type = INPUT_GET;
-		// phcps:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Using filter_input on INPUT_SERVER doesn't work with fastcgi
-		$request_method = isset( $_SERVER['REQUEST_METHOD'] ) ? filter_var( $_SERVER['REQUEST_METHOD'] ) : '';
+		$request_method    = isset( $_SERVER['REQUEST_METHOD'] ) ? filter_var( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) : '';
 
-		if ( strtoupper( wp_unslash( $request_method ) ) === 'POST' ) {
+		if ( strtoupper( $request_method ) === 'POST' ) {
 			$filter_input_type = INPUT_POST;
 		}
 

--- a/admin/tracking/class-tracking-server-data.php
+++ b/admin/tracking/class-tracking-server-data.php
@@ -31,7 +31,7 @@ class WPSEO_Tracking_Server_Data implements WPSEO_Collection {
 
 		// Validate if the server address is a valid IP-address.
 		// phcps:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Using filter_input on INPUT_SERVER doesn't work with fastcgi
-		$ipaddress = $_SERVER['SERVER_ADDR'];
+		$ipaddress = filter_var( $_SERVER['SERVER_ADDR'], FILTER_VALIDATE_IP );
 		if ( $ipaddress ) {
 			$server_data['ip']       = $ipaddress;
 			$server_data['Hostname'] = gethostbyaddr( $ipaddress );

--- a/admin/tracking/class-tracking-server-data.php
+++ b/admin/tracking/class-tracking-server-data.php
@@ -30,8 +30,7 @@ class WPSEO_Tracking_Server_Data implements WPSEO_Collection {
 		$server_data = [];
 
 		// Validate if the server address is a valid IP-address.
-		// phcps:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Using filter_input on INPUT_SERVER doesn't work with fastcgi
-		$ipaddress = filter_var( $_SERVER['SERVER_ADDR'], FILTER_VALIDATE_IP );
+		$ipaddress = isset( $_SERVER['SERVER_ADDR'] ) ? filter_var( wp_unslash( $_SERVER['SERVER_ADDR'] ), FILTER_VALIDATE_IP ) : '';
 		if ( $ipaddress ) {
 			$server_data['ip']       = $ipaddress;
 			$server_data['Hostname'] = gethostbyaddr( $ipaddress );

--- a/admin/tracking/class-tracking-server-data.php
+++ b/admin/tracking/class-tracking-server-data.php
@@ -30,7 +30,8 @@ class WPSEO_Tracking_Server_Data implements WPSEO_Collection {
 		$server_data = [];
 
 		// Validate if the server address is a valid IP-address.
-		$ipaddress = filter_input( INPUT_SERVER, 'SERVER_ADDR', FILTER_VALIDATE_IP );
+		// phcps:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Using filter_input on INPUT_SERVER doesn't work with fastcgi
+		$ipaddress = $_SERVER['SERVER_ADDR'];
 		if ( $ipaddress ) {
 			$server_data['ip']       = $ipaddress;
 			$server_data['Hostname'] = gethostbyaddr( $ipaddress );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* FILTER_INPUT doesn't work for INPUT_SERVER when using fastcgi ( see https://stackoverflow.com/questions/25232975/php-filter-inputinput-server-request-method-returns-null )

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the update notification not being dismissable.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have a server with FastCGI enabled.
* Attempt to dismiss the update notification.
* It should work.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.
* [ ] 
## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The notification center and the tracking data send.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
