### PR TITLE
Avoid race condition in get_role_caps(), fixes #16108

### DIFF
--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -281,12 +281,7 @@ class Yoast_Notification {
 	 */
 	private function has_capability( $capability ) {
 		$user = $this->options['user'];
-
-		$role_caps = $user->get_role_caps();
-		if ( array_key_exists( $capability, $role_caps ) ) {
-			return $role_caps[ $capability ];
-		}
-		return false;
+		return $user->has_cap($capability);
 	}
 
 	/**

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -281,7 +281,7 @@ class Yoast_Notification {
 	 */
 	private function has_capability( $capability ) {
 		$user = $this->options['user'];
-		return $user->has_cap($capability);
+		return $user->has_cap( $capability );
 	}
 
 	/**

--- a/tests/integration/notifications/test-class-yoast-notification-center.php
+++ b/tests/integration/notifications/test-class-yoast-notification-center.php
@@ -928,7 +928,7 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 * Creates a mock WordPress user.
 	 *
 	 * @param int   $user_id   The ID of the user.
-	 * @param array $role_caps A map, mapping capabilities to `true` (user has capability) or `false` ( user has not).
+	 * @param array $caps A map, mapping capabilities to `true` (user has capability) or `false` ( user has not).
 	 *
 	 * @return PHPUnit_Framework_MockObject_Invocation_Object | WP_User
 	 */
@@ -941,10 +941,14 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 		$user_mock
 			->expects( $this->any() )
 			->method( 'has_cap' )
-			->with( $this->isType('string') )
-			->willReturn( $this->returnCallback(function($argument) use ($caps) {
-				   return isset($caps[$argument]) ? $caps[$argument] : false;
-			} ));
+			->with( $this->isType( 'string' ) )
+			->willReturn(
+				$this->returnCallback(
+					function( $argument ) use ( $caps ) {
+						return isset( $caps[ $argument ] ) ? $caps[ $argument ] : false;
+					}
+				)
+			);
 
 		$user_mock->ID = $user_id;
 

--- a/tests/integration/notifications/test-class-yoast-notification-center.php
+++ b/tests/integration/notifications/test-class-yoast-notification-center.php
@@ -932,15 +932,19 @@ class Yoast_Notification_Center_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @return PHPUnit_Framework_MockObject_Invocation_Object | WP_User
 	 */
-	private function mock_wp_user( $user_id, $role_caps ) {
+	private function mock_wp_user( $user_id, $caps ) {
 		$user_mock = $this
 			->getMockBuilder( 'WP_User' )
-			->setMethods( [ 'get_role_caps' ] )
+			->setMethods( [ 'has_cap' ] )
 			->getMock();
 
 		$user_mock
-			->method( 'get_role_caps' )
-			->willReturn( $role_caps );
+			->expects( $this->any() )
+			->method( 'has_cap' )
+			->with( $this->isType('string') )
+			->willReturn( $this->returnCallback(function($argument) use ($caps) {
+				   return isset($caps[$argument]) ? $caps[$argument] : false;
+			} ));
 
 		$user_mock->ID = $user_id;
 


### PR DESCRIPTION
## Context

This change allows the Wordpress to avoid a race condition caused by a [call to `WP_User->get_role_caps()`](https://github.com/Yoast/wordpress-seo/blob/23d97720eeefbc604a73703b180072a01366f8d1/admin/class-yoast-notification.php#L285) which momentarily [resets the `allcaps` property](https://github.com/WordPress/WordPress/blob/bf83c368fdfcee2b879d00b193f505038e1681f0/wp-includes/class-wp-user.php#L513), causing custom capabilites on the site to malfunction.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where custom capabilities could be reset due to our code. Props to [Jerome Charaoui](https://github.com/jcharaoui).

## Relevant technical choices:

* This replaces a WP core function `get_role_caps` with another, `user_can`, which also serves to simplifiy the `has_capabilities` function.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Existing capabilities tests should pass.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Capabilities

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #16108
