### PR TITLE
Removed the release notification

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -36,7 +36,6 @@ class WPSEO_Admin_Init {
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_dismissible' ] );
 		add_action( 'admin_init', [ $this, 'yoast_plugin_suggestions_notification' ], 15 );
-		add_action( 'admin_init', [ $this, 'yoast_plugin_update_notification' ] );
 		add_action( 'admin_init', [ $this, 'unsupported_php_notice' ], 15 );
 		add_action( 'admin_init', [ $this->asset_manager, 'register_assets' ] );
 		add_action( 'admin_init', [ $this, 'show_hook_deprecation_warnings' ] );
@@ -128,106 +127,6 @@ class WPSEO_Admin_Init {
 			[
 				'id'   => 'wpseo-suggested-plugin-' . $name,
 				'type' => Yoast_Notification::WARNING,
-			]
-		);
-	}
-
-	/**
-	 * Determines whether a update notification needs to be displayed.
-	 *
-	 * @return void
-	 */
-	public function yoast_plugin_update_notification() {
-		$notification_center   = Yoast_Notification_Center::get();
-		$current_minor_version = $this->get_major_minor_version( WPSEO_Options::get( 'version', WPSEO_VERSION ) );
-		$file                  = plugin_dir_path( WPSEO_FILE ) . 'release-info.json';
-
-		// Remove if file is not present.
-		if ( ! file_exists( $file ) ) {
-			$notification_center->remove_notification_by_id( 'wpseo-plugin-updated' );
-			return;
-		}
-
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Retrieving a local file.
-		$release_json = file_get_contents( $file );
-
-		/**
-		 * Filter: 'wpseo_update_notice_content' - Allow filtering of the content
-		 * of the update notice read from the release-info.json file.
-		 *
-		 * @api object The object from the release-info.json file.
-		 */
-		$release_info = apply_filters( 'wpseo_update_notice_content', json_decode( $release_json ) );
-
-		// Remove if file is malformed or for a different version.
-		if ( is_null( $release_info )
-			|| empty( $release_info->version )
-			|| version_compare( $this->get_major_minor_version( $release_info->version ), $current_minor_version, '!=' )
-			|| empty( $release_info->release_description )
-		) {
-			$notification_center->remove_notification_by_id( 'wpseo-plugin-updated' );
-			return;
-		}
-
-		$notification = $this->get_yoast_seo_update_notification( $release_info );
-
-		// Restore notification if it was dismissed in a previous minor version.
-		$last_dismissed_version = get_user_option( $notification->get_dismissal_key() );
-		if ( ! $last_dismissed_version
-			|| version_compare( $this->get_major_minor_version( $last_dismissed_version ), $current_minor_version, '<' )
-		) {
-			Yoast_Notification_Center::restore_notification( $notification );
-		}
-		$notification_center->add_notification( $notification );
-	}
-
-	/**
-	 * Helper to truncate the version string up to the minor number
-	 *
-	 * @param string $version The version string to extract the major.minor number from.
-	 * @return string The version string up to the minor number.
-	 */
-	private function get_major_minor_version( $version ) {
-		$version_parts = preg_split( '/[^0-9]+/', $version, 3 );
-		return join( '.', array_slice( $version_parts, 0, 2 ) );
-	}
-
-	/**
-	 * Builds Yoast SEO update notification.
-	 *
-	 * @param object $release_info The release information.
-	 *
-	 * @return Yoast_Notification The notification for the present version
-	 */
-	private function get_yoast_seo_update_notification( $release_info ) {
-		$info_message  = '<strong>';
-		$info_message .= sprintf(
-			/* translators: %1$s expands to Yoast SEO, %2$s expands to the plugin version. */
-			__( 'New in %1$s %2$s: ', 'wordpress-seo' ),
-			'Yoast SEO',
-			$release_info->version
-		);
-		$info_message .= '</strong>';
-		$info_message .= $release_info->release_description;
-
-		if ( ! empty( $release_info->shortlink ) ) {
-			$link          = esc_url( WPSEO_Shortlinker::get( $release_info->shortlink ) );
-			$info_message .= ' <a href="' . esc_url( $link ) . '" target="_blank">';
-			$info_message .= sprintf(
-				/* translators: %s expands to the plugin version. */
-				__( 'Read all about version %s here', 'wordpress-seo' ),
-				$release_info->version
-			);
-			$info_message .= '</a>';
-		}
-
-		return new Yoast_Notification(
-			$info_message,
-			[
-				'id'            => 'wpseo-plugin-updated',
-				'type'          => Yoast_Notification::UPDATED,
-				'data_json'     => [ 'dismiss_value' => WPSEO_Options::get( 'version', WPSEO_VERSION ) ],
-				'dismissal_key' => 'wpseo-plugin-updated',
 			]
 		);
 	}

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -164,8 +164,8 @@ class Yoast_Notification_Center {
 			return true;
 		}
 
-		$dismissal_key     = $notification->get_dismissal_key();
-		$notification_id   = $notification->get_id();
+		$dismissal_key   = $notification->get_dismissal_key();
+		$notification_id = $notification->get_id();
 
 		$is_dismissing = ( $dismissal_key === self::get_user_input( 'notification' ) );
 		if ( ! $is_dismissing ) {

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -166,7 +166,6 @@ class Yoast_Notification_Center {
 
 		$dismissal_key     = $notification->get_dismissal_key();
 		$notification_id   = $notification->get_id();
-		$notification_json = $notification->get_json();
 
 		$is_dismissing = ( $dismissal_key === self::get_user_input( 'notification' ) );
 		if ( ! $is_dismissing ) {
@@ -185,13 +184,6 @@ class Yoast_Notification_Center {
 		$user_nonce = self::get_user_input( 'nonce' );
 		if ( wp_verify_nonce( $user_nonce, $notification_id ) === false ) {
 			return false;
-		}
-
-		if ( ! empty( $notification_json ) ) {
-			$notification_data = json_decode( $notification_json );
-			if ( ! is_null( $notification_data ) && isset( $notification_data->dismiss_value ) ) {
-				$meta_value = $notification_data->dismiss_value;
-			}
 		}
 
 		return self::dismiss_notification( $notification, $meta_value );

--- a/config/grunt/task-config/copy.js
+++ b/config/grunt/task-config/copy.js
@@ -120,7 +120,6 @@ module.exports = {
 					"wp-seo.php",
 					"wp-seo-main.php",
 					"wpml-config.xml",
-					"release-info.json",
 					"!vendor/bin/**",
 					"!vendor/composer/installed.json",
 					"!vendor/composer/installers/**",

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -793,7 +793,7 @@ class WPSEO_Upgrade {
 	 * @return void
 	 */
 	private function upgrade_157() {
-		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-plugin-updated' );
+		add_action( 'init', [ $this, 'remove_plugin_updated_notification_for_157' ] );
 	}
 
 	/**
@@ -900,6 +900,15 @@ class WPSEO_Upgrade {
 	 */
 	public function remove_acf_notification_for_142() {
 		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-suggested-plugin-yoast-acf-analysis' );
+	}
+
+	/**
+	 * Removes the wpseo-plugin-updated notification from the Notification center for the 15.7 upgrade.
+	 *
+	 * @return void
+	 */
+	public function remove_plugin_updated_notification_for_157() {
+		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-plugin-updated' );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -69,7 +69,7 @@ class WPSEO_Upgrade {
 			'15.1-RC0'   => 'upgrade_151',
 			'15.3-RC0'   => 'upgrade_153',
 			'15.5-RC0'   => 'upgrade_155',
-			'15.7'       => 'upgrade_157',
+			'15.7-RC0'   => 'upgrade_157',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -69,6 +69,7 @@ class WPSEO_Upgrade {
 			'15.1-RC0'   => 'upgrade_151',
 			'15.3-RC0'   => 'upgrade_153',
 			'15.5-RC0'   => 'upgrade_155',
+			'15.7'       => 'upgrade_157',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -784,6 +785,15 @@ class WPSEO_Upgrade {
 			unset( $wpseo_social_option['fbadminapp'] );
 			update_option( 'wpseo_social', $wpseo_social_option );
 		}
+	}
+
+	/**
+	 * Performs the 15.7 upgrade.
+	 *
+	 * @return void
+	 */
+	private function upgrade_157() {
+		Yoast_Notification_Center::get()->remove_notification_by_id( 'wpseo-plugin-updated' );
 	}
 
 	/**

--- a/release-info.json
+++ b/release-info.json
@@ -1,5 +1,0 @@
-{
-  "version": "15.6",
-  "release_description": "In the latest version of Yoast SEO, you’ll find a number of bug fixes and performance enhancements. And install the free Yoast Duplicate Post plugin to unlock the Rewrite & Republish feature, offering you the possibility to update a post/page without taking it offline or having to take extra steps!",
-  "shortlink": "https://yoa.st/yoast15-6"
-}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Removes the release notification as the added benefit of having it, is minimal and seems to result in more questions from users.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the release notification as the added benefit of having it, is minimal.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* First, ensure that you have the 15.6 release notification present in the notification center:
  * Switch to the `rebased-release/15.6` branch
  * Install and activate the Yoast Test Helper plugin
  * Go to Tools > Yoast Test, and set the Yoast SEO DB Version to 15.6
* Navigate to the notification center (SEO -> General)
* See that the notification is present.
* Checkout this branch and build everything accordingly.
* Refresh the notification center. See that the notification is gone.
* Check the database table `wp_usermeta` and search for the meta_key `wp_yoast_notifications`. In the meta_value field, there should no longer be a reference to `wpseo-plugin-updated`.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* First, ensure you're running version 15.6 of the plugin.
* Ensure that you have the 15.6 release notification present in the notification center. The notification text starts with "New in Yoast SEO 15.6: In the latest version of Yoast SEO, you’ll find ..." 
* Navigate to the notification center (SEO -> General)
* See that the notification is present.
* If it's not, that means your database isn't a clean new db: Install and activate the Yoast Test Helper plugin. Go to Tools > Yoast Test, and set the Yoast SEO DB Version to 15.6
* Refresh the notification center page: You should now see the notification.
* Install the latest 15.7 RC that includes this PR
* Refresh the notification center. See that the notification is gone.
* Check the database table `wp_usermeta` and search for the meta_key `wp_yoast_notifications`. In the meta_value field, there should no longer be a reference to `wpseo-plugin-updated`.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-317]
Fixes https://github.com/Yoast/wordpress-seo/issues/16001
