### PR TITLE
Replace `@inheritDoc` with `{@inheritDoc}`

### DIFF
--- a/admin/class-helpscout.php
+++ b/admin/class-helpscout.php
@@ -54,7 +54,7 @@ class WPSEO_HelpScout implements WPSEO_WordPress_Integration {
 	}
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	public function register_hooks() {
 		if ( ! $this->is_beacon_page() ) {

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=388",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=364",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=227",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/deprecated/frontend/class-opengraph-oembed.php
+++ b/src/deprecated/frontend/class-opengraph-oembed.php
@@ -13,7 +13,7 @@
 class WPSEO_OpenGraph_OEmbed implements WPSEO_WordPress_Integration {
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 *
 	 * @codeCoverageIgnore
 	 * @deprecated 14.0

--- a/src/integrations/admin/cron-integration.php
+++ b/src/integrations/admin/cron-integration.php
@@ -19,7 +19,7 @@ class Cron_Integration implements Integration_Interface {
 	protected $date_helper;
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
 		return [ Admin_Conditional::class ];
@@ -37,7 +37,7 @@ class Cron_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	public function register_hooks() {
 		if ( ! \wp_next_scheduled( Indexing_Notification_Integration::NOTIFICATION_ID ) ) {

--- a/src/integrations/admin/link-count-columns-integration.php
+++ b/src/integrations/admin/link-count-columns-integration.php
@@ -60,7 +60,7 @@ class Link_Count_Columns_Integration implements Integration_Interface {
 	protected $admin_columns_cache;
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
 		return [
@@ -91,7 +91,7 @@ class Link_Count_Columns_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	public function register_hooks() {
 		\add_filter( 'posts_clauses', [ $this, 'order_by_links' ], 1, 2 );

--- a/src/integrations/admin/migration-error-integration.php
+++ b/src/integrations/admin/migration-error-integration.php
@@ -20,7 +20,7 @@ class Migration_Error_Integration implements Integration_Interface {
 	protected $migration_status;
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
 		return [ Admin_Conditional::class ];
@@ -36,7 +36,7 @@ class Migration_Error_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	public function register_hooks() {
 		if ( $this->migration_status->get_error( 'free' ) === false ) {

--- a/src/integrations/blocks/abstract-dynamic-block.php
+++ b/src/integrations/blocks/abstract-dynamic-block.php
@@ -24,18 +24,14 @@ abstract class Dynamic_Block implements Integration_Interface {
 	protected $script;
 
 	/**
-	 * Get conditionals.
-	 *
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
 		return [];
 	}
 
 	/**
-	 * Register hooks.
-	 *
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	public function register_hooks() {
 		\add_action( 'init', [ $this, 'register_block' ], 11 );

--- a/src/integrations/blocks/block-categories.php
+++ b/src/integrations/blocks/block-categories.php
@@ -10,14 +10,14 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 class Internal_Linking_Category implements Integration_Interface {
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
 		return [];
 	}
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	public function register_hooks() {
 		\add_filter( 'block_categories', [ $this, 'add_block_categories' ] );

--- a/src/integrations/blocks/structured-data-blocks.php
+++ b/src/integrations/blocks/structured-data-blocks.php
@@ -18,7 +18,7 @@ class Structured_Data_Blocks implements Integration_Interface {
 	protected $asset_manager;
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
 		return [];

--- a/src/main.php
+++ b/src/main.php
@@ -38,10 +38,8 @@ class Main extends Abstract_Main {
 	 */
 	const WP_CLI_NAMESPACE = 'yoast';
 
-	// @phpcs:disable Generic.Commenting.DocComment.MissingShort -- Description is included in the inherited comment.
-
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	protected function get_container() {
 		if ( $this->is_development() && \class_exists( '\Yoast\WP\SEO\Dependency_Injection\Container_Compiler' ) ) {
@@ -65,14 +63,14 @@ class Main extends Abstract_Main {
 	}
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	protected function get_name() {
 		return 'yoast-seo';
 	}
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	protected function get_surfaces() {
 		return [

--- a/tests/unit/presentations/abstract-presentation-test.php
+++ b/tests/unit/presentations/abstract-presentation-test.php
@@ -23,7 +23,7 @@ class Abstract_Presentation_Test extends TestCase {
 	private $instance;
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	protected function set_up() {
 		parent::set_up();

--- a/tests/unit/repositories/indexable-hierarchy-repository-test.php
+++ b/tests/unit/repositories/indexable-hierarchy-repository-test.php
@@ -35,7 +35,7 @@ class Indexable_Hierarchy_Repository_Test extends TestCase {
 	protected $builder;
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	protected function set_up() {
 		parent::set_up();

--- a/tests/unit/routes/indexables-head-route-test.php
+++ b/tests/unit/routes/indexables-head-route-test.php
@@ -34,7 +34,7 @@ class Indexables_Head_Route_Test extends TestCase {
 	protected $instance;
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	protected function set_up() {
 		parent::set_up();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Coding Standards will recognize `{@inheritDoc}` as a valid inheritance declaration.
This is resolving a couple of CS errors.

Seems this was possible all along: https://github.com/squizlabs/PHP_CodeSniffer/pull/214

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* None

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* None, only documentation change in code.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* None

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P2-609
