### PR TITLE
Fix link classifier

### DIFF
--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -136,8 +136,9 @@ class Url_Helper {
 	 * @return string The link type.
 	 */
 	public function get_link_type( $url, $home_url = null, $is_image = false ) {
-		// If there is no scheme the link is always internal.
-		if ( empty( $url['scheme'] ) ) {
+		// If there is no scheme and no host the link is always internal.
+		// Beware, checking just the scheme isn't enough as a link can be //yoast.com for instance.
+		if ( empty( $url['scheme'] ) && empty( $url['host'] ) ) {
 			return ( $is_image ) ? SEO_Links::TYPE_INTERNAL_IMAGE : SEO_Links::TYPE_INTERNAL;
 		}
 

--- a/tests/unit/helpers/url-helper-test.php
+++ b/tests/unit/helpers/url-helper-test.php
@@ -345,11 +345,27 @@ class Url_Helper_Test extends TestCase {
 	public function get_link_type_test_data() {
 		return [
 			[
-				[ 'scheme' => '' ],
+				[
+					'scheme' => '',
+					'host'   => ''
+				],
 				[],
 				false,
 				SEO_Links::TYPE_INTERNAL,
-				'URLs with no scheme should be internal',
+				'URLs with no scheme and no host should be internal',
+			],
+			[
+				[
+					'scheme' => '',
+					'host'   => 'example.net',
+				],
+				[
+					'scheme' => 'http',
+					'host'   => 'example.com',
+				],
+				false,
+				SEO_Links::TYPE_EXTERNAL,
+				'URLs with no scheme, but an external host should be external',
 			],
 			[
 				[ 'scheme' => 'not-http(s)?' ],
@@ -411,7 +427,7 @@ class Url_Helper_Test extends TestCase {
 				false,
 				SEO_Links::TYPE_INTERNAL,
 				'When home_url has a path URLs that do start with it should be internal',
-			],
+			]
 		];
 	}
 }

--- a/tests/unit/helpers/url-helper-test.php
+++ b/tests/unit/helpers/url-helper-test.php
@@ -347,7 +347,7 @@ class Url_Helper_Test extends TestCase {
 			[
 				[
 					'scheme' => '',
-					'host'   => ''
+					'host'   => '',
 				],
 				[],
 				false,
@@ -427,7 +427,7 @@ class Url_Helper_Test extends TestCase {
 				false,
 				SEO_Links::TYPE_INTERNAL,
 				'When home_url has a path URLs that do start with it should be internal',
-			]
+			],
 		];
 	}
 }


### PR DESCRIPTION
## Context

The link classifier was erroneously parsing scheme relative links as internal. So this link:

```html
<a href="//d33v4339jhl8k0.cloudfront.net/docs/assets/5375d691e4b0d833740d56cc/images/54ab21d7e4b047ebb774ac27/file-gOxSkpNUXo.jpg">image</a>
```

Would be parsed as internal, even though it's only scheme relative.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Correctly classify scheme relative links.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Should be tested properly by the new unit tests, but can also be tested by running this code:

```php
$url = parse_url( '//d33v4339jhl8k0.cloudfront.net/docs/assets/5375d691e4b0d833740d56cc/images/54ab21d7e4b047ebb774ac27/file-gOxSkpNUXo.jpg' );
echo '<pre>' . print_r( $url, 1 ) . '</pre>';
echo YoastSEO()->helpers->url->get_link_type( $url );
```


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
