### PR TITLE
P3 318 fix semrush timestamp tests

### DIFF
--- a/tests/unit/config/semrush-client-test.php
+++ b/tests/unit/config/semrush-client-test.php
@@ -160,6 +160,8 @@ class SEMrush_Client_Test extends TestCase {
 			]
 		);
 
+		$this->time = \time();
+
 		$this->provider
 			->expects( 'getAccessToken' )
 			->once()
@@ -181,7 +183,7 @@ class SEMrush_Client_Test extends TestCase {
 					'refresh_token' => '000001',
 					'expires'       => 604800,
 					'has_expired'   => true,
-					'created_at'    => \time(),
+					'created_at'    => $this->time,
 				]
 			)
 			->andReturns( $this->token );
@@ -192,6 +194,8 @@ class SEMrush_Client_Test extends TestCase {
 		);
 
 		$instance->set_provider( $this->provider );
+
+		$instance->request_tokens( '123456' )->created_at = $this->time;
 
 		$this->assertInstanceOf( SEMrush_Token::class, $instance->request_tokens( '123456' ) );
 	}

--- a/tests/unit/config/semrush-client-test.php
+++ b/tests/unit/config/semrush-client-test.php
@@ -61,6 +61,13 @@ class SEMrush_Client_Test extends TestCase {
 	protected $instance;
 
 	/**
+	 * The current time value. This is stored so slow travis tests can't crash on differing timestamps.
+	 *
+	 * @var time
+	 */
+	protected $time;
+
+	/**
 	 * Set up the test fixtures.
 	 */
 	protected function set_up() {
@@ -226,13 +233,15 @@ class SEMrush_Client_Test extends TestCase {
 	public function test_storing_token_failure() {
 		$this->expectException( Failed_Storage_Exception::class );
 
+		$this->time = \time();
+
 		$this->token->expects( 'to_array' )->once()->andReturns(
 			[
 				'access_token'  => '000000',
 				'refresh_token' => '000001',
 				'expires'       => 604800,
 				'has_expired'   => true,
-				'created_at'    => \time(),
+				'created_at'    => $this->time,
 			]
 		);
 
@@ -245,7 +254,7 @@ class SEMrush_Client_Test extends TestCase {
 					'refresh_token' => '000001',
 					'expires'       => 604800,
 					'has_expired'   => true,
-					'created_at'    => \time(),
+					'created_at'    => $this->time,
 				]
 			)
 			->once()

--- a/tests/unit/config/semrush-client-test.php
+++ b/tests/unit/config/semrush-client-test.php
@@ -195,9 +195,10 @@ class SEMrush_Client_Test extends TestCase {
 
 		$instance->set_provider( $this->provider );
 
-		$instance->request_tokens( '123456' )->created_at = $this->time;
+		$requested_tokens             = $instance->request_tokens( '123456' );
+		$requested_tokens->created_at = $this->time;
 
-		$this->assertInstanceOf( SEMrush_Token::class, $instance->request_tokens( '123456' ) );
+		$this->assertInstanceOf( SEMrush_Token::class, $requested_tokens );
 	}
 
 	/**

--- a/tests/unit/config/semrush-client-test.php
+++ b/tests/unit/config/semrush-client-test.php
@@ -63,7 +63,7 @@ class SEMrush_Client_Test extends TestCase {
 	/**
 	 * The current time value. This is stored so slow travis tests can't crash on differing timestamps.
 	 *
-	 * @var time
+	 * @var int
 	 */
 	protected $time;
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes a occasion where travis fails on differing timestamps in two tests.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where 2 tests unrightfully fail by differing timestamps due to travis running slower then the tests expect.

## Relevant technical choices:

* Defined the time at the beginning of the tests, and uses that value instead of getting it seperately

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* N/A, this is a travis only thing


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [X] I have added unittests to verify the code works as intended

Fixes #
