### PR TITLE
Replace image uploads with new ImageSelect component

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -59,6 +59,7 @@ class WPSEO_Admin_Pages {
 		wp_enqueue_style( 'wp-admin' );
 		$this->asset_manager->enqueue_style( 'select2' );
 		$this->asset_manager->enqueue_style( 'admin-css' );
+		$this->asset_manager->enqueue_style( 'monorepo' );
 
 		$page = filter_input( INPUT_GET, 'page' );
 		if ( $page === 'wpseo_titles' ) {

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -59,11 +59,14 @@ class WPSEO_Admin_Pages {
 		wp_enqueue_style( 'wp-admin' );
 		$this->asset_manager->enqueue_style( 'select2' );
 		$this->asset_manager->enqueue_style( 'admin-css' );
-		$this->asset_manager->enqueue_style( 'monorepo' );
 
 		$page = filter_input( INPUT_GET, 'page' );
 		if ( $page === 'wpseo_titles' ) {
 			$this->asset_manager->enqueue_style( 'search-appearance' );
+		}
+
+		if ( $page === 'wpseo_social' ) {
+			$this->asset_manager->enqueue_style( 'monorepo' );
 		}
 	}
 
@@ -122,6 +125,10 @@ class WPSEO_Admin_Pages {
 
 		if ( $page === 'wpseo_tools' ) {
 			$this->enqueue_tools_scripts();
+		}
+
+		if ( $page === 'wpseo_social' ) {
+			$script_data['social'] = true;
 		}
 
 		$this->asset_manager->localize_script( 'settings', 'wpseoScriptData', $script_data );

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -68,14 +68,14 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 		$yform->textinput( 'company_name', __( 'Organization name', 'wordpress-seo' ), [ 'autocomplete' => 'organization' ] );
 		$yform->hidden( 'company_logo', 'company_logo' );
 		?>
-		<div id="organization-image-select"></div>
+		<div id="yoast-organization-image-select"></div>
 		<div id="wpseo-local-seo-upsell"></div>
 	</div>
 	<div id="knowledge-graph-person">
 		<h3><?php esc_html_e( 'Personal info', 'wordpress-seo' ); ?></h3>
 
 		<div id="wpseo-person-selector"></div>
-		<div id="person-image-select"></div>
+		<div id="yoast-person-image-select"></div>
 		<?php
 		$yform->hidden( 'person_logo', 'person_logo' );
 		$yform->hidden( 'company_or_person_user_id', 'person_id' );

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -67,6 +67,7 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 
 		$yform->textinput( 'company_name', __( 'Organization name', 'wordpress-seo' ), [ 'autocomplete' => 'organization' ] );
 		$yform->hidden( 'company_logo', 'company_logo' );
+		$yform->hidden( 'company_logo_id', 'company_logo_id' );
 		?>
 		<div id="yoast-organization-image-select"></div>
 		<div id="wpseo-local-seo-upsell"></div>
@@ -78,6 +79,7 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 		<div id="yoast-person-image-select"></div>
 		<?php
 		$yform->hidden( 'person_logo', 'person_logo' );
+		$yform->hidden( 'person_logo_id', 'person_logo_id' );
 		$yform->hidden( 'company_or_person_user_id', 'person_id' );
 		?>
 	</div>

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -66,16 +66,18 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 		endif;
 
 		$yform->textinput( 'company_name', __( 'Organization name', 'wordpress-seo' ), [ 'autocomplete' => 'organization' ] );
-//		$yform->media_input( 'company_logo', __( 'Organization logo', 'wordpress-seo' ) );
+		$yform->hidden( 'company_logo', 'company_logo' );
 		?>
 		<div id="organization-image-select"></div>
 		<div id="wpseo-local-seo-upsell"></div>
 	</div>
 	<div id="knowledge-graph-person">
 		<h3><?php esc_html_e( 'Personal info', 'wordpress-seo' ); ?></h3>
+
+		<div id="wpseo-person-selector"></div>
+		<div id="person-image-select"></div>
 		<?php
-		echo '<div id="wpseo-person-selector"></div>';
-		$yform->media_input( 'person_logo', __( 'Person logo / avatar', 'wordpress-seo' ) );
+		$yform->hidden( 'person_logo', 'person_logo' );
 		$yform->hidden( 'company_or_person_user_id', 'person_id' );
 		?>
 	</div>

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -66,8 +66,9 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 		endif;
 
 		$yform->textinput( 'company_name', __( 'Organization name', 'wordpress-seo' ), [ 'autocomplete' => 'organization' ] );
-		$yform->media_input( 'company_logo', __( 'Organization logo', 'wordpress-seo' ) );
+//		$yform->media_input( 'company_logo', __( 'Organization logo', 'wordpress-seo' ) );
 		?>
+		<div id="organization-image-select"></div>
 		<div id="wpseo-local-seo-upsell"></div>
 	</div>
 	<div id="knowledge-graph-person">

--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -41,7 +41,7 @@ if ( get_option( 'show_on_front' ) === 'posts' ) {
 
 	$yform->hidden( 'og_frontpage_image', 'og_frontpage_image' );
 	?>
-	<div id="og-frontpage-image-select"></div>
+	<div id="yoast-og-frontpage-image-select"></div>
 	<?php
 	$yform->textinput( 'og_frontpage_title', __( 'Title', 'wordpress-seo' ) );
 	$yform->textinput( 'og_frontpage_desc', __( 'Description', 'wordpress-seo' ) );
@@ -84,7 +84,7 @@ $yform->hidden( 'og_default_image', 'og_default_image' );
 	<p>
 		<?php esc_html_e( 'This image is used if the post/page being shared does not contain any images.', 'wordpress-seo' ); ?>
 	</p>
-	<div id="og-default-image-select"></div>
+	<div id="yoast-og-default-image-select"></div>
 </div>
 <?php
 

--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -40,6 +40,7 @@ if ( get_option( 'show_on_front' ) === 'posts' ) {
 	echo $social_facebook_frontpage_help->get_panel_html();
 
 	$yform->hidden( 'og_frontpage_image', 'og_frontpage_image' );
+	$yform->hidden( 'og_frontpage_image_id', 'og_frontpage_image_id' );
 	?>
 	<div id="yoast-og-frontpage-image-select"></div>
 	<?php
@@ -79,6 +80,7 @@ if ( get_option( 'show_on_front' ) === 'posts' ) {
 echo '<h2>' . esc_html__( 'Default settings', 'wordpress-seo' ) . '</h2>';
 
 $yform->hidden( 'og_default_image', 'og_default_image' );
+$yform->hidden( 'og_default_image_id', 'og_default_image_id' );
 
 ?>
 	<p>

--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -39,7 +39,10 @@ if ( get_option( 'show_on_front' ) === 'posts' ) {
 	// phpcs:ignore WordPress.Security.EscapeOutput -- get_panel_html() output is properly escaped.
 	echo $social_facebook_frontpage_help->get_panel_html();
 
-	$yform->media_input( 'og_frontpage_image', __( 'Image URL', 'wordpress-seo' ) );
+	$yform->hidden( 'og_frontpage_image', 'og_frontpage_image' );
+	?>
+	<div id="og-frontpage-image-select"></div>
+	<?php
 	$yform->textinput( 'og_frontpage_title', __( 'Title', 'wordpress-seo' ) );
 	$yform->textinput( 'og_frontpage_desc', __( 'Description', 'wordpress-seo' ) );
 
@@ -75,12 +78,10 @@ if ( get_option( 'show_on_front' ) === 'posts' ) {
 
 echo '<h2>' . esc_html__( 'Default settings', 'wordpress-seo' ) . '</h2>';
 
-$yform->media_input( 'og_default_image', __( 'Image URL', 'wordpress-seo' ) );
+$yform->hidden( 'og_default_image', 'og_default_image' );
 
 ?>
-	<p class="desc label">
-		<?php esc_html_e( 'This image is used if the post/page being shared does not contain any images.', 'wordpress-seo' ); ?>
-	</p>
+	<div id="og-default-image-select"></div>
 </div>
 <?php
 

--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -81,6 +81,9 @@ echo '<h2>' . esc_html__( 'Default settings', 'wordpress-seo' ) . '</h2>';
 $yform->hidden( 'og_default_image', 'og_default_image' );
 
 ?>
+	<p>
+		<?php esc_html_e( 'This image is used if the post/page being shared does not contain any images.', 'wordpress-seo' ); ?>
+	</p>
 	<div id="og-default-image-select"></div>
 </div>
 <?php

--- a/js/src/components/ImageSelectComponent.js
+++ b/js/src/components/ImageSelectComponent.js
@@ -33,7 +33,7 @@ class ImageSelectComponent extends Component {
 	 * @returns {string} The image url.
 	 */
 	getInitialValue() {
-		return this.element.imageUrl;
+		return this.element.value;
 	}
 
 	/**
@@ -47,7 +47,7 @@ class ImageSelectComponent extends Component {
 	 */
 	setMyImageUrl( imageUrl ) {
 		this.setState( { imageUrl }, () => {
-			this.element.imageUrl = imageUrl;
+			this.element.value = imageUrl;
 		} );
 	}
 

--- a/js/src/components/ImageSelectComponent.js
+++ b/js/src/components/ImageSelectComponent.js
@@ -94,7 +94,7 @@ class ImageSelectComponent extends Component {
 				hasPreview={ this.state.hasPreview }
 				imageUrl={ this.state.imageUrl }
 				onClick={ this.onClick }
-				onRemoveImageClick= { this.removeImage }
+				onRemoveImageClick={ this.removeImage }
 			/>
 		);
 	}

--- a/js/src/components/ImageSelectComponent.js
+++ b/js/src/components/ImageSelectComponent.js
@@ -2,7 +2,7 @@ import { ImageSelect } from "@yoast/components";
 import { openMedia } from "../helpers/selectMedia";
 
 import { Component } from "@wordpress/element";
-/* eslint-disable */
+
 /**
  * Renders the ImageSelect.
  */

--- a/js/src/components/ImageSelectComponent.js
+++ b/js/src/components/ImageSelectComponent.js
@@ -1,7 +1,8 @@
 import { ImageSelect } from "@yoast/components";
-import { openMedia } from "../helpers/selectMedia";
-
 import { Component } from "@wordpress/element";
+
+import { openMedia } from "../helpers/selectMedia";
+import PropTypes from "prop-types";
 
 /**
  * Renders the ImageSelect.
@@ -18,8 +19,6 @@ class ImageSelectComponent extends Component {
 		this.element = document.getElementById( this.props.hiddenField );
 		this.state = {
 			imageUrl: this.getInitialValue(),
-			label: this.props.label,
-			hasPreview: this.props.hasPreview,
 		};
 
 		this.setMyImageUrl = this.setMyImageUrl.bind( this );
@@ -90,8 +89,8 @@ class ImageSelectComponent extends Component {
 	render() {
 		return (
 			<ImageSelect
-				label={ this.state.label }
-				hasPreview={ this.state.hasPreview }
+				label={ this.props.label }
+				hasPreview={ this.props.hasPreview }
 				imageUrl={ this.state.imageUrl }
 				onClick={ this.onClick }
 				onRemoveImageClick={ this.removeImage }
@@ -99,5 +98,16 @@ class ImageSelectComponent extends Component {
 		);
 	}
 }
+
+ImageSelectComponent.propTypes = {
+	hiddenField: PropTypes.string.isRequired,
+	label: PropTypes.string,
+	hasPreview: PropTypes.bool,
+};
+
+ImageSelectComponent.defaultProps = {
+	label: "",
+	hasPreview: true,
+};
 
 export default ImageSelectComponent;

--- a/js/src/components/ImageSelectComponent.js
+++ b/js/src/components/ImageSelectComponent.js
@@ -16,12 +16,15 @@ class ImageSelectComponent extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.element = document.getElementById( this.props.hiddenField );
+		this.hiddenField = document.getElementById( this.props.hiddenField );
+		this.hiddenFieldImageId = document.getElementById( this.props.hiddenFieldImageId );
 		this.state = {
 			imageUrl: this.getInitialValue(),
+			imageId: this.getInitialId(),
 		};
 
 		this.setMyImageUrl = this.setMyImageUrl.bind( this );
+		this.setMyImageId = this.setMyImageId.bind( this );
 		this.onClick = this.onClick.bind( this );
 		this.removeImage = this.removeImage.bind( this );
 	}
@@ -32,13 +35,24 @@ class ImageSelectComponent extends Component {
 	 * @returns {string} The image url.
 	 */
 	getInitialValue() {
-		return this.element.value;
+		return this.hiddenField.value;
+	}
+
+	/**
+	 * Gets the initial value from the hidden input field for the image id, if it exists.
+	 *
+	 * @returns {string} The image id.
+	 */
+	getInitialId() {
+		if ( this.hiddenFieldImageId !== null ) {
+			return this.hiddenFieldImageId.value;
+		}
 	}
 
 	/**
 	 * Handles change event for the image select.
 	 *
-	 * First updates its internal state and then updates the hidden input.
+	 * First updates its internal state and then updates the hidden input for the image.
 	 *
 	 * @param {string} imageUrl The image url.
 	 *
@@ -46,7 +60,22 @@ class ImageSelectComponent extends Component {
 	 */
 	setMyImageUrl( imageUrl ) {
 		this.setState( { imageUrl }, () => {
-			this.element.value = imageUrl;
+			this.hiddenField.value = imageUrl;
+		} );
+	}
+
+	/**
+	 * Handles change event for the image select.
+	 *
+	 * First updates its internal state and then updates the hidden input for the image id.
+	 *
+	 * @param {string} imageId The image id.
+	 *
+	 * @returns {void}
+	 */
+	setMyImageId( imageId ) {
+		this.setState( { imageId }, () => {
+			this.hiddenFieldImageId.value = imageId;
 		} );
 	}
 
@@ -67,6 +96,9 @@ class ImageSelectComponent extends Component {
 		 */
 		const imageCallback = ( image ) => {
 			this.setMyImageUrl( image.url );
+			if ( this.hiddenFieldImageId !== null ) {
+				this.setMyImageId( image.id );
+			}
 		};
 		openMedia( imageCallback );
 	}
@@ -78,7 +110,11 @@ class ImageSelectComponent extends Component {
 	 */
 	removeImage() {
 		const imageUrl = "";
+		const imageId = "";
 		this.setMyImageUrl( imageUrl );
+		if ( this.hiddenFieldImageId !== null ) {
+			this.setMyImageId( imageId );
+		}
 	}
 
 	/**
@@ -92,6 +128,7 @@ class ImageSelectComponent extends Component {
 				label={ this.props.label }
 				hasPreview={ this.props.hasPreview }
 				imageUrl={ this.state.imageUrl }
+				imageId={ this.state.imageId }
 				onClick={ this.onClick }
 				onRemoveImageClick={ this.removeImage }
 			/>
@@ -101,11 +138,13 @@ class ImageSelectComponent extends Component {
 
 ImageSelectComponent.propTypes = {
 	hiddenField: PropTypes.string.isRequired,
+	hiddenFieldImageId: PropTypes.string,
 	label: PropTypes.string,
 	hasPreview: PropTypes.bool,
 };
 
 ImageSelectComponent.defaultProps = {
+	hiddenFieldImageId: "",
 	label: "",
 	hasPreview: true,
 };

--- a/js/src/components/ImageSelectComponent.js
+++ b/js/src/components/ImageSelectComponent.js
@@ -1,7 +1,68 @@
 import { ImageSelect } from "@yoast/components";
 
-const ImageSelectComponent = ( props ) => {
-	return <ImageSelect label={ props.label } hasPreview={ props.hasPreview } />
+import { Component } from "@wordpress/element";
+/* eslint-disable */
+/**
+ * Renders the ImageSelect.
+ */
+class ImageSelectComponent extends Component {
+	/**
+	 * The ImageSelectComponent constructor.
+	 *
+	 * @param {Object} props The components props.
+	 */
+	constructor( props ) {
+		super( props );
+
+		this.element = document.getElementById( this.props.hiddenField );
+		this.state = {
+			imageUrl: this.getInitialValue(),
+			label: this.props.label,
+			hasPreview: this.props.hasPreview,
+		};
+
+		this.onClick = this.onClick.bind( this );
+	}
+
+	/**
+	 * Gets the initial value from the hidden input field.
+	 *
+	 * @returns {string} The image url.
+	 */
+	getInitialValue() {
+		return this.element.imageUrl;
+	}
+
+	/**
+	 * Handles change event for the image select.
+	 *
+	 * First updates its internal state and then updates the hidden input.
+	 *
+	 * @param {string} imageUrl The image url.
+	 *
+	 * @returns {void}
+	 */
+	onClick( imageUrl ) {
+		this.setState( { imageUrl }, () => {
+			this.element.imageUrl = imageUrl;
+		} );
+	}
+
+	/**
+	 * Renders the ImageSelect component.
+	 *
+	 * @returns {wp.Element} The rendered component.
+	 */
+	render() {
+		return (
+			<ImageSelect
+				label={ this.state.label }
+				hasPreview={ this.state.hasPreview }
+				imageUrl={ this.state.imageUrl }
+				onClick={ this.onClick }
+			/>
+		);
+	}
 }
 
 export default ImageSelectComponent;

--- a/js/src/components/ImageSelectComponent.js
+++ b/js/src/components/ImageSelectComponent.js
@@ -1,0 +1,7 @@
+import { ImageSelect } from "@yoast/components";
+
+const ImageSelectComponent = ( props ) => {
+	return <ImageSelect label={ props.label } hasPreview={ props.hasPreview } />
+}
+
+export default ImageSelectComponent;

--- a/js/src/components/ImageSelectComponent.js
+++ b/js/src/components/ImageSelectComponent.js
@@ -1,4 +1,5 @@
 import { ImageSelect } from "@yoast/components";
+import { openMedia } from "../helpers/selectMedia";
 
 import { Component } from "@wordpress/element";
 /* eslint-disable */
@@ -21,7 +22,9 @@ class ImageSelectComponent extends Component {
 			hasPreview: this.props.hasPreview,
 		};
 
+		this.setMyImageUrl = this.setMyImageUrl.bind( this );
 		this.onClick = this.onClick.bind( this );
+		this.removeImage = this.removeImage.bind( this );
 	}
 
 	/**
@@ -42,10 +45,41 @@ class ImageSelectComponent extends Component {
 	 *
 	 * @returns {void}
 	 */
-	onClick( imageUrl ) {
+	setMyImageUrl( imageUrl ) {
 		this.setState( { imageUrl }, () => {
 			this.element.imageUrl = imageUrl;
 		} );
+	}
+
+	/**
+	 * Function called when ImageSelect component button is clicked.
+	 *
+	 * @returns {void}
+	 */
+	onClick() {
+		/**
+		 * Callback function for selectMedia. Performs actions with the 'image' Object that it gets as an argument.
+		 *
+		 * @param {Object} image Object containing data about the selected image.
+		 *
+		 * @param {Function} onSelect Callback function received from openMedia. Gets object image' as an argument.
+		 *
+		 * @returns {void}
+		 */
+		const imageCallback = ( image ) => {
+			this.setMyImageUrl( image.url );
+		};
+		openMedia( imageCallback );
+	}
+
+	/**
+	 * Function called when 'remove image' button of ImageSelect component is clicked.
+	 *
+	 * @returns {void}
+	 */
+	removeImage() {
+		const imageUrl = "";
+		this.setMyImageUrl( imageUrl );
 	}
 
 	/**
@@ -60,6 +94,7 @@ class ImageSelectComponent extends Component {
 				hasPreview={ this.state.hasPreview }
 				imageUrl={ this.state.imageUrl }
 				onClick={ this.onClick }
+				onRemoveImageClick= { this.removeImage }
 			/>
 		);
 	}

--- a/js/src/components/portals/ImageSelectPortal.js
+++ b/js/src/components/portals/ImageSelectPortal.js
@@ -11,13 +11,14 @@ import Portal from "./Portal";
  * @returns {null|wp.Element} The element.
  * @constructor
  */
-export default function ImageSelectPortal( { target, label, hasPreview, hiddenField } ) {
+export default function ImageSelectPortal( { target, label, hasPreview, hiddenField, hiddenFieldImageId } ) {
 	return (
 		<Portal target={ target }>
 			<ImageSelectComponent
 				label={ label }
 				hasPreview={ hasPreview }
 				hiddenField={ hiddenField }
+				hiddenFieldImageId={ hiddenFieldImageId }
 			/>
 		</Portal>
 	);

--- a/js/src/components/portals/ImageSelectPortal.js
+++ b/js/src/components/portals/ImageSelectPortal.js
@@ -3,10 +3,22 @@ import PropTypes from "prop-types";
 import ImageSelectComponent from "../ImageSelectComponent";
 import Portal from "./Portal";
 
-export default function ImageSelectPortal( { target, label, hasPreview } ) {
+/**
+ *
+ * @param {string}  target A target element ID in which to render the portal.
+ * @param {string}  label The label for the Image Select component.
+ * @param {Boolean} hasPreview A boolean to determine if a preview should be rendered.
+ * @returns {null|wp.Element} The element.
+ * @constructor
+ */
+export default function ImageSelectPortal( { target, label, hasPreview, hiddenField } ) {
 	return (
 		<Portal target={ target }>
-			<ImageSelectComponent label={ label } hasPreview={ hasPreview } />
+			<ImageSelectComponent
+				label={ label }
+				hasPreview={ hasPreview }
+				hiddenField={ hiddenField }
+			/>
 		</Portal>
 	);
 }
@@ -15,4 +27,5 @@ ImageSelectPortal.propTypes = {
 	target: PropTypes.string.isRequired,
 	label: PropTypes.string.isRequired,
 	hasPreview: PropTypes.bool.isRequired,
+	hiddenField: PropTypes.string.isRequired,
 };

--- a/js/src/components/portals/ImageSelectPortal.js
+++ b/js/src/components/portals/ImageSelectPortal.js
@@ -29,4 +29,9 @@ ImageSelectPortal.propTypes = {
 	label: PropTypes.string.isRequired,
 	hasPreview: PropTypes.bool.isRequired,
 	hiddenField: PropTypes.string.isRequired,
+	hiddenFieldImageId: PropTypes.string,
+};
+
+ImageSelectPortal.defaultProps = {
+	hiddenFieldImageId: "",
 };

--- a/js/src/components/portals/ImageSelectPortal.js
+++ b/js/src/components/portals/ImageSelectPortal.js
@@ -1,0 +1,18 @@
+import PropTypes from "prop-types";
+
+import ImageSelectComponent from "../ImageSelectComponent";
+import Portal from "./Portal";
+
+export default function ImageSelectPortal( { target, label, hasPreview } ) {
+	return (
+		<Portal target={ target }>
+			<ImageSelectComponent label={ label } hasPreview={ hasPreview } />
+		</Portal>
+	);
+}
+
+ImageSelectPortal.propTypes = {
+	target: PropTypes.string.isRequired,
+	label: PropTypes.string.isRequired,
+	hasPreview: PropTypes.bool.isRequired,
+};

--- a/js/src/containers/FacebookEditor.js
+++ b/js/src/containers/FacebookEditor.js
@@ -8,41 +8,25 @@ import { validateFacebookImage } from "@yoast/helpers";
 import FacebookWrapper from "../components/social/FacebookWrapper";
 import getL10nObject from "../analysis/getL10nObject";
 import withLocation from "../helpers/withLocation";
+import { openMedia } from "../helpers/selectMedia";
 
 const socialMediumName = "Facebook";
 
 /**
- * The cached instance of the media object.
+ * Callback function for selectMedia. Performs actions with the 'image' Object that it gets as an argument.
  *
- * @type {wp.media} The media object
- */
-let media = null;
-
-/**
- * Lazy function to get the media object and hook the right action dispatchers.
+ * @param {Object} image Object containing data about the selected image.
+ *
+ * @param {Function} onSelect Callback function received from openMedia. Gets object image' as an argument.
  *
  * @returns {void}
  */
-const getMedia = () => {
-	if ( ! media ) {
-		media = window.wp.media();
-		// Listens for the selection of an image. Then gets the right data and dispatches the data to the store.
-		media.on( "select", () => {
-			const selected = media.state().get( "selection" ).first();
-			const image = {
-				type: selected.attributes.subtype,
-				width: selected.attributes.width,
-				height: selected.attributes.height,
-			};
-			wpDataDispatch( "yoast-seo/editor" ).setFacebookPreviewImage( {
-				url: selected.attributes.url,
-				id: selected.attributes.id,
-				warnings: validateFacebookImage( image ),
-			} );
-		} );
-	}
-
-	return media;
+const imageCallback = ( image ) => {
+	wpDataDispatch( "yoast-seo/editor" ).setFacebookPreviewImage( {
+		url: image.url,
+		id: image.id,
+		warnings: validateFacebookImage( image ),
+	} );
 };
 
 /**
@@ -50,8 +34,8 @@ const getMedia = () => {
  *
  * @returns {void}
  */
-const openMedia = () => {
-	return getMedia().open();
+const selectMedia = () => {
+	openMedia( imageCallback );
 };
 
 export default compose( [
@@ -111,7 +95,7 @@ export default compose( [
 			loadFacebookPreviewData,
 		} = dispatch( "yoast-seo/editor" );
 		return {
-			onSelectImageClick: openMedia,
+			onSelectImageClick: selectMedia,
 			onRemoveImageClick: clearFacebookPreviewImage,
 			onDescriptionChange: setFacebookPreviewDescription,
 			onTitleChange: setFacebookPreviewTitle,

--- a/js/src/containers/TwitterEditor.js
+++ b/js/src/containers/TwitterEditor.js
@@ -8,41 +8,25 @@ import { validateTwitterImage } from "@yoast/helpers";
 import TwitterWrapper from "../components/social/TwitterWrapper";
 import getL10nObject from "../analysis/getL10nObject";
 import withLocation from "../helpers/withLocation";
+import { openMedia } from "../helpers/selectMedia";
 
 const socialMediumName = "Twitter";
 
 /**
- * The cached instance of the media object.
+ * Callback function for selectMedia. Performs actions with the 'image' Object that it gets as an argument.
  *
- * @type {wp.media} The media object
- */
-let media = null;
-
-/**
- * Lazy function to get the media object and hook the right action dispatchers.
+ * @param {Object} image Object containing data about the selected image.
+ *
+ * @param {Function} onSelect Callback function received from openMedia. Gets object image' as an argument.
  *
  * @returns {void}
  */
-const getMedia = () => {
-	if ( ! media ) {
-		media = window.wp.media();
-		// Listens for the selection of an image. Then gets the right data and dispatches the data to the store.
-		media.on( "select", () => {
-			const selected = media.state().get( "selection" ).first();
-			const image = {
-				type: selected.attributes.subtype,
-				width: selected.attributes.width,
-				height: selected.attributes.height,
-			};
-			wpDataDispatch( "yoast-seo/editor" ).setTwitterPreviewImage( {
-				url: selected.attributes.url,
-				id: selected.attributes.id,
-				warnings: validateTwitterImage( image ),
-			} );
-		} );
-	}
-
-	return media;
+const imageCallback = ( image ) => {
+	wpDataDispatch( "yoast-seo/editor" ).setTwitterPreviewImage( {
+		url: image.url,
+		id: image.id,
+		warnings: validateTwitterImage( image ),
+	} );
 };
 
 /**
@@ -50,8 +34,8 @@ const getMedia = () => {
  *
  * @returns {void}
  */
-const openMedia = () => {
-	return getMedia().open();
+const selectMedia = () => {
+	openMedia( imageCallback );
 };
 
 /* eslint-disable complexity */
@@ -118,7 +102,7 @@ export default compose( [
 		} = dispatch( "yoast-seo/editor" );
 
 		return {
-			onSelectImageClick: openMedia,
+			onSelectImageClick: selectMedia,
 			onRemoveImageClick:	clearTwitterPreviewImage,
 			onDescriptionChange: setTwitterPreviewDescription,
 			onTitleChange: setTwitterPreviewTitle,

--- a/js/src/editor-modules.js
+++ b/js/src/editor-modules.js
@@ -20,6 +20,7 @@ import Modal from "./components/modals/Modal";
 import SidebarItem from "./components/SidebarItem";
 import * as ajaxHelper from "./helpers/ajaxHelper";
 import EditorModal from "./containers/EditorModal";
+import ImageSelectPortal from "./components/portals/ImageSelectPortal";
 
 window.yoast = window.yoast || {};
 window.yoast.editorModules = {
@@ -46,6 +47,9 @@ window.yoast.editorModules = {
 		SidebarCollapsible,
 		MetaboxCollapsible,
 		Modal,
+		portals: {
+			ImageSelectPortal,
+		},
 	},
 	containers: {
 		EditorModal,

--- a/js/src/helpers/selectMedia.js
+++ b/js/src/helpers/selectMedia.js
@@ -1,5 +1,3 @@
-let media = null;
-
 /**
  * Function to get the media object and hook the right action dispatchers.
  *
@@ -8,21 +6,20 @@ let media = null;
  * @returns {void}
  */
 function getMedia( onSelect ) {
-	if ( ! media ) {
-		media = window.wp.media();
-		// Listens for the selection of an image. Then gets the right data and dispatches the data to the store.
-		media.on( "select", () => {
-			const selected = media.state().get( "selection" ).first();
-			const image = {
-				type: selected.attributes.subtype,
-				width: selected.attributes.width,
-				height: selected.attributes.height,
-				url: selected.attributes.url,
-				id: selected.attributes.id,
-			};
-			onSelect( image );
-		} );
-	}
+	let media = null;
+	media = window.wp.media();
+	// Listens for the selection of an image. Then gets the right data and dispatches the data to the store.
+	media.on( "select", () => {
+		const selected = media.state().get( "selection" ).first();
+		const image = {
+			type: selected.attributes.subtype,
+			width: selected.attributes.width,
+			height: selected.attributes.height,
+			url: selected.attributes.url,
+			id: selected.attributes.id,
+		};
+		onSelect( image );
+	} );
 
 	return media;
 }

--- a/js/src/helpers/selectMedia.js
+++ b/js/src/helpers/selectMedia.js
@@ -1,0 +1,44 @@
+/**
+ * Just temporarily, should be provided through an ImageSelect prop
+ */
+function onSelect( image ) {
+	wpDataDispatch( "yoast-seo/editor" ).setFacebookPreviewImage( {
+		url: image.url,
+		id: image.id,
+		warnings: validateFacebookImage( image ),
+	} );
+}
+
+/**
+ * Function to get the media object and hook the right action dispatchers.
+ *
+ * @returns {void}
+ */
+function getMedia( media, onSelect ) {
+	if ( ! media ) {
+		media = window.wp.media();
+		// Listens for the selection of an image. Then gets the right data and dispatches the data to the store.
+		media.on( "select", () => {
+			const selected = media.state().get( "selection" ).first();
+			const image = {
+				type: selected.attributes.subtype,
+				width: selected.attributes.width,
+				height: selected.attributes.height,
+				url: selected.attributes.url,
+				id: selected.attributes.id,
+			};
+			onSelect( image );
+		} );
+	}
+
+	return media;
+}
+
+/**
+ * Function to open the media instance.
+ *
+ * @returns {void}
+ */
+export function openMedia( media, onSelect ) {
+	return getMedia( media, onSelect ).open();
+}

--- a/js/src/helpers/selectMedia.js
+++ b/js/src/helpers/selectMedia.js
@@ -1,20 +1,13 @@
-/**
- * Just temporarily, should be provided through an ImageSelect prop
- */
-function onSelect( image ) {
-	wpDataDispatch( "yoast-seo/editor" ).setFacebookPreviewImage( {
-		url: image.url,
-		id: image.id,
-		warnings: validateFacebookImage( image ),
-	} );
-}
+let media = null;
 
 /**
  * Function to get the media object and hook the right action dispatchers.
  *
+ * @param {Function} onSelect Callback function received from openMedia. Gets object image' as an argument.
+ *
  * @returns {void}
  */
-function getMedia( media, onSelect ) {
+function getMedia( onSelect ) {
 	if ( ! media ) {
 		media = window.wp.media();
 		// Listens for the selection of an image. Then gets the right data and dispatches the data to the store.
@@ -37,8 +30,10 @@ function getMedia( media, onSelect ) {
 /**
  * Function to open the media instance.
  *
+ * @param {Function} onSelect Callback function passed through to getMedia.
+ *
  * @returns {void}
  */
-export function openMedia( media, onSelect ) {
-	return getMedia( media, onSelect ).open();
+export function openMedia( onSelect ) {
+	return getMedia( onSelect ).open();
 }

--- a/js/src/initializers/search-appearance.js
+++ b/js/src/initializers/search-appearance.js
@@ -98,12 +98,14 @@ export default function initSearchAppearance() {
 						hasPreview={ true }
 						target="yoast-organization-image-select"
 						hiddenField="company_logo"
+						hiddenFieldImageId="company_logo_id"
 					/>
 					<ImageSelectPortal
 						label="Person logo / avatar"
 						hasPreview={ true }
 						target="yoast-person-image-select"
 						hiddenField="person_logo"
+						hiddenFieldImageId="person_logo_id"
 					/>
 					{ showLocalSEOUpsell && (
 						<LocalSEOUpsellPortal

--- a/js/src/initializers/search-appearance.js
+++ b/js/src/initializers/search-appearance.js
@@ -96,13 +96,13 @@ export default function initSearchAppearance() {
 					<ImageSelectPortal
 						label="Organization logo"
 						hasPreview={ true }
-						target="organization-image-select"
+						target="yoast-organization-image-select"
 						hiddenField="company_logo"
 					/>
 					<ImageSelectPortal
 						label="Person logo / avatar"
 						hasPreview={ true }
-						target="person-image-select"
+						target="yoast-person-image-select"
 						hiddenField="person_logo"
 					/>
 					{ showLocalSEOUpsell && (

--- a/js/src/initializers/search-appearance.js
+++ b/js/src/initializers/search-appearance.js
@@ -18,6 +18,7 @@ import UserSelectPortal from "../components/portals/UserSelectPortal";
 import CompanyInfoMissingPortal from "../components/portals/CompanyInfoMissingPortal";
 import LocalSEOUpsellPortal from "../components/portals/LocalSEOUpsellPortal";
 import SchemaSettings from "../containers/SchemaSettings";
+import ImageSelectPortal from "../components/portals/ImageSelectPortal";
 
 /**
  * @summary Initializes the search appearance settings script.
@@ -92,6 +93,12 @@ export default function initSearchAppearance() {
 						message={ knowledgeGraphCompanyInfoMissing.message }
 						link={ knowledgeGraphCompanyInfoMissing.URL }
 					/>
+					<ImageSelectPortal
+						label="organizaion"
+						hasPreview={ true }
+						target="organization-image-select"
+					/>
+					<ImageSelectPortal target="organization-image-select" />
 					{ showLocalSEOUpsell && (
 						<LocalSEOUpsellPortal
 							target="wpseo-local-seo-upsell"

--- a/js/src/initializers/search-appearance.js
+++ b/js/src/initializers/search-appearance.js
@@ -94,11 +94,17 @@ export default function initSearchAppearance() {
 						link={ knowledgeGraphCompanyInfoMissing.URL }
 					/>
 					<ImageSelectPortal
-						label="organizaion"
+						label="Organization logo"
 						hasPreview={ true }
 						target="organization-image-select"
+						hiddenField="company_logo"
 					/>
-					<ImageSelectPortal target="organization-image-select" />
+					<ImageSelectPortal
+						label="Person logo / avatar"
+						hasPreview={ true }
+						target="person-image-select"
+						hiddenField="person_logo"
+					/>
 					{ showLocalSEOUpsell && (
 						<LocalSEOUpsellPortal
 							target="wpseo-local-seo-upsell"

--- a/js/src/initializers/social-settings.js
+++ b/js/src/initializers/social-settings.js
@@ -1,0 +1,29 @@
+import { render, Fragment } from "@wordpress/element";
+import ImageSelectPortal from "../components/portals/ImageSelectPortal";
+
+/**
+ * @summary Initializes the search appearance settings script.
+ * @returns {void}
+ */
+export default function initSocialSettings() {
+	const element = document.createElement( "div" );
+	document.body.appendChild( element );
+
+	render(
+		<Fragment>
+			<ImageSelectPortal
+				label="Image"
+				hasPreview={ true }
+				target="og-frontpage-image-select"
+				hiddenField="og_frontpage_image"
+			/>
+			<ImageSelectPortal
+				label="Image"
+				hasPreview={ true }
+				target="og-default-image-select"
+				hiddenField="og_default_image"
+			/>
+		</Fragment>,
+		element
+	);
+}

--- a/js/src/initializers/social-settings.js
+++ b/js/src/initializers/social-settings.js
@@ -16,12 +16,14 @@ export default function initSocialSettings() {
 				hasPreview={ true }
 				target="yoast-og-frontpage-image-select"
 				hiddenField="og_frontpage_image"
+				hiddenFieldImageId="og_frontpage_image_id"
 			/>
 			<ImageSelectPortal
 				label="Image"
 				hasPreview={ true }
 				target="yoast-og-default-image-select"
 				hiddenField="og_default_image"
+				hiddenFieldImageId="og_default_image_id"
 			/>
 		</Fragment>,
 		element

--- a/js/src/initializers/social-settings.js
+++ b/js/src/initializers/social-settings.js
@@ -14,13 +14,13 @@ export default function initSocialSettings() {
 			<ImageSelectPortal
 				label="Image"
 				hasPreview={ true }
-				target="og-frontpage-image-select"
+				target="yoast-og-frontpage-image-select"
 				hiddenField="og_frontpage_image"
 			/>
 			<ImageSelectPortal
 				label="Image"
 				hasPreview={ true }
-				target="og-default-image-select"
+				target="yoast-og-default-image-select"
 				hiddenField="og_default_image"
 			/>
 		</Fragment>,

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -2,10 +2,12 @@
 import initAdminMedia from "./initializers/admin-media";
 import initAdmin from "./initializers/admin";
 import initSearchAppearance from "./initializers/search-appearance";
+import initSocialSettings from "./initializers/social-settings";
 
 initAdmin( jQuery );
 if ( wpseoScriptData && typeof wpseoScriptData.media !== "undefined" ) {
 	initAdminMedia( jQuery );
+	initSocialSettings();
 }
 if ( wpseoScriptData && typeof wpseoScriptData.searchAppearance !== "undefined" ) {
 	initSearchAppearance();

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -7,8 +7,10 @@ import initSocialSettings from "./initializers/social-settings";
 initAdmin( jQuery );
 if ( wpseoScriptData && typeof wpseoScriptData.media !== "undefined" ) {
 	initAdminMedia( jQuery );
-	initSocialSettings();
 }
 if ( wpseoScriptData && typeof wpseoScriptData.searchAppearance !== "undefined" ) {
 	initSearchAppearance();
+}
+if ( wpseoScriptData && typeof wpseoScriptData.social !== "undefined" ) {
+	initSocialSettings();
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The ImageSelect component features a preview and this PR replaces the old image upload in the metabox and settings pages with the new ImageSelect

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Replaces the image uploads with the new ImageSelect component.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

ImageSelect should look like this:
![afbeelding](https://user-images.githubusercontent.com/12784125/105841293-a91eb700-5fd4-11eb-986a-779ceaf0ccfc.png)


* Test this PR together with the same [branch on the monorepo](https://github.com/Yoast/javascript/pull/1023)
* Check the following pages to see if the new ImageSelect renders like it should 
    * Search Appearance > General > organization image
    * Search Appearance > General > person image
    * Social Settings > Facebook > frontpage
    * Social Settings > Facebook > default image
    * Metabox > Social > Facebook
    * Metabox > Social > Twitter 
* Test the same also on Premium
* Make sure the metaboxes for Facebook and Social do not show an image preview


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P1-297](https://yoast.atlassian.net/browse/P1-297)
