### PR TITLE
Made type definitions added to the container automatically public

### DIFF
--- a/config/dependency-injection/inject-from-registry-pass.php
+++ b/config/dependency-injection/inject-from-registry-pass.php
@@ -122,6 +122,7 @@ class Inject_From_Registry_Pass extends AbstractRecursivePass {
 		}
 
 		$definition = new Definition( $type, [ $other_container_name, $type ] );
+		$definition->setPublic( true );
 		$definition->setFactory( [ Container_Registry::class, 'get' ] );
 		$this->container->setDefinition( $type, $definition );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a not released bug where WordPress SEO Premium would show deprecation warnings when visiting a page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Note**: Though this code is in free, the deprecation warnings only occur in Premium, so this should be tested in Premium.

#### Reproducing the bug
On `release/15.7` / previous RC:
* Make sure you use Premium.
	* E.g. merge this branch into the Premium release branch. 
* Make sure that you have the Query Monitor plugin installed and activated.
* Visit any admin page.
* See deprecation warnings like these inside of the Query Monitor logs:
  ```
  Deprecated (Suppressed)	The "Yoast\WP\SEO\Conditionals\Admin_Conditional" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead.
  ```
  * Note: the amount of deprecation errors and for which services vary based on the admin page you visit.

#### Checking if the bug has been fixed
On this branch / current RC:
* Make sure you use Premium.
	* E.g. merge this branch into the Premium release branch. 	
* Make sure that you have the Query Monitor plugin installed and activated.
* Visit any admin page.
* You should not see any of the deprecation warnings in the QM logs.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
