### PR TITLE
Make wpseo-form class output optional and add ids to Modal buttons

### DIFF
--- a/admin/metabox/class-metabox-section-additional.php
+++ b/admin/metabox/class-metabox-section-additional.php
@@ -46,6 +46,13 @@ class WPSEO_Metabox_Section_Additional implements WPSEO_Metabox_Section {
 	private $link_aria_label;
 
 	/**
+	 * Represents the content class.
+	 *
+	 * @var string
+	 */
+	private $content_class;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $name         The name of the section, used as an identifier in the html.
@@ -60,11 +67,13 @@ class WPSEO_Metabox_Section_Additional implements WPSEO_Metabox_Section {
 		$default_options       = [
 			'link_class'      => '',
 			'link_aria_label' => '',
+			'content_class'   => 'wpseo-form',
 		];
 		$options               = wp_parse_args( $options, $default_options );
 		$this->link_content    = $link_content;
 		$this->link_class      = $options['link_class'];
 		$this->link_aria_label = $options['link_aria_label'];
+		$this->content_class   = $options['content_class'];
 	}
 
 	/**
@@ -89,8 +98,9 @@ class WPSEO_Metabox_Section_Additional implements WPSEO_Metabox_Section {
 	 */
 	public function display_content() {
 		$html  = sprintf(
-			'<div role="tabpanel" id="wpseo-meta-section-%1$s" aria-labelledby="wpseo-meta-tab-%1$s" tabindex="0" class="wpseo-meta-section wpseo-form">',
-			esc_attr( $this->name )
+			'<div role="tabpanel" id="wpseo-meta-section-%1$s" aria-labelledby="wpseo-meta-tab-%1$s" tabindex="0" class="wpseo-meta-section %2$s">',
+			esc_attr( $this->name ),
+			esc_attr( $this->content_class ),
 		);
 		$html .= $this->content;
 		$html .= '</div>';

--- a/admin/metabox/class-metabox-section-additional.php
+++ b/admin/metabox/class-metabox-section-additional.php
@@ -100,7 +100,7 @@ class WPSEO_Metabox_Section_Additional implements WPSEO_Metabox_Section {
 		$html  = sprintf(
 			'<div role="tabpanel" id="wpseo-meta-section-%1$s" aria-labelledby="wpseo-meta-tab-%1$s" tabindex="0" class="wpseo-meta-section %2$s">',
 			esc_attr( $this->name ),
-			esc_attr( $this->content_class ),
+			esc_attr( $this->content_class )
 		);
 		$html .= $this->content;
 		$html .= '</div>';

--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -788,4 +788,11 @@ div.interface-pinned-items button.components-button.is-pressed[aria-label="Yoast
 	mask-image: var(--yoast-svg-icon-chevron-up);
 }
 
+/* FormTokenField ("gutenberg tag selectors") used inside the .yoast metabox will be Yoast purple. */
+.yoast .components-form-token-field__token-text,
+.yoast .components-form-token-field__remove-token.components-button {
+	background-color: var(--yoast-color-primary);
+	color: var(--yoast-color-white);
+}
+
 /*# sourceMappingURL=metabox.css.map */

--- a/js/src/components/SidebarButton.js
+++ b/js/src/components/SidebarButton.js
@@ -12,6 +12,7 @@ const SidebarButton = ( props ) => {
 	return <div className="yoast components-panel__body">
 		<h2 className="components-panel__body-title">
 			<button
+				id={ props.id }
 				onClick={ props.onClick }
 				className="components-button components-panel__body-toggle"
 			>
@@ -35,11 +36,13 @@ export default SidebarButton;
 SidebarButton.propTypes = {
 	onClick: PropTypes.func.isRequired,
 	title: PropTypes.string.isRequired,
+	id: PropTypes.string,
 	subTitle: PropTypes.string,
 	suffixIcon: PropTypes.object,
 };
 
 SidebarButton.defaultProps = {
+	id: "",
 	suffixIcon: null,
 	subTitle: "",
 };

--- a/js/src/components/modals/editorModals/EditorModal.js
+++ b/js/src/components/modals/editorModals/EditorModal.js
@@ -32,7 +32,7 @@ export const isCloseEvent = ( event ) => {
  *
  * @returns {*} A button wrapped in a div.
  */
-const EditorModal = ( { postTypeName, children, title } ) => {
+const EditorModal = ( { id, postTypeName, children, title } ) => {
 	const [ isOpen, changeIsOpen ] = useState( false );
 
 	const closeModal = useCallback( ( event ) => {
@@ -84,6 +84,7 @@ const EditorModal = ( { postTypeName, children, title } ) => {
 				</LocationProvider>
 			) }
 			<SidebarButton
+				id={ id + "-open-button" }
 				title={ title }
 				suffixIcon={ { size: "20px", icon: "pencil-square" } }
 				onClick={ openModal }
@@ -93,6 +94,7 @@ const EditorModal = ( { postTypeName, children, title } ) => {
 };
 
 EditorModal.propTypes = {
+	id: PropTypes.string.isRequired,
 	postTypeName: PropTypes.string.isRequired,
 	children: PropTypes.oneOfType( [ PropTypes.node, PropTypes.arrayOf( PropTypes.node ) ] ).isRequired,
 	title: PropTypes.string.isRequired,

--- a/js/src/components/modals/editorModals/FacebookPreviewModal.js
+++ b/js/src/components/modals/editorModals/FacebookPreviewModal.js
@@ -12,7 +12,10 @@ import FacebookEditor from "../../../containers/FacebookEditor";
  */
 const FacebookPreviewModal = () => {
 	return (
-		<EditorModal title={ __( "Facebook preview", "wordpress-seo" ) }>
+		<EditorModal
+			title={ __( "Facebook preview", "wordpress-seo" ) }
+			id="yoast-facebook-preview-modal"
+		>
 			<FacebookEditor />
 		</EditorModal>
 	);

--- a/js/src/components/modals/editorModals/GooglePreviewModal.js
+++ b/js/src/components/modals/editorModals/GooglePreviewModal.js
@@ -14,6 +14,7 @@ const GooglePreviewModal = () => {
 	return (
 		<EditorModal
 			title={ __( "Google preview", "wordpress-seo" ) }
+			id="yoast-google-preview-modal"
 		>
 			<SnippetEditorWrapper showCloseButton={ false } hasPaperStyle={ false } />
 		</EditorModal>

--- a/js/src/components/modals/editorModals/TwitterPreviewModal.js
+++ b/js/src/components/modals/editorModals/TwitterPreviewModal.js
@@ -14,6 +14,7 @@ const TwitterPreviewModal = () => {
 	return (
 		<EditorModal
 			title={ __( "Twitter preview", "wordpress-seo" ) }
+			id="yoast-twitter-preview-modal"
 		>
 			<TwitterEditor />
 		</EditorModal>

--- a/js/src/elementor/components/modals/editorModals/FacebookPreviewModal.js
+++ b/js/src/elementor/components/modals/editorModals/FacebookPreviewModal.js
@@ -12,7 +12,10 @@ import FacebookEditor from "../../../containers/FacebookEditor";
  */
 const FacebookPreviewModal = () => {
 	return (
-		<EditorModal title={ __( "Facebook preview", "wordpress-seo" ) }>
+		<EditorModal
+			title={ __( "Facebook preview", "wordpress-seo" ) }
+			id="yoast-facebook-preview-modal"
+		>
 			<FacebookEditor />
 		</EditorModal>
 	);

--- a/js/src/elementor/components/modals/editorModals/GooglePreviewModal.js
+++ b/js/src/elementor/components/modals/editorModals/GooglePreviewModal.js
@@ -14,6 +14,7 @@ const GooglePreviewModal = () => {
 	return (
 		<EditorModal
 			title={ __( "Google preview", "wordpress-seo" ) }
+			id="yoast-google-preview-modal"
 		>
 			<SnippetEditorWrapper showCloseButton={ false } hasPaperStyle={ false } />
 		</EditorModal>

--- a/js/src/elementor/components/modals/editorModals/TwitterPreviewModal.js
+++ b/js/src/elementor/components/modals/editorModals/TwitterPreviewModal.js
@@ -14,6 +14,7 @@ const TwitterPreviewModal = () => {
 	return (
 		<EditorModal
 			title={ __( "Twitter preview", "wordpress-seo" ) }
+			id="yoast-twitter-preview-modal"
 		>
 			<TwitterEditor />
 		</EditorModal>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* [We want to "reactify" the Video metabox](https://github.com/Yoast/wpseo-video/pull/860), and this required some changes in Free and the monorepo.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the option to adjust the additional metabox section classnames.
* Adds ids to the Modal buttons in the sidebar.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test together with the [Video PR](https://github.com/Yoast/wpseo-video/pull/860). Follow test instructions there.
* Test without the Video PR, but with the monorepo PR. All should work as normal.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes N/A
