### PR TITLE
Replace deprecated SQL && operators with AND

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -964,7 +964,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 			"
 				 	SELECT *
 				 	FROM {$wpdb->postmeta}
-				 	WHERE post_id IN({$post_ids}) && meta_key = '" . WPSEO_Meta::$meta_prefix . $this->target_db_field . "'
+				 	WHERE post_id IN({$post_ids}) AND meta_key = '" . WPSEO_Meta::$meta_prefix . $this->target_db_field . "'
 				"
 		);
 

--- a/admin/filters/class-cornerstone-filter.php
+++ b/admin/filters/class-cornerstone-filter.php
@@ -121,7 +121,7 @@ class WPSEO_Cornerstone_Filter extends WPSEO_Abstract_Post_Filter {
 				'
 				SELECT COUNT( 1 )
 				FROM ' . $wpdb->postmeta . '
-				WHERE post_id IN( SELECT ID FROM ' . $wpdb->posts . ' WHERE post_type = %s ) &&
+				WHERE post_id IN( SELECT ID FROM ' . $wpdb->posts . ' WHERE post_type = %s ) AND
 				meta_value = "1" AND meta_key = %s
 				',
 				$this->get_current_post_type(),


### PR DESCRIPTION
## Context

* `&&` and `||` are SQL operators that should be avoided due to double usage (in the case of `||`) and [deprecation](https://dev.mysql.com/doc/refman/8.0/en/logical-operators.html#operator_and).

## Summary
This PR can be summarized in the following changelog entry:

* Improves interoperability and consistency in database queries.

## Relevant technical choices:

* Simply replaced SQL `&&` operators with `AND`. This should cause no issues.
* Inspired by https://yoast.atlassian.net/browse/QAK-1440, but that needs fixing in Premium.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In the posts overview; make sure the cornerstoned articles are the same before and after this change.
* In SEO -> Tools -> Bulk editor; make sure that any saved changes are reflected correctly on page reload.


### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Cornerstone content
* Bulk editor in SEO -> Tools

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [*] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
