### PR TITLE
Move opcache reset before autoloading

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -17,6 +17,13 @@ if ( ! function_exists( 'add_filter' ) ) {
  */
 define( 'WPSEO_VERSION', '15.8-RC1' );
 
+// Can't use constants or the options framework here as we need to do this before autoloading.
+$wpseo_option    = get_option( 'wpseo', [ 'version' => '0.0.0' ] );
+$current_version = $wpseo_option['version'];
+if ( version_compare( $current_version, WPSEO_VERSION, '<' ) && function_exists( 'opcache_reset' ) ) {
+	// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Prevent notices when opcache.restrict_api is set.
+	@opcache_reset();
+}
 
 if ( ! defined( 'WPSEO_PATH' ) ) {
 	define( 'WPSEO_PATH', plugin_dir_path( WPSEO_FILE ) );
@@ -295,11 +302,6 @@ function wpseo_init() {
 	WPSEO_Meta::init();
 
 	if ( version_compare( WPSEO_Options::get( 'version', 1 ), WPSEO_VERSION, '<' ) ) {
-		if ( function_exists( 'opcache_reset' ) ) {
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Prevent notices when opcache.restrict_api is set.
-			@opcache_reset();
-		}
-
 		new WPSEO_Upgrade();
 		// Get a cleaned up version of the $options.
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Currently opcache reset is called after the `autoload.php` is required and several classes have already been loaded. This means it won't be reset for those classes. Call it earlier should prevent issues such as https://yoast.atlassian.net/browse/QAK-2616
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves resetting opcache to prevent rare fatal errors when upgrading the plugin.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have not been able to reproduce https://yoast.atlassian.net/browse/QAK-2616 myself but ideally that should be the way to test this.
* At the very least it should be tested that the `if` block is entered on version upgrades ( for example by adding a touch, https://www.php.net/manual/en/function.touch.php, statement and seeing if the file is created ).


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The opcache reset is moved from being one of the first things we do to being the first thing we do.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/QAK-2616
