### PR TITLE
Added pagination support for WooCommerce shop pages.

### DIFF
--- a/src/integrations/third-party/woocommerce.php
+++ b/src/integrations/third-party/woocommerce.php
@@ -6,6 +6,7 @@ use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Pagination_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Models\Indexable;
@@ -46,6 +47,13 @@ class WooCommerce implements Integration_Interface {
 	private $repository;
 
 	/**
+	 * The pagination helper.
+	 *
+	 * @var Pagination_Helper
+	 */
+	protected $pagination_helper;
+
+	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
 	 * @return array
@@ -57,21 +65,24 @@ class WooCommerce implements Integration_Interface {
 	/**
 	 * WooCommerce constructor.
 	 *
-	 * @param Options_Helper             $options          The options helper.
-	 * @param WPSEO_Replace_Vars         $replace_vars     The replace vars helper.
-	 * @param Meta_Tags_Context_Memoizer $context_memoizer The meta tags context memoizer.
-	 * @param Indexable_Repository       $repository       The indexable repository.
+	 * @param Options_Helper             $options           The options helper.
+	 * @param WPSEO_Replace_Vars         $replace_vars      The replace vars helper.
+	 * @param Meta_Tags_Context_Memoizer $context_memoizer  The meta tags context memoizer.
+	 * @param Indexable_Repository       $repository        The indexable repository.
+	 * @param Pagination_Helper          $pagination_helper The paginataion helper.
 	 */
 	public function __construct(
 		Options_Helper $options,
 		WPSEO_Replace_Vars $replace_vars,
 		Meta_Tags_Context_Memoizer $context_memoizer,
-		Indexable_Repository $repository
+		Indexable_Repository $repository,
+		Pagination_Helper $pagination_helper
 	) {
-		$this->options          = $options;
-		$this->replace_vars     = $replace_vars;
-		$this->context_memoizer = $context_memoizer;
-		$this->repository       = $repository;
+		$this->options           = $options;
+		$this->replace_vars      = $replace_vars;
+		$this->context_memoizer  = $context_memoizer;
+		$this->repository        = $repository;
+		$this->pagination_helper = $pagination_helper;
 	}
 
 	/**
@@ -83,9 +94,40 @@ class WooCommerce implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_filter( 'wpseo_frontend_page_type_simple_page_id', [ $this, 'get_page_id' ] );
+		\add_filter( 'wpseo_breadcrumb_indexables', [ $this, 'add_shop_to_breadcrumbs' ] );
+
 		\add_filter( 'wpseo_title', [ $this, 'title' ], 10, 2 );
 		\add_filter( 'wpseo_metadesc', [ $this, 'description' ], 10, 2 );
-		\add_filter( 'wpseo_breadcrumb_indexables', [ $this, 'add_shop_to_breadcrumbs' ] );
+		\add_filter( 'wpseo_canonical', [ $this, 'canonical' ], 10, 2 );
+		\add_filter( 'wpseo_opengraph_url', [ $this, 'canonical' ], 10, 2 );
+	}
+
+	/**
+	 * Returns the correct canonical when WooCommerces is enabled.
+	 *
+	 * @param string                      $canonical    The current canonical.
+	 * @param Indexable_Presentation|null $presentation The indexable presentation.
+	 *
+	 * @return string The correct canonical.
+	 */
+	public function canonical( $canonical, $presentation = null ) {
+		if ( ! $this->is_shop_page() ) {
+			return $canonical;
+		}
+
+		$presentation = $this->ensure_presentation( $presentation );
+
+		$permalink = $presentation->get_permalink();
+		if ( ! $permalink ) {
+			return '';
+		}
+
+		$current_page = $this->pagination_helper->get_current_archive_page_number();
+		if ( $current_page > 1 ) {
+			return $this->pagination_helper->get_paginated_url( $permalink, $current_page );
+		}
+
+		return $permalink;
 	}
 
 	/**
@@ -237,7 +279,7 @@ class WooCommerce implements Integration_Interface {
 	 */
 	protected function get_shop_page_id() {
 		if ( ! \function_exists( 'wc_get_page_id' ) ) {
-			return -1;
+			return - 1;
 		}
 
 		return \wc_get_page_id( 'shop' );

--- a/src/integrations/third-party/woocommerce.php
+++ b/src/integrations/third-party/woocommerce.php
@@ -99,7 +99,6 @@ class WooCommerce implements Integration_Interface {
 		\add_filter( 'wpseo_title', [ $this, 'title' ], 10, 2 );
 		\add_filter( 'wpseo_metadesc', [ $this, 'description' ], 10, 2 );
 		\add_filter( 'wpseo_canonical', [ $this, 'canonical' ], 10, 2 );
-		\add_filter( 'wpseo_opengraph_url', [ $this, 'canonical' ], 10, 2 );
 	}
 
 	/**

--- a/src/integrations/third-party/woocommerce.php
+++ b/src/integrations/third-party/woocommerce.php
@@ -119,7 +119,7 @@ class WooCommerce implements Integration_Interface {
 
 		$permalink = $presentation->get_permalink();
 		if ( ! $permalink ) {
-			return '';
+			return $canonical;
 		}
 
 		$current_page = $this->pagination_helper->get_current_archive_page_number();

--- a/tests/unit/inc/sitemaps/sitemaps-admin-test.php
+++ b/tests/unit/inc/sitemaps/sitemaps-admin-test.php
@@ -111,9 +111,18 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
+		$start = \time();
+
 		Monkey\Functions\expect( 'wp_schedule_single_event' )
 			->once()
-			->with( ( \time() + 300 ), 'wpseo_ping_search_engines' );
+			->withArgs(
+				function( $timestamp, $function_name ) use ( $start ) {
+					if ( $function_name === 'wpseo_ping_search_engines' ) {
+						return ( $timestamp < $start + 600 );
+					}
+					return false;
+				}
+			);
 
 		$this->instance->status_transition( 'publish', 'draft', $this->mock_post );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where paginated WooCommerce shop pages did not have the right canonical.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure that you have a WooCommerce shop with more than 12 products.
	* This ensures that you have a paginated shop.	
* Go to page 2 (or higher) of your paginated shop.
	* E.g. https://woocommerce.wordpress.test/shop/page/2
* Inspect the page's source code.
* The source code should contain a canonical link with the same link as the page.
	* E.g.    
	```html
	<link rel="canonical" href="http://woocommerce.wordpress.test/shop/page/2/">
	```	

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
