### PR TITLE
P3-349 Fix light switch toggle disabled style.

### DIFF
--- a/css/src/toggle-switch.css
+++ b/css/src/toggle-switch.css
@@ -64,10 +64,10 @@
 		/* Override core style. */
 	}
 
-	.switch-light input[type=radio].disabled,
-	.switch-light input[type=radio].disabled:checked:before,
-	.switch-light input[type=radio]:disabled,
-	.switch-light input[type=radio]:disabled:checked:before {
+	.switch-light input[type="checkbox"].disabled,
+	.switch-light input[type="checkbox"].disabled:checked:before,
+	.switch-light input[type="checkbox"]:disabled,
+	.switch-light input[type="checkbox"]:disabled:checked:before {
 		opacity: 0;
 	}
 
@@ -117,10 +117,10 @@
 		/* Override core style. */
 	}
 
-	.switch-toggle input[type=radio].disabled,
-	.switch-toggle input[type=radio].disabled:checked:before,
-	.switch-toggle input[type=radio]:disabled,
-	.switch-toggle input[type=radio]:disabled:checked:before {
+	.switch-toggle input[type="radio"].disabled,
+	.switch-toggle input[type="radio"].disabled:checked:before,
+	.switch-toggle input[type="radio"]:disabled,
+	.switch-toggle input[type="radio"]:disabled:checked:before {
 		opacity: 0;
 	}
 
@@ -328,7 +328,9 @@
 	.switch-toggle.switch-yoast-seo input:disabled + a,
 	.switch-toggle.switch-yoast-seo input:disabled ~ a,
 	.switch-light.switch-yoast-seo input.disabled + span a,
-	.switch-light.switch-yoast-seo input:disabled + span a {
+	.switch-light.switch-yoast-seo input:disabled + span a,
+	.switch-light.switch-yoast-seo input.disabled:checked + span a,
+	.switch-light.switch-yoast-seo input:disabled:checked + span a {
 		background: #9b9b9b;
 		border: 0;
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We need to fix the disabled style for the switch toggles.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the disabled style of the switch toggles didn't look right.

## Relevant technical choices:

* Note: this emerged in the ongoing work on Local SEO where some toggles may be disabled even when the underlying option is set to "enabled"

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* activate Yoast SEO switched to this branch (build it, of course)
* activate Local SEO switched to the `P3-329-new-toggle-shared-opening-hours` branch (build it, of course)
* go to SEO > Local SEO > Opening hours
* set "Locations inherit shared opening hours" to Yes
* set "Open 24/7" to No
* set "I have two sets of opening hours per day" to Yes
* set "Locations inherit shared opening hours" back to No
* at this point, "Open 24/7" is disabled on the position No, and "I have two sets of opening hours per day" is disabled on the position Yes
* check the "knob" of  both toggles isn't purple any longer and it's grey instead
* check both toggles have some CSS opacity
* check there are no glitches e.g. the underlying checkbox should stay hidden

Screenshot before (notice the underlying checkbox was showing up);

<img width="441" alt="before" src="https://user-images.githubusercontent.com/1682452/106254615-34888a00-6219-11eb-9ef7-e3418d6ac354.png">

Screenshot after:

<img width="440" alt="after" src="https://user-images.githubusercontent.com/1682452/106254640-3ce0c500-6219-11eb-95bc-eb390d2400c9.png">


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* This can be tested with a Local SEO 13.9 RC in combination with a Yoast SEO 15.9 RC.
* Activate Yoast SEO and Local SEO.
* Go to SEO > Local SEO > Opening hours.
* Play with the toggles and set them to the same positions as described above.
* Check that the disabled style looks okay for both cases: when the "knob" is on the left and when it's on the right.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-349]
