### PR TITLE
Fix static class map in custom loader

### DIFF
--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -24,6 +24,13 @@ class Custom_Loader extends PhpFileLoader {
 	private $class_map_path;
 
 	/**
+	 * The class map.
+	 *
+	 * @var array
+	 */
+	private $class_map;
+
+	/**
 	 * Custom_Loader constructor.
 	 *
 	 * @param ContainerBuilder $container      The ContainerBuilder to load classes for.
@@ -42,16 +49,14 @@ class Custom_Loader extends PhpFileLoader {
 	 * @return bool|string The classname.
 	 */
 	private function getClassFromClassMap( $path ) {
-		static $class_map;
-
-		if ( ! $class_map ) {
-			$class_map = require $this->class_map_path;
-			$class_map = \array_map( [ $this, 'normalize_slashes' ], $class_map );
-			$class_map = \array_flip( $class_map );
+		if ( ! $this->class_map ) {
+			$this->class_map = require $this->class_map_path;
+			$this->class_map = \array_map( [ $this, 'normalize_slashes' ], $this->class_map );
+			$this->class_map = \array_flip( $this->class_map );
 		}
 
-		if ( isset( $class_map[ $path ] ) ) {
-			return $class_map[ $path ];
+		if ( isset( $this->class_map[ $path ] ) ) {
+			return $this->class_map[ $path ];
 		}
 
 		return false;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* If two containers are compiled in the same request, such as when an addon is deactivated or activates during development then the second compile will fail due to the class map being static and thus reused between both compilations.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a fatal that would occur in development versions of the plugin when activating or deactivating one of our addons.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you're running a git clone of the repo.
* Deactivate an addon.
* There should be no fatals.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* This does not affect production builds.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Development versions of the plugin.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
