### PR TITLE
P1-361 Add redux flow and self-contained implementation for the modals

### DIFF
--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -107,6 +107,7 @@ ul.wpseo-metabox-tabs li.active {
 }
 
 .wpseo-metabox-menu {
+  max-width: 600px;
   padding: 0;
   background-color: #fff;
 }

--- a/js/src/components/modals/editorModals/EditorModal.js
+++ b/js/src/components/modals/editorModals/EditorModal.js
@@ -1,5 +1,5 @@
 import { __, sprintf } from "@wordpress/i18n";
-import { useState, useCallback, Fragment } from "@wordpress/element";
+import { useCallback, Fragment } from "@wordpress/element";
 import Modal from "../Modal";
 import PropTypes from "prop-types";
 import SidebarButton from "../../SidebarButton";
@@ -32,26 +32,23 @@ export const isCloseEvent = ( event ) => {
  *
  * @returns {*} A button wrapped in a div.
  */
-const EditorModal = ( { id, postTypeName, children, title } ) => {
-	const [ isOpen, changeIsOpen ] = useState( false );
-
-	const closeModal = useCallback( ( event ) => {
+const EditorModal = ( { id, postTypeName, children, title, isOpen, close, open } ) => {
+	const requestClose = useCallback( ( event ) => {
 		// Prevent the modal from closing when the event is a false positive.
 		if ( ! isCloseEvent( event ) ) {
 			return;
 		}
 
-		changeIsOpen( false );
-	}, [] );
-	const openModal = useCallback( () => changeIsOpen( true ), [] );
+		close();
+	}, [ close ] );
 
 	return (
 		<Fragment>
-			{ isOpen && (
+			{ isOpen &&
 				<LocationProvider value="modal">
 					<Modal
 						title={ title }
-						onRequestClose={ closeModal }
+						onRequestClose={ requestClose }
 						additionalClassName="yoast-collapsible-modal yoast-post-settings-modal"
 					>
 						<div className="yoast-content-container">
@@ -71,7 +68,7 @@ const EditorModal = ( { id, postTypeName, children, title } ) => {
 								<button
 									className="yoast-button yoast-button--primary yoast-button--post-settings-modal"
 									type="button"
-									onClick={ closeModal }
+									onClick={ requestClose }
 								>
 									{
 										/* Translators: %s translates to the Post Label in singular form */
@@ -82,12 +79,12 @@ const EditorModal = ( { id, postTypeName, children, title } ) => {
 						</div>
 					</Modal>
 				</LocationProvider>
-			) }
+			}
 			<SidebarButton
 				id={ id + "-open-button" }
 				title={ title }
 				suffixIcon={ { size: "20px", icon: "pencil-square" } }
-				onClick={ openModal }
+				onClick={ open }
 			/>
 		</Fragment>
 	);
@@ -98,6 +95,9 @@ EditorModal.propTypes = {
 	postTypeName: PropTypes.string.isRequired,
 	children: PropTypes.oneOfType( [ PropTypes.node, PropTypes.arrayOf( PropTypes.node ) ] ).isRequired,
 	title: PropTypes.string.isRequired,
+	isOpen: PropTypes.bool.isRequired,
+	open: PropTypes.func.isRequired,
+	close: PropTypes.func.isRequired,
 };
 
 export default EditorModal;

--- a/js/src/containers/EditorModal.js
+++ b/js/src/containers/EditorModal.js
@@ -1,12 +1,30 @@
-import { withSelect } from "@wordpress/data";
+/* External dependencies */
+import { compose } from "@wordpress/compose";
+import { withDispatch, withSelect } from "@wordpress/data";
+
 import EditorModal from "../components/modals/editorModals/EditorModal";
 
-export default withSelect( select => {
-	const {
-		getPostOrPageString,
-	} = select( "yoast-seo/editor" );
+export default compose( [
+	withSelect( ( select, ownProps ) => {
+		const {
+			getPostOrPageString,
+			getIsModalOpen,
+		} = select( "yoast-seo/editor" );
 
-	return {
-		postTypeName: getPostOrPageString(),
-	};
-} )( EditorModal );
+		return {
+			postTypeName: getPostOrPageString(),
+			isOpen: getIsModalOpen( ownProps.id ),
+		};
+	} ),
+	withDispatch( ( dispatch, ownProps ) => {
+		const {
+			openEditorModal,
+			closeEditorModal,
+		} = dispatch( "yoast-seo/editor" );
+
+		return {
+			open: () => openEditorModal( ownProps.id ),
+			close: closeEditorModal,
+		};
+	} ),
+] )( EditorModal );

--- a/js/src/redux/actions/editorModals.js
+++ b/js/src/redux/actions/editorModals.js
@@ -1,0 +1,27 @@
+export const OPEN_EDITOR_MODAL = "OPEN_MODAL";
+export const CLOSE_EDITOR_MODAL = "CLOSE_MODAL";
+
+/**
+ * Opens a modal by setting its key in the store.
+ *
+ * @param {string} modalKey The key that identifies the modal that should be opened.
+ *
+ * @returns {Object} The OPEN_EDITOR_MODAL action.
+ */
+export function openEditorModal( modalKey ) {
+	return {
+		type: OPEN_EDITOR_MODAL,
+		modalKey,
+	};
+}
+
+/**
+ * Closes any editor modal.
+ *
+ * @returns {Object} The CLOSE_EDITOR_MODAL action.
+ */
+export function closeEditorModal() {
+	return {
+		type: CLOSE_EDITOR_MODAL,
+	};
+}

--- a/js/src/redux/actions/index.js
+++ b/js/src/redux/actions/index.js
@@ -9,6 +9,7 @@ export * from "./advancedSettings";
 export * from "./analysis";
 export * from "./cornerstoneContent";
 export * from "./editorData";
+export * from "./editorModals";
 export * from "./estimatedReadingTime";
 export * from "./focusKeyword";
 export * from "./markerButtons";

--- a/js/src/redux/reducers/editorContext.js
+++ b/js/src/redux/reducers/editorContext.js
@@ -1,3 +1,5 @@
+import { get } from "lodash";
+
 /**
  * Gets the default state.
  *
@@ -5,12 +7,13 @@
  */
 function getDefaultState() {
 	return {
-		contentLocale: window.wpseoScriptData.metabox.contentLocale,
-		isPost: window.wpseoScriptData.hasOwnProperty( "isPost" ),
-		isTerm: window.wpseoScriptData.hasOwnProperty( "isTerm" ),
-		noIndex: window.wpseoAdminL10n.noIndex === "1",
-		postTypeNameSingular: window.wpseoAdminL10n.postTypeNameSingular,
-		postTypeNamePlural: window.wpseoAdminL10n.postTypeNamePlural,
+		contentLocale: get( window, "wpseoScriptData.metabox.contentLocale", "" ),
+		isBlockEditor: get( window, "wpseoScriptData.isBlockEditor", "0" ) === "1",
+		isPost: get( window, "wpseoScriptData", {} ).hasOwnProperty( "isPost" ),
+		isTerm: get( window, "wpseoScriptData", {} ).hasOwnProperty( "isTerm" ),
+		noIndex: get( window, "wpseoAdminL10n.noIndex", "0" ) === "1",
+		postTypeNameSingular: get( window, "wpseoAdminL10n.postTypeNameSingular", "" ),
+		postTypeNamePlural: get( window, "wpseoAdminL10n.postTypeNamePlural", "" ),
 	};
 }
 

--- a/js/src/redux/reducers/editorModals.js
+++ b/js/src/redux/reducers/editorModals.js
@@ -1,0 +1,31 @@
+import { OPEN_EDITOR_MODAL, CLOSE_EDITOR_MODAL } from "../actions";
+
+const INITIAL_STATE = {
+	openedModal: "",
+};
+
+/**
+ * Reduces the dispatched action for the snippet editor state.
+ *
+ * @param {Object} state The current state.
+ * @param {Object} action The action that was just dispatched.
+ *
+ * @returns {Object} The new state.
+ */
+function editorModalsReducer( state = INITIAL_STATE, action ) {
+	switch ( action.type ) {
+		case OPEN_EDITOR_MODAL:
+			return {
+				...state,
+				openedModal: action.modalKey,
+			};
+		case CLOSE_EDITOR_MODAL:
+			return {
+				...state,
+				openedModal: "",
+			};
+	}
+	return state;
+}
+
+export default editorModalsReducer;

--- a/js/src/redux/reducers/index.js
+++ b/js/src/redux/reducers/index.js
@@ -4,6 +4,7 @@ import { analysis } from "yoast-components";
 import analysisData from "./analysisData";
 import editorContext from "./editorContext";
 import editorData from "./editorData";
+import editorModals from "./editorModals";
 import estimatedReadingTime from "./estimatedReadingTime";
 import facebookEditor from "./facebookEditor";
 import focusKeyword from "./focusKeyword";
@@ -28,6 +29,7 @@ export default {
 	analysisData,
 	editorContext,
 	editorData,
+	editorModals,
 	estimatedReadingTime,
 	facebookEditor,
 	focusKeyword,

--- a/js/src/redux/selectors/editorContext.js
+++ b/js/src/redux/selectors/editorContext.js
@@ -23,6 +23,17 @@ export function getPostOrPageString( state ) {
 }
 
 /**
+ * Returns whether this is the block editor or not.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {Boolean} Whether this is a page or a post editor.
+ */
+export function getIsBlockEditor( state ) {
+	return get( state, "editorContext.isBlockEditor", false );
+}
+
+/**
  * Gets the content locale.
  *
  * @param {Object} state The state.

--- a/js/src/redux/selectors/editorModals.js
+++ b/js/src/redux/selectors/editorModals.js
@@ -1,0 +1,10 @@
+import { get } from "lodash";
+
+/** Returns true if the modalKey is in openedModal, false otherwise.
+ *
+ * @param {Object} state The state.
+ * @param {Object} modalKey The key for the modal to check opened state for.
+ *
+ * @returns {Boolean} Whether or not the modal is open.
+ */
+export const getIsModalOpen = ( state, modalKey ) => get( state, "editorModals.openedModal", "" ) === modalKey;

--- a/js/src/redux/selectors/index.js
+++ b/js/src/redux/selectors/index.js
@@ -3,6 +3,7 @@ export * from "./analysis";
 export * from "./cornerstoneContent";
 export * from "./editorContext";
 export * from "./editorData";
+export * from "./editorModals";
 export * from "./estimatedReadingTime";
 export * from "./facebookEditor";
 export * from "./fallbacks";


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Needed for [P1-361 in Video](https://github.com/Yoast/wpseo-video/pull/867).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds actions and selectors that can be used to open and close the editor modals.

## Relevant technical choices:

* Needed for [P1-361 in Video](https://github.com/Yoast/wpseo-video/pull/867).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Should be mainly tested together with the [Video PR](https://github.com/Yoast/wpseo-video/pull/867), but on it's own, these are the changes you should test.
* *In the block-editor:*
	* Make sure all modals in the Sidebar can still be opened and closed. Without new console errors.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-361
