### PR TITLE
P3-353 Refactor the light switch toggle by introducing a presenter

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -5,6 +5,8 @@
  * @package WPSEO\Admin
  */
 
+use Yoast\WP\SEO\Presenters\Admin\Light_Switch_Presenter;
+
 /**
  * Admin form class.
  *
@@ -357,17 +359,19 @@ class Yoast_Form {
 
 		$disabled_attribute = $this->get_disabled_attribute( $var, $attr );
 
-		echo '<div class="switch-container', $help_class, '">',
-		'<span class="switch-light-visual-label' . $strong_class . '" id="', esc_attr( $var . '-label' ), '">', esc_html( $label ), '</span>' . $help,
-		'<label class="', $class, '"><b class="switch-yoast-seo-jaws-a11y">&nbsp;</b>',
-		// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: $disabled_attribute output is hardcoded and all other output is properly escaped.
-		'<input type="checkbox" aria-labelledby="', esc_attr( $var . '-label' ), '" id="', esc_attr( $var ), '" name="', esc_attr( $this->option_name ), '[', esc_attr( $var ), ']" value="on"', checked( $val, 'on', false ), $disabled_attribute, '/>',
-		'<span aria-hidden="true">
-			<span>', esc_html( $off_button ), '</span>
-			<span>', esc_html( $on_button ), '</span>
-			<a></a>
-		 </span>
-		 </label><div class="clear"></div></div>';
+		echo new Light_Switch_Presenter(
+			$var,
+			$label,
+			$off_button,
+			$on_button,
+			$this->option_name,
+			$val,
+			$disabled_attribute,
+			$class,
+			$help,
+			$help_class,
+			$strong_class
+		);
 	}
 
 	/**

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -322,10 +322,10 @@ class Yoast_Form {
 	 * @since 3.1
 	 *
 	 * @param string $var     The variable within the option to create the checkbox for.
-	 * @param string $label   The label element text for the checkbox.
+	 * @param string $label   The visual label text for the toggle.
 	 * @param array  $buttons Array of two visual labels for the buttons (defaults Disabled/Enabled).
 	 * @param bool   $reverse Reverse order of buttons (default true).
-	 * @param string $help    Inline Help that will be printed out before the visible toggles text.
+	 * @param string $help    Inline Help that will be printed out before the toggle.
 	 * @param bool   $strong  Whether the visual label is displayed in strong text. Default is false.
 	 * @param array  $attr    Extra attributes to add to the light switch.
 	 */
@@ -341,37 +341,22 @@ class Yoast_Form {
 			$val = 'on';
 		}
 
-		$class = 'switch-light switch-candy switch-yoast-seo';
-
-		if ( $reverse ) {
-			$class .= ' switch-yoast-seo-reverse';
-		}
-
-		if ( empty( $buttons ) ) {
-			$buttons = [ __( 'Disabled', 'wordpress-seo' ), __( 'Enabled', 'wordpress-seo' ) ];
-		}
-
-		list( $off_button, $on_button ) = $buttons;
-
-		$help_class = ! empty( $help ) ? ' switch-container__has-help' : '';
-
-		$strong_class = ( $strong ) ? ' switch-light-visual-label__strong' : '';
-
 		$disabled_attribute = $this->get_disabled_attribute( $var, $attr );
 
-		echo new Light_Switch_Presenter(
+		$output = new Light_Switch_Presenter(
 			$var,
 			$label,
-			$off_button,
-			$on_button,
-			$this->option_name,
+			$buttons,
+			$this->option_name . '[' . $var . ']',
 			$val,
-			$disabled_attribute,
-			$class,
+			$reverse,
 			$help,
-			$help_class,
-			$strong_class
+			$strong,
+			$disabled_attribute
 		);
+
+		// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: All output is properly escaped or hardcoded in the presenter.
+		echo $output;
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=352",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=348",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=227",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/presenters/admin/light-switch-presenter.php
+++ b/src/presenters/admin/light-switch-presenter.php
@@ -112,7 +112,7 @@ class Light_Switch_Presenter extends Abstract_Presenter {
 	/**
 	 * Presents the light switch toggle.
 	 *
-	 * @return string The list item HTML.
+	 * @return string The light switch's HTML.
 	 */
 	public function present() {
 		if ( empty( $this->buttons ) ) {

--- a/src/presenters/admin/light-switch-presenter.php
+++ b/src/presenters/admin/light-switch-presenter.php
@@ -12,51 +12,101 @@ use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 class Light_Switch_Presenter extends Abstract_Presenter {
 
 	/**
-	 * The short link helper.
+	 * The variable to create the checkbox for.
 	 *
 	 * @var string
 	 */
 	protected $var;
 
 	/**
+	 * The visual label text for the toggle.
+	 *
+	 * @var string
+	 */
+	protected $label;
+
+	/**
+	 * Array of two visual labels for the buttons.
+	 *
+	 * @var array
+	 */
+	protected $buttons;
+
+	/**
+	 * The name of the underlying checkbox.
+	 *
+	 * @var string
+	 */
+	protected $name;
+
+	/**
+	 * The variable current value.
+	 *
+	 * @var string|bool
+	 */
+	protected $value;
+
+	/**
+	 * Reverse order of buttons.
+	 *
+	 * @var bool
+	 */
+	protected $reverse;
+
+	/**
+	 * The inline Help HTML.
+	 *
+	 * @var string
+	 */
+	protected $help;
+
+	/**
+	 * Whether the visual label is displayed in strong text.
+	 *
+	 * @var bool
+	 */
+	protected $strong;
+
+	/**
+	 * The disabled attribute HTML.
+	 *
+	 * @var string
+	 */
+	protected $disabled_attribute;
+
+	/**
 	 * Light_Switch_Presenter constructor.
 	 *
 	 * @param string      $var                The variable to create the checkbox for.
-	 * @param string      $label              The label element text for the checkbox.
-	 * @param string      $off_button         Visual label for the "off" button (defaults to Disabled).
-	 * @param string      $on_button          Visual label for the "on" button (defaults to Enabled).
-	 * @param string      $name               The name of the toggle underlying option.
-	 * @param string|bool $val                Value to determine the checked attribute.
-	 * @param bool        $disabled_attribute Whether the toggle is disabled.
-	 * @param string      $class              The CSS class for the toggle.
-	 * @param string      $help               Inline Help that will be printed out before the visible toggle text.
-	 * @param string      $help_class         The CSS class for the help.
-	 * @param bool        $strong_class       Whether the visual label is displayed in strong text. Default is false.
+	 * @param string      $label              The visual label text for the toggle.
+	 * @param array       $buttons            Array of two visual labels for the buttons (defaults Disabled/Enabled).
+	 * @param string      $name               The name of the underlying checkbox.
+	 * @param string|bool $value              The variable current value, to determine the checked attribute.
+	 * @param bool        $reverse            Optional. Reverse order of buttons (default true).
+	 * @param string      $help               Optional. Inline Help HTML that will be printed out before the toggle. Default is empty.
+	 * @param bool        $strong             Optional. Whether the visual label is displayed in strong text. Default is false.
+	 * @param string      $disabled_attribute Optional. The disabled HTML attribute. Default is empty.
 	 */
 	public function __construct(
 		$var,
 		$label,
-		$off_button,
-		$on_button,
+		$buttons,
 		$name,
-		$val,
-		$disabled_attribute,
-		$class,
-		$help,
-		$help_class,
-		$strong_class
+		$value,
+		$reverse = true,
+		$help = '',
+		$strong = false,
+		$disabled_attribute = ''
 	) {
 		$this->var                = $var;
 		$this->label              = $label;
-		$this->off_button         = $off_button;
-		$this->on_button          = $on_button;
+		$this->buttons            = $buttons;
 		$this->name               = $name;
-		$this->val                = $val;
-		$this->disabled_attribute = $disabled_attribute;
-		$this->class              = $class;
+		$this->value              = $value;
+		$this->reverse            = $reverse;
 		$this->help               = $help;
-		$this->help_class         = $help_class;
-		$this->strong_class       = $strong_class;
+		$this->strong             = $strong;
+		$this->disabled_attribute = $disabled_attribute;
 	}
 
 	/**
@@ -65,14 +115,41 @@ class Light_Switch_Presenter extends Abstract_Presenter {
 	 * @return string The list item HTML.
 	 */
 	public function present() {
-		$output  = '<div class="switch-container' . $this->help_class . '">';
-		$output .= '<span class="switch-light-visual-label' . $this->strong_class . '" id="' . esc_attr( $this->var . '-label' ) . '">' . esc_html( $this->label ) . '</span>' . $this->help;
-		$output .= '<label class="' . $this->class . '"><b class="switch-yoast-seo-jaws-a11y">&nbsp;</b>';
-		// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: $disabled_attribute output is hardcoded and all other output is properly escaped.
-		$output .= '<input type="checkbox" aria-labelledby="' . esc_attr( $this->var . '-label' ) . '" id="' . esc_attr( $this->var ) . '" name="' . esc_attr( $this->name ) . '[' . esc_attr( $this->var ) . ']" value="on"' . checked( $this->val, 'on', false ) . $this->disabled_attribute . '/>';
+		if ( empty( $this->buttons ) ) {
+			$this->buttons = [ __( 'Disabled', 'wordpress-seo' ), __( 'Enabled', 'wordpress-seo' ) ];
+		}
+
+		list( $off_button, $on_button ) = $this->buttons;
+
+		$class = 'switch-light switch-candy switch-yoast-seo';
+
+		if ( $this->reverse ) {
+			$class .= ' switch-yoast-seo-reverse';
+		}
+
+		$help_class   = ! empty( $this->help ) ? ' switch-container__has-help' : '';
+		$strong_class = ( $this->strong ) ? ' switch-light-visual-label__strong' : '';
+
+		$output  = '<div class="switch-container' . $help_class . '">';
+		$output .= sprintf(
+			'<span class="switch-light-visual-label%1$s" id="%2$s">%3$s</span>%4$s',
+			$strong_class, // phpcs:ignore WordPress.Security.EscapeOutput -- Reason: $strong_class output is hardcoded.
+			\esc_attr( $this->var . '-label' ),
+			\esc_html( $this->label ),
+			$this->help // phpcs:ignore WordPress.Security.EscapeOutput -- Reason: The help contains HTML.
+		);
+		$output .= '<label class="' . $class . '"><b class="switch-yoast-seo-jaws-a11y">&nbsp;</b>';
+		$output .= sprintf(
+			'<input type="checkbox" aria-labelledby="%1$s" id="%2$s" name="%3$s" value="on"%4$s%5$s/>',
+			\esc_attr( $this->var . '-label' ),
+			\esc_attr( $this->var ),
+			\esc_attr( $this->name ),
+			\checked( $this->value, 'on', false ), // phpcs:ignore WordPress.Security.EscapeOutput -- Reason: The output is hardcoded by WordPress.
+			$this->disabled_attribute // phpcs:ignore WordPress.Security.EscapeOutput -- Reason: $disabled_attribute output is hardcoded.
+		);
 		$output .= '<span aria-hidden="true">';
-		$output .= '<span>' . esc_html( $this->off_button ) . '</span>';
-		$output .= '<span>' . esc_html( $this->on_button ) . '</span>';
+		$output .= '<span>' . \esc_html( $off_button ) . '</span>';
+		$output .= '<span>' . \esc_html( $on_button ) . '</span>';
 		$output .= '<a></a>';
 		$output .= '</span></label><div class="clear"></div></div>';
 

--- a/src/presenters/admin/light-switch-presenter.php
+++ b/src/presenters/admin/light-switch-presenter.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Yoast\WP\SEO\Presenters\Admin;
+
+use Yoast\WP\SEO\Presenters\Abstract_Presenter;
+
+/**
+ * Class Light_Switch_Presenter.
+ *
+ * @package Yoast\WP\SEO\Presenters\Admin
+ */
+class Light_Switch_Presenter extends Abstract_Presenter {
+
+	/**
+	 * The short link helper.
+	 *
+	 * @var string
+	 */
+	protected $var;
+
+	/**
+	 * Light_Switch_Presenter constructor.
+	 *
+	 * @param string      $var                The variable to create the checkbox for.
+	 * @param string      $label              The label element text for the checkbox.
+	 * @param string      $off_button         Visual label for the "off" button (defaults to Disabled).
+	 * @param string      $on_button          Visual label for the "on" button (defaults to Enabled).
+	 * @param string      $name               The name of the toggle underlying option.
+	 * @param string|bool $val                Value to determine the checked attribute.
+	 * @param bool        $disabled_attribute Whether the toggle is disabled.
+	 * @param string      $class              The CSS class for the toggle.
+	 * @param string      $help               Inline Help that will be printed out before the visible toggle text.
+	 * @param string      $help_class         The CSS class for the help.
+	 * @param bool        $strong_class       Whether the visual label is displayed in strong text. Default is false.
+	 */
+	public function __construct(
+		$var,
+		$label,
+		$off_button,
+		$on_button,
+		$name,
+		$val,
+		$disabled_attribute,
+		$class,
+		$help,
+		$help_class,
+		$strong_class
+	) {
+		$this->var                = $var;
+		$this->label              = $label;
+		$this->off_button         = $off_button;
+		$this->on_button          = $on_button;
+		$this->name               = $name;
+		$this->val                = $val;
+		$this->disabled_attribute = $disabled_attribute;
+		$this->class              = $class;
+		$this->help               = $help;
+		$this->help_class         = $help_class;
+		$this->strong_class       = $strong_class;
+	}
+
+	/**
+	 * Presents the light switch toggle.
+	 *
+	 * @return string The list item HTML.
+	 */
+	public function present() {
+		$output  = '<div class="switch-container' . $this->help_class . '">';
+		$output .= '<span class="switch-light-visual-label' . $this->strong_class . '" id="' . esc_attr( $this->var . '-label' ) . '">' . esc_html( $this->label ) . '</span>' . $this->help;
+		$output .= '<label class="' . $this->class . '"><b class="switch-yoast-seo-jaws-a11y">&nbsp;</b>';
+		// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: $disabled_attribute output is hardcoded and all other output is properly escaped.
+		$output .= '<input type="checkbox" aria-labelledby="' . esc_attr( $this->var . '-label' ) . '" id="' . esc_attr( $this->var ) . '" name="' . esc_attr( $this->name ) . '[' . esc_attr( $this->var ) . ']" value="on"' . checked( $this->val, 'on', false ) . $this->disabled_attribute . '/>';
+		$output .= '<span aria-hidden="true">';
+		$output .= '<span>' . esc_html( $this->off_button ) . '</span>';
+		$output .= '<span>' . esc_html( $this->on_button ) . '</span>';
+		$output .= '<a></a>';
+		$output .= '</span></label><div class="clear"></div></div>';
+
+		return $output;
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make the "light switch" toggle more flexible so that it can be used also with post meta. We need this in Local SEO, see P3-333.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors the light switch toggle by introducing a presenter class.

## Relevant technical choices:

* also lowers the PHPCS threshold to 348.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* activate Yoast SEO switched to this branch and build
* test a "light switch" toggle: for example, the one under SEO > Search Appearance > Taxonomies > Remove the categories prefix
* check the toggle styling looks okay 
* check the "?" help button works as expected and reveals the inline help when clicked
* set the toggle to "Keep" and save
* got to Posts > Categories and click the "View" link of one of the categories
* check the visited category page URL contains the `/category/` part 
* go back to the toggle, set it to "Remove" and save
* open an incognito tab (some browsers may cache redirects, especially Chrome)
* in your incognito tab, visit the previous category page
* check the category page URL does _not_ contain the `/category/` part 
* close the incognito tab
* go back to the toggle, set it again to "Keep" and save
* open a new incognito tab
* in your incognito tab, visit the previous category page
* check the category page URL does contain the `/category/` part again


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

Of course, except building this branch.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-353]