### PR TITLE
P1-360 add allowed dismissable alerts

### DIFF
--- a/src/actions/alert-dismissal-action.php
+++ b/src/actions/alert-dismissal-action.php
@@ -139,20 +139,7 @@ class Alert_Dismissal_Action {
 	 * @return bool Whether the alert is allowed.
 	 */
 	public function is_allowed( $alert_identifier ) {
-		return \in_array( $alert_identifier, $this->get_allowed_dismissable_alerts() );
-	}
-
-	/**
-	 * Checks if the alert identifier is valid.
-	 *
-	 * Only allow alphanumeric characters, dashes and underscores.
-	 *
-	 * @param string $alert_identifier The alert identifier.
-	 *
-	 * @return boolean Whether the alert identifier is valid or not.
-	 */
-	public function is_valid_alert_identifier( $alert_identifier ) {
-		return \is_string( $alert_identifier ) && \preg_match( '/^[A-Za-z0-9_\-]+$/', $alert_identifier ) === 1;
+		return \in_array( $alert_identifier, $this->get_allowed_dismissable_alerts(), true );
 	}
 
 	/**
@@ -189,7 +176,7 @@ class Alert_Dismissal_Action {
 		/**
 		 * Filter: 'wpseo_allowed_dismissable_alerts' - List of allowed dismissable alerts.
 		 *
-		 * @api string[] $allowed_dismissable_alerts Allowed dismissable alerts list. An alert can only have alphanumeric characters, dashes and underscores.
+		 * @api string[] $allowed_dismissable_alerts Allowed dismissable alerts list.
 		 */
 		$allowed_dismissable_alerts = \apply_filters( 'wpseo_allowed_dismissable_alerts', [] );
 
@@ -197,11 +184,8 @@ class Alert_Dismissal_Action {
 			return [];
 		}
 
-		// Only allow strings with alphanumeric characters, dashes and underscores.
-		$allowed_dismissable_alerts = \array_filter( $allowed_dismissable_alerts, [
-			$this,
-			'is_valid_alert_identifier',
-		] );
+		// Only allow strings.
+		$allowed_dismissable_alerts = \array_filter( $allowed_dismissable_alerts, 'is_string' );
 
 		// Filter unique and reorder indices.
 		$allowed_dismissable_alerts = \array_values( \array_unique( $allowed_dismissable_alerts ) );

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -244,7 +244,7 @@ class Indexable_Post_Builder {
 		/**
 		 * Filter: 'wpseo_public_post_statuses' - List of public post statuses.
 		 *
-		 * @apo array $post_statuses Post status list, defaults to array( 'publish' ).
+		 * @api array $post_statuses Post status list, defaults to array( 'publish' ).
 		 */
 		return \apply_filters( 'wpseo_public_post_statuses', [ 'publish' ] );
 	}

--- a/src/integrations/alerts/abstract-dismissable-alert.php
+++ b/src/integrations/alerts/abstract-dismissable-alert.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Alerts;
+
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Dismissable_Alert class.
+ */
+abstract class Dismissable_Alert implements Integration_Interface {
+
+	/**
+	 * Holds the alert identifier.
+	 *
+	 * @var string
+	 */
+	protected $alert_identifier;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_conditionals() {
+		return [];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register_hooks() {
+		\add_filter( 'wpseo_allowed_dismissable_alerts', [ $this, 'register_dismissable_alert' ] );
+	}
+
+	/**
+	 * Registers the dismissable alert.
+	 *
+	 * @param string[] $allowed_dismissable_alerts The allowed dismissable alerts.
+	 *
+	 * @return string[] The allowed dismissable alerts.
+	 */
+	public function register_dismissable_alert( $allowed_dismissable_alerts ) {
+		$allowed_dismissable_alerts[] = $this->alert_identifier;
+
+		return $allowed_dismissable_alerts;
+	}
+}

--- a/src/integrations/alerts/abstract-dismissable-alert.php
+++ b/src/integrations/alerts/abstract-dismissable-alert.php
@@ -7,7 +7,7 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 /**
  * Dismissable_Alert class.
  */
-abstract class Dismissable_Alert implements Integration_Interface {
+abstract class Abstract_Dismissable_Alert implements Integration_Interface {
 
 	/**
 	 * Holds the alert identifier.

--- a/src/routes/alert-dismissal-route.php
+++ b/src/routes/alert-dismissal-route.php
@@ -64,7 +64,7 @@ class Alert_Dismissal_Route implements Route_Interface {
 			'permission_callback' => [ $this, 'can_dismiss' ],
 			'args'                => [
 				'key' => [
-					'validate_callback' => [ $this->alert_dismissal_action, 'is_valid_alert_identifier' ],
+					'validate_callback' => [ $this->alert_dismissal_action, 'is_allowed' ],
 					'required'          => true,
 				],
 			],

--- a/src/routes/alert-dismissal-route.php
+++ b/src/routes/alert-dismissal-route.php
@@ -64,7 +64,7 @@ class Alert_Dismissal_Route implements Route_Interface {
 			'permission_callback' => [ $this, 'can_dismiss' ],
 			'args'                => [
 				'key' => [
-					'validate_callback' => [ $this, 'has_valid_key' ],
+					'validate_callback' => [ $this->alert_dismissal_action, 'is_valid_alert_identifier' ],
 					'required'          => true,
 				],
 			],
@@ -91,17 +91,6 @@ class Alert_Dismissal_Route implements Route_Interface {
 			],
 			$status
 		);
-	}
-
-	/**
-	 * Checks if a valid key was returned.
-	 *
-	 * @param string $key The key to check.
-	 *
-	 * @return boolean Whether or not the key is valid.
-	 */
-	public function has_valid_key( $key ) {
-		return \is_string( $key ) && $key !== '';
 	}
 
 	/**

--- a/tests/unit/actions/alert-dismissal-action-test.php
+++ b/tests/unit/actions/alert-dismissal-action-test.php
@@ -777,42 +777,4 @@ class Alert_Dismissal_Action_Test extends TestCase {
 
 		$this->assertFalse( $this->instance->is_allowed( 1 ) );
 	}
-
-	/**
-	 * Tests that a non-string is an invalid alert identifier.
-	 *
-	 * @covers ::is_valid_alert_identifier
-	 */
-	public function test_is_valid_alert_identifier_non_string() {
-		$this->assertFalse( $this->instance->is_valid_alert_identifier( 1 ) );
-		$this->assertFalse( $this->instance->is_valid_alert_identifier( [] ) );
-	}
-
-	/**
-	 * Tests that an empty string is an invalid alert identifier.
-	 *
-	 * @covers ::is_valid_alert_identifier
-	 */
-	public function test_is_valid_alert_identifier_empty_string() {
-		$this->assertFalse( $this->instance->is_valid_alert_identifier( '' ) );
-	}
-
-	/**
-	 * Tests that certain characters are not allowd in an alert identifier.
-	 *
-	 * @covers ::is_valid_alert_identifier
-	 */
-	public function test_is_valid_alert_identifier_unallowed_characters() {
-		$this->assertFalse( $this->instance->is_valid_alert_identifier( 'invalid!' ) );
-	}
-
-	/**
-	 * Tests valid alert identifiers.
-	 *
-	 * @covers ::is_valid_alert_identifier
-	 */
-	public function test_is_valid_alert_identifier() {
-		$this->assertTrue( $this->instance->is_valid_alert_identifier( 'abcdefghijklnmnopqrstuvwxyzABCDEFGHIJKLNMNOPQRSTUVWXYZ0123456789_-' ) );
-		$this->assertTrue( $this->instance->is_valid_alert_identifier( '1' ) );
-	}
 }

--- a/tests/unit/actions/alert-dismissal-action-test.php
+++ b/tests/unit/actions/alert-dismissal-action-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Actions;
 
 use Mockery;
+use Brain\Monkey;
 use Yoast\WP\SEO\Actions\Alert_Dismissal_Action;
 use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -11,6 +12,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * Class Alert_Dismissal_Action_Test.
  *
  * @group actions
+ * @group dismissable-alerts
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Alert_Dismissal_Action
  */
@@ -57,12 +59,19 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	 *
 	 * @covers ::dismiss
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_dismiss_alert() {
 		$this->user
 			->expects( 'get_current_user_id' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'test' ] );
 
 		$this->user
 			->expects( 'get_meta' )
@@ -85,10 +94,42 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	}
 
 	/**
+	 * Tests dismissing an alert that is not allowed.
+	 *
+	 * @covers ::dismiss
+	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
+	 */
+	public function test_dismiss_alert_not_allowed() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'allowed_alert' ] );
+
+		$this->user
+			->expects( 'get_meta' )
+			->never();
+
+		$this->user
+			->expects( 'update_meta' )
+			->never();
+
+		$this->assertFalse( $this->instance->dismiss( 'test' ) );
+	}
+
+	/**
 	 * Tests dismissing an alert that is already dismissed.
 	 *
 	 * @covers ::dismiss
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_dismiss_alert_already_dismissed() {
 		$this->user
@@ -96,17 +137,22 @@ class Alert_Dismissal_Action_Test extends TestCase {
 			->once()
 			->andReturn( 1 );
 
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'already_dismissed' ] );
+
 		$this->user
 			->expects( 'get_meta' )
 			->with( 1, Alert_Dismissal_Action::USER_META_KEY, true )
 			->once()
-			->andReturn( [ 'already dismissed' => true ] );
+			->andReturn( [ 'already_dismissed' => true ] );
 
 		$this->user
 			->expects( 'update_meta' )
 			->never();
 
-		$this->assertTrue( $this->instance->dismiss( 'already dismissed' ) );
+		$this->assertTrue( $this->instance->dismiss( 'already_dismissed' ) );
 	}
 
 	/**
@@ -114,12 +160,19 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	 *
 	 * @covers ::dismiss
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_dismiss_alert_wrong_dismissed_alerts() {
 		$this->user
 			->expects( 'get_current_user_id' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'test' ] );
 
 		$this->user
 			->expects( 'get_meta' )
@@ -161,12 +214,19 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	 *
 	 * @covers ::dismiss
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_dismiss_alert_update_failure() {
 		$this->user
 			->expects( 'get_current_user_id' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'test' ] );
 
 		$this->user
 			->expects( 'get_meta' )
@@ -188,12 +248,19 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	 *
 	 * @covers ::reset
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_reset_alert() {
 		$this->user
 			->expects( 'get_current_user_id' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'test' ] );
 
 		$this->user
 			->expects( 'get_meta' )
@@ -233,16 +300,57 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	}
 
 	/**
+	 * Tests resetting an alert - that is not allowed.
+	 *
+	 * @covers ::reset
+	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
+	 */
+	public function test_reset_alert_not_allowed() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'allowed_alert' ] );
+
+		$this->user
+			->expects( 'get_meta' )
+			->never();
+
+		$this->user
+			->expects( 'delete_meta' )
+			->never();
+
+		$this->user
+			->expects( 'update_meta' )
+			->never();
+
+		$this->assertFalse( $this->instance->reset( 'test' ) );
+	}
+
+	/**
 	 * Tests resetting the only dismissed alert.
 	 *
 	 * @covers ::reset
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_reset_alert_last_remaining() {
 		$this->user
 			->expects( 'get_current_user_id' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'test' ] );
 
 		$this->user
 			->expects( 'get_meta' )
@@ -267,12 +375,19 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	 *
 	 * @covers ::reset
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_reset_alert_last_remaining_delete_failure() {
 		$this->user
 			->expects( 'get_current_user_id' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'test' ] );
 
 		$this->user
 			->expects( 'get_meta' )
@@ -297,12 +412,19 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	 *
 	 * @covers ::reset
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_reset_alert_non_dismissed_alert() {
 		$this->user
 			->expects( 'get_current_user_id' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'test' ] );
 
 		$this->user
 			->expects( 'get_meta' )
@@ -326,12 +448,19 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	 *
 	 * @covers ::reset
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_reset_alert_no_dismissed_alerts() {
 		$this->user
 			->expects( 'get_current_user_id' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'test' ] );
 
 		$this->user
 			->expects( 'get_meta' )
@@ -355,12 +484,19 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	 *
 	 * @covers ::reset
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_reset_alert_wrong_dismissed_alerts() {
 		$this->user
 			->expects( 'get_current_user_id' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'test' ] );
 
 		$this->user
 			->expects( 'get_meta' )
@@ -410,12 +546,19 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	 *
 	 * @covers ::reset
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_reset_alert_update_failure() {
 		$this->user
 			->expects( 'get_current_user_id' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'test' ] );
 
 		$this->user
 			->expects( 'get_meta' )
@@ -454,12 +597,19 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	 *
 	 * @covers ::is_dismissed
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_is_dismissed_true() {
 		$this->user
 			->expects( 'get_current_user_id' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'test' ] );
 
 		$this->user
 			->expects( 'get_meta' )
@@ -475,12 +625,19 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	 *
 	 * @covers ::is_dismissed
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_is_dismissed_false() {
 		$this->user
 			->expects( 'get_current_user_id' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'test' ] );
 
 		$this->user
 			->expects( 'get_meta' )
@@ -492,16 +649,49 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that the alert is not dismissed when it is not allowed.
+	 *
+	 * @covers ::is_dismissed
+	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
+	 */
+	public function test_is_dismissed_not_allowed() {
+		$this->user
+			->expects( 'get_current_user_id' )
+			->once()
+			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'allowed_alert' ] );
+
+		$this->user
+			->expects( 'get_meta' )
+			->never();
+
+		$this->assertFalse( $this->instance->is_dismissed( 'test' ) );
+	}
+
+	/**
 	 * Tests that the alert is not dismissed - retrieving the dismissed alerts goes wrong.
 	 *
 	 * @covers ::is_dismissed
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_is_dismissed_wrong_dismissed_alerts() {
 		$this->user
 			->expects( 'get_current_user_id' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'test' ] );
 
 		$this->user
 			->expects( 'get_meta' )
@@ -535,12 +725,19 @@ class Alert_Dismissal_Action_Test extends TestCase {
 	 * Tests that get dismissed alerts returns an empty array when get_meta returns an empty string.
 	 *
 	 * @covers ::get_dismissed_alerts
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
 	 */
 	public function test_get_dismissed_alerts_empty_array() {
 		$this->user
 			->expects( 'get_current_user_id' )
 			->once()
 			->andReturn( 1 );
+
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 'test' ] );
 
 		$this->user
 			->expects( 'get_meta' )
@@ -549,5 +746,73 @@ class Alert_Dismissal_Action_Test extends TestCase {
 			->andReturn( '' );
 
 		$this->assertFalse( $this->instance->is_dismissed( 'test' ) );
+	}
+
+	/**
+	 * Tests that get allowed dismissable alerts requires an array back.
+	 *
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
+	 */
+	public function test_get_allowed_array_check() {
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( 'not an array' );
+
+		$this->assertFalse( $this->instance->is_allowed( 'test' ) );
+	}
+
+	/**
+	 * Tests that get allowed dismissable alerts requires an array with only strings.
+	 *
+	 * @covers ::is_allowed
+	 * @covers ::get_allowed_dismissable_alerts
+	 */
+	public function test_get_allowed_string_check() {
+		Monkey\Filters\expectApplied( 'wpseo_allowed_dismissable_alerts' )
+			->with( [] )
+			->once()
+			->andReturn( [ 1 ] );
+
+		$this->assertFalse( $this->instance->is_allowed( 1 ) );
+	}
+
+	/**
+	 * Tests that a non-string is an invalid alert identifier.
+	 *
+	 * @covers ::is_valid_alert_identifier
+	 */
+	public function test_is_valid_alert_identifier_non_string() {
+		$this->assertFalse( $this->instance->is_valid_alert_identifier( 1 ) );
+		$this->assertFalse( $this->instance->is_valid_alert_identifier( [] ) );
+	}
+
+	/**
+	 * Tests that an empty string is an invalid alert identifier.
+	 *
+	 * @covers ::is_valid_alert_identifier
+	 */
+	public function test_is_valid_alert_identifier_empty_string() {
+		$this->assertFalse( $this->instance->is_valid_alert_identifier( '' ) );
+	}
+
+	/**
+	 * Tests that certain characters are not allowd in an alert identifier.
+	 *
+	 * @covers ::is_valid_alert_identifier
+	 */
+	public function test_is_valid_alert_identifier_unallowed_characters() {
+		$this->assertFalse( $this->instance->is_valid_alert_identifier( 'invalid!' ) );
+	}
+
+	/**
+	 * Tests valid alert identifiers.
+	 *
+	 * @covers ::is_valid_alert_identifier
+	 */
+	public function test_is_valid_alert_identifier() {
+		$this->assertTrue( $this->instance->is_valid_alert_identifier( 'abcdefghijklnmnopqrstuvwxyzABCDEFGHIJKLNMNOPQRSTUVWXYZ0123456789_-' ) );
+		$this->assertTrue( $this->instance->is_valid_alert_identifier( '1' ) );
 	}
 }

--- a/tests/unit/routes/alert-dismissal-route-test.php
+++ b/tests/unit/routes/alert-dismissal-route-test.php
@@ -12,6 +12,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * Class Alert_Dismissal_Route_Test.
  *
  * @group routes
+ * @group dismissable-alerts
  *
  * @coversDefaultClass \Yoast\WP\SEO\Routes\Alert_Dismissal_Route
  */
@@ -115,24 +116,6 @@ class Alert_Dismissal_Route_Test extends TestCase {
 		$response = $this->instance->dismiss( $request );
 
 		$this->assertInstanceOf( 'WP_REST_Response', $response );
-	}
-
-	/**
-	 * Tests that the key is an invalid key.
-	 *
-	 * @covers ::has_valid_key
-	 */
-	public function test_is_valid_code_with_invalid_code_given() {
-		$this->assertFalse( $this->instance->has_valid_key( '' ) );
-	}
-
-	/**
-	 * Tests that the key is a valid key.
-	 *
-	 * @covers ::has_valid_key
-	 */
-	public function test_is_valid_key_with_valid_key_given() {
-		$this->assertTrue( $this->instance->has_valid_key( 'some_alert' ) );
 	}
 
 	/**

--- a/tests/unit/routes/alert-dismissal-route-test.php
+++ b/tests/unit/routes/alert-dismissal-route-test.php
@@ -82,8 +82,8 @@ class Alert_Dismissal_Route_Test extends TestCase {
 					'callback'            => [ $this->instance, 'dismiss' ],
 					'permission_callback' => [ $this->instance, 'can_dismiss' ],
 					'args'                => [
-						'code' => [
-							'validate_callback' => [ $this->instance, 'has_valid_key' ],
+						'key' => [
+							'validate_callback' => [ $this->alert_dismissal_action, 'is_allowed' ],
 							'required'          => true,
 						],
 					],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* To increase security, use an allow list for the dismissable alerts. Original PR for dismissable alerts: https://github.com/Yoast/wordpress-seo/pull/16544

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an allowed dismissable alerts interface (to an unreleased feature).

## Relevant technical choices:

* The allow list is checked in the route. Meaning that a key has to be registered in PHP in order for the route to be able to dismiss it.
* Added public `is_allowed` to the action that is used in the `dismiss`, `reset` and `is_dismissed` functions and in the route for validation.
* Added an Abstract_Dismissable_Alert class to use as a higher level integration.
* Includes tiny unrelated documentation codescout.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* To check a working alert see the video PR for an implementation: https://github.com/Yoast/wpseo-video/pull/868

### Dismiss alert endpoint
* Check your database. In the `wp_usermeta` (the `wp_` prefix is the default) a row will be added to hold the dismissed alerts for each user that has dismissed at least 1 alert. The `meta_key` is `_yoast_alerts_dismissed`. Maybe delete any entries to make it easier to spot if more are created.
* Try the script in the issue. Adapt the <insert> parts to their actual values. To get the cookie and nonce, edit a post, open your network tab in the console, update the post and select that (latest) request. The request headers holds the values.
```sh
for i in {1..10}; do curl --location --request POST "http://basic.wordpress.test/wp-json/yoast/v1/alerts/dismiss?key=testing${i}" \
--header 'Cookie: <insert user cookie data here>' \
--header 'X-WP-Nonce: <insert user nonce here>'; done
```
* Then paste the code in your terminal and press enter to run it.
* Ensure the responses are about the invalid parameter: key.
* Check your database. There should be no (extra) alerts.
* Now register an alert by adding the following in the code (active theme's functions.php?):
```php
add_filter( 'wpseo_allowed_dismissable_alerts', function () {
	return [ 'testing1', 'testing5', 'testing9' ];
} );
```
* Run the script again, the requests of the 1, 5 and 9 should've succeeded now, while the other still went wrong.
* Check your database. There should be the 1, 5 and 9 alerts.
* Remove the code you added to your theme's functions.php again.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-360
