### PR TITLE
Introduce the filter `wpseo_sitemap_post_type_first_links`

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -414,7 +414,13 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			];
 		}
 
-		return $links;
+		/**
+		 * Filters the first post type links.
+		 *
+		 * @param array $links      The first post type links.
+		 * @param string $post_type The post type this archive is for.
+		 */
+		return apply_filters( 'wpseo_sitemap_post_type_first_links', $links, $post_type );
 	}
 
 	/**


### PR DESCRIPTION
https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlwpseo-143

## Context
Allow to filter the first links of the post type sitemap provider. The first link is either for the home page or the CPT archive page.

## Summary
This is needed for WPML in order to pass the related secondary languages page.

Ex:
-> https://domain.com
-> https://domain.com/fr/
-> https://domain.com/de/

Or:
-> https://domain.com/city/
-> https://domain.com/fr/ville/
-> https://domain.com/de/stadt/


## Relevant technical choices:

Currently, WPML is adding some output at the end of the rendered sitemap, but this was done a long time ago. Now we would like to enhance the sitemap with alternative language links (i.e. https://yoast.com/hreflang-ultimate-guide/#hreflang-implementation-choices), but we would like to do this on a robust base (and refactor part of our code with this new filter).


## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended