### PR TITLE
Cache (shortly) retrieving the home-page indexable

### DIFF
--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -151,6 +151,7 @@ class Indexable_Hierarchy_Builder {
 	private function save_ancestors( $indexable ) {
 		if ( empty( $indexable->ancestors ) ) {
 			$this->indexable_hierarchy_repository->add_ancestor( $indexable->id, 0, 0 );
+			return;
 		}
 		$depth = \count( $indexable->ancestors );
 		foreach ( $indexable->ancestors as $ancestor ) {

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -149,6 +149,9 @@ class Indexable_Hierarchy_Builder {
 	 * @return void
 	 */
 	private function save_ancestors( $indexable ) {
+		if ( empty( $indexable->ancestors ) ) {
+			$this->indexable_hierarchy_repository->add_ancestor( $indexable->id, 0, 0 );
+		}
 		$depth = \count( $indexable->ancestors );
 		foreach ( $indexable->ancestors as $ancestor ) {
 			$this->indexable_hierarchy_repository->add_ancestor( $indexable->id, $ancestor->id, $depth-- );

--- a/src/repositories/indexable-hierarchy-repository.php
+++ b/src/repositories/indexable-hierarchy-repository.php
@@ -78,7 +78,7 @@ class Indexable_Hierarchy_Repository {
 			->find_array();
 
 		if ( ! empty( $ancestors ) ) {
-			if ( count( $ancestors ) === 1 && $ancestors[0]['ancestor_id'] === "0" ) {
+			if ( count( $ancestors ) === 1 && $ancestors[0]['ancestor_id'] === '0' ) {
 				return [];
 			}
 			return \wp_list_pluck( $ancestors, 'ancestor_id' );

--- a/src/repositories/indexable-hierarchy-repository.php
+++ b/src/repositories/indexable-hierarchy-repository.php
@@ -78,6 +78,9 @@ class Indexable_Hierarchy_Repository {
 			->find_array();
 
 		if ( ! empty( $ancestors ) ) {
+			if ( count( $ancestors ) === 1 && $ancestors[0]['ancestor_id'] === "0" ) {
+				return [];
+			}
 			return \wp_list_pluck( $ancestors, 'ancestor_id' );
 		}
 

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -223,18 +223,24 @@ class Indexable_Repository {
 	 * @return bool|Indexable Instance of indexable.
 	 */
 	public function find_for_home_page( $auto_create = true ) {
-		/**
-		 * Indexable instance.
-		 *
-		 * @var Indexable $indexable
-		 */
-		$indexable = $this->query()->where( 'object_type', 'home-page' )->find_one();
+		static $indexable;
 
-		if ( $auto_create && ! $indexable ) {
-			$indexable = $this->builder->build_for_home_page();
+		if ( ! isset( $indexable ) ) {
+			/**
+			 * Indexable instance.
+			 *
+			 * @var Indexable $indexable
+			 */
+			$indexable = $this->query()->where( 'object_type', 'home-page' )->find_one();
+
+			if ( $auto_create && ! $indexable ) {
+				$indexable = $this->builder->build_for_home_page();
+			}
+
+			$indexable = $this->ensure_permalink( $indexable );
 		}
 
-		return $this->ensure_permalink( $indexable );
+		return $indexable;
 	}
 
 	/**

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -223,9 +223,8 @@ class Indexable_Repository {
 	 * @return bool|Indexable Instance of indexable.
 	 */
 	public function find_for_home_page( $auto_create = true ) {
-		static $indexable;
-
-		if ( ! isset( $indexable ) ) {
+		$indexable = wp_cache_get( 'home-page', 'yoast-seo-indexables' );
+		if ( ! $indexable ) {
 			/**
 			 * Indexable instance.
 			 *
@@ -238,6 +237,8 @@ class Indexable_Repository {
 			}
 
 			$indexable = $this->ensure_permalink( $indexable );
+
+			wp_cache_set( 'home-page', $indexable,'yoast-seo-indexables', 5 * MINUTE_IN_SECONDS );
 		}
 
 		return $indexable;

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -238,7 +238,7 @@ class Indexable_Repository {
 
 			$indexable = $this->ensure_permalink( $indexable );
 
-			wp_cache_set( 'home-page', $indexable,'yoast-seo-indexables', 5 * MINUTE_IN_SECONDS );
+			wp_cache_set( 'home-page', $indexable, 'yoast-seo-indexables', ( 5 * MINUTE_IN_SECONDS ) );
 		}
 
 		return $indexable;

--- a/tests/unit/builders/indexable-hierarchy-builder-test.php
+++ b/tests/unit/builders/indexable-hierarchy-builder-test.php
@@ -119,6 +119,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 					'post_type'   => 'post',
 				]
 			);
+		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 0, 0 );
 
 		$actual = $this->instance->build( $indexable );
 		$this->assertEmpty( $actual->ancestors );
@@ -157,6 +158,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 					'post_type'   => 'post',
 				]
 			);
+		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 0, 0 );
 
 		$actual = $this->instance->build( $indexable );
 		$this->assertEmpty( $actual->ancestors );
@@ -180,6 +182,7 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 
 		$this->indexable_hierarchy_repository->expects( 'clear_ancestors' )->with( 1 )->andReturnTrue();
 		$this->post->expects( 'get_post' )->with( 1 )->andReturn( (object) [ 'post_type' => 'post' ] );
+		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 0, 0 );
 
 		$actual = $this->instance->build( $indexable );
 		$this->assertEmpty( $actual->ancestors );

--- a/tests/unit/builders/indexable-hierarchy-builder-test.php
+++ b/tests/unit/builders/indexable-hierarchy-builder-test.php
@@ -353,6 +353,8 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 				]
 			);
 
+		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 0, 0 );
+
 		$actual = $this->instance->build( $indexable );
 		$this->assertEmpty( $actual->ancestors );
 	}
@@ -458,6 +460,8 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 					'post_type'   => 'post',
 				]
 			);
+
+		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 0, 0 );
 
 		$actual = $this->instance->build( $indexable );
 		$this->assertEmpty( $actual->ancestors );
@@ -593,6 +597,8 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 					'post_type'   => 'post',
 				]
 			);
+
+		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 0, 0 );
 
 		$actual = $this->instance->build( $indexable );
 		$this->assertEmpty( $actual->ancestors );
@@ -808,6 +814,8 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 				]
 			);
 
+		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 0, 0 );
+
 		$actual = $this->instance->build( $indexable );
 		$this->assertEmpty( $actual->ancestors );
 	}
@@ -858,6 +866,8 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 					'post_type'   => 'post',
 				]
 			);
+
+		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 0, 0 );
 
 		$actual = $this->instance->build( $indexable );
 		$this->assertEmpty( $actual->ancestors );
@@ -1067,6 +1077,8 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 			->with( 2, 'term' )
 			->andReturn( $parent_indexable );
 
+		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 0, 0 );
+
 		$actual = $this->instance->build( $indexable );
 		$this->assertEmpty( $actual->ancestors );
 	}
@@ -1117,6 +1129,8 @@ class Indexable_Hierarchy_Builder_Test extends TestCase {
 			->expects( 'find_by_id_and_type' )
 			->with( 2, 'term' )
 			->andReturn( $indexable );
+
+		$this->indexable_hierarchy_repository->expects( 'add_ancestor' )->with( 1, 0, 0 );
 
 		$actual = $this->instance->build( $indexable );
 		$this->assertEmpty( $actual->ancestors );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Since the homepage isn't really going to change and we need it on every page load, shortly caching the request for that should save a query per pageload.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Performance: prevents database queries for the homepage indexable.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* When visiting the homepage:
  * There should be only one query for the home page indexable.
  * There should not be any delete queries for the ancestors table apart from the very first query with this PR active.
* All metadata, including the breadcrumb, should be unchanged.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
