### PR TITLE
Setup the tasks for building the translations for schema-blocks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,6 +79,7 @@ module.exports = function( grunt ) {
 				yoastJsConfigurationWizard: "<%= paths.languages %>yoast-js-configuration-wizard.pot",
 				yoastJsHelpers: "<%= paths.languages %>yoast-js-helpers.pot",
 				yoastJsSearchMetadataPreviews: "<%= paths.languages %>yoast-js-search-metadata-previews.pot",
+				yoastSchemaBocks: "<%= paths.languages %>yoast-schema-blocks.pot",
 
 				yoastseojs: "<%= paths.languages %>yoast-seo-js.pot",
 				yoastComponents: "<%= paths.languages %>yoast-components.pot",

--- a/config/grunt/task-config/aliases.yaml
+++ b/config/grunt/task-config/aliases.yaml
@@ -53,6 +53,8 @@
   - 'copy:makepot-yoast-js-helpers'
   - 'shell:makepot-yoast-js-search-metadata-previews'
   - 'copy:makepot-yoast-js-search-metadata-previews'
+  - 'shell:makepot-yoast-js-schema-blocks'
+  - 'copy:makepot-yoast-js-schema-blocks'
   - 'shell:makepot-yoast-components-remaining'
   - 'shell:combine-pots-yoast-components'
   - 'shell:makepot-yoastseojs'

--- a/config/grunt/task-config/copy.js
+++ b/config/grunt/task-config/copy.js
@@ -79,6 +79,10 @@ module.exports = {
 		src: "gettext.pot",
 		dest: "<%= files.pot.yoastJsSearchMetadataPreviews %>",
 	},
+	"makepot-yoast-js-schema-blocks": {
+		src: "gettext.pot",
+		dest: "<%= files.pot.yoastSchemaBocks %>",
+	},
 
 	// The default de_CH is formal on WordPress.org, but that one is not translated enough for wordpress-seo.
 	// So we need to copy the `-informal` so we have a good translation.

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -29,6 +29,7 @@ module.exports = function( grunt ) {
 				"languages/<%= pkg.plugin.textdomain %>-temp.pot",
 				"<%= files.pot.yoastseojs %>",
 				"<%= files.pot.yoastComponents %>",
+				"<%= files.pot.yoastSchemaBocks %>",
 			],
 			toFile: "languages/<%= pkg.plugin.textdomain %>.pot",
 			command: function() {
@@ -84,6 +85,9 @@ module.exports = function( grunt ) {
 		},
 		"makepot-yoast-js-search-metadata-previews": {
 			command: "yarn i18n-yoast-js-search-metadata-previews",
+		},
+		"makepot-yoast-js-schema-blocks": {
+			command: "yarn i18n-yoast-js-schema-blocks",
 		},
 
 		"makepot-yoast-components-configuration-wizard": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "i18n-yoast-js-configuration-wizard": "cross-env NODE_ENV=production babel node_modules/@yoast/configuration-wizard --ignore node_modules/@yoast/configuration-wizard/node_modules --plugins=@wordpress/babel-plugin-makepot | shusher",
     "i18n-yoast-js-helpers": "cross-env NODE_ENV=production babel node_modules/@yoast/helpers --ignore node_modules/@yoast/helpers/node_modules --plugins=@wordpress/babel-plugin-makepot | shusher",
     "i18n-yoast-js-search-metadata-previews": "cross-env NODE_ENV=production babel node_modules/@yoast/search-metadata-previews --ignore node_modules/@yoast/search-metadata-previews/node_modules,__mocks__/*.js --plugins=@wordpress/babel-plugin-makepot | shusher",
+    "i18n-yoast-js-schema-blocks": "cross-env NODE_ENV=production babel node_modules/@yoast/schema-blocks --ignore node_modules/@yoast/schema-blocks/node_modules,__mocks__/*.js --plugins=@wordpress/babel-plugin-makepot | shusher",
     "prestart": "grunt build:css && grunt copy:js-dependencies",
     "start": "webpack-dev-server --config ./config/webpack/webpack.config.js --progress --env.environment=development",
     "link-monorepo": "node config/yarn/link_monorepo_to_plugin.js",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Get the translatable strings from the schema blocks package


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Checkout this branch
* Do the yarn magic
* Run `grunt build:i18n:potFiles`
* Verify that you have the `languages/yoast-schema-blocks.pot` file
* Also make sure that `languages/wordpress-seo.pot` contains `No, please undo this`
   * This is a string from the schema blocks package and should be in wordpress-seo which will be read by WordPress to fill load in the translator site.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
