### PR TITLE
Put recipe schema behind feature flag

### DIFF
--- a/config/dependency-injection/schema-templates-loader.php
+++ b/config/dependency-injection/schema-templates-loader.php
@@ -20,6 +20,16 @@ class Schema_Templates_Loader {
 			$templates = [];
 		}
 
+		foreach ( $templates as $index => $template ) {
+			// Replace the root path based on current path from the template.
+			$template = str_replace( $root_directory, '', $template );
+
+			// Removes the slashes in the beginning and the end.
+			$template = trim( $template, '/' );
+
+			$templates[ $index ] = $template;
+		}
+
 		return $templates;
 	}
 }

--- a/config/dependency-injection/schema-templates-pass.php
+++ b/config/dependency-injection/schema-templates-pass.php
@@ -40,12 +40,6 @@ class Schema_Templates_Pass implements CompilerPassInterface {
 		$schema_blocks_definition = $container->getDefinition( Schema_Blocks::class );
 
 		foreach ( $this->schema_templates_loader->get_templates() as $template ) {
-			// Replace the root path based on current path from the template.
-			$template = str_replace( dirname( dirname( __DIR__ ) ), '', $template );
-
-			// Removes the slashes in the beginning and the end.
-			$template = trim( $template, '/' );
-
 			$schema_blocks_definition->addMethodCall( 'register_template', [ $template ] );
 		}
 	}

--- a/config/dependency-injection/schema-templates-pass.php
+++ b/config/dependency-injection/schema-templates-pass.php
@@ -40,6 +40,12 @@ class Schema_Templates_Pass implements CompilerPassInterface {
 		$schema_blocks_definition = $container->getDefinition( Schema_Blocks::class );
 
 		foreach ( $this->schema_templates_loader->get_templates() as $template ) {
+			// Replace the root path based on current path from the template.
+			$template = str_replace( dirname( dirname( __DIR__ ) ), '', $template );
+
+			// Removes the slashes in the beginning and the end.
+			$template = trim( $template, '/' );
+
 			$schema_blocks_definition->addMethodCall( 'register_template', [ $template ] );
 		}
 	}

--- a/src/integrations/schema-blocks.php
+++ b/src/integrations/schema-blocks.php
@@ -25,25 +25,33 @@ class Schema_Blocks implements Integration_Interface {
 	protected $asset_manager;
 
 	/**
+	 * Represents the schema blocks conditional.
+	 *
+	 * @var Schema_Blocks_Conditional
+	 */
+	protected $blocks_conditional;
+
+	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
 	 * @return array
 	 */
 	public static function get_conditionals() {
-		return [
-			Schema_Blocks_Conditional::class,
-		];
+		return [];
 	}
 
 	/**
 	 * Schema_Blocks constructor.
 	 *
-	 * @param WPSEO_Admin_Asset_Manager $asset_manager The asset manager.
+	 * @param WPSEO_Admin_Asset_Manager $asset_manager      The asset manager.
+	 * @param Schema_Blocks_Conditional $blocks_conditional The schema blocks conditional.
 	 */
 	public function __construct(
-		WPSEO_Admin_Asset_Manager $asset_manager
+		WPSEO_Admin_Asset_Manager $asset_manager,
+		Schema_Blocks_Conditional $blocks_conditional
 	) {
-		$this->asset_manager = $asset_manager;
+		$this->asset_manager      = $asset_manager;
+		$this->blocks_conditional = $blocks_conditional;
 	}
 
 	/**
@@ -93,12 +101,19 @@ class Schema_Blocks implements Integration_Interface {
 			return;
 		}
 
+		$templates = [];
+
+		// When the schema blocks feature flag is enabled, use the registered templates.
+		if ( $this->blocks_conditional->is_met() ) {
+			$templates = $this->templates;
+		}
+
 		/**
 		 * Filter: 'wpseo_load_schema_templates' - Allow adding additional schema templates.
 		 *
 		 * @param array $templates The templates to filter.
 		 */
-		$templates = \apply_filters( 'wpseo_load_schema_templates', $this->templates );
+		$templates = \apply_filters( 'wpseo_load_schema_templates', $templates );
 		if ( ! is_array( $templates ) || empty( $templates ) ) {
 			return;
 		}

--- a/tests/unit/dependency-injection/schema-templates-loader-test.php
+++ b/tests/unit/dependency-injection/schema-templates-loader-test.php
@@ -36,7 +36,7 @@ class Schema_Templates_Loader_Test extends TestCase {
 	 * @covers ::get_templates
 	 */
 	public function test_get_templates() {
-		$schema_directory = dirname( WPSEO_FILE ) . '/src/schema-templates/';
+		$schema_directory = 'src/schema-templates/';
 
 		$expected_schema_blocks = [
 			$schema_directory . 'image.schema.php',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to release the recipe schema block already

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Puts the recipe schema blocks behind a feature flag.

## Relevant technical choices:

* Used the feature check in an `if-condition` in the integration that loads the templates. I've located it here because the dependency container isn't aware of any feature flag that is set on the user's site.
* Also made the path build by the dependency container (machine) relative. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run `composer compile-di` and verify that the path in the calls to the `$instance->register_template` method are relative in `src/generated/container.php`
* Disable the feature flag and see that no templates are loaded
* Enable the feature flag and see the templates are loaded.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
