### PR TITLE
#16645 fixing the posts indexation get_query method by adding a LEFT JOIN

### DIFF
--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -128,9 +128,9 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 		$post_types      = $this->get_post_types();
 		$replacements    = $post_types;
 
-		$select = 'ID';
+		$select = 'P.ID';
 		if ( $count ) {
-			$select = 'COUNT(ID)';
+			$select = 'COUNT(P.ID)';
 		}
 		$limit_query = '';
 		if ( ! $count ) {
@@ -141,14 +141,13 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 		return $this->wpdb->prepare(
 			"
 			SELECT $select
-			FROM {$this->wpdb->posts}
-			WHERE ID NOT IN (
-				SELECT object_id
-				FROM $indexable_table
-				WHERE object_type = 'post'
-				AND permalink_hash IS NOT NULL
-			)
-			AND post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ")
+			FROM {$this->wpdb->posts} as P
+			LEFT JOIN $indexable_table AS I 
+				ON P.ID = I.object_id 
+				AND I.object_type = 'post' 
+				AND I.permalink_hash IS NOT NULL
+			WHERE I.object_id is Null 
+				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ")
 			$limit_query",
 			$replacements
 		);

--- a/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
@@ -81,15 +81,14 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	public function test_get_total_unindexed() {
 		$limit_placeholder = '';
 		$expected_query    = "
-			SELECT COUNT(ID)
-			FROM wp_posts
-			WHERE ID NOT IN (
-				SELECT object_id
-				FROM wp_yoast_indexable
-				WHERE object_type = 'post'
-				AND permalink_hash IS NOT NULL
-			)
-			AND post_type IN (%s)
+			SELECT COUNT(P.ID)
+			FROM wp_posts as P
+			LEFT JOIN wp_yoast_indexable AS I 
+				ON P.ID = I.object_id 
+				AND I.object_type = 'post' 
+				AND I.permalink_hash IS NOT NULL
+			WHERE I.object_id is Null 
+				AND P.post_type IN (%s)
 			$limit_placeholder";
 
 		Functions\expect( 'get_transient' )->once()->with( 'wpseo_total_unindexed_posts' )->andReturnFalse();
@@ -155,15 +154,14 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 
 		$limit_placeholder = '';
 		$expected_query    = "
-			SELECT COUNT(ID)
-			FROM wp_posts
-			WHERE ID NOT IN (
-				SELECT object_id
-				FROM wp_yoast_indexable
-				WHERE object_type = 'post'
-				AND permalink_hash IS NOT NULL
-			)
-			AND post_type IN (%s)
+			SELECT COUNT(P.ID)
+			FROM wp_posts as P
+			LEFT JOIN wp_yoast_indexable AS I 
+				ON P.ID = I.object_id 
+				AND I.object_type = 'post' 
+				AND I.permalink_hash IS NOT NULL
+			WHERE I.object_id is Null 
+				AND P.post_type IN (%s)
 			$limit_placeholder";
 
 		Functions\expect( 'get_transient' )->once()->with( 'wpseo_total_unindexed_posts' )->andReturnFalse();
@@ -191,17 +189,16 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	 * @covers ::get_post_types
 	 */
 	public function test_index() {
-		$expected_query = '
-			SELECT ID
-			FROM wp_posts
-			WHERE ID NOT IN (
-				SELECT object_id
-				FROM wp_yoast_indexable
-				WHERE object_type = \'post\'
-				AND permalink_hash IS NOT NULL
-			)
-			AND post_type IN (%s)
-			LIMIT %d';
+		$expected_query = "
+			SELECT P.ID
+			FROM wp_posts as P
+			LEFT JOIN wp_yoast_indexable AS I 
+				ON P.ID = I.object_id 
+				AND I.object_type = 'post' 
+				AND I.permalink_hash IS NOT NULL
+			WHERE I.object_id is Null 
+				AND P.post_type IN (%s)
+			LIMIT %d";
 
 		Filters\expectApplied( 'wpseo_post_indexation_limit' )->andReturn( 25 );
 
@@ -274,17 +271,16 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$public_post_types   = [ 'public_post_type', 'excluded_post_type' ];
 		$excluded_post_types = [ 'excluded_post_type' ];
 
-		$expected_query = '
-			SELECT ID
-			FROM wp_posts
-			WHERE ID NOT IN (
-				SELECT object_id
-				FROM wp_yoast_indexable
-				WHERE object_type = \'post\'
-				AND permalink_hash IS NOT NULL
-			)
-			AND post_type IN (%s)
-			LIMIT %d';
+		$expected_query = "
+			SELECT P.ID
+			FROM wp_posts as P
+			LEFT JOIN wp_yoast_indexable AS I 
+				ON P.ID = I.object_id 
+				AND I.object_type = 'post' 
+				AND I.permalink_hash IS NOT NULL
+			WHERE I.object_id is Null 
+				AND P.post_type IN (%s)
+			LIMIT %d";
 
 		Filters\expectApplied( 'wpseo_post_indexation_limit' )->andReturn( 25 );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Addresses a slow query  related to posts indexing, details can be found in this ticket https://github.com/Yoast/wordpress-seo/issues/16645
* phpunit tests have been also modified to comply with the new query

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the performance of the post indexing. Props to [Ovidiu Liuta](https://github.com/ovidiul).

## Relevant technical choices:

* the NOT IN SQL check is not performance and can lead to performance issues for sites with a large number of posts, instead, a LEFT JOIN should be considered as a better alternative

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast Test Helper
* Switch to Yoast SEO 16.0
* Reset the indexable tables: Tools -> Yoast Test -> Reset indexables tables & migrations
* Run the indexation, either via the menu (SEO -> Tools -> Optimize SEO Data) or via WP CLI (yoast index) and have an eye on the elapsing time
* Note the amount of rows in your `wp_yoast_indexable` table
* Switch to the current Yoast SEO version (16.1)
* Reset the indexable tables: Tools -> Yoast Test -> Reset indexables tables & migrations
* Run the indexation, either via the menu (SEO -> Tools -> Optimize SEO Data) or via WP CLI (yoast index) and have an eye on the elapsing time again
* Verify the amount of rows is the same
* Verify that the indexing is at least as fast on the new version as on the old, probably test with smaller and larger datasets

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* posts indexing

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/16645
