### PR TITLE
Prevent fatal error due to type declaration

### DIFF
--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -335,13 +335,18 @@ class Indexable_Hierarchy_Builder {
 	/**
 	 * Checks if an ancestor is valid to add.
 	 *
-	 * @param Indexable $ancestor     The ancestor to check.
+	 * @param           $ancestor     The ancestor (presumed indexable) to check.
 	 * @param int       $indexable_id The indexable id we're adding ancestors for.
 	 * @param int[]     $parents      The indexable ids of the parents already added.
 	 *
 	 * @return boolean
 	 */
-	private function is_invalid_ancestor( Indexable $ancestor, $indexable_id, $parents ) {
+	private function is_invalid_ancestor( $ancestor, $indexable_id, $parents ) {
+		// If the ancestor is not an Indexable, it is invalid by default.
+		if ( ! \is_a( $ancestor, 'Indexable' ) ) {
+			return false;
+		}
+
 		// Don't add ancestors if they're unindexed, already added or the same as the main object.
 		if ( $ancestor->post_status === 'unindexed' ) {
 			return true;

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -343,7 +343,7 @@ class Indexable_Hierarchy_Builder {
 	 */
 	private function is_invalid_ancestor( $ancestor, $indexable_id, $parents ) {
 		// If the ancestor is not an Indexable, it is invalid by default.
-		if ( ! \is_a( $ancestor, 'Indexable' ) ) {
+		if ( ! \is_a( $ancestor, 'Yoast\WP\SEO\Models\Indexable' ) ) {
 			return false;
 		}
 

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -344,7 +344,7 @@ class Indexable_Hierarchy_Builder {
 	private function is_invalid_ancestor( $ancestor, $indexable_id, $parents ) {
 		// If the ancestor is not an Indexable, it is invalid by default.
 		if ( ! \is_a( $ancestor, 'Yoast\WP\SEO\Models\Indexable' ) ) {
-			return false;
+			return true;
 		}
 
 		// Don't add ancestors if they're unindexed, already added or the same as the main object.

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -335,7 +335,7 @@ class Indexable_Hierarchy_Builder {
 	/**
 	 * Checks if an ancestor is valid to add.
 	 *
-	 * @param           $ancestor     The ancestor (presumed indexable) to check.
+	 * @param Indexable $ancestor     The ancestor (presumed indexable) to check.
 	 * @param int       $indexable_id The indexable id we're adding ancestors for.
 	 * @param int[]     $parents      The indexable ids of the parents already added.
 	 *


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The function `is_invalid_ancestor()` may be passed a non-Indexable object which would cause a fatal error due to type declaration. We want to prevent this but still check for the object type.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a fatal error when a post ancestor is not an indexable.

## Relevant technical choices:

* The function checks if an ancestor is invalid. If the argument is not an indexable object, it is also invalid, so the function should be able to expect a non-Indexable as an argument.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create and save a page
* Create another page and set the previous page as parent, save this page.
* Both pages should save normally.
* Indexables should be created for both pages as usual.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*N/A

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/16654
