### PR TITLE
Introduce broken breadcrumb array check

### DIFF
--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -133,14 +133,26 @@ class Breadcrumb extends Abstract_Schema_Piece {
 
 	/**
 	 * Tests if the breadcrumb is broken.
-	 * A breadcrumb is considered broken when it has no URL or text.
+	 * A breadcrumb is considered broken:
+	 * - when it is not an array.
+	 * - when it has no URL or text.
 	 *
 	 * @param array $breadcrumb The breadcrumb to test.
 	 *
 	 * @return bool `true` if the breadcrumb is broken.
 	 */
 	private function is_broken( $breadcrumb ) {
-		return ! \array_key_exists( 'url', $breadcrumb ) || ! \array_key_exists( 'text', $breadcrumb );
+		// A breadcrumb is broken if it is not an array.
+		if ( ! is_array( $breadcrumb ) ) {
+			return true;
+		}
+
+		// A breadcrumb is broken if it does not contain a URL or text.
+		if ( ! \array_key_exists( 'url', $breadcrumb ) || ! \array_key_exists( 'text', $breadcrumb ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When we check for broken schema breadcrumbs, we assume the passed variable is an array. If it is not, the array checks will throw warnings. This can be prevented by checking for an array first, as a non-array breadcrumb is broken anyways.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where invalid breadcrumbs may show PHP warnings. 

## Relevant technical choices:

* A non-array breadcrumb is broken either way, so no need to check it for array values.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure breadcrumbs keep working the way they do. This fix covers theoretical edge-cases which I have not yet reproduced myself.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
