### PR TITLE
P2-668 Use the helper to get the product name

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -1110,13 +1110,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return string The product title.
 	 */
 	protected function get_product_title() {
-		$product_title = 'Yoast SEO';
-
-		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
-			$product_title .= ' Premium';
-		}
-
-		return $product_title;
+		return YoastSEO()->helpers->product->get_product_name();
 	}
 
 	/* ********************* DEPRECATED METHODS ********************* */

--- a/admin/taxonomy/class-taxonomy-metabox.php
+++ b/admin/taxonomy/class-taxonomy-metabox.php
@@ -160,12 +160,6 @@ class WPSEO_Taxonomy_Metabox {
 	 * @return string The product title.
 	 */
 	protected function get_product_title() {
-		$product_title = 'Yoast SEO';
-
-		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
-			$product_title .= ' Premium';
-		}
-
-		return $product_title;
+		return YoastSEO()->helpers->product->get_product_name();
 	}
 }

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -88,10 +88,7 @@ class WPSEO_Taxonomy {
 	 * @return void
 	 */
 	private function show_internet_explorer_notice() {
-		$product_title = 'Yoast SEO';
-		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
-			$product_title .= ' Premium';
-		}
+		$product_title = YoastSEO()->helpers->product->get_name();
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $product_title is hardcoded.
 		printf( '<div id="wpseo_meta" class="postbox yoast wpseo-taxonomy-metabox-postbox"><h2><span>%1$s</span></h2>', $product_title );

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -89,7 +89,7 @@ class WPSEO_Taxonomy {
 	 */
 	private function show_internet_explorer_notice() {
 		$product_title = 'Yoast SEO';
-		if ( file_exists( WPSEO_PATH . 'premium/' ) ) {
+		if ( WPSEO_Utils::is_yoast_seo_premium() ) {
 			$product_title .= ' Premium';
 		}
 

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -88,7 +88,7 @@ class WPSEO_Taxonomy {
 	 * @return void
 	 */
 	private function show_internet_explorer_notice() {
-		$product_title = YoastSEO()->helpers->product->get_name();
+		$product_title = YoastSEO()->helpers->product->get_product_name();
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $product_title is hardcoded.
 		printf( '<div id="wpseo_meta" class="postbox yoast wpseo-taxonomy-metabox-postbox"><h2><span>%1$s</span></h2>', $product_title );

--- a/src/helpers/product-helper.php
+++ b/src/helpers/product-helper.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
-use WPSEO_Utils;
-
 /**
  * A helper object for the Yoast products.
  */
@@ -34,11 +32,9 @@ class Product_Helper {
 	/**
 	 * Checks if the installed version is Yoast SEO Premium.
 	 *
-	 * @codeCoverageIgnore It just wraps a static method.
-	 *
 	 * @return bool True when is premium.
 	 */
 	public function is_premium() {
-		return WPSEO_Utils::is_yoast_seo_premium();
+		return \defined( 'WPSEO_PREMIUM_PLUGIN_FILE' );
 	}
 }

--- a/src/helpers/product-helper.php
+++ b/src/helpers/product-helper.php
@@ -10,16 +10,25 @@ use WPSEO_Utils;
 class Product_Helper {
 
 	/**
-	 * Get the product name in the head section.
+	 * Gets the product name.
+	 *
+	 * @return string
+	 */
+	public function get_product_name() {
+		if ( $this->is_premium() ) {
+			return 'Yoast SEO Premium';
+		}
+
+		return 'Yoast SEO';
+	}
+
+	/**
+	 * Gets the product name in the head section.
 	 *
 	 * @return string
 	 */
 	public function get_name() {
-		if ( $this->is_premium() ) {
-			return 'Yoast SEO Premium plugin';
-		}
-
-		return 'Yoast SEO plugin';
+		return $this->get_product_name() . ' plugin';
 	}
 
 	/**

--- a/tests/unit/helpers/product-helper-test.php
+++ b/tests/unit/helpers/product-helper-test.php
@@ -50,9 +50,9 @@ class Product_Helper_Test extends TestCase {
 	 * @covers ::is_premium
 	 */
 	public function test_get_name_premium() {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Intended use, constant already exists.
 		\define( 'WPSEO_PREMIUM_PLUGIN_FILE', 'the_premium_plugin_file' );
 
 		$this->assertEquals( 'Yoast SEO Premium plugin', $this->instance->get_name() );
 	}
-
 }

--- a/tests/unit/helpers/product-helper-test.php
+++ b/tests/unit/helpers/product-helper-test.php
@@ -28,36 +28,31 @@ class Product_Helper_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->instance = Mockery::mock( Product_Helper::class )
-			->makePartial()
-			->shouldAllowMockingProtectedMethods();
-	}
-
-	/**
-	 * Retrieves the name when premium is 'active'.
-	 *
-	 * @covers ::get_name
-	 */
-	public function test_get_name_premium() {
-		$this->instance
-			->expects( 'is_premium' )
-			->once()
-			->andReturnTrue();
-
-		$this->assertEquals( 'Yoast SEO Premium plugin', $this->instance->get_name() );
+		$this->instance = new Product_Helper();
 	}
 
 	/**
 	 * Retrieves the name when premium is not 'active'.
 	 *
 	 * @covers ::get_name
+	 * @covers ::get_product_name
+	 * @covers ::is_premium
 	 */
 	public function test_get_name_not_premium() {
-		$this->instance
-			->expects( 'is_premium' )
-			->once()
-			->andReturnFalse();
-
 		$this->assertEquals( 'Yoast SEO plugin', $this->instance->get_name() );
 	}
+
+	/**
+	 * Retrieves the name when premium is 'active'.
+	 *
+	 * @covers ::get_name
+	 * @covers ::get_product_name
+	 * @covers ::is_premium
+	 */
+	public function test_get_name_premium() {
+		\define( 'WPSEO_PREMIUM_PLUGIN_FILE', 'the_premium_plugin_file' );
+
+		$this->assertEquals( 'Yoast SEO Premium plugin', $this->instance->get_name() );
+	}
+
 }

--- a/tests/unit/helpers/product-helper-test.php
+++ b/tests/unit/helpers/product-helper-test.php
@@ -20,7 +20,7 @@ class Product_Helper_Test extends TestCase {
 	 *
 	 * @var Mockery\Mock|Product_Helper
 	 */
-	private $instance;
+	protected $instance;
 
 	/**
 	 * Prepares the test.


### PR DESCRIPTION
The path no longer works since Premium became an add-on

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Because Premium is becoming an add-on, the `/premium` path no longer exists.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where we were using a path to check whether we are in the Premium plugin. This path no longer exists when Premium becomes an add-on.
* Adds a helper function to retrieve the plugin name, and simplifies the code in several places by calling this function.

## Relevant technical choices:

* I wanted to [remove the partial mock from the test](https://yoast.atlassian.net/wiki/spaces/DEV/pages/1081770041/Architecture+decision+log#Partial-mocks-are-discouraged-and-should-never-be-used-for-dependencies.), but then had the problem of having to mock a static method (`WPSEO_Utils:is_yoast_seo_premium`). Therefore, I moved the code from that util function to the helper.
* I didn't replace all the calls to `WPSEO_Utils:is_yoast_seo_premium` in the codebase with a call to the helper, since these were 16 instances and seem outside the scope of this PR, especially since it gets merged into the release branch.
* It doesn't seem great to have two functions named `get_name` and `get_product_name` in the `product-helper`, but since `get_name` is a released public function I didn't rename it.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Note**: this PR does some refactoring. The behavior of the code should stay the same as compared to `trunk` / the previous RC.

**To test in Free**

* Edit a post. In Free, the 'title' of the metabox should be `Yoast SEO`.
* See the same behaviour when editing a taxonomy.
* Inspect the page source of a published post. See it contains this text: "<!-- This site is optimized with the Yoast SEO plugin...".

Also perform the above steps in Internet Explorer and see the outcomes are the same (note: I didn't test this myself since I don't have Internet Explorer installed).

**To test in Premium**

* Check-out and pull Premium `trunk`.
* Run `composer require --dev yoast/wordpress-seo:dev-use-helper-to-check-for-premium@dev` to load the code from this branch.
* Build Premium
* Edit a post. The 'title' of the metabox should be `Yoast SEO Premium`.
* See the same behaviour when editing a taxonomy.
* Inspect the page source of a published post. See it contains this text: "<!-- This site is optimized with the Yoast SEO Premium plugin...".

Also perform the above steps in Internet Explorer and see the outcomes are the same (note: I didn't test this myself since I don't have Internet Explorer installed).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* The same steps as above, except that for Premium you can just use the RC rather than having to follow the check-out and build steps.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
