### PR TITLE
Replaces the deprecated indexable_prepare_indexation_action in the indexing command with the appropriate replacement.

### DIFF
--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -9,7 +9,6 @@ use Yoast\WP\SEO\Actions\Indexing\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Indexing_Complete_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Type_Archive_Indexation_Action;
-use Yoast\WP\SEO\Actions\Indexing\Indexable_Prepare_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexation_Action_Interface;
 use Yoast\WP\SEO\Actions\Indexing\Indexing_Prepare_Action;
@@ -56,11 +55,11 @@ class Index_Command implements Command_Interface {
 	private $complete_indexation_action;
 
 	/**
-	 * The prepare indexation action.
+	 * The indexing prepare action.
 	 *
-	 * @var Indexable_Prepare_Indexation_Action
+	 * @var Indexing_Prepare_Action
 	 */
-	private $prepare_indexation_action;
+	private $prepare_indexing_action;
 
 	/**
 	 * Generate_Indexables_Command constructor.
@@ -75,7 +74,7 @@ class Index_Command implements Command_Interface {
 	 *                                                                                             action.
 	 * @param Indexable_Indexing_Complete_Action            $complete_indexation_action            The complete indexation
 	 *                                                                                             action.
-	 * @param Indexing_Prepare_Action                       $prepare_indexation_action             The prepare indexation
+	 * @param Indexing_Prepare_Action                       $prepare_indexing_action               The prepare indexing
 	 *                                                                                             action.
 	 */
 	public function __construct(
@@ -84,14 +83,14 @@ class Index_Command implements Command_Interface {
 		Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation_action,
 		Indexable_General_Indexation_Action $general_indexation_action,
 		Indexable_Indexing_Complete_Action $complete_indexation_action,
-		Indexing_Prepare_Action $prepare_indexation_action
+		Indexing_Prepare_Action $prepare_indexing_action
 	) {
 		$this->post_indexation_action              = $post_indexation_action;
 		$this->term_indexation_action              = $term_indexation_action;
 		$this->post_type_archive_indexation_action = $post_type_archive_indexation_action;
 		$this->general_indexation_action           = $general_indexation_action;
 		$this->complete_indexation_action          = $complete_indexation_action;
-		$this->prepare_indexation_action           = $prepare_indexation_action;
+		$this->prepare_indexing_action             = $prepare_indexing_action;
 	}
 
 	/**
@@ -181,7 +180,7 @@ class Index_Command implements Command_Interface {
 			'general objects'    => $this->general_indexation_action,
 		];
 
-		$this->prepare_indexation_action->prepare();
+		$this->prepare_indexing_action->prepare();
 
 		foreach ( $indexation_actions as $name => $indexation_action ) {
 			$this->run_indexation_action( $name, $indexation_action );

--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -12,6 +12,7 @@ use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Type_Archive_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Prepare_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexation_Action_Interface;
+use Yoast\WP\SEO\Actions\Indexing\Indexing_Prepare_Action;
 use Yoast\WP\SEO\Main;
 
 /**
@@ -64,18 +65,18 @@ class Index_Command implements Command_Interface {
 	/**
 	 * Generate_Indexables_Command constructor.
 	 *
-	 * @param Indexable_Post_Indexation_Action              $post_indexation_action              The post indexation
-	 *                                                                                           action.
-	 * @param Indexable_Term_Indexation_Action              $term_indexation_action              The term indexation
-	 *                                                                                           action.
-	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation_action The post type archive
-	 *                                                                                           indexation action.
-	 * @param Indexable_General_Indexation_Action           $general_indexation_action           The general indexation
-	 *                                                                                           action.
-	 * @param Indexable_Indexing_Complete_Action            $complete_indexation_action          The complete indexation
+	 * @param Indexable_Post_Indexation_Action              $post_indexation_action                The post indexation
 	 *                                                                                             action.
-	 * @param Indexable_Prepare_Indexation_Action           $prepare_indexation_action           The prepare indexation
-	 *                                                                                           action.
+	 * @param Indexable_Term_Indexation_Action              $term_indexation_action                The term indexation
+	 *                                                                                             action.
+	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation_action   The post type archive
+	 *                                                                                             indexation action.
+	 * @param Indexable_General_Indexation_Action           $general_indexation_action             The general indexation
+	 *                                                                                             action.
+	 * @param Indexable_Indexing_Complete_Action            $complete_indexation_action            The complete indexation
+	 *                                                                                             action.
+	 * @param Indexing_Prepare_Action                       $prepare_indexation_action             The prepare indexation
+	 *                                                                                             action.
 	 */
 	public function __construct(
 		Indexable_Post_Indexation_Action $post_indexation_action,
@@ -83,7 +84,7 @@ class Index_Command implements Command_Interface {
 		Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation_action,
 		Indexable_General_Indexation_Action $general_indexation_action,
 		Indexable_Indexing_Complete_Action $complete_indexation_action,
-		Indexable_Prepare_Indexation_Action $prepare_indexation_action
+		Indexing_Prepare_Action $prepare_indexation_action
 	) {
 		$this->post_indexation_action              = $post_indexation_action;
 		$this->term_indexation_action              = $term_indexation_action;

--- a/src/deprecated/src/actions/indexing/indexable-prepare-indexation-action.php
+++ b/src/deprecated/src/actions/indexing/indexable-prepare-indexation-action.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\SEO\Actions\Indexing;
 
-use Yoast\WP\SEO\Actions\Indexing\Indexing_Prepare_Action;
-
 /**
  * Action for preparing the indexing routine.
  *

--- a/src/routes/indexing-route.php
+++ b/src/routes/indexing-route.php
@@ -187,7 +187,7 @@ class Indexing_Route extends Abstract_Indexation_Route {
 	 *
 	 * @var Indexing_Prepare_Action
 	 */
-	protected $prepare_indexation_action;
+	protected $prepare_indexing_action;
 
 	/**
 	 * The indexable indexing complete action.
@@ -240,7 +240,7 @@ class Indexing_Route extends Abstract_Indexation_Route {
 	 * @param Indexable_General_Indexation_Action           $general_indexation_action           The general indexing action.
 	 * @param Indexable_Indexing_Complete_Action            $indexable_indexing_complete_action  The complete indexing action.
 	 * @param Indexing_Complete_Action                      $indexing_complete_action            The complete indexing action.
-	 * @param Indexing_Prepare_Action                       $prepare_indexation_action           The prepare indexing action.
+	 * @param Indexing_Prepare_Action                       $prepare_indexing_action             The prepare indexing action.
 	 * @param Post_Link_Indexing_Action                     $post_link_indexing_action           The post link indexing action.
 	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action           The term link indexing action.
 	 * @param Options_Helper                                $options_helper                      The options helper.
@@ -253,7 +253,7 @@ class Indexing_Route extends Abstract_Indexation_Route {
 		Indexable_General_Indexation_Action $general_indexation_action,
 		Indexable_Indexing_Complete_Action $indexable_indexing_complete_action,
 		Indexing_Complete_Action $indexing_complete_action,
-		Indexing_Prepare_Action $prepare_indexation_action,
+		Indexing_Prepare_Action $prepare_indexing_action,
 		Post_Link_Indexing_Action $post_link_indexing_action,
 		Term_Link_Indexing_Action $term_link_indexing_action,
 		Options_Helper $options_helper,
@@ -265,7 +265,7 @@ class Indexing_Route extends Abstract_Indexation_Route {
 		$this->general_indexation_action           = $general_indexation_action;
 		$this->indexable_indexing_complete_action  = $indexable_indexing_complete_action;
 		$this->indexing_complete_action            = $indexing_complete_action;
-		$this->prepare_indexation_action           = $prepare_indexation_action;
+		$this->prepare_indexing_action             = $prepare_indexing_action;
 		$this->post_link_indexing_action           = $post_link_indexing_action;
 		$this->term_link_indexing_action           = $term_link_indexing_action;
 		$this->options_helper                      = $options_helper;
@@ -370,7 +370,7 @@ class Indexing_Route extends Abstract_Indexation_Route {
 	 * @return WP_REST_Response The response.
 	 */
 	public function prepare() {
-		$this->prepare_indexation_action->prepare();
+		$this->prepare_indexing_action->prepare();
 
 		return $this->respond_with( [], false );
 	}

--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -8,7 +8,6 @@ use Yoast\WP\SEO\Actions\Indexing\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Indexing_Complete_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Type_Archive_Indexation_Action;
-use Yoast\WP\SEO\Actions\Indexing\Indexable_Prepare_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexing_Prepare_Action;
 use Yoast\WP\SEO\Commands\Index_Command;
@@ -63,9 +62,9 @@ class Index_Command_Test extends TestCase {
 	/**
 	 * The prepare indexation action.
 	 *
-	 * @var Indexable_Prepare_Indexation_Action
+	 * @var Indexing_Prepare_Action
 	 */
-	private $prepare_indexation_action;
+	private $prepare_indexing_action;
 
 	/**
 	 * The instance
@@ -85,7 +84,7 @@ class Index_Command_Test extends TestCase {
 		$this->post_type_archive_indexation_action = Mockery::mock( Indexable_Post_Type_Archive_Indexation_Action::class );
 		$this->general_indexation_action           = Mockery::mock( Indexable_General_Indexation_Action::class );
 		$this->complete_indexation_action          = Mockery::mock( Indexable_Indexing_Complete_Action::class );
-		$this->prepare_indexation_action           = Mockery::mock( Indexable_Prepare_Indexation_Action::class );
+		$this->prepare_indexing_action             = Mockery::mock( Indexing_Prepare_Action::class );
 
 		$this->instance = new Index_Command(
 			$this->post_indexation_action,
@@ -93,7 +92,7 @@ class Index_Command_Test extends TestCase {
 			$this->post_type_archive_indexation_action,
 			$this->general_indexation_action,
 			$this->complete_indexation_action,
-			$this->prepare_indexation_action
+			$this->prepare_indexing_action
 		);
 	}
 
@@ -121,7 +120,7 @@ class Index_Command_Test extends TestCase {
 		);
 		self::assertInstanceOf(
 			Indexing_Prepare_Action::class,
-			self::getPropertyValue( $this->instance, 'prepare_indexation_action' )
+			self::getPropertyValue( $this->instance, 'prepare_indexing_action' )
 		);
 	}
 
@@ -147,7 +146,7 @@ class Index_Command_Test extends TestCase {
 				->andReturn( \array_fill( 0, 25, true ), \array_fill( 0, 5, true ) );
 		}
 
-		$this->prepare_indexation_action->expects( 'prepare' )->once();
+		$this->prepare_indexing_action->expects( 'prepare' )->once();
 
 		$this->complete_indexation_action->expects( 'complete' )->once();
 
@@ -188,7 +187,7 @@ class Index_Command_Test extends TestCase {
 
 		$this->complete_indexation_action->expects( 'complete' )->once();
 
-		$this->prepare_indexation_action->expects( 'prepare' )->once();
+		$this->prepare_indexing_action->expects( 'prepare' )->once();
 
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
@@ -291,7 +290,7 @@ class Index_Command_Test extends TestCase {
 
 		// Expect the complete and prepare actions twice: once for each site in the multisite.
 		$this->complete_indexation_action->expects( 'complete' )->twice();
-		$this->prepare_indexation_action->expects( 'prepare' )->twice();
+		$this->prepare_indexing_action->expects( 'prepare' )->twice();
 
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )

--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -10,6 +10,7 @@ use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Type_Archive_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Prepare_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
+use Yoast\WP\SEO\Actions\Indexing\Indexing_Prepare_Action;
 use Yoast\WP\SEO\Commands\Index_Command;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -102,21 +103,25 @@ class Index_Command_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		$this->assertInstanceOf(
+		self::assertInstanceOf(
 			Indexable_Post_Indexation_Action::class,
-			$this->getPropertyValue( $this->instance, 'post_indexation_action' )
+			self::getPropertyValue( $this->instance, 'post_indexation_action' )
 		);
-		$this->assertInstanceOf(
+		self::assertInstanceOf(
 			Indexable_Term_Indexation_Action::class,
-			$this->getPropertyValue( $this->instance, 'term_indexation_action' )
+			self::getPropertyValue( $this->instance, 'term_indexation_action' )
 		);
-		$this->assertInstanceOf(
+		self::assertInstanceOf(
 			Indexable_Post_Type_Archive_Indexation_Action::class,
-			$this->getPropertyValue( $this->instance, 'post_type_archive_indexation_action' )
+			self::getPropertyValue( $this->instance, 'post_type_archive_indexation_action' )
 		);
-		$this->assertInstanceOf(
+		self::assertInstanceOf(
 			Indexable_General_Indexation_Action::class,
-			$this->getPropertyValue( $this->instance, 'general_indexation_action' )
+			self::getPropertyValue( $this->instance, 'general_indexation_action' )
+		);
+		self::assertInstanceOf(
+			Indexing_Prepare_Action::class,
+			self::getPropertyValue( $this->instance, 'prepare_indexation_action' )
 		);
 	}
 

--- a/tests/unit/routes/indexing-route-test.php
+++ b/tests/unit/routes/indexing-route-test.php
@@ -8,7 +8,7 @@ use Yoast\WP\SEO\Actions\Indexing\Indexable_General_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Indexing_Complete_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Type_Archive_Indexation_Action;
-use Yoast\WP\SEO\Actions\Indexing\Indexable_Prepare_Indexation_Action;
+use Yoast\WP\SEO\Actions\Indexing\Indexing_Prepare_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexing_Complete_Action;
 use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
@@ -72,11 +72,11 @@ class Indexing_Route_Test extends TestCase {
 	protected $indexing_complete_action;
 
 	/**
-	 * Represents the prepare indexation action.
+	 * Represents the prepare indexing action.
 	 *
-	 * @var Mockery\MockInterface|Indexable_Prepare_Indexation_Action
+	 * @var Mockery\MockInterface|Indexing_Prepare_Action
 	 */
-	protected $prepare_indexation_action;
+	protected $prepare_indexing_action;
 
 	/**
 	 * Represents the prepare indexation action.
@@ -125,7 +125,7 @@ class Indexing_Route_Test extends TestCase {
 		$this->general_indexation_action           = Mockery::mock( Indexable_General_Indexation_Action::class );
 		$this->indexable_indexing_complete_action  = Mockery::mock( Indexable_Indexing_Complete_Action::class );
 		$this->indexing_complete_action            = Mockery::mock( Indexing_Complete_Action::class );
-		$this->prepare_indexation_action           = Mockery::mock( Indexable_Prepare_Indexation_Action::class );
+		$this->prepare_indexing_action             = Mockery::mock( Indexing_Prepare_Action::class );
 		$this->post_link_indexing_action           = Mockery::mock( Post_Link_Indexing_Action::class );
 		$this->term_link_indexing_action           = Mockery::mock( Term_Link_Indexing_Action::class );
 		$this->options_helper                      = Mockery::mock( Options_Helper::class );
@@ -140,7 +140,7 @@ class Indexing_Route_Test extends TestCase {
 			$this->general_indexation_action,
 			$this->indexable_indexing_complete_action,
 			$this->indexing_complete_action,
-			$this->prepare_indexation_action,
+			$this->prepare_indexing_action,
 			$this->post_link_indexing_action,
 			$this->term_link_indexing_action,
 			$this->options_helper,
@@ -179,8 +179,8 @@ class Indexing_Route_Test extends TestCase {
 			$this->getPropertyValue( $this->instance, 'indexing_complete_action' )
 		);
 		$this->assertInstanceOf(
-			Indexable_Prepare_Indexation_Action::class,
-			$this->getPropertyValue( $this->instance, 'prepare_indexation_action' )
+			Indexing_Prepare_Action::class,
+			$this->getPropertyValue( $this->instance, 'prepare_indexing_action' )
 		);
 		$this->assertInstanceOf(
 			Post_Link_Indexing_Action::class,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We do not want to use our own deprecated classes.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a deprecation notice would be shown when in a WordPress development environment and visiting a page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Reproduction steps
* Make sure that the Query Monitor plugin is installed and activated.
* Run `composer compile-di`.
* Go to any webpage on your website.
* Click on the Query Monitor bar in the admin bar at the top of the page.
* You should see this deprecation warning:
  ```
  Deprecated (Suppressed) | Relying on service auto-registration for type 
  "Yoast\WP\SEO\Actions\Indexing\Indexable_Prepare_Indexation_Action" is deprecated since Symfony 3.4 
  and won't be supported in 4.0. Create a service named 
  "Yoast\WP\SEO\Actions\Indexing\Indexable_Prepare_Indexation_Action" instead.
  ```

### Checking it it has been fixed
* Make sure that the Query Monitor plugin is installed and activated.
* Run `composer compile-di`.
* Go to any webpage on your website.
* Click on the Query Monitor bar in the admin bar at the top of the page.
* You should not see any deprecation warnings.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A: the error only occurs in development builds with query monitor installed.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The index command, e.g. running `wp yoast index` using the WordPress Command Line Interface (WP CLI). It should still work as expected: creating indexable for the posts, terms and other objects (homepage, 404-page, etc.) on your site.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
