### PR TITLE
P3-368 Reinstate code added to Free files in Premium repo by mistake

### DIFF
--- a/admin/views/class-yoast-feature-toggle.php
+++ b/admin/views/class-yoast-feature-toggle.php
@@ -76,7 +76,7 @@ class Yoast_Feature_Toggle {
 	 *
 	 *     @type string $name            Required. Feature toggle identifier.
 	 *     @type string $setting         Required. Name of the setting the feature toggle is associated with.
-	 *     @type string $label           Required. Feature toggle label.
+	 *     @type string $label           Feature toggle label.
 	 *     @type string $read_more_url   URL to learn more about the feature. Default empty string.
 	 *     @type string $read_more_label Label for the learn more link. Default empty string.
 	 *     @type string $extra           Additional help content for the feature. Default empty string.
@@ -87,7 +87,7 @@ class Yoast_Feature_Toggle {
 	 * @throws InvalidArgumentException Thrown when a required argument is missing.
 	 */
 	public function __construct( array $args ) {
-		$required_keys = [ 'name', 'setting', 'label' ];
+		$required_keys = [ 'name', 'setting' ];
 
 		foreach ( $required_keys as $key ) {
 			if ( empty( $args[ $key ] ) ) {

--- a/admin/views/tabs/dashboard/integrations.php
+++ b/admin/views/tabs/dashboard/integrations.php
@@ -59,6 +59,7 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 			);
 
 			if ( ! empty( $integration->after ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput -- after contains HTMl and we assume it's properly escape on object creation.
 				echo $integration->after;
 			}
 		}

--- a/admin/views/tabs/dashboard/integrations.php
+++ b/admin/views/tabs/dashboard/integrations.php
@@ -57,6 +57,10 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 				'<strong>' . $integration->name . '</strong>',
 				$feature_help->get_button_html() . $feature_help->get_panel_html()
 			);
+
+			if ( ! empty( $integration->after ) ) {
+				echo $integration->after;
+			}
 		}
 		?>
 	</div>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Code used by the Zapier integration toggle was adeed to the Free files in the Premium repo by mistake, so it was not present anymore since Free was imported as a dependency. We should fix that

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where integrations toggles wouldn't display following content.

## Relevant technical choices:

* The PR which added to Premium code meant to Free is: https://github.com/Yoast/wordpress-seo-premium/pull/3035
Only the changes for the first two files are needed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* this needs to be tested on Premium: check out the `hotfix/15.8.1` branch there
* run `composer require --dev yoast/wordpress-seo:dev-P3-368-fix-missing-info-after-integration-toggles@dev`
* build
* visit SEO->General, Integrations tab
* switch on the toggle for Zapier and see that the text + the box with the API key and the buttons are present.
* save and see that the text is still there on reload
* switch on and off the toggle, saving in the middle, to see the text is always displayed when you set the toggle to on



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-368]
