### PR TITLE
Add custom versions to the migration runner

### DIFF
--- a/src/config/migration-status.php
+++ b/src/config/migration-status.php
@@ -26,11 +26,12 @@ class Migration_Status {
 	/**
 	 * Checks if a given migration should be run.
 	 *
-	 * @param string $name The name of the migration.
+	 * @param string $name    The name of the migration.
+	 * @param string $version The current version.
 	 *
 	 * @return bool Whether or not the migration should be run.
 	 */
-	public function should_run_migration( $name ) {
+	public function should_run_migration( $name, $version = \WPSEO_VERSION ) {
 		$migration_status = $this->get_migration_status( $name );
 
 		// Check if we've attempted to run this migration in the past 10 minutes. If so, it may still be running.
@@ -41,7 +42,7 @@ class Migration_Status {
 		}
 
 		// Is the migration version less than the current version.
-		return \version_compare( $migration_status['version'], \WPSEO_VERSION, '<' );
+		return \version_compare( $migration_status['version'], $version, '<' );
 	}
 
 	/**
@@ -80,15 +81,16 @@ class Migration_Status {
 	 *
 	 * @param string $name    The name of the migration.
 	 * @param string $message Message explaining the reason for the error.
+	 * @param string $version The current version.
 	 *
 	 * @return void
 	 */
-	public function set_error( $name, $message ) {
+	public function set_error( $name, $message, $version = \WPSEO_VERSION ) {
 		$migration_status = $this->get_migration_status( $name );
 
 		$migration_status['error'] = [
 			'time'    => \strtotime( 'now' ),
-			'version' => \WPSEO_VERSION,
+			'version' => $version,
 			'message' => $message,
 		];
 
@@ -98,15 +100,16 @@ class Migration_Status {
 	/**
 	 * Updates the migration version to the latest version.
 	 *
-	 * @param string $name The name of the migration.
+	 * @param string $name    The name of the migration.
+	 * @param string $version The current version.
 	 *
 	 * @return void
 	 */
-	public function set_success( $name ) {
+	public function set_success( $name, $version = \WPSEO_VERSION ) {
 		$migration_status = $this->get_migration_status( $name );
 		unset( $migration_status['lock'] );
 		unset( $migration_status['error'] );
-		$migration_status['version'] = \WPSEO_VERSION;
+		$migration_status['version'] = $version;
 		$this->set_migration_status( $name, $migration_status );
 	}
 

--- a/src/initializers/migration-runner.php
+++ b/src/initializers/migration-runner.php
@@ -90,14 +90,15 @@ class Migration_Runner implements Initializer_Interface {
 	/**
 	 * Initializes the migrations.
 	 *
-	 * @param string $name The name of the migration.
+	 * @param string $name    The name of the migration.
+	 * @param string $version The current version.
 	 *
 	 * @return bool True on success, false on failure.
 	 *
 	 * @throws Exception If the migration fails and YOAST_ENVIRONMENT is not production.
 	 */
-	public function run_migrations( $name ) {
-		if ( ! $this->migration_status->should_run_migration( $name ) ) {
+	public function run_migrations( $name, $version = \WPSEO_VERSION ) {
+		if ( ! $this->migration_status->should_run_migration( $name, $version ) ) {
 			return true;
 		}
 
@@ -108,7 +109,7 @@ class Migration_Runner implements Initializer_Interface {
 		$migrations = $this->loader->get_migrations( $name );
 
 		if ( $migrations === false ) {
-			$this->migration_status->set_error( $name, "Could not perform $name migrations. No migrations found." );
+			$this->migration_status->set_error( $name, "Could not perform $name migrations. No migrations found.", $version );
 			return false;
 		}
 
@@ -120,13 +121,14 @@ class Migration_Runner implements Initializer_Interface {
 
 			\sort( $to_do_versions, \SORT_STRING );
 
-			foreach ( $to_do_versions as $version ) {
-				$class = $migrations[ $version ];
-				$this->run_migration( $version, $class );
+			foreach ( $to_do_versions as $to_do_version ) {
+				$class = $migrations[ $to_do_version ];
+				$this->run_migration( $to_do_version, $class );
 			}
 		} catch ( Exception $exception ) {
 			// Something went wrong...
-			$this->migration_status->set_error( $name, $exception->getMessage() );
+			var_dump( $name, $exception->getMessage(), $version );
+			$this->migration_status->set_error( $name, $exception->getMessage(), $version );
 
 			if ( \defined( 'YOAST_ENVIRONMENT' ) && \YOAST_ENVIRONMENT !== 'production' ) {
 				throw $exception;
@@ -135,7 +137,7 @@ class Migration_Runner implements Initializer_Interface {
 			return false;
 		}
 
-		$this->migration_status->set_success( $name );
+		$this->migration_status->set_success( $name, $version );
 
 		return true;
 	}

--- a/src/initializers/migration-runner.php
+++ b/src/initializers/migration-runner.php
@@ -127,7 +127,6 @@ class Migration_Runner implements Initializer_Interface {
 			}
 		} catch ( Exception $exception ) {
 			// Something went wrong...
-			var_dump( $name, $exception->getMessage(), $version );
 			$this->migration_status->set_error( $name, $exception->getMessage(), $version );
 
 			if ( \defined( 'YOAST_ENVIRONMENT' ) && \YOAST_ENVIRONMENT !== 'production' ) {

--- a/tests/unit/database/migration-runner-test.php
+++ b/tests/unit/database/migration-runner-test.php
@@ -69,9 +69,9 @@ class Migration_Runner_Test extends TestCase {
 		$loader_mock  = Mockery::mock( Loader::class );
 		$adapter_mock = Mockery::mock( Adapter::class );
 
-		$status_mock->expects( 'should_run_migration' )->once()->with( 'test' )->andReturn( true );
+		$status_mock->expects( 'should_run_migration' )->once()->with( 'test', \WPSEO_VERSION )->andReturn( true );
 		$status_mock->expects( 'lock_migration' )->once()->with( 'test' )->andReturn( true );
-		$status_mock->expects( 'set_success' )->once()->with( 'test' );
+		$status_mock->expects( 'set_success' )->once()->with( 'test', \WPSEO_VERSION );
 		$adapter_mock->expects( 'create_schema_version_table' )->once();
 		$adapter_mock->expects( 'get_migrated_versions' )->once()->andReturn( [] );
 		$adapter_mock->expects( 'start_transaction' )->once();
@@ -98,7 +98,7 @@ class Migration_Runner_Test extends TestCase {
 		$loader_mock  = Mockery::mock( Loader::class );
 		$adapter_mock = Mockery::mock( Adapter::class );
 
-		$status_mock->expects( 'should_run_migration' )->once()->with( 'test' )->andReturn( false );
+		$status_mock->expects( 'should_run_migration' )->once()->with( 'test', \WPSEO_VERSION )->andReturn( false );
 
 		$instance = new Migration_Runner( $status_mock, $loader_mock, $adapter_mock );
 
@@ -115,7 +115,7 @@ class Migration_Runner_Test extends TestCase {
 		$loader_mock  = Mockery::mock( Loader::class );
 		$adapter_mock = Mockery::mock( Adapter::class );
 
-		$status_mock->expects( 'should_run_migration' )->once()->with( 'test' )->andReturn( true );
+		$status_mock->expects( 'should_run_migration' )->once()->with( 'test', \WPSEO_VERSION )->andReturn( true );
 		$status_mock->expects( 'lock_migration' )->once()->with( 'test' )->andReturn( false );
 
 		$instance = new Migration_Runner( $status_mock, $loader_mock, $adapter_mock );
@@ -133,9 +133,9 @@ class Migration_Runner_Test extends TestCase {
 		$loader_mock  = Mockery::mock( Loader::class );
 		$adapter_mock = Mockery::mock( Adapter::class );
 
-		$status_mock->expects( 'should_run_migration' )->once()->with( 'test' )->andReturn( true );
+		$status_mock->expects( 'should_run_migration' )->once()->with( 'test', \WPSEO_VERSION )->andReturn( true );
 		$status_mock->expects( 'lock_migration' )->once()->with( 'test' )->andReturn( true );
-		$status_mock->expects( 'set_error' )->once()->with( 'test', 'Could not perform test migrations. No migrations found.' );
+		$status_mock->expects( 'set_error' )->once()->with( 'test', 'Could not perform test migrations. No migrations found.', \WPSEO_VERSION );
 		$loader_mock->expects( 'get_migrations' )->once()->with( 'test' )->andReturn( false );
 
 		$instance = new Migration_Runner( $status_mock, $loader_mock, $adapter_mock );
@@ -156,9 +156,9 @@ class Migration_Runner_Test extends TestCase {
 		$loader_mock  = Mockery::mock( Loader::class );
 		$adapter_mock = Mockery::mock( Adapter::class );
 
-		$status_mock->expects( 'should_run_migration' )->once()->with( 'test' )->andReturn( true );
+		$status_mock->expects( 'should_run_migration' )->once()->with( 'test', \WPSEO_VERSION )->andReturn( true );
 		$status_mock->expects( 'lock_migration' )->once()->with( 'test' )->andReturn( true );
-		$status_mock->expects( 'set_error' )->once()->with( 'test', Migration_Double::class . ' - Migration error' );
+		$status_mock->expects( 'set_error' )->once()->with( 'test', Migration_Double::class . ' - Migration error', \WPSEO_VERSION );
 		$adapter_mock->expects( 'create_schema_version_table' )->once();
 		$adapter_mock->expects( 'get_migrated_versions' )->once()->andReturn( [] );
 		$adapter_mock->expects( 'start_transaction' )->once();

--- a/tests/unit/database/migration-status-test.php
+++ b/tests/unit/database/migration-status-test.php
@@ -33,6 +33,22 @@ class Migration_Status_Test extends TestCase {
 	}
 
 	/**
+	 * Tests whether the migration is run when the migration option key exists.
+	 *
+	 * @covers ::should_run_migration
+	 */
+	public function test_should_run_migration_with_custom_version() {
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		Monkey\Functions\expect( 'get_option' )->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
+			->once()
+			->andReturn( [ 'version' => '1.0' ] );
+
+		$instance = new Migration_Status();
+
+		$this->assertFalse( $instance->should_run_migration( 'test', '0.9' ) );
+	}
+
+	/**
 	 * Tests whether the migration is run when the migration option key doesn't exist.
 	 *
 	 * @covers ::should_run_migration
@@ -271,6 +287,37 @@ class Migration_Status_Test extends TestCase {
 	}
 
 	/**
+	 * Tests setting the error.
+	 *
+	 * @covers ::set_error
+	 */
+	public function test_set_error_custom_version() {
+		$error_message   = 'Something went wrong';
+		$expected_option = [
+			'version' => '1.0',
+			'error'   => [
+				'message' => $error_message,
+				'time'    => \strtotime( 'now' ),
+				'version' => '1.9',
+			],
+		];
+
+		Monkey\Functions\expect( 'get_current_blog_id' )->twice()->andReturn( 1 );
+		Monkey\Functions\expect( 'get_option' )
+			->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
+			->once()
+			->andReturn( [ 'version' => '1.0' ] );
+		Monkey\Functions\expect( 'update_option' )
+			->with( Migration_Status::MIGRATION_OPTION_KEY . 'test', $expected_option )
+			->once()
+			->andReturn( true );
+
+		$instance = new Migration_Status();
+
+		$instance->set_error( 'test', $error_message, '1.9' );
+	}
+
+	/**
 	 * Tests the success status setting.
 	 *
 	 * @covers ::set_success
@@ -291,6 +338,29 @@ class Migration_Status_Test extends TestCase {
 		$instance = new Migration_Status();
 
 		$instance->set_success( 'test' );
+	}
+
+	/**
+	 * Tests the success status setting.
+	 *
+	 * @covers ::set_success
+	 */
+	public function test_set_success_custom_version() {
+		$expected_option = [ 'version' => '1.9' ];
+
+		Monkey\Functions\expect( 'get_current_blog_id' )->twice()->andReturn( 1 );
+		Monkey\Functions\expect( 'get_option' )
+			->with( Migration_Status::MIGRATION_OPTION_KEY . 'test' )
+			->once()
+			->andReturn( [ 'version' => '1.0' ] );
+		Monkey\Functions\expect( 'update_option' )
+			->with( Migration_Status::MIGRATION_OPTION_KEY . 'test', $expected_option )
+			->once()
+			->andReturn( true );
+
+		$instance = new Migration_Status();
+
+		$instance->set_success( 'test', '1.9' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Allows using the migration runner with other versions than `WPSEO_VERSION`. This is preparation for premium as an addon.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* The Migration_Runner class now accepts an optional `$version` argument to the `run_migrations` function allowing it to be used in addons.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* When installing the plugin on a clean database migrations should be run as they normally are.
* Can also be tested by simply clearing the indexable tables from the test helper plugin.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Running DB migrations.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
