### PR TITLE
Only show schema validation result when block has an 'is-yoast-schema-block' attribute that is set to 'true'.

### DIFF
--- a/js/src/helpers/addCheckToChecklist.js
+++ b/js/src/helpers/addCheckToChecklist.js
@@ -73,7 +73,7 @@ export function maybeAddSEOCheck( checklist, store ) {
  * @returns {boolean} If the list of blocks contains schema blocks.
  */
 function includesSchemaBlocks( blocks ) {
-	return blocks.some( block => Object.keys( block.attributes ).includes( "yoast-schema" ) );
+	return blocks.some( block => block.attributes[ "is-yoast-schema-block" ] === true );
 }
 
 /**

--- a/js/tests/containers/DocumentSidebar.test.js
+++ b/js/tests/containers/DocumentSidebar.test.js
@@ -33,7 +33,7 @@ describe( "The DocumentSidebar container", () => {
 				name: "yoast/recipe",
 				clientId: "0890e6b3-235b-4b71-9d27-c0c9fd980137",
 				attributes: {
-					"yoast-schema": {},
+					"is-yoast-schema-block": true,
 				},
 			},
 			{
@@ -108,7 +108,7 @@ describe( "The DocumentSidebar container", () => {
 				name: "yoast/recipe",
 				clientId: "0890e6b3-235b-4b71-9d27-c0c9fd980137",
 				attributes: {
-					"yoast-schema": {},
+					"is-yoast-schema-block": true,
 				},
 			},
 			{

--- a/js/tests/containers/PrePublish.test.js
+++ b/js/tests/containers/PrePublish.test.js
@@ -36,7 +36,7 @@ describe( "The PrePublish container", () => {
 				name: "yoast/recipe",
 				clientId: "0890e6b3-235b-4b71-9d27-c0c9fd980137",
 				attributes: {
-					"yoast-schema": {},
+					"is-yoast-schema-block": true,
 				},
 			},
 			{


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where no schema analysis was shown when no block schema was generated yet.

## Relevant technical choices:

* The code now checks specifically for blocks with the `is-yoast-schema-block` attribute, rather than looking at whether or not the `yoast-schema` attribute is defined.
	* Reasoning: it is better to be explicit than to deduce it implicitly. 	

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Companion PR of https://github.com/Yoast/wordpress-seo-premium/pull/3196. Please follow its test instructions.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
