### PR TITLE
P1 332 persistent dismissable alert for addon settings

### DIFF
--- a/js/src/containers/PersistentDismissableAlert.js
+++ b/js/src/containers/PersistentDismissableAlert.js
@@ -11,7 +11,7 @@ export default compose( [
 	withSelect( ( select, ownProps ) => {
 		const {
 			isAlertDismissed,
-		} = select( "yoast-seo/editor" );
+		} = select( ownProps.store || "yoast-seo/editor" );
 
 		return {
 			isAlertDismissed: isAlertDismissed( ownProps.alertKey ),
@@ -21,7 +21,7 @@ export default compose( [
 	withDispatch( ( dispatch, ownProps ) => {
 		const {
 			dismissAlert,
-		} = dispatch( "yoast-seo/editor" );
+		} = dispatch( ownProps.store || "yoast-seo/editor" );
 
 		return {
 			onDismissed: () => dismissAlert( ownProps.alertKey ),

--- a/js/src/editor-modules.js
+++ b/js/src/editor-modules.js
@@ -21,6 +21,7 @@ import SidebarItem from "./components/SidebarItem";
 import * as ajaxHelper from "./helpers/ajaxHelper";
 import EditorModal from "./containers/EditorModal";
 import ImageSelectPortal from "./components/portals/ImageSelectPortal";
+import PersistentDismissableAlert from "./containers/PersistentDismissableAlert";
 
 window.yoast = window.yoast || {};
 window.yoast.editorModules = {
@@ -53,6 +54,7 @@ window.yoast.editorModules = {
 	},
 	containers: {
 		EditorModal,
+		PersistentDismissableAlert,
 		Results,
 		SEMrushRelatedKeyphrases,
 	},

--- a/js/src/initializers/settings-store.js
+++ b/js/src/initializers/settings-store.js
@@ -1,0 +1,26 @@
+import { pickBy } from "lodash";
+import { registerStore, combineReducers } from "@wordpress/data";
+import dismissedAlertsReducer from "../redux/reducers/dismissedAlerts";
+import * as selectors from "../redux/selectors/dismissedAlerts";
+import * as actions from "../redux/actions/dismissedAlerts";
+import * as controls from "../redux/controls/dismissedAlerts";
+
+const reducers = {
+	dismissedAlerts: dismissedAlertsReducer,
+};
+
+/**
+ * Initializes the Yoast SEO settings store.
+ *
+ * @returns {object} The Yoast SEO settings store.
+ */
+export default function initSettingsStore() {
+	const store = registerStore( "yoast-seo/settings", {
+		reducer: combineReducers( reducers ),
+		selectors,
+		actions: pickBy( actions, x => typeof x === "function" ),
+		controls,
+	} );
+
+	return store;
+}

--- a/js/src/settings.js
+++ b/js/src/settings.js
@@ -3,6 +3,7 @@ import initAdminMedia from "./initializers/admin-media";
 import initAdmin from "./initializers/admin";
 import initSearchAppearance from "./initializers/search-appearance";
 import initSocialSettings from "./initializers/social-settings";
+import initSettingsStore from "./initializers/settings-store";
 
 initAdmin( jQuery );
 if ( wpseoScriptData && typeof wpseoScriptData.media !== "undefined" ) {
@@ -13,4 +14,7 @@ if ( wpseoScriptData && typeof wpseoScriptData.searchAppearance !== "undefined" 
 }
 if ( wpseoScriptData && typeof wpseoScriptData.social !== "undefined" ) {
 	initSocialSettings();
+}
+if ( wpseoScriptData && typeof wpseoScriptData.dismissedAlerts !== "undefined" ) {
+	initSettingsStore();
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The PersistentDismissableAlert Container wasn't useable on settings pages and not useable in add-ons. This PR adds functionality for this uses.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enhances the Dismissible Alert, so that it can be used in more places.

## Relevant technical choices:

* Exposed the PersistentDismissableAlert Container via Editor Modules
* Introduced a little store to the Settings pages
* Using an optional prop to connect the Persistent Dismissable Alert to another store when needed

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check that the PersistentDismissableAlert Container still functions like before in the Editor. You can follow the test instructions from [P1-341](https://github.com/Yoast/wordpress-seo/pull/16643) for that.
* Check that there is a Settings store present on Settings pages.
* Add a PersistentDismissableAlert to a Settings page and confirm that it functions the same as in the Editor. Don't forget to delete your key from the database when necessary. Example code:
```
<PersistentDismissableAlert
	store="yoast-seo/settings"
	type="info"
	alertKey="video-editor-reactification-alert"
>
	My test Alert!
</PersistentDismissableAlert>
```


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* This code is for future use and not exposed yet.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [X] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-332
