### PR TITLE
Fix conflict between Yoast Seo and Polylang For WooCommerce

### DIFF
--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -96,11 +96,7 @@ class Indexable_Link_Builder {
 	public function build( $indexable, $content ) {
 		if ( $indexable->object_type === 'post' ) {
 			$post = $this->post_helper->get_post( $indexable->object_id );
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- To setup the post we need to do this explicitly.
-			$GLOBALS['post'] = $post;
-			\setup_postdata( $post );
-			$content = \apply_filters( 'the_content', $content );
-			\wp_reset_postdata();
+			$content = \apply_filters( 'the_content', $post->post_content );
 		}
 
 		$content = \str_replace( ']]>', ']]&gt;', $content );

--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -94,9 +94,16 @@ class Indexable_Link_Builder {
 	 * @return SEO_Links[] The created SEO links.
 	 */
 	public function build( $indexable, $content ) {
+		global $post;
 		if ( $indexable->object_type === 'post' ) {
+			$post_backup = $post;
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- To setup the post we need to do this explicitly.
 			$post = $this->post_helper->get_post( $indexable->object_id );
-			$content = \apply_filters( 'the_content', $post->post_content );
+			\setup_postdata( $post );
+			$content = \apply_filters( 'the_content', $content );
+			\wp_reset_postdata();
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- To setup the post we need to do this explicitly.
+			$post = $post_backup;
 		}
 
 		$content = \str_replace( ']]>', ']]&gt;', $content );


### PR DESCRIPTION
Some of our customers reported that they can't create anymore translations of variable product.
Indeed a fatal error is triggered and breaks the variable product translation creation:
```
[22-Feb-2021 07:52:45 UTC] PHP Fatal error:  Uncaught Error: Call to a member function is_taxonomy() on string in C:\wamp64\www\wordpress-support\wp-content\plugins\woocommerce-5.0.0\includes\admin\meta-boxes\views\html-product-data-attributes.php:40
Stack trace:
#0 C:\wamp64\www\wordpress-support\wp-content\plugins\woocommerce-5.0.0\includes\admin\meta-boxes\class-wc-meta-box-product-data.php(46): include()
#1 C:\wamp64\www\wordpress-support\wp-content\plugins\woocommerce-5.0.0\includes\admin\meta-boxes\views\html-product-data-panel.php(51): WC_Meta_Box_Product_Data::output_tabs()
#2 C:\wamp64\www\wordpress-support\wp-content\plugins\woocommerce-5.0.0\includes\admin\meta-boxes\class-wc-meta-box-product-data.php(33): include('C:\\wamp64\\www\\w...')
#3 C:\wamp64\www\wordpress-support\wp-admin\includes\template.php(1389): WC_Meta_Box_Product_Data::output(Object(WP_Post), Array)
#4 C:\wamp64\www\wordpress-support\wp-admin\edit-form-advanced.php(688): do_meta_boxes(Object(WP_Screen), 'normal', Object(WP_Post))
#5 C:\wamp64\www\wordpress-support\wp-admin\po in C:\wamp64\www\wordpress-support\wp-content\plugins\woocommerce-5.0.0\includes\admin\meta-boxes\views\html-product-data-attributes.php on line 40
```

After investigating on each of their installation, we pointed that the issue comes since an update of Yoast Seo to its 15.8 release specifically this line https://github.com/Yoast/wordpress-seo/pull/16609/files#diff-3b3c3fe90f75b2e93fe8ed4d29c14aebd7f0924f5b198c9cea29f9ccbce90b86R100 of the PR https://github.com/Yoast/wordpress-seo/pull/16609

## What happens
In fact when we create a translation on any post type from the WordPress admin it is made outside any query WordPress loop by using `post-new.php` which does a `wp_insert_post()` directly. So the `WP_Query` object exists and its `WP_Query::post` property set to `null`.

Change `$GLOBALS['post']` could cause problem because it could be never reverted back to its inital value when the property `WP_Query::post` is `null`

See https://github.com/WordPress/WordPress/blob/5.6.1/wp-includes/query.php#L126-L132

```
function wp_reset_postdata() {
	global $wp_query;

	if ( isset( $wp_query ) ) {
		$wp_query->reset_postdata();
	}
}
```

and https://github.com/WordPress/WordPress/blob/5.6.1/wp-includes/class-wp-query.php#L4409-L4414

```
public function reset_postdata() {
	if ( ! empty( $this->post ) ) {
		$GLOBALS['post'] = $this->post;
		$this->setup_postdata( $this->post );
	}
}
```

It is exactly what happens with our plugin Polylang For WooCommerce because  WooCommerce variable product are a little bit more complex:
- the variable product itself: the main post
- its variations which are each a post

In the same `post-new.php` process to create a translation we insert the new product and the new variations by using the `WC_Product_Variation::save()` method which also do a `wp_insert_post()` outside any query WordPress loop.
So, as we see above, call `wp_reset_postdata()` never reverts back `$GLOBALS['post']` to the variable product and stay on its latest variation. It then triggers the fatal error mentioned at the beginning because the WooCommerce try to display a variable product but it receive one of its variations.

## How to fix
I seems to me that to apply 'the_content' filter there is no need to use the `$GLOBALS['post']`. We can to do that to pass directly the `WP_Post::post_content` to the filter.
This is what this PR propose.

Alternatively, if there is something I didn't saw about the use of `$GLOBALS['post']`, we could save it before changing it and revert it back in all the cases. Something like that:

```
$post_backup = $GLOBALS['post'];
$GLOBALS['post'] = $post;
\setup_postdata( $post );
$content = \apply_filters( 'the_content', $content );
\wp_reset_postdata();
$GLOBALS['post'] = $post_backup;
```

Let me know
Regards