### PR TITLE
PHP 8: prevent warning in Yoast_Integration_Toggles

### DIFF
--- a/admin/views/class-yoast-integration-toggles.php
+++ b/admin/views/class-yoast-integration-toggles.php
@@ -126,12 +126,16 @@ class Yoast_Integration_Toggles {
 	/**
 	 * Callback for sorting integration toggles by their order.
 	 *
+	 * {@internal Once the minimum PHP version goes up to PHP 7.0, the logic in the function
+	 * can be replaced with the spaceship operator `<=>`.}
+	 *
 	 * @param Yoast_Feature_Toggle $feature_a Feature A.
 	 * @param Yoast_Feature_Toggle $feature_b Feature B.
 	 *
-	 * @return bool Whether order for feature A is bigger than for feature B.
+	 * @return int An integer less than, equal to, or greater than zero indicating respectively
+	 *             that feature A is considered to be less than, equal to, or greater than feature B.
 	 */
 	protected function sort_toggles_callback( Yoast_Feature_Toggle $feature_a, Yoast_Feature_Toggle $feature_b ) {
-		return ( $feature_a->order > $feature_b->order );
+		return ( $feature_a->order - $feature_b->order );
 	}
 }

--- a/tests/unit/admin/views/integration-toggles-test.php
+++ b/tests/unit/admin/views/integration-toggles-test.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Admin\Views;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast_Feature_Toggle;
+use Yoast_Integration_Toggles;
+
+/**
+ * Unit Test Class.
+ *
+ * @covers \Yoast_Integration_Toggles
+ */
+class Yoast_Integration_Toggles_Test extends TestCase {
+
+	/**
+	 * Test the basic functionality of the Yoast_Integration_Toggles class.
+	 *
+	 * @return void
+	 */
+	public function test_integration_toggles() {
+		$expected_names = [
+			0 => 'SEMrush integration',
+			1 => 'Ryte integration',
+		];
+
+		$this->stubTranslationFunctions();
+
+		$instance = new Yoast_Integration_Toggles();
+		$result   = $instance->get_all();
+
+		// Verify the final result.
+		foreach ( $result as $key => $toggle ) {
+			$this->assertInstanceOf( Yoast_Feature_Toggle::class, $toggle );
+			$this->assertSame( $expected_names[ $key ], $toggle->name );
+		}
+
+		$this->assertEmpty( $result[0]->read_more_url );
+		$this->assertNotEmpty( $result[1]->read_more_url );
+	}
+
+	/**
+	 * Test that the sorting of the integration toggles works as expected when more items are added.
+	 *
+	 * @link https://yoast.atlassian.net/browse/QAK-2609
+	 *
+	 * @return void
+	 */
+	public function test_toggle_sorting() {
+		$expected_names = [
+			0 => 'Dummy prio 5',
+			1 => 'SEMrush integration',
+			2 => 'Ryte integration',
+			3 => 'Dummy prio 50',
+		];
+
+		$this->stubTranslationFunctions();
+
+		Filters\expectApplied( 'wpseo_integration_toggles' )
+			->once()
+			->andReturnUsing( [ $this, 'toggle_filter_callback' ] );
+
+		$instance = new Yoast_Integration_Toggles();
+		$result   = $instance->get_all();
+
+		foreach ( $result as $key => $toggle ) {
+			$this->assertInstanceOf( Yoast_Feature_Toggle::class, $toggle );
+			$this->assertSame( $expected_names[ $key ], $toggle->name );
+		}
+	}
+
+	/**
+	 * Add two dummy toggles with out of order "order" values.
+	 *
+	 * @param array $toggles Current array with integration toggle objects where each object
+	 *                       should have a `name`, `setting` and `label` property.
+	 *
+	 * @return Adjusted array with integration toggle objects.
+	 */
+	public function toggle_filter_callback( $toggles ) {
+		$toggles[] = (object) [
+			'name'    => 'Dummy prio 50',
+			'setting' => 'dummy_50',
+			'label'   => 'Dummy prio 50',
+			'order'   => 50,
+		];
+		$toggles[] = (object) [
+			'name'    => 'Dummy prio 5',
+			'setting' => 'dummy_5',
+			'label'   => 'Dummy prio 5',
+			'order'   => 5,
+		];
+
+		return $toggles;
+	}
+}


### PR DESCRIPTION
## Context

* Improved PHP 8.0 compatibility

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a warning when running the plugin on PHP 8.0

## Relevant technical choices:

Related to: https://yoast.atlassian.net/browse/QAK-2609

### Yoast_Integration_Toggles: add unit tests

As there appeared to be no tests for the class at all, adding a minimal test function testing the basic functionality, as well as a specific test covering the PHP 8 sorting issue.

### Yoast_Integration_Toggles: fix PHP 8 warning

The `u*sort()` functions in PHP have always been expected to return an integer: a negative integer for when A should be considered "less than" B, a `0` when they should be considered as equal and positive integer for when B should be considered "more than" A.

The `Yoast_Integration_Toggles::sort_toggles_callback()` did not comply with this and returned a boolean value instead.

As of PHP 8.0, PHP checks more strictly on the callback implementation being correct and will throw a `usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero` warning.

This warning has now been mitigated by a slightly changed implementation, which will return an integer, as expected.

Note: when the `order` for two toggles is equal, the sort order is undefined. This behaviour has not been adjusted.
In PHP < 8, this means that those toggles can be in the final array in any order.
As of PHP 8, the order for two items which are considered equal, will be determined based on the original input order.
If so desired, the callback function can be adjusted to make the "equal" sort for the toggles more stable by adding a second criteria, like the `name`, but that is outside the scope of the current fix.

Refs:
* https://wiki.php.net/rfc/stable_sorting
* https://www.php.net/manual/en/function.usort.php



## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Technical testing:
* Switch to PHP 8.0
* Run `composer require phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs`
* Check out the first commit from this PR.
* Run the tests via `vendor/bin/phpunit --filter Yoast_Integration_Toggles_Test` and see them fail on the warning.
* Check out the second (head) commit form this PR.
* Run the same test command again and see the tests pass.

Functional testing:

On `trunk`:
1. Switch to a PHP 8.0 environment
2. Visit the SEO integrations page
3. Check the PHP logs (or WP debug log) to see the warning.

Switch to this branch and repeat the above steps. The warning should no longer be generated.

Optionally, hook into the `wpseo_integration_toggles` filter and add some extra "toggles" with various `order` values, for instance, one with `order` set to `5` and another with order set to `15`.

Verify that the toggles are displayed in the expected order (5 - `SEMrush` - 15 - `Ryte`) on the page.


### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/QAK-2609
