### PR TITLE
PHP 8: prevent warning in Yoast_Feature_Toggles

### DIFF
--- a/admin/views/class-yoast-feature-toggles.php
+++ b/admin/views/class-yoast-feature-toggles.php
@@ -217,12 +217,16 @@ class Yoast_Feature_Toggles {
 	/**
 	 * Callback for sorting feature toggles by their order.
 	 *
+	 * {@internal Once the minimum PHP version goes up to PHP 7.0, the logic in the function
+	 * can be replaced with the spaceship operator `<=>`.}
+	 *
 	 * @param Yoast_Feature_Toggle $feature_a Feature A.
 	 * @param Yoast_Feature_Toggle $feature_b Feature B.
 	 *
-	 * @return bool Whether order for feature A is bigger than for feature B.
+	 * @return int An integer less than, equal to, or greater than zero indicating respectively
+	 *             that feature A is considered to be less than, equal to, or greater than feature B.
 	 */
 	protected function sort_toggles_callback( Yoast_Feature_Toggle $feature_a, Yoast_Feature_Toggle $feature_b ) {
-		return ( $feature_a->order > $feature_b->order );
+		return ( $feature_a->order - $feature_b->order );
 	}
 }

--- a/tests/unit/admin/views/feature-toggles-test.php
+++ b/tests/unit/admin/views/feature-toggles-test.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Admin\Views;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast_Feature_Toggle;
+use Yoast_Feature_Toggles;
+
+/**
+ * Unit Test Class.
+ *
+ * @covers \Yoast_Feature_Toggles
+ */
+class Yoast_Feature_Toggles_Test extends TestCase {
+
+	/**
+	 * Limited data copy of the `$feature_toggles` array from the `Yoast_Feature_Toggles::load_toggles() method.
+	 *
+	 * @var array
+	 */
+	protected $expected_feature_toggles = [
+		0 => [
+			'name'          => 'SEO analysis',
+			'has_read_more' => true,
+			'has_after'     => false,
+		],
+		1 => [
+			'name'          => 'Readability analysis',
+			'has_read_more' => true,
+			'has_after'     => false,
+		],
+		2 => [
+			'name'          => 'Cornerstone content',
+			'has_read_more' => true,
+			'has_after'     => false,
+		],
+		3 => [
+			'name'          => 'Text link counter',
+			'has_read_more' => true,
+			'has_after'     => false,
+		],
+		4 => [
+			'name'          => 'XML sitemaps',
+			'has_read_more' => true,
+			'has_after'     => true,
+		],
+		5 => [
+			'name'          => 'Admin bar menu',
+			'has_read_more' => false,
+			'has_after'     => false,
+		],
+		6 => [
+			'name'          => 'Security: no advanced or schema settings for authors',
+			'has_read_more' => false,
+			'has_after'     => false,
+		],
+		7 => [
+			'name'          => 'Usage tracking',
+			'has_read_more' => true,
+			'has_after'     => false,
+		],
+		8 => [
+			'name'          => 'REST API: Head endpoint',
+			'has_read_more' => false,
+			'has_after'     => false,
+		],
+		9 => [
+			'name'          => 'Enhanced Slack sharing',
+			'has_read_more' => true,
+			'has_after'     => false,
+		],
+	];
+
+	/**
+	 * Test the basic functionality of the Yoast_Feature_Toggles class.
+	 *
+	 * @return void
+	 */
+	public function test_feature_toggles() {
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		Functions\expect( 'add_query_arg' )->andReturn( '' );
+		Functions\expect( 'wp_enqueue_style' )->andReturn( '' );
+		Functions\expect( 'plugin_dir_url' )->andReturn( '' );
+
+		$instance = new Yoast_Feature_Toggles();
+		$result   = $instance->get_all();
+
+		// Verify the final result.
+		foreach ( $result as $key => $toggle ) {
+			$this->assertInstanceOf( Yoast_Feature_Toggle::class, $toggle );
+
+			$actual_name = $toggle->name;
+			$this->assertSame( $this->expected_feature_toggles[ $key ]['name'], $actual_name );
+
+			if ( $this->expected_feature_toggles[ $key ]['has_read_more'] === true ) {
+				$this->assertNotEmpty( $toggle->read_more_url, 'Read more URL is empty for ' . $actual_name );
+			}
+			else {
+				$this->assertEmpty( $toggle->read_more_url, 'Read more URL is not empty for ' . $actual_name );
+			}
+
+			if ( $this->expected_feature_toggles[ $key ]['has_after'] === true ) {
+				$this->assertNotEmpty( $toggle->after, 'After is empty for ' . $actual_name );
+			}
+			else {
+				$this->assertEmpty( $toggle->after, 'After is not empty for ' . $actual_name );
+			}
+		}
+	}
+
+	/**
+	 * Test that the sorting of the feature toggles works as expected.
+	 *
+	 * @link https://yoast.atlassian.net/browse/QAK-2609
+	 *
+	 * @return void
+	 */
+	public function test_toggle_sorting() {
+		$expected_names = [
+			0 => 'Usage tracking',
+			1 => 'Readability analysis',
+			2 => 'REST API: Head endpoint',
+			3 => 'Text link counter',
+			4 => 'SEO analysis',
+			5 => 'XML sitemaps',
+			6 => 'Admin bar menu',
+			7 => 'Security: no advanced or schema settings for authors',
+			8 => 'Cornerstone content',
+			9 => 'Enhanced Slack sharing',
+		];
+
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		Functions\expect( 'add_query_arg' )->andReturn( '' );
+		Functions\expect( 'wp_enqueue_style' )->andReturn( '' );
+		Functions\expect( 'plugin_dir_url' )->andReturn( '' );
+
+		Filters\expectApplied( 'wpseo_feature_toggles' )
+			->once()
+			->andReturnUsing( [ $this, 'toggle_filter_callback' ] );
+
+		$instance = new Yoast_Feature_Toggles();
+		$result   = $instance->get_all();
+
+		foreach ( $result as $key => $toggle ) {
+			$this->assertInstanceOf( Yoast_Feature_Toggle::class, $toggle );
+			$this->assertSame( $expected_names[ $key ], $toggle->name );
+		}
+	}
+
+	/**
+	 * Add two dummy toggles with out of order "order" values.
+	 *
+	 * @param array $toggles Current array with integration toggle objects where each object
+	 *                       should have a `name`, `setting` and `label` property.
+	 *
+	 * @return Adjusted array with integration toggle objects.
+	 */
+	public function toggle_filter_callback( $toggles ) {
+		$toggles[0]->order = 50;
+		$toggles[2]->order = 92;
+		$toggles[7]->order = 0;
+		$toggles[8]->order = 25;
+
+		return $toggles;
+	}
+}


### PR DESCRIPTION
## Context

* Improved PHP 8.0 compatibility

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a warning when running the plugin on PHP 8.0

## Relevant technical choices:

Related to: https://yoast.atlassian.net/browse/QAK-2609

### Yoast_Feature_Toggles: add unit tests

As there appeared to be no tests for the class at all, adding a minimal test function to test the basic functionality, as well as a specific test covering the PHP 8 sorting issue.

### Yoast_Feature_Toggles: fix PHP 8 warning

The `u*sort()` functions in PHP have always been expected to return an integer: a negative integer for when A should be considered "less than" B, a `0` when they should be considered as equal and positive integer for when B should be considered "more than" A.

The `Yoast_Feature_Toggles::sort_toggles_callback()` did not comply with this and returned a boolean value instead.

As of PHP 8.0, PHP checks more strictly on the callback implementation being correct and will throw a `usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero` warning.

This warning has now been mitigated by a slightly changed implementation, which will return an integer, as expected.

Note: when the `order` for two toggles is equal, the sort order is undefined. This behaviour has not been adjusted.
In PHP < 8, this means that those toggles can be in the final array in any order.
As of PHP 8, the order for two items which are considered equal, will be determined based on the original input order.
If so desired, the callback function can be adjusted to make the "equal" sort for the toggles more stable by adding a second criteria, like the `name`, but that is outside the scope of the current fix.

Refs:
* https://wiki.php.net/rfc/stable_sorting
* https://www.php.net/manual/en/function.usort.php



### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Technical testing:
* Switch to PHP 8.0
* Run `composer require phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs`
* Check out the first commit from this PR.
* Run the tests via `vendor/bin/phpunit --filter Yoast_Feature_Toggles_Test` and see them fail on the warning.
* Check out the second (head) commit from this PR.
* Run the same test command again and see the tests pass.

Functional testing:

On `trunk`:
1. Switch to a PHP 8.0 environment
2. Visit the SEO features page
3. Check the PHP logs (or WP debug log) to see the warning.

Switch to this branch and repeat the above steps. The warning should no longer be generated.

Optionally, hook into the `wpseo_feature_toggles` filter and add some extra "toggles" with various `order` values and/or change the order of some existing toggles.

Verify that the toggles are displayed in the expected order on the page.


### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/QAK-2609
