### PR TITLE
For RC1, also add the release date to the changelog

### DIFF
--- a/config/grunt/custom-tasks/update-readme.js
+++ b/config/grunt/custom-tasks/update-readme.js
@@ -91,8 +91,8 @@ module.exports = function( grunt ) {
 					changelogVersionNumber += "." + versionNumber.patch;
 				}
 
-				// Present the user with only the version number.
-				getUserInput( { initialContent: `= ${changelogVersionNumber} =` } ).then( newChangelog => {
+				// Present the user with only the version number, and a release date to fill in.
+				getUserInput( { initialContent: `= ${changelogVersionNumber} =\nRelease Date:` } ).then( newChangelog => {
 					// Update the grunt reference to the changelog.
 					grunt.option( "changelog", newChangelog );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The dev who creates RC1 should be reminded to add the release date to the changelog.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds "Release Date:" to the changelog in the RC automatization, so we are prompted to fill in a release date.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check-out this branch.
* Make sure you have your environment [configured](https://yoast.atlassian.net/wiki/spaces/PLUGIN/pages/656080932/Yoast+SEO+Free+releasing+using+automation) for running the RC automatization.
* In your terminal, run `grunt update-readme --plugin-version=16.2 --type=release` (make sure the plugin version is higher than the highest version in the `readme.txt`).
* In the editor that opens, see that "Release Date:" is now shown in the changelog (the dev should still add the actual date).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* No need for QA to test this, it is just dev tooling.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
