### PR TITLE
Integrate with wp_robots

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=344",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=340",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=227",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/conditionals/wp-robots-conditional.php
+++ b/src/conditionals/wp-robots-conditional.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Class that checks if wp_robots exists.
+ */
+class WP_Robots_Conditional implements Conditional {
+
+	/**
+	 * Checks if the wp_robots function exists.
+	 *
+	 * @return bool True when the wp_robots function exists.
+	 */
+	public function is_met() {
+		return \function_exists( 'wp_robots' );
+	}
+}

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -209,6 +209,9 @@ class Front_End_Integration implements Integration_Interface {
 		// Filter the title for compatibility with other plugins and themes.
 		\add_filter( 'wp_title', [ $this, 'filter_title' ], 15 );
 
+		// Removes our robots presenter from the list when wp_robots is handling this.
+		\add_filter( 'wpseo_frontend_presenter_classes', [ $this, 'filter_robots_presenter' ] );
+
 		\add_action( 'wpseo_head', [ $this, 'present_head' ], -9999 );
 
 		\remove_action( 'wp_head', 'rel_canonical' );
@@ -234,6 +237,27 @@ class Front_End_Integration implements Integration_Interface {
 		$title_presenter->helpers      = $this->helpers;
 
 		return \esc_html( $title_presenter->get() );
+	}
+
+	/**
+	 * Filters our robots presenter, but only when wp_robots is attached to the wp_head action.
+	 *
+	 * @param array $presenters The presenters for current page.
+	 *
+	 * @return array The filtered presenters.
+	 */
+	public function filter_robots_presenter( $presenters ) {
+		if ( ! function_exists( 'wp_robots' ) ) {
+			return $presenters;
+		}
+
+		if ( ! \has_action( 'wp_head', 'wp_robots' ) ) {
+			return $presenters;
+		}
+
+		return \array_filter( $presenters, static function( $presenter ) {
+			return $presenter !== "Yoast\WP\SEO\Presenters\Robots_Presenter";
+		} );
 	}
 
 	/**

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -255,9 +255,12 @@ class Front_End_Integration implements Integration_Interface {
 			return $presenters;
 		}
 
-		return \array_filter( $presenters, static function( $presenter ) {
-			return $presenter !== "Yoast\WP\SEO\Presenters\Robots_Presenter";
-		} );
+		return \array_filter(
+			$presenters,
+			static function( $presenter ) {
+				return $presenter !== 'Yoast\\WP\\SEO\\Presenters\\Robots_Presenter';
+			}
+		);
 	}
 
 	/**

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -255,12 +255,7 @@ class Front_End_Integration implements Integration_Interface {
 			return $presenters;
 		}
 
-		return \array_filter(
-			$presenters,
-			static function( $presenter ) {
-				return $presenter !== 'Yoast\\WP\\SEO\\Presenters\\Robots_Presenter';
-			}
-		);
+		return \array_diff( $presenters, [ 'Yoast\\WP\\SEO\\Presenters\\Robots_Presenter' ] );
 	}
 
 	/**

--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -66,7 +66,11 @@ class WP_Robots_Integration implements Integration_Interface {
 			return $this->get_robots_value();
 		}
 
-		return array_merge( $robots, $this->get_robots_value() );
+		$merged_robots   = array_merge( $robots, $this->get_robots_value() );
+		$filtered_robots = $this->filter_robots_no_index( $merged_robots );
+
+		// Filter all falsy-null robot values.
+		return array_filter( $filtered_robots );
 	}
 
 	/**
@@ -102,8 +106,7 @@ class WP_Robots_Integration implements Integration_Interface {
 
 			// When index => noindex, we want a separate noindex as entry in array.
 			if ( strpos( $value, 'no' ) === 0 ) {
-				unset( $robots[ $key ] );
-
+				$robots[ $key ]   = false;
 				$robots[ $value ] = true;
 
 				continue;
@@ -114,6 +117,34 @@ class WP_Robots_Integration implements Integration_Interface {
 				$robots[ $key ] = true;
 			}
 		}
+
+		return $robots;
+	}
+
+	/**
+	 * Filters robots value when page is set noindex.
+	 *
+	 * WordPress might add some robot values again.
+	 * When the page is set to noindex we want to filter out these values.
+	 *
+	 * @param array $robots The robots.
+	 *
+	 * @return array The filtered robots.
+	 */
+	protected function filter_robots_no_index( $robots ) {
+		if ( ! isset( $robots['noindex'] ) ) {
+			return $robots;
+		}
+
+		$robots['imageindex']        = null;
+		$robots['noimageindex']      = null;
+		$robots['archive']           = null;
+		$robots['noarchive']         = null;
+		$robots['snippet']           = null;
+		$robots['nosnippet']         = null;
+		$robots['max-snippet']       = null;
+		$robots['max-image-preview'] = null;
+		$robots['max-video-preview'] = null;
 
 		return $robots;
 	}

--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -74,9 +74,9 @@ class WP_Robots_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Retrieves the robots presenter.
+	 * Retrieves the robots key-value pairs.
 	 *
-	 * @returns Robots_Presenter Instance of the robots presenter.
+	 * @returns array The robots key-value pairs.
 	 */
 	protected function get_robots_value() {
 		$context = $this->context_memoizer->for_current_page();

--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -127,6 +127,9 @@ class WP_Robots_Integration implements Integration_Interface {
 	 * WordPress might add some robot values again.
 	 * When the page is set to noindex we want to filter out these values.
 	 *
+	 * Our format: [ 'index' => 'noindex', 'follow' => 'follow', ... ]
+	 * WordPress format: [ 'noindex' => true, 'follow' => true, ... ]
+	 *
 	 * @param array $robots The robots.
 	 *
 	 * @return array The filtered robots.

--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -90,6 +90,9 @@ class WP_Robots_Integration implements Integration_Interface {
 	/**
 	 * Formats our robots fields, to match the pattern WordPress is using.
 	 *
+	 * Our format: `[ 'index' => 'noindex', 'max-image-preview' => 'max-image-preview:large', ... ]`
+	 * WordPress format: `[ 'noindex' => true, 'max-image-preview' => 'large', ... ]`
+	 *
 	 * @param array $robots Our robots value.
 	 *
 	 * @return array The formatted robots.
@@ -126,9 +129,6 @@ class WP_Robots_Integration implements Integration_Interface {
 	 *
 	 * WordPress might add some robot values again.
 	 * When the page is set to noindex we want to filter out these values.
-	 *
-	 * Our format: [ 'index' => 'noindex', 'follow' => 'follow', ... ]
-	 * WordPress format: [ 'noindex' => true, 'follow' => true, ... ]
 	 *
 	 * @param array $robots The robots.
 	 *

--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Front_End;
+
+use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
+use Yoast\WP\SEO\Conditionals\WP_Robots_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Presenters\Robots_Presenter;
+
+/**
+ * Class WP_Robots_Integration
+ *
+ * @package Yoast\WP\SEO\Integrations\Front_End
+ */
+class WP_Robots_Integration implements Integration_Interface {
+
+	/**
+	 * The meta tags context memoizer.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	protected $context_memoizer;
+
+	/**
+	 * Sets the dependencies for this integration.
+	 *
+	 * @param Meta_Tags_Context_Memoizer $context_memoizer
+	 */
+	public function __construct( Meta_Tags_Context_Memoizer $context_memoizer ) {
+		$this->context_memoizer = $context_memoizer;
+	}
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * This is the place to register hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_filter( 'wp_robots', [ $this, 'add_robots' ], PHP_INT_MAX );
+	}
+
+	/**
+	 * Returns the conditionals based on which this loadable should be active.
+	 *
+	 * @return array The conditionals.
+	 */
+	public static function get_conditionals() {
+		return [
+			Front_End_Conditional::class,
+			WP_Robots_Conditional::class
+		];
+	}
+
+	/**
+	 * Adds our robots tag value to the WordPress robots tag output.
+	 *
+	 * @param array $robots The current robots data
+	 *
+	 * @return array The robots data.
+	 */
+	public function add_robots( $robots ) {
+		if ( ! is_array( $robots ) ) {
+			return $this->get_robots_value();
+		}
+
+		return array_merge( $robots, $this->get_robots_value() );
+	}
+
+	/**
+	 * Retrieves the robots presenter.
+	 *
+	 * @returns Robots_Presenter Instance of the robots presenter.
+	 */
+	protected function get_robots_value() {
+		$context = $this->context_memoizer->for_current_page();
+
+		$robots_presenter               = new Robots_Presenter();
+		$robots_presenter->presentation = $context->presentation;
+
+		return $this->format_robots( $robots_presenter->get() );
+	}
+
+	/**
+	 * Formats our robots fields, to match the pattern WordPress is using.
+	 *
+	 * @param array $robots Our robots value.
+	 *
+	 * @return array The formatted robots.
+	 */
+	protected function format_robots( $robots ) {
+		foreach ( $robots as $key => $value ) {
+			// When the entry represents for example: max-image-preview:large.
+			$colon_position = \strpos( $value, ':' );
+			if ( $colon_position !== false ) {
+				$robots[ $key ] = \substr( $value, $colon_position + 1 );
+
+				continue;
+			}
+
+			// When index => noindex, we want a separate noindex as entry in array.
+			if ( strpos( $value, 'no' ) === 0 ) {
+				unset( $robots[ $key ] );
+
+				$robots[ $value ] = true;
+
+				continue;
+			}
+
+			// When the key is equal to the value, just make its value a boolean.
+			if ( $key === $value ) {
+				$robots[ $key ] = true;
+			}
+		}
+
+		return $robots;
+	}
+}

--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -25,7 +25,7 @@ class WP_Robots_Integration implements Integration_Interface {
 	/**
 	 * Sets the dependencies for this integration.
 	 *
-	 * @param Meta_Tags_Context_Memoizer $context_memoizer
+	 * @param Meta_Tags_Context_Memoizer $context_memoizer The meta tags context memoizer.
 	 */
 	public function __construct( Meta_Tags_Context_Memoizer $context_memoizer ) {
 		$this->context_memoizer = $context_memoizer;
@@ -50,14 +50,14 @@ class WP_Robots_Integration implements Integration_Interface {
 	public static function get_conditionals() {
 		return [
 			Front_End_Conditional::class,
-			WP_Robots_Conditional::class
+			WP_Robots_Conditional::class,
 		];
 	}
 
 	/**
 	 * Adds our robots tag value to the WordPress robots tag output.
 	 *
-	 * @param array $robots The current robots data
+	 * @param array $robots The current robots data.
 	 *
 	 * @return array The robots data.
 	 */
@@ -99,7 +99,7 @@ class WP_Robots_Integration implements Integration_Interface {
 			// When the entry represents for example: max-image-preview:large.
 			$colon_position = \strpos( $value, ':' );
 			if ( $colon_position !== false ) {
-				$robots[ $key ] = \substr( $value, $colon_position + 1 );
+				$robots[ $key ] = \substr( $value, ( $colon_position + 1 ) );
 
 				continue;
 			}

--- a/tests/unit/conditionals/wp-robots-conditional-test.php
+++ b/tests/unit/conditionals/wp-robots-conditional-test.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Conditionals;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Conditionals\WP_Robots_Conditional;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Web_Stories_Conditional_Test.
+ *
+ * @group conditionals
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Conditionals\WP_Robots_Conditional
+ */
+class WP_Robots_Conditional_Test extends TestCase {
+
+	/**
+	 * Represents the insstance to test.
+	 *
+	 * @var WP_Robots_Conditional
+	 */
+	protected $instance;
+
+	/**
+	 * Handles the setup.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new WP_Robots_Conditional();
+	}
+
+	/**
+	 * Tests the scenario where the wp_robots isn't present.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_met_without_having_wp_robots_function() {
+		static::assertFalse( $this->instance->is_met() );
+	}
+
+	/**
+	 * Tests the scenario where the wp_robots isn't present.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_met() {
+		Monkey\Functions\expect( 'wp_robots' )->never();
+
+		static::assertTrue( $this->instance->is_met() );
+	}
+}

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -97,6 +97,7 @@ class Front_End_Integration_Test extends TestCase {
 		$this->assertNotFalse( \has_action( 'wp_head', [ $this->instance, 'call_wpseo_head' ] ), 'Does not have expected wp_head action' );
 		$this->assertNotFalse( \has_action( 'wpseo_head', [ $this->instance, 'present_head' ] ), 'Does not have expected wpseo_head action' );
 		$this->assertNotFalse( \has_filter( 'wp_title', [ $this->instance, 'filter_title' ] ), 'Does not have expected wp_title filter' );
+		$this->assertNotFalse( \has_filter( 'wpseo_frontend_presenter_classes', [ $this->instance, 'filter_robots_presenter' ] ), 'Does not have expected wpseo_frontend_presenter_classes filter' );
 	}
 
 	/**
@@ -385,6 +386,63 @@ class Front_End_Integration_Test extends TestCase {
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 			],
 			$expected
+		);
+	}
+
+	/**
+	 * Tests the filter robots presenter method without having the wp_robots function.
+	 *
+	 * @covers ::filter_robots_presenter
+	 */
+	public function test_filter_robots_presenter_with_wp_robots_absent() {
+		$presenters = [
+			'Yoast\WP\SEO\Presenters\Title_Presenter',
+			'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
+			'Yoast\WP\SEO\Presenters\Robots_Presenter',
+		];
+
+		static::assertEquals( $presenters, $this->instance->filter_robots_presenter( $presenters ) );
+	}
+
+	/**
+	 * Tests the filter robots presenter without having the wp_robots attached to the wp_head action.
+	 *
+	 * @covers ::filter_robots_presenter
+	 */
+	public function test_filter_robots_presenter_and_wp_robots_not_attached_to_wp_head_filter() {
+		Monkey\Functions\expect( 'wp_robots' )->never();
+
+		$presenters = [
+			'Yoast\WP\SEO\Presenters\Title_Presenter',
+			'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
+			'Yoast\WP\SEO\Presenters\Robots_Presenter',
+		];
+
+		static::assertEquals( $presenters, $this->instance->filter_robots_presenter( $presenters ) );
+	}
+
+	/**
+	 * Tests the filter robots presenter with having wp_robots attached to the wp_head action.
+	 *
+	 * @covers ::filter_robots_presenter
+	 */
+	public function test_filter_robots_presenter_and_wp_robots_to_wp_head_filter() {
+		Monkey\Functions\expect( 'wp_robots' )->never();
+
+		\add_action( 'wp_head', 'wp_robots' );
+
+		$presenters = [
+			'Yoast\WP\SEO\Presenters\Title_Presenter',
+			'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
+			'Yoast\WP\SEO\Presenters\Robots_Presenter',
+		];
+
+		static::assertEquals(
+			[
+				'Yoast\WP\SEO\Presenters\Title_Presenter',
+				'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
+			],
+			$this->instance->filter_robots_presenter( $presenters )
 		);
 	}
 }

--- a/tests/unit/integrations/front-end/wp-robots-integration-test.php
+++ b/tests/unit/integrations/front-end/wp-robots-integration-test.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Front_End;
+
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
+use Yoast\WP\SEO\Conditionals\WP_Robots_Conditional;
+use Yoast\WP\SEO\Integrations\Front_End\WP_Robots_Integration;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class WP_Robots_Integration_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Front_End\WP_Robots_Integration
+ *
+ * @group integrations
+ * @group front-end
+ */
+class WP_Robots_Integration_Test extends TestCase {
+
+	/**
+	 * Represents the meta tags context memoizer.
+	 *
+	 * @var Mockery\MockInterface|Meta_Tags_Context_Memoizer
+	 */
+	protected $context_memoizer;
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var WP_Robots_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * Method that runs before each test case.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->context_memoizer = Mockery::mock( Meta_Tags_Context_Memoizer::class );
+		$this->instance = new WP_Robots_Integration( $this->context_memoizer );
+	}
+
+	/**
+	 * Tests if the dependencies are set correct.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct() {
+		static::assertInstanceOf(
+			Meta_Tags_Context_Memoizer::class,
+			static::getPropertyValue( $this->instance, 'context_memoizer' )
+		);
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		static::assertNotFalse( has_filter( 'wp_robots', [ $this->instance, 'add_robots' ] ) );
+	}
+
+	/**
+	 * Tests the retrieval of the current conditionals.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		static::assertEquals(
+			[
+				Front_End_Conditional::class,
+				WP_Robots_Conditional::class,
+			],
+			WP_Robots_Integration::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the add robots with having the robots input value being a string.
+	 *
+	 * @covers ::add_robots
+	 * @covers ::get_robots_value
+	 */
+	public function test_add_robots_string_given() {
+		$context = (object) [
+			'presentation' => (object) [
+				'robots' => [
+					'index'  => 'index',
+					'follow' => 'follow',
+				],
+			],
+		];
+
+		$this->context_memoizer
+			->expects( 'for_current_page' )
+			->once()
+			->andReturn( $context );
+
+		static::assertEquals(
+			[
+				'index'  => true,
+				'follow' => true,
+			],
+			$this->instance->add_robots( 'robots_string' )
+		);
+	}
+
+	/**
+	 * Tests the add robots with having the robots input being overwritten by our data.
+	 *
+	 * @covers ::add_robots
+	 * @covers ::get_robots_value
+	 * @covers ::format_robots
+	 */
+	public function test_add_robots() {
+		$context = (object) [
+			'presentation' => (object) [
+				'robots' => [
+					'index'             => 'index',
+					'follow'            => 'follow',
+					'max-image-preview' => 'max-image-preview:large',
+					'imageindex'        => 'noimageindex',
+				],
+			],
+		];
+
+		$this->context_memoizer
+			->expects( 'for_current_page' )
+			->once()
+			->andReturn( $context );
+
+		static::assertEquals(
+			[
+				'index'             => true,
+				'follow'            => true,
+				'max-image-preview' => 'large',
+				'noimageindex'      => true,
+			],
+			$this->instance->add_robots(
+				[
+					'index'  => 'noindex',
+					'follow' => 'nofollow',
+				]
+			)
+		);
+	}
+}

--- a/tests/unit/integrations/front-end/wp-robots-integration-test.php
+++ b/tests/unit/integrations/front-end/wp-robots-integration-test.php
@@ -40,7 +40,7 @@ class WP_Robots_Integration_Test extends TestCase {
 		parent::set_up();
 
 		$this->context_memoizer = Mockery::mock( Meta_Tags_Context_Memoizer::class );
-		$this->instance = new WP_Robots_Integration( $this->context_memoizer );
+		$this->instance         = new WP_Robots_Integration( $this->context_memoizer );
 	}
 
 	/**

--- a/tests/unit/integrations/front-end/wp-robots-integration-test.php
+++ b/tests/unit/integrations/front-end/wp-robots-integration-test.php
@@ -117,6 +117,7 @@ class WP_Robots_Integration_Test extends TestCase {
 	 * @covers ::add_robots
 	 * @covers ::get_robots_value
 	 * @covers ::format_robots
+	 * @covers ::filter_robots_no_index
 	 */
 	public function test_add_robots() {
 		$context = (object) [
@@ -137,15 +138,54 @@ class WP_Robots_Integration_Test extends TestCase {
 
 		static::assertEquals(
 			[
-				'index'             => true,
 				'follow'            => true,
-				'max-image-preview' => 'large',
+				'index'             => true,
 				'noimageindex'      => true,
+				'max-image-preview' => 'large',
 			],
 			$this->instance->add_robots(
 				[
-					'index'  => 'noindex',
-					'follow' => 'nofollow',
+					'index'  => true,
+					'follow' => true,
+				]
+			)
+		);
+	}
+
+	/**
+	 * Tests the add robots with having the robots input being overwritten by our data.
+	 *
+	 * @covers ::add_robots
+	 * @covers ::get_robots_value
+	 * @covers ::format_robots
+	 * @covers ::filter_robots_no_index
+	 */
+	public function test_add_robots_with_noindex_set() {
+		$context = (object) [
+			'presentation' => (object) [
+				'robots' => [
+					'index'             => 'noindex',
+					'follow'            => 'follow',
+					'max-image-preview' => 'max-image-preview:large',
+					'imageindex'        => 'noimageindex',
+				],
+			],
+		];
+
+		$this->context_memoizer
+			->expects( 'for_current_page' )
+			->once()
+			->andReturn( $context );
+
+		static::assertEquals(
+			[
+				'follow'  => true,
+				'noindex' => true,
+			],
+			$this->instance->add_robots(
+				[
+					'index'  => true,
+					'follow' => true,
 				]
 			)
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Integrates with `wp_robots` by hooking into it and using our settings there. 

## Relevant technical choices:

* I decided to filter out the values that aren't relevant when noindex is set. We are doing the same at the moment, but WordPress is adding some values again. This will keep the behaviour the same.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* You can install WordPress 5.7 by installing this plugin https://nl.wordpress.org/plugins/wordpress-beta-tester/
* Make a new a post
* Set robot meta values by using the advanced panel (it's in the metabox).
* Save the post
* View the source of your post and verify that the robots metatag is outside the Yoast SEO metatags block.
* Check if the set values are correctly shown.  

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
