### PR TITLE
Delay Elementor load

### DIFF
--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Integrations\Third_Party;
 
+use Elementor\Controls_Manager;
+use Elementor\Core\DocumentTypes\PageBase;
 use WP_Post;
 use WP_Screen;
 use WPSEO_Admin_Asset;
@@ -16,14 +18,12 @@ use WPSEO_Metabox_Analysis_SEO;
 use WPSEO_Metabox_Formatter;
 use WPSEO_Post_Metabox_Formatter;
 use WPSEO_Utils;
+use Yoast\WP\SEO\Conditionals\Admin\Estimated_Reading_Time_Conditional;
 use Yoast\WP\SEO\Conditionals\Third_Party\Elementor_Edit_Conditional;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Meta_Fields_Presenter;
-use Elementor\Controls_Manager;
-use Elementor\Core\DocumentTypes\PageBase;
-use Yoast\WP\SEO\Conditionals\Admin\Estimated_Reading_Time_Conditional;
 
 /**
  * Integrates the Yoast SEO metabox in the Elementor editor.
@@ -113,7 +113,8 @@ class Elementor implements Integration_Interface {
 	 * @param WPSEO_Admin_Asset_Manager          $asset_manager                      The asset manager.
 	 * @param Options_Helper                     $options                            The options helper.
 	 * @param Capability_Helper                  $capability                         The capability helper.
-	 * @param Estimated_Reading_Time_Conditional $estimated_reading_time_conditional The Estimated Reading Time conditional.
+	 * @param Estimated_Reading_Time_Conditional $estimated_reading_time_conditional The Estimated Reading Time
+	 *                                                                               conditional.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
@@ -142,6 +143,14 @@ class Elementor implements Integration_Interface {
 	public function register_hooks() {
 		\add_action( 'wp_ajax_wpseo_elementor_save', [ $this, 'save_postdata' ] );
 
+		// We need to delay the post type lookup to give other plugins a chance to register custom post types.
+		\add_action( 'init', [ $this, 'register_elementor_hooks' ], \PHP_INT_MAX );
+	}
+
+	/**
+	 * Registers our Elementor hooks.
+	 */
+	public function register_elementor_hooks() {
 		if ( ! $this->display_metabox( $this->get_metabox_post()->post_type ) ) {
 			return;
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Our Elementor integration aborted loading because it didn't detect a correct post type. Adjust the load order to give plugins a chance to register custom post types on init.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where CPT would not have our Elementor integration due to a load order problem.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO plugin 16.0-RC4 (or later / this branch) in combination with Elementor and Elementor pro Version 3.1.1.
* Install and activate Yoast Test Helper
* Navigate to Tools > Yoast Test > enable Post Types and Taxonomies
* Navigate to Elementor > Settings > General > Tick Books and Movies
* Create a CPT, then click Edit in Elementor
* Notice that Yoast SEO is no longer missing from the sidebar!
* Verify that our implementation works still:
  * Save something and see it reflected on the frontend. E.g. the SEO title and then check the title in the source.
  * Verify the same for a post.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-402
