### PR TITLE
Correctly reference the current webpage in breadcrumb schema

### DIFF
--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -98,16 +98,23 @@ class Breadcrumb extends Abstract_Schema_Piece {
 	 * @return array A breadcrumb listItem.
 	 */
 	private function create_breadcrumb( $index, $breadcrumb ) {
-		return [
+		$crumb = [
 			'@type'    => 'ListItem',
 			'position' => ( $index + 1 ),
-			'item'     => [
-				'@type' => 'WebPage',
-				'@id'   => $breadcrumb['url'],
-				'url'   => $breadcrumb['url'], // For future proofing, we're trying to change the standard for this.
-				'name'  => $this->helpers->schema->html->smart_strip_tags( $breadcrumb['text'] ),
-			],
+			'item'     => []
 		];
+
+		if ( ! isset( $breadcrumb['url'] ) && isset( $breadcrumb['@id'] ) ) {
+			$crumb['item']['@id'] = $breadcrumb['@id'];
+			return $crumb;
+		}
+
+		$crumb['item']['@type'] = 'WebPage';
+		$crumb['item']['@id']   = $breadcrumb['url'];
+		$crumb['item']['url']   = $breadcrumb['url'];
+		$crumb['item']['name']  = $this->helpers->schema->html->smart_strip_tags( $breadcrumb['text'] );
+
+		return $crumb;
 	}
 
 	/**
@@ -121,12 +128,8 @@ class Breadcrumb extends Abstract_Schema_Piece {
 	 * @return array The last of the breadcrumbs.
 	 */
 	private function format_last_breadcrumb( $breadcrumb ) {
-		if ( empty( $breadcrumb['url'] ) ) {
-			$breadcrumb['url'] = $this->context->canonical;
-		}
-		if ( empty( $breadcrumb['text'] ) ) {
-			$breadcrumb['text'] = $this->helpers->schema->html->smart_strip_tags( $this->context->title );
-		}
+		unset( $breadcrumb['url'], $breadcrumb['text'], $breadcrumb['@type'] );
+		$breadcrumb['@id'] = $this->context->canonical . Schema_IDs::WEBPAGE_HASH;
 
 		return $breadcrumb;
 	}

--- a/tests/unit/generators/schema/breadcrumb-test.php
+++ b/tests/unit/generators/schema/breadcrumb-test.php
@@ -118,12 +118,6 @@ class Breadcrumb_Test extends TestCase {
 			->once()
 			->andReturnArg( 0 );
 
-		$this->html
-			->expects( 'smart_strip_tags' )
-			->with( 'Test post' )
-			->once()
-			->andReturnArg( 0 );
-
 		$actual = $this->instance->generate();
 
 		$expected = [
@@ -144,16 +138,13 @@ class Breadcrumb_Test extends TestCase {
 					'@type'    => 'ListItem',
 					'position' => 2,
 					'item'     => [
-						'@type' => 'WebPage',
-						'@id'   => 'https://basic.wordpress.test/test_post/',
-						'url'   => 'https://basic.wordpress.test/test_post/',
-						'name'  => 'Test post',
+						'@id'   => 'https://wordpress.example.com/canonical#webpage',
 					],
 				],
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		self::assertEquals( $expected, $actual );
 	}
 
 	/**
@@ -178,12 +169,6 @@ class Breadcrumb_Test extends TestCase {
 		$this->current_page->expects( 'is_paged' )->andReturnFalse();
 		$this->current_page->expects( 'is_home_static_page' )->once()->andReturnTrue();
 
-		$this->html
-			->expects( 'smart_strip_tags' )
-			->with( 'Home' )
-			->once()
-			->andReturnArg( 0 );
-
 		$actual = $this->instance->generate();
 
 		$expected = [
@@ -194,13 +179,13 @@ class Breadcrumb_Test extends TestCase {
 					'@type'    => 'ListItem',
 					'position' => 1,
 					'item'     => [
-						'@id'   => 'https://basic.wordpress.test/#webpage',
+						'@id'   => 'https://wordpress.example.com/canonical#webpage',
 					],
 				],
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		self::assertEquals( $expected, $actual );
 	}
 
 	/**
@@ -230,12 +215,6 @@ class Breadcrumb_Test extends TestCase {
 		$this->current_page->expects( 'is_paged' )->andReturnFalse();
 		$this->current_page->expects( 'is_home_static_page' )->once()->andReturnTrue();
 
-		$this->html
-			->expects( 'smart_strip_tags' )
-			->with( 'Home' )
-			->once()
-			->andReturnArg( 0 );
-
 		$actual = $this->instance->generate();
 
 		$expected = [
@@ -246,16 +225,13 @@ class Breadcrumb_Test extends TestCase {
 					'@type'    => 'ListItem',
 					'position' => 1,
 					'item'     => [
-						'@type' => 'WebPage',
-						'@id'   => 'https://basic.wordpress.test/',
-						'url'   => 'https://basic.wordpress.test/',
-						'name'  => 'Home',
+						'@id'   => 'https://wordpress.example.com/canonical#webpage',
 					],
 				],
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		self::assertEquals( $expected, $actual );
 	}
 
 	/**
@@ -287,12 +263,6 @@ class Breadcrumb_Test extends TestCase {
 		$this->current_page->expects( 'is_paged' )->andReturnFalse();
 		$this->current_page->expects( 'is_home_static_page' )->once()->andReturnFalse();
 
-		$this->html
-			->expects( 'smart_strip_tags' )
-			->with( 'Home' )
-			->once()
-			->andReturnArg( 0 );
-
 		$actual = $this->instance->generate();
 
 		$expected = [
@@ -303,13 +273,13 @@ class Breadcrumb_Test extends TestCase {
 					'@type'    => 'ListItem',
 					'position' => 1,
 					'item'     => [
-						'@id'   => 'https://wordpress.example.com/#webpage',
+						'@id'   => 'https://wordpress.example.com/canonical#webpage',
 					],
 				],
 			],
 		];
 
-		$this->assertEquals( $expected, $actual );
+		self::assertEquals( $expected, $actual );
 	}
 
 	/**
@@ -386,12 +356,6 @@ class Breadcrumb_Test extends TestCase {
 			->once()
 			->andReturnArg( 0 );
 
-		$this->html
-			->expects( 'smart_strip_tags' )
-			->with( 'Page title' )
-			->once()
-			->andReturnArg( 0 );
-
 		$expected = [
 			'@type'           => 'BreadcrumbList',
 			'@id'             => 'https://wordpress.example.com/canonical#breadcrumb',
@@ -420,10 +384,7 @@ class Breadcrumb_Test extends TestCase {
 					'@type'    => 'ListItem',
 					'position' => 3,
 					'item'     => [
-						'@type' => 'WebPage',
-						'@id'   => 'https://wordpress.example.com/canonical',
-						'url'   => 'https://wordpress.example.com/canonical',
-						'name'  => 'Page title',
+						'@id' => 'https://wordpress.example.com/canonical#webpage',
 					],
 				],
 			],
@@ -431,7 +392,7 @@ class Breadcrumb_Test extends TestCase {
 
 		$actual = $this->instance->generate();
 
-		$this->assertEquals( $expected, $actual );
+		self::assertEquals( $expected, $actual );
 	}
 
 	/**
@@ -478,12 +439,6 @@ class Breadcrumb_Test extends TestCase {
 			->once()
 			->andReturnArg( 0 );
 
-		$this->html
-			->expects( 'smart_strip_tags' )
-			->with( 'Page title' )
-			->once()
-			->andReturnArg( 0 );
-
 		$expected = [
 			'@type'           => 'BreadcrumbList',
 			'@id'             => 'https://wordpress.example.com/canonical#breadcrumb',
@@ -512,10 +467,7 @@ class Breadcrumb_Test extends TestCase {
 					'@type'    => 'ListItem',
 					'position' => 3,
 					'item'     => [
-						'@type' => 'WebPage',
-						'@id'   => 'https://wordpress.example.com/canonical',
-						'url'   => 'https://wordpress.example.com/canonical',
-						'name'  => 'Page title',
+						'@id'   => 'https://wordpress.example.com/canonical#webpage',
 					],
 				],
 			],
@@ -523,7 +475,7 @@ class Breadcrumb_Test extends TestCase {
 
 		$actual = $this->instance->generate();
 
-		$this->assertEquals( $expected, $actual );
+		self::assertEquals( $expected, $actual );
 	}
 
 	/**
@@ -562,12 +514,6 @@ class Breadcrumb_Test extends TestCase {
 			->once()
 			->andReturnArg( 0 );
 
-		$this->html
-			->expects( 'smart_strip_tags' )
-			->with( 'Test post' )
-			->once()
-			->andReturnArg( 0 );
-
 		$expected = [
 			'@type'           => 'BreadcrumbList',
 			'@id'             => 'https://wordpress.example.com/canonical#breadcrumb',
@@ -586,11 +532,7 @@ class Breadcrumb_Test extends TestCase {
 					'@type'    => 'ListItem',
 					'position' => 2,
 					'item'     => [
-						'@type' => 'WebPage',
-						// Fall back to canonical for ID and URL properties.
-						'@id'   => 'https://wordpress.example.com/canonical',
-						'url'   => 'https://wordpress.example.com/canonical',
-						'name'  => 'Test post',
+						'@id'   => 'https://wordpress.example.com/canonical#webpage',
 					],
 				],
 			],
@@ -598,7 +540,7 @@ class Breadcrumb_Test extends TestCase {
 
 		$actual = $this->instance->generate();
 
-		$this->assertEquals( $expected, $actual );
+		self::assertEquals( $expected, $actual );
 	}
 
 	/**
@@ -631,8 +573,11 @@ class Breadcrumb_Test extends TestCase {
 		$this->current_page->expects( 'is_paged' )->andReturnFalse();
 		$this->current_page->expects( 'is_home_static_page' )->once()->andReturnFalse();
 
-		$this->html->expects( 'smart_strip_tags' )->once()->with( 'Home' )->andReturn( 'Home' );
-		$this->html->expects( 'smart_strip_tags' )->twice()->with( 'Page title' )->andReturn( 'Page title' );
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->once()
+			->with( 'Home' )
+			->andReturn( 'Home' );
 
 		$expected = [
 			'@type'           => 'BreadcrumbList',
@@ -652,11 +597,7 @@ class Breadcrumb_Test extends TestCase {
 					'@type'    => 'ListItem',
 					'position' => 2,
 					'item'     => [
-						'@type' => 'WebPage',
-						// Fall back to canonical for ID and URL properties.
-						'@id'   => 'https://wordpress.example.com/post-title',
-						'url'   => 'https://wordpress.example.com/post-title',
-						'name'  => 'Page title',
+						'@id' => 'https://wordpress.example.com/canonical#webpage',
 					],
 				],
 			],
@@ -664,7 +605,7 @@ class Breadcrumb_Test extends TestCase {
 
 		$actual = $this->instance->generate();
 
-		$this->assertEquals( $expected, $actual );
+		self::assertEquals( $expected, $actual );
 	}
 
 	/**

--- a/tests/unit/generators/schema/breadcrumb-test.php
+++ b/tests/unit/generators/schema/breadcrumb-test.php
@@ -194,10 +194,7 @@ class Breadcrumb_Test extends TestCase {
 					'@type'    => 'ListItem',
 					'position' => 1,
 					'item'     => [
-						'@type' => 'WebPage',
-						'@id'   => 'https://basic.wordpress.test/',
-						'url'   => 'https://basic.wordpress.test/',
-						'name'  => 'Home',
+						'@id'   => 'https://basic.wordpress.test/#webpage',
 					],
 				],
 			],
@@ -306,10 +303,7 @@ class Breadcrumb_Test extends TestCase {
 					'@type'    => 'ListItem',
 					'position' => 1,
 					'item'     => [
-						'@type' => 'WebPage',
-						'@id'   => 'https://wordpress.example.com/',
-						'url'   => 'https://wordpress.example.com/',
-						'name'  => 'Home',
+						'@id'   => 'https://wordpress.example.com/#webpage',
 					],
 				],
 			],


### PR DESCRIPTION
## Summary

⚠️ Tests still need fixing, as this changes some logic and the tests were annoying to fix :) ⚠️ 

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Correctly reference the current webpage in breadcrumb schema output.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See that the last bit of the breadcrumbs schema output is always a reference to the `#webpage` by `@id`.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes PRODUCT-208
