### PR TITLE
Hide mark buttons in Elementor

### DIFF
--- a/js/src/elementor/initializers/editor-store.js
+++ b/js/src/elementor/initializers/editor-store.js
@@ -18,6 +18,8 @@ const populateStore = store => {
 	store.dispatch( actions.loadCornerstoneContent() );
 	// Initialize the focus keyphrase.
 	store.dispatch( actions.loadFocusKeyword() );
+	// Disable marker buttons.
+	store.dispatch( actions.setMarkerStatus( "hidden" ) );
 
 	store.dispatch(
 		actions.setSettings( {

--- a/js/src/elementor/initializers/editor-store.js
+++ b/js/src/elementor/initializers/editor-store.js
@@ -18,7 +18,7 @@ const populateStore = store => {
 	store.dispatch( actions.loadCornerstoneContent() );
 	// Initialize the focus keyphrase.
 	store.dispatch( actions.loadFocusKeyword() );
-	// Disable marker buttons.
+	// Hide marker buttons.
 	store.dispatch( actions.setMarkerStatus( "hidden" ) );
 
 	store.dispatch(


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Currently, we disable the mark (eye icon) button on Elementor. This leads to confusion with users. Let's remove the mark button on Elementor.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the analysis highlight button would be visible in our Elementor integration even though we don't support it.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install & activate
  * Yoast SEO 16.1-RC1 (or higher / this branch)
  * Elementor 3.1.1 (or higher) (Elementor pro is optional)
* Create a new post
* Edit it in Elementor
* Add some text and use a transition word. I used:
```txt
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut elit tellus, luctus nec ullamcorper mattis, pulvinar dapibus leo. Furthermore, lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut elit tellus, luctus nec ullamcorper mattis, pulvinar dapibus leo.
```
* Go to the readability analysis results
* Verify there is no eye icon anymore next to the transition word improvement.
  * Before:
![before](https://user-images.githubusercontent.com/35524806/109505206-a6642580-7a9c-11eb-8e05-938e87ed6b4e.png)
  * After:
![after](https://user-images.githubusercontent.com/35524806/109505221-a95f1600-7a9c-11eb-8490-0c32e1660df8.png)


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-372
