### PR TITLE
Add a filter which allows the Gutenberg compatibility notification to be disabled

### DIFF
--- a/admin/class-admin-gutenberg-compatibility-notification.php
+++ b/admin/class-admin-gutenberg-compatibility-notification.php
@@ -65,7 +65,8 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification implements WPSEO_WordPres
 		if (
 			! $this->compatibility_checker->is_installed()
 			|| $this->compatibility_checker->is_fully_compatible()
-			|| ! $display_notification ) {
+			|| ! $display_notification
+		) {
 			$this->notification_center->remove_notification_by_id( $this->notification_id );
 
 			return;

--- a/admin/class-admin-gutenberg-compatibility-notification.php
+++ b/admin/class-admin-gutenberg-compatibility-notification.php
@@ -22,14 +22,14 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification implements WPSEO_WordPres
 	 *
 	 * @var WPSEO_Gutenberg_Compatibility
 	 */
-	private $compatibility_checker;
+	protected $compatibility_checker;
 
 	/**
 	 * Instance of Yoast Notification Center.
 	 *
 	 * @var Yoast_Notification_Center
 	 */
-	private $notification_center;
+	protected $notification_center;
 
 	/**
 	 * WPSEO_Admin_Gutenberg_Compatibility_Notification constructor.
@@ -54,7 +54,18 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification implements WPSEO_WordPres
 	 * @return void
 	 */
 	public function manage_notification() {
-		if ( ! $this->compatibility_checker->is_installed() || $this->compatibility_checker->is_fully_compatible() ) {
+		/**
+		 * Filter: 'yoast_display_gutenberg_compat_notification' - Allows developer to disable the Gutenberg compatibility
+		 * notification.
+		 *
+		 * @api bool
+		 */
+		$display_notification = apply_filters( 'yoast_display_gutenberg_compat_notification', true );
+
+		if (
+			! $this->compatibility_checker->is_installed()
+			|| $this->compatibility_checker->is_fully_compatible()
+			|| ! $display_notification ) {
 			$this->notification_center->remove_notification_by_id( $this->notification_id );
 
 			return;
@@ -68,7 +79,7 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification implements WPSEO_WordPres
 	 *
 	 * @return void
 	 */
-	private function add_notification() {
+	protected function add_notification() {
 		$level = $this->compatibility_checker->is_below_minimum() ? Yoast_Notification::ERROR : Yoast_Notification::WARNING;
 
 		$message = sprintf(

--- a/tests/unit/admin/admin-gutenberg-compatibility-notification-test.php
+++ b/tests/unit/admin/admin-gutenberg-compatibility-notification-test.php
@@ -47,9 +47,8 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification_Test extends TestCase {
 	/**
 	 * Set up the mocked dependencies.
 	 */
-	public function setUp() {
-		parent::setUp();
-		Monkey\setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->gutenberg_compatibility_mock = Mockery::mock( 'WPSEO_Gutenberg_Compatibility' )->makePartial();
 		$this->notification_center_mock     = Mockery::mock( 'Yoast_Notification_Center' );
@@ -61,9 +60,8 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification_Test extends TestCase {
 	/**
 	 * Tear down the test mocks.
 	 */
-	public function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		Mockery::close();
 	}
 

--- a/tests/unit/admin/admin-gutenberg-compatibility-notification-test.php
+++ b/tests/unit/admin/admin-gutenberg-compatibility-notification-test.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Admin
+ */
+
+namespace Yoast\WP\SEO\Tests\Unit\Admin;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Admin\WPSEO_Admin_Gutenberg_Compatibility_Notification_Double;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Unit test class
+ *
+ * @group MyYoast
+ *
+ * @coversDefaultClass WPSEO_Admin_Gutenberg_Compatibility_Notification
+ */
+class WPSEO_Admin_Gutenberg_Compatibility_Notification_Test extends TestCase {
+
+	/**
+	 * Holds the WPSEO_Gutenberg_Compatibility mock instance.
+	 *
+	 * @var WPSEO_Gutenberg_Compatibility
+	 */
+	private $gutenberg_compatibility_mock;
+
+	/**
+	 * Holds the Yoast_Notification_Center mock instance.
+	 *
+	 * @var Yoast_Notification_Center
+	 */
+	private $notification_center_mock;
+
+	/**
+	 * Set up the mocked dependencies.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->gutenberg_compatibility_mock = $this
+			->getMockBuilder( 'WPSEO_Gutenberg_Compatibility' )
+			->setMethods( [ 'is_installed', 'is_fully_compatible' ] )
+			->getMock();
+
+		$this->notification_center_mock = $this
+			->getMockBuilder( 'Yoast_Notification_Center_Double' )
+			->setMethods( [ 'remove_notification_by_id' ] )
+			->getMock();
+	}
+
+	/**
+	 * Tests the conditions that remove the Gutenberg notification.
+	 *
+	 * @param bool $installed        The return value of WPSEO_Gutenberg_Compatibility::is_installed.
+	 * @param bool $fully_compatible The return value of WPSEO_Gutenberg_Compatibility::is_fully_compatible.
+	 * @param bool $filter_value     The return value of the 'yoast_display_gutenberg_compat_notification' filter.
+	 *
+	 * @covers WPSEO_Admin_Gutenberg_Compatibility_Notification::manage_notification
+	 *
+	 * @dataProvider data_provider_manage_notification_remove_notification
+	 */
+	public function test_manage_notification_remove_notification( $installed, $fully_compatible, $filter_value ) {
+
+		if ( ! $filter_value ) {
+			// Set the filter's return value to false.
+			Monkey\Filters\expectApplied( 'yoast_display_gutenberg_compat_notification' )
+				->once()
+				->andReturn( false );
+		}
+
+		$this->gutenberg_compatibility_mock->method( 'is_installed' )
+			->willReturn( $installed );
+
+		$this->gutenberg_compatibility_mock->method( 'is_fully_compatible' )
+			->willReturn( $fully_compatible );
+
+		$this->notification_center_mock->expects( $this->once() )
+			->method( 'remove_notification_by_id' );
+
+		$gutenberg_notification = new WPSEO_Admin_Gutenberg_Compatibility_Notification_Double();
+		$gutenberg_notification->set_dependencies( $this->gutenberg_compatibility_mock, $this->notification_center_mock );
+
+		$output = $gutenberg_notification->manage_notification();
+		$this->assertNull( $output );
+	}
+
+	/**
+	 * Test data provider for the test_manage_notification_remove_notification test method.
+	 *
+	 * @return array
+	 */
+	public function data_provider_manage_notification_remove_notification() {
+		return [
+			'filter is false'  => [
+				'installed'        => true,
+				'fully compatible' => false,
+				'filter_value'     => false,
+			],
+			'not installed'    => [
+				'installed'        => false,
+				'fully compatible' => false,
+				'filter_value'     => true,
+			],
+			'fully compatible' => [
+				'installed'        => true,
+				'fully compatible' => true,
+				'filter_value'     => true,
+			],
+		];
+	}
+
+	/**
+	 * Tests the condition that adds the Gutenberg compatibility notification.
+	 *
+	 * @covers WPSEO_Gutenberg_Compatibility::get_installed_version
+	 */
+	public function test_manage_notification_gutenberg_show_notification() {
+		$this->gutenberg_compatibility_mock->method( 'is_installed' )
+			->willReturn( true );
+
+		$this->gutenberg_compatibility_mock->method( 'is_fully_compatible' )
+			->willReturn( false );
+
+		$notification = $this
+			->getMockBuilder( 'WPSEO_Admin_Gutenberg_Compatibility_Notification_Double' )
+			->setMethods( [ 'add_notification' ] )
+			->getMock();
+
+		$notification->set_dependencies( $this->gutenberg_compatibility_mock, $this->notification_center_mock );
+		$notification->expects( $this->once() )
+			->method( 'add_notification' );
+
+		$notification->manage_notification();
+	}
+}

--- a/tests/unit/doubles/admin/admin-gutenberg-compatibility-notification-double.php
+++ b/tests/unit/doubles/admin/admin-gutenberg-compatibility-notification-double.php
@@ -1,9 +1,5 @@
 <?php
-/**
- * WPSEO plugin test file.
- *
- * @package WPSEO\Tests\Admin
- */
+// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- WPSEO_Admin_Gutenberg_Compatibility_Notification_Double.
 
 namespace Yoast\WP\SEO\Tests\Unit\Doubles\Admin;
 
@@ -12,7 +8,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Doubles\Admin;
  *
  * Class WPSEO_Gutenberg_Compatibility_Double.
  */
-class WPSEO_Admin_Gutenberg_Compatibility_Notification_Double extends WPSEO_Admin_Gutenberg_Compatibility_Notification {
+class WPSEO_Admin_Gutenberg_Compatibility_Notification_Double extends \WPSEO_Admin_Gutenberg_Compatibility_Notification {
 
 	/**
 	 * Sets the dependency instances.

--- a/tests/unit/doubles/admin/class-admin-gutenberg-compatibility-notification-double.php
+++ b/tests/unit/doubles/admin/class-admin-gutenberg-compatibility-notification-double.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * WPSEO plugin test file.
+ *
+ * @package WPSEO\Tests\Admin
+ */
+
+namespace Yoast\WP\SEO\Tests\Unit\Doubles\Admin;
+
+/**
+ * Test helper class.
+ *
+ * Class WPSEO_Gutenberg_Compatibility_Double.
+ */
+class WPSEO_Admin_Gutenberg_Compatibility_Notification_Double extends WPSEO_Admin_Gutenberg_Compatibility_Notification {
+
+	/**
+	 * Sets the dependency instances.
+	 *
+	 * @param WPSEO_Gutenberg_Compatibility $compatibility_checker The WPSEO_Gutenberg_Compatibility object.
+	 * @param Yoast_Notification_Center     $notification_center    The Yoast_Notification_Center object.
+	 */
+	public function set_dependencies( $compatibility_checker, $notification_center ) {
+		$this->compatibility_checker = $compatibility_checker;
+		$this->notification_center   = $notification_center;
+	}
+}


### PR DESCRIPTION
## Context
A notification is displayed on the Yoast dashboard when an incompatible version of the Gutenberg plugin is installed. In some environments, such as multisites, the user can not update the Gutenberg plugin. It would be nice to allow the Gutenberg compatibility notification to be disabled in these types of environments.

## Summary
This PR can be summarized in the following changelog entry:

* Adds a filter that allows the Gutenberg compatibility notification to be disabled.

## Relevant technical choices:

* Note that I changed the visibility of two properties and a method in the `WPSEO_Admin_Gutenberg_Compatibility_Notification` class from 'private' to 'protected'. I made these changes to accommodate unit testing. Please carefully evaluate whether these changes are acceptable or if a different approach should be used.

## Test instructions
1. Install and activate this branch of Yoast.
2. Install and activate an incompatible version of the Gutenberg plugin. For example, this WP CLI command will install the 9.9.3 version of Gutenberg:
    `wp plugin install gutenberg --version=9.9.3`
3. In wp-admin, navigate to SEO -> General. The Gutenberg compatibility notification should be displayed.
4. Use the filter to disable the Gutenberg compatibility notification. For example, add the following code to a snippet using the Code Snippets plugin:
    `add_action( 'yoast_display_gutenberg_compat_notification', '__return_false' );`
5. In wp-admin, navigate to SEO -> General. The Gutenberg compatibility notification should not be displayed.

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* n/a

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* n/a

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
