### PR TITLE
Filter posts with status 'auto-draft' from the post watcher indexable builder

### DIFF
--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -175,7 +175,7 @@ class Indexable_Post_Builder {
 			return $this->is_public_attachment( $indexable );
 		}
 
-		if ( ! \in_array( $indexable->post_status, $this->is_public_post_status(), true ) ) {
+		if ( ! \in_array( $indexable->post_status, $this->post_helper->get_public_post_statuses(), true ) ) {
 			return false;
 		}
 
@@ -233,20 +233,6 @@ class Indexable_Post_Builder {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Retrieves the list of public posts statuses.
-	 *
-	 * @return array The public post statuses.
-	 */
-	protected function is_public_post_status() {
-		/**
-		 * Filter: 'wpseo_public_post_statuses' - List of public post statuses.
-		 *
-		 * @api array $post_statuses Post status list, defaults to array( 'publish' ).
-		 */
-		return \apply_filters( 'wpseo_public_post_statuses', [ 'publish' ] );
 	}
 
 	/**

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -155,4 +155,30 @@ class Post_Helper {
 
 		return $updated !== false;
 	}
+
+	/**
+	 * Determines if the post can be indexed.
+	 *
+	 * @param int $post_id Post ID to check.
+	 *
+	 * @return bool True if the post can be indexed.
+	 */
+	public function is_post_indexable( $post_id ) {
+		// Don't index auto-drafts.
+		if ( \get_post_status( $post_id ) === 'auto-draft' ) {
+			return false;
+		}
+
+		// Don't index revisions of posts.
+		if ( \wp_is_post_revision( $post_id ) ) {
+			return false;
+		}
+
+		// Don't index autosaves that are not caught by the auto-draft check.
+		if ( \wp_is_post_autosave( $post_id ) ) {
+			return false;
+		}
+
+		return true;
+	}
 }

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -181,4 +181,18 @@ class Post_Helper {
 
 		return true;
 	}
+
+	/**
+	 * Retrieves the list of public posts statuses.
+	 *
+	 * @return array The public post statuses.
+	 */
+	public function get_public_post_statuses() {
+		/**
+		 * Filter: 'wpseo_public_post_statuses' - List of public post statuses.
+		 *
+		 * @api array $post_statuses Post status list, defaults to array( 'publish' ).
+		 */
+		return \apply_filters( 'wpseo_public_post_statuses', [ 'publish' ] );
+	}
 }

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -185,10 +185,17 @@ class Indexable_Post_Watcher implements Integration_Interface {
 	 * @return bool True if the post can be indexed.
 	 */
 	protected function is_post_indexable( $post_id ) {
+		// Don't index auto-drafts.
+		if ( \get_post_status( $post_id )  === 'auto-draft' ) {
+			return false;
+		}
+
+		// Don't index revisions of posts.
 		if ( \wp_is_post_revision( $post_id ) ) {
 			return false;
 		}
 
+		// Don't index autosaves that are not caught by the auto-draft check.
 		if ( \wp_is_post_autosave( $post_id ) ) {
 			return false;
 		}

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -178,32 +178,6 @@ class Indexable_Post_Watcher implements Integration_Interface {
 	}
 
 	/**
-	 * Determines if the post can be indexed.
-	 *
-	 * @param int $post_id Post ID to check.
-	 *
-	 * @return bool True if the post can be indexed.
-	 */
-	protected function is_post_indexable( $post_id ) {
-		// Don't index auto-drafts.
-		if ( \get_post_status( $post_id )  === 'auto-draft' ) {
-			return false;
-		}
-
-		// Don't index revisions of posts.
-		if ( \wp_is_post_revision( $post_id ) ) {
-			return false;
-		}
-
-		// Don't index autosaves that are not caught by the auto-draft check.
-		if ( \wp_is_post_autosave( $post_id ) ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
 	 * Saves post meta.
 	 *
 	 * @param int $post_id Post ID.
@@ -216,7 +190,7 @@ class Indexable_Post_Watcher implements Integration_Interface {
 			return;
 		}
 
-		if ( ! $this->is_post_indexable( $post_id ) ) {
+		if ( ! $this->post->is_post_indexable( $post_id ) ) {
 			return;
 		}
 

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -201,7 +201,8 @@ class Indexable_Post_Watcher implements Integration_Interface {
 			$post = $this->post->get_post( $post_id );
 
 			// Build links for this post.
-			if ( $post && $indexable && $post->post_status === 'publish' ) {
+			$public_post_statuses = \array_values( \get_post_stati( [ 'public' => true ] ) );
+			if ( $post && $indexable && \in_array( $post->post_status, $public_post_statuses, true ) ) {
 				$this->link_builder->build( $indexable, $post->post_content );
 				// Save indexable to persist the updated link count.
 				$indexable->save();

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -201,8 +201,7 @@ class Indexable_Post_Watcher implements Integration_Interface {
 			$post = $this->post->get_post( $post_id );
 
 			// Build links for this post.
-			$public_post_statuses = \array_values( \get_post_stati( [ 'public' => true ] ) );
-			if ( $post && $indexable && \in_array( $post->post_status, $public_post_statuses, true ) ) {
+			if ( $post && $indexable && \in_array( $post->post_status, $this->post->get_public_post_statuses(), true ) ) {
 				$this->link_builder->build( $indexable, $post->post_content );
 				// Save indexable to persist the updated link count.
 				$indexable->save();

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -201,7 +201,7 @@ class Indexable_Post_Watcher implements Integration_Interface {
 			$post = $this->post->get_post( $post_id );
 
 			// Build links for this post.
-			if ( $post && $indexable ) {
+			if ( $post && $indexable && $post->post_status !== 'draft' ) {
 				$this->link_builder->build( $indexable, $post->post_content );
 				// Save indexable to persist the updated link count.
 				$indexable->save();

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -201,7 +201,7 @@ class Indexable_Post_Watcher implements Integration_Interface {
 			$post = $this->post->get_post( $post_id );
 
 			// Build links for this post.
-			if ( $post && $indexable && $post->post_status !== 'draft' ) {
+			if ( $post && $indexable && $post->post_status === 'publish' ) {
 				$this->link_builder->build( $indexable, $post->post_content );
 				// Save indexable to persist the updated link count.
 				$indexable->save();

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Routes;
 
 use Yoast\WP\SEO\Actions\Indexables\Indexable_Head_Action;
 use Yoast\WP\SEO\Conditionals\Headless_Rest_Endpoints_Enabled_Conditional;
+use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 
@@ -37,6 +38,13 @@ class Yoast_Head_REST_Field implements Route_Interface {
 	protected $taxonomy_helper;
 
 	/**
+	 * The post helper.
+	 *
+	 * @var Post_Helper
+	 */
+	protected $post_helper;
+
+	/**
 	 * The head action.
 	 *
 	 * @var Indexable_Head_Action
@@ -57,15 +65,18 @@ class Yoast_Head_REST_Field implements Route_Interface {
 	 *
 	 * @param Post_Type_Helper      $post_type_helper The post type helper.
 	 * @param Taxonomy_Helper       $taxonomy_helper  The taxonomy helper.
+	 * @param Post_Helper           $post_helper      The post helper.
 	 * @param Indexable_Head_Action $head_action      The head action.
 	 */
 	public function __construct(
 		Post_Type_Helper $post_type_helper,
 		Taxonomy_Helper $taxonomy_helper,
+		Post_Helper $post_helper,
 		Indexable_Head_Action $head_action
 	) {
 		$this->post_type_helper = $post_type_helper;
 		$this->taxonomy_helper  = $taxonomy_helper;
+		$this->post_helper      = $post_helper;
 		$this->head_action      = $head_action;
 	}
 
@@ -103,6 +114,13 @@ class Yoast_Head_REST_Field implements Route_Interface {
 	 * @return string The head.
 	 */
 	public function for_post( $params ) {
+		if ( ! isset( $params['id'] ) ) {
+			return null;
+		}
+
+		if ( ! $this->post_helper->is_post_indexable( $params['id'] ) ) {
+			return null;
+		}
 		$obj = $this->head_action->for_post( $params['id'] );
 
 		if ( $obj->status === 404 ) {

--- a/tests/unit/builders/indexable-post-builder-test.php
+++ b/tests/unit/builders/indexable-post-builder-test.php
@@ -687,7 +687,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$this->indexable->object_sub_type   = 'post';
 		$this->indexable->post_status       = 'private';
 
-		Monkey\Filters\expectApplied( 'wpseo_public_post_statuses' )->once();
+		$this->post->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
 
 		$this->assertFalse( $this->instance->is_public( $this->indexable ) );
 	}
@@ -703,6 +703,8 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$this->indexable->object_sub_type   = 'post';
 		$this->indexable->post_status       = 'publish';
 
+		$this->post->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
+
 		$this->assertTrue( $this->instance->is_public( $this->indexable ) );
 	}
 
@@ -716,6 +718,8 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$this->indexable->is_robots_noindex = null;
 		$this->indexable->object_sub_type   = 'post';
 		$this->indexable->post_status       = 'publish';
+
+		$this->post->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
 
 		$this->assertNull( $this->instance->is_public( $this->indexable ) );
 	}

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -195,17 +195,14 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	 * Tests the save meta functionality.
 	 *
 	 * @covers ::build_indexable
-	 * @covers ::is_post_indexable
 	 */
 	public function test_build_indexable() {
 		$post_id      = 1;
 		$post_content = '<p>A post with a <a href="https://example.com/post-2">a link</a>.</p>';
 		$post         = (object) [
 			'post_content' => $post_content,
+			'post_status'  => 'publish',
 		];
-
-		Monkey\Functions\expect( 'wp_is_post_revision' )->once()->with( $post_id )->andReturn( false );
-		Monkey\Functions\expect( 'wp_is_post_autosave' )->once()->with( $post_id )->andReturn( false );
 
 		$indexable_mock = Mockery::mock( Indexable_Mock::class );
 
@@ -232,6 +229,12 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->with( $post_id )
 			->andReturn( $post );
 
+		$this->post
+			->expects( 'is_post_indexable' )
+			->once()
+			->with( $post_id )
+			->andReturn( true );
+
 		$this->link_builder
 			->expects( 'build' )
 			->once()
@@ -244,27 +247,15 @@ class Indexable_Post_Watcher_Test extends TestCase {
 	 * Tests the early return for non-indexable post.
 	 *
 	 * @covers ::build_indexable
-	 * @covers ::is_post_indexable
 	 */
-	public function test_build_indexable_is_post_revision() {
+	public function test_build_indexable_is_not_indexable() {
 		$id = 1;
 
-		Monkey\Functions\expect( 'wp_is_post_revision' )->once()->with( $id )->andReturn( true );
-
-		$this->instance->build_indexable( $id );
-	}
-
-	/**
-	 * Tests the early return for non-indexable post.
-	 *
-	 * @covers ::build_indexable
-	 * @covers ::is_post_indexable
-	 */
-	public function test_build_indexable_is_post_autosave() {
-		$id = 1;
-
-		Monkey\Functions\expect( 'wp_is_post_revision' )->once()->with( $id )->andReturn( false );
-		Monkey\Functions\expect( 'wp_is_post_autosave' )->once()->with( $id )->andReturn( true );
+		$this->post
+			->expects( 'is_post_indexable' )
+			->once()
+			->with( $id )
+			->andReturn( false );
 
 		$this->instance->build_indexable( $id );
 	}
@@ -304,7 +295,7 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->once()
 			->andReturnFalse();
 
-		$this->instance
+		$this->post
 			->expects( 'is_post_indexable' )
 			->with( $post_id )
 			->once()
@@ -333,10 +324,14 @@ class Indexable_Post_Watcher_Test extends TestCase {
 		$post_content = '<p>A post with a <a href="https://example.com/post-2">a link</a>.</p>';
 		$post         = (object) [
 			'post_content' => $post_content,
+			'post_status'  => 'publish',
 		];
 
-		Monkey\Functions\expect( 'wp_is_post_revision' )->once()->with( $post_id )->andReturn( false );
-		Monkey\Functions\expect( 'wp_is_post_autosave' )->once()->with( $post_id )->andReturn( false );
+		$this->post
+			->expects( 'is_post_indexable' )
+			->with( $post_id )
+			->once()
+			->andReturnTrue();
 
 		$indexable_mock = Mockery::mock( Indexable_Mock::class );
 		$indexable_mock->expects( 'save' )->once();

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -235,6 +235,8 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->with( $post_id )
 			->andReturn( true );
 
+		Monkey\Functions\expect( 'get_post_stati' )->with( [ 'public' => true ] )->andReturn( [ 'publish' => 'publish' ] );
+
 		$this->link_builder
 			->expects( 'build' )
 			->once()
@@ -349,6 +351,8 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->expects( 'build' )
 			->once()
 			->with( $indexable_mock, $post_content );
+
+		Monkey\Functions\expect( 'get_post_stati' )->with( [ 'public' => true ] )->andReturn( [ 'publish' => 'publish' ] );
 
 		$this->instance->build_indexable( $post_id );
 	}

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -235,7 +235,10 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->with( $post_id )
 			->andReturn( true );
 
-		Monkey\Functions\expect( 'get_post_stati' )->with( [ 'public' => true ] )->andReturn( [ 'publish' => 'publish' ] );
+		$this->post
+			->expects( 'get_public_post_statuses' )
+			->once()
+			->andReturn( [ 'publish' ] );
 
 		$this->link_builder
 			->expects( 'build' )
@@ -352,7 +355,10 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->once()
 			->with( $indexable_mock, $post_content );
 
-		Monkey\Functions\expect( 'get_post_stati' )->with( [ 'public' => true ] )->andReturn( [ 'publish' => 'publish' ] );
+		$this->post
+			->expects( 'get_public_post_statuses' )
+			->once()
+			->andReturn( [ 'publish' ] );
 
 		$this->instance->build_indexable( $post_id );
 	}

--- a/tests/unit/routes/yoast-head-rest-field-test.php
+++ b/tests/unit/routes/yoast-head-rest-field-test.php
@@ -6,6 +6,7 @@ use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Actions\Indexables\Indexable_Head_Action;
 use Yoast\WP\SEO\Conditionals\Headless_Rest_Endpoints_Enabled_Conditional;
+use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Routes\Yoast_Head_REST_Field;
@@ -36,6 +37,13 @@ class Yoast_Head_REST_Field_Test extends TestCase {
 	protected $taxonomy_helper;
 
 	/**
+	 * The post helper.
+	 *
+	 * @var Post_Helper
+	 */
+	protected $post_helper;
+
+	/**
 	 * The head action.
 	 *
 	 * @var Indexable_Head_Action
@@ -57,11 +65,13 @@ class Yoast_Head_REST_Field_Test extends TestCase {
 
 		$this->post_type_helper = Mockery::mock( Post_Type_Helper::class );
 		$this->taxonomy_helper  = Mockery::mock( Taxonomy_Helper::class );
+		$this->post_helper      = Mockery::mock( Post_Helper::class );
 		$this->head_action      = Mockery::mock( Indexable_Head_Action::class );
 
 		$this->instance = new Yoast_Head_REST_Field(
 			$this->post_type_helper,
 			$this->taxonomy_helper,
+			$this->post_helper,
 			$this->head_action
 		);
 	}
@@ -180,6 +190,10 @@ class Yoast_Head_REST_Field_Test extends TestCase {
 				]
 			);
 
+		if ( $method === 'for_post' ) {
+			$this->post_helper->expects( 'is_post_indexable' )->once()->with( $params['id'] )->andReturnTrue();
+		}
+
 		if ( $method === 'for_post_type_archive' ) {
 			$this->post_type_helper->expects( 'has_archive' )->with( $input )->andReturnTrue();
 		}
@@ -246,6 +260,10 @@ class Yoast_Head_REST_Field_Test extends TestCase {
 					'head'   => 'this is the 404 head',
 				]
 			);
+
+		if ( $method === 'for_post' ) {
+			$this->post_helper->expects( 'is_post_indexable' )->once()->with( $params['id'] )->andReturnTrue();
+		}
 
 		if ( $method === 'for_post_type_archive' ) {
 			$this->post_type_helper->expects( 'has_archive' )->with( $input )->andReturnTrue();


### PR DESCRIPTION
⚠️ Take care: travis tests are failing because the tests that touch the changes in this PR have not been changed yet!

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Prevent indexable creation on `auto-draft` posts.
* Prevent link building on drafts
* Prevent indexable creation on the yoast_head route for non-indexable objects.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entries:

[Bugfix]
* Fixes a bug where indexable creation caused compatibility problems with code that would hook in to new post creation.

[Enhancement]
* Performance enhancements in the post indexable builder by skipping link creation on drafts.

## Relevant technical choices:

* Initial creation of a post does not trigger `wp_is_post_revision()` or `wp_is_post_autosave()`, so we needed another method. Posts with status `auto-save` do not merit the resources of an indexable creation.
* If the yoast_head API is called for a non-useable indexable, it will return and not create an indexable.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Acceptance testing done by stepping through the code and verifying the different usecases.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->
QA can test this PR by following these steps:

**In this RC, all indexables and linking functionalities should remain operational in normal usage.** 

To check that the PR does what it was created for:

For this test, keep the `_yoast_indexable` table and the `_yoast_seo_links` table of your database at the ready.
1. Under `Posts`, click `Add new`
2. Check the indexables table once the page is loaded, no indexable should be created.
3. Add a title and a bit of content
4. Wait for the autosave (if you keep your network tab of the browser inspector open, you can see the request to `/autosaves?_locale=user` fire.
5. Check the indexable table again, a new indexable is created for this post with the post_status `draft`.
6. Add some more text, and a link (internal or external).
7. Wait for the autosave again
8. Check that the indexable has not changed, and that no link was added to the links table.
9. Publish the post
10. The indexables table will now show the correct permalink and the links table will contain the link that was added in step 6

https://github.com/Yoast/wordpress-seo/issues/16716 contains a somewhat difficult problem which is also fixed with this PR:

1. Install WooCommerce
2. Add the custom code from the reproduction steps in the issue to your functions.php
3. In Products -> Attributes, create 2 attributes with name and slug `pa_brand` and `pa_maker`
4. Now go create a new product, when the editor is loaded, check the WooCommerce `Product data` metabox. Under the `Attributes` tab it should mention the 2 aforementioned attributes. Without this PR, those attributes would not be there.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The indexables, take extra care checking that all indexable data of live posts is correct.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/16716
Maybe https://github.com/Yoast/wordpress-seo/issues/16672 (please check)
There may be more that are fixed with this.
