### PR TITLE
LINGO-685 Make researcher argument of assessor

### DIFF
--- a/js/src/initializers/post-scraper.js
+++ b/js/src/initializers/post-scraper.js
@@ -256,6 +256,7 @@ export default function initPostScraper( $, store, editorData ) {
 			keywordAnalysisActive: isKeywordAnalysisActive(),
 			hasSnippetPreview: false,
 			debouncedRefresh: false,
+			researcher: new window.yoast.Researcher.default(),
 		};
 
 		if ( isKeywordAnalysisActive() ) {

--- a/js/src/initializers/term-scraper.js
+++ b/js/src/initializers/term-scraper.js
@@ -274,6 +274,7 @@ export default function initTermScraper( $, store, editorData ) {
 			keywordAnalysisActive: isKeywordAnalysisActive(),
 			hasSnippetPreview: false,
 			debouncedRefresh: false,
+			researcher: new window.yoast.Researcher.default(),
 		};
 
 		if ( isKeywordAnalysisActive() ) {
@@ -345,7 +346,7 @@ export default function initTermScraper( $, store, editorData ) {
 		store.subscribe( handleStoreChange.bind( null, store, app.refresh ) );
 
 		if ( isKeywordAnalysisActive() ) {
-			app.seoAssessor = new TaxonomyAssessor( app.i18n );
+			app.seoAssessor = new TaxonomyAssessor( app.i18n, app.config.researcher );
 			app.seoAssessorPresenter.assessor = app.seoAssessor;
 		}
 

--- a/js/tests/Pluggable.test.js
+++ b/js/tests/Pluggable.test.js
@@ -1,4 +1,5 @@
 import { Assessor } from "yoastseo";
+import Researcher from "yoastseo/src/languageProcessing/languages/_default/Researcher"
 
 import Pluggable from "../src/lib/Pluggable";
 import Factory from "./helpers/factory";
@@ -26,7 +27,7 @@ describe( "the pluggable interface", function() {
 		} );
 
 		it( "should be able to add an assessment", function() {
-			const assessor = new Assessor( i18n );
+			const assessor = new Assessor( i18n, new Researcher() );
 			expect( pluggable._registerAssessment( assessor, "name", function() {}, "test-plugin" ) ).toEqual( true );
 		} );
 	} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adapt plugin-side code to changes made in the accompanying [yoastseo PR](https://github.com/Yoast/javascript/pull/1095).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:
* This PR makes sure that the researcher is also passed when an app is constructed in the `post-scraper.js` and `term-scraper.js` legacy code. We don't use this legacy code anymore, since we run the analysis in the web worker, but some integrations might. So we want to keep that code working as long as we haven't properly deprecated it.
* This branch refers to an incorrect issue number, so I added the correct issue number in the PR title. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See associated javascript PR.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-685
