### PR TITLE
Created abstract model Settings_Model for options framework refactor

### DIFF
--- a/src/models/settings-model.php
+++ b/src/models/settings-model.php
@@ -1,0 +1,74 @@
+<?php
+
+
+namespace Yoast\WP\SEO\Models;
+
+use Exception;
+
+/**
+ * Class Settings_Model.
+ */
+abstract class Settings_Model {
+
+	/**
+	 * List of settings stored as key-value pairs, where the name is the key and value is the value.
+	 *
+	 * @var array<string, mixed>
+	 */
+	protected $values = [];
+
+	/**
+	 * Get value of setting.
+	 *
+	 * @param string $name Name of the setting which value to return.
+	 *
+	 * @return mixed The value for the setting.
+	 *
+	 * @throws Exception When the setting does not exist.
+	 */
+	public function __get( $name ) {
+		if ( ! $this->is_existing_setting( $name ) ) {
+			throw new Exception( "Setting $name does not exist." );
+		}
+
+		return $this->values[ $name ];
+	}
+
+	/**
+	 * Set setting with name to value.
+	 *
+	 * @param string $name  Name of the setting whose value will be set.
+	 * @param mixed  $value The new value for the setting.
+	 *
+	 * @return void
+	 *
+	 * @throws Exception When the setting does not exist.
+	 */
+	public function __set( $name, $value ) {
+		if ( ! $this->is_existing_setting( $name ) ) {
+			throw new Exception( "Setting $name does not exist." );
+		}
+
+		$this->values[ $name ] = $value;
+	}
+
+	/**
+	 * Check if given setting exists.
+	 *
+	 * @param string $name Name of setting that might exist.
+	 *
+	 * @return bool Whether the setting exists.
+	 */
+	protected function is_existing_setting( $name ) {
+		$settings = $this->get_settings();
+
+		return array_key_exists( $name, $settings );
+	}
+
+	/**
+	 * Get the definitions for the settings.
+	 *
+	 * @return array<string, array> Description of the settings with the setting name as key.
+	 */
+	abstract public function get_settings();
+}

--- a/tests/unit/models/settings-model-test.php
+++ b/tests/unit/models/settings-model-test.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Models;
+
+use Exception;
+use Mockery;
+use Mockery\MockInterface;
+use Yoast\WP\SEO\Models\Settings_Model;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+
+/**
+ * Class Settings_Model_Test.
+ *
+ * @group models
+ *
+ * @coversDefaultClass \\Yoast\WP\SEO\Models\Settings_Model
+ */
+class Settings_Model_Test extends TestCase {
+
+	/**
+	 * The instance under test.
+	 *
+	 * @var Settings_Model|MockInterface
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the class under test and mock objects.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->instance = Mockery::mock( Settings_Model::class );
+	}
+
+	/**
+	 * Test setting a non-existing setting.
+	 *
+	 * @covers ::__set
+	 */
+	public function test_setting_non_existing_setting() {
+		$this->instance->expects( 'get_settings' )->once()->andReturn( [ 'existing_setting' => [] ] );
+
+		$this->expectException( Exception::class );
+
+		$this->instance->non_existing_setting = 'value';
+	}
+
+	/**
+	 * Test setting an existing setting.
+	 *
+	 * @covers ::__set
+	 * @covers ::__get
+	 */
+	public function test_getting_setting_existing_setting() {
+		$this->instance->expects( 'get_settings' )->twice()->andReturn( [ 'existing_setting' => [] ] );
+
+		$this->instance->existing_setting = 'value';
+
+		self::assertSame( 'value', $this->instance->existing_setting );
+	}
+
+	/**
+	 * Test getting an non-existing setting.
+	 *
+	 * @covers ::__get
+	 */
+	public function test_getting_non_existing_setting() {
+		$this->instance->expects( 'get_settings' )->once()->andReturn( [ 'existing_setting' => [] ] );
+
+		$this->expectException( Exception::class );
+
+		$this->instance->non_existing_setting;
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Base model to store options framework in a more modern approach

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduce an abstract Settings_Model class

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* n/a. code is not yet used anywhere.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

