### PR TITLE
[QAK-2748] Fix auto update notification serialization

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -5,6 +5,8 @@
  * @package WPSEO\Admin\Notifications
  */
 
+use Yoast\WP\SEO\Presenters\Abstract_Presenter;
+
 /**
  * Handles notifications storage and display.
  */
@@ -787,6 +789,13 @@ class Yoast_Notification_Center {
 
 		if ( isset( $notification_data['options']['nonce'] ) ) {
 			unset( $notification_data['options']['nonce'] );
+		}
+
+		if (
+			isset( $notification_data['message'] ) &&
+			\is_subclass_of( $notification_data['message'], Abstract_Presenter::class, false )
+		) {
+			$notification_data['message'] = $notification_data['message']->present();
 		}
 
 		return new Yoast_Notification(

--- a/src/integrations/watchers/auto-update-watcher.php
+++ b/src/integrations/watchers/auto-update-watcher.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Integrations\Watchers;
 
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Helpers\Notification_Helper;
-use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Auto_Update_Notification_Presenter;
 use Yoast_Notification;

--- a/src/integrations/watchers/auto-update-watcher.php
+++ b/src/integrations/watchers/auto-update-watcher.php
@@ -193,7 +193,7 @@ class Auto_Update_Watcher implements Integration_Interface {
 		$presenter = new Auto_Update_Notification_Presenter();
 
 		return new Yoast_Notification(
-			$presenter,
+			$presenter->present(),
 			[
 				'type'         => Yoast_Notification::WARNING,
 				'id'           => self::NOTIFICATION_ID,

--- a/tests/unit/integrations/watchers/auto-update-watcher-test.php
+++ b/tests/unit/integrations/watchers/auto-update-watcher-test.php
@@ -223,6 +223,13 @@ class Auto_Update_Watcher_Test extends TestCase {
 			->expects( 'add_notification' )
 			->once();
 
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		Monkey\Functions\expect( 'get_admin_url' )
+			->with( null, 'plugins.php' )
+			->andReturn( 'https://example.com/wp-admin/plugins.php' );
+
 		$this->instance->auto_update_notification_even_if_dismissed();
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* If the auto update message is serialized then the class will be serialized which causes errors. Instead pass along the string.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a fatal error when upgrading from 15.9.1 to 16.0.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See https://yoast.atlassian.net/browse/QAK-2748


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Upgrading from 15.9.1 to 16.0 while the auto update notification is in the notification center.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/QAK-2748
