### PR TITLE
AR-74 AR-75 Adds global and object settings model

### DIFF
--- a/src/models/settings/global-settings-model.php
+++ b/src/models/settings/global-settings-model.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Yoast\WP\SEO\Models\Settings;
+
+use Yoast\WP\SEO\Models\Settings_Model;
+
+/**
+ * Class Global_Settings_Model.
+ */
+abstract class Global_Settings_Model extends Settings_Model {
+
+}

--- a/src/models/settings/object-settings-model.php
+++ b/src/models/settings/object-settings-model.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Yoast\WP\SEO\Models\Settings;
+
+use Yoast\WP\SEO\Models\Settings_Model;
+
+/**
+ * Class Object_Settings_Model
+ */
+abstract class Object_Settings_Model extends Settings_Model {
+
+	/**
+	 * Holds the object name, e.g. the post type or taxonomy name.
+	 *
+	 * @var string
+	 */
+	protected $object_name;
+
+	/**
+	 * Object_Settings_Model constructor.
+	 *
+	 * @param string $object_name The object name to set.
+	 */
+	public function __construct( $object_name ) {
+		$this->object_name = $object_name;
+	}
+
+	/**
+	 * Retrieves the object name.
+	 *
+	 * @return string The object name.
+	 */
+	public function get_object_name() {
+		return $this->object_name;
+	}
+}

--- a/tests/unit/models/settings/object-settings-model-test.php
+++ b/tests/unit/models/settings/object-settings-model-test.php
@@ -39,7 +39,10 @@ class Object_Settings_Model_Test extends TestCase {
 	 * @covers ::__construct
 	 */
 	public function test_construct() {
-		static::assertAttributeEquals( 'object_type', 'object_name', $this->instance );
+		static::assertSame(
+			'object_type',
+			static::getPropertyValue( $this->instance, 'object_name' )
+		);
 	}
 
 	/**

--- a/tests/unit/models/settings/object-settings-model-test.php
+++ b/tests/unit/models/settings/object-settings-model-test.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Models\Settings;
+
+use Mockery;
+use Mockery\MockInterface;
+use Yoast\WP\SEO\Models\Settings\Object_Settings_Model;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+
+/**
+ * Class Object_Settings_Model_Test.
+ *
+ * @group models
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Models\Settings\Object_Settings_Model
+ */
+class Object_Settings_Model_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var MockInterface|Object_Settings_Model
+	 */
+	protected $instance;
+
+	/**
+	 * Sets the instance to test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->instance = Mockery::mock( Object_Settings_Model::class, [ 'object_type' ] )->makePartial();
+	}
+
+	/**
+	 * Tests the constructor by checking the assignment of object_name.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct() {
+		static::assertAttributeEquals( 'object_type', 'object_name', $this->instance );
+	}
+
+	/**
+	 * Tests the retrieval of the object name.
+	 *
+	 * @covers ::get_object_name
+	 */
+	public function test_get_object_name() {
+		static::assertSame( 'object_type', $this->instance->get_object_name() );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want an abstract class for global and object specific settings.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds abstract classes for the global and object setting models 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* It adds code that isn't implemented yet.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [AR-75]


[AR-75]: https://yoast.atlassian.net/browse/AR-75