### PR TITLE
[P3-430] Delay disabling core sitemaps until WP has the required locale functi…

### DIFF
--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -21,7 +21,6 @@ class Options_Helper {
 	 * @return mixed|null Returns value if found, $default if not.
 	 */
 	public function get( $key, $default = null ) {
-		WPSEO_Options::get_instance();
 		return WPSEO_Options::get( $key, $default );
 	}
 

--- a/src/initializers/disable-core-sitemaps.php
+++ b/src/initializers/disable-core-sitemaps.php
@@ -44,6 +44,16 @@ class Disable_Core_Sitemaps implements Initializer_Interface {
 	 * Disable the WP core XML sitemaps.
 	 */
 	public function initialize() {
+		// This needs to be on priority 15 as that is after our options initialize.
+		\add_action( 'plugins_loaded', [ $this, 'maybe_disable_core_sitemaps' ], 15 );
+	}
+
+	/**
+	 * Disables the core sitemaps if Yoast SEO sitemaps are enabled.
+	 *
+	 * @return void
+	 */
+	public function maybe_disable_core_sitemaps() {
 		if ( $this->options->get( 'enable_xml_sitemap' ) ) {
 			\add_filter( 'wp_sitemaps_enabled', '__return_false' );
 


### PR DESCRIPTION
…ons and our options framework has loaded

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This delays loading our options framework, which calls translations, until all functions are available so WP can accurately determine the user's locale. Otherwise the site language is always loaded.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes Yoast SEO not translating correctly if your site's language was different from your user language and your site language was note "en_US"

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Install Yoast SEO 16.0-RC5
2. in Settings->General, set the site language to Italian, then save
3. in Settings->General, set the site language to Dutch, then save
4. in your user profile, switch the language to Italian
5. Your SEO settings should be in italian.

As this affects our sitemap loading to test those:
1. Visit `/wp-sitemap.xml`.
2. You should be redirected to `/sitemap_index.xml`.
3. Disable Yoast SEO sitemaps.
4. Visit `/wp-sitemap.xml`.
5. You should not be redirected.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This affects disabling core sitemaps.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P3-430
