### PR TITLE
AR-69 use boolean values for instead of 0|1 for localized variables

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -263,7 +263,7 @@ class WPSEO_Admin {
 	public function config_page_scripts() {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$asset_manager->enqueue_script( 'admin-global-script' );
-		$asset_manager->localize_script( 'admin-global-script', 'wpseoAdminGlobalL10n', $this->localize_adFmin_global_script() );
+		$asset_manager->localize_script( 'admin-global-script', 'wpseoAdminGlobalL10n', $this->localize_admin_global_script() );
 	}
 
 	/**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -263,7 +263,7 @@ class WPSEO_Admin {
 	public function config_page_scripts() {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 		$asset_manager->enqueue_script( 'admin-global-script' );
-		$asset_manager->localize_script( 'admin-global-script', 'wpseoAdminGlobalL10n', $this->localize_admin_global_script() );
+		$asset_manager->localize_script( 'admin-global-script', 'wpseoAdminGlobalL10n', $this->localize_adFmin_global_script() );
 	}
 
 	/**

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -70,10 +70,10 @@ class WPSEO_Metabox_Formatter {
 			'keyword_usage'               => [],
 			'title_template'              => '',
 			'metadesc_template'           => '',
-			'contentAnalysisActive'       => $analysis_readability->is_enabled() ? 1 : 0,
-			'keywordAnalysisActive'       => $analysis_seo->is_enabled() ? 1 : 0,
-			'cornerstoneActive'           => WPSEO_Options::get( 'enable_cornerstone_content', false ) ? 1 : 0,
-			'semrushIntegrationActive'    => WPSEO_Options::get( 'semrush_integration_active', true ) ? 1 : 0,
+			'contentAnalysisActive'       => $analysis_readability->is_enabled(),
+			'keywordAnalysisActive'       => $analysis_seo->is_enabled(),
+			'cornerstoneActive'           => WPSEO_Options::get( 'enable_cornerstone_content', false ),
+			'semrushIntegrationActive'    => WPSEO_Options::get( 'semrush_integration_active', true ),
 			'intl'                        => $this->get_content_analysis_component_translations(),
 			'isRtl'                       => is_rtl(),
 			'isPremium'                   => YoastSEO()->helpers->product->is_premium(),
@@ -164,8 +164,8 @@ class WPSEO_Metabox_Formatter {
 			],
 			'markdownEnabled'             => $this->is_markdown_enabled(),
 			'analysisHeadingTitle'        => __( 'Analysis', 'wordpress-seo' ),
-			'zapierIntegrationActive'     => WPSEO_Options::get( 'zapier_integration_active', false ) ? 1 : 0,
-			'zapierConnectedStatus'       => ! empty( WPSEO_Options::get( 'zapier_subscription', [] ) ) ? 1 : 0,
+			'zapierIntegrationActive'     => WPSEO_Options::get( 'zapier_integration_active', false ),
+			'zapierConnectedStatus'       => ! empty( WPSEO_Options::get( 'zapier_subscription', [] ) ),
 
 			/**
 			 * Filter to determine whether the PreviouslyUsedKeyword assessment should run.

--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -61,7 +61,7 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 				'title_template'           => $this->get_title_template(),
 				'metadesc_template'        => $this->get_metadesc_template(),
 				'first_content_image'      => $this->get_image_url(),
-				'semrushIntegrationActive' => 0,
+				'semrushIntegrationActive' => false,
 			];
 		}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -295,7 +295,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		}
 
 		if ( $values['semrushIntegrationActive'] && $this->post->post_type === 'attachment' ) {
-			$values['semrushIntegrationActive'] = 0;
+			$values['semrushIntegrationActive'] = false;
 		}
 
 		return $values;

--- a/js/src/analysis/isContentAnalysisActive.js
+++ b/js/src/analysis/isContentAnalysisActive.js
@@ -10,5 +10,5 @@ import { get } from "lodash-es";
 export default function isContentAnalysisActive() {
 	const l10nObject = getL10nObject();
 
-	return get( l10nObject, "contentAnalysisActive", 0 ) === 1;
+	return get( l10nObject, "contentAnalysisActive", false );
 }

--- a/js/src/analysis/isCornerstoneContentActive.js
+++ b/js/src/analysis/isCornerstoneContentActive.js
@@ -10,5 +10,5 @@ import { get } from "lodash-es";
 export default function isCornerstoneContentActive() {
 	const l10nObject = getL10nObject();
 
-	return get( l10nObject, "cornerstoneActive", 0 ) === 1;
+	return get( l10nObject, "cornerstoneActive", false );
 }

--- a/js/src/analysis/isKeywordAnalysisActive.js
+++ b/js/src/analysis/isKeywordAnalysisActive.js
@@ -10,5 +10,5 @@ import { get } from "lodash-es";
 export default function isKeywordAnalysisActive() {
 	const l10nObject = getL10nObject();
 
-	return get( l10nObject, "keywordAnalysisActive", 0 ) === 1;
+	return get( l10nObject, "keywordAnalysisActive", false );
 }

--- a/js/src/analysis/isSEMrushIntegrationActive.js
+++ b/js/src/analysis/isSEMrushIntegrationActive.js
@@ -12,5 +12,5 @@ import getL10nObject from "./getL10nObject";
 export default function isSEMrushIntegrationActive() {
 	const l10nObject = getL10nObject();
 
-	return get( l10nObject, "semrushIntegrationActive", 0 ) === 1;
+	return get( l10nObject, "semrushIntegrationActive", false );
 }

--- a/js/src/analysis/isZapierConnected.js
+++ b/js/src/analysis/isZapierConnected.js
@@ -12,5 +12,5 @@ import getL10nObject from "./getL10nObject";
 export default function isZapierConnected() {
 	const l10nObject = getL10nObject();
 
-	return get( l10nObject, "zapierConnectedStatus", 0 ) === 1;
+	return get( l10nObject, "zapierConnectedStatus", false );
 }

--- a/js/src/analysis/isZapierIntegrationActive.js
+++ b/js/src/analysis/isZapierIntegrationActive.js
@@ -12,5 +12,5 @@ import getL10nObject from "./getL10nObject";
 export default function isZapierIntegrationActive() {
 	const l10nObject = getL10nObject();
 
-	return get( l10nObject, "zapierIntegrationActive", 0 ) === 1;
+	return get( l10nObject, "zapierIntegrationActive", false );
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to ensure consistency in the JS code base. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Uses booleans everywhere instead of 0|1 in localized data.

## Relevant technical choices:

Localised variables that were changed:
* `'contentAnalysisActive'`
* `'keywordAnalysisActive'`
* `'cornerstoneActive'`
* `'semrushIntegrationActive'`
* `'zapierIntegrationActive'`
* `'zapierConnectedStatus'`


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to this branch and build with `composer install && yarn install && grunt build:dev`.
* Create a new post or edit an existing one.
* Make sure all features of the Yoast metabox / sidebar are there.
* Smoke test the metabox / sidebar. 
* Pay special attention to the content analysis, keyword analysis, cornerstone content and SEMrush integration.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [AR-69]


[AR-69]: https://yoast.atlassian.net/browse/AR-69