### PR TITLE
[QAK-2758] Sort robots

### DIFF
--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -173,7 +173,7 @@ class WP_Robots_Integration implements Integration_Interface {
 				$ai    = isset( $order[ $a ] ) ? $order[ $a ] : 4;
 				$bi    = isset( $order[ $b ] ) ? $order[ $b ] : 4;
 
-				return ( $bi - $ai );
+				return ( $ai - $bi );
 			}
 		);
 

--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -68,9 +68,10 @@ class WP_Robots_Integration implements Integration_Interface {
 
 		$merged_robots   = array_merge( $robots, $this->get_robots_value() );
 		$filtered_robots = $this->filter_robots_no_index( $merged_robots );
+		$sorted_robots   = $this->sort_robots( $filtered_robots );
 
 		// Filter all falsy-null robot values.
-		return array_filter( $filtered_robots );
+		return array_filter( $sorted_robots );
 	}
 
 	/**
@@ -148,6 +149,36 @@ class WP_Robots_Integration implements Integration_Interface {
 		$robots['max-snippet']       = null;
 		$robots['max-image-preview'] = null;
 		$robots['max-video-preview'] = null;
+
+		return $robots;
+	}
+
+	/**
+	 * Sorts the robots array.
+	 *
+	 * @param array $robots The robots array.
+	 *
+	 * @return array The sorted robots array.
+	 */
+	protected function sort_robots( $robots ) {
+		\uksort(
+			$robots,
+			function ( $a, $b ) {
+				$order = [
+					'index'             => 0,
+					'follow'            => 1,
+					'max-snippet'       => 2,
+					'max-image-preview' => 3,
+					'max-video-preview' => 4,
+					'archive'           => 5,
+					'snippet'           => 6,
+				];
+				$ai    = isset( $order[ $a ] ) ? $order[ $a ] : 7;
+				$bi    = isset( $order[ $b ] ) ? $order[ $b ] : 7;
+
+				return ( $bi - $ai );
+			}
+		);
 
 		return $robots;
 	}

--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -173,10 +173,11 @@ class WP_Robots_Integration implements Integration_Interface {
 					'max-image-preview' => 5,
 					'max-video-preview' => 6,
 					'archive'           => 7,
-					'snippet'           => 8,
+					'noarchive'         => 8,
+					'snippet'           => 9,
 				];
-				$ai    = isset( $order[ $a ] ) ? $order[ $a ] : 9;
-				$bi    = isset( $order[ $b ] ) ? $order[ $b ] : 9;
+				$ai    = isset( $order[ $a ] ) ? $order[ $a ] : 10;
+				$bi    = isset( $order[ $b ] ) ? $order[ $b ] : 10;
 
 				return ( $bi - $ai );
 			}

--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -169,15 +169,9 @@ class WP_Robots_Integration implements Integration_Interface {
 					'noindex'           => 1,
 					'follow'            => 2,
 					'nofollow'          => 3,
-					'max-snippet'       => 4,
-					'max-image-preview' => 5,
-					'max-video-preview' => 6,
-					'archive'           => 7,
-					'noarchive'         => 8,
-					'snippet'           => 9,
 				];
-				$ai    = isset( $order[ $a ] ) ? $order[ $a ] : 10;
-				$bi    = isset( $order[ $b ] ) ? $order[ $b ] : 10;
+				$ai    = isset( $order[ $a ] ) ? $order[ $a ] : 4;
+				$bi    = isset( $order[ $b ] ) ? $order[ $b ] : 4;
 
 				return ( $bi - $ai );
 			}

--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -166,15 +166,17 @@ class WP_Robots_Integration implements Integration_Interface {
 			function ( $a, $b ) {
 				$order = [
 					'index'             => 0,
-					'follow'            => 1,
-					'max-snippet'       => 2,
-					'max-image-preview' => 3,
-					'max-video-preview' => 4,
-					'archive'           => 5,
-					'snippet'           => 6,
+					'noindex'           => 1,
+					'follow'            => 2,
+					'nofollow'          => 3,
+					'max-snippet'       => 4,
+					'max-image-preview' => 5,
+					'max-video-preview' => 6,
+					'archive'           => 7,
+					'snippet'           => 8,
 				];
-				$ai    = isset( $order[ $a ] ) ? $order[ $a ] : 7;
-				$bi    = isset( $order[ $b ] ) ? $order[ $b ] : 7;
+				$ai    = isset( $order[ $a ] ) ? $order[ $a ] : 9;
+				$bi    = isset( $order[ $b ] ) ? $order[ $b ] : 9;
 
 				return ( $bi - $ai );
 			}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Correctly sorts the robots tags.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes sure the robots values are sorted in the optimal order when running WordPress 5.7.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See https://yoast.atlassian.net/browse/QAK-2758


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* All robots values but only on WordPress 5.7.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/QAK-2758
