### PR TITLE
Replace a11y-speak with @wordpress/a11y

### DIFF
--- a/js/src/initializers/admin.js
+++ b/js/src/initializers/admin.js
@@ -1,6 +1,6 @@
 /* global wpseoAdminGlobalL10n, ajaxurl, wpseoScriptData, ClipboardJS */
 
-import a11ySpeak from "a11y-speak";
+import { speak } from "@wordpress/a11y";
 import { debounce } from "lodash-es";
 
 /**
@@ -75,7 +75,7 @@ export default function initAdmin( jQuery ) {
 					e.after( ' <div id="' + errorId + '" class="wpseo-variable-warning">' + msg + "</div>" );
 				}
 
-				a11ySpeak( wpseoAdminGlobalL10n.variable_warning.replace( "%s", variable ), "assertive" );
+				speak( wpseoAdminGlobalL10n.variable_warning.replace( "%s", variable ), "assertive" );
 
 				warn = true;
 			} else {

--- a/js/src/initializers/featured-image.js
+++ b/js/src/initializers/featured-image.js
@@ -3,7 +3,7 @@
 /* global YoastSEO */
 /* jshint -W097 */
 /* jshint -W003 */
-import a11ySpeak from "a11y-speak";
+import { speak } from "@wordpress/a11y";
 import isBlockEditor from "../helpers/isBlockEditor";
 
 /**
@@ -120,7 +120,7 @@ export default function initFeaturedImageIntegration( $ ) {
 
 				$postImageDiv.addClass( "yoast-opengraph-image-notice" );
 
-				a11ySpeak( wpseoScriptData.featuredImage.featured_image_notice, "assertive" );
+				speak( wpseoScriptData.featuredImage.featured_image_notice, "assertive" );
 			}
 		} else {
 			// Force reset warning

--- a/js/src/network-admin.js
+++ b/js/src/network-admin.js
@@ -1,6 +1,6 @@
 /* global wpseoNetworkAdminGlobalL10n, ajaxurl */
 
-import a11ySpeak from "a11y-speak";
+import { speak } from "@wordpress/a11y";
 
 ( function( $ ) {
 	/**
@@ -30,7 +30,7 @@ import a11ySpeak from "a11y-speak";
 			prefix = wpseoNetworkAdminGlobalL10n.success_prefix;
 		}
 
-		a11ySpeak( prefix.replace( "%s", settingsErrors[ 0 ].message ), "assertive" );
+		speak( prefix.replace( "%s", settingsErrors[ 0 ].message ), "assertive" );
 	}
 
 	/**

--- a/js/src/reindex-links.js
+++ b/js/src/reindex-links.js
@@ -3,7 +3,7 @@
 const settings = yoastReindexLinksData.data;
 let linkIndexingCompleted = false;
 
-import a11ySpeak from "a11y-speak";
+import { speak } from "@wordpress/a11y";
 
 /**
  * Represents the progressbar for the reindexing for the links.
@@ -98,7 +98,7 @@ function reindexLinks() {
  */
 function completeReindexing() {
 	linkIndexingCompleted = true;
-	a11ySpeak( settings.l10n.calculationCompleted );
+	speak( settings.l10n.calculationCompleted );
 	jQuery( "#reindexLinks" ).html( settings.message.indexingCompleted );
 
 	tb_remove();
@@ -110,7 +110,7 @@ function completeReindexing() {
  * @returns {void}
  */
 function startReindexing() {
-	a11ySpeak( settings.l10n.calculationInProgress );
+	speak( settings.l10n.calculationInProgress );
 
 	const promises = [];
 	promises.push( reindexLinks() );

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "@yoast/search-metadata-previews": "^2.21.0-rc.0",
     "@yoast/social-metadata-forms": "^1.14.0-rc.0",
     "@yoast/style-guide": "^0.13.0",
-    "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#master",
     "babel-polyfill": "^6.26.0",
     "draft-js": "^0.10.5",
     "draft-js-mention-plugin": "^3.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,10 +1742,6 @@
   resolved "https://registry.yarnpkg.com/@yoast/style-guide/-/style-guide-0.13.0.tgz#69e41ddacc62e378fbc98df9aebe1d63115ea047"
   integrity sha512-6FpEKT/So8mixs+3ZuK9KJy0grsI0GKNLesGsyKEgx5ObRd9/vW7JLHiCJ+/DFgTKNQdzNRmcxrSTkSnV4DxLA==
 
-"a11y-speak@git+https://github.com/Yoast/a11y-speak.git#master":
-  version "0.0.1"
-  resolved "git+https://github.com/Yoast/a11y-speak.git#4e772809a2fed1a54ba29176ada175b15436e977"
-
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Replaces and removes a11y-speak as a dependency

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Replaces and removes a11y-speak as a dependency

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Functionally nothing should change, so just do a smoketest for example with VoiceOver on your Mac to see if speak still works the same. Test for example the featured image warning.
* Go to Safari and open a post in the classic editor
* Activate VoiceOver on your Mac with cmd + F5 (your Mac will now read out loud everything you do)
* Set an image smaller than 200x200 pixels as featured image
* Your Mac will now read aloud: "SEO issue: The featured image should be at least 200 by 200 pixels to be picked up by Facebook and other social media sites."


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [AR-73](https://yoast.atlassian.net/browse/AR-73)
