### PR TITLE
AR-64 AR-89 Creates Settings_Repository to save all the combined options

### DIFF
--- a/src/models/settings-model.php
+++ b/src/models/settings-model.php
@@ -4,6 +4,7 @@
 namespace Yoast\WP\SEO\Models;
 
 use Exception;
+use Yoast\WP\SEO\Repositories\Settings_Repository;
 
 /**
  * Class Settings_Model.
@@ -16,6 +17,22 @@ abstract class Settings_Model {
 	 * @var array<string, mixed>
 	 */
 	protected $values = [];
+
+	/**
+	 * Represents the settings repository.
+	 *
+	 * @var Settings_Repository
+	 */
+	protected $settings_repository;
+
+	/**
+	 * Settings_Model constructor.
+	 *
+	 * @param Settings_Repository $settings_repository The settings repository.
+	 */
+	public function __construct( Settings_Repository $settings_repository ) {
+		$this->settings_repository = $settings_repository;
+	}
 
 	/**
 	 * Get value of setting.

--- a/src/models/settings-model.php
+++ b/src/models/settings-model.php
@@ -77,6 +77,19 @@ abstract class Settings_Model {
 	}
 
 	/**
+	 * Saves the data to the repository.
+	 */
+	public function save() {
+		foreach ( $this->get_settings() as $name => $settings ) {
+			if ( ! isset( $this->values[ $name ] ) ) {
+				$this->values[ $name ] = $settings['default'];
+			}
+		}
+
+		$this->settings_repository->save( $this->values );
+	}
+
+	/**
 	 * Check if given setting exists.
 	 *
 	 * @param string $name Name of setting that might exist.

--- a/src/models/settings/object-settings-model.php
+++ b/src/models/settings/object-settings-model.php
@@ -20,7 +20,7 @@ abstract class Object_Settings_Model extends Settings_Model {
 	/**
 	 * Object_Settings_Model constructor.
 	 *
-	 * @param Settings_Repository $settings_repository
+	 * @param Settings_Repository $settings_repository The settings repository.
 	 * @param string              $object_name         The object name to set.
 	 */
 	public function __construct( Settings_Repository $settings_repository, $object_name ) {

--- a/src/models/settings/object-settings-model.php
+++ b/src/models/settings/object-settings-model.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Models\Settings;
 
 use Yoast\WP\SEO\Models\Settings_Model;
+use Yoast\WP\SEO\Repositories\Settings_Repository;
 
 /**
  * Class Object_Settings_Model
@@ -19,9 +20,12 @@ abstract class Object_Settings_Model extends Settings_Model {
 	/**
 	 * Object_Settings_Model constructor.
 	 *
-	 * @param string $object_name The object name to set.
+	 * @param Settings_Repository $settings_repository
+	 * @param string              $object_name         The object name to set.
 	 */
-	public function __construct( $object_name ) {
+	public function __construct( Settings_Repository $settings_repository, $object_name ) {
+		parent::__construct( $settings_repository );
+
 		$this->object_name = $object_name;
 	}
 

--- a/src/repositories/settings-repository.php
+++ b/src/repositories/settings-repository.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Yoast\WP\SEO\Repositories;
+
+use Yoast\WP\SEO\Models\Settings\Open_Graph_Settings;
+use Yoast\WP\SEO\Models\Settings\Search_Engine_Verify_Settings;
+use Yoast\WP\SEO\Models\Settings\Social_Settings;
+use Yoast\WP\SEO\Models\Settings_Model;
+
+/**
+ * Class Settings_Repository.
+ *
+ * @method Open_Graph_Settings           for_open_graph()
+ * @method Search_Engine_Verify_Settings for_search_engine_verifications()
+ * @method Social_Settings               for_social()
+ */
+class Settings_Repository {
+
+	/**
+	 * The initializers for the different settings classes.
+	 *
+	 * @var array<string, string>
+	 */
+	protected $initializers = [
+		'social'                      => Social_Settings::class,
+		'open-graph'                  => Open_Graph_Settings::class,
+		'search-engine-verifications' => Search_Engine_Verify_Settings::class,
+	];
+
+	/**
+	 * Holds the initialized settings where the key is the setting name and the value is the instance.
+	 *
+	 * @var array<string, Settings_Model>
+	 */
+	protected $settings = [];
+
+	/**
+	 * Magic method that magically makes an instance of a Settings Model for requested method.
+	 *
+	 * @param string $method    The requested method.
+	 * @param array  $arguments The arguments that are given.
+	 *
+	 * @return Settings_Model
+	 *
+	 * @phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $arguments will be implemented later.
+	 */
+	public function __call( $method, $arguments = null ) {
+		if ( strpos( $method, 'for_' ) !== 0 ) {
+			return null;
+		}
+
+		$settings_name = substr( $method, 4 );
+		$settings_name = str_replace( '_', '-', $settings_name );
+
+		if ( ! array_key_exists( $settings_name, $this->initializers ) ) {
+			return null;
+		}
+
+		return $this->get_setting( $settings_name );
+	}
+
+	// 	phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+
+	/**
+	 * Gets the settings class for given settings name.
+	 *
+	 * @param string $settings_name The name to get the settings class for.
+	 *
+	 * @return Settings_Model The initialized class for given settings name.
+	 */
+	protected function get_setting( $settings_name ) {
+		if ( ! array_key_exists( $settings_name, $this->settings ) ) {
+			$class_name = $this->initializers[ $settings_name ];
+
+			$this->settings[ $settings_name ] = new $class_name();
+		}
+
+		return $this->settings[ $settings_name ];
+	}
+}

--- a/src/repositories/settings-repository.php
+++ b/src/repositories/settings-repository.php
@@ -38,20 +38,20 @@ class Settings_Repository {
 	 *
 	 * @var array<string, Settings_Model>
 	 */
-	protected $settings = [];
+	protected $models = [];
 
 	/**
-	 * Represents the current state for the option value from that database.
+	 * Represents the current state for the settings.
 	 *
 	 * @var array
 	 */
-	protected $option_value;
+	protected $settings;
 
 	/**
-	 * Sets the current options state with value from the option.
+	 * Sets the current settings state with value from the option.
 	 */
 	public function __construct() {
-		$this->option_value = \get_option( self::OPTION_NAME, [] );
+		$this->settings = \get_option( self::OPTION_NAME, [] );
 	}
 
 	/**
@@ -76,7 +76,7 @@ class Settings_Repository {
 			return null;
 		}
 
-		return $this->get_setting( $settings_name );
+		return $this->get_settings_model( $settings_name );
 	}
 
 	// 	phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
@@ -91,11 +91,11 @@ class Settings_Repository {
 			throw new InvalidArgumentException( 'Settings is not an array' );
 		}
 
-		$new_option_value = \array_replace_recursive( $this->option_value, $settings );
+		$new_option_value = \array_replace_recursive( $this->settings, $settings );
 		$is_saved         = \update_option( self::OPTION_NAME, $new_option_value, true );
 
 		if ( $is_saved ) {
-			$this->option_value = $new_option_value;
+			$this->settings = $new_option_value;
 		}
 	}
 
@@ -106,13 +106,15 @@ class Settings_Repository {
 	 *
 	 * @return Settings_Model The initialized class for given settings name.
 	 */
-	protected function get_setting( $settings_name ) {
-		if ( ! array_key_exists( $settings_name, $this->settings ) ) {
-			$class_name = $this->initializers[ $settings_name ];
+	protected function get_settings_model( $settings_name ) {
+		if ( ! array_key_exists( $settings_name, $this->models ) ) {
+			$class_name        = $this->initializers[ $settings_name ];
+			$initialized_model = new $class_name( $this );
 
-			$this->settings[ $settings_name ] = new $class_name( $this );
+
+			$this->models[ $settings_name ] = $initialized_model;
 		}
 
-		return $this->settings[ $settings_name ];
+		return $this->models[ $settings_name ];
 	}
 }

--- a/src/repositories/settings-repository.php
+++ b/src/repositories/settings-repository.php
@@ -17,6 +17,11 @@ use Yoast\WP\SEO\Models\Settings_Model;
 class Settings_Repository {
 
 	/**
+	 * Represents the option name.
+	 */
+	const OPTION_NAME = 'yoast_seo_settings';
+
+	/**
 	 * The initializers for the different settings classes.
 	 *
 	 * @var array<string, string>
@@ -33,6 +38,20 @@ class Settings_Repository {
 	 * @var array<string, Settings_Model>
 	 */
 	protected $settings = [];
+
+	/**
+	 * Represents the current state for the option value from that database.
+	 *
+	 * @var array
+	 */
+	protected $option_value;
+
+	/**
+	 * Sets the current options state with value from the option.
+	 */
+	public function __construct() {
+		$this->option_value = \get_option( self::OPTION_NAME, [] );
+	}
 
 	/**
 	 * Magic method that magically makes an instance of a Settings Model for requested method.

--- a/src/repositories/settings-repository.php
+++ b/src/repositories/settings-repository.php
@@ -44,7 +44,7 @@ class Settings_Repository {
 	 *
 	 * @phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- $arguments will be implemented later.
 	 */
-	public function __call( $method, $arguments = null ) {
+	public function __call( $method, $arguments ) {
 		if ( strpos( $method, 'for_' ) !== 0 ) {
 			return null;
 		}
@@ -72,7 +72,7 @@ class Settings_Repository {
 		if ( ! array_key_exists( $settings_name, $this->settings ) ) {
 			$class_name = $this->initializers[ $settings_name ];
 
-			$this->settings[ $settings_name ] = new $class_name();
+			$this->settings[ $settings_name ] = new $class_name( $this );
 		}
 
 		return $this->settings[ $settings_name ];

--- a/src/repositories/settings-repository.php
+++ b/src/repositories/settings-repository.php
@@ -111,10 +111,29 @@ class Settings_Repository {
 			$class_name        = $this->initializers[ $settings_name ];
 			$initialized_model = new $class_name( $this );
 
+			$this->initialize_settings_for_model( $initialized_model, $this->settings );
 
 			$this->models[ $settings_name ] = $initialized_model;
 		}
 
 		return $this->models[ $settings_name ];
+	}
+
+	/**
+	 * Initializes the settings for the given model. It only sets the settings known by the repository.
+	 *
+	 * @param Settings_Model $model    The model to set the properties for.
+	 * @param array          $settings The settings to use for setting the properties.
+	 */
+	protected function initialize_settings_for_model( Settings_Model $model, $settings ) {
+		$setting_names = array_keys( $model->get_settings() );
+
+		foreach ( $setting_names as $setting_name ) {
+			if ( ! isset( $settings[ $setting_name ] ) ) {
+				continue;
+			}
+
+			$model->$setting_name = $settings[ $setting_name ];
+		}
 	}
 }

--- a/src/repositories/settings-repository.php
+++ b/src/repositories/settings-repository.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Repositories;
 
+use InvalidArgumentException;
 use Yoast\WP\SEO\Models\Settings\Open_Graph_Settings;
 use Yoast\WP\SEO\Models\Settings\Search_Engine_Verify_Settings;
 use Yoast\WP\SEO\Models\Settings\Social_Settings;
@@ -79,6 +80,24 @@ class Settings_Repository {
 	}
 
 	// 	phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+
+	/**
+	 * Handles the saving of the settings.
+	 *
+	 * @param array $settings The settings to save.
+	 */
+	public function save( $settings ) {
+		if ( ! is_array( $settings ) ) {
+			throw new InvalidArgumentException( 'Settings is not an array' );
+		}
+
+		$new_option_value = \array_replace_recursive( $this->option_value, $settings );
+		$is_saved         = \update_option( self::OPTION_NAME, $new_option_value, true );
+
+		if ( $is_saved ) {
+			$this->option_value = $new_option_value;
+		}
+	}
 
 	/**
 	 * Gets the settings class for given settings name.

--- a/src/repositories/settings-repository.php
+++ b/src/repositories/settings-repository.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Repositories;
 
+use Exception;
 use InvalidArgumentException;
 use Yoast\WP\SEO\Models\Settings\Open_Graph_Settings;
 use Yoast\WP\SEO\Models\Settings\Search_Engine_Verify_Settings;
@@ -80,6 +81,22 @@ class Settings_Repository {
 	}
 
 	// 	phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+
+	/**
+	 * Adds an initializer to the list of initializers..
+	 *
+	 * @param string $name       The name of the initializer.
+	 * @param string $class_name Fully Qualified Classname for class that extends Setting_Model to initialize.
+	 *
+	 * @throws Exception When the initializer already exists.
+	 */
+	public function add_initializer( $name, $class_name ) {
+		if ( array_key_exists( $name, $this->initializers ) ) {
+			throw new Exception( 'Initializer for ' . $name . ' already exists.' );
+		}
+
+		$this->initializers[ $name ] = $class_name;
+	}
 
 	/**
 	 * Handles the saving of the settings.

--- a/tests/unit/doubles/models/settings-model-double.php
+++ b/tests/unit/doubles/models/settings-model-double.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Doubles\Models;
+
+use Yoast\WP\SEO\Models\Settings\Global_Settings_Model;
+
+/**
+ * Class Settings_Model_Double.
+ */
+class Settings_Model_Double extends Global_Settings_Model {
+
+	/**
+	 * Get the definitions for the settings.
+	 *
+	 * @return array<string, array> Description of the settings with the setting name as key.
+	 */
+	public function get_settings() {
+		return [
+			'settings_key' => [
+				'default' => '',
+			],
+			'new_settings_key' => [
+				'default' => '',
+			],
+		];
+	}
+}

--- a/tests/unit/doubles/models/settings-model-double.php
+++ b/tests/unit/doubles/models/settings-model-double.php
@@ -6,6 +6,9 @@ use Yoast\WP\SEO\Models\Settings\Global_Settings_Model;
 
 /**
  * Class Settings_Model_Double.
+ *
+ * @property string $settings_key
+ * @property string $new_settings_key
  */
 class Settings_Model_Double extends Global_Settings_Model {
 

--- a/tests/unit/models/settings-model-test.php
+++ b/tests/unit/models/settings-model-test.php
@@ -6,6 +6,7 @@ use Exception;
 use Mockery;
 use Mockery\MockInterface;
 use Yoast\WP\SEO\Models\Settings_Model;
+use Yoast\WP\SEO\Repositories\Settings_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 
@@ -13,8 +14,9 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * Class Settings_Model_Test.
  *
  * @group models
+ * @group settings
  *
- * @coversDefaultClass \\Yoast\WP\SEO\Models\Settings_Model
+ * @coversDefaultClass \Yoast\WP\SEO\Models\Settings_Model
  */
 class Settings_Model_Test extends TestCase {
 
@@ -26,12 +28,20 @@ class Settings_Model_Test extends TestCase {
 	protected $instance;
 
 	/**
+	 * Represents the settings repository.
+	 *
+	 * @var Mockery\MockInterface|Settings_Repository
+	 */
+	protected $settings_repository;
+
+	/**
 	 * Sets up the class under test and mock objects.
 	 */
 	public function set_up() {
 		parent::set_up();
 
-		$this->instance = Mockery::mock( Settings_Model::class );
+		$this->settings_repository = Mockery::mock( Settings_Repository::class );
+		$this->instance            = Mockery::mock( Settings_Model::class, [ $this->settings_repository ] )->makePartial();
 	}
 
 	/**
@@ -83,5 +93,55 @@ class Settings_Model_Test extends TestCase {
 		$this->instance->expects( 'get_settings' )->twice()->andReturn( [ 'default_setting' => [ 'default' => 12 ] ] );
 
 		self::assertSame( 12, $this->instance->default_setting );
+	}
+
+	/**
+	 * Tests the save function by setting the value of the model.
+	 *
+	 * @covers ::save
+	 */
+	public function test_save_with_set_data() {
+		$this->instance
+			->expects( 'get_settings' )
+			->twice()
+			->andReturn( [ 'settings_key' => [] ] );
+
+		$this->instance->settings_key = 'settings_value';
+
+		$this->settings_repository
+			->expects( 'save' )
+			->once()
+			->with( [
+				'settings_key' => 'settings_value',
+			] );
+
+		$this->instance->save();
+	}
+
+	/**
+	 * Tests the save function with fallback to a default value for the settings of the model.
+	 *
+	 * @covers ::save
+	 */
+	public function test_save_with_default_data() {
+		$this->instance
+			->expects( 'get_settings' )
+			->once()
+			->andReturn(
+				[
+					'settings_key' => [
+						'default' => 'default_settings_value',
+					],
+				]
+			);
+
+		$this->settings_repository
+			->expects( 'save' )
+			->once()
+			->with( [
+				'settings_key' => 'default_settings_value',
+			] );
+
+		$this->instance->save();
 	}
 }

--- a/tests/unit/models/settings-model-test.php
+++ b/tests/unit/models/settings-model-test.php
@@ -111,9 +111,11 @@ class Settings_Model_Test extends TestCase {
 		$this->settings_repository
 			->expects( 'save' )
 			->once()
-			->with( [
-				'settings_key' => 'settings_value',
-			] );
+			->with(
+				[
+					'settings_key' => 'settings_value',
+				]
+			);
 
 		$this->instance->save();
 	}
@@ -138,9 +140,11 @@ class Settings_Model_Test extends TestCase {
 		$this->settings_repository
 			->expects( 'save' )
 			->once()
-			->with( [
-				'settings_key' => 'default_settings_value',
-			] );
+			->with(
+				[
+					'settings_key' => 'default_settings_value',
+				]
+			);
 
 		$this->instance->save();
 	}

--- a/tests/unit/models/settings/object-settings-model-test.php
+++ b/tests/unit/models/settings/object-settings-model-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Models\Settings;
 use Mockery;
 use Mockery\MockInterface;
 use Yoast\WP\SEO\Models\Settings\Object_Settings_Model;
+use Yoast\WP\SEO\Repositories\Settings_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 
@@ -25,12 +26,20 @@ class Object_Settings_Model_Test extends TestCase {
 	protected $instance;
 
 	/**
+	 * Represents the settings repository.
+	 *
+	 * @var Mockery\MockInterface|Settings_Repository
+	 */
+	protected $settings_repository;
+
+	/**
 	 * Sets the instance to test.
 	 */
 	public function set_up() {
 		parent::set_up();
 
-		$this->instance = Mockery::mock( Object_Settings_Model::class, [ 'object_type' ] )->makePartial();
+		$this->settings_repository = Mockery::mock( Settings_Repository::class )->makePartial();
+		$this->instance            = Mockery::mock( Object_Settings_Model::class, [ $this->settings_repository, 'object_type' ] )->makePartial();
 	}
 
 	/**

--- a/tests/unit/models/settings/open-graph-settings-test.php
+++ b/tests/unit/models/settings/open-graph-settings-test.php
@@ -2,9 +2,9 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Models\Settings;
 
+use Mockery;
 use Yoast\WP\SEO\Models\Settings\Open_Graph_Settings;
-use Yoast\WP\SEO\Models\Settings\Search_Engine_Verify_Settings;
-use Yoast\WP\SEO\Models\Settings\Social_Settings;
+use Yoast\WP\SEO\Repositories\Settings_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 
@@ -25,12 +25,20 @@ class Open_Graph_Settings_Test extends TestCase {
 	protected $instance;
 
 	/**
+	 * Represents the settings repository.
+	 *
+	 * @var Mockery\MockInterface|Settings_Repository
+	 */
+	protected $settings_repository;
+
+	/**
 	 * Sets up the class under test and mock objects.
 	 */
 	public function set_up() {
 		parent::set_up();
 
-		$this->instance = new Open_Graph_Settings();
+		$this->settings_repository = Mockery::mock( Settings_Repository::class )->makePartial();
+		$this->instance            = new Open_Graph_Settings( $this->settings_repository );
 	}
 
 	/**

--- a/tests/unit/models/settings/search-engine-verify-settings-test.php
+++ b/tests/unit/models/settings/search-engine-verify-settings-test.php
@@ -2,7 +2,9 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Models\Settings;
 
+use Mockery;
 use Yoast\WP\SEO\Models\Settings\Search_Engine_Verify_Settings;
+use Yoast\WP\SEO\Repositories\Settings_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 
@@ -25,12 +27,20 @@ class Search_Engine_Verify_Settings_Test extends TestCase {
 	protected $instance;
 
 	/**
+	 * Represents the settings repository.
+	 *
+	 * @var Mockery\MockInterface|Settings_Repository
+	 */
+	protected $settings_repository;
+
+	/**
 	 * Sets up the class under test and mock objects.
 	 */
 	public function set_up() {
 		parent::set_up();
 
-		$this->instance = new Search_Engine_Verify_Settings();
+		$this->settings_repository = Mockery::mock( Settings_Repository::class );
+		$this->instance            = new Search_Engine_Verify_Settings( $this->settings_repository );
 	}
 
 	/**

--- a/tests/unit/models/settings/social-settings-test.php
+++ b/tests/unit/models/settings/social-settings-test.php
@@ -2,8 +2,10 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Models\Settings;
 
+use Mockery;
 use Yoast\WP\SEO\Models\Settings\Search_Engine_Verify_Settings;
 use Yoast\WP\SEO\Models\Settings\Social_Settings;
+use Yoast\WP\SEO\Repositories\Settings_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 
@@ -24,12 +26,20 @@ class Social_Settings_Test extends TestCase {
 	protected $instance;
 
 	/**
+	 * Represents the settings repository.
+	 *
+	 * @var Mockery\MockInterface|Settings_Repository
+	 */
+	protected $settings_repository;
+
+	/**
 	 * Sets up the class under test and mock objects.
 	 */
 	public function set_up() {
 		parent::set_up();
 
-		$this->instance = new Social_Settings();
+		$this->settings_repository = Mockery::mock( Settings_Repository::class );
+		$this->instance            = new Social_Settings( $this->settings_repository );
 	}
 
 	/**

--- a/tests/unit/repositories/settings-repository-test.php
+++ b/tests/unit/repositories/settings-repository-test.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Repositories;
+
+use Yoast\WP\SEO\Models\Settings\Open_Graph_Settings;
+use Yoast\WP\SEO\Models\Settings\Search_Engine_Verify_Settings;
+use Yoast\WP\SEO\Models\Settings\Social_Settings;
+use Yoast\WP\SEO\Repositories\Settings_Repository;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Settings_Repository_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Repositories\Settings_Repository
+ *
+ * @group repositories
+ */
+class Settings_Repository_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var Settings_Repository
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the instance to test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->instance = new Settings_Repository();
+	}
+
+	/**
+	 * Tests the magic __call method without having the for_ prefix.
+	 *
+	 * @covers ::__call
+	 */
+	public function test_method_without_the_for_prefix() {
+		static::assertNull( $this->instance->foo() );
+	}
+
+	/**
+	 * Tests the magic __call method for an unsupported setting.
+	 *
+	 * @covers ::__call
+	 */
+	public function test_call_method_for_unsupported_setting() {
+		static::assertNull( $this->instance->for_bar() );
+	}
+
+	/**
+	 * Tests the magic __call method for a supported setting.
+	 *
+	 * @covers ::__call
+	 * @covers ::get_setting
+	 *
+	 * @dataProvider supported_setting_provider
+	 *
+	 * @param string $expected_instance The expected instance.
+	 * @param string $method            The method to call.
+	 */
+	public function test_call_method_for_supported_setting( $expected_instance, $method ) {
+		static::assertInstanceOf( $expected_instance, $this->instance->$method() );
+	}
+
+	/**
+	 * The data provider for test `test_call_method_for_supported_setting`
+	 *
+	 * @return array<array<string, string>>
+	 */
+	public function supported_setting_provider() {
+		return [
+			[
+				'expected_instance' => Social_Settings::class,
+				'method'            => 'for_social',
+			],
+			[
+				'expected_instance' => Open_Graph_Settings::class,
+				'method'            => 'for_open_graph',
+			],
+			[
+				'expected_instance' => Search_Engine_Verify_Settings::class,
+				'method'            => 'for_search_engine_verifications',
+			],
+		];
+	}
+}

--- a/tests/unit/repositories/settings-repository-test.php
+++ b/tests/unit/repositories/settings-repository-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Repositories;
 
+use Brain\Monkey;
 use Yoast\WP\SEO\Models\Settings\Open_Graph_Settings;
 use Yoast\WP\SEO\Models\Settings\Search_Engine_Verify_Settings;
 use Yoast\WP\SEO\Models\Settings\Social_Settings;
@@ -14,6 +15,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @coversDefaultClass \Yoast\WP\SEO\Repositories\Settings_Repository
  *
  * @group repositories
+ * @group settings
  */
 class Settings_Repository_Test extends TestCase {
 
@@ -30,7 +32,28 @@ class Settings_Repository_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( Settings_Repository::OPTION_NAME, [] )
+			->andReturn( [
+				'settings_key' => 'settings_value',
+			] );
+
 		$this->instance = new Settings_Repository();
+	}
+
+	/**
+	 * Tests the constructor
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		self::assertSame(
+			[
+				'settings_key' => 'settings_value',
+			],
+			self::getPropertyValue( $this->instance, 'option_value' )
+		);
 	}
 
 	/**

--- a/tests/unit/repositories/settings-repository-test.php
+++ b/tests/unit/repositories/settings-repository-test.php
@@ -3,10 +3,12 @@
 namespace Yoast\WP\SEO\Tests\Unit\Repositories;
 
 use Brain\Monkey;
+use Exception;
 use InvalidArgumentException;
 use Yoast\WP\SEO\Models\Settings\Open_Graph_Settings;
 use Yoast\WP\SEO\Models\Settings\Search_Engine_Verify_Settings;
 use Yoast\WP\SEO\Models\Settings\Social_Settings;
+use Yoast\WP\SEO\Models\Settings_Model;
 use Yoast\WP\SEO\Repositories\Settings_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -79,7 +81,8 @@ class Settings_Repository_Test extends TestCase {
 	 * Tests the magic __call method for a supported setting.
 	 *
 	 * @covers ::__call
-	 * @covers ::get_setting
+	 * @covers ::get_settings_model
+	 * @covers ::initialize_settings_for_model
 	 *
 	 * @dataProvider supported_setting_provider
 	 *
@@ -110,6 +113,34 @@ class Settings_Repository_Test extends TestCase {
 				'method'            => 'for_search_engine_verifications',
 			],
 		];
+	}
+
+	/**
+	 * Tests adding an initializer to the list of initializers.
+	 *
+	 * @covers ::add_initializer
+	 */
+	public function test_adding_an_initializer() {
+		$this->instance->add_initializer( 'test-initializer', Settings_Model::class );
+
+		$initializers = self::getPropertyValue( $this->instance, 'initializers' );
+
+		static::assertArrayHasKey( 'test-initializer', $initializers );
+		static::assertEquals( Settings_Model::class, $initializers[ 'test-initializer' ] );
+	}
+
+	/**
+	 * Tests adding an existing initializer to the list of initializers.
+	 *
+	 * @covers ::add_initializer
+	 */
+	public function test_add_an_existing_initializer() {
+		$this->instance->add_initializer( 'test-initializer', Settings_Model::class );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Initializer for test-initializer already exists.' );
+
+		$this->instance->add_initializer( 'test-initializer', Settings_Model::class );
 	}
 
 	/**

--- a/tests/unit/repositories/settings-repository-test.php
+++ b/tests/unit/repositories/settings-repository-test.php
@@ -53,7 +53,7 @@ class Settings_Repository_Test extends TestCase {
 			[
 				'settings_key' => 'settings_value',
 			],
-			self::getPropertyValue( $this->instance, 'option_value' )
+			self::getPropertyValue( $this->instance, 'settings' )
 		);
 	}
 
@@ -130,22 +130,22 @@ class Settings_Repository_Test extends TestCase {
 	 * @covers ::save
 	 */
 	public function test_saving_settings_with_update_option_failed() {
-		$option_value = [
+		$settings = [
 			'settings_key' => 'new_settings_value',
 		];
 
 		Monkey\Functions\expect( 'update_option' )
 			->once()
-			->with( Settings_Repository::OPTION_NAME, $option_value, true )
+			->with( Settings_Repository::OPTION_NAME, $settings, true )
 			->andReturnFalse();
 
-		$this->instance->save( $option_value );
+		$this->instance->save( $settings );
 
 		self::assertSame(
 			[
 				'settings_key' => 'settings_value',
 			],
-			self::getPropertyValue( $this->instance, 'option_value' )
+			self::getPropertyValue( $this->instance, 'settings' )
 		);
 	}
 
@@ -155,20 +155,20 @@ class Settings_Repository_Test extends TestCase {
 	 * @covers ::save
 	 */
 	public function test_saving_settings_where_an_existing_value_is_changed() {
-		$option_value = [
+		$settings = [
 			'settings_key' => 'new_settings_value',
 		];
 
 		Monkey\Functions\expect( 'update_option' )
 			->once()
-			->with( Settings_Repository::OPTION_NAME, $option_value, true )
+			->with( Settings_Repository::OPTION_NAME, $settings, true )
 			->andReturnTrue();
 
-		$this->instance->save( $option_value );
+		$this->instance->save( $settings );
 
 		self::assertSame(
-			$option_value,
-			self::getPropertyValue( $this->instance, 'option_value' )
+			$settings,
+			self::getPropertyValue( $this->instance, 'settings' )
 		);
 	}
 	/**
@@ -177,14 +177,14 @@ class Settings_Repository_Test extends TestCase {
 	 * @covers ::save
 	 */
 	public function test_saving_settings_where_a_new_value_is_added() {
-		$expected_option_value = [
+		$expected_settings = [
 			'settings_key'     => 'settings_value',
 			'new_settings_key' => 'new_settings_value',
 		];
 
 		Monkey\Functions\expect( 'update_option' )
 			->once()
-			->with( Settings_Repository::OPTION_NAME, $expected_option_value, true )
+			->with( Settings_Repository::OPTION_NAME, $expected_settings, true )
 			->andReturn( true );
 
 		$this->instance->save(
@@ -194,8 +194,8 @@ class Settings_Repository_Test extends TestCase {
 		);
 
 		self::assertSame(
-			$expected_option_value,
-			self::getPropertyValue( $this->instance, 'option_value' )
+			$expected_settings,
+			self::getPropertyValue( $this->instance, 'settings' )
 		);
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Retrieving, saving and merging all values into our one option through an easy to use interface

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Preparation to allow easy management of the settings values

## Relevant technical choices:

* The Settings_Repository can be easily extended by add-ons by letting them add additional initializers.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* n/a. code is not yet in use.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

