### PR TITLE
AR-77 AR-78 AR-91 Create validators to validate the settings

### DIFF
--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -37,6 +37,7 @@ $container->register( Adapter::class, Adapter::class )->setAutowired( true )->se
 
 $yoast_seo_excluded_files = [
 	'main.php',
+	'values/validation-error.php',
 ];
 
 $yoast_seo_excluded_directories = [

--- a/src/validators/search-engine-verify/baidu-verify-validator.php
+++ b/src/validators/search-engine-verify/baidu-verify-validator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators\Search_Engine_Verify;
+
+/**
+ * Class Baidu_Verify_Validator.
+ */
+class Baidu_Verify_Validator extends Search_Engine_Verify_Validator {
+
+	/**
+	 * Get the name of the search engine for which the verification code is validated.
+	 *
+	 * @return string The name of the search engine.
+	 */
+	protected function get_search_engine_name() {
+		return 'Baidu Webmaster tools';
+	}
+
+	/**
+	 * Get the regex to validate the verification code against.
+	 *
+	 * @return string The regex to use for validation.
+	 */
+	protected function get_validation_regex() {
+		return '`^[A-Za-z0-9_-]+$`';
+	}
+}

--- a/src/validators/search-engine-verify/bing-verify-validator.php
+++ b/src/validators/search-engine-verify/bing-verify-validator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators\Search_Engine_Verify;
+
+/**
+ * Class Bing_Verify_Validator.
+ */
+class Bing_Verify_Validator extends Search_Engine_Verify_Validator {
+
+	/**
+	 * Get the name of the search engine for which the verification code is validated.
+	 *
+	 * @return string The name of the search engine.
+	 */
+	protected function get_search_engine_name() {
+		return 'Bing Webmaster tools';
+	}
+
+	/**
+	 * Get the regex to validate the verification code against.
+	 *
+	 * @return string The regex to use for validation.
+	 */
+	protected function get_validation_regex() {
+		return '`^[A-Fa-f0-9_-]+$`';
+	}
+}

--- a/src/validators/search-engine-verify/google-verify-validator.php
+++ b/src/validators/search-engine-verify/google-verify-validator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators\Search_Engine_Verify;
+
+/**
+ * Class Google_Verify_Validator.
+ */
+class Google_Verify_Validator extends Search_Engine_Verify_Validator {
+
+	/**
+	 * Get the name of the search engine for which the verification code is validated.
+	 *
+	 * @return string The name of the search engine.
+	 */
+	protected function get_search_engine_name() {
+		return 'Google Webmaster tools';
+	}
+
+	/**
+	 * Get the regex to validate the verification code against.
+	 *
+	 * @return string The regex to use for validation.
+	 */
+	protected function get_validation_regex() {
+		return '`^[A-Za-z0-9_-]+$`';
+	}
+}

--- a/src/validators/search-engine-verify/pinterest-verify-validator.php
+++ b/src/validators/search-engine-verify/pinterest-verify-validator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators\Search_Engine_Verify;
+
+/**
+ * Class Pinterest_Verify_Validator.
+ */
+class Pinterest_Verify_Validator extends Search_Engine_Verify_Validator {
+
+	/**
+	 * Get the name of the search engine for which the verification code is validated.
+	 *
+	 * @return string The name of the search engine.
+	 */
+	protected function get_search_engine_name() {
+		return 'Pinterest';
+	}
+
+	/**
+	 * Get the regex to validate the verification code against.
+	 *
+	 * @return string The regex to use for validation.
+	 */
+	protected function get_validation_regex() {
+		return '`^[A-Fa-f0-9_-]+$`';
+	}
+}

--- a/src/validators/search-engine-verify/search-engine-verify-validator.php
+++ b/src/validators/search-engine-verify/search-engine-verify-validator.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators\Search_Engine_Verify;
+
+use Yoast\WP\SEO\Validators\Validator_Interface;
+use Yoast\WP\SEO\Values\Validation_Error;
+
+/**
+ * Class Search_Engine_Verify_Validator.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- 4 words is fine.
+ */
+abstract class Search_Engine_Verify_Validator implements Validator_Interface {
+
+	/**
+	 * Validate the search engine verification value against a specific regex.
+	 *
+	 * @param mixed $value The value that needs to be validated.
+	 *
+	 * @return bool|Validation_Error For an invalid value a Validation_Error will be returned, or true when the value is valid.
+	 */
+	public function validate( $value ) {
+		return $this->validate_against_regex( $value, $this->get_validation_regex() );
+	}
+
+	/**
+	 * Validate the verification value against a regex.
+	 *
+	 * @param mixed  $value The value that needs to be validated.
+	 * @param string $regex The regex that should be used to validate the value.
+	 *
+	 * @return bool|Validation_Error For an invalid value a Validation_Error will be returned, or true when the value is valid.
+	 */
+	protected function validate_against_regex( $value, $regex ) {
+		if ( preg_match( $regex, $value ) !== 1 ) {
+			return new Validation_Error(
+				sprintf(
+					/* translators: 1: Verification string from user input; 2: Search engine name. */
+					\__( '%1$s does not seem to be a valid %2$s verification string. Please correct.', 'wordpress-seo' ),
+					'<strong>' . esc_html( $value ) . '</strong>',
+					$this->get_search_engine_name()
+				)
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the name of the search engine for which the verification code is validated.
+	 *
+	 * @return string The name of the search engine.
+	 */
+	abstract protected function get_search_engine_name();
+
+	/**
+	 * Get the regex to validate the verification code against.
+	 *
+	 * @return string The regex to use for validation.
+	 */
+	abstract protected function get_validation_regex();
+}

--- a/src/validators/search-engine-verify/yandex-verify-validator.php
+++ b/src/validators/search-engine-verify/yandex-verify-validator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators\Search_Engine_Verify;
+
+/**
+ * Class Yandex_Verify_Validator.
+ */
+class Yandex_Verify_Validator extends Search_Engine_Verify_Validator {
+
+	/**
+	 * Get the name of the search engine for which the verification code is validated.
+	 *
+	 * @return string The name of the search engine.
+	 */
+	protected function get_search_engine_name() {
+		return 'Yandex Webmaster tools';
+	}
+
+	/**
+	 * Get the regex to validate the verification code against.
+	 *
+	 * @return string The regex to use for validation.
+	 */
+	protected function get_validation_regex() {
+		return '`^[A-Fa-f0-9_-]+$`';
+	}
+}

--- a/src/validators/url-validator.php
+++ b/src/validators/url-validator.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace Yoast\WP\SEO\Validators;
+
+
+use Yoast\WP\SEO\Values\Validation_Error;
+
+class Url_Validator implements Validator_Interface {
+
+	/**
+	 * Validate that the given value is a correct url.
+	 *
+	 * @param mixed $value The value that needs to be validated.
+	 *
+	 * @return Validation_Error|bool For an invalid value a Validation_Error will be returned, or true when the value is valid.
+	 */
+	public function validate( $value ) {
+		// extracted from \WPSEO_Option::validate_url.
+
+		$validated_url = filter_var( $value, FILTER_VALIDATE_URL );
+
+		if ( $validated_url === false ) {
+			return new Validation_Error(
+				sprintf(
+					/* translators: %s expands to an invalid URL. */
+					__( '%s does not seem to be a valid url. Please correct.', 'wordpress-seo' ),
+					'<strong>' . esc_html( $value ) . '</strong>'
+				)
+			);
+		}
+
+		return true;
+	}
+}

--- a/src/validators/url-validator.php
+++ b/src/validators/url-validator.php
@@ -1,11 +1,12 @@
 <?php
 
-
 namespace Yoast\WP\SEO\Validators;
-
 
 use Yoast\WP\SEO\Values\Validation_Error;
 
+/**
+ * Class Url_Validator.
+ */
 class Url_Validator implements Validator_Interface {
 
 	/**
@@ -16,16 +17,14 @@ class Url_Validator implements Validator_Interface {
 	 * @return Validation_Error|bool For an invalid value a Validation_Error will be returned, or true when the value is valid.
 	 */
 	public function validate( $value ) {
-		// extracted from \WPSEO_Option::validate_url.
-
 		$validated_url = filter_var( $value, FILTER_VALIDATE_URL );
 
 		if ( $validated_url === false ) {
 			return new Validation_Error(
 				sprintf(
 					/* translators: %s expands to an invalid URL. */
-					__( '%s does not seem to be a valid url. Please correct.', 'wordpress-seo' ),
-					'<strong>' . esc_html( $value ) . '</strong>'
+					\__( '%s does not seem to be a valid url. Please correct.', 'wordpress-seo' ),
+					'<strong>' . \esc_html( $value ) . '</strong>'
 				)
 			);
 		}

--- a/src/validators/validator-interface.php
+++ b/src/validators/validator-interface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+use Yoast\WP\SEO\Values\Validation_Error;
+
+/**
+ * Interface Validator_Interface.
+ */
+interface Validator_Interface {
+
+	/**
+	 * Validate the given value against a specific set of rules.
+	 *
+	 * @param mixed $value The value that needs to be validated.
+	 *
+	 * @return Validation_Error|bool For an invalid value a Validation_Error will be returned, or true when the value is valid.
+	 */
+	public function validate( $value );
+}

--- a/src/values/validation-error.php
+++ b/src/values/validation-error.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace Yoast\WP\SEO\Values;
+
+/**
+ * Class Validation_Error.
+ */
+class Validation_Error {
+
+	/**
+	 * The message to describe the error.
+	 *
+	 * @var string
+	 */
+	protected $error_message;
+
+	/**
+	 * Validation_Error constructor.
+	 *
+	 * @param string $error_message Message describing the error.
+	 */
+	public function __construct( $error_message ) {
+		$this->error_message = $error_message;
+	}
+
+	/**
+	 * Get the error message.
+	 *
+	 * @return string The error message.
+	 */
+	public function get_error_message() {
+		return $this->error_message;
+	}
+}

--- a/tests/unit/validators/search-engine-verify/baidu-verify-validator-test.php
+++ b/tests/unit/validators/search-engine-verify/baidu-verify-validator-test.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators\Search_Engine_Verify;
+
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Search_Engine_Verify\Baidu_Verify_Validator;
+use Yoast\WP\SEO\Values\Validation_Error;
+
+/**
+ * Class Baidu_Verify_Validator_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Search_Engine_Verify\Baidu_Verify_Validator
+ *
+ * @group validators
+ */
+class Baidu_Verify_Validator_Test extends TestCase {
+
+	/**
+	 * Represents the class to test.
+	 *
+	 * @var Baidu_Verify_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Baidu_Verify_Validator();
+	}
+
+	/**
+	 * Test validating a valid url.
+	 *
+	 * @covers ::validate
+	 * @covers ::get_validation_regex
+	 */
+	public function test_validate_a_valid_baidu_verify_code() {
+		$valid_verify_code = 'AXby19_-';
+
+		self::assertTrue(
+			$this->instance->validate( $valid_verify_code )
+		);
+	}
+
+	/**
+	 * Test validating an invalid verification code.
+	 *
+	 * @covers ::validate
+	 * @covers ::get_validation_regex
+	 * @covers ::get_search_engine_name
+	 */
+	public function test_validate_an_invalid_verification_code() {
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$invalid_code  = '<meta content="abcDEF123" />';
+		$error_message = '<strong><meta content="abcDEF123" /></strong> does not seem to be a valid Baidu Webmaster tools verification string. Please correct.';
+
+		self::assertEquals(
+			new Validation_Error( $error_message ),
+			$this->instance->validate( $invalid_code )
+		);
+	}
+}

--- a/tests/unit/validators/search-engine-verify/bing-verify-validator-test.php
+++ b/tests/unit/validators/search-engine-verify/bing-verify-validator-test.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators\Search_Engine_Verify;
+
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Search_Engine_Verify\Bing_Verify_Validator;
+use Yoast\WP\SEO\Values\Validation_Error;
+
+/**
+ * Class Bing_Verify_Validator_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Search_Engine_Verify\Bing_Verify_Validator
+ *
+ * @group validators
+ */
+class Bing_Verify_Validator_Test extends TestCase {
+
+	/**
+	 * Represents the class to test.
+	 *
+	 * @var Bing_Verify_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Bing_Verify_Validator();
+	}
+
+	/**
+	 * Test validating a valid url.
+	 *
+	 * @covers ::validate
+	 * @covers ::get_validation_regex
+	 */
+	public function test_validate_a_valid_verify_code() {
+		$valid_verify_code = 'AFbf19_-';
+
+		self::assertTrue(
+			$this->instance->validate( $valid_verify_code )
+		);
+	}
+
+	/**
+	 * Test validating an invalid verification code.
+	 *
+	 * @covers ::validate
+	 * @covers ::get_validation_regex
+	 * @covers ::get_search_engine_name
+	 */
+	public function test_validate_an_invalid_verification_code() {
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$invalid_code  = '<meta content="abcDEF123" />';
+		$error_message = '<strong><meta content="abcDEF123" /></strong> does not seem to be a valid Bing Webmaster tools verification string. Please correct.';
+
+		self::assertEquals(
+			new Validation_Error( $error_message ),
+			$this->instance->validate( $invalid_code )
+		);
+	}
+}

--- a/tests/unit/validators/search-engine-verify/google-verify-validator-test.php
+++ b/tests/unit/validators/search-engine-verify/google-verify-validator-test.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators\Search_Engine_Verify;
+
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Search_Engine_Verify\Google_Verify_Validator;
+use Yoast\WP\SEO\Values\Validation_Error;
+
+/**
+ * Class Google_Verify_Validator_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Search_Engine_Verify\Google_Verify_Validator
+ *
+ * @group validators
+ */
+class Google_Verify_Validator_Test extends TestCase {
+
+	/**
+	 * Represents the class to test.
+	 *
+	 * @var Google_Verify_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Google_Verify_Validator();
+	}
+
+	/**
+	 * Test validating a valid url.
+	 *
+	 * @covers ::validate
+	 * @covers ::get_validation_regex
+	 */
+	public function test_validate_a_valid_verify_code() {
+		$valid_verify_code = 'AYbz19_-';
+
+		self::assertTrue(
+			$this->instance->validate( $valid_verify_code )
+		);
+	}
+
+	/**
+	 * Test validating an invalid verification code.
+	 *
+	 * @covers ::validate
+	 * @covers ::get_validation_regex
+	 * @covers ::get_search_engine_name
+	 */
+	public function test_validate_an_invalid_verification_code() {
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$invalid_code  = '<meta content="abcDEF123" />';
+		$error_message = '<strong><meta content="abcDEF123" /></strong> does not seem to be a valid Google Webmaster tools verification string. Please correct.';
+
+		self::assertEquals(
+			new Validation_Error( $error_message ),
+			$this->instance->validate( $invalid_code )
+		);
+	}
+}

--- a/tests/unit/validators/search-engine-verify/pinterest-verify-validator-test.php
+++ b/tests/unit/validators/search-engine-verify/pinterest-verify-validator-test.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators\Search_Engine_Verify;
+
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Search_Engine_Verify\Pinterest_Verify_Validator;
+use Yoast\WP\SEO\Values\Validation_Error;
+
+/**
+ * Class Pinterest_Verify_Validator_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Search_Engine_Verify\Pinterest_Verify_Validator
+ *
+ * @group validators
+ */
+class Pinterest_Verify_Validator_Test extends TestCase {
+
+	/**
+	 * Represents the class to test.
+	 *
+	 * @var Pinterest_Verify_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Pinterest_Verify_Validator();
+	}
+
+	/**
+	 * Test validating a valid url.
+	 *
+	 * @covers ::validate
+	 * @covers ::get_validation_regex
+	 */
+	public function test_validate_a_valid_verify_code() {
+		$valid_verify_code = 'AFbe19_-';
+
+		self::assertTrue(
+			$this->instance->validate( $valid_verify_code )
+		);
+	}
+
+	/**
+	 * Test validating an invalid verification code.
+	 *
+	 * @covers ::validate
+	 * @covers ::get_validation_regex
+	 * @covers ::get_search_engine_name
+	 */
+	public function test_validate_an_invalid_verification_code() {
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$invalid_code  = '<meta content="abcDEF123" />';
+		$error_message = '<strong><meta content="abcDEF123" /></strong> does not seem to be a valid Pinterest verification string. Please correct.';
+
+		self::assertEquals(
+			new Validation_Error( $error_message ),
+			$this->instance->validate( $invalid_code )
+		);
+	}
+}

--- a/tests/unit/validators/search-engine-verify/search-engine-verify-validator-test.php
+++ b/tests/unit/validators/search-engine-verify/search-engine-verify-validator-test.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators\Search_Engine_Verify;
+
+use Mockery\Mock;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Search_Engine_Verify\Search_Engine_Verify_Validator;
+use Yoast\WP\SEO\Values\Validation_Error;
+
+/**
+ * Class Search_Engine_Verify_Validator_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Search_Engine_Verify\Search_Engine_Verify_Validator
+ *
+ * @group validators
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- 5 words is fine.
+ */
+class Search_Engine_Verify_Validator_Test extends TestCase {
+
+	/**
+	 * Represents the class to test.
+	 *
+	 * @var Search_Engine_Verify_Validator|Mock
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = \Mockery::mock( Search_Engine_Verify_Validator::class )
+			->shouldAllowMockingProtectedMethods()
+			->makePartial();
+		$this->instance
+			->expects( 'get_validation_regex' )
+			->once()
+			->andReturn( '(^[A-Fa-f0-9_-]+$)' );
+	}
+
+	/**
+	 * Test validating a valid url.
+	 *
+	 * @covers ::validate
+	 * @covers ::validate_against_regex
+	 */
+	public function test_validate_a_valid_verify_code() {
+		$valid_verify_code = 'AEbf19_-';
+
+		self::assertTrue(
+			$this->instance->validate( $valid_verify_code )
+		);
+	}
+
+	/**
+	 * Test validating an invalid verification code.
+	 *
+	 * @covers ::validate
+	 * @covers ::validate_against_regex
+	 */
+	public function test_validate_an_invalid_verification_code() {
+		$this->instance
+			->expects( 'get_search_engine_name' )
+			->zeroOrMoreTimes()
+			->andReturn( 'Test webmaster tools' );
+
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$invalid_code  = '<meta content="abcDEF123" />';
+		$error_message = '<strong><meta content="abcDEF123" /></strong> does not seem to be a valid Test webmaster tools verification string. Please correct.';
+
+		self::assertEquals(
+			new Validation_Error( $error_message ),
+			$this->instance->validate( $invalid_code )
+		);
+	}
+}

--- a/tests/unit/validators/search-engine-verify/yandex-verify-validator-test.php
+++ b/tests/unit/validators/search-engine-verify/yandex-verify-validator-test.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators\Search_Engine_Verify;
+
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Search_Engine_Verify\Yandex_Verify_Validator;
+use Yoast\WP\SEO\Values\Validation_Error;
+
+/**
+ * Class Yandex_Verify_Validator_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Search_Engine_Verify\Yandex_Verify_Validator
+ *
+ * @group validators
+ */
+class Yandex_Verify_Validator_Test extends TestCase {
+
+	/**
+	 * Represents the class to test.
+	 *
+	 * @var Yandex_Verify_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Yandex_Verify_Validator();
+	}
+
+	/**
+	 * Test validating a valid url.
+	 *
+	 * @covers ::validate
+	 * @covers ::get_validation_regex
+	 */
+	public function test_validate_a_valid_verify_code() {
+		$valid_verify_code = 'AFbe19_-';
+
+		self::assertTrue(
+			$this->instance->validate( $valid_verify_code )
+		);
+	}
+
+	/**
+	 * Test validating an invalid verification code.
+	 *
+	 * @covers ::validate
+	 * @covers ::get_validation_regex
+	 * @covers ::get_search_engine_name
+	 */
+	public function test_validate_an_invalid_verification_code() {
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$invalid_code  = '<meta content="abcDEF123" />';
+		$error_message = '<strong><meta content="abcDEF123" /></strong> does not seem to be a valid Yandex Webmaster tools verification string. Please correct.';
+
+		self::assertEquals(
+			new Validation_Error( $error_message ),
+			$this->instance->validate( $invalid_code )
+		);
+	}
+}

--- a/tests/unit/validators/url-validator-test.php
+++ b/tests/unit/validators/url-validator-test.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Url_Validator;
+use Yoast\WP\SEO\Values\Validation_Error;
+
+/**
+ * Class Url_Validator_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Url_Validator
+ *
+ * @group validators
+ */
+class Url_Validator_Test extends TestCase {
+
+	/**
+	 * Represents the class to test.
+	 *
+	 * @var Url_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Url_Validator();
+	}
+
+	/**
+	 * Test validating a valid url.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate_a_valid_url() {
+		$valid_url = 'https://yoast.com';
+
+		self::assertTrue(
+			$this->instance->validate( $valid_url )
+		);
+	}
+
+	/**
+	 * Test validating an invalid url.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate_an_invalid_url() {
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$invalid_url = 'invalid_url';
+
+		$error_message = '<strong>invalid_url</strong> does not seem to be a valid url. Please correct.';
+
+		self::assertEquals(
+			new Validation_Error( $error_message ),
+			$this->instance->validate( $invalid_url )
+		);
+	}
+}

--- a/tests/unit/values/validation-error-test.php
+++ b/tests/unit/values/validation-error-test.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Values;
+
+use Mockery;
+use Yoast\WP\SEO\Helpers\Image_Helper;
+use Yoast\WP\SEO\Helpers\Url_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Values\Images;
+use Yoast\WP\SEO\Values\Validation_Error;
+
+/**
+ * Class Images_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Values\Validation_Error
+ *
+ * @group values
+ */
+class Validation_Error_Test extends TestCase {
+
+	/**
+	 * Represents the class to test.
+	 *
+	 * @var Validation_Error
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Validation_Error( 'Message explaining the error.' );
+	}
+
+	/**
+	 * Test that the constructor saves the error message on the right property.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		self::assertEquals(
+			'Message explaining the error.',
+			self::getObjectAttribute( $this->instance, 'error_message' )
+		);
+	}
+
+	/**
+	 * Test that the get_error_message function returns the given error message.
+	 *
+	 * @covers ::get_error_message
+	 */
+	public function test_get_error_message() {
+		self::assertEquals(
+			'Message explaining the error.',
+			$this->instance->get_error_message()
+		);
+	}
+}

--- a/tests/unit/values/validation-error-test.php
+++ b/tests/unit/values/validation-error-test.php
@@ -42,7 +42,7 @@ class Validation_Error_Test extends TestCase {
 	public function test_constructor() {
 		self::assertEquals(
 			'Message explaining the error.',
-			self::getObjectAttribute( $this->instance, 'error_message' )
+			self::getPropertyValue( $this->instance, 'error_message' )
 		);
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Create the Validators that can make sure that instances of the Settings_Model contain valid data

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Validators that can validate the new Settings_Model data to store options.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* n/a. this code is not yet used anywhere.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
