### PR TITLE
Add gmt_offset and timezoneString to tracking data

### DIFF
--- a/admin/tracking/class-tracking-default-data.php
+++ b/admin/tracking/class-tracking-default-data.php
@@ -17,13 +17,15 @@ class WPSEO_Tracking_Default_Data implements WPSEO_Collection {
 	 */
 	public function get() {
 		return [
-			'siteTitle'    => get_option( 'blogname' ),
-			'@timestamp'   => (int) date( 'Uv' ),
-			'wpVersion'    => $this->get_wordpress_version(),
-			'homeURL'      => home_url(),
-			'adminURL'     => admin_url(),
-			'isMultisite'  => is_multisite(),
-			'siteLanguage' => get_bloginfo( 'language' ),
+			'siteTitle'      => get_option( 'blogname' ),
+			'@timestamp'     => (int) date( 'Uv' ),
+			'wpVersion'      => $this->get_wordpress_version(),
+			'homeURL'        => home_url(),
+			'adminURL'       => admin_url(),
+			'isMultisite'    => is_multisite(),
+			'siteLanguage'   => get_bloginfo( 'language' ),
+			'gmt_offset'     => get_option( 'gmt_offset' ),
+			'timezoneString' => get_option( 'timezone_string' ),
 		];
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds gmt_offset and timezone_string to tracking data

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In `class-tracking.php`, add `return true;` at the top of `should_send_tracking` (line 145).
* In `class-collector.php`, add `var_dump( $data );` before the return statement in `collect` (line 40). 
* Visit Settings > General, and see `gmt_offset` and `timezoneString` in the tracking data:
   * `gmt_offset` contains a numeral offset.
   * `timezoneString` contains the name of the time zone. NB: when an numerical offset (like `UTC-12`) is selected, the value of this will be an empty string. If a location (like `Amsterdam`) is selected, it will contain the name of the timezone. 
* NB: You might need to remove the `var_dump` before saving new time zone settings. I couldn't save settings as long as the `var_dump` was there.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* I don't think there is a way to test this without altering code 😬.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
