### PR TITLE
P3-387 Improve social links accessibility in the post publish panel

### DIFF
--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -700,8 +700,6 @@ ul.wpseo-metabox-tabs li.wpseo-tab-add-keyword {
 ul.yoast-seo-social-share-buttons li {
 	display: inline-block;
 	margin-right: 8px;
-	width: 32px;
-	height: 32px;
 }
 
 ul.yoast-seo-social-share-buttons svg {
@@ -710,9 +708,9 @@ ul.yoast-seo-social-share-buttons svg {
 }
 
 ul.yoast-seo-social-share-buttons a {
-	width: 32px;
-	height: 32px;
-	display: inline-block;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 }
 
 div.interface-pinned-items button.components-button[aria-label="Yoast SEO"] > svg,

--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -699,12 +699,13 @@ ul.wpseo-metabox-tabs li.wpseo-tab-add-keyword {
 
 ul.yoast-seo-social-share-buttons li {
 	display: inline-block;
-	margin-right: 8px;
+	margin-right: 16px;
 }
 
 ul.yoast-seo-social-share-buttons svg {
 	width: 32px;
 	height: 32px;
+	margin-bottom: 8px;
 }
 
 ul.yoast-seo-social-share-buttons a {

--- a/js/src/components/PostPublish.js
+++ b/js/src/components/PostPublish.js
@@ -18,13 +18,17 @@ export default function PostPublish( { permalink } ) {
 		</div>
 		<ul className="yoast-seo-social-share-buttons">
 			<li>
-				<a href={ "https://www.facebook.com/sharer/sharer.php?u=" + encodedUrl } target="_blank" rel="noopener noreferrer">
+				<a href={ "https://www.facebook.com/sharer/sharer.php?u=" + encodedUrl } rel="noopener noreferrer">
 					<FacebookIcon />
+					Facebook
+					<span className="screen-reader-text">{ __( "(Opens in a new browser tab)", "yoast-components" ) }</span>
 				</a>
 			</li>
 			<li>
-				<a href={ "https://twitter.com/share?url=" + encodedUrl } target="_blank" rel="noopener noreferrer">
+				<a href={ "https://twitter.com/share?url=" + encodedUrl } rel="noopener noreferrer">
 					<TwitterIcon />
+					Twitter
+					<span className="screen-reader-text">{ __( "(Opens in a new browser tab)", "yoast-components" ) }</span>
 				</a>
 			</li>
 		</ul>

--- a/js/src/components/PostPublish.js
+++ b/js/src/components/PostPublish.js
@@ -18,14 +18,14 @@ export default function PostPublish( { permalink } ) {
 		</div>
 		<ul className="yoast-seo-social-share-buttons">
 			<li>
-				<a href={ "https://www.facebook.com/sharer/sharer.php?u=" + encodedUrl } rel="noopener noreferrer">
+				<a href={ "https://www.facebook.com/sharer/sharer.php?u=" + encodedUrl } target="_blank" rel="noopener noreferrer">
 					<FacebookIcon />
 					Facebook
 					<span className="screen-reader-text">{ __( "(Opens in a new browser tab)", "yoast-components" ) }</span>
 				</a>
 			</li>
 			<li>
-				<a href={ "https://twitter.com/share?url=" + encodedUrl } rel="noopener noreferrer">
+				<a href={ "https://twitter.com/share?url=" + encodedUrl } target="_blank" rel="noopener noreferrer">
 					<TwitterIcon />
 					Twitter
 					<span className="screen-reader-text">{ __( "(Opens in a new browser tab)", "yoast-components" ) }</span>

--- a/js/src/components/PostPublish.js
+++ b/js/src/components/PostPublish.js
@@ -20,14 +20,14 @@ export default function PostPublish( { permalink } ) {
 			<li>
 				<a href={ "https://www.facebook.com/sharer/sharer.php?u=" + encodedUrl } target="_blank" rel="noopener noreferrer">
 					<FacebookIcon />
-					Facebook
+					{ __( "Facebook", "wordpress-seo" ) }
 					<span className="screen-reader-text">{ __( "(Opens in a new browser tab)", "yoast-components" ) }</span>
 				</a>
 			</li>
 			<li>
 				<a href={ "https://twitter.com/share?url=" + encodedUrl } target="_blank" rel="noopener noreferrer">
 					<TwitterIcon />
-					Twitter
+					{ __( "Twitter", "wordpress-seo" ) }
 					<span className="screen-reader-text">{ __( "(Opens in a new browser tab)", "yoast-components" ) }</span>
 				</a>
 			</li>

--- a/js/src/components/PostPublish.js
+++ b/js/src/components/PostPublish.js
@@ -21,14 +21,14 @@ export default function PostPublish( { permalink } ) {
 				<a href={ "https://www.facebook.com/sharer/sharer.php?u=" + encodedUrl } target="_blank" rel="noopener noreferrer">
 					<FacebookIcon />
 					{ __( "Facebook", "wordpress-seo" ) }
-					<span className="screen-reader-text">{ __( "(Opens in a new browser tab)", "yoast-components" ) }</span>
+					<span className="screen-reader-text">{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }</span>
 				</a>
 			</li>
 			<li>
 				<a href={ "https://twitter.com/share?url=" + encodedUrl } target="_blank" rel="noopener noreferrer">
 					<TwitterIcon />
 					{ __( "Twitter", "wordpress-seo" ) }
-					<span className="screen-reader-text">{ __( "(Opens in a new browser tab)", "yoast-components" ) }</span>
+					<span className="screen-reader-text">{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }</span>
 				</a>
 			</li>
 		</ul>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improve the accessibility for the social sharing links in the post publish panel

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves accessibility for the social sharing links in the post publish panel

## Relevant technical choices:

* I decided not to use `makeOutboundLink` from `@yoast/helpers`, because it did not allow the the `rel` attribute to be configured as it was.
* I used flexbox to implement the design of the link, which could need extra support for IE11 but falls back to an acceptable layout with the text next to the icon: 
![image](https://user-images.githubusercontent.com/1767166/111301637-bb22ea80-8652-11eb-9eb8-6f6da551731c.png)


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Checkout this branch and build accordingly (`$ composer install; yarn; grunt build`).
* Add a new post with a title and publish it
* On the post publish confirmation panel, check the Facebook and Twitter icons + texts match with the designs mentioned in [P3-387]
* Open up some screen reader software. On Mac you can open VoiceOver on System Preferences > Accessibility > VoiceOver by enabling the checkbox before "Enable voiceover"
* Click the link to let the screen reader inform you about it. Note that with VoiceOver the link is actually followed, before explained fully. You'll need to click and hold the link, and then drag until the cursor leaves the link: 
<img width="780" alt="afbeelding" src="https://user-images.githubusercontent.com/1767166/111303134-7a2bd580-8654-11eb-880e-e5112b385e3a.png">

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Add a new post with a title and publish it
* On the post publish confirmation panel, check the Facebook and Twitter icons + texts match with the designs mentioned in [P3-387]
* Open up some screen reader software. On Mac you can open VoiceOver on System Preferences > Accessibility > VoiceOver by enabling the checkbox before "Enable voiceover"
* Click the link to let the screen reader inform you about it. Note that with VoiceOver the link is actually followed, before explained fully. You'll need to click and hold the link, and then drag until the cursor leaves the link: 
<img width="780" alt="afbeelding" src="https://user-images.githubusercontent.com/1767166/111303134-7a2bd580-8654-11eb-880e-e5112b385e3a.png">

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

