### PR TITLE
Bring auto-updates for Yoast ACF Analysis in sync with Yoast SEO

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
 		],
 		"check-cs-thresholds": [
 			"@putenv YOASTCS_THRESHOLD_ERRORS=340",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=227",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=225",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs-summary": [

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -67,16 +67,24 @@ class WPSEO_Addon_Manager {
 	const LOCAL_SLUG = 'yoast-seo-local';
 
 	/**
+	 * Holds the slug for ACF.
+	 *
+	 * @var string
+	 */
+	const ACF_SLUG = 'acf-content-analysis-for-yoast-seo';
+
+	/**
 	 * The expected addon data.
 	 *
 	 * @var array
 	 */
 	protected static $addons = [
-		'wp-seo-premium.php'    => self::PREMIUM_SLUG,
-		'wpseo-news.php'        => self::NEWS_SLUG,
-		'video-seo.php'         => self::VIDEO_SLUG,
-		'wpseo-woocommerce.php' => self::WOOCOMMERCE_SLUG,
-		'local-seo.php'         => self::LOCAL_SLUG,
+		'wp-seo-premium.php'     => self::PREMIUM_SLUG,
+		'wpseo-news.php'         => self::NEWS_SLUG,
+		'video-seo.php'          => self::VIDEO_SLUG,
+		'wpseo-woocommerce.php'  => self::WOOCOMMERCE_SLUG,
+		'local-seo.php'          => self::LOCAL_SLUG,
+		'yoast-acf-analysis.php' => self::ACF_SLUG,
 	];
 
 	/**

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -72,11 +72,11 @@ class WPSEO_Addon_Manager {
 	 * @var array
 	 */
 	protected static $addons = [
-		'wp-seo-premium.php'     => self::PREMIUM_SLUG,
-		'wpseo-news.php'         => self::NEWS_SLUG,
-		'video-seo.php'          => self::VIDEO_SLUG,
-		'wpseo-woocommerce.php'  => self::WOOCOMMERCE_SLUG,
-		'local-seo.php'          => self::LOCAL_SLUG,
+		'wp-seo-premium.php'    => self::PREMIUM_SLUG,
+		'wpseo-news.php'        => self::NEWS_SLUG,
+		'video-seo.php'         => self::VIDEO_SLUG,
+		'wpseo-woocommerce.php' => self::WOOCOMMERCE_SLUG,
+		'local-seo.php'         => self::LOCAL_SLUG,
 	];
 
 	/**

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -67,13 +67,6 @@ class WPSEO_Addon_Manager {
 	const LOCAL_SLUG = 'yoast-seo-local';
 
 	/**
-	 * Holds the slug for ACF.
-	 *
-	 * @var string
-	 */
-	const ACF_SLUG = 'acf-content-analysis-for-yoast-seo';
-
-	/**
 	 * The expected addon data.
 	 *
 	 * @var array
@@ -84,7 +77,6 @@ class WPSEO_Addon_Manager {
 		'video-seo.php'          => self::VIDEO_SLUG,
 		'wpseo-woocommerce.php'  => self::WOOCOMMERCE_SLUG,
 		'local-seo.php'          => self::LOCAL_SLUG,
-		'yoast-acf-analysis.php' => self::ACF_SLUG,
 	];
 
 	/**

--- a/src/integrations/watchers/addon-update-watcher.php
+++ b/src/integrations/watchers/addon-update-watcher.php
@@ -24,7 +24,7 @@ class Addon_Update_Watcher implements Integration_Interface {
 	 *
 	 * @var string[]
 	 */
-	const ADD_ONS = [
+	const ADD_ON_PLUGIN_FILES = [
 		'wordpress-seo-premium/wp-seo-premium.php',
 		'wpseo-video/video-seo.php',
 		'wpseo-local/local-seo.php',
@@ -73,7 +73,7 @@ class Addon_Update_Watcher implements Integration_Interface {
 			return $old_html;
 		}
 
-		$not_a_yoast_addon = ! \in_array( $plugin, self::ADD_ONS, true );
+		$not_a_yoast_addon = ! \in_array( $plugin, self::ADD_ON_PLUGIN_FILES, true );
 
 		if ( $not_a_yoast_addon ) {
 			return $old_html;
@@ -140,7 +140,7 @@ class Addon_Update_Watcher implements Integration_Interface {
 	 * @param string[] $auto_updated_plugins The current list of auto-updated plugins.
 	 */
 	protected function enable_auto_updates_for_addons( $auto_updated_plugins ) {
-		$plugins = \array_merge( $auto_updated_plugins, self::ADD_ONS );
+		$plugins = \array_merge( $auto_updated_plugins, self::ADD_ON_PLUGIN_FILES );
 		\update_option( 'auto_update_plugins', $plugins );
 	}
 
@@ -150,7 +150,7 @@ class Addon_Update_Watcher implements Integration_Interface {
 	 * @param string[] $auto_updated_plugins The current list of auto-updated plugins.
 	 */
 	protected function disable_auto_updates_for_addons( $auto_updated_plugins ) {
-		\update_option( 'auto_update_plugins', \array_values( \array_diff( $auto_updated_plugins, self::ADD_ONS ) ) );
+		\update_option( 'auto_update_plugins', \array_values( \array_diff( $auto_updated_plugins, self::ADD_ON_PLUGIN_FILES ) ) );
 	}
 
 	/**

--- a/src/integrations/watchers/addon-update-watcher.php
+++ b/src/integrations/watchers/addon-update-watcher.php
@@ -30,6 +30,7 @@ class Addon_Update_Watcher implements Integration_Interface {
 		'wpseo-local/local-seo.php',
 		'wpseo-woocommerce/wpseo-woocommerce.php',
 		'wpseo-news/wpseo-news.php',
+		'yoast-acf-analysis/yoast-acf-analysis.php',
 	];
 
 	/**

--- a/src/integrations/watchers/addon-update-watcher.php
+++ b/src/integrations/watchers/addon-update-watcher.php
@@ -27,10 +27,10 @@ class Addon_Update_Watcher implements Integration_Interface {
 	const ADD_ON_PLUGIN_FILES = [
 		'wordpress-seo-premium/wp-seo-premium.php',
 		'wpseo-video/video-seo.php',
-		'wpseo-local/local-seo.php',
+		'wpseo-local/local-seo.php', // When installing Local through a released zip, the path is different from the path on a dev environment.
 		'wpseo-woocommerce/wpseo-woocommerce.php',
 		'wpseo-news/wpseo-news.php',
-		'yoast-acf-analysis/yoast-acf-analysis.php',
+		'acf-content-analysis-for-yoast-seo/yoast-acf-analysis.php', // When installing ACF for Yoast through a released zip, the path is different from the path on a dev environment.
 	];
 
 	/**

--- a/tests/unit/integrations/watchers/addon-update-watcher-test.php
+++ b/tests/unit/integrations/watchers/addon-update-watcher-test.php
@@ -108,6 +108,7 @@ class Addon_Update_Watcher_Test extends TestCase {
 			'wpseo-local/local-seo.php',
 			'wpseo-woocommerce/wpseo-woocommerce.php',
 			'wpseo-news/wpseo-news.php',
+			'acf-content-analysis-for-yoast-seo/yoast-acf-analysis.php',
 		];
 
 		Monkey\Functions\expect( 'update_option' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enables/disables auto-updates for the `ACF Content Analysis for Yoast SEO` plugin when auto-updates for Yoast SEO are enabled/disabled.

## Relevant technical choices:

* The [issue](https://yoast.atlassian.net/browse/P2-744) said that "the `update_supported` setting of the ACF plugin is never set to true" in `class-addon-manager`. But this is not the right solution, because the `class-addon-manager` revolves around our paid add-ons that have a subscription, this is not the case for ACF for Yoast. 
* I will now explain in some more detail why we don't have to set `update_supported` for ACF for Yoast.
* The `class-addon-manager` uses the filter `_site_transient_update_plugins` to add plugin information to the `_site_transient_update_plugins` option.
* ([source](https://make.wordpress.org/core/2020/07/30/recommended-usage-of-the-updates-api-to-support-the-auto-updates-ui-for-plugins-and-themes-in-wordpress-5-5/)) "The responses received from querying the WordPress.org Updates API are stored in the `update_plugins` site transient. There are several existing filters that developers can use to add information about the availability or lack of available updates for a specific plugin that is not hosted in the WordPress Plugin Directory to that transient."
* Since ACF for Yoast _is_ hosted in the WordPress Plugin Directory, we need to add information about this plugin through the `_site_transient_update_plugins` filter, and that for resolving this issue it is enough to make sure the `addon-update-watcher` adds ACF to the `auto_update_plugins` option whenever the auto-update setting for Yoast SEO is toggled. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install `ACF Content Analysis for Yoast SEO` through a released zip (in other words, don't clone it from GitHub, but install it through the WordPress backend - the auto-updates won't work otherwise).
* Go to the Plugins page in your back-end.
* See that auto-updates for ACF for Yoast are in sync with Yoast SEO (`"Auto-updates are enabled based on this setting for Yoast SEO."` --> make sure that auto-updates for Yoast SEO are enabled).
* Click on `Plugin Editor` and lower the version of ACF to 3.0.0, so that it will be eligible to update.
<img width="105" alt="Screenshot 2021-03-16 at 15 07 50" src="https://user-images.githubusercontent.com/20280513/111322590-62128100-8669-11eb-856c-f528c64060fd.png">

* Enable auto-updates for another plugin (not from Yoast) which is not at its latest version. This will help to check whether the next step is working.
* On line 901 of `wordpress/wp-includes/update.php`, change `add_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );` to `add_action( 'admin_init', 'wp_maybe_auto_update' );` to trigger the plugin auto updates.
* Refresh the plugins page and see that both ACF and the non-Yoast plugin have been updated to their latest version.
* Restore `update.php` to its original version 😉 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-744
