### PR TITLE
Add missing quote to indexing queries in the tests.

### DIFF
--- a/tests/unit/actions/indexing/post-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/post-link-indexing-action-test.php
@@ -119,7 +119,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			LEFT JOIN wp_yoast_indexable AS I
 				ON p.ID = I.object_id
 				AND link_count IS NOT NULL
-				AND object_type = 'post
+				AND object_type = 'post'
 			LEFT JOIN wp_yoast_seo_links AS L
 				ON L.post_id = P.ID
 				AND L.target_indexable_id IS NULL
@@ -181,7 +181,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			LEFT JOIN wp_yoast_indexable AS I
 				ON p.ID = I.object_id
 				AND link_count IS NOT NULL
-				AND object_type = 'post
+				AND object_type = 'post'
 			LEFT JOIN wp_yoast_seo_links AS L
 				ON L.post_id = P.ID
 				AND L.target_indexable_id IS NULL
@@ -241,7 +241,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			LEFT JOIN wp_yoast_indexable AS I
 				ON p.ID = I.object_id
 				AND link_count IS NOT NULL
-				AND object_type = 'post
+				AND object_type = 'post'
 			LEFT JOIN wp_yoast_seo_links AS L
 				ON L.post_id = P.ID
 				AND L.target_indexable_id IS NULL


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Quick follow up to https://github.com/Yoast/wordpress-seo/commit/248a7fcedd5061ffe28e40b161550be4c6e40b92 to add 
a missing quote to the indexing queries used in the tests. See https://github.com/Yoast/wordpress-seo/pull/16764 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes failing tests due to missing quote in sql statements.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See the tests pass.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
