### PR TITLE
Ensure the query is reset before fetching the indexable

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -272,6 +272,7 @@ class Front_End_Integration implements Integration_Interface {
 
 		\do_action( 'wpseo_head' );
 
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Reason: we have to restore the query.
 		$GLOBALS['wp_query'] = $old_wp_query;
 	}
 

--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -80,7 +80,16 @@ class WP_Robots_Integration implements Integration_Interface {
 	 * @returns array The robots key-value pairs.
 	 */
 	protected function get_robots_value() {
+		global $wp_query;
+
+		$old_wp_query = $wp_query;
+		// phpcs:ignore WordPress.WP.DiscouragedFunctions.wp_reset_query_wp_reset_query -- Reason: The recommended function, wp_reset_postdata, doesn't reset wp_query.
+		\wp_reset_query();
+
 		$context = $this->context_memoizer->for_current_page();
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Reason: we have to restore the query.
+		$GLOBALS['wp_query'] = $old_wp_query;
 
 		$robots_presenter               = new Robots_Presenter();
 		$robots_presenter->presentation = $context->presentation;

--- a/tests/unit/integrations/front-end/wp-robots-integration-test.php
+++ b/tests/unit/integrations/front-end/wp-robots-integration-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Front_End;
 
+use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Conditionals\WP_Robots_Conditional;
@@ -97,6 +98,8 @@ class WP_Robots_Integration_Test extends TestCase {
 			],
 		];
 
+		Monkey\Functions\expect( 'wp_reset_query' )->once();
+
 		$this->context_memoizer
 			->expects( 'for_current_page' )
 			->once()
@@ -130,6 +133,8 @@ class WP_Robots_Integration_Test extends TestCase {
 				],
 			],
 		];
+
+		Monkey\Functions\expect( 'wp_reset_query' )->once();
 
 		$this->context_memoizer
 			->expects( 'for_current_page' )
@@ -171,6 +176,8 @@ class WP_Robots_Integration_Test extends TestCase {
 				],
 			],
 		];
+
+		Monkey\Functions\expect( 'wp_reset_query' )->once();
 
 		$this->context_memoizer
 			->expects( 'for_current_page' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We reset the global Query before running wpseo_head, however with WordPress 5.7 the indexable is fetched before that in the `wp_robots` filter. This ensures the query is also reset before fetching the indexable.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an issue where usage of WP_Query without properly resetting globals could lead to incorrect SEO data.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add an action to `template_redirect` in which you construct a new `WP_Query` and call `the_post` on it. ie:
```php
function do_something_with_query() {
	global $wp_query;

	if ( $wp_query->post->ID === 2 ) {
			$need_some_data = new WP_Query( ['page_id' => 1] );
			$data_from_the_post = $need_some_data->the_post();
	}

}
add_action( 'template_redirect', 'do_something_with_query' );
```
This code assumes that you have a post with an ID of 1 (this is the default `Hello World!` post), and a post with an ID. of 2 (this is the default `Sample Page` page).
* Visit the `Sample Page` page on the frontend (ID 2).
* Your SEO data should match the page and should not contain data of the post `Hello World!` (ID 1)
  * Without this PR, you will notice data from ID 1 in the source code of ID 2


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The SEO meta tags in the head.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended