### PR TITLE
P3-443 Fix saving of company and person logo meta options.

### DIFF
--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -72,6 +72,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		'company_logo'                  => '',
 		'company_logo_id'               => 0,
 		'company_logo_meta'             => false,
+		'person_logo_meta'              => false,
 		'company_name'                  => '',
 		'company_or_person'             => 'company',
 		'company_or_person_user_id'     => false,
@@ -337,7 +338,9 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				// Only ever set programmatically, so no reason for intense validation.
 				case 'company_logo_meta':
 				case 'person_logo_meta':
-					$clean[ $key ] = $dirty[ $key ];
+					if ( isset( $dirty[ $key ] ) ) {
+						$clean[ $key ] = $dirty[ $key ];
+					}
 					break;
 
 				/* Breadcrumbs text fields. */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid a PHP notice while saving the organization / person settings and have properly saved options.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a PHP notice while saving the Organization or Person name and logo.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged

**Note:**  right now there's an sql error that originates from current trunk and may be printed out on some pages. It's unrelated to this PR. It's tracked [on another Jira issue](https://yoast.atlassian.net/browse/P3-445), so please ignore it while testing this PR>

This PR can be acceptance tested by following these steps:

- First, test on latest trunk. 
- Disable all plugins, including Query Monitor.
- Keep only Yoast SEO activated.
- Go to SEO > Search appearance.
- Set "Choose whether the site represents an organization or a person" to "Organization"
- Do not set a name and logo.
- Hit "Save changes".
- At this point you should get a PHP notice on a blank page (see screenshot 01).

<img width="1440" alt="01 php notice" src="https://user-images.githubusercontent.com/1682452/111336899-ec60e200-8675-11eb-8523-4169deee570f.png">


- If not, start from scratch using a clean database. For the Docker environment, follow the instructions under "Resetting everything" on this page https://github.com/Yoast/plugin-development-docker#setting-up-the-container
- After you get the PHP notice, inspect your database and check the `wpseo_titles` option in the `wp_options` table 
- See that `company_logo_meta` has been saved with a value of `N`, which I guess means `null` (see screenshot 02)

<img width="702" alt="02 saved as N" src="https://user-images.githubusercontent.com/1682452/111336945-f4b91d00-8675-11eb-86ec-7db07ebe1d63.png">


- Expected: `company_logo_meta` shouldn't have been saved because a logo wasn't set.
- Switch to this branch and build.
- Go to SEO > Search appearance and repeat the steps above.
- See there's no PHP notice. 
- Inspect the database `wp_options` table > `wpseo_titles`
- See that `company_logo_meta` hasn't been saved: this is the correct behavior.
- See also that `person_logo_meta` hasn't been saved (also correct).
- Go to SEO > Search appearance again and this time set the organization name and logo and then save.
- Inspect again the database option and see that:
  - `company_logo_meta` has been saved and it's a serialized array of 9 items with width, height, url, etc. 
  - `person_logo_meta` has been saved and its value is `b:0` (which means boolean "false").
- Go to SEO > Search appearance again and this time set the site to represent a person.
- Choose a user and set a logo, then save.
- Inspect again the database option and see that:
  - `company_logo_meta` has been saved and its value is `b:0`
  - `person_logo_meta` has been saved and it's a serialized array of 9 items with width, height, url, etc. 



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

- Go to SEO > Search appearance.
- Set "Choose whether the site represents an organization or a person" to "Organization"
- Do not set a name and logo.
- Hit "Save changes".
- See there's no PHP notice. 
- Inspect the database `wp_options` table > `wpseo_titles`
- See that `company_logo_meta` hasn't been saved: this is the correct behavior.
- See also that `person_logo_meta` hasn't been saved (also correct).
- Go to SEO > Search appearance again and this time set the organization name and logo and then save.
- Inspect again the database option and see that:
  - `company_logo_meta` has been saved and it's a serialized array of 9 items with width, height, url, etc. 
  - `person_logo_meta` has been saved and its value is `b:0` (which means boolean "false").
- Go to SEO > Search appearance again and this time set the site to represent a person.
- Choose a user and set a logo, then save.
- Inspect again the database option and see that:
  - `company_logo_meta` has been saved and its value is `b:0`
  - `person_logo_meta` has been saved and it's a serialized array of 9 items with width, height, url, etc. 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-443]
