### PR TITLE
P3-445 Resolved ambiguous fields in SQL query

### DIFF
--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -76,7 +76,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 
 		$select = 'ID, post_content';
 		if ( $count ) {
-			$select = 'COUNT(ID)';
+			$select = 'COUNT(P.ID)';
 		}
 		$limit_query = '';
 		if ( ! $count ) {
@@ -88,7 +88,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 			"SELECT $select
 			FROM {$this->wpdb->posts} AS P
 			LEFT JOIN $indexable_table AS I
-				ON p.ID = I.object_id
+				ON P.ID = I.object_id
 				AND link_count IS NOT NULL
 				AND object_type = 'post'
 			LEFT JOIN $links_table AS L
@@ -98,7 +98,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 				AND L.target_post_id IS NOT NULL
 				AND L.target_post_id != 0
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
-				AND post_status = 'publish'
+				AND P.post_status = 'publish'
 				AND post_type IN ($placeholders)
 			$limit_query
 			",

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -74,7 +74,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		$links_table       = Model::get_table_name( 'SEO_Links' );
 		$replacements      = $public_post_types;
 
-		$select = 'ID, post_content';
+		$select = 'P.ID, P.post_content';
 		if ( $count ) {
 			$select = 'COUNT(P.ID)';
 		}
@@ -89,8 +89,8 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 			FROM {$this->wpdb->posts} AS P
 			LEFT JOIN $indexable_table AS I
 				ON P.ID = I.object_id
-				AND link_count IS NOT NULL
-				AND object_type = 'post'
+				AND I.link_count IS NOT NULL
+				AND I.object_type = 'post'
 			LEFT JOIN $links_table AS L
 				ON L.post_id = P.ID
 				AND L.target_indexable_id IS NULL
@@ -99,7 +99,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 				AND L.target_post_id != 0
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
 				AND P.post_status = 'publish'
-				AND post_type IN ($placeholders)
+				AND P.post_type IN ($placeholders)
 			$limit_query
 			",
 			$replacements

--- a/src/actions/indexing/term-link-indexing-action.php
+++ b/src/actions/indexing/term-link-indexing-action.php
@@ -73,9 +73,9 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$replacements      = $public_taxonomies;
 
-		$select = 'term_id, description';
+		$select = 'T.term_id, T.description';
 		if ( $count ) {
-			$select = 'COUNT(term_id)';
+			$select = 'COUNT(T.term_id)';
 		}
 		$limit_query = '';
 		if ( ! $count ) {
@@ -89,9 +89,9 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 			LEFT JOIN $indexable_table AS I
 				ON T.term_id = I.object_id
 				AND I.object_type = 'term'
-				AND link_count IS NOT NULL
+				AND I.link_count IS NOT NULL
 			WHERE I.object_id IS NULL
-				AND taxonomy IN ($placeholders)
+				AND T.taxonomy IN ($placeholders)
 			$limit_query
 			",
 			$replacements

--- a/tests/unit/actions/indexing/post-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/post-link-indexing-action-test.php
@@ -114,12 +114,12 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->andReturn( [ 'post', 'page' ] );
 
 		$empty_string   = '';
-		$expected_query = "SELECT COUNT(ID)
+		$expected_query = "SELECT COUNT(P.ID)
 			FROM wp_posts AS P
 			LEFT JOIN wp_yoast_indexable AS I
-				ON p.ID = I.object_id
-				AND link_count IS NOT NULL
-				AND object_type = 'post'
+				ON P.ID = I.object_id
+				AND I.link_count IS NOT NULL
+				AND I.object_type = 'post'
 			LEFT JOIN wp_yoast_seo_links AS L
 				ON L.post_id = P.ID
 				AND L.target_indexable_id IS NULL
@@ -127,8 +127,8 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 				AND L.target_post_id IS NOT NULL
 				AND L.target_post_id != 0
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
-				AND post_status = 'publish'
-				AND post_type IN (%s, %s)
+				AND P.post_status = 'publish'
+				AND P.post_type IN (%s, %s)
 			$empty_string
 			";
 
@@ -176,12 +176,12 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->once()
 			->andReturn( [ 'post', 'page' ] );
 
-		$expected_query = "SELECT ID, post_content
+		$expected_query = "SELECT P.ID, P.post_content
 			FROM wp_posts AS P
 			LEFT JOIN wp_yoast_indexable AS I
-				ON p.ID = I.object_id
-				AND link_count IS NOT NULL
-				AND object_type = 'post'
+				ON P.ID = I.object_id
+				AND I.link_count IS NOT NULL
+				AND I.object_type = 'post'
 			LEFT JOIN wp_yoast_seo_links AS L
 				ON L.post_id = P.ID
 				AND L.target_indexable_id IS NULL
@@ -189,8 +189,8 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 				AND L.target_post_id IS NOT NULL
 				AND L.target_post_id != 0
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
-				AND post_status = 'publish'
-				AND post_type IN (%s, %s)
+				AND P.post_status = 'publish'
+				AND P.post_type IN (%s, %s)
 			LIMIT %d
 			";
 
@@ -236,12 +236,12 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->once()
 			->andReturn( [ 'post', 'page' ] );
 
-		$expected_query = "SELECT ID, post_content
+		$expected_query = "SELECT P.ID, P.post_content
 			FROM wp_posts AS P
 			LEFT JOIN wp_yoast_indexable AS I
-				ON p.ID = I.object_id
-				AND link_count IS NOT NULL
-				AND object_type = 'post'
+				ON P.ID = I.object_id
+				AND I.link_count IS NOT NULL
+				AND I.object_type = 'post'
 			LEFT JOIN wp_yoast_seo_links AS L
 				ON L.post_id = P.ID
 				AND L.target_indexable_id IS NULL
@@ -249,8 +249,8 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 				AND L.target_post_id IS NOT NULL
 				AND L.target_post_id != 0
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
-				AND post_status = 'publish'
-				AND post_type IN (%s, %s)
+				AND P.post_status = 'publish'
+				AND P.post_type IN (%s, %s)
 			LIMIT %d
 			";
 

--- a/tests/unit/actions/indexing/term-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/term-link-indexing-action-test.php
@@ -114,14 +114,14 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 			->andReturn( [ 'category', 'tag' ] );
 
 		$empty_string   = '';
-		$expected_query = "SELECT COUNT(term_id)
+		$expected_query = "SELECT COUNT(T.term_id)
 			FROM wp_term_taxonomy AS T
 			LEFT JOIN wp_yoast_indexable AS I
 				ON T.term_id = I.object_id
 				AND I.object_type = 'term'
-				AND link_count IS NOT NULL
+				AND I.link_count IS NOT NULL
 			WHERE I.object_id IS NULL
-				AND taxonomy IN (%s, %s)
+				AND T.taxonomy IN (%s, %s)
 			$empty_string
 			";
 
@@ -178,14 +178,14 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 			->andReturn( [ 'category', 'tag' ] );
 
 		$empty_string   = '';
-		$expected_query = "SELECT COUNT(term_id)
+		$expected_query = "SELECT COUNT(T.term_id)
 			FROM wp_term_taxonomy AS T
 			LEFT JOIN wp_yoast_indexable AS I
 				ON T.term_id = I.object_id
 				AND I.object_type = 'term'
-				AND link_count IS NOT NULL
+				AND I.link_count IS NOT NULL
 			WHERE I.object_id IS NULL
-				AND taxonomy IN (%s, %s)
+				AND T.taxonomy IN (%s, %s)
 			$empty_string
 			";
 
@@ -234,14 +234,14 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 			->once()
 			->andReturn( [ 'category', 'tag' ] );
 
-		$expected_query = "SELECT term_id, description
+		$expected_query = "SELECT T.term_id, T.description
 			FROM wp_term_taxonomy AS T
 			LEFT JOIN wp_yoast_indexable AS I
 				ON T.term_id = I.object_id
 				AND I.object_type = 'term'
-				AND link_count IS NOT NULL
+				AND I.link_count IS NOT NULL
 			WHERE I.object_id IS NULL
-				AND taxonomy IN (%s, %s)
+				AND T.taxonomy IN (%s, %s)
 			LIMIT %d
 			";
 
@@ -287,14 +287,14 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 			->once()
 			->andReturn( [ 'category', 'tag' ] );
 
-		$expected_query = "SELECT term_id, description
+		$expected_query = "SELECT T.term_id, T.description
 			FROM wp_term_taxonomy AS T
 			LEFT JOIN wp_yoast_indexable AS I
 				ON T.term_id = I.object_id
 				AND I.object_type = 'term'
-				AND link_count IS NOT NULL
+				AND I.link_count IS NOT NULL
 			WHERE I.object_id IS NULL
-				AND taxonomy IN (%s, %s)
+				AND T.taxonomy IN (%s, %s)
 			LIMIT %d
 			";
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The reindexing action for post links should not throw exceptions from SQL queries.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where reindexing the post links would not succeed.

## Relevant technical choices:

* I've prefixed all other fields in the query as well to prevent future issues from arising in case any of the other tables being joined change.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Build the environment (`$ composer; yarn; grunt install`)
* Make sure not to have any plugin activated like Debug Bar or Query Monitor
* Go to any of the Yoast SEO admin pages
* Verify that no Database error is reported at the top of the screen
* Now go to SEO > Tools and click "Start SEO data optimization" button
* Verify that the success message is shown


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Make sure not to have any plugin activated like Debug Bar or Query Monitor
* Go to any of the Yoast SEO admin pages
* Verify that no Database error is reported at the top of the screen
* Now go to SEO > Tools and click "Start SEO data optimization" button
* Verify that the success message is shown

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
