### PR TITLE
Show auto update notification on multisite subsites

### DIFF
--- a/src/helpers/site-helper.php
+++ b/src/helpers/site-helper.php
@@ -20,8 +20,6 @@ class Site_Helper {
 	 * Checks if the current installation is a multisite and there has been a switch
 	 * between the set multisites.
 	 *
-	 * @codeCoverageIgnore It wraps WordPress functions.
-	 *
 	 * @return bool True when there was a switch between the multisites.
 	 */
 	public function is_multisite_and_switched() {

--- a/src/integrations/watchers/auto-update-watcher.php
+++ b/src/integrations/watchers/auto-update-watcher.php
@@ -60,8 +60,8 @@ class Auto_Update_Watcher implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'admin_init', [ $this, 'auto_update_notification_not_if_dismissed' ] );
-		\add_action( 'update_option_auto_update_core_major', [ $this, 'auto_update_notification_even_if_dismissed' ] );
-		\add_action( 'update_option_auto_update_plugins', [ $this, 'auto_update_notification_not_if_dismissed' ] );
+		\add_action( 'update_site_option_auto_update_core_major', [ $this, 'auto_update_notification_even_if_dismissed' ] );
+		\add_action( 'update_site_option_auto_update_plugins', [ $this, 'auto_update_notification_not_if_dismissed' ] );
 	}
 
 	/**
@@ -107,7 +107,7 @@ class Auto_Update_Watcher implements Integration_Interface {
 	 * @return bool Whether the notification should be shown.
 	 */
 	protected function should_show_notification() {
-		$core_updates_enabled  = \get_option( 'auto_update_core_major' ) === 'enabled';
+		$core_updates_enabled  = \get_site_option( 'auto_update_core_major' ) === 'enabled';
 		$yoast_updates_enabled = $this->yoast_auto_updates_enabled();
 
 		return $core_updates_enabled && ! $yoast_updates_enabled;
@@ -172,7 +172,7 @@ class Auto_Update_Watcher implements Integration_Interface {
 	 * @return bool True if they are enabled, false if not.
 	 */
 	protected function yoast_auto_updates_enabled() {
-		$plugins_to_auto_update = \get_option( 'auto_update_plugins' );
+		$plugins_to_auto_update = \get_site_option( 'auto_update_plugins' );
 
 		// If no plugins are set to be automatically updated, it means that Yoast SEO isn't either.
 		if ( ! $plugins_to_auto_update ) {

--- a/src/presenters/admin/auto-update-notification-presenter.php
+++ b/src/presenters/admin/auto-update-notification-presenter.php
@@ -16,7 +16,30 @@ class Auto_Update_Notification_Presenter extends Abstract_Presenter {
 	 */
 	public function present() {
 		$notification_text  = '<p>';
-		$notification_text .= \sprintf(
+		$notification_text .= $this->get_message();
+		$notification_text .= '</p>';
+
+		return $notification_text;
+	}
+
+	/**
+	 * Returns the message to show.
+	 *
+	 * @return string The message.
+	 */
+	protected function get_message() {
+		if ( \is_multisite() ) {
+			return \sprintf(
+				/* Translators: %1$s expands to 'Yoast SEO', %2$s to an opening anchor tag for a link leading to the Plugins page, and %3$s to a closing anchor tag. */
+				\esc_html__(
+					'We see that you enabled automatic updates for Wordpress. We recommend that you do this for %1$s as well. This way we can guarantee that Wordpress and %1$s will continue to run smoothly together. Please contact your network admin to enable auto-updates for %1$s.',
+					'wordpress-seo'
+				),
+				'Yoast SEO'
+			);
+		}
+
+		return \sprintf(
 			/* Translators: %1$s expands to 'Yoast SEO', %2$s to an opening anchor tag for a link leading to the Plugins page, and %3$s to a closing anchor tag. */
 			\esc_html__(
 				'We see that you enabled automatic updates for WordPress. We recommend that you do this for %1$s as well. This way we can guarantee that WordPress and %1$s will continue to run smoothly together. %2$sGo to your plugins overview to enable auto-updates for %1$s.%3$s',
@@ -26,8 +49,6 @@ class Auto_Update_Notification_Presenter extends Abstract_Presenter {
 			'<a href="' . \esc_url( \get_admin_url( null, 'plugins.php' ) ) . '">',
 			'</a>'
 		);
-		$notification_text .= '</p>';
-
-		return $notification_text;
 	}
+
 }

--- a/tests/unit/helpers/site-helper-test.php
+++ b/tests/unit/helpers/site-helper-test.php
@@ -16,6 +16,22 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 class Site_Helper_Test extends TestCase {
 
 	/**
+	 * The instance to test.
+	 *
+	 * @var Site_Helper
+	 */
+	protected $instance;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->instance = new Site_Helper();
+	}
+
+	/**
 	 * Tests retrieval of the site name.
 	 *
 	 * @covers ::get_site_name
@@ -32,5 +48,21 @@ class Site_Helper_Test extends TestCase {
 		$site_helper = new Site_Helper();
 
 		$this->assertEquals( 'name', $site_helper->get_site_name() );
+	}
+
+	/**
+	 * Checks the result of is_multisite_and_switched.
+	 *
+	 * @covers ::is_multisite_and_switched
+	 */
+	public function test_is_multisite_and_switched() {
+		Monkey\Functions\stubs(
+			[
+				'is_multisite'   => true,
+				'ms_is_switched' => true,
+			]
+		);
+
+		self::assertTrue( $this->instance->is_multisite_and_switched() );
 	}
 }

--- a/tests/unit/integrations/watchers/auto-update-watcher-test.php
+++ b/tests/unit/integrations/watchers/auto-update-watcher-test.php
@@ -81,8 +81,8 @@ class Auto_Update_Watcher_Test extends TestCase {
 	 */
 	public function test_register_hooks() {
 		Monkey\Actions\expectAdded( 'admin_init' );
-		Monkey\Actions\expectAdded( 'update_option_auto_update_core_major' );
-		Monkey\Actions\expectAdded( 'update_option_auto_update_plugins' );
+		Monkey\Actions\expectAdded( 'update_site_option_auto_update_core_major' );
+		Monkey\Actions\expectAdded( 'update_site_option_auto_update_plugins' );
 
 		$this->instance->register_hooks();
 	}
@@ -102,12 +102,12 @@ class Auto_Update_Watcher_Test extends TestCase {
 	 * @covers ::save_dismissal_status
 	 */
 	public function test_toggle_core_auto_updates_no_notification( $core_updates_enabled, $plugins_to_auto_update ) {
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_core_major' )
 			->once()
 			->andReturn( $core_updates_enabled );
 
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_plugins' )
 			->once()
 			->andReturn( $plugins_to_auto_update );
@@ -157,12 +157,12 @@ class Auto_Update_Watcher_Test extends TestCase {
 	 * @covers ::maybe_create_notification
 	 */
 	public function test_auto_update_notification_enable_core_while_yoast_disabled() {
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_core_major' )
 			->once()
 			->andReturn( 'enabled' );
 
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_plugins' )
 			->once()
 			->andReturn( [ 'not_yoast_seo', 'another_plugin_file' ] );
@@ -192,12 +192,12 @@ class Auto_Update_Watcher_Test extends TestCase {
 	 * @covers ::notification
 	 */
 	public function test_auto_update_notification_enable_core_while_yoast_disabled_create_notification() {
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_core_major' )
 			->once()
 			->andReturn( 'enabled' );
 
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_plugins' )
 			->once()
 			->andReturn( [ 'not_yoast_seo', 'another_plugin_file' ] );
@@ -246,12 +246,12 @@ class Auto_Update_Watcher_Test extends TestCase {
 	 * @covers ::maybe_remove_notification
 	 */
 	public function test_auto_update_notification_enable_yoast_while_core_enabled_save_dismiss_status() {
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_core_major' )
 			->once()
 			->andReturn( 'enabled' );
 
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_plugins' )
 			->once()
 			->andReturn( [ 'wordpress-seo/wp-seo.php', 'another_plugin_file' ] );
@@ -299,12 +299,12 @@ class Auto_Update_Watcher_Test extends TestCase {
 	 * @covers ::maybe_create_notification_if_not_dismissed
 	 */
 	public function test_auto_update_notification_disable_yoast_while_core_enabled() {
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_core_major' )
 			->once()
 			->andReturn( 'enabled' );
 
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_plugins' )
 			->twice()
 			->andReturn( [ 'not_yoast_seo', 'another_plugin_file' ] );
@@ -340,12 +340,12 @@ class Auto_Update_Watcher_Test extends TestCase {
 	 * @covers ::maybe_create_notification_if_not_dismissed
 	 */
 	public function test_auto_update_notification_disable_yoast_while_core_enabled_notification_dismissed() {
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_core_major' )
 			->once()
 			->andReturn( 'enabled' );
 
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_plugins' )
 			->twice()
 			->andReturn( [ 'not_yoast_seo', 'another_plugin_file' ] );

--- a/tests/unit/presenters/admin/auto-update-notification-presenter-test.php
+++ b/tests/unit/presenters/admin/auto-update-notification-presenter-test.php
@@ -40,6 +40,7 @@ class Auto_Update_Notification_Presenter_Test extends TestCase {
 	 * Tests returning the notification as an HTML string.
 	 *
 	 * @covers ::present
+	 * @covers ::get_message
 	 */
 	public function test_present() {
 		Monkey\Functions\expect( 'get_admin_url' )
@@ -53,5 +54,23 @@ class Auto_Update_Notification_Presenter_Test extends TestCase {
 		$expected = '<p>We see that you enabled automatic updates for WordPress. We recommend that you do this for Yoast SEO as well. This way we can guarantee that WordPress and Yoast SEO will continue to run smoothly together. <a href="http://basic.wordpress.test/wp-admin/plugins.php">Go to your plugins overview to enable auto-updates for Yoast SEO.</a></p>';
 
 		$this->assertSame( $expected, $this->instance->present() );
+	}
+
+	/**
+	 * Tests returning the multisite notification as an HTML string.
+	 *
+	 * @covers ::present
+	 * @covers ::get_message
+	 */
+	public function test_present_for_multisite() {
+		Monkey\Functions\stubs(
+			[
+				'is_multisite' => true,
+			]
+		);
+
+		$expected = '<p>We see that you enabled automatic updates for Wordpress. We recommend that you do this for Yoast SEO as well. This way we can guarantee that Wordpress and Yoast SEO will continue to run smoothly together. Please contact your network admin to enable auto-updates for Yoast SEO.</p>';
+
+		self::assertSame( $expected, $this->instance->present() );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Sites in an network don't have the ability to enable/disable auto updates. This has to be done on network admin level.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the message in the notification for sites in a network to tell them to contact there network admin to enable automatic updates for Yoast SEO. 

## Relevant technical choices:

* It added unit tests for `Site_Helper::test_is_multisite_and_switched` because I implemented a method there that I removed later because it felt useless to have a wrapper method for `is_multisite`. Because I added also a test for the existing method I decided to keep this test.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have auto updates for WordPress enabled
* Have the auto updates for Yoast SEO disabled
* Visit the admin of a site in your network
* See a notification being given that tells the user to contact his admin
* Hide the notification
* Enable the auto updates for Yoast SEO
* The notification is completely gone
* Disable the auto updates for Yoast SEO
* The notification should be still gone.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
