### PR TITLE
Make the addon-update-watcher work for multisite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,8 +80,8 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=340",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=227",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=339",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=225",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs-summary": [

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -803,7 +803,7 @@ class WPSEO_Upgrade {
 	private function upgrade_1591() {
 		$enabled_auto_updates = \get_option( 'auto_update_plugins' );
 		$addon_update_watcher = YoastSEO()->classes->get( \Yoast\WP\SEO\Integrations\Watchers\Addon_Update_Watcher::class );
-		$addon_update_watcher->toggle_auto_updates_for_add_ons( [], $enabled_auto_updates );
+		$addon_update_watcher->toggle_auto_updates_for_add_ons( 'auto_update_plugins', [], $enabled_auto_updates );
 	}
 
 	/**

--- a/src/integrations/watchers/addon-update-watcher.php
+++ b/src/integrations/watchers/addon-update-watcher.php
@@ -112,14 +112,15 @@ class Addon_Update_Watcher implements Integration_Interface {
 	 */
 	public function toggle_auto_updates_for_add_ons( $option, $new_value, $old_value ) {
 		if ( $option !== 'auto_update_plugins' ) {
+			// If future versions of WordPress change this filter's behavior, our behavior should stay consistent.
 			return;
 		}
 
-		if ( ! \is_array( $old_value ) || ! \is_array( $new_value ) ) {
+		if ( !\is_array( $old_value ) || !\is_array( $new_value )) {
 			return;
 		}
 
-		$auto_updates_are_enabled  = $this->are_auto_updates_enabled( self::WPSEO_FREE_PLUGIN_ID, $new_value );
+		$auto_updates_are_enabled = $this->are_auto_updates_enabled( self::WPSEO_FREE_PLUGIN_ID, $new_value );
 		$auto_updates_were_enabled = $this->are_auto_updates_enabled( self::WPSEO_FREE_PLUGIN_ID, $old_value );
 
 		if ( $auto_updates_are_enabled === $auto_updates_were_enabled ) {
@@ -127,15 +128,13 @@ class Addon_Update_Watcher implements Integration_Interface {
 			return;
 		}
 
-		$auto_updates_have_been_enabled = $auto_updates_are_enabled && ! $auto_updates_were_enabled;
+		$auto_updates_have_been_enabled = $auto_updates_are_enabled && !$auto_updates_were_enabled;
 
 		if ( $auto_updates_have_been_enabled ) {
 			$this->enable_auto_updates_for_addons( $new_value );
-
-			return;
+		} else {
+			$this->disable_auto_updates_for_addons( $new_value );
 		}
-
-		$this->disable_auto_updates_for_addons( $new_value );
 	}
 
 	/**

--- a/src/integrations/watchers/addon-update-watcher.php
+++ b/src/integrations/watchers/addon-update-watcher.php
@@ -37,13 +37,13 @@ class Addon_Update_Watcher implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action(
-			'update_option_auto_update_plugins',
+			'update_site_option_auto_update_plugins',
 			[
 				$this,
 				'toggle_auto_updates_for_add_ons',
 			],
 			10,
-			2
+			3
 		);
 		\add_filter( 'plugin_auto_update_setting_html', [ $this, 'replace_auto_update_toggles_of_addons' ], 10, 2 );
 	}
@@ -78,7 +78,7 @@ class Addon_Update_Watcher implements Integration_Interface {
 			return $old_html;
 		}
 
-		$auto_updated_plugins = \get_option( 'auto_update_plugins' );
+		$auto_updated_plugins = \get_site_option( 'auto_update_plugins' );
 
 		if ( $this->are_auto_updates_enabled( self::WPSEO_FREE_PLUGIN_ID, $auto_updated_plugins ) ) {
 			return \sprintf(
@@ -104,12 +104,17 @@ class Addon_Update_Watcher implements Integration_Interface {
 	/**
 	 * Enables premium auto updates when free are enabled and the other way around.
 	 *
-	 * @param array $old_value The old value of the `auto_update_plugins` option.
-	 * @param array $new_value The new value of the `auto_update_plugins` option.
+	 * @param string $option    The name of the option that has been updated.
+	 * @param array  $new_value The new value of the `auto_update_plugins` option.
+	 * @param array  $old_value The old value of the `auto_update_plugins` option.
 	 *
 	 * @return void
 	 */
-	public function toggle_auto_updates_for_add_ons( $old_value, $new_value ) {
+	public function toggle_auto_updates_for_add_ons( $option, $new_value, $old_value ) {
+		if ( $option !== 'auto_update_plugins' ) {
+			return;
+		}
+
 		if ( ! \is_array( $old_value ) || ! \is_array( $new_value ) ) {
 			return;
 		}
@@ -140,7 +145,7 @@ class Addon_Update_Watcher implements Integration_Interface {
 	 */
 	protected function enable_auto_updates_for_addons( $auto_updated_plugins ) {
 		$plugins = \array_merge( $auto_updated_plugins, self::ADD_ONS );
-		\update_option( 'auto_update_plugins', $plugins );
+		\update_site_option( 'auto_update_plugins', $plugins );
 	}
 
 	/**
@@ -149,7 +154,7 @@ class Addon_Update_Watcher implements Integration_Interface {
 	 * @param string[] $auto_updated_plugins The current list of auto-updated plugins.
 	 */
 	protected function disable_auto_updates_for_addons( $auto_updated_plugins ) {
-		\update_option( 'auto_update_plugins', \array_values( \array_diff( $auto_updated_plugins, self::ADD_ONS ) ) );
+		\update_site_option( 'auto_update_plugins', \array_values( \array_diff( $auto_updated_plugins, self::ADD_ONS ) ) );
 	}
 
 	/**

--- a/src/integrations/watchers/addon-update-watcher.php
+++ b/src/integrations/watchers/addon-update-watcher.php
@@ -154,7 +154,8 @@ class Addon_Update_Watcher implements Integration_Interface {
 	 * @param string[] $auto_updated_plugins The current list of auto-updated plugins.
 	 */
 	protected function disable_auto_updates_for_addons( $auto_updated_plugins ) {
-		\update_site_option( 'auto_update_plugins', \array_values( \array_diff( $auto_updated_plugins, self::ADD_ONS ) ) );
+		$plugins = \array_values( \array_diff( $auto_updated_plugins, self::ADD_ONS ) );
+		\update_site_option( 'auto_update_plugins', $plugins );
 	}
 
 	/**

--- a/src/integrations/watchers/addon-update-watcher.php
+++ b/src/integrations/watchers/addon-update-watcher.php
@@ -116,11 +116,11 @@ class Addon_Update_Watcher implements Integration_Interface {
 			return;
 		}
 
-		if ( !\is_array( $old_value ) || !\is_array( $new_value )) {
+		if ( ! \is_array( $old_value ) || ! \is_array( $new_value ) ) {
 			return;
 		}
 
-		$auto_updates_are_enabled = $this->are_auto_updates_enabled( self::WPSEO_FREE_PLUGIN_ID, $new_value );
+		$auto_updates_are_enabled  = $this->are_auto_updates_enabled( self::WPSEO_FREE_PLUGIN_ID, $new_value );
 		$auto_updates_were_enabled = $this->are_auto_updates_enabled( self::WPSEO_FREE_PLUGIN_ID, $old_value );
 
 		if ( $auto_updates_are_enabled === $auto_updates_were_enabled ) {
@@ -128,11 +128,12 @@ class Addon_Update_Watcher implements Integration_Interface {
 			return;
 		}
 
-		$auto_updates_have_been_enabled = $auto_updates_are_enabled && !$auto_updates_were_enabled;
+		$auto_updates_have_been_enabled = $auto_updates_are_enabled && ! $auto_updates_were_enabled;
 
 		if ( $auto_updates_have_been_enabled ) {
 			$this->enable_auto_updates_for_addons( $new_value );
-		} else {
+		}
+		else {
 			$this->disable_auto_updates_for_addons( $new_value );
 		}
 	}

--- a/src/presenters/admin/auto-update-notification-presenter.php
+++ b/src/presenters/admin/auto-update-notification-presenter.php
@@ -32,7 +32,7 @@ class Auto_Update_Notification_Presenter extends Abstract_Presenter {
 			return \sprintf(
 				/* Translators: %1$s expands to 'Yoast SEO', %2$s to an opening anchor tag for a link leading to the Plugins page, and %3$s to a closing anchor tag. */
 				\esc_html__(
-					'We see that you enabled automatic updates for Wordpress. We recommend that you do this for %1$s as well. This way we can guarantee that Wordpress and %1$s will continue to run smoothly together. Please contact your network admin to enable auto-updates for %1$s.',
+					'We see that you enabled automatic updates for WordPress. We recommend that you do this for %1$s as well. This way we can guarantee that WordPress and %1$s will continue to run smoothly together. Please contact your network admin to enable auto-updates for %1$s.',
 					'wordpress-seo'
 				),
 				'Yoast SEO'
@@ -50,5 +50,4 @@ class Auto_Update_Notification_Presenter extends Abstract_Presenter {
 			'</a>'
 		);
 	}
-
 }

--- a/tests/unit/integrations/watchers/addon-update-watcher-test.php
+++ b/tests/unit/integrations/watchers/addon-update-watcher-test.php
@@ -43,7 +43,7 @@ class Addon_Update_Watcher_Test extends TestCase {
 	 * @covers ::register_hooks
 	 */
 	public function test_register_hooks() {
-		Monkey\Actions\expectAdded( 'update_option_auto_update_plugins' )
+		Monkey\Actions\expectAdded( 'update_site_option_auto_update_plugins' )
 			->with( [ $this->instance, 'toggle_auto_updates_for_add_ons' ] )
 			->once();
 
@@ -69,10 +69,10 @@ class Addon_Update_Watcher_Test extends TestCase {
 	 * @covers ::toggle_auto_updates_for_add_ons
 	 */
 	public function test_do_not_toggle_when_old_value_not_array() {
-		Monkey\Functions\expect( 'update_option' )
+		Monkey\Functions\expect( 'update_site_option' )
 			->never();
 
-		$this->instance->toggle_auto_updates_for_add_ons( 'the old value', [ 'the_new_value' ] );
+		$this->instance->toggle_auto_updates_for_add_ons( 'auto_update_plugins', [ 'the_new_value' ], 'the old value' );
 	}
 
 	/**
@@ -81,26 +81,38 @@ class Addon_Update_Watcher_Test extends TestCase {
 	 * @covers ::toggle_auto_updates_for_add_ons
 	 */
 	public function test_do_not_toggle_when_new_value_not_array() {
-		Monkey\Functions\expect( 'update_option' )
+		Monkey\Functions\expect( 'update_site_option' )
 			->never();
 
-		$this->instance->toggle_auto_updates_for_add_ons( [ 'the old value' ], 'the_new_value' );
+		$this->instance->toggle_auto_updates_for_add_ons( 'auto_update_plugins', 'the_new_value', [ 'the old value' ] );
 	}
 
 	/**
-	 * Tests that auto updates for add-ons are ensabled when auto updates
-	 * for Free are ensabled.
+	 * Tests that nothing happens when the option is not 'auto_update_plugins'.
+	 *
+	 * @covers ::toggle_auto_updates_for_add_ons
+	 */
+	public function test_do_not_toggle_when_option_has_unexpected_value() {
+		Monkey\Functions\expect( 'update_site_option' )
+			->never();
+
+		$this->instance->toggle_auto_updates_for_add_ons( 'another_option', [ 'the_new_value' ], [ 'the old value' ] );
+	}
+
+	/**
+	 * Tests that auto updates for add-ons are enabled when auto updates
+	 * for Free are enabled.
 	 *
 	 * @covers ::toggle_auto_updates_for_add_ons
 	 * @covers ::are_auto_updates_enabled
 	 * @covers ::disable_auto_updates_for_addons
 	 * @covers ::enable_auto_updates_for_addons
 	 */
-	public function test_enable_auto_updates_for_add_ons_on_free_auto_update_enable() {
+	public function test_enable_auto_updates_for_add_ons_on_free_auto_update_enabled() {
 		$old = [ 'other-plugin/plugin.php' ];
 		$new = [ 'other-plugin/plugin.php', 'wordpress-seo/wp-seo.php' ];
 
-		$option = [
+		$plugins = [
 			'other-plugin/plugin.php',
 			'wordpress-seo/wp-seo.php',
 			'wordpress-seo-premium/wp-seo-premium.php',
@@ -110,14 +122,15 @@ class Addon_Update_Watcher_Test extends TestCase {
 			'wpseo-news/wpseo-news.php',
 		];
 
-		Monkey\Functions\expect( 'update_option' )
+		Monkey\Functions\expect( 'update_site_option' )
 			->once()
-			->with( 'auto_update_plugins', $option )
+			->with( 'auto_update_plugins', $plugins )
 			->andReturn( true );
 
 		$this->instance->toggle_auto_updates_for_add_ons(
-			$old,
-			$new
+			'auto_update_plugins',
+			$new,
+			$old
 		);
 	}
 
@@ -151,24 +164,24 @@ class Addon_Update_Watcher_Test extends TestCase {
 			'yoast-acf-analysis/yoast-acf-analysis.php',
 		];
 
-		$option = [
+		$plugins = [
 			'other-plugin/plugin.php',
 			'yoast-acf-analysis/yoast-acf-analysis.php',
 		];
 
-		Monkey\Functions\expect( 'update_option' )
+		Monkey\Functions\expect( 'update_site_option' )
 			->once()
-			->with( 'auto_update_plugins', $option );
+			->with( 'auto_update_plugins', $plugins );
 
 		$this->instance->toggle_auto_updates_for_add_ons(
-			$old,
-			$new
+			'auto_update_plugins',
+			$new,
+			$old
 		);
 	}
 
 	/**
-	 * Tests that auto updates for add-ons are enabled when auto updates
-	 * for Free are enabled.
+	 * Tests that nothing happens when auto updates are toggled for a plugin other than Yoast SEO.
 	 *
 	 * @covers ::toggle_auto_updates_for_add_ons
 	 * @covers ::are_auto_updates_enabled
@@ -194,17 +207,18 @@ class Addon_Update_Watcher_Test extends TestCase {
 			'yoast-acf-analysis/yoast-acf-analysis.php',
 		];
 
-		$option = [
+		$plugins = [
 			'other-plugin/plugin.php',
 		];
 
-		Monkey\Functions\expect( 'update_option' )
-			->with( 'auto_update_plugins', $option )
+		Monkey\Functions\expect( 'update_site_option' )
+			->with( 'auto_update_plugins', $plugins )
 			->never();
 
 		$this->instance->toggle_auto_updates_for_add_ons(
-			$old,
-			$new
+			'auto_update_plugins',
+			$new,
+			$old
 		);
 	}
 
@@ -217,7 +231,7 @@ class Addon_Update_Watcher_Test extends TestCase {
 	public function test_html_not_replaced_when_html_not_string() {
 		$old_html = 123;
 
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->never();
 
 		$new_html = $this->instance->replace_auto_update_toggles_of_addons(
@@ -237,7 +251,7 @@ class Addon_Update_Watcher_Test extends TestCase {
 	public function test_html_not_replaced_when_auto_updated_plugins_does_not_exist() {
 		$old_html = 'old_html';
 
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_plugins' )
 			->andReturn( false );
 
@@ -258,7 +272,7 @@ class Addon_Update_Watcher_Test extends TestCase {
 	public function test_html_not_replaced_when_auto_updated_plugins_not_an_array() {
 		$old_html = 'old_html';
 
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_plugins' )
 			->andReturn( 'the_plugin_as_string' );
 
@@ -280,7 +294,7 @@ class Addon_Update_Watcher_Test extends TestCase {
 	public function test_do_not_replace_auto_update_toggles_from_other_plugins() {
 		$old_html = 'old_html';
 
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_plugins' )
 			->andReturn( [ 'wordpress-seo/wp-seo.php' ] );
 
@@ -306,7 +320,7 @@ class Addon_Update_Watcher_Test extends TestCase {
 	public function test_replace_auto_update_toggles_from_addons_with_enabled_text( $plugin ) {
 		$old_html = 'old_html';
 
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_plugins' )
 			->andReturn( [ 'wordpress-seo/wp-seo.php' ] );
 
@@ -324,6 +338,7 @@ class Addon_Update_Watcher_Test extends TestCase {
 	 * when auto-updates for WordPress SEO are disabled.
 	 *
 	 * @covers ::replace_auto_update_toggles_of_addons
+	 * @covers ::are_auto_updates_enabled
 	 *
 	 * @param string $plugin The plugin string to test.
 	 *
@@ -332,9 +347,63 @@ class Addon_Update_Watcher_Test extends TestCase {
 	public function test_replace_auto_update_toggles_from_addons_with_disabled_text( $plugin ) {
 		$old_html = 'old_html';
 
-		Monkey\Functions\expect( 'get_option' )
+		Monkey\Functions\expect( 'get_site_option' )
 			->with( 'auto_update_plugins' )
 			->andReturn( [] );
+
+		$new_html = $this->instance->replace_auto_update_toggles_of_addons(
+			$old_html,
+			$plugin
+		);
+
+		self::assertEquals( '<em>Auto-updates are disabled based on this setting for Yoast SEO.</em>', $new_html );
+	}
+
+	/**
+	 * Tests the replacement of the auto-update toggles with the text
+	 * 'Auto-updates are disabled based on this setting for Yoast SEO.'
+	 * when the 'auto_update_plugins' database option returns false.
+	 *
+	 * @covers ::replace_auto_update_toggles_of_addons
+	 * @covers ::are_auto_updates_enabled
+	 *
+	 * @param string $plugin The plugin string to test.
+	 *
+	 * @dataProvider plugin_provider
+	 */
+	public function test_replace_auto_update_toggles_from_addons_when_enabled_plugins_false( $plugin ) {
+		$old_html = 'old_html';
+
+		Monkey\Functions\expect( 'get_site_option' )
+			->with( 'auto_update_plugins' )
+			->andReturn( false );
+
+		$new_html = $this->instance->replace_auto_update_toggles_of_addons(
+			$old_html,
+			$plugin
+		);
+
+		self::assertEquals( '<em>Auto-updates are disabled based on this setting for Yoast SEO.</em>', $new_html );
+	}
+
+	/**
+	 * Tests the replacement of the auto-update toggles with the text
+	 * 'Auto-updates are disabled based on this setting for Yoast SEO.'
+	 * when the 'auto_update_plugins' database option does not return an array.
+	 *
+	 * @covers ::replace_auto_update_toggles_of_addons
+	 * @covers ::are_auto_updates_enabled
+	 *
+	 * @param string $plugin The plugin string to test.
+	 *
+	 * @dataProvider plugin_provider
+	 */
+	public function test_replace_auto_update_toggles_from_addons_when_enabled_plugins_not_an_array( $plugin ) {
+		$old_html = 'old_html';
+
+		Monkey\Functions\expect( 'get_site_option' )
+			->with( 'auto_update_plugins' )
+			->andReturn( 'a string' );
 
 		$new_html = $this->instance->replace_auto_update_toggles_of_addons(
 			$old_html,

--- a/tests/unit/presenters/admin/auto-update-notification-presenter-test.php
+++ b/tests/unit/presenters/admin/auto-update-notification-presenter-test.php
@@ -69,7 +69,7 @@ class Auto_Update_Notification_Presenter_Test extends TestCase {
 			]
 		);
 
-		$expected = '<p>We see that you enabled automatic updates for Wordpress. We recommend that you do this for Yoast SEO as well. This way we can guarantee that Wordpress and Yoast SEO will continue to run smoothly together. Please contact your network admin to enable auto-updates for Yoast SEO.</p>';
+		$expected = '<p>We see that you enabled automatic updates for WordPress. We recommend that you do this for Yoast SEO as well. This way we can guarantee that WordPress and Yoast SEO will continue to run smoothly together. Please contact your network admin to enable auto-updates for Yoast SEO.</p>';
 
 		self::assertSame( $expected, $this->instance->present() );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* On multisite, when enabling auto-updates for Yoast SEO the auto-updates were not automatically enabled for the add-ons (as it works on single site).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where, on a multisite installation, enabling/disabling auto-updates for Yoast SEO would not automatically enable/disable auto-updates for Yoast SEO Premium and the other Yoast add-ons.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Preparations**
* Make sure that your site has (at least one of) the following Yoast add-ons:
	* Video SEO.
	* News SEO.
	* WooCommerce SEO.
* Install the ACF add-on through WordPress (in other words, using a released zip, not a GitHub clone).
* Add `'acf-content-analysis-for-yoast-seo/yoast-acf-analysis.php'` to the array of add-on plugin files in `addon-update-watcher.php`. 
    * We will use this plugin to test whether the auto-updates are actually working. For this, you need to be working with a released zip, and I'm assuming you don't want to delete your clones of the other Yoast add-ons 😉 
    
**Testing whether single site still works as expected**

_Testing the HTML output_
* Go to the plugins admin page.
* Toggle the auto-updates for Yoast SEO (Free) to **off**.
* Refresh the page.
* See that the add-ons (as listed above) have the following text in place of the 'enable auto-updates' toggle:
  > Auto-updates are disabled based on this setting for Yoast SEO.
* In your database, in the `wp_options` table, see that the option `auto_update_plugins` does NOT contain all the above add-ons.
* Toggle the auto-updates for Yoast SEO to **on**.
* Refresh the page.
* See that the add-ons (as listed above) have the following text in place of the 'disable auto-updates' toggle:
  > Auto-updates are enabled based on this setting for Yoast SEO.
* In your database, in the `wp_options` table, see that the option `auto_update_plugins` is an array which contains all the above add-ons (and potentially other plugins too).

_Testing whether auto-updates work_
* Using the Plugin Editor in the WordPress back-end, set the version of the ACF add-on to `3.0.0`.
* On line 901 of `wordpress/wp-includes/update.php`, change `add_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );` to `add_action( 'admin_init', 'wp_maybe_auto_update' );` to trigger the plugin auto updates.
* Refresh the plugins page and see that ACF has been updated to its latest version.
* Restore `update.php` to its original version. 

**Testing on multisite**

_Testing the HTML output_
* Go to the plugins admin page.
* Toggle the auto-updates for Yoast SEO (Free) to **off**.
* Refresh the page.
* See that the add-ons (as listed above) have the following text in place of the 'enable auto-updates' toggle:
  > Auto-updates are disabled based on this setting for Yoast SEO.
* In your database, in the `wp_sitemeta` table, see that the option `auto_update_plugins` does NOT contain all the above add-ons.
* Toggle the auto-updates for Yoast SEO to **on**.
* Refresh the page.
* See that the add-ons (as listed above) have the following text in place of the 'disable auto-updates' toggle:
  > Auto-updates are enabled based on this setting for Yoast SEO.
* In your database, in the `wp_sitemeta` table, see that the option `auto_update_plugins` is an array which contains all the above add-ons (and potentially other plugins too).

_Testing whether auto-updates work_
* Using the Plugin Editor in the WordPress back-end, set the version of the ACF add-on to `3.0.0`.
* On line 901 of `wordpress/wp-includes/update.php`, change `add_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );` to `add_action( 'admin_init', 'wp_maybe_auto_update' );` to trigger the plugin auto updates.
* Refresh the plugins page and see that ACF has been updated to its latest version.
* Restore `update.php` to its original version. 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Since QA doesn't work with GitHub clones, the part I wrote about ACF is not applicable. 
* So QA can follow the above steps, but should lower the plugin version in another add-on (for example Video or News) to test whether that add-on is correctly auto-updated when `wp_maybe_auto_update` triggers the plugin auto-updates.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-745
