### PR TITLE
Add buffer and htmlparser as externals

### DIFF
--- a/config/webpack/externals.js
+++ b/config/webpack/externals.js
@@ -19,7 +19,7 @@ const externals = {
 	"styled-components": "window.yoast.styledComponents",
 	"draft-js": "window.yoast.draftJs",
 	buffer: "window.yoast.buffer",
-	//htmlparser2: "window.yoast.htmlparser2/lib",
+	htmlparser2: "window.yoast.htmlparser2",
 };
 
 /**

--- a/config/webpack/externals.js
+++ b/config/webpack/externals.js
@@ -18,6 +18,8 @@ const externals = {
 	"react-redux": "window.yoast.reactRedux",
 	"styled-components": "window.yoast.styledComponents",
 	"draft-js": "window.yoast.draftJs",
+	buffer: "window.yoast.buffer",
+	//htmlparser2: "window.yoast.htmlparser2/lib",
 };
 
 /**

--- a/js/src/externals/analysis.js
+++ b/js/src/externals/analysis.js
@@ -1,2 +1,4 @@
 window.yoast = window.yoast || {};
 window.yoast.analysis = require( "yoastseo/index.js" );
+window.yoast.buffer = require( "buffer" );
+window.yoast.htmlparser2 = require( "htmlparser2/lib" );

--- a/js/src/externals/analysis.js
+++ b/js/src/externals/analysis.js
@@ -1,4 +1,6 @@
+import * as htmlParser from "../../../node_modules/htmlparser2/lib";
+
 window.yoast = window.yoast || {};
 window.yoast.analysis = require( "yoastseo/index.js" );
 window.yoast.buffer = require( "buffer" );
-window.yoast.htmlparser2 = require( "htmlparser2/lib" );
+window.yoast.htmlparser2 = htmlParser;

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "draft-js": "^0.10.5",
     "draft-js-mention-plugin": "^3.0.4",
     "find-with-regex": "~1.0.2",
-    "htmlparser2": "^6.0.1",
     "interpolate-components": "^1.1.0",
     "jed": "^1.1.1",
     "marked": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "draft-js": "^0.10.5",
     "draft-js-mention-plugin": "^3.0.4",
     "find-with-regex": "~1.0.2",
+    "htmlparser2": "^6.0.1",
     "interpolate-components": "^1.1.0",
     "jed": "^1.1.1",
     "marked": "^0.7.0",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Within the separate language bundles, there are duplicate files `buffer` and `htmlparser2/lib` which contribute to the large zip size. This can be fixed by changing the files to externals.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes `buffer` and `htmlparser2/lib` to externals.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check out the `language-split-2` branch in javascript and link the wordpress-seo branch to the monorepo.
* Run `BUNDLE_ANALYZER=true grunt build:dev`
* This should open files in the browser, the last of these files should show the language bundles.
* Make sure that you do not see `buffer` and `htmlParser2` in the language bundles.
* Build the plugin, open the post editor, and make sure there are no (new) console errors.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* No testing from QA needed.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
