### PR TITLE
Patch for Issue #16803

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -124,6 +124,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 				    ORDER BY post_modified_gmt ASC
 				";
 
+				$wpdb->query('SET @rownum = 0');
 				$all_dates = $wpdb->get_col( $wpdb->prepare( $sql, $post_type, $max_entries ) );
 			}
 


### PR DESCRIPTION
## Context

Issue occured where the sitemap would yield error due to SQL query returning null/zero results in class-post-type-sitemap-provider.php when fetching dates for WooCommerce products from WordPress database. The query in question is defined between the code line numbers 117-125 in class-post-type-sitemap-provider.php.

## Summary

Fixes a bug where the user-defined variable within forementioned query is not properly yielded thus resulting in null/zero-row results despite data being generated - It has been resolved by executing a small query where the user-defined variable is explicitly defined and set before main SQL query.

## Quality assurance

* [-] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
