### PR TITLE
Adapt settings replacement form to support custom field labels and placeholder

### DIFF
--- a/admin/menu/class-replacevar-editor.php
+++ b/admin/menu/class-replacevar-editor.php
@@ -21,11 +21,14 @@ class WPSEO_Replacevar_Editor {
 	 * The arguments required for the div to render.
 	 *
 	 * @var array {
-	 *      @type string $title                 The title field id.
-	 *      @type string $description           The description field id.
-	 *      @type string $page_type_recommended The page type for the context of the recommended replace vars.
-	 *      @type string $page_type_specific    The page type for the context of the editor specific replace vars.
-	 *      @type bool   $paper_style           Optional. Whether the editor has paper style.
+	 *      @type string $title                   The title field id.
+	 *      @type string $description             The description field id.
+	 *      @type string $page_type_recommended   The page type for the context of the recommended replace vars.
+	 *      @type string $page_type_specific      The page type for the context of the editor specific replace vars.
+	 *      @type bool   $paper_style             Optional. Whether the editor has paper style.
+	 *      @type string $label_title             Optional. The label to use for the title field.
+	 *      @type string $label_description       Optional. The label to use for the description field.
+	 *      @type string $description_placeholder Optional. The placeholder text to use for the description field.
 	 * }
 	 */
 	private $arguments;
@@ -37,18 +40,24 @@ class WPSEO_Replacevar_Editor {
 	 * @param array      $arguments {
 	 *      The arguments that can be given.
 	 *
-	 *      @type string $title                 The title field id.
-	 *      @type string $description           The description field id.
-	 *      @type string $page_type_recommended The page type for the context of the recommended replace vars.
-	 *      @type string $page_type_specific    The page type for the context of the editor specific replace vars.
-	 *      @type bool   $paper_style           Optional. Whether the editor has paper style.
+	 *      @type string $title                   The title field id.
+	 *      @type string $description             The description field id.
+	 *      @type string $page_type_recommended   The page type for the context of the recommended replace vars.
+	 *      @type string $page_type_specific      The page type for the context of the editor specific replace vars.
+	 *      @type bool   $paper_style             Optional. Whether the editor has paper style.
+	 *      @type string $label_title             Optional. The label to use for the title field.
+	 *      @type string $label_description       Optional. The label to use for the description field.
+	 *      @type string $description_placeholder Optional. The placeholder text to use for the description field.
 	 * }
 	 */
 	public function __construct( Yoast_Form $yform, $arguments ) {
 		$arguments = wp_parse_args(
 			$arguments,
 			[
-				'paper_style' => true,
+				'paper_style'             => true,
+				'label_title'             => '',
+				'label_description'       => '',
+				'description_placeholder' => '',
 			]
 		);
 
@@ -56,11 +65,14 @@ class WPSEO_Replacevar_Editor {
 
 		$this->yform     = $yform;
 		$this->arguments = [
-			'title'                 => (string) $arguments['title'],
-			'description'           => (string) $arguments['description'],
-			'page_type_recommended' => (string) $arguments['page_type_recommended'],
-			'page_type_specific'    => (string) $arguments['page_type_specific'],
-			'paper_style'           => (bool) $arguments['paper_style'],
+			'title'                   => (string) $arguments['title'],
+			'description'             => (string) $arguments['description'],
+			'page_type_recommended'   => (string) $arguments['page_type_recommended'],
+			'page_type_specific'      => (string) $arguments['page_type_specific'],
+			'paper_style'             => (bool) $arguments['paper_style'],
+			'label_title'             => (string) $arguments['label_title'],
+			'label_description'       => (string) $arguments['label_description'],
+			'description_placeholder' => (string) $arguments['description_placeholder'],
 		];
 	}
 
@@ -82,12 +94,18 @@ class WPSEO_Replacevar_Editor {
 				data-react-replacevar-metadesc-field-id="%2$s"
 				data-react-replacevar-page-type-recommended="%3$s"
 				data-react-replacevar-page-type-specific="%4$s"
-				data-react-replacevar-paper-style="%5$s"></div>',
+				data-react-replacevar-paper-style="%5$s"
+				data-react-replacevar-label-title="%6$s"
+				data-react-replacevar-label-description="%7$s"
+				data-react-replacevar-description-placeholder="%8$s"></div>',
 			esc_attr( $this->arguments['title'] ),
 			esc_attr( $this->arguments['description'] ),
 			esc_attr( $this->arguments['page_type_recommended'] ),
 			esc_attr( $this->arguments['page_type_specific'] ),
-			esc_attr( $this->arguments['paper_style'] )
+			esc_attr( $this->arguments['paper_style'] ),
+			esc_attr( $this->arguments['label_title'] ),
+			esc_attr( $this->arguments['label_description'] ),
+			esc_attr( $this->arguments['description_placeholder'] )
 		);
 	}
 

--- a/js/src/components/SettingsReplacementVariableEditor.js
+++ b/js/src/components/SettingsReplacementVariableEditor.js
@@ -29,6 +29,7 @@ class SettingsReplacementVariableEditor extends Component {
 			recommendedReplacementVariables,
 			titleTarget,
 			descriptionTarget,
+			descriptionPlaceholder,
 		} = this.props;
 
 		return (
@@ -36,7 +37,7 @@ class SettingsReplacementVariableEditor extends Component {
 				hasPaperStyle={ this.props.hasPaperStyle }
 			>
 				<SettingsSnippetEditor
-					descriptionEditorFieldPlaceholder={ __( "Modify your meta description by editing it right here", "wordpress-seo" ) }
+					descriptionEditorFieldPlaceholder={ descriptionPlaceholder }
 					onChange={ ( field, value ) => {
 						switch ( field ) {
 							case "title":
@@ -58,6 +59,7 @@ class SettingsReplacementVariableEditor extends Component {
 						title: titleTarget + "-snippet-editor",
 						description: descriptionTarget + "-snippet-editor",
 					} }
+					labels={ labels }
 				/>
 			</SnippetPreviewSection>
 		);
@@ -73,10 +75,20 @@ SettingsReplacementVariableEditor.propTypes = {
 	hasPaperStyle: PropTypes.bool,
 	titleTarget: PropTypes.string.isRequired,
 	descriptionTarget: PropTypes.string.isRequired,
+	labels: PropTypes.shape( {
+		title: PropTypes.string,
+		description: PropTypes.string,
+	} ),
+	descriptionPlaceholder: PropTypes.string,
 };
 
 SettingsReplacementVariableEditor.defaultProps = {
 	hasPaperStyle: true,
+	labels: {
+		title: "",
+		description: "",
+	},
+	descriptionPlaceholder: __( "Modify your meta description by editing it right here", "wordpress-seo" ),
 };
 
 export default linkHiddenFields( props => {

--- a/js/src/components/SettingsReplacementVariableEditor.js
+++ b/js/src/components/SettingsReplacementVariableEditor.js
@@ -33,12 +33,14 @@ class SettingsReplacementVariableEditor extends Component {
 			descriptionPlaceholder,
 		} = this.props;
 
+		const placeholder = descriptionPlaceholder || __( "Modify your meta description by editing it right here", "wordpress-seo" );
+
 		return (
 			<SnippetPreviewSection
 				hasPaperStyle={ this.props.hasPaperStyle }
 			>
 				<SettingsSnippetEditor
-					descriptionEditorFieldPlaceholder={ descriptionPlaceholder || __( "Modify your meta description by editing it right here", "wordpress-seo" ) }
+					descriptionEditorFieldPlaceholder={ placeholder }
 					onChange={ ( field, value ) => {
 						switch ( field ) {
 							case "title":

--- a/js/src/components/SettingsReplacementVariableEditor.js
+++ b/js/src/components/SettingsReplacementVariableEditor.js
@@ -29,6 +29,7 @@ class SettingsReplacementVariableEditor extends Component {
 			recommendedReplacementVariables,
 			titleTarget,
 			descriptionTarget,
+			labels,
 			descriptionPlaceholder,
 		} = this.props;
 
@@ -37,7 +38,7 @@ class SettingsReplacementVariableEditor extends Component {
 				hasPaperStyle={ this.props.hasPaperStyle }
 			>
 				<SettingsSnippetEditor
-					descriptionEditorFieldPlaceholder={ descriptionPlaceholder }
+					descriptionEditorFieldPlaceholder={ descriptionPlaceholder || __( "Modify your meta description by editing it right here", "wordpress-seo" ) }
 					onChange={ ( field, value ) => {
 						switch ( field ) {
 							case "title":
@@ -84,11 +85,6 @@ SettingsReplacementVariableEditor.propTypes = {
 
 SettingsReplacementVariableEditor.defaultProps = {
 	hasPaperStyle: true,
-	labels: {
-		title: "",
-		description: "",
-	},
-	descriptionPlaceholder: __( "Modify your meta description by editing it right here", "wordpress-seo" ),
 };
 
 export default linkHiddenFields( props => {

--- a/js/src/components/SettingsReplacementVariableEditors.js
+++ b/js/src/components/SettingsReplacementVariableEditors.js
@@ -67,11 +67,20 @@ class SettingsReplacementVariableEditors extends Component {
 				reactReplacevarPageTypeRecommended,
 				reactReplacevarPageTypeSpecific,
 				reactReplacevarPaperStyle,
+				reactReplaceVarTitleLabel,
+				reactReplaceVarDescriptionLabel,
+				reactReplaceVarDescriptionPlaceholder,
 			} = targetElement.dataset;
+
 			const filteredReplacementVariables = this.filterEditorSpecificReplaceVars(
 				this.props.replacementVariables,
 				reactReplacevarPageTypeSpecific,
 			);
+
+			const labels = {
+				title: reactReplaceVarTitleLabel || "",
+				description: reactReplaceVarDescriptionLabel || "",
+			};
 
 			return (
 				<SettingsEditorPortal
@@ -82,6 +91,8 @@ class SettingsReplacementVariableEditors extends Component {
 					titleTarget={ reactReplacevarTitleFieldId }
 					descriptionTarget={ reactReplacevarMetadescFieldId }
 					hasPaperStyle={ reactReplacevarPaperStyle === "1" }
+					labels={ labels }
+					descriptionPlaceholder={ reactReplaceVarDescriptionPlaceholder || "" }
 				/>
 			);
 		} );

--- a/js/src/components/SettingsReplacementVariableEditors.js
+++ b/js/src/components/SettingsReplacementVariableEditors.js
@@ -67,9 +67,9 @@ class SettingsReplacementVariableEditors extends Component {
 				reactReplacevarPageTypeRecommended,
 				reactReplacevarPageTypeSpecific,
 				reactReplacevarPaperStyle,
-				reactReplaceVarTitleLabel,
-				reactReplaceVarDescriptionLabel,
-				reactReplaceVarDescriptionPlaceholder,
+				reactReplacevarLabelTitle,
+				reactReplacevarLabelDescription,
+				reactReplacevarDescriptionPlaceholder,
 			} = targetElement.dataset;
 
 			const filteredReplacementVariables = this.filterEditorSpecificReplaceVars(
@@ -78,8 +78,8 @@ class SettingsReplacementVariableEditors extends Component {
 			);
 
 			const labels = {
-				title: reactReplaceVarTitleLabel || "",
-				description: reactReplaceVarDescriptionLabel || "",
+				title: reactReplacevarLabelTitle,
+				description: reactReplacevarLabelDescription,
 			};
 
 			return (
@@ -92,7 +92,7 @@ class SettingsReplacementVariableEditors extends Component {
 					descriptionTarget={ reactReplacevarMetadescFieldId }
 					hasPaperStyle={ reactReplacevarPaperStyle === "1" }
 					labels={ labels }
-					descriptionPlaceholder={ reactReplaceVarDescriptionPlaceholder || "" }
+					descriptionPlaceholder={ reactReplacevarDescriptionPlaceholder }
 				/>
 			);
 		} );

--- a/js/src/components/portals/SettingsEditorPortal.js
+++ b/js/src/components/portals/SettingsEditorPortal.js
@@ -26,6 +26,8 @@ export default function SettingsEditorPortal( {
 	titleTarget,
 	descriptionTarget,
 	hasPaperStyle,
+	labels,
+	descriptionPlaceholder,
 } ) {
 	return (
 		<Portal target={ target }>

--- a/js/src/components/portals/SettingsEditorPortal.js
+++ b/js/src/components/portals/SettingsEditorPortal.js
@@ -35,6 +35,8 @@ export default function SettingsEditorPortal( {
 				titleTarget={ titleTarget }
 				descriptionTarget={ descriptionTarget }
 				hasPaperStyle={ hasPaperStyle }
+				labels={ labels }
+				descriptionPlaceholder={ descriptionPlaceholder }
 			/>
 		</Portal>
 	);
@@ -47,4 +49,9 @@ SettingsEditorPortal.propTypes = {
 	titleTarget: PropTypes.string.isRequired,
 	descriptionTarget: PropTypes.string.isRequired,
 	hasPaperStyle: PropTypes.bool,
+	labels: PropTypes.shape( {
+		title: PropTypes.string,
+		description: PropTypes.string,
+	} ),
+	descriptionPlaceholder: PropTypes.string,
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds the possibility to pass along custom labels for the SEO title field label, Meta description field label and the Meta description field placeholder text.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the possibility to pass along custom labels for the SEO title field label, Meta description field label and the Meta description field placeholder text.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In case https://github.com/Yoast/javascript/pull/1114 hasn't been merged yet, ensure your local version of the JavaScript monorepo uses the branch from that PR.
* Run `composer install`, followed by `yarn link-monorepo` and `grunt build`.
* Navigate to SEO -> Search Appearance -> Content Types.
* See that nothing has changed in the forms and the usual SEO title and Meta description labels are still present. 
* Edit the file `admin/views/tabs/metas/paper-content/post_type/post-type.php` and test the new properties by passing the following properties with a string as its value, to the `WPSEO_Replacevar_Editor` instance:
    * `label_title`
    * `label_description`
    * `description_placeholder`
* Save your changes.
* Refresh the SEO -> Search Appearance -> Content Types page. You should now see your custom values being used instead of the defaults.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* N/A. This PR is only to support P3-379, which will contain an actual implementation that requires these changes. QA can possibly do a regression test to ensure these changes don't break any of the exist forms that utilize replace vars.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A (see above)

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-418]
