### PR TITLE
Fix slug changing in block editor

### DIFF
--- a/js/src/containers/SnippetEditor.js
+++ b/js/src/containers/SnippetEditor.js
@@ -122,6 +122,7 @@ export function mapDispatchToProps( dispatch ) {
 		switchMode,
 		updateAnalysisData,
 	} = dispatch( "yoast-seo/editor" );
+	const coreEditorDispatch = dispatch( "core/editor" );
 
 	return {
 		onChange: ( key, value ) => {
@@ -131,6 +132,14 @@ export function mapDispatchToProps( dispatch ) {
 					break;
 				case "slug":
 					updateData( { slug: value } );
+
+					/*
+					 * Update the gutenberg store with the new slug, after updating our own store,
+					 * to make sure our store isn't updated twice.
+					 */
+					if ( coreEditorDispatch ) {
+						coreEditorDispatch.editPost( { slug: value } );
+					}
 					break;
 				default:
 					updateData( {

--- a/js/tests/containers/SnippetEditor.test.js
+++ b/js/tests/containers/SnippetEditor.test.js
@@ -66,32 +66,39 @@ describe( "SnippetEditor container", () => {
 	} );
 
 	it( "maps dispatch to props", () => {
-		const dispatchers = {
+		const yoastEditorDispatch = {
 			switchMode: jest.fn(),
 			updateData: jest.fn(),
 			updateAnalysisData: jest.fn(),
 		};
+		const coreEditorDispatch = {
+			editPost: jest.fn(),
+		};
 		const dispatch = jest.fn( name => {
-			if ( name === "yoast-seo/editor" ) {
-				return dispatchers;
+			switch ( name ) {
+				case "yoast-seo/editor":
+					return yoastEditorDispatch;
+				case "core/editor":
+					return coreEditorDispatch;
 			}
 		} );
 
 		const result = mapDispatchToProps( dispatch );
 
 		expect( typeof result.onChange ).toEqual( "function" );
-		expect( result.onChangeAnalysisData ).toBe( dispatchers.updateAnalysisData );
+		expect( result.onChangeAnalysisData ).toBe( yoastEditorDispatch.updateAnalysisData );
 
 		result.onChange( "mode", "mobile" );
-		expect( dispatchers.switchMode ).toHaveBeenCalledWith( "mobile" );
+		expect( yoastEditorDispatch.switchMode ).toHaveBeenCalledWith( "mobile" );
 
 		result.onChange( "slug", "snail" );
-		expect( dispatchers.updateData ).toHaveBeenCalledWith( { slug: "snail" } );
+		expect( yoastEditorDispatch.updateData ).toHaveBeenCalledWith( { slug: "snail" } );
+		expect( coreEditorDispatch.editPost ).toHaveBeenCalledWith( { slug: "snail" } );
 
 		result.onChange( "title", "Title" );
-		expect( dispatchers.updateData ).toHaveBeenCalledWith( { title: "Title" } );
+		expect( yoastEditorDispatch.updateData ).toHaveBeenCalledWith( { title: "Title" } );
 
 		result.onChangeAnalysisData( "data" );
-		expect( dispatchers.updateAnalysisData ).toHaveBeenCalledWith( "data" );
+		expect( yoastEditorDispatch.updateAnalysisData ).toHaveBeenCalledWith( "data" );
 	} );
 } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Thank you automated tests 🎉 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where editing the slug in the snippet editor would no longer work in the block editor.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new post using the block editor
* Add a title like `test-slug`
* Publish the post
* View the post and verify the slug is what you expected: `test-slug`
* Edit the slug in the Google preview: `test-slug123`
* Update the post
* View the post and verify the slug changed to `test-slug123`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* You could verify the slug changing still works in the classic and elementor editors. They have different ways of saving it and it worked in my tests.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-449
