### PR TITLE
map_taxonomies_for_js() - speed up get_terms call by avoiding priming term meta caches

### DIFF
--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -263,7 +263,24 @@ class WPSEO_Primary_Term_Admin implements WPSEO_WordPress_Integration {
 			$primary_term = '';
 		}
 
-		$terms = get_terms( $taxonomy->name );
+		$terms = get_terms(
+			[
+				'taxonomy'               => $taxonomy->name,
+				'update_term_meta_cache' => false,
+				'fields'                 => 'id=>name',
+			]
+		);
+
+		$mapped_terms_for_js = [];
+		array_walk(
+			$terms,
+			function ( &$value, $key ) use ( &$mapped_terms_for_js ) {
+				$mapped_terms_for_js[] = [
+					'id'   => $key,
+					'name' => $value,
+				];
+			}
+		);
 
 		return [
 			'title'         => $taxonomy->labels->singular_name,
@@ -272,21 +289,7 @@ class WPSEO_Primary_Term_Admin implements WPSEO_WordPress_Integration {
 			'singularLabel' => $taxonomy->labels->singular_name,
 			'fieldId'       => $this->generate_field_id( $taxonomy->name ),
 			'restBase'      => ( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name,
-			'terms'         => array_map( [ $this, 'map_terms_for_js' ], $terms ),
-		];
-	}
-
-	/**
-	 * Returns an array suitable for use in the javascript.
-	 *
-	 * @param stdClass $term The term to map.
-	 *
-	 * @return array The mapped terms.
-	 */
-	private function map_terms_for_js( $term ) {
-		return [
-			'id'   => $term->term_id,
-			'name' => $term->name,
+			'terms'         => $mapped_terms_for_js,
 		];
 	}
 

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -272,15 +272,12 @@ class WPSEO_Primary_Term_Admin implements WPSEO_WordPress_Integration {
 		);
 
 		$mapped_terms_for_js = [];
-		array_walk(
-			$terms,
-			function ( &$value, $key ) use ( &$mapped_terms_for_js ) {
-				$mapped_terms_for_js[] = [
-					'id'   => $key,
-					'name' => $value,
-				];
-			}
-		);
+		foreach ( $terms as $id => $name ) {
+			$mapped_terms_for_js[] = [
+				'id'   => $id,
+				'name' => $name,
+			];
+		}
 
 		return [
 			'title'         => $taxonomy->labels->singular_name,


### PR DESCRIPTION
## Context
For sites that have a lot of terms, there is a slowdown happening at the `map_taxonomies_for_js()` level since `update_term_meta_cache` is set to `true` by default and we are grabbing all fields which calls `update_term_cache()`. Since we are just grabbing the terms and using the ID and name for return, we don't need to prime the term meta caches each time.  We can avoid all of that by only requesting for the `id=>name` fields in the term query and setting `update_term_meta_cache` to false: https://developer.wordpress.org/reference/classes/wp_term_query/get_terms/.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Skip priming term cache when map_taxonomies_for_js is called
