### PR TITLE
Add DismissAlert control to Elementor store

### DIFF
--- a/js/src/elementor/initializers/editor-store.js
+++ b/js/src/elementor/initializers/editor-store.js
@@ -1,10 +1,11 @@
 import { combineReducers, registerStore } from "@wordpress/data";
 import { pickBy } from "lodash";
 import reducers from "../../redux/reducers";
-import * as selectors from "../../redux/selectors";
 import * as actions from "../../redux/actions";
-import * as snippetEditorActions from "../redux/actions/snippetEditor";
 import * as analysisSelectors from "../redux/selectors/analysis";
+import * as controls from "../../redux/controls";
+import * as selectors from "../../redux/selectors";
+import * as snippetEditorActions from "../redux/actions/snippetEditor";
 
 /**
  * Populates the store.
@@ -70,6 +71,7 @@ export default function initEditorStore() {
 			// Add or override actions that are specific for Elementor.
 			...snippetEditorActions,
 		}, x => typeof x === "function" ),
+		controls,
 	} );
 
 	populateStore( store );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Needed for https://github.com/Yoast/wpseo-video/pull/876

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Implements the recently added control for dismissible alerts to our Elementor store, from which it was accidentally omitted.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test with these Video PR https://github.com/Yoast/wpseo-video/pull/876 test instructions, on the correct branch.
* Make sure there are no errors in the Elementor store.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* On a fresh install or a new user, dismiss the Alert in the Video section in Elementor. Reload the page. The alert should not reappear. This should only work after https://github.com/Yoast/wpseo-video/pull/876 has been merged and released.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-342
