### PR TITLE
Moved options regarding enabling of metabox insights and linking suggestions

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -47,6 +47,8 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'wikipedia_url',
 		'semrush_tokens',
 		'zapier_api_key',
+		'enable_metabox_insights',
+		'enable_link_suggestions',
 	];
 
 	/**
@@ -163,6 +165,8 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'enable_enhanced_slack_sharing',
 		'zapier_integration_active',
 		'zapier_api_key',
+		'enable_metabox_insights',
+		'enable_link_suggestions',
 	];
 
 	/**

--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -47,8 +47,6 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'wikipedia_url',
 		'semrush_tokens',
 		'zapier_api_key',
-		'enable_metabox_insights',
-		'enable_link_suggestions',
 	];
 
 	/**

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -76,6 +76,8 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'zapier_integration_active'                => false,
 		'zapier_subscription'                      => [],
 		'zapier_api_key'                           => '',
+		'enable_metabox_insights'                  => true,
+		'enable_link_suggestions'                  => true,
 	];
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes a bug where the metabox insights and linking suggestions options from Premium would reset after Premium and Free were deactivated and reactivated again. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the metabox insights and linking suggestions options from Premium would reset after Premium and Free were deactivated and reactivated again. 

## Relevant technical choices:

* Opted to also include these option in the tracking class, as this seems to be commonplace for most options.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Checkout this branch and build accordingly (`composer install`, `yarn`, `grunt build`)
* Use your preferred database software and inspect the `wpseo` entry in the `wp_options` table.
* See that `enable_metabox_insights` and `enable_link_suggestions` are present. On a **clean** environment, these values to be set to true (`b:1`) upon plugin activation.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Use your preferred database software and inspect the `wpseo` entry in the `wp_options` table.
* See that `enable_metabox_insights` and `enable_link_suggestions` are present. On a **clean** environment, these values to be set to true (`b:1`) upon plugin activation.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
