### PR TITLE
P2-797 Avoid `check_admin_referer` to die

### DIFF
--- a/src/conditionals/admin/doing-post-quick-edit-save-conditional.php
+++ b/src/conditionals/admin/doing-post-quick-edit-save-conditional.php
@@ -21,7 +21,9 @@ class Doing_Post_Quick_Edit_Save_Conditional implements Conditional {
 		}
 
 		// Perform the same nonce check as is done in wp_ajax_inline_save.
-		check_ajax_referer( 'inlineeditnonce', '_inline_edit' );
+		if ( \check_ajax_referer( 'inlineeditnonce', '_inline_edit', false ) ) {
+			return false;
+		}
 
 		if ( ! isset( $_POST['action'] ) ) {
 			return false;

--- a/tests/unit/conditionals/admin/doing-post-quick-edit-save-conditional-test.php
+++ b/tests/unit/conditionals/admin/doing-post-quick-edit-save-conditional-test.php
@@ -54,7 +54,7 @@ class Doing_Post_Quick_Edit_Save_Conditional_Test extends TestCase {
 			->andReturn( true );
 
 		Monkey\Functions\expect( 'check_ajax_referer' )
-			->with( 'inlineeditnonce', '_inline_edit' );
+			->with( 'inlineeditnonce', '_inline_edit', false );
 
 		self::assertFalse( $this->instance->is_met() );
 	}
@@ -69,7 +69,7 @@ class Doing_Post_Quick_Edit_Save_Conditional_Test extends TestCase {
 			->andReturn( true );
 
 		Monkey\Functions\expect( 'check_ajax_referer' )
-			->with( 'inlineeditnonce', '_inline_edit' );
+			->with( 'inlineeditnonce', '_inline_edit', false );
 
 		$_POST['action'] = 'wrong-action';
 
@@ -86,7 +86,7 @@ class Doing_Post_Quick_Edit_Save_Conditional_Test extends TestCase {
 			->andReturn( true );
 
 		Monkey\Functions\expect( 'check_ajax_referer' )
-			->with( 'inlineeditnonce', '_inline_edit' );
+			->with( 'inlineeditnonce', '_inline_edit', false );
 
 		$_POST['action'] = 'inline-save';
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The Media Library (inserting an image into a post by browsing the available attachments) is currently broken. `git bisect` helped revealt that the problem was the implied `die()` raised by a call to `check_admin_referer()` introduced by [this commit](https://github.com/Yoast/wordpress-seo/commit/3b971b2edd012b856451ccb6cd08709f6f9b0b3c)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where inserting an image from the Media Library was broken.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post
* insert an image block and click on the "Media Library" button
* see that the popup is populated with the thumbnails
* check that you don't get any `403` error as a response to a call to `admin-ajax.php`


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* We should make sure the fix doesn't impact [the original PR](https://github.com/Yoast/wordpress-seo/pull/16817) 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [QAK-2831]


[QAK-2831]: https://yoast.atlassian.net/browse/QAK-2831