### PR TITLE
P3-380 Allow dynamic ImageSelectPortal on the Search Appearance pages

### DIFF
--- a/js/src/initializers/search-appearance.js
+++ b/js/src/initializers/search-appearance.js
@@ -19,6 +19,7 @@ export default function initSearchAppearance() {
 
 	const editorElements = document.querySelectorAll( "[data-react-replacevar-editor]" );
 	const singleFieldElements = document.querySelectorAll( "[data-react-replacevar-field]" );
+	const imagePortals = Array.from( document.querySelectorAll( "[data-react-image-portal]" ) );
 
 	const schemaSettingsElements = document.querySelectorAll( "[data-schema-settings]" );
 
@@ -69,6 +70,21 @@ export default function initSearchAppearance() {
 					replaceImageButtonId="yoast-person-image-replace-button"
 					removeImageButtonId="yoast-person-image-remove-button"
 				/>
+
+				{ imagePortals.map((portal) => {
+					return (<ImageSelectPortal
+						key={ portal.id }
+						label="Social default image"
+						hasPreview={ true }
+						target={ portal.id }
+						hiddenField={ portal.dataset.reactImagePortalTargetImage }
+						hiddenFieldImageId={ portal.dataset.reactImagePortalTargetImageId }
+						selectImageButtonId={ portal.id + '-select-button' }
+						replaceImageButtonId={ portal.id + '-replace-button' }
+						removeImageButtonId={ portal.id + '-remove-button' }
+					/> )
+				})}
+
 				{ showLocalSEOUpsell && (
 					<LocalSEOUpsellPortal
 						target="wpseo-local-seo-upsell"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* After #16807 allows dynamic fields to be added, this allows an unlimited number of instances of the `ImageSelectPortal` to be added to the search appearance admin pages. This is just a preparation for subsequent changes that will combine both features (the hooks + the image select portal).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds support for dynamically added image select portals to the search appearance admin pages.

## Relevant technical choices:

* There's no direct dependency on #16807, but the new hooks added there allow for the addition of new `ImageSelectPortal` instances

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Checkout this PR together with #16807, build the plugin (`$ composer install; yarn; grunt build`)
* Add a callback for one of the hooks introduced in #16807 and let it print: 
```
<input type="hidden" id="image-url" />
<input type="hidden" id="image-id" />
<div id="unique-id" data-react-image-portal data-react-image-portal-target-image="image-url" data-react-image-portal-target-image-id="image-id"></div>
```
* Go to the related Search Appearance tab and check at the location of the hook that an image selector is shown
* In the DevTools you can see the hidden inputs getting values inserted once you select an image

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Add a callback for one of the hooks introduced in #16807 and let it print an image portal: 
```
function author_archives_custom_image() {
	echo '<input type="hidden" id="image-url" /><input type="hidden" id="image-id" /><div id="unique-id" data-react-image-portal data-react-image-portal-target-image="image-url" data-react-image-portal-target-image-id="image-id"></div>';
}
add_action('Yoast\WP\SEO\admin_author_archives_meta', 'author_archives_custom_image');
```
* Go to SEO > Search Appearance > Archives tab and check at the bottom of the Author archives setting that an image selector is shown
* In the DevTools you can see the hidden inputs getting values inserted once you select an image

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
