### PR TITLE
P2 690 expose shortlinks

### DIFF
--- a/src/integrations/schema-blocks.php
+++ b/src/integrations/schema-blocks.php
@@ -107,7 +107,7 @@ class Schema_Blocks implements Integration_Interface {
 
 		$this->asset_manager->localize_script(
 			'schema-blocks',
-			'schemaBlocks',
+			'yoastSchemaBlocks',
 			[
 				'requiredLink'    => $this->short_link_helper->build( 'yoa.st/required-fields' ),
 				'recommendedLink' => $this->short_link_helper->build( 'yoa.st/recommended-fields' ),

--- a/src/integrations/schema-blocks.php
+++ b/src/integrations/schema-blocks.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Integrations;
 
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Schema_Blocks_Conditional;
+use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 
 /**
  * Loads schema block templates into Gutenberg.
@@ -32,6 +33,13 @@ class Schema_Blocks implements Integration_Interface {
 	protected $blocks_conditional;
 
 	/**
+	 * Represents the short link helper.
+	 *
+	 * @var Short_Link_Helper
+	 */
+	protected $short_link_helper;
+
+	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
 	 * @return array
@@ -47,13 +55,16 @@ class Schema_Blocks implements Integration_Interface {
 	 *
 	 * @param WPSEO_Admin_Asset_Manager $asset_manager      The asset manager.
 	 * @param Schema_Blocks_Conditional $blocks_conditional The schema blocks conditional.
+	 * @param Short_Link_Helper         $short_link_helper  The short link helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
-		Schema_Blocks_Conditional $blocks_conditional
+		Schema_Blocks_Conditional $blocks_conditional,
+		Short_Link_Helper $short_link_helper
 	) {
 		$this->asset_manager      = $asset_manager;
 		$this->blocks_conditional = $blocks_conditional;
+		$this->short_link_helper  = $short_link_helper;
 	}
 
 	/**
@@ -93,6 +104,15 @@ class Schema_Blocks implements Integration_Interface {
 	public function load() {
 		$this->asset_manager->enqueue_script( 'schema-blocks' );
 		$this->asset_manager->enqueue_style( 'schema-blocks' );
+
+		$this->asset_manager->localize_script(
+			'schema-blocks',
+			'schemaBlocks',
+			[
+				'requiredLink'    => $this->short_link_helper->build( 'yoa.st/required-fields' ),
+				'recommendedLink' => $this->short_link_helper->build( 'yoa.st/recommended-fields' ),
+			]
+		);
 	}
 
 	/**

--- a/src/integrations/schema-blocks.php
+++ b/src/integrations/schema-blocks.php
@@ -109,8 +109,8 @@ class Schema_Blocks implements Integration_Interface {
 			'schema-blocks',
 			'yoastSchemaBlocks',
 			[
-				'requiredLink'    => $this->short_link_helper->build( 'yoa.st/required-fields' ),
-				'recommendedLink' => $this->short_link_helper->build( 'yoa.st/recommended-fields' ),
+				'requiredLink'    => $this->short_link_helper->build( 'https://yoa.st/required-fields' ),
+				'recommendedLink' => $this->short_link_helper->build( 'https://yoa.st/recommended-fields' ),
 			]
 		);
 	}

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -160,13 +160,13 @@ class Schema_Blocks_Test extends TestCase {
 		$this->short_links_helper
 			->expects( 'build' )
 			->once()
-			->with( 'yoa.st/required-fields' )
+			->with( 'https://yoa.st/required-fields' )
 			->andReturnArg( 0 );
 
 		$this->short_links_helper
 			->expects( 'build' )
 			->once()
-			->with( 'yoa.st/recommended-fields' )
+			->with( 'https://yoa.st/recommended-fields' )
 			->andReturnArg( 0 );
 
 		$this->asset_manager
@@ -176,8 +176,8 @@ class Schema_Blocks_Test extends TestCase {
 				'schema-blocks',
 				'schemaBlocks',
 				[
-					'requiredLink'    => 'yoa.st/required-fields',
-					'recommendedLink' => 'yoa.st/recommended-fields',
+					'requiredLink'    => 'https://yoa.st/required-fields',
+					'recommendedLink' => 'https://yoa.st/recommended-fields',
 				]
 			);
 

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -7,6 +7,7 @@ use Mockery;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Schema_Blocks_Conditional;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
+use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Integrations\Schema_Blocks;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -57,6 +58,13 @@ class Schema_Blocks_Test extends TestCase {
 	protected $blocks_conditional;
 
 	/**
+	 * The short links helper.
+	 *
+	 * @var Mockery\MockInterface|Short_Link_Helper
+	 */
+	protected $short_links_helper;
+
+	/**
 	 * Runs the setup to prepare the needed instance.
 	 */
 	public function set_up() {
@@ -64,10 +72,12 @@ class Schema_Blocks_Test extends TestCase {
 
 		$this->asset_manager      = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
 		$this->blocks_conditional = Mockery::mock( Schema_Blocks_Conditional::class );
+		$this->short_links_helper = Mockery::mock( Short_Link_Helper::class );
 
 		$this->instance = new Schema_Blocks(
 			$this->asset_manager,
-			$this->blocks_conditional
+			$this->blocks_conditional,
+			$this->short_links_helper
 		);
 	}
 
@@ -79,6 +89,7 @@ class Schema_Blocks_Test extends TestCase {
 	public function test_constructor() {
 		static::assertInstanceOf( WPSEO_Admin_Asset_Manager::class, self::getPropertyValue( $this, 'asset_manager' ) );
 		static::assertInstanceOf( Schema_Blocks_Conditional::class, self::getPropertyValue( $this, 'blocks_conditional' ) );
+		static::assertInstanceOf( Short_Link_Helper::class, self::getPropertyValue( $this, 'short_links_helper' ) );
 	}
 
 	/**
@@ -112,7 +123,7 @@ class Schema_Blocks_Test extends TestCase {
 
 		static::assertEquals(
 			[ WPSEO_PATH . '/template.php' ],
-			$this->getPropertyValue( $this->instance, 'templates' )
+			self::getPropertyValue( $this->instance, 'templates' )
 		);
 	}
 
@@ -126,7 +137,7 @@ class Schema_Blocks_Test extends TestCase {
 
 		static::assertEquals(
 			[ '/template.php' ],
-			$this->getPropertyValue( $this->instance, 'templates' )
+			self::getPropertyValue( $this->instance, 'templates' )
 		);
 	}
 
@@ -145,6 +156,30 @@ class Schema_Blocks_Test extends TestCase {
 			->expects( 'enqueue_style' )
 			->with( 'schema-blocks' )
 			->once();
+
+		$this->short_links_helper
+			->expects( 'build' )
+			->once()
+			->with( 'yoa.st/required-fields' )
+			->andReturnArg( 0 );
+
+		$this->short_links_helper
+			->expects( 'build' )
+			->once()
+			->with( 'yoa.st/recommended-fields' )
+			->andReturnArg( 0 );
+
+		$this->asset_manager
+			->expects( 'localize_script' )
+			->once()
+			->with(
+				'schema-blocks',
+				'schemaBlocks',
+				[
+					'requiredLink'    => 'yoa.st/required-fields',
+					'recommendedLink' => 'yoa.st/recommended-fields',
+				]
+			);
 
 		$this->instance->load();
 	}

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -174,7 +174,7 @@ class Schema_Blocks_Test extends TestCase {
 			->once()
 			->with(
 				'schema-blocks',
-				'schemaBlocks',
+				'yoastSchemaBlocks',
 				[
 					'requiredLink'    => 'https://yoa.st/required-fields',
 					'recommendedLink' => 'https://yoa.st/recommended-fields',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to show a warning message with a link that navigates the user to additional info about required en recommended blocks.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Exposes two shortlinks by using localize script

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test this against https://github.com/Yoast/javascript/pull/1117


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

P2-690
