### PR TITLE
Moved recipe block to Yoast category instead of default

### DIFF
--- a/src/schema-templates/recipe.block.php
+++ b/src/schema-templates/recipe.block.php
@@ -1,5 +1,5 @@
 <?php // phpcs:ignore Internal.NoCodeFound ?>
-{{block name="yoast/recipe" title="Recipe" category="common" }}
+{{block name="yoast/recipe" title="Recipe" category="yoast-structured-data-blocks" }}
 {{sidebar-duration name="cook-time" output=false label="Cook time" }}
 {{sidebar-duration name="prep-time" output=false label="Preparation time" }}
 {{sidebar-input name="yield" output=false type="number" label="Serves #" }}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Move the recipe schema block to the correct category in the blocks overview.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Recipe schema block turns up under the `text` blocks category in the blocks overview, instead of the Yoast SEO blocks.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure the `YOAST_SEO_SCHEMA_BLOCKS` feature flag is active.
* Click the `Add block` (+) in the top left of the editor.
* See that the Recipe block is under the `Yoast Structured Data Blocks` category, instead of the `Text` category.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
