### PR TITLE
Prevent valid nonce to stop further execution of code

### DIFF
--- a/src/conditionals/admin/doing-post-quick-edit-save-conditional.php
+++ b/src/conditionals/admin/doing-post-quick-edit-save-conditional.php
@@ -20,7 +20,7 @@ class Doing_Post_Quick_Edit_Save_Conditional implements Conditional {
 			return false;
 		}
 
-		// Perform the same nonce check as is done in wp_ajax_inline_save.
+		// Do the same nonce check as is done in wp_ajax_inline_save because we hook into that request.
 		if ( ! \check_ajax_referer( 'inlineeditnonce', '_inline_edit', false ) ) {
 			return false;
 		}

--- a/src/conditionals/admin/doing-post-quick-edit-save-conditional.php
+++ b/src/conditionals/admin/doing-post-quick-edit-save-conditional.php
@@ -21,7 +21,7 @@ class Doing_Post_Quick_Edit_Save_Conditional implements Conditional {
 		}
 
 		// Perform the same nonce check as is done in wp_ajax_inline_save.
-		if ( \check_ajax_referer( 'inlineeditnonce', '_inline_edit', false ) ) {
+		if ( ! \check_ajax_referer( 'inlineeditnonce', '_inline_edit', false ) ) {
 			return false;
 		}
 

--- a/tests/unit/conditionals/admin/doing-post-quick-edit-save-conditional-test.php
+++ b/tests/unit/conditionals/admin/doing-post-quick-edit-save-conditional-test.php
@@ -86,7 +86,8 @@ class Doing_Post_Quick_Edit_Save_Conditional_Test extends TestCase {
 			->andReturn( true );
 
 		Monkey\Functions\expect( 'check_ajax_referer' )
-			->with( 'inlineeditnonce', '_inline_edit', false );
+			->with( 'inlineeditnonce', '_inline_edit', false )
+			->andReturn( 1 );
 
 		$_POST['action'] = 'inline-save';
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When the nonce is valid we shouldn't early return from the method.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a valid nonce causes the logic to stop further execution. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Please keep in mind that this fixes https://github.com/Yoast/wordpress-seo/pull/16820 which was a fix one https://github.com/Yoast/wordpress-seo/pull/16817

* Create 2 categories for posts
* Create a post and assign it to category A
* Set the breadcrumbs of Yoast to use categories.
* Check the breadcrumbs of the created post (either in schema or HTML) and note the category
*. Go to the posts overview and use "quick-edit" on the created post. Set the category to B and update.
*. Check the breadcrumbs of the post again, the category should be updated.
* Also verify that the media library is still working by adding a featured image to a post


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
