### PR TITLE
P1 464 og image fix

### DIFF
--- a/src/generators/twitter-image-generator.php
+++ b/src/generators/twitter-image-generator.php
@@ -73,11 +73,6 @@ class Twitter_Image_Generator implements Generator_Interface {
 	 * @param Images    $image_container The image container.
 	 */
 	protected function add_from_indexable( Indexable $indexable, Images $image_container ) {
-		if ( $indexable->open_graph_image_meta ) {
-			$image_container->add_image_by_meta( $indexable->open_graph_image_meta );
-			return;
-		}
-
 		if ( $indexable->twitter_image_id ) {
 			$image_container->add_image_by_id( $indexable->twitter_image_id );
 			return;

--- a/src/values/images.php
+++ b/src/values/images.php
@@ -75,7 +75,7 @@ class Images {
 	 * @return void
 	 */
 	public function add_image_by_meta( $image_meta ) {
-		$this->add_image( json_decode( $image_meta ) );
+		$this->add_image( (array) json_decode( $image_meta ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* After merging [https://github.com/Yoast/wordpress-seo/pull/16644](this community patch) a set `og:image` for a specific post was always replaced by the default fallback. That needed fixing.
* Also above PR changed the OG Twitter image to the Facebook (fallback) image, which wasn't in line with the Twitter Tags Functional specifcation. So we decided to fix that as well.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug in which the `og:image` tags for Facebook and Twitter didn't reflect the correct images.

## Relevant technical choices:

* Decided to revive the old somewhat less performant functionality for Twitter, since the new functionality was faulty.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set a default image on the Facebook Settings Admin page
* Create a new post and publish
* Check that the `og:image` tag shows the fallback image url
* Edit your post and set a custom Facebook Image in WP SEO
* Publish your post and verify that the `og:image` tag now shows the url to the set custom image
* Please also check that the `og:image` tags for Twitter comply to the [Functional description](https://developer.yoast.com/features/twitter/functional-specification/#twitter-metadata) again


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-464
