### PR TITLE
P2-224 Add recipe name block and schema templates

### DIFF
--- a/src/schema-templates/recipe-name.block.php
+++ b/src/schema-templates/recipe-name.block.php
@@ -1,2 +1,10 @@
+<?php
+/**
+ * Recipe name block schema template.
+ *
+ * @package Yoast\WP\SEO\Schema_Templates
+ */
+
+?>
 {{block name="yoast/recipe-name" title="Recipe name" category="yoast-structured-data-blocks" parent=[ "yoast/recipe" ] }}
 {{variable-tag-rich-text name="name" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="<?php esc_attr_e( 'Enter a recipe name', 'wordpress-seo' ); ?>" }}

--- a/src/schema-templates/recipe-name.block.php
+++ b/src/schema-templates/recipe-name.block.php
@@ -1,2 +1,2 @@
 {{block name="yoast/recipe-name" title="Recipe name" category="yoast-structured-data-blocks" parent=[ "yoast/recipe" ] }}
-{{variable-tag-rich-text name="name" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="<?php esc_attr_e( 'Enter recipe name', 'wordpress-seo' ); ?>" }}
+{{variable-tag-rich-text name="name" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="<?php esc_attr_e( 'Enter a recipe name', 'wordpress-seo' ); ?>" }}

--- a/src/schema-templates/recipe-name.block.php
+++ b/src/schema-templates/recipe-name.block.php
@@ -1,0 +1,2 @@
+{{block name="yoast/recipe-name" title="Recipe name" category="yoast-structured-data-blocks" parent=[ "yoast/recipe" ] }}
+{{variable-tag-rich-text name="name" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="<?php esc_attr_e( 'Enter recipe name', 'wordpress-seo' ); ?>" }}

--- a/src/schema-templates/recipe-name.schema.php
+++ b/src/schema-templates/recipe-name.schema.php
@@ -1,0 +1,5 @@
+<?php // phpcs:ignore Internal.NoCodeFound ?>
+{{schema name="yoast/recipe-name" only-nested=true}}
+{
+	"name": {{html name="name"}}
+}

--- a/src/schema-templates/recipe.block.php
+++ b/src/schema-templates/recipe.block.php
@@ -1,9 +1,36 @@
-<?php // phpcs:ignore Internal.NoCodeFound ?>
-{{block name="yoast/recipe" title="Recipe" category="yoast-structured-data-blocks" }}
-{{sidebar-duration name="cook-time" output=false label="Cook time" }}
-{{sidebar-duration name="prep-time" output=false label="Preparation time" }}
-{{sidebar-input name="yield" output=false type="number" label="Serves #" }}
+<?php
+/**
+ * Recipe block schema template.
+ *
+ * @package Yoast\WP\SEO\Schema_Templates
+ */
+
+/* translators: %1$s expands to Yoast */
+$yoast_seo_block_title = sprintf( __( '%1$s Recipe', 'wordpress-seo' ), 'Yoast' );
+
+$yoast_seo_block_template = [
+	[ 'yoast/recipe-name' ],
+	[ 'core/image' ],
+	[ 'yoast/ingredients' ],
+	[ 'yoast/steps' ],
+];
+
+$yoast_seo_required_blocks = [
+	[ 'name' => 'yoast/recipe-name' ],
+	[ 'name' => 'core/image' ],
+	[ 'name' => 'yoast/ingredients' ],
+	[ 'name' => 'yoast/steps' ],
+];
+
+$yoast_seo_recommended_blocks = [
+	[ 'name' => 'core/paragraph' ],
+];
+?>
+
+{{block name="yoast/recipe" title="<?php echo esc_attr( $yoast_seo_block_title ); ?>" category="yoast-structured-data-blocks" keywords=[ "SEO", "Schema"] description="<?php esc_attr_e( 'Create a Recipe in an SEO-friendly way. You can only use one Recipe block per post.', 'wordpress-seo' ); ?>" supports={"multiple": false} }}
+{{sidebar-duration name="cook-time" output=false label="<?php esc_attr_e( 'Cook time', 'wordpress-seo' ); ?>" }}
+{{sidebar-duration name="prep-time" output=false label="<?php esc_attr_e( 'Preparation time', 'wordpress-seo' ); ?>" }}
+{{sidebar-input name="yield" output=false type="number" label="<?php esc_attr_e( 'Serves #', 'wordpress-seo' ); ?>" }}
 <div class={{class-name}}>
-	{{variable-tag-rich-text name="title" tags=[ "h1", "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="Recipe title" }}
-	{{inner-blocks required-blocks=[ { "name": "core/paragraph", "option": "Multiple" } , { "name": "core/image", "option": "One" } ] recommended-blocks=[ "core/image", "core/paragraph" ] appender="button" appenderLabel="Add to recipe" }}
+	{{inner-blocks template=<?php echo WPSEO_Utils::format_json_encode( $yoast_seo_block_template ); ?> required-blocks=<?php echo WPSEO_Utils::format_json_encode( $yoast_seo_required_blocks ); ?> recommended-blocks=<?php echo WPSEO_Utils::format_json_encode( $yoast_seo_recommended_blocks ); ?> appender="button" appenderLabel="<?php esc_attr_e( 'Add a block to your recipe...', 'wordpress-seo' ); ?>" }}
 </div>

--- a/src/schema-templates/recipe.block.php
+++ b/src/schema-templates/recipe.block.php
@@ -25,8 +25,9 @@ $yoast_seo_required_blocks = [
 $yoast_seo_recommended_blocks = [
 	[ 'name' => 'core/paragraph' ],
 ];
-?>
 
+// phpcs:disable WordPress.Security.EscapeOutput -- Reason: WPSEO_Utils::format_json_encode is safe.
+?>
 {{block name="yoast/recipe" title="<?php echo esc_attr( $yoast_seo_block_title ); ?>" category="yoast-structured-data-blocks" keywords=[ "SEO", "Schema"] description="<?php esc_attr_e( 'Create a Recipe in an SEO-friendly way. You can only use one Recipe block per post.', 'wordpress-seo' ); ?>" supports={"multiple": false} }}
 {{sidebar-duration name="cook-time" output=false label="<?php esc_attr_e( 'Cook time', 'wordpress-seo' ); ?>" }}
 {{sidebar-duration name="prep-time" output=false label="<?php esc_attr_e( 'Preparation time', 'wordpress-seo' ); ?>" }}

--- a/src/schema-templates/recipe.schema.php
+++ b/src/schema-templates/recipe.schema.php
@@ -7,7 +7,7 @@
 		"@id": "%%main_schema_id%%"
 	},
 	"image": {{inner-blocks-id allowed-blocks=[ "core/image" ] only-first=true null-when-empty=true }},
-	"name": {{html name="title"}},
+	"name": {{inner-blocks-html blocks={ "yoast/recipe-name": "name" } null-when-empty=true allowed-tags=[ "h1","h2","h3","h4","h5","h6","br","a","p","b","strong","i","em", "ul", "ol", "li" ] }},
 	"author": {
 		"@id": "%%author_id%%"
 	},

--- a/tests/unit/dependency-injection/schema-templates-loader-test.php
+++ b/tests/unit/dependency-injection/schema-templates-loader-test.php
@@ -42,6 +42,8 @@ class Schema_Templates_Loader_Test extends TestCase {
 			$schema_directory . 'image.schema.php',
 			$schema_directory . 'ingredients.block.php',
 			$schema_directory . 'ingredients.schema.php',
+			$schema_directory . 'recipe-name.block.php',
+			$schema_directory . 'recipe-name.schema.php',
 			$schema_directory . 'recipe.block.php',
 			$schema_directory . 'recipe.schema.php',
 			$schema_directory . 'step.block.php',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add a recipe name block and accompanying schema template for the recipe block.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the recipe-name block to the recipe block.

## Relevant technical choices:

* Also did some refactoring so the implementation of the recipe block lines up with the implementation of the jobs-posting block in premium.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new post
* Add a recipe block
* Give the post a title, give the recipe a name, image, at least one step and at least one ingredient.
* Save the post
* On the front-end inspect the schema output and make sure the recipe schema is present and the name property is the same as the value you filled in as your recipe's name.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
