### PR TITLE
P3-501 Add new yost form method and related CSS.

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -417,6 +417,8 @@ class Yoast_Form {
 	 * @param string $var   The variable within the option to create the text input field for.
 	 * @param string $label The label to show for the variable.
 	 * @param array  $attr  Extra attributes to add to the input field.
+	 *
+	 * @return void
 	 */
 	public function textinput_extra_content( $var, $label, $attr = [] ) {
 		$type = 'text';
@@ -426,7 +428,7 @@ class Yoast_Form {
 			'disabled'    => false,
 		];
 
-		$attr = wp_parse_args( $attr, $defaults );
+		$attr = \wp_parse_args( $attr, $defaults );
 		$val  = $this->get_field_value( $var, '' );
 
 		if ( isset( $attr['type'] ) && $attr['type'] === 'url' ) {
@@ -459,13 +461,13 @@ class Yoast_Form {
 		printf(
 			'<input type="%1$s" name="%2$s" id="%3$s" class="%4$s"%5$s%6$s%7$s value="%8$s"%9$s>',
 			$type,
-			esc_attr( $this->option_name ) . '[' . esc_attr( $var ) . ']',
-			esc_attr( $var ),
-			esc_attr( $attr['class'] ),
-			isset( $attr['placeholder'] ) ? ' placeholder="' . esc_attr( $attr['placeholder'] ) . '"' : '',
-			isset( $attr['autocomplete'] ) ? ' autocomplete="' . esc_attr( $attr['autocomplete'] ) . '"' : '',
+			\esc_attr( $this->option_name ) . '[' . \esc_attr( $var ) . ']',
+			\esc_attr( $var ),
+			\esc_attr( $attr['class'] ),
+			isset( $attr['placeholder'] ) ? ' placeholder="' . \esc_attr( $attr['placeholder'] ) . '"' : '',
+			isset( $attr['autocomplete'] ) ? ' autocomplete="' . \esc_attr( $attr['autocomplete'] ) . '"' : '',
 			$aria_attributes,
-			esc_attr( $val ),
+			\esc_attr( $val ),
 			$this->get_disabled_attribute( $var, $attr )
 		);
 		// phpcs:enable

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -412,6 +412,68 @@ class Yoast_Form {
 	}
 
 	/**
+	 * Creates a text input field with with the ability to add content after the label.
+	 *
+	 * @param string $var   The variable within the option to create the text input field for.
+	 * @param string $label The label to show for the variable.
+	 * @param array  $attr  Extra attributes to add to the input field.
+	 */
+	public function textinput_extra_content( $var, $label, $attr = [] ) {
+		$type = 'text';
+
+		$defaults = [
+			'class'       => 'yoast-field-group__inputfield',
+			'disabled'    => false,
+		];
+
+		$attr = wp_parse_args( $attr, $defaults );
+		$val  = $this->get_field_value( $var, '' );
+
+		if ( isset( $attr['type'] ) && $attr['type'] === 'url' ) {
+			$val  = urldecode( $val );
+			$type = 'url';
+		}
+
+		echo '<div class="yoast-field-group__title">';
+		$this->label(
+			$label,
+			[
+				'for'   => $var,
+				'class' => $attr['class'] . '--label',
+			]
+		);
+
+		if ( isset( $attr['extra_content'] ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: may contain HTML that should not be escaped.
+			echo $attr['extra_content'];
+		}
+		echo '</div>';
+
+		$has_input_error = Yoast_Input_Validation::yoast_form_control_has_error( $var );
+		$aria_attributes = Yoast_Input_Validation::get_the_aria_invalid_attribute( $var );
+
+		Yoast_Input_Validation::set_error_descriptions();
+		$aria_attributes .= Yoast_Input_Validation::get_the_aria_describedby_attribute( $var );
+
+		// phpcs:disable WordPress.Security.EscapeOutput -- Reason: output is properly escaped or hardcoded.
+		printf(
+			'<input type="%1$s" name="%2$s" id="%3$s" class="%4$s"%5$s%6$s%7$s value="%8$s"%9$s>',
+			$type,
+			esc_attr( $this->option_name ) . '[' . esc_attr( $var ) . ']',
+			esc_attr( $var ),
+			esc_attr( $attr['class'] ),
+			isset( $attr['placeholder'] ) ? ' placeholder="' . esc_attr( $attr['placeholder'] ) . '"' : '',
+			isset( $attr['autocomplete'] ) ? ' autocomplete="' . esc_attr( $attr['autocomplete'] ) . '"' : '',
+			$aria_attributes,
+			esc_attr( $val ),
+			$this->get_disabled_attribute( $var, $attr )
+		);
+		// phpcs:enable
+		// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: output is properly escaped.
+		echo Yoast_Input_Validation::get_the_error_description( $var );
+	}
+
+	/**
 	 * Create a textarea.
 	 *
 	 * @since 2.0

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -897,4 +897,16 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
   vertical-align: top;
 }
 
+.yoast-settings-section {
+	margin: 40px 0;
+}
+
+.yoast-settings-section.yoast-settings-section--last {
+	margin-bottom: 0;
+}
+
+.yoast-settings-section .yoast-help-icon::before {
+	margin-top: -3px;
+}
+
 /*# sourceMappingURL=yst_plugin_tools.css.map */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want an input field with extra content to the right of the label to match the design for the Global social templates.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a new method to generate an input field with the new styling and help link.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* build 
* use the new method somewhere, for example in `admin/views/tabs/metas/paper-content/author-archive-settings.php`
* add `use Yoast\WP\SEO\Presenters\Admin\Help_Link_Presenter;` at the top of the file, after the file block comment
* add the following snippet fo code after `$editor->render();`

```
$breadcrumbs_title_help_link = new Help_Link_Presenter(
	WPSEO_Shortlinker::get( 'https://yoa.st/4cf' ),
	__( 'Learn more about the breadcrumbs title', 'wordpress-seo' )
);

$yform->textinput_extra_content(
	'bctitle-author-archive',
	__( 'Breadcrumbs title', 'wordpress-seo' ),
	[ 'extra_content' => $breadcrumbs_title_help_link ]
);
```

* check the input field styling matches the design 
* check the Help link works
* to add vertical spacing before and after the input field, wrap it in a div element with the CSS class introduced in this PR:

```
echo '<div class="yoast-settings-section">';
{input field code here}
echo '</div>';
```
* check the spacing matches the design (40 pixels)
* to add vertical spacing only before the field (in the case the input field is the last thing within a panel) add the class `yoast-settings-section--last` to the wrapper div and check the spacing matches the design

Screenshot:

<img width="675" alt="Screenshot 2021-04-01 at 13 23 07" src="https://user-images.githubusercontent.com/1682452/113287173-7b643000-92ed-11eb-8868-77c69c1a9fab.png">


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* QA doesn't need to test this PR, as this will be tested as part of the overall "Global social templates" feature.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-501]
