### PR TITLE
Allow lower priority hooks to wp_robots

### DIFF
--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -39,7 +39,9 @@ class WP_Robots_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_filter( 'wp_robots', [ $this, 'add_robots' ], PHP_INT_MAX );
+		/* Allow control of the `wp_robots` filter by prioritizing our hook 10 less than max.
+		   Use the `wpseo_robots` filter to filter the Yoast robots output, instead of WordPress core. */
+		\add_filter( 'wp_robots', [ $this, 'add_robots' ], ( PHP_INT_MAX - 10 ) );
 	}
 
 	/**

--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -39,8 +39,10 @@ class WP_Robots_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		/* Allow control of the `wp_robots` filter by prioritizing our hook 10 less than max.
-		   Use the `wpseo_robots` filter to filter the Yoast robots output, instead of WordPress core. */
+		/**
+		 * Allow control of the `wp_robots` filter by prioritizing our hook 10 less than max.
+		 * Use the `wpseo_robots` filter to filter the Yoast robots output, instead of WordPress core.
+		 */
 		\add_filter( 'wp_robots', [ $this, 'add_robots' ], ( PHP_INT_MAX - 10 ) );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Allow for other plugins to override the core robots meta tag after Yoast.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [non-user-facing] Lower the priority of the `wp_robots` hook so that other plugins can hook in after us.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have a post on your website that is allowing indexing.
* Add the following filter to a functions.php:
```php
add_filter( 'wp_robots', 'override_yoast', PHP_INT_MAX );

function override_yoast( ){
	return [ 'noindex' => true, 'nofollow' => true ];
}
```
* Without this PR: 
  * the content in `<meta name='robots' content='{{}}' />` will either not change or conflict with itself.
* With this PR: 
  * the content in `<meta name='robots' content='{{}}' />` will always be `noindex, nofollow`.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/16823
