### PR TITLE
Excluded post types are now not build anymore in the build_post_hierarchy method.

### DIFF
--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -391,6 +391,6 @@ class Indexable_Post_Builder {
 	 * @return bool `true` if the post should be excluded from building, `false` if not.
 	 */
 	protected function should_exclude_post( $post ) {
-		return \in_array( $post->post_type, $this->post_type_helper->get_excluded_post_types_for_indexables(), true );
+		return $this->post_type_helper->is_excluded( $post->post_type );
 	}
 }

--- a/src/helpers/post-type-helper.php
+++ b/src/helpers/post-type-helper.php
@@ -103,6 +103,17 @@ class Post_Type_Helper {
 	}
 
 	/**
+	 * Checks if the post type is excluded.
+	 *
+	 * @param string $post_type The post type to check.
+	 *
+	 * @return bool If the post type is exclude.
+	 */
+	public function is_excluded( $post_type ) {
+		return \in_array( $post_type, $this->get_excluded_post_types_for_indexables(), true );
+	}
+
+	/**
 	 * Checks if the post type with the given name has an archive page.
 	 *
 	 * @param WP_Post_Type|string $post_type The name of the post type to check.

--- a/src/integrations/watchers/indexable-ancestor-watcher.php
+++ b/src/integrations/watchers/indexable-ancestor-watcher.php
@@ -6,6 +6,7 @@ use wpdb;
 use Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Permalink_Helper;
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
@@ -54,6 +55,13 @@ class Indexable_Ancestor_Watcher implements Integration_Interface {
 	protected $permalink_helper;
 
 	/**
+	 * The post type helper.
+	 *
+	 * @var Post_Type_Helper
+	 */
+	protected $post_type_helper;
+
+	/**
 	 * Sets the needed dependencies.
 	 *
 	 * @param Indexable_Repository           $indexable_repository           The indexable repository.
@@ -61,19 +69,22 @@ class Indexable_Ancestor_Watcher implements Integration_Interface {
 	 * @param Indexable_Hierarchy_Repository $indexable_hierarchy_repository The indexable hierarchy repository.
 	 * @param wpdb                           $wpdb                           The wpdb object.
 	 * @param Permalink_Helper               $permalink_helper               The permalink helper.
+	 * @param Post_Type_Helper               $post_type_helper               The post type helper.
 	 */
 	public function __construct(
 		Indexable_Repository $indexable_repository,
 		Indexable_Hierarchy_Builder $indexable_hierarchy_builder,
 		Indexable_Hierarchy_Repository $indexable_hierarchy_repository,
 		wpdb $wpdb,
-		Permalink_Helper $permalink_helper
+		Permalink_Helper $permalink_helper,
+		Post_Type_Helper $post_type_helper
 	) {
 		$this->indexable_repository           = $indexable_repository;
 		$this->indexable_hierarchy_builder    = $indexable_hierarchy_builder;
 		$this->wpdb                           = $wpdb;
 		$this->indexable_hierarchy_repository = $indexable_hierarchy_repository;
 		$this->permalink_helper               = $permalink_helper;
+		$this->post_type_helper               = $post_type_helper;
 	}
 
 	/**
@@ -81,7 +92,7 @@ class Indexable_Ancestor_Watcher implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'wpseo_save_indexable', [ $this, 'reset_children' ], \PHP_INT_MAX, 2 );
-		\add_action( 'set_object_terms', [ $this, 'build_post_hierarchy' ], \PHP_INT_MAX );
+		\add_action( 'set_object_terms', [ $this, 'build_post_hierarchy' ], \PHP_INT_MAX, 2 );
 	}
 
 	/**
@@ -168,11 +179,18 @@ class Indexable_Ancestor_Watcher implements Integration_Interface {
 	 * Builds the hierarchy for a post.
 	 *
 	 * @param int $object_id The post id.
+	 * @param int $post_type The post type.
 	 */
-	public function build_post_hierarchy( $object_id ) {
+	public function build_post_hierarchy( $object_id, $post_type ) {
+		if ( $this->post_type_helper->is_excluded( $post_type ) ) {
+			return;
+		}
+
 		$indexable = $this->indexable_repository->find_by_id_and_type( $object_id, 'post' );
 
-		$this->indexable_hierarchy_builder->build( $indexable );
+		if ( $indexable instanceof Indexable ) {
+			$this->indexable_hierarchy_builder->build( $indexable );
+		}
 	}
 
 	/**

--- a/tests/unit/builders/indexable-post-builder-test.php
+++ b/tests/unit/builders/indexable-post-builder-test.php
@@ -247,8 +247,10 @@ class Indexable_Post_Builder_Test extends TestCase {
 				]
 			);
 
-		$this->post_type_helper->expects( 'get_excluded_post_types_for_indexables' )
-			->andReturn( [] );
+		$this->post_type_helper
+			->expects( 'is_excluded' )
+			->with( 'post' )
+			->andReturn( false );
 
 		$indexable_expectations = [
 			'object_id'                      => 1,
@@ -869,7 +871,7 @@ class Indexable_Post_Builder_Test extends TestCase {
 
 		$this->post_type_helper->expects( 'is_excluded' )
 			->once()
-			->andReturn( false );
+			->andReturnTrue();
 
 		self::assertFalse( $this->instance->build( $post_id, false ) );
 	}

--- a/tests/unit/builders/indexable-post-builder-test.php
+++ b/tests/unit/builders/indexable-post-builder-test.php
@@ -867,9 +867,9 @@ class Indexable_Post_Builder_Test extends TestCase {
 				]
 			);
 
-		$this->post_type_helper->expects( 'get_excluded_post_types_for_indexables' )
+		$this->post_type_helper->expects( 'is_excluded' )
 			->once()
-			->andReturn( [ 'excluded_post_type' ] );
+			->andReturn( false );
 
 		self::assertFalse( $this->instance->build( $post_id, false ) );
 	}

--- a/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
@@ -401,6 +401,11 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 			->once()
 			->with( $indexable );
 
+		$this->post_type_helper
+			->expects( 'is_excluded' )
+			->with( 'post_type' )
+			->andReturn( false );
+
 		$this->instance->build_post_hierarchy( 123, 'post_type' );
 	}
 
@@ -419,6 +424,33 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 		$this->indexable_hierarchy_builder
 			->expects( 'build' )
 			->never();
+
+		$this->post_type_helper
+			->expects( 'is_excluded' )
+			->with( 'post_type' )
+			->andReturn( false );
+
+		$this->instance->build_post_hierarchy( 123, 'post_type' );
+	}
+
+	/**
+	 * Tests that no post hierarchy is built when its post type is excluded.
+	 *
+	 * @covers ::build_post_hierarchy
+	 */
+	public function test_do_not_build_post_hierarchy_when_post_is_excluded() {
+		$this->indexable_repository
+			->expects( 'find_by_id_and_type' )
+			->never();
+
+		$this->indexable_hierarchy_builder
+			->expects( 'build' )
+			->never();
+
+		$this->post_type_helper
+			->expects( 'is_excluded' )
+			->with( 'post_type' )
+			->andReturn( true );
 
 		$this->instance->build_post_hierarchy( 123, 'post_type' );
 	}

--- a/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
@@ -8,6 +8,7 @@ use wpdb;
 use Yoast\WP\SEO\Builders\Indexable_Hierarchy_Builder;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Helpers\Permalink_Helper;
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Ancestor_Watcher;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
@@ -76,6 +77,13 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 	protected $permalink_helper;
 
 	/**
+	 * The post type helper.
+	 *
+	 * @var Mockery\LegacyMockInterface|Mockery\MockInterface|Post_Type_Helper
+	 */
+	protected $post_type_helper;
+
+	/**
 	 * Sets up the tests.
 	 */
 	protected function set_up() {
@@ -86,13 +94,15 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 		$this->indexable_hierarchy_repository = Mockery::mock( Indexable_Hierarchy_Repository::class );
 		$this->wpdb                           = Mockery::mock( wpdb::class );
 		$this->permalink_helper               = Mockery::mock( Permalink_Helper::class );
+		$this->post_type_helper               = Mockery::mock( Post_Type_Helper::class );
 
 		$this->instance = new Indexable_Ancestor_Watcher(
 			$this->indexable_repository,
 			$this->indexable_hierarchy_builder,
 			$this->indexable_hierarchy_repository,
 			$this->wpdb,
-			$this->permalink_helper
+			$this->permalink_helper,
+			$this->post_type_helper
 		);
 	}
 
@@ -391,7 +401,26 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 			->once()
 			->with( $indexable );
 
-		$this->instance->build_post_hierarchy( 123 );
+		$this->instance->build_post_hierarchy( 123, 'post_type' );
+	}
+
+	/**
+	 * Tests that no post hierarchy is built when no indexable is found.
+	 *
+	 * @covers ::build_post_hierarchy
+	 */
+	public function test_build_post_hierarchy_not_an_indexable() {
+		$this->indexable_repository
+			->expects( 'find_by_id_and_type' )
+			->once()
+			->with( 123, 'post' )
+			->andReturn( false );
+
+		$this->indexable_hierarchy_builder
+			->expects( 'build' )
+			->never();
+
+		$this->instance->build_post_hierarchy( 123, 'post_type' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error would be thrown when creating a new Elementor template or editing an existing one.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new Elementor template.
* No fatal PHP error should be shown.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/QAK-2844
