### PR TITLE
Asset location backward compatibility

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -195,7 +195,7 @@ class WPSEO_Admin_Asset_Manager {
 			return new WPSEO_Admin_Asset_Dev_Server_Location( $url );
 		}
 
-		return new WPSEO_Admin_Asset_SEO_Location( WPSEO_FILE );
+		return new WPSEO_Admin_Asset_SEO_Location( WPSEO_FILE, false );
 	}
 
 	/**

--- a/admin/class-admin-asset-seo-location.php
+++ b/admin/class-admin-asset-seo-location.php
@@ -18,12 +18,21 @@ final class WPSEO_Admin_Asset_SEO_Location implements WPSEO_Admin_Asset_Location
 	protected $plugin_file;
 
 	/**
+	 * Whether or not to add the file suffix to the asset.
+	 *
+	 * @var boolean
+	 */
+	protected $add_suffix = true;
+
+	/**
 	 * The plugin file to base the asset location upon.
 	 *
-	 * @param string $plugin_file The plugin file string.
+	 * @param string  $plugin_file The plugin file string.
+	 * @param boolean $add_suffix  Optional. Whether or not a file suffix should be added.
 	 */
-	public function __construct( $plugin_file ) {
+	public function __construct( $plugin_file, $add_suffix = true ) {
 		$this->plugin_file = $plugin_file;
+		$this->add_suffix  = $add_suffix;
 	}
 
 	/**
@@ -58,6 +67,9 @@ final class WPSEO_Admin_Asset_SEO_Location implements WPSEO_Admin_Asset_Location
 		switch ( $type ) {
 			case WPSEO_Admin_Asset::TYPE_JS:
 				$relative_path = 'js/dist/' . $asset->get_src();
+				if ( $this->add_suffix ) {
+					$relative_path = $relative_path . $asset->get_suffix() . '.js';
+				}
 				break;
 
 			case WPSEO_Admin_Asset::TYPE_CSS:


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Preserves backwards compatibility for the asset location class by adding a new optional constructor argument.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See https://yoast.atlassian.net/browse/LINGO-770


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Asset loading. A quick test on our most important pages to scan for 404s on assets should be enough.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-770