### PR TITLE
P3-507 Add hook inside the post type archive section of the Search appearance

### DIFF
--- a/admin/views/tabs/metas/paper-content/author-archive-settings.php
+++ b/admin/views/tabs/metas/paper-content/author-archive-settings.php
@@ -67,6 +67,8 @@ $yform->index_switch(
 
 <?php
 
+echo '<div class="yoast-settings-section">';
+
 $recommended_replace_vars     = new WPSEO_Admin_Recommended_Replace_Vars();
 $editor_specific_replace_vars = new WPSEO_Admin_Editor_Specific_Replace_Vars();
 $editor                       = new WPSEO_Replacevar_Editor(
@@ -81,6 +83,8 @@ $editor                       = new WPSEO_Replacevar_Editor(
 );
 
 $editor->render();
+
+echo '</div>';
 
 /**
  * Allow adding custom fields to the admin meta page - Author Archives tab.

--- a/admin/views/tabs/metas/paper-content/author-archive-settings.php
+++ b/admin/views/tabs/metas/paper-content/author-archive-settings.php
@@ -87,11 +87,9 @@ $editor->render();
 echo '</div>';
 
 /**
- * Allow adding custom fields to the admin meta page - Author Archives tab.
+ * Allow adding custom fields to the admin meta page - Author archives panel in the Archives tab.
  *
- * @since 16.2
- *
- * @param WPSEO_Admin_Pages $yform The WPSEO_Admin_Pages object
+ * @param Yoast_Form $yform The Yoast_Form object.
  */
 do_action( 'Yoast\WP\SEO\admin_author_archives_meta', $yform );
 ?>

--- a/admin/views/tabs/metas/paper-content/date-archives-settings.php
+++ b/admin/views/tabs/metas/paper-content/date-archives-settings.php
@@ -58,11 +58,9 @@ $yform->toggle_switch(
 	echo '</div>';
 
 	/**
-	 * Allow adding custom fields to the admin meta page - Date Archives tab.
+	 * Allow adding custom fields to the admin meta page - Date archives panel in the Archives tab.
 	 *
-	 * @since 16.2
-	 *
-	 * @param WPSEO_Admin_Pages $yform The WPSEO_Admin_Pages object
+	 * @param Yoast_Form $yform The Yoast_Form object.
 	 */
 	do_action( 'Yoast\WP\SEO\admin_date_archives_meta', $yform );
 	?>

--- a/admin/views/tabs/metas/paper-content/date-archives-settings.php
+++ b/admin/views/tabs/metas/paper-content/date-archives-settings.php
@@ -37,6 +37,8 @@ $yform->toggle_switch(
 		$date_archives_help->get_button_html() . $date_archives_help->get_panel_html()
 	);
 
+	echo '<div class="yoast-settings-section">';
+
 	$recommended_replace_vars     = new WPSEO_Admin_Recommended_Replace_Vars();
 	$editor_specific_replace_vars = new WPSEO_Admin_Editor_Specific_Replace_Vars();
 
@@ -52,6 +54,8 @@ $yform->toggle_switch(
 	);
 
 	$editor->render();
+
+	echo '</div>';
 
 	/**
 	 * Allow adding custom fields to the admin meta page - Date Archives tab.

--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -25,7 +25,7 @@ require __DIR__ . '/post_type/post-type.php';
  * @param WPSEO_Admin_Pages $yform  The WPSEO_Admin_Pages object
  * @param string            $name   The post type name
  */
-do_action( 'Yoast\WP\SEO\admin_post_types_archive', $yform, $wpseo_post_type->name );
+do_action( 'Yoast\WP\SEO\admin_post_types_beforearchive', $yform, $wpseo_post_type->name );
 
 if ( $wpseo_post_type->name === 'product' && YoastSEO()->helpers->woocommerce->is_active() ) {
 	require __DIR__ . '/post_type/woocommerce-shop-page.php';
@@ -36,8 +36,14 @@ if ( $wpseo_post_type->name === 'product' && YoastSEO()->helpers->woocommerce->i
 if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 	$plural_label = $wpseo_post_type->labels->name;
 
+	echo '<div class="yoast-settings-section">';
+
 	/* translators: %s is the plural version of the post type's name. */
 	echo '<h3>' . esc_html( sprintf( __( 'Settings for %s archive', 'wordpress-seo' ), $plural_label ) ) . '</h3>';
+
+	echo '</div>';
+
+	echo '<div class="yoast-settings-section">';
 
 	$custom_post_type_archive_help = $view_utils->search_results_setting_help( $wpseo_post_type, 'archive' );
 
@@ -50,6 +56,10 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 		),
 		$custom_post_type_archive_help->get_button_html() . $custom_post_type_archive_help->get_panel_html()
 	);
+
+	echo '</div>';
+
+	echo '<div class="yoast-settings-section">';
 
 	$page_type = $recommended_replace_vars->determine_for_archive( $wpseo_post_type->name );
 
@@ -65,6 +75,16 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 	);
 	$editor->render();
 
+	echo '</div>';
+
+	/**
+	 * Allow adding custom fields to the admin meta page, just before the archive settings - Post Types tab.
+	 *
+	 * @param WPSEO_Admin_Pages $yform  The WPSEO_Admin_Pages object
+	 * @param string            $name   The post type name
+	 */
+	do_action( 'Yoast\WP\SEO\admin_post_types_archive', $yform, $wpseo_post_type->name );
+
 	if ( WPSEO_Options::get( 'breadcrumbs-enable' ) === true ) {
 		/* translators: %s is the plural version of the post type's name. */
 		echo '<h4>' . esc_html( sprintf( __( 'Breadcrumb settings for %s archive', 'wordpress-seo' ), $plural_label ) ) . '</h4>';
@@ -75,7 +95,7 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 /**
  * Allow adding a custom checkboxes to the admin meta page - Post Types tab.
  *
- * @deprecated 16.2 Use the {@see 'Yoast\WP\SEO\admin_post_types_archive'} action instead.
+ * @deprecated 16.2 Use the {@see 'Yoast\WP\SEO\admin_post_types_beforearchive'} action instead.
  *
  * @param  WPSEO_Admin_Pages  $yform The WPSEO_Admin_Pages object
  * @param  string             $name  The post type name
@@ -84,5 +104,5 @@ do_action_deprecated(
 	'wpseo_admin_page_meta_post_types',
 	[ $yform, $wpseo_post_type->name ],
 	'16.2',
-	'Yoast\WP\SEO\admin_post_types_archive'
+	'Yoast\WP\SEO\admin_post_types_beforearchive'
 );

--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -97,8 +97,8 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
  *
  * @deprecated 16.3 Use the {@see 'Yoast\WP\SEO\admin_post_types_beforearchive'} action instead.
  *
- * @param  Yoast_Form  $yform The Yoast_Form object
- * @param  string      $name  The post type name
+ * @param Yoast_Form $yform The Yoast_Form object.
+ * @param string     $name  The post type name.
  */
 do_action_deprecated(
 	'wpseo_admin_page_meta_post_types',

--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -95,14 +95,14 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 /**
  * Allow adding a custom checkboxes to the admin meta page - Post Types tab.
  *
- * @deprecated 16.2 Use the {@see 'Yoast\WP\SEO\admin_post_types_beforearchive'} action instead.
+ * @deprecated 16.3 Use the {@see 'Yoast\WP\SEO\admin_post_types_beforearchive'} action instead.
  *
- * @param  WPSEO_Admin_Pages  $yform The WPSEO_Admin_Pages object
- * @param  string             $name  The post type name
+ * @param  Yoast_Form  $yform The Yoast_Form object
+ * @param  string      $name  The post type name
  */
 do_action_deprecated(
 	'wpseo_admin_page_meta_post_types',
 	[ $yform, $wpseo_post_type->name ],
-	'16.2',
+	'16.3',
 	'Yoast\WP\SEO\admin_post_types_beforearchive'
 );

--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -20,10 +20,10 @@ echo '<h3>' . esc_html( sprintf( __( 'Settings for single %s URLs', 'wordpress-s
 require __DIR__ . '/post_type/post-type.php';
 
 /**
- * Allow adding custom fields to the admin meta page, just before the archive settings - Post Types tab.
+ * Allow adding custom fields to the admin meta page, just before the archive settings - Content Types tab.
  *
- * @param WPSEO_Admin_Pages $yform  The WPSEO_Admin_Pages object
- * @param string            $name   The post type name
+ * @param Yoast_Form $yform The Yoast_Form object.
+ * @param string     $name  The post type name.
  */
 do_action( 'Yoast\WP\SEO\admin_post_types_beforearchive', $yform, $wpseo_post_type->name );
 

--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -78,7 +78,7 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 	echo '</div>';
 
 	/**
-	 * Allow adding custom fields to the admin meta page, just before the archive settings - Post Types tab.
+	 * Allow adding custom fields to the admin meta page at the end of the archive settings for a post type.
 	 *
 	 * @param WPSEO_Admin_Pages $yform  The WPSEO_Admin_Pages object
 	 * @param string            $name   The post type name

--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -80,8 +80,8 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 	/**
 	 * Allow adding custom fields to the admin meta page at the end of the archive settings for a post type.
 	 *
-	 * @param WPSEO_Admin_Pages $yform  The WPSEO_Admin_Pages object
-	 * @param string            $name   The post type name
+	 * @param Yoast_Form $yform The Yoast_Form object.
+	 * @param string     $name  The post type name.
 	 */
 	do_action( 'Yoast\WP\SEO\admin_post_types_archive', $yform, $wpseo_post_type->name );
 

--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -78,7 +78,7 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 	echo '</div>';
 
 	/**
-	 * Allow adding custom fields to the admin meta page at the end of the archive settings for a post type.
+	 * Allow adding custom fields to the admin meta page at the end of the archive settings for a post type - Content Types tab.
 	 *
 	 * @param Yoast_Form $yform The Yoast_Form object.
 	 * @param string     $name  The post type name.

--- a/admin/views/tabs/metas/paper-content/post_type/post-type.php
+++ b/admin/views/tabs/metas/paper-content/post_type/post-type.php
@@ -16,6 +16,7 @@ use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
 $show_post_type_help = $view_utils->search_results_setting_help( $wpseo_post_type );
 $noindex_option_name = 'noindex-' . $wpseo_post_type->name;
 
+echo '<div class="yoast-settings-section">';
 
 $yform->index_switch(
 	$noindex_option_name,
@@ -29,6 +30,10 @@ $yform->show_hide_switch(
 	sprintf( esc_html__( 'Show SEO settings for %1$s', 'wordpress-seo' ), '<strong>' . $wpseo_post_type->labels->name . '</strong>' )
 );
 
+echo '</div>';
+
+echo '<div class="yoast-settings-section">';
+
 $editor = new WPSEO_Replacevar_Editor(
 	$yform,
 	[
@@ -41,6 +46,8 @@ $editor = new WPSEO_Replacevar_Editor(
 );
 $editor->render();
 
+echo '</div>';
+
 /**
  * Allow adding custom fields to the admin meta page - Post Types tab.
  *
@@ -50,6 +57,8 @@ $editor->render();
  * @param string            $name   The post type name
  */
 do_action( 'Yoast\WP\SEO\admin_post_types_meta', $yform, $wpseo_post_type->name );
+
+echo '<div class="yoast-settings-section">';
 
 // Schema settings.
 $article_helper             = new Article_Helper();
@@ -68,3 +77,5 @@ printf(
 	WPSEO_Options::get_default( 'wpseo_titles', $schema_page_type_option ),
 	WPSEO_Options::get_default( 'wpseo_titles', $schema_article_type_option )
 );
+
+echo '</div>';

--- a/admin/views/tabs/metas/paper-content/post_type/post-type.php
+++ b/admin/views/tabs/metas/paper-content/post_type/post-type.php
@@ -49,12 +49,10 @@ $editor->render();
 echo '</div>';
 
 /**
- * Allow adding custom fields to the admin meta page - Post Types tab.
+ * Allow adding custom fields to the admin meta page - Content Types tab.
  *
- * @since 16.2
- *
- * @param WPSEO_Admin_Pages $yform  The WPSEO_Admin_Pages object
- * @param string            $name   The post type name
+ * @param Yoast_Form $yform The Yoast_Form object.
+ * @param string     $name  The post type name.
  */
 do_action( 'Yoast\WP\SEO\admin_post_types_meta', $yform, $wpseo_post_type->name );
 

--- a/admin/views/tabs/metas/paper-content/taxonomy-content.php
+++ b/admin/views/tabs/metas/paper-content/taxonomy-content.php
@@ -12,6 +12,8 @@
  * @uses WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
  */
 
+echo '<div class="yoast-settings-section">';
+
 if ( $wpseo_taxonomy->name === 'post_format' ) {
 	$yform->light_switch(
 		'disable-post_format',
@@ -31,6 +33,17 @@ $yform->index_switch(
 	$taxonomies_help->get_button_html() . $taxonomies_help->get_panel_html()
 );
 
+if ( $wpseo_taxonomy->name !== 'post_format' ) {
+	$yform->show_hide_switch(
+		'display-metabox-tax-' . $wpseo_taxonomy->name,
+		/* translators: %s expands to an indexable object's name, like a post type or taxonomy */
+		sprintf( __( 'Show SEO settings for %1$s', 'wordpress-seo' ), '<strong>' . $title . '</strong>' )
+	);
+}
+
+echo '</div>';
+
+echo '<div class="yoast-settings-section">';
 
 // Determine the page type for the term, this is needed for the recommended replacement variables.
 $page_type = $recommended_replace_vars->determine_for_term( $wpseo_taxonomy->name );
@@ -47,13 +60,7 @@ $editor = new WPSEO_Replacevar_Editor(
 );
 $editor->render();
 
-if ( $wpseo_taxonomy->name !== 'post_format' ) {
-	$yform->show_hide_switch(
-		'display-metabox-tax-' . $wpseo_taxonomy->name,
-		/* translators: %s expands to an indexable object's name, like a post type or taxonomy */
-		sprintf( __( 'Show SEO settings for %1$s', 'wordpress-seo' ), '<strong>' . $title . '</strong>' )
-	);
-}
+echo '</div>';
 
 /**
  * Allow adding custom checkboxes to the admin meta page - Taxonomies tab.

--- a/admin/views/tabs/metas/paper-content/taxonomy-content.php
+++ b/admin/views/tabs/metas/paper-content/taxonomy-content.php
@@ -73,15 +73,15 @@ do_action( 'Yoast\WP\SEO\admin_taxonomies_meta', $yform, $wpseo_taxonomy );
 /**
  * Allow adding custom checkboxes to the admin meta page - Taxonomies tab.
  *
- * @deprecated 16.2 Use {@see 'Yoast\WP\SEO\admin_taxonomies_meta'} instead.
+ * @deprecated 16.3 Use {@see 'Yoast\WP\SEO\admin_taxonomies_meta'} instead.
  *
- * @param  WPSEO_Admin_Pages  $yform  The WPSEO_Admin_Pages object
- * @param  Object             $tax    The taxonomy
+ * @param  Yoast_Form  $yform  The Yoast_Form object
+ * @param  WP_Taxonomy $tax    The taxonomy
  */
 do_action_deprecated(
 	'wpseo_admin_page_meta_taxonomies',
 	[ $yform, $wpseo_taxonomy ],
-	'16.2',
+	'16.3',
 	'Yoast\WP\SEO\admin_taxonomies_meta'
 );
 

--- a/admin/views/tabs/metas/paper-content/taxonomy-content.php
+++ b/admin/views/tabs/metas/paper-content/taxonomy-content.php
@@ -36,7 +36,7 @@ $yform->index_switch(
 if ( $wpseo_taxonomy->name !== 'post_format' ) {
 	$yform->show_hide_switch(
 		'display-metabox-tax-' . $wpseo_taxonomy->name,
-		/* translators: %s expands to an indexable object's name, like a post type or taxonomy */
+		/* translators: %s: Expands to an indexable object's name, like a post type or taxonomy. */
 		sprintf( __( 'Show SEO settings for %1$s', 'wordpress-seo' ), '<strong>' . $title . '</strong>' )
 	);
 }
@@ -75,8 +75,8 @@ do_action( 'Yoast\WP\SEO\admin_taxonomies_meta', $yform, $wpseo_taxonomy );
  *
  * @deprecated 16.3 Use {@see 'Yoast\WP\SEO\admin_taxonomies_meta'} instead.
  *
- * @param  Yoast_Form  $yform  The Yoast_Form object
- * @param  WP_Taxonomy $tax    The taxonomy
+ * @param Yoast_Form  $yform          The Yoast_Form object.
+ * @param WP_Taxonomy $wpseo_taxonomy The taxonomy.
  */
 do_action_deprecated(
 	'wpseo_admin_page_meta_taxonomies',

--- a/admin/views/tabs/metas/paper-content/taxonomy-content.php
+++ b/admin/views/tabs/metas/paper-content/taxonomy-content.php
@@ -65,10 +65,8 @@ echo '</div>';
 /**
  * Allow adding custom checkboxes to the admin meta page - Taxonomies tab.
  *
- * @since 16.2
- *
- * @param  WPSEO_Admin_Pages  $yform  The WPSEO_Admin_Pages object
- * @param  Object             $tax    The taxonomy
+ * @param Yoast_Form  $yform          The Yoast_Form object.
+ * @param WP_Taxonomy $wpseo_taxonomy The taxonomy.
  */
 do_action( 'Yoast\WP\SEO\admin_taxonomies_meta', $yform, $wpseo_taxonomy );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The changes in the hooks by #16807 are not enough to add the new social templates fields for post type archives
* We also want to have distinct sections in distinct container to apply the expected spacing, and move all the toggles in the Taxonomies collapsibles to the top.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Deprecates the `wpseo_admin_page_meta_post_types` hook in favor of a new hook `Yoast\WP\SEO\admin_post_types_beforearchive`.
* Deprecates the `wpseo_admin_page_meta_taxonomies` hook in favor of a new jook `Yoast\WP\SEO\admin_taxonomies_meta`.
* Introduces a new `Yoast\WP\SEO\admin_post_types_beforearchive` hook.
* Adds a new hook `Yoast\WP\SEO\admin_post_types_archive` at the end of the archive section of the custom post types in Search Appearance.
* Improves the layout of the Search Appearance collapsibles.

## Relevant technical choices:

* #16807 had renamed `wpseo_admin_page_meta_post_types` to `Yoast\WP\SEO\admin_post_types_archive` and moved it before the post type archives.  This PR uses `Yoast\WP\SEO\admin_post_types_archive` for the hook _inside_ the archive section, while renaming the former one to `Yoast\WP\SEO\admin_post_types_beforearchive`. Since the previous change hadn't been released yet, we don't need a deprecation warning.
 
## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Hook change:
* this will need to be tested with the companion PR in Premium: https://github.com/Yoast/wordpress-seo-premium/pull/3277

#### Layout:
* visit `SEO` > `Search Appearance` and see that every section has a 40px spacing from the next and the previous one. This is the list of the sections:
```
CONTENT TYPES

    [thing] collapsible

        [thing] toggles section

        single [thing] settings section

            SEO section

            Social section

            Schema section

            Custom fields section

        [thing] archive settings section

            SEO section

            Social section

            Breadcrumbs section

TAXONOMIES & ARCHIVES

    [thing] collapsible

        [thing] toggles section

        SEO section

        Social section

        Breadcrumbs section
```
* Note that there is already an issue for a final check against the design. Some things like Breadcrumbs and Custom fields are being touched by other issues in the meantime.
* visit the `Taxonomy` tab, and see that the toggles are grouped at the top of each collapsibles:
  * for the Post Format taxonomy, the toggles are: "Format-based archives" and "Show Formats in search results?"
  * for any other taxonomy, the toggles are: "Show _Taxonomy_ in search results?" and "Show SEO settings for _Taxonomy_"

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* **N/A** the feature needs to be tested in its entirety

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-507]
