### PR TITLE
Fix news dependencies

### DIFF
--- a/src/conditionals/news-conditional.php
+++ b/src/conditionals/news-conditional.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Conditional that is only met when news SEO is activated.
+ */
+class News_Conditional implements Conditional {
+
+	/**
+	 * Returns whether or not this conditional is met.
+	 *
+	 * @return boolean Whether or not the conditional is met.
+	 */
+	public function is_met() {
+		return \defined( 'WPSEO_NEWS_VERSION' );
+	}
+}

--- a/src/integrations/admin/fix-news-dependencies-integration.php
+++ b/src/integrations/admin/fix-news-dependencies-integration.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use WP_Screen;
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\News_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Fix_News_Dependencies_Integration class.
+ */
+class Fix_News_Dependencies_Integration implements Integration_Interface {
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * In this case: when on an admin page.
+	 *
+	 * @return array The conditionals.
+	 */
+	public static function get_conditionals() {
+		return [ Admin_Conditional::class, News_Conditional::class ];
+	}
+
+	/**
+	 * Registers an action to disable script concatenation.
+	 */
+	public function register_hooks() {
+		global $pagenow;
+
+		// Load the editor script when on an edit post or new post page.
+		$is_post_edit_page = $pagenow === 'post.php' || $pagenow === 'post-new.php';
+		if ( $is_post_edit_page ) {
+			add_action( 'admin_enqueue_scripts', [ $this, 'add_news_script_dependency' ], 11 );
+		}
+
+		// Load the editor script when on an elementor edit page.
+		$get_action             = \filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING );
+		$is_elementor_edit_page = $pagenow === 'post.php' && $get_action === 'elementor';
+		if ( $is_elementor_edit_page ) {
+			add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'add_news_script_dependency' ], 11 );
+		}
+	}
+
+	/**
+	 * Fixes the news script dependency.
+	 *
+	 * @return void
+	 */
+	public function add_news_script_dependency() {
+		$scripts = wp_scripts();
+
+		if ( ! isset( $scripts->registered['wpseo-news-editor'] ) ) {
+			return;
+		}
+
+		$is_block_editor  = WP_Screen::get()->is_block_editor();
+		$post_edit_handle = 'post-edit';
+		if ( ! $is_block_editor ) {
+			$post_edit_handle = 'post-edit-classic';
+		}
+
+		$scripts->registered['wpseo-news-editor']->deps[] = WPSEO_Admin_Asset_Manager::PREFIX . $post_edit_handle;
+	}
+}

--- a/src/integrations/admin/fix-news-dependencies-integration.php
+++ b/src/integrations/admin/fix-news-dependencies-integration.php
@@ -35,13 +35,6 @@ class Fix_News_Dependencies_Integration implements Integration_Interface {
 		if ( $is_post_edit_page ) {
 			add_action( 'admin_enqueue_scripts', [ $this, 'add_news_script_dependency' ], 11 );
 		}
-
-		// Load the editor script when on an elementor edit page.
-		$get_action             = \filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING );
-		$is_elementor_edit_page = $pagenow === 'post.php' && $get_action === 'elementor';
-		if ( $is_elementor_edit_page ) {
-			add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'add_news_script_dependency' ], 11 );
-		}
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a News dependency issue that was causing an error with the Classic editor in News SEO.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Classic editor.
* Go to create new post in Classic editor.
* Make sure there are no console errors.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-771
