### PR TITLE
P3-522 Revert renaming of `wpseo_admin_page_meta_post_types` hook

### DIFF
--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -19,14 +19,6 @@ echo '<h3>' . esc_html( sprintf( __( 'Settings for single %s URLs', 'wordpress-s
 
 require __DIR__ . '/post_type/post-type.php';
 
-/**
- * Allow adding custom fields to the admin meta page, just before the archive settings - Post Types tab.
- *
- * @param WPSEO_Admin_Pages $yform  The WPSEO_Admin_Pages object
- * @param string            $name   The post type name
- */
-do_action( 'Yoast\WP\SEO\admin_post_types_archive', $yform, $wpseo_post_type->name );
-
 if ( $wpseo_post_type->name === 'product' && YoastSEO()->helpers->woocommerce->is_active() ) {
 	require __DIR__ . '/post_type/woocommerce-shop-page.php';
 
@@ -75,14 +67,7 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 /**
  * Allow adding a custom checkboxes to the admin meta page - Post Types tab.
  *
- * @deprecated 16.2 Use the {@see 'Yoast\WP\SEO\admin_post_types_archive'} action instead.
- *
- * @param  WPSEO_Admin_Pages  $yform The WPSEO_Admin_Pages object
- * @param  string             $name  The post type name
+ * @api  WPSEO_Admin_Pages  $yform  The WPSEO_Admin_Pages object
+ * @api  String  $name  The post type name
  */
-do_action_deprecated(
-	'wpseo_admin_page_meta_post_types',
-	[ $yform, $wpseo_post_type->name ],
-	'16.2',
-	'Yoast\WP\SEO\admin_post_types_archive'
-);
+do_action( 'wpseo_admin_page_meta_post_types', $yform, $wpseo_post_type->name );

--- a/admin/views/tabs/metas/paper-content/taxonomy-content.php
+++ b/admin/views/tabs/metas/paper-content/taxonomy-content.php
@@ -58,26 +58,9 @@ if ( $wpseo_taxonomy->name !== 'post_format' ) {
 /**
  * Allow adding custom checkboxes to the admin meta page - Taxonomies tab.
  *
- * @since 16.2
- *
- * @param  WPSEO_Admin_Pages  $yform  The WPSEO_Admin_Pages object
- * @param  Object             $tax    The taxonomy
+ * @api  WPSEO_Admin_Pages  $yform  The WPSEO_Admin_Pages object
+ * @api  Object             $tax    The taxonomy
  */
-do_action( 'Yoast\WP\SEO\admin_taxonomies_meta', $yform, $wpseo_taxonomy );
-
-/**
- * Allow adding custom checkboxes to the admin meta page - Taxonomies tab.
- *
- * @deprecated 16.2 Use {@see 'Yoast\WP\SEO\admin_taxonomies_meta'} instead.
- *
- * @param  WPSEO_Admin_Pages  $yform  The WPSEO_Admin_Pages object
- * @param  Object             $tax    The taxonomy
- */
-do_action_deprecated(
-	'wpseo_admin_page_meta_taxonomies',
-	[ $yform, $wpseo_taxonomy ],
-	'16.2',
-	'Yoast\WP\SEO\admin_taxonomies_meta'
-);
+do_action( 'wpseo_admin_page_meta_taxonomies', $yform, $wpseo_taxonomy );
 
 echo '</div>';


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We need to revert in Free 16.2 the hook renaming that was done by  #16807 because there won't be a matching Premium release and a deprecation warning will be displayed to users.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reverts the changes in `post-type-content.php` and `taxonomy-content.php` introduced by #16807

## Relevant technical choices:

* While #16807 introduced hooks in other files, we need just to revert the renaming so only the `post-type-content.php`  and  `taxonomy-content.php` file are touched by this PR.
* the hook formerly known as `wpseo_admin_page_meta_taxonomies` isn't used by our code at all so it can't be tested. It was decided to revert the renaming as well so both deprecation go live in 16.3 which is more consistent 
.
## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Premium 16.1
* make sure you have notices visible
* checkout `release/16.2` and build
* visit `SEO` > `Search Appearance`, `Content Types` tab, and check that there is a deprecation notice in the `Posts` collapsible just above the "Add custom fields to page analysis" (or it's in your log):
```
Deprecated: wpseo_admin_page_meta_post_types is deprecated since version 16.2! Use Yoast\WP\SEO\admin_post_types_archive instead. in /var/www/html/wp-includes/functions.php on line 5236 
```
* checkout this branch and build
* visit `SEO` > `Search Appearance`, `Content Types` tab, and check that there is no deprecation notice in the `Posts` collapsible just above the "Add custom fields to page analysis"


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:
* Activate Premium 16.1
* make sure you have notices visible
* visit `SEO` > `Search Appearance`, `Content Types` tab, and check that there is no deprecation notice in the `Posts` collapsible just above the "Add custom fields to page analysis" (or in your log)
The notice would have been:
```
Deprecated: wpseo_admin_page_meta_post_types is deprecated since version 16.2! Use Yoast\WP\SEO\admin_post_types_archive instead. in /var/www/html/wp-includes/functions.php on line 5236 
```

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-522]
