### PR TITLE
Make sure translations for the schema-blocks are working

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,7 +79,7 @@ module.exports = function( grunt ) {
 				yoastJsConfigurationWizard: "<%= paths.languages %>yoast-js-configuration-wizard.pot",
 				yoastJsHelpers: "<%= paths.languages %>yoast-js-helpers.pot",
 				yoastJsSearchMetadataPreviews: "<%= paths.languages %>yoast-js-search-metadata-previews.pot",
-				yoastSchemaBocks: "<%= paths.languages %>yoast-schema-blocks.pot",
+				yoastSchemaBlocks: "<%= paths.languages %>yoast-schema-blocks.pot",
 
 				yoastseojs: "<%= paths.languages %>yoast-seo-js.pot",
 				yoastComponents: "<%= paths.languages %>yoast-components.pot",
@@ -90,6 +90,7 @@ module.exports = function( grunt ) {
 				php: {
 					yoastseojs: "<%= paths.languages %>yoast-seo-js.php",
 					yoastComponents: "<%= paths.languages %>yoast-components.php",
+					yoastSchemaBlocks: "<%= paths.languages %>yoast-schema-blocks.php",
 					wordpressSeoJs: "<%= paths.languages %>wordpress-seojs.php",
 				},
 			},

--- a/admin/class-admin-asset-yoast-components-l10n.php
+++ b/admin/class-admin-asset-yoast-components-l10n.php
@@ -33,8 +33,9 @@ final class WPSEO_Admin_Asset_Yoast_Components_L10n {
 	 */
 	public function localize_script( $script_handle ) {
 		$translations = [
-			'yoast-components' => $this->get_translations( 'yoast-components' ),
-			'wordpress-seo'    => $this->get_translations( 'wordpress-seojs' ),
+			'yoast-components'    => $this->get_translations( 'yoast-components' ),
+			'wordpress-seo'       => $this->get_translations( 'wordpress-seojs' ),
+			'yoast-schema-blocks' => $this->get_translations( 'yoast-schema-blocks' ),
 		];
 		$this->asset_manager->localize_script( $script_handle, 'wpseoYoastJSL10n', $translations );
 	}

--- a/config/grunt/custom-tasks/i18n-clean-json.js
+++ b/config/grunt/custom-tasks/i18n-clean-json.js
@@ -81,6 +81,7 @@ module.exports = function( grunt ) {
 	function cleanJSONFiles() {
 		cleanJSON( "languages/yoast-seo-js.json", "languages/wordpress-seo-*.json", "wordpress-seo", "messages", "wordpress-seo" );
 		cleanJSON( "languages/yoast-components.json", "languages/yoast-components-*.json", "wordpress-seo", "messages", "yoast-components" );
+		cleanJSON( "languages/yoast-schema-blocks.json", "languages/yoast-schema-blocks-*.json", "wordpress-seo", "messages", "yoast-schema-blocks" );
 		cleanJSON( "languages/wordpress-seojs.json", "languages/wordpress-seojs-*.json", "wordpress-seo", "messages", "wordpress-seo" );
 	}
 

--- a/config/grunt/task-config/clean.js
+++ b/config/grunt/task-config/clean.js
@@ -11,6 +11,7 @@ module.exports = {
 		"<%= paths.languages %>*.po",
 		"<%= paths.languages %>*.pot",
 		"<%= paths.languages %>yoast-components.json",
+		"<%= paths.languages %>yoast-schema-blocks.json",
 		"<%= paths.languages %>yoast-seo.json",
 		"<%= paths.languages %>yoastseojsfiles.txt",
 	],

--- a/config/grunt/task-config/convert-pot-to-wp.js
+++ b/config/grunt/task-config/convert-pot-to-wp.js
@@ -11,6 +11,10 @@ module.exports = {
 		src: "<%= files.pot.yoastseojs %>",
 		dest: "<%= files.pot.php.yoastseojs %>",
 	},
+	yoastSchemaBlocks: {
+		src: "<%= files.pot.yoastSchemaBlocks %>",
+		dest: "<%= files.pot.php.yoastSchemaBlocks %>",
+	},
 	wordpressSeoJs: {
 		src: "<%= files.pot.wordpressSeoJs %>",
 		dest: "<%= files.pot.php.wordpressSeoJs %>",

--- a/config/grunt/task-config/copy.js
+++ b/config/grunt/task-config/copy.js
@@ -81,7 +81,7 @@ module.exports = {
 	},
 	"makepot-yoast-js-schema-blocks": {
 		src: "gettext.pot",
-		dest: "<%= files.pot.yoastSchemaBocks %>",
+		dest: "<%= files.pot.yoastSchemaBlocks %>",
 	},
 
 	// The default de_CH is formal on WordPress.org, but that one is not translated enough for wordpress-seo.

--- a/config/grunt/task-config/copy.js
+++ b/config/grunt/task-config/copy.js
@@ -53,6 +53,15 @@ module.exports = {
 					return dest + src.replace( "wordpress-seo", "wordpress-seojs" );
 				},
 			},
+			{
+				expand: true,
+				cwd: "languages/",
+				src: [ "wordpress-seo-*.json" ],
+				dest: "languages/",
+				rename: ( dest, src ) => {
+					return dest + src.replace( "wordpress-seo", "yoast-schema-blocks" );
+				},
+			},
 		],
 	},
 	"makepot-wordpress-seo": {

--- a/config/grunt/task-config/makepot.js
+++ b/config/grunt/task-config/makepot.js
@@ -15,6 +15,7 @@ module.exports = {
 				"premium/.*",
 				"<%= files.pot.php.yoastseojs %>",
 				"<%= files.pot.php.yoastComponents %>",
+				"<%= files.pot.php.yoastSchemaBlocks %>",
 				"<%= files.artifact %>",
 				"<%= files.artifactComposer %>",
 				".wordpress-svn",

--- a/config/grunt/task-config/po2json.js
+++ b/config/grunt/task-config/po2json.js
@@ -9,6 +9,7 @@ module.exports = {
 			"<%= files.pot.yoastseojs %>",
 			"<%= files.pot.yoastComponents %>",
 			"<%= files.pot.wordpressSeoJs %>",
+			"<%= files.pot.yoastSchemaBlocks %>",
 		],
 		dest: "languages",
 	},

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -29,7 +29,7 @@ module.exports = function( grunt ) {
 				"languages/<%= pkg.plugin.textdomain %>-temp.pot",
 				"<%= files.pot.yoastseojs %>",
 				"<%= files.pot.yoastComponents %>",
-				"<%= files.pot.yoastSchemaBocks %>",
+				"<%= files.pot.yoastSchemaBlocks %>",
 			],
 			toFile: "languages/<%= pkg.plugin.textdomain %>.pot",
 			command: function() {

--- a/js/src/schema-blocks.js
+++ b/js/src/schema-blocks.js
@@ -1,4 +1,7 @@
 import initialize from "@yoast/schema-blocks";
 import { LogLevel } from "@yoast/schema-blocks";
+import { setTextdomainL10n } from "./helpers/i18n";
+
+setTextdomainL10n( "yoast-schema-blocks" );
 
 initialize( LogLevel.ERROR );

--- a/src/integrations/schema-blocks.php
+++ b/src/integrations/schema-blocks.php
@@ -158,6 +158,5 @@ class Schema_Blocks implements Integration_Interface {
 	public function load_translations() {
 		$yoast_components_l10n = new \WPSEO_Admin_Asset_Yoast_Components_L10n();
 		$yoast_components_l10n->localize_script( 'schema-blocks' );
-
 	}
 }

--- a/src/integrations/schema-blocks.php
+++ b/src/integrations/schema-blocks.php
@@ -113,6 +113,9 @@ class Schema_Blocks implements Integration_Interface {
 				'recommendedLink' => $this->short_link_helper->build( 'https://yoa.st/recommended-fields' ),
 			]
 		);
+
+		$yoast_components_l10n = new \WPSEO_Admin_Asset_Yoast_Components_L10n();
+		$yoast_components_l10n->localize_script( 'schema-blocks' );
 	}
 
 	/**

--- a/src/integrations/schema-blocks.php
+++ b/src/integrations/schema-blocks.php
@@ -76,6 +76,7 @@ class Schema_Blocks implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'enqueue_block_editor_assets', [ $this, 'load' ] );
+		\add_action( 'enqueue_block_editor_assets', [ $this, 'load_translations' ] );
 		\add_action( 'admin_enqueue_scripts', [ $this, 'output' ] );
 	}
 
@@ -113,9 +114,6 @@ class Schema_Blocks implements Integration_Interface {
 				'recommendedLink' => $this->short_link_helper->build( 'https://yoa.st/recommended-fields' ),
 			]
 		);
-
-		$yoast_components_l10n = new \WPSEO_Admin_Asset_Yoast_Components_L10n();
-		$yoast_components_l10n->localize_script( 'schema-blocks' );
 	}
 
 	/**
@@ -152,5 +150,14 @@ class Schema_Blocks implements Integration_Interface {
 			include $template;
 			echo '</script>';
 		}
+	}
+
+	/**
+	 * Loads the translations and localizes the schema-blocks script file.
+	 */
+	public function load_translations() {
+		$yoast_components_l10n = new \WPSEO_Admin_Asset_Yoast_Components_L10n();
+		$yoast_components_l10n->localize_script( 'schema-blocks' );
+
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The setup wasn't completed the right way. This pull makes sure that the right translations are loaded.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the schema-blocks translations aren't loaded well.

## Relevant technical choices:

* In short how it works:
   * The potfile builder will look to all the strings with the text domain `yoast-schema-package`
   * All these strings are extracted and put in the `yoast-schema-blocks.php` file. Here it will get the `wordpress-seo` text domain. This allows translators to translate the strings in `translate.wordpress.org`
   * The next step is to get all translated values and put them in separate `yoast-schema-blocks-{language}.json` files for each language. 
   * All strings not present in the main file `yoast-schema-blocks.json` will be filtered out of the json file
   * A localize script will expose the translations to WordPress and the already translated strings will be shown in the user/site language.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test this against https://github.com/Yoast/javascript/pull/1153 
* Run `grunt build:i18n`
* Set your site to Dutch
* Add a job posting to your post
* See that the datepicker for closes on will have an translated value: `Selecteer een datum`
* Not all strings are translated at the moment, this is because the translations aren't extracted correct before
* In `language/yoast-schema-blocks.php` you will see all the translatable strings. These should have the textdomain `wordpress-seo`. In the further process of building the language file the right strings are extracted for the schema-blocks package.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
