### PR TITLE
Remove return documentation from constructors

### DIFF
--- a/inc/class-wpseo-replacement-variable.php
+++ b/inc/class-wpseo-replacement-variable.php
@@ -40,8 +40,6 @@ class WPSEO_Replacement_Variable {
 	 * @param string $variable    The variable that is replaced.
 	 * @param string $label       The label of the replacement variable.
 	 * @param string $description The description of the replacement variable.
-	 *
-	 * @return \WPSEO_Replacement_Variable
 	 */
 	public function __construct( $variable, $label, $description ) {
 		$this->variable    = $variable;

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -142,7 +142,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	/**
 	 * Add the actions and filters for the option.
 	 *
-	 * @return \WPSEO_Option_Wpseo
 	 * @todo [JRF => testers] Check if the extra actions below would run into problems if an option
 	 *       is updated early on and if so, change the call to schedule these for a later action on add/update
 	 *       instead of running them straight away.

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -142,8 +142,6 @@ abstract class WPSEO_Option {
 
 	/**
 	 * Add all the actions and filters for the option.
-	 *
-	 * @return \WPSEO_Option
 	 */
 	protected function __construct() {
 

--- a/lib/migrations/column.php
+++ b/lib/migrations/column.php
@@ -53,8 +53,6 @@ class Column {
 	 * @param array   $options The column options.
 	 *
 	 * @throws Exception If invalid arguments provided.
-	 *
-	 * @return Column
 	 */
 	public function __construct( $adapter, $name, $type, $options = [] ) {
 		if ( ! $adapter instanceof Adapter ) {

--- a/lib/migrations/migration.php
+++ b/lib/migrations/migration.php
@@ -39,8 +39,6 @@ abstract class Migration {
 	 * Creates a new migration.
 	 *
 	 * @param Adapter $adapter The current adapter.
-	 *
-	 * @return \Migration
 	 */
 	public function __construct( Adapter $adapter ) {
 		$this->set_adapter( $adapter );

--- a/lib/migrations/table.php
+++ b/lib/migrations/table.php
@@ -73,8 +73,6 @@ class Table {
 	 * @param array   $options The options.
 	 *
 	 * @throws Exception If invalid arguments are passed.
-	 *
-	 * @return Table
 	 */
 	public function __construct( $adapter, $name, $options = [] ) {
 		// Sanity checks.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Since constructors do not explicitly return anything, a CS error was thrown for six constructors which included an `@return` statement in their documentation.
* I removed these return statements to fix Travis, which was failing on this (although locally the tests didn't fail).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes `@return` statements from the documentation of some constructors, since they do not return anything.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* No test is needed, since this change only concerns documentation.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
