### PR TITLE
For RC1, as well as for beta1, ask the user to enter the full QA changelog

### DIFF
--- a/config/grunt/custom-tasks/github-pre-release.js
+++ b/config/grunt/custom-tasks/github-pre-release.js
@@ -44,12 +44,9 @@ module.exports = function( grunt ) {
 			// For the first beta and RC, use the full changelog. For follow-up betas and RCs, only use the changes.
 			let initialContent = `Changes compared to ${grunt.config.get( "previousPluginVersion" )}:\n`;
 
-			if ( pluginVersion.substr( pluginVersion.length - 3 ) === "beta1" ) {
-				initialContent = `Changes in this beta (${pluginVersion}):\n`;
-			}
-
-			if ( pluginVersion.substr( pluginVersion.length - 3 ) === "RC1" ) {
-				initialContent = `Changes in this RC (${pluginVersion}):\n`;
+			// Grab the string after index 5 (after "xx.x-") and check if it's the first beta or RC.
+			if ( pluginVersion.substr( 5 ) === "beta1" || pluginVersion.substr( 5 ) === "RC1" ) {
+				initialContent = `Changes in (${pluginVersion}):\n`;
 			}
 
 			// Open a text editor to get the changelog.

--- a/config/grunt/custom-tasks/github-pre-release.js
+++ b/config/grunt/custom-tasks/github-pre-release.js
@@ -45,7 +45,7 @@ module.exports = function( grunt ) {
 			let initialContent = `Changes compared to ${grunt.config.get( "previousPluginVersion" )}:\n`;
 
 			// Grab the string after index 5 (after "xx.x-") and check if it's the first beta or RC.
-			if ( pluginVersion.substr( 5 ) === "beta1" || pluginVersion.substr( 5 ) === "RC1" ) {
+			if ( pluginVersion.endsWith( "beta1" ) || pluginVersion.endsWith( "RC1" ) ) {
 				initialContent = `Changes in (${pluginVersion}):\n`;
 			}
 

--- a/config/grunt/custom-tasks/github-pre-release.js
+++ b/config/grunt/custom-tasks/github-pre-release.js
@@ -41,10 +41,15 @@ module.exports = function( grunt ) {
 
 			const pluginVersion = grunt.file.readJSON( "package.json" ).yoast.pluginVersion;
 
-			// For the first beta use the full changelog. For follow-up betas and RCs, only use the changes.
+			// For the first beta and RC, use the full changelog. For follow-up betas and RCs, only use the changes.
 			let initialContent = `Changes compared to ${grunt.config.get( "previousPluginVersion" )}:\n`;
+
 			if ( pluginVersion.substr( pluginVersion.length - 3 ) === "beta1" ) {
 				initialContent = `Changes in this beta (${pluginVersion}):\n`;
+			}
+
+			if ( pluginVersion.substr( pluginVersion.length - 3 ) === "RC1" ) {
+				initialContent = `Changes in this RC (${pluginVersion}):\n`;
 			}
 
 			// Open a text editor to get the changelog.

--- a/config/grunt/custom-tasks/github-pre-release.js
+++ b/config/grunt/custom-tasks/github-pre-release.js
@@ -44,7 +44,6 @@ module.exports = function( grunt ) {
 			// For the first beta and RC, use the full changelog. For follow-up betas and RCs, only use the changes.
 			let initialContent = `Changes compared to ${grunt.config.get( "previousPluginVersion" )}:\n`;
 
-			// Grab the string after index 5 (after "xx.x-") and check if it's the first beta or RC.
 			if ( pluginVersion.endsWith( "beta1" ) || pluginVersion.endsWith( "RC1" ) ) {
 				initialContent = `Changes in (${pluginVersion}):\n`;
 			}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* QA wants the complete changelog when it's RC1, not just the changes to the last beta.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prompts the dev to enter the full QA changelog for RC1 rather than just the changes to the last beta.
* Fixes a bug where the QA changelog did not contain the correct initial content.

## Relevant technical choices:

* I think the code for `beta1` also contained a bug, which I fixed here. 
    * If the version number is "16.1-beta1", the old code `pluginVersion.substr( pluginVersion.length - 3 )` would yield `ta1`, and would therefore never match to `beta1`. 
    * When you inspect the 16.1-beta1 [on GitHub releases](https://github.com/Yoast/wordpress-seo/releases/tag/16.1-beta1), it says "Changes compared to 16.0", which suggests the conditional wasn't entered at that time (while it should have been).
* The dev will still need to copy/paste the changelog. This just changes the prompt.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* I think we can just test this PR when creating the next beta1 and RC1, agreed? Testing this PR is a bit of a hassle: the code would have to be present in the release branch, and we might be pushing to GitHub, which is not desired. Of course it's possible to test this code but I don't think it's worth it.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* No need for QA to test this PR, it is just tooling.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
