### PR TITLE
Prevent the css/src folder from being shipped

### DIFF
--- a/config/grunt/task-config/copy.js
+++ b/config/grunt/task-config/copy.js
@@ -105,7 +105,7 @@ module.exports = {
 				cwd: ".",
 				src: [
 					"admin/**",
-					"css/**/*.css",
+					"css/dist/*.css",
 					"css/main-sitemap.xsl",
 					"deprecated/**",
 					"frontend/**",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We are shipping the `css/src` directory but we don't use these files.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where we accidentally ship the `css/src` directory.

## Relevant technical choices:

* Situation before:
<img width="486" alt="wordpress-seo_–_copy_js" src="https://user-images.githubusercontent.com/325040/114533542-45f50600-9c4e-11eb-8929-ae907274580c.png">

* Situation after:
![wordpress-seo_–_copy_js](https://user-images.githubusercontent.com/325040/114533461-35449000-9c4e-11eb-9e11-c2408813d578.png)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Checkout this branch
* Run `grunt artifact` in the terminal
* Open the artifact folder and see that there is no `css/src` directory anymore

Some sanity checks:
* You can unpack the artifact.zip file to verify the same, but that is just the compressed `artifact` folder.
* You can also install the zipfile to check if the styling is still loaded the right way.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
