### PR TITLE
New hooks on meta tabs for additional form fields

### DIFF
--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -19,6 +19,16 @@ echo '<h3>' . esc_html( sprintf( __( 'Settings for single %s URLs', 'wordpress-s
 
 require __DIR__ . '/post_type/post-type.php';
 
+/**
+ * Allow adding custom fields to the admin meta page, just before the archive settings - Post Types tab.
+ *
+ * @since 16.3
+ *
+ * @param Yoast_Form $yform The Yoast_Form object
+ * @param string     $name  The post type name
+ */
+do_action( 'Yoast\WP\SEO\admin_post_types_archive', $yform, $wpseo_post_type->name );
+
 if ( $wpseo_post_type->name === 'product' && YoastSEO()->helpers->woocommerce->is_active() ) {
 	require __DIR__ . '/post_type/woocommerce-shop-page.php';
 
@@ -67,7 +77,14 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 /**
  * Allow adding a custom checkboxes to the admin meta page - Post Types tab.
  *
- * @api  WPSEO_Admin_Pages  $yform  The WPSEO_Admin_Pages object
- * @api  String  $name  The post type name
+ * @deprecated 16.3 Use the {@see 'Yoast\WP\SEO\admin_post_types_archive'} action instead.
+ *
+ * @param Yoast_Form $yform The Yoast_Form object
+ * @param string     $name  The post type name
  */
-do_action( 'wpseo_admin_page_meta_post_types', $yform, $wpseo_post_type->name );
+do_action_deprecated(
+	'wpseo_admin_page_meta_post_types',
+	[ $yform, $wpseo_post_type->name ],
+	'16.3',
+	'Yoast\WP\SEO\admin_post_types_archive'
+);

--- a/admin/views/tabs/metas/paper-content/taxonomy-content.php
+++ b/admin/views/tabs/metas/paper-content/taxonomy-content.php
@@ -56,11 +56,28 @@ if ( $wpseo_taxonomy->name !== 'post_format' ) {
 }
 
 /**
+ * Allow adding custom fields to the admin meta page - Taxonomies tab.
+ *
+ * @since 16.3
+ *
+ * @param Yoast_Form $yform The Yoast_Form object
+ * @param Object     $tax   The taxonomy
+ */
+do_action( 'Yoast\WP\SEO\admin_taxonomies_meta', $yform, $wpseo_taxonomy );
+
+/**
  * Allow adding custom checkboxes to the admin meta page - Taxonomies tab.
  *
- * @api  WPSEO_Admin_Pages  $yform  The WPSEO_Admin_Pages object
- * @api  Object             $tax    The taxonomy
+ * @deprecated 16.3 Use {@see 'Yoast\WP\SEO\admin_taxonomies_meta'} instead.
+ *
+ * @param Yoast_Form $yform The Yoast_Form object
+ * @param Object     $tax   The taxonomy
  */
-do_action( 'wpseo_admin_page_meta_taxonomies', $yform, $wpseo_taxonomy );
+do_action_deprecated(
+	'wpseo_admin_page_meta_taxonomies',
+	[ $yform, $wpseo_taxonomy ],
+	'16.3',
+	'Yoast\WP\SEO\admin_taxonomies_meta'
+);
 
 echo '</div>';


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the additional form fields for `post-type-content.php` to be shown above the archives section
* We want the naming of the hooks to follow our naming guidelines
* We want this to be released in 16.3 at the same time as the 16.2 release of Premium

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* New hooks on meta tabs for content types & taxonomies for expanding the forms

## Relevant technical choices:

* This reverts commit dc930dcc so these new hooks can be released in 16.3 together with Premium 16.2. dc930dcc already reverted the introduction of these hooks, which would've introduced them in free 16.2 already. So this is in fact a revert of that revert (with the proper version numbers).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Checkout this PR and build the code (`$ composer install; yarn; grunt build`)
* Install the WooCommerce plugin
* Install the Yoast SEO: Local plugin

Checking the position of the premium "Add custom fields to page analysis" field.

Verify the old behavior first:
* Install the latest released version 16.1 of the Premium plugin (if necessary: `$ git checkout trunk; git reset --hard tags/16.1; composer install; yarn; grunt build`)
* Go to SEO > Search appearance > Content types
* In the `post` card there should be a deprecation warning above the field labeled "Add custom fields to page analysis"
* In the `product` card that field should not be available
* In the `wpseo_locations` card that field should be shown below the **Settings for Locations archive**

Now confirm the new behavior:
* update the Premium plugin to latest trunk (`$ git checkout trunk; git pull; composer install; yarn; grunt build`)
* Go to SEO > Search appearance > Content types
* In the `post` card there should be **no** deprecation warning above the field labeled "Add custom fields to page analysis"
* In the `product` card that field should now be available before the section about the archive
* In the `wpseo_locations` card that field should be shown **above** the Settings for Locations archive

Checking the deprecation messages

* Go to Appearance > Theme Editor. Select `functions.php`. At the end of the file add:
```lang=php
function hello_world() {
	echo 'Hello, world!';
}
add_action( 'wpseo_admin_page_meta_taxonomies', 'hello_world' );
add_action( 'wpseo_admin_page_meta_post_types', 'hello_world' );
```
* Go to SEO > Search appearance > Content Types
* At the end of the `post` card there should be a deprecation warning followed by the "Hello, world!" output from your custom action.
* Go to SEO > Search appearance > Taxonomies
* At the end of the `category` card there should be a deprecation warning followed by the "Hello, world!" output from your custom action.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Install the WooCommerce plugin
* Install the Yoast SEO: Local plugin

Checking the position of the premium "Add custom fields to page analysis" field.

* Install the latest version of the Premium plugin
* Go to SEO > Search appearance > Content types
* In the `post` card there should be **no** deprecation warning above the field labeled "Add custom fields to page analysis"
* In the `product` card that field should now be available before the section about the archive
* In the `wpseo_locations` card that field should be shown **above** the Settings for Locations archive

Checking the deprecation messages

* Go to Appearance > Theme Editor. Select `functions.php`. At the end of the file add:
```lang=php
function hello_world() {
	echo 'Hello, world!';
}
add_action( 'wpseo_admin_page_meta_taxonomies', 'hello_world' );
add_action( 'wpseo_admin_page_meta_post_types', 'hello_world' );
```
* Go to SEO > Search appearance > Content Types
* At the end of the `post` card there should be a deprecation warning followed by the "Hello, world!" output from your custom action.
* Go to SEO > Search appearance > Taxonomies
* At the end of the `category` card there should be a deprecation warning followed by the "Hello, world!" output from your custom action.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
