### PR TITLE
Removed call to error code in remote handler class as we can't be sure it's an integer

### DIFF
--- a/src/wrappers/wp-remote-handler.php
+++ b/src/wrappers/wp-remote-handler.php
@@ -48,7 +48,7 @@ class WP_Remote_Handler {
 
 		$raw_response = \wp_remote_request( $request->getUri(), $args );
 		if ( \is_wp_error( $raw_response ) ) {
-			$exception = new Exception( $raw_response->get_error_message(), $raw_response->get_error_code() );
+			$exception = new Exception( $raw_response->get_error_message() );
 			return new RejectedPromise( $exception );
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Removes call to `$raw_response->get_error_code()` in the `WP_Remote_Handler` class as `Exception` expects an integer, but would sometimes receive a string instead.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes call to `$raw_response->get_error_code()` in the `WP_Remote_Handler` class as `Exception` expects an integer, but would sometimes receive a string instead.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Ensure you've correctly built this branch (`composer install`, `yarn`, `grunt build`).
* Create a new post and add a keyphrase.
* Click the 'Get related keyphrases' button and see the Semrush window pop up.
* Log in with your account, if prompted to do so.
* Add the following line to the hosts file (can be found as `/etc/hosts` and make sure you open it as `sudo`) on your machine: `127.0.0.1 oauth.semrush.com`.
* Go back to the Semrush window and click 'Approve'.
* A fatal error should no longer show up in your Docker's error log.
* **Make sure to remove the entry added to your host's file after testing.**

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Create a new post and add a keyphrase.
* Click the 'Get related keyphrases' button and see the Semrush window pop up.
* Log in with your account, if prompted to do so.
* Add the following line to the hosts file (can be found as `/etc/hosts` and make sure you open it as `sudo`) on your machine: `127.0.0.1 oauth.semrush.com`.
* Go back to the Semrush window and click 'Approve'.
* A fatal error should no longer show up in your Docker's error log.
* **Make sure to remove the entry added to your host's file after testing.**

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-528]
