### PR TITLE
P2-857 Use the same hooks when handling primary terms

### DIFF
--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -20,7 +20,7 @@ class WPSEO_Primary_Term_Admin implements WPSEO_WordPress_Integration {
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 
-		add_action( 'save_post', [ $this, 'save_primary_terms' ] );
+		add_action( 'set_object_terms', [ $this, 'save_primary_terms' ], ( \PHP_INT_MAX - 1000 ) );
 	}
 
 	/**

--- a/src/integrations/watchers/primary-term-watcher.php
+++ b/src/integrations/watchers/primary-term-watcher.php
@@ -79,7 +79,7 @@ class Primary_Term_Watcher implements Integration_Interface {
 	 * This is the place to register hooks and filters.
 	 */
 	public function register_hooks() {
-		\add_action( 'save_post', [ $this, 'save_primary_terms' ] );
+		\add_action( 'set_object_terms', [ $this, 'save_primary_terms' ], ( \PHP_INT_MAX - 500 ) );
 		\add_action( 'delete_post', [ $this, 'delete_primary_terms' ] );
 	}
 

--- a/tests/unit/integrations/watchers/primary-term-watcher-test.php
+++ b/tests/unit/integrations/watchers/primary-term-watcher-test.php
@@ -100,7 +100,7 @@ class Primary_Term_Watcher_Test extends TestCase {
 	public function test_register_hooks() {
 		$this->instance->register_hooks();
 
-		$this->assertNotFalse( Monkey\Actions\has( 'save_post', [ $this->instance, 'save_primary_terms' ] ) );
+		$this->assertNotFalse( Monkey\Actions\has( 'set_object_terms', [ $this->instance, 'save_primary_terms' ] ) );
 		$this->assertNotFalse( Monkey\Actions\has( 'delete_post', [ $this->instance, 'delete_primary_terms' ] ) );
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to save the primary term the right way

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Fixes a bug where the primary term isn't saved at the right moment resulting in having an unexpected term for the breadcrumbs.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Create a post and select a category. For example: Cat A
* Save the post and see that Cat A is in the breadcrumbs
* Now choose Cat B and deselect Cat A and save.
* Cat B is now the one reflected in the breadcrumbs
* Select Cat A, Cat B en Cat C and choose Cat C to be the primary term and save.
* Cat C is now reflected in the breadcrumbs.

* Go to the post overview and quick edit the post
* Deselect all categories and select Cat D.
* Cat D should be reflected in the breadcrumbs


## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
