### PR TITLE
P2-818 Removed Schema blocks feature flag conditional from Schema blocks integration.

### DIFF
--- a/src/integrations/schema-blocks.php
+++ b/src/integrations/schema-blocks.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Integrations;
 
 use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Conditionals\Schema_Blocks_Conditional;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 
@@ -10,6 +11,8 @@ use Yoast\WP\SEO\Helpers\Short_Link_Helper;
  * Loads schema block templates into Gutenberg.
  */
 class Schema_Blocks implements Integration_Interface {
+
+	use No_Conditionals;
 
 	/**
 	 * The registered templates.
@@ -38,17 +41,6 @@ class Schema_Blocks implements Integration_Interface {
 	 * @var Short_Link_Helper
 	 */
 	protected $short_link_helper;
-
-	/**
-	 * Returns the conditionals based in which this loadable should be active.
-	 *
-	 * @return array
-	 */
-	public static function get_conditionals() {
-		return [
-			Schema_Blocks_Conditional::class,
-		];
-	}
 
 	/**
 	 * Schema_Blocks constructor.

--- a/tests/unit/integrations/schema-blocks-test.php
+++ b/tests/unit/integrations/schema-blocks-test.php
@@ -98,7 +98,7 @@ class Schema_Blocks_Test extends TestCase {
 	 * @covers ::get_conditionals
 	 */
 	public function test_get_conditionals() {
-		static::assertSame( [ Schema_Blocks_Conditional::class ], Schema_Blocks::get_conditionals() );
+		static::assertSame( [], Schema_Blocks::get_conditionals() );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We need to enable the schema blocks feature for upcoming WordPress SEO Premium functionality to work.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enables the Schema blocks feature feature for upcoming WordPress SEO Premium functionality to work.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Companion PR of https://github.com/Yoast/wordpress-seo-premium/pull/3283.
	* You only have to test this once in WordPress SEO Premium!  
	* Use the steps as described in that PR. 
* **Note**: This PR may impact some functionality in Free. See the _Impact check_ below.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Please test whether the recipe block is still behind the Schema blocks feature flag.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
