### PR TITLE
Fix additional space between setting titles and settings.

### DIFF
--- a/admin/views/tabs/metas/paper-content/author-archive-settings.php
+++ b/admin/views/tabs/metas/paper-content/author-archive-settings.php
@@ -19,6 +19,7 @@ $yform->toggle_switch(
 ?>
 
 <div id='author-archives-titles-metas-content' class='archives-titles-metas-content'>
+<div class="yoast-settings-section">
 
 <?php
 $author_archives_help = new WPSEO_Admin_Help_Panel(
@@ -63,6 +64,7 @@ $yform->index_switch(
 );
 
 ?>
+</div>
 </div>
 
 <?php

--- a/admin/views/tabs/metas/paper-content/date-archives-settings.php
+++ b/admin/views/tabs/metas/paper-content/date-archives-settings.php
@@ -18,6 +18,7 @@ $yform->toggle_switch(
 
 ?>
 <div id='date-archives-titles-metas-content' class='archives-titles-metas-content'>
+<div class="yoast-settings-section">
 	<?php
 	$date_archives_help = new WPSEO_Admin_Help_Panel(
 		'noindex-archive-wpseo',
@@ -37,6 +38,7 @@ $yform->toggle_switch(
 		$date_archives_help->get_button_html() . $date_archives_help->get_panel_html()
 	);
 
+	echo '</div>';
 	echo '<div class="yoast-settings-section">';
 
 	$recommended_replace_vars     = new WPSEO_Admin_Recommended_Replace_Vars();

--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -36,12 +36,8 @@ if ( $wpseo_post_type->name === 'product' && YoastSEO()->helpers->woocommerce->i
 if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 	$plural_label = $wpseo_post_type->labels->name;
 
-	echo '<div class="yoast-settings-section">';
-
 	/* translators: %s is the plural version of the post type's name. */
 	echo '<h3>' . esc_html( sprintf( __( 'Settings for %s archive', 'wordpress-seo' ), $plural_label ) ) . '</h3>';
-
-	echo '</div>';
 
 	echo '<div class="yoast-settings-section">';
 

--- a/admin/views/tabs/metas/paper-content/taxonomy-content.php
+++ b/admin/views/tabs/metas/paper-content/taxonomy-content.php
@@ -12,8 +12,6 @@
  * @uses WPSEO_Admin_Editor_Specific_Replace_Vars $editor_specific_replace_vars
  */
 
-echo '<div class="yoast-settings-section">';
-
 if ( $wpseo_taxonomy->name === 'post_format' ) {
 	$yform->light_switch(
 		'disable-post_format',
@@ -23,6 +21,7 @@ if ( $wpseo_taxonomy->name === 'post_format' ) {
 	);
 }
 
+echo '<div class="yoast-settings-section">';
 echo "<div id='" . esc_attr( $wpseo_taxonomy->name ) . "-titles-metas'>";
 
 $taxonomies_help = $view_utils->search_results_setting_help( $wpseo_taxonomy );
@@ -41,6 +40,7 @@ if ( $wpseo_taxonomy->name !== 'post_format' ) {
 	);
 }
 
+echo '</div>';
 echo '</div>';
 
 echo '<div class="yoast-settings-section">';
@@ -84,5 +84,3 @@ do_action_deprecated(
 	'16.3',
 	'Yoast\WP\SEO\admin_taxonomies_meta'
 );
-
-echo '</div>';

--- a/admin/views/tabs/metas/post-types.php
+++ b/admin/views/tabs/metas/post-types.php
@@ -49,7 +49,7 @@ if ( get_option( 'show_on_front' ) === 'posts' && WPSEO_Options::get( 'opengraph
 				'editor_specific_replace_vars' => $editor_specific_replace_vars,
 			],
 			'title'       => $frontpage_settings_title,
-			'class'       => 'search-appearance',
+			'class'       => 'search-appearance has-paper-container-no-top-padding',
 		]
 	);
 

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -278,6 +278,10 @@ tr.yst_row.even {
   padding: 16px;
 }
 
+.wpseo_content_wrapper .paper.tab-block.has-paper-container-no-top-padding .paper-container {
+	padding-top: 0;
+}
+
 .wpseo_content_wrapper .paper.tab-block .paper-container:first-child {
   margin-top: 0;
 }
@@ -530,10 +534,6 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 .wpseo-progressbar .ui-progressbar-value {
   height: 25px;
   background: #006691;
-}
-
-.archives-titles-metas-content {
-  padding-top: 1em;
 }
 
 /* Banners sidebar. */
@@ -897,12 +897,8 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
   vertical-align: top;
 }
 
-.yoast-settings-section {
-	margin: 40px 0;
-}
-
-.yoast-settings-section.yoast-settings-section--last {
-	margin-bottom: 0;
+.yoast-settings-section:not(:last-child) {
+	margin-bottom: 40px;
 }
 
 .yoast-settings-section .yoast-help-icon::before {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid to introduce in trunk some extra vertical spacing displayed in the settings pages, between titles and settings. These changes were introduced as part of the preparation for the Global Social Templates feature. See https://github.com/Yoast/wordpress-seo/pull/16858 and https://github.com/Yoast/wordpress-seo/pull/16872. At the same time, we want to introduce some spacing between sections of settings, in preparation for the Global Social Templates.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves spacing between settings sections.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* install and activate Yoast SEO (switched to this branch and built)
* make sure you don't have the `YOAST_SEO_SOCIAL_TEMPLATES` feature flag enabled
* on a different environment, e.g. Local by Flywheel, install and activate Yoast SEO 16.2RC1
* compare the settings pages in this branch with the ones on 16.2RC1
* go to SEO > Search Appearance
* check the Content Types, Taxonomies, and Archives tabs 
* make sure the space between the main titles and the settings is the same on this branch and 16.2RC1
* check that in this branch the vertical spacing between single settings within a section is even, for example: between the toggles
* check that in this branch _there is_ a 40 pixels vertical space between setting sections
* the settings sections are typically made of the following groups of settings:
  *  toggles
  * SEO title and description 
  * Schema settings (only in the Content Types tab)
  * the "Custom fields to include in page analysis" (only with Premium activated)

Note: the extra space between sections is necessary in preparation of the Global Social Templates feature.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

Except building this branch, of course.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-531]
