### PR TITLE
Handle the situation where the auto_update_plugins option did not previously exist

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -71,6 +71,7 @@ class WPSEO_Upgrade {
 			'15.5-RC0'   => 'upgrade_155',
 			'15.7-RC0'   => 'upgrade_157',
 			'15.9.1-RC0' => 'upgrade_1591',
+			'16.2-RC0'   => 'upgrade_162',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -804,6 +805,15 @@ class WPSEO_Upgrade {
 		$enabled_auto_updates = \get_option( 'auto_update_plugins' );
 		$addon_update_watcher = YoastSEO()->classes->get( \Yoast\WP\SEO\Integrations\Watchers\Addon_Update_Watcher::class );
 		$addon_update_watcher->toggle_auto_updates_for_add_ons( 'auto_update_plugins', [], $enabled_auto_updates );
+	}
+
+	/**
+	 * Performs the 16.2 upgrade routine.
+	 */
+	private function upgrade_162() {
+		$enabled_auto_updates = \get_site_option( 'auto_update_plugins' );
+		$addon_update_watcher = YoastSEO()->classes->get( \Yoast\WP\SEO\Integrations\Watchers\Addon_Update_Watcher::class );
+		$addon_update_watcher->toggle_auto_updates_for_add_ons( 'auto_update_plugins', $enabled_auto_updates, [] );
 	}
 
 	/**

--- a/src/integrations/watchers/addon-update-watcher.php
+++ b/src/integrations/watchers/addon-update-watcher.php
@@ -37,7 +37,7 @@ class Addon_Update_Watcher implements Integration_Interface {
 	 * Registers the hooks.
 	 */
 	public function register_hooks() {
-		\add_action( 'add_option_auto_update_plugins', [ $this, 'call_toggle_auto_updates_with_empty_array' ], 10, 2 );
+		\add_action( 'add_site_option_auto_update_plugins', [ $this, 'call_toggle_auto_updates_with_empty_array' ], 10, 2 );
 		\add_action( 'update_site_option_auto_update_plugins', [ $this, 'toggle_auto_updates_for_add_ons' ], 10, 3 );
 		\add_filter( 'plugin_auto_update_setting_html', [ $this, 'replace_auto_update_toggles_of_addons' ], 10, 2 );
 	}

--- a/src/integrations/watchers/addon-update-watcher.php
+++ b/src/integrations/watchers/addon-update-watcher.php
@@ -37,15 +37,8 @@ class Addon_Update_Watcher implements Integration_Interface {
 	 * Registers the hooks.
 	 */
 	public function register_hooks() {
-		\add_action(
-			'update_site_option_auto_update_plugins',
-			[
-				$this,
-				'toggle_auto_updates_for_add_ons',
-			],
-			10,
-			3
-		);
+		\add_action( 'add_option_auto_update_plugins', [ $this, 'call_toggle_auto_updates_with_empty_array' ], 10, 2 );
+		\add_action( 'update_site_option_auto_update_plugins', [ $this, 'toggle_auto_updates_for_add_ons' ], 10, 3 );
 		\add_filter( 'plugin_auto_update_setting_html', [ $this, 'replace_auto_update_toggles_of_addons' ], 10, 2 );
 	}
 
@@ -100,6 +93,20 @@ class Addon_Update_Watcher implements Integration_Interface {
 				'Yoast SEO'
 			)
 		);
+	}
+
+	/**
+	 * Handles the situation where the auto_update_plugins option did not previously exist.
+	 *
+	 * @param string      $option The name of the option that is being created.
+	 * @param array|mixed $value  The new (and first) value of the option that is being created.
+	 */
+	public function call_toggle_auto_updates_with_empty_array( $option, $value ) {
+		if ( $option !== 'auto_update_plugins' ) {
+			return;
+		}
+
+		$this->toggle_auto_updates_for_add_ons( $option, $value, [] );
 	}
 
 	/**

--- a/tests/unit/integrations/watchers/addon-update-watcher-test.php
+++ b/tests/unit/integrations/watchers/addon-update-watcher-test.php
@@ -43,6 +43,10 @@ class Addon_Update_Watcher_Test extends TestCase {
 	 * @covers ::register_hooks
 	 */
 	public function test_register_hooks() {
+		Monkey\Actions\expectAdded( 'add_option_auto_update_plugins' )
+			->with( [ $this->instance, 'call_toggle_auto_updates_with_empty_array' ] )
+			->once();
+
 		Monkey\Actions\expectAdded( 'update_site_option_auto_update_plugins' )
 			->with( [ $this->instance, 'toggle_auto_updates_for_add_ons' ] )
 			->once();
@@ -61,6 +65,30 @@ class Addon_Update_Watcher_Test extends TestCase {
 	 */
 	public function test_get_conditionals() {
 		self::assertEquals( [ Admin_Conditional::class ], Addon_Update_Watcher::get_conditionals() );
+	}
+
+	/**
+	 * Tests that add-on auto-updates are enabled when the `auto_update_plugins` option didn't previously exist.
+	 *
+	 * @covers ::call_toggle_auto_updates_with_empty_array
+	 */
+	public function test_auto_update_plugins_option_did_not_exist() {
+		$plugins = [
+			'wordpress-seo/wp-seo.php',
+			'wordpress-seo-premium/wp-seo-premium.php',
+			'wpseo-video/video-seo.php',
+			'wpseo-local/local-seo.php',
+			'wpseo-woocommerce/wpseo-woocommerce.php',
+			'wpseo-news/wpseo-news.php',
+			'acf-content-analysis-for-yoast-seo/yoast-acf-analysis.php',
+		];
+
+		Monkey\Functions\expect( 'update_site_option' )
+			->once()
+			->with( 'auto_update_plugins', $plugins )
+			->andReturn( true );
+
+		$this->instance->call_toggle_auto_updates_with_empty_array( 'auto_update_plugins', [ 'wordpress-seo/wp-seo.php' ] );
 	}
 
 	/**

--- a/tests/unit/integrations/watchers/addon-update-watcher-test.php
+++ b/tests/unit/integrations/watchers/addon-update-watcher-test.php
@@ -43,7 +43,7 @@ class Addon_Update_Watcher_Test extends TestCase {
 	 * @covers ::register_hooks
 	 */
 	public function test_register_hooks() {
-		Monkey\Actions\expectAdded( 'add_option_auto_update_plugins' )
+		Monkey\Actions\expectAdded( 'add_site_option_auto_update_plugins' )
 			->with( [ $this->instance, 'call_toggle_auto_updates_with_empty_array' ] )
 			->once();
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The `update_site_option_auto_update_plugins` hook would not fire if the `auto_update_plugins` option did not yet exist. This would be the case when a user would have never enabled auto-updates for a plugin before.
* In this case, where Yoast SEO would be a user's first ever plugin for which auto-updates were enabled, all the add-ons would not be added to the list of plugins to auto-update.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where our add-ons would not automatically be updated if Yoast SEO was the first plugin for which the user ever enabled auto-updates.

## Relevant technical choices:

* I added the `add_site_option_auto_update_plugins` hook, which fires when an option is created for the first time.
* I wrote an upgrade routine to fix the situation where users only have working auto-updates for Yoast SEO (due to the bug that is fixed in this PR), even though they think that auto-updates are enabled for the add-ons as well.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

_For reference_, our add-ons are: Premium, Video, News, Local, WooCommerce and ACF Content Analysis for Yoast SEO.

**To reproduce the problem on single-site**
* Use `trunk` or an RC zip that doesn't contain this fix.
* Either start from a clean installation, or manually remove the `auto_update_plugins` option from the `wp_options` table in your database.
* Go to the Plugins page and activate Yoast SEO.
* Enable auto-updates for Yoast SEO.
* Refresh the page.
* See that the add-ons now have this text: "Auto-updates are enabled based on this setting for Yoast SEO."
* In your database, inspect the `auto_update_plugins` option in `wp_options` and see that it only holds Yoast SEO (`'wordpress-seo/wp-seo.php`), and not the filenames of the other add-ons.

**To test the fix on single-site**
* Use this branch or an RC zip that does contain this fix.
* Repeat the above steps except for the last one.
* In your database, inspect the `auto_update_plugins` option in `wp_options` and see that it holds Yoast SEO (`'wordpress-seo/wp-seo.php`), as well as our other add-ons.

**To test the upgrade routine on single-site**
* Use this branch or an RC zip that does contain this fix.
* Install and activate the Yoast Test Helper plugin.
* In your database, in the `wp_options` table, set the option `auto_update_plugins` to the following value:
  ```
  a:1:{i:0;s:24:"wordpress-seo/wp-seo.php";}
  ```
  * This emulates that auto-updates for the Yoast SEO plugin, and only for that plugin, have been enabled.
* Execute the upgrade routine manually by going to the test helper and setting the version number of the Yoast SEO plugin to something before `16.2` (e.g. `16.0`).
* In your database, in the `wp_options` table, see that the option `auto_update_plugins` is an array which contains all the above add-ons (and potentially other plugins too).

**To reproduce the problem on multi-site**
* Use `trunk` or an RC zip that doesn't contain this fix.
* Either start from a clean installation, or manually remove the `auto_update_plugins` option from the `wp_sitemeta` table in your database.
* Go to the Plugins page in the Network admin and (network) activate Yoast SEO.
* Enable auto-updates for Yoast SEO.
* Refresh the page.
* See that the add-ons now have this text: "Auto-updates are enabled based on this setting for Yoast SEO."
* In your database, inspect the `auto_update_plugins` option in `wp_sitemeta` and see that it only holds Yoast SEO (`'wordpress-seo/wp-seo.php`), and not the filenames of the other add-ons.

**To test the fix on multi-site**
* Use this branch or an RC zip that does contain this fix.
* Repeat the above steps except for the last one.
* In your database, inspect the `auto_update_plugins` option in `wp_sitemeta` and see that it holds Yoast SEO (`'wordpress-seo/wp-seo.php`), as well as our other add-ons.

**To test the upgrade routine on multi-site**
* Use this branch or an RC zip that does contain this fix.
* Install and activate the Yoast Test Helper plugin in the network admin.
* In your database, in the `wp_sitemeta` table, set the option `auto_update_plugins` to the following value:
  ```
  a:1:{i:0;s:24:"wordpress-seo/wp-seo.php";}
  ```
* Execute the upgrade routine manually by going to the test helper (in a subsite) and setting the version number of the Yoast SEO plugin to something before `16.2` (e.g. `16.0`).
* In your database, in the `wp_sitemeta` table, see that the option `auto_update_plugins` is an array which contains all the above add-ons (and potentially other plugins too).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The add-on auto-update functionality on single-site and multi-site.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
