### PR TITLE
Rename variable-tag-rich-text to heading

### DIFF
--- a/src/schema-templates/ingredients.block.php
+++ b/src/schema-templates/ingredients.block.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore Internal.NoCodeFound ?>
 {{block name="yoast/ingredients" title="Ingredients" category="common" parent=[ "yoast/recipe" ] }}
 <div class={{class-name}}>
-	{{heading name="title" defaultHeadingLevel="3" placeholder="Ingredients title" }}
+	{{heading name="title" defaultHeadingLevel=3 placeholder="Ingredients title" }}
 	{{rich-text name="ingredients" tag=["ul"] multiline="li" placeholder="Ingredient 1" }}
 </div>

--- a/src/schema-templates/ingredients.block.php
+++ b/src/schema-templates/ingredients.block.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore Internal.NoCodeFound ?>
 {{block name="yoast/ingredients" title="Ingredients" category="common" parent=[ "yoast/recipe" ] }}
 <div class={{class-name}}>
-	{{variable-tag-rich-text name="ingredients" tags=["ul", "ol"] multiline="li" placeholder="Ingredient 1" }}
 	{{heading name="title" default-tag="h3" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="Ingredients title" }}
+	{{rich-text name="ingredients" tag=["ul"] multiline="li" placeholder="Ingredient 1" }}
 </div>

--- a/src/schema-templates/ingredients.block.php
+++ b/src/schema-templates/ingredients.block.php
@@ -2,5 +2,5 @@
 {{block name="yoast/ingredients" title="Ingredients" category="common" parent=[ "yoast/recipe" ] }}
 <div class={{class-name}}>
 	{{heading name="title" defaultHeadingLevel=3 placeholder="Ingredients title" }}
-	{{rich-text name="ingredients" tag=["ul"] multiline="li" placeholder="Ingredient 1" }}
+	{{rich-text name="ingredients" tag="ul" multiline="li" placeholder="Ingredient 1" }}
 </div>

--- a/src/schema-templates/ingredients.block.php
+++ b/src/schema-templates/ingredients.block.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore Internal.NoCodeFound ?>
 {{block name="yoast/ingredients" title="Ingredients" category="common" parent=[ "yoast/recipe" ] }}
 <div class={{class-name}}>
-	{{variable-tag-rich-text name="title" default-tag="h3" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="Ingredients title" }}
 	{{variable-tag-rich-text name="ingredients" tags=["ul", "ol"] multiline="li" placeholder="Ingredient 1" }}
+	{{heading name="title" default-tag="h3" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="Ingredients title" }}
 </div>

--- a/src/schema-templates/ingredients.block.php
+++ b/src/schema-templates/ingredients.block.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore Internal.NoCodeFound ?>
 {{block name="yoast/ingredients" title="Ingredients" category="common" parent=[ "yoast/recipe" ] }}
 <div class={{class-name}}>
-	{{heading name="title" default-tag="h3" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="Ingredients title" }}
+	{{heading name="title" defaultHeadingLevel="3" placeholder="Ingredients title" }}
 	{{rich-text name="ingredients" tag=["ul"] multiline="li" placeholder="Ingredient 1" }}
 </div>

--- a/src/schema-templates/recipe-name.block.php
+++ b/src/schema-templates/recipe-name.block.php
@@ -7,4 +7,4 @@
 
 ?>
 {{block name="yoast/recipe-name" title="Recipe name" category="yoast-structured-data-blocks" parent=[ "yoast/recipe" ] }}
-{{variable-tag-rich-text name="name" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="<?php esc_attr_e( 'Enter a recipe name', 'wordpress-seo' ); ?>" }}
+{{heading name="name" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="<?php esc_attr_e( 'Enter a recipe name', 'wordpress-seo' ); ?>" }}

--- a/src/schema-templates/recipe-name.block.php
+++ b/src/schema-templates/recipe-name.block.php
@@ -7,4 +7,4 @@
 
 ?>
 {{block name="yoast/recipe-name" title="Recipe name" category="yoast-structured-data-blocks" parent=[ "yoast/recipe" ] }}
-{{heading name="name" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="<?php esc_attr_e( 'Enter a recipe name', 'wordpress-seo' ); ?>" }}
+{{heading name="name" defaultHeadingLevel="2"  placeholder="<?php esc_attr_e( 'Enter a recipe name', 'wordpress-seo' ); ?>" }}

--- a/src/schema-templates/recipe-name.block.php
+++ b/src/schema-templates/recipe-name.block.php
@@ -7,4 +7,4 @@
 
 ?>
 {{block name="yoast/recipe-name" title="Recipe name" category="yoast-structured-data-blocks" parent=[ "yoast/recipe" ] }}
-{{heading name="name" defaultHeadingLevel="2"  placeholder="<?php esc_attr_e( 'Enter a recipe name', 'wordpress-seo' ); ?>" }}
+{{heading name="name" defaultHeadingLevel=2 placeholder="<?php esc_attr_e( 'Enter a recipe name', 'wordpress-seo' ); ?>" }}

--- a/src/schema-templates/steps.block.php
+++ b/src/schema-templates/steps.block.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore Internal.NoCodeFound ?>
 {{block name="yoast/steps" title="Steps" category="common" parent=[ "yoast/recipe" ] }}
 <ul class={{class-name}}>
-	{{heading name="title" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="Steps title" }}
+	{{heading name="title" defaultHeadingLevel="3" placeholder="Steps title" }}
 	{{inner-blocks allowed-blocks=["yoast/step"] appender="button" appenderLabel="Add step" }}
 </ul>

--- a/src/schema-templates/steps.block.php
+++ b/src/schema-templates/steps.block.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore Internal.NoCodeFound ?>
 {{block name="yoast/steps" title="Steps" category="common" parent=[ "yoast/recipe" ] }}
 <ul class={{class-name}}>
-	{{heading name="title" defaultHeadingLevel="3" placeholder="Steps title" }}
+	{{heading name="title" defaultHeadingLevel=3 placeholder="Steps title" }}
 	{{inner-blocks allowed-blocks=["yoast/step"] appender="button" appenderLabel="Add step" }}
 </ul>

--- a/src/schema-templates/steps.block.php
+++ b/src/schema-templates/steps.block.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore Internal.NoCodeFound ?>
 {{block name="yoast/steps" title="Steps" category="common" parent=[ "yoast/recipe" ] }}
 <ul class={{class-name}}>
-	{{variable-tag-rich-text name="title" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="Steps title" }}
+	{{heading name="title" tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] placeholder="Steps title" }}
 	{{inner-blocks allowed-blocks=["yoast/step"] appender="button" appenderLabel="Add step" }}
 </ul>


### PR DESCRIPTION
The name of the instruction has changed## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the way the heading level is chosen for headings inside of the recipe block. You can now change the heading level using the block's block controls instead of using a select element in the block's sidebar.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Companion PR of https://github.com/Yoast/wordpress-seo-premium/pull/3288, please follow its test instructions instead.
	* **Note**: these steps should only be followed once in Premium. Do not test this in Free.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
