### PR TITLE
Replace SEMrush by Semrush in user-facing strings

### DIFF
--- a/admin/views/class-yoast-integration-toggles.php
+++ b/admin/views/class-yoast-integration-toggles.php
@@ -63,13 +63,13 @@ class Yoast_Integration_Toggles {
 	protected function load_toggles() {
 		$integration_toggles = [
 			(object) [
-				/* translators: %s: 'SEMrush' */
-				'name'            => sprintf( __( '%s integration', 'wordpress-seo' ), 'SEMrush' ),
+				/* translators: %s: 'Semrush' */
+				'name'            => sprintf( __( '%s integration', 'wordpress-seo' ), 'Semrush' ),
 				'setting'         => 'semrush_integration_active',
 				'label'           => sprintf(
-					/* translators: %s: 'SEMrush' */
+					/* translators: %s: 'Semrush' */
 					__( 'The %s integration offers suggestions and insights for keywords related to the entered focus keyphrase.', 'wordpress-seo' ),
-					'SEMrush'
+					'Semrush'
 				),
 				'order'           => 10,
 			],

--- a/js/src/components/modals/SEMrushKeyphrasesTable.js
+++ b/js/src/components/modals/SEMrushKeyphrasesTable.js
@@ -169,9 +169,9 @@ class SEMrushKeyphrasesTable extends Component {
 				<p style={ { marginBottom: 0 } }>
 					<GetMoreInsightsLink href={ url }>
 						{ sprintf(
-							/* translators: %s expands to SEMrush */
+							/* translators: %s expands to Semrush */
 							__( "Get more insights at %s", "wordpress-seo" ),
-							"SEMrush"
+							"Semrush"
 						) }
 					</GetMoreInsightsLink>
 				</p>

--- a/js/src/components/modals/SEMrushLimitReached.js
+++ b/js/src/components/modals/SEMrushLimitReached.js
@@ -18,9 +18,9 @@ const SEMrushLimitReached = () => {
 			<p>
 				{
 					sprintf(
-						/* translators: %s : Expands to "SEMrush". */
+						/* translators: %s : Expands to "Semrush". */
 						__( "You've reached your request limit for today. Check back tomorrow or upgrade your plan over at %s.", "wordpress-seo" ),
-						"SEMrush"
+						"Semrush"
 					)
 				}
 			</p>
@@ -30,9 +30,9 @@ const SEMrushLimitReached = () => {
 			>
 				{
 					sprintf(
-						/* translators: %s : Expands to "SEMrush". */
+						/* translators: %s : Expands to "Semrush". */
 						__( "Upgrade your %s plan", "wordpress-seo" ),
-						"SEMrush"
+						"Semrush"
 					)
 				}
 				<span aria-hidden="true" className="yoast-button-upsell__caret" />

--- a/js/src/components/modals/SEMrushLoading.js
+++ b/js/src/components/modals/SEMrushLoading.js
@@ -14,10 +14,10 @@ const SEMrushLoading = () => {
 		<p className="yoast-related-keyphrases-modal__loading-message">
 			{
 				sprintf(
-					/* translators: %1$s expands to "Yoast SEO", %2$s expands to "SEMrush". */
+					/* translators: %1$s expands to "Yoast SEO", %2$s expands to "Semrush". */
 					__( "Please wait while %1$s connects to %2$s to get related keyphrases...", "wordpress-seo" ),
 					"Yoast SEO",
-					"SEMrush"
+					"Semrush"
 				)
 			}
 			&nbsp;

--- a/tests/unit/admin/views/integration-toggles-test.php
+++ b/tests/unit/admin/views/integration-toggles-test.php
@@ -22,7 +22,7 @@ class Yoast_Integration_Toggles_Test extends TestCase {
 	 */
 	public function test_integration_toggles() {
 		$expected_names = [
-			0 => 'SEMrush integration',
+			0 => 'Semrush integration',
 			1 => 'Ryte integration',
 		];
 
@@ -51,7 +51,7 @@ class Yoast_Integration_Toggles_Test extends TestCase {
 	public function test_toggle_sorting() {
 		$expected_names = [
 			0 => 'Dummy prio 5',
-			1 => 'SEMrush integration',
+			1 => 'Semrush integration',
 			2 => 'Ryte integration',
 			3 => 'Dummy prio 50',
 		];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* SEMrush changed the spelling of their name to Semrush

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Replace all occurrences of 'SEMrush' by 'Semrush' to reflect Semrush's spelling change.

## Relevant technical choices:

* I only changed the userfacing occurrences to prevent possible bugs caused by incomplete replacements in function, action, namespace and class names.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Check the spelling of 'Semrush' in the following places (but please think if you can think of more places!): 
* Yoast SEO > General > Integrations (also click the question mark behind the heading)
* In the post editor:
    * Enter a focus keyphrase, click the 'get related keyphrases' button, scroll down in the modal. See 'Get more insights at Semrush'. 
    * Enter a new focus keyphrase, see for a very short time while the data is loading 'Please wait while Yoast SEO connects to Semrush to get related keyphrases'
    * Do 8 more requests with 8 more keyphrases to hit the limit. See 'You've reached your request limit for today. Check back tomorrow or upgrade your plan over at Semrush.' and 'Upgrade your Semrush plan'
* On multisite: check the network admin Yoast SEO > General > Integrations settings (also click the question mark behind the heading)
* I could not find any user-facing occurrences in Premium, but please think if you can think of any.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
