### PR TITLE
P3-472 Disappearing 'New' badges

### DIFF
--- a/admin/menu/class-replacevar-editor.php
+++ b/admin/menu/class-replacevar-editor.php
@@ -60,6 +60,7 @@ class WPSEO_Replacevar_Editor {
 				'label_title'             => '',
 				'label_description'       => '',
 				'description_placeholder' => '',
+				'has_new_badge'           => false,
 			]
 		);
 

--- a/admin/views/tabs/metas/paper-content/front-page-content.php
+++ b/admin/views/tabs/metas/paper-content/front-page-content.php
@@ -12,7 +12,7 @@
 
 use Yoast\WP\SEO\Presenters\Admin\Badge_Presenter;
 
-$frontpage_settings_badge = new Badge_Presenter( 'frontpage_settings' );
+$frontpage_settings_badge = new Badge_Presenter( 'frontpage_settings', '', 'global-templates' );
 
 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Is correctly escaped in the present() method.
 echo '<div>' . $frontpage_settings_badge->present() . '</div>';

--- a/js/src/initializers/search-appearance.js
+++ b/js/src/initializers/search-appearance.js
@@ -93,7 +93,7 @@ export default function initSearchAppearance() {
 						selectImageButtonId={ portal.id + "-select-button" }
 						replaceImageButtonId={ portal.id + "-replace-button" }
 						removeImageButtonId={ portal.id + "-remove-button" }
-						hasNewBadge={ true }
+						hasNewBadge={ portal.dataset.reactImagePortalHasNewBadge === "1" }
 					/> );
 				} ) }
 

--- a/src/config/badge-group-names.php
+++ b/src/config/badge-group-names.php
@@ -43,7 +43,7 @@ class Badge_Group_Names {
 	 * @param string $group           One of the GROUP_* constants.
 	 * @param string $current_version The current version of the plugin that's being checked.
 	 *
-	 * @return bool
+	 * @return bool Whether a group of badges is still eligible for a "new" badge.
 	 */
 	public function is_still_eligible_for_new_badge( $group, $current_version = null ) {
 		if ( ! array_key_exists( $group, $this::GROUP_NAMES ) ) {

--- a/src/config/badge-group-names.php
+++ b/src/config/badge-group-names.php
@@ -33,6 +33,6 @@ class Badge_Group_Names {
 
 		$group_version = self::GROUP_NAMES[ $group ];
 
-		return (bool) version_compare( $group_version, $current_version, '>' );
+		return (bool) version_compare( $current_version, $group_version, '<=' );
 	}
 }

--- a/src/config/badge-group-names.php
+++ b/src/config/badge-group-names.php
@@ -15,7 +15,7 @@ class Badge_Group_Names {
 	 * Constant describing when certain groups of new badges will no longer be shown.
 	 */
 	const GROUP_NAMES = [
-		self::GROUP_GLOBAL_TEMPLATES => '16.5',
+		self::GROUP_GLOBAL_TEMPLATES => '16.5-beta0',
 	];
 
 	/**
@@ -33,6 +33,6 @@ class Badge_Group_Names {
 
 		$group_version = self::GROUP_NAMES[ $group ];
 
-		return (bool) version_compare( $current_version, $group_version, '<=' );
+		return (bool) version_compare( $group_version, $current_version, '>' );
 	}
 }

--- a/src/config/badge-group-names.php
+++ b/src/config/badge-group-names.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Yoast\WP\SEO\Config;
+
+/**
+ * Class Badge_Group_Names.
+ *
+ * This class defines groups for "new" badges, with the version in which those groups are no longer considered
+ * to be "new".
+ */
+class Badge_Group_Names {
+	const GROUP_GLOBAL_TEMPLATES = 'global-templates';
+
+	/**
+	 * Constant describing when certain groups of new badges will no longer be shown.
+	 */
+	const GROUP_NAMES = [
+		self::GROUP_GLOBAL_TEMPLATES => '16.5',
+	];
+
+	/**
+	 * Check whether a group of badges is still eligible for a "new" badge.
+	 *
+	 * @param string $group           One of the GROUP_* constants.
+	 * @param string $current_version The current version of the plugin that's being checked.
+	 *
+	 * @return bool
+	 */
+	public function is_still_eligible_for_new_badge( $group, $current_version = \WPSEO_VERSION ) {
+		if ( ! array_key_exists( $group, self::GROUP_NAMES ) ) {
+			return false;
+		}
+
+		$group_version = self::GROUP_NAMES[ $group ];
+
+		return (bool) version_compare( $group_version, $current_version, '>' );
+	}
+}

--- a/src/config/badge-group-names.php
+++ b/src/config/badge-group-names.php
@@ -19,6 +19,25 @@ class Badge_Group_Names {
 	];
 
 	/**
+	 * The current plugin version.
+	 *
+	 * @var string
+	 */
+	protected $version;
+
+	/**
+	 * Badge_Group_Names constructor.
+	 *
+	 * @param string $version Optional: the current plugin version.
+	 */
+	public function __construct( $version = null ) {
+		if ( ! $version ) {
+			$version = \WPSEO_VERSION;
+		}
+		$this->version = $version;
+	}
+
+	/**
 	 * Check whether a group of badges is still eligible for a "new" badge.
 	 *
 	 * @param string $group           One of the GROUP_* constants.
@@ -26,12 +45,16 @@ class Badge_Group_Names {
 	 *
 	 * @return bool
 	 */
-	public function is_still_eligible_for_new_badge( $group, $current_version = \WPSEO_VERSION ) {
-		if ( ! array_key_exists( $group, self::GROUP_NAMES ) ) {
+	public function is_still_eligible_for_new_badge( $group, $current_version = null ) {
+		if ( ! array_key_exists( $group, $this::GROUP_NAMES ) ) {
 			return false;
 		}
 
-		$group_version = self::GROUP_NAMES[ $group ];
+		$group_version = $this::GROUP_NAMES[ $group ];
+
+		if ( \is_null( $current_version ) ) {
+			$current_version = $this->version;
+		}
 
 		return (bool) version_compare( $group_version, $current_version, '>' );
 	}

--- a/src/presenters/admin/badge-presenter.php
+++ b/src/presenters/admin/badge-presenter.php
@@ -35,6 +35,15 @@ class Badge_Presenter extends Abstract_Presenter {
 	private $group;
 
 	/**
+	 * Optional object storing the group names and expiration versions.
+	 *
+	 * The group names set in Yoast SEO are used by default, but they can be overridden to use custom ones for an add-on.
+	 *
+	 * @var Badge_Group_Names
+	 */
+	private $badge_group_names;
+
+	/**
 	 * An instance of the WPSEO_Admin_Asset_Manager class.
 	 *
 	 * @var WPSEO_Admin_Asset_Manager
@@ -42,13 +51,14 @@ class Badge_Presenter extends Abstract_Presenter {
 	private $asset_manager;
 
 	/**
-	 * New_Badge_Presenter constructor.
+	 * Badge_Presenter constructor.
 	 *
-	 * @param string $id    Id of the badge.
-	 * @param string $link  Optional link of the badge.
-	 * @param string $group Optional group which the badge belongs to.
+	 * @param string            $id                Id of the badge.
+	 * @param string            $link              Optional link of the badge.
+	 * @param string            $group             Optional group which the badge belongs to.
+	 * @param Badge_Group_Names $badge_group_names Optional object storing the group names.
 	 */
-	public function __construct( $id, $link = '', $group = '' ) {
+	public function __construct( $id, $link = '', $group = '', $badge_group_names = null ) {
 		$this->id    = $id;
 		$this->link  = $link;
 		$this->group = $group;
@@ -56,6 +66,11 @@ class Badge_Presenter extends Abstract_Presenter {
 		if ( ! $this->asset_manager ) {
 			$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 		}
+
+		if ( ! $badge_group_names instanceof Badge_Group_Names ) {
+			$badge_group_names = new Badge_Group_Names();
+		}
+		$this->badge_group_names = $badge_group_names;
 
 		if ( $this->is_group_still_new() ) {
 			$this->asset_manager->enqueue_style( 'badge' );
@@ -100,7 +115,6 @@ class Badge_Presenter extends Abstract_Presenter {
 			return true;
 		}
 
-		$badge_group_names = new Badge_Group_Names();
-		return $badge_group_names->is_still_eligible_for_new_badge( $this->group );
+		return $this->badge_group_names->is_still_eligible_for_new_badge( $this->group );
 	}
 }

--- a/src/presenters/admin/badge-presenter.php
+++ b/src/presenters/admin/badge-presenter.php
@@ -28,7 +28,7 @@ class Badge_Presenter extends Abstract_Presenter {
 	/**
 	 * Optional group which the badge belongs to.
 	 *
-	 * Each group has a fixed period after which the the group will no longer be considered new and the badges will disappear.
+	 * Each group has a fixed period after which the group will no longer be considered new and the badges will disappear.
 	 *
 	 * @var string
 	 */

--- a/src/presenters/admin/badge-presenter.php
+++ b/src/presenters/admin/badge-presenter.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Presenters\Admin;
 
 use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Config\Badge_Group_Names;
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
 /**
@@ -25,6 +26,15 @@ class Badge_Presenter extends Abstract_Presenter {
 	private $link;
 
 	/**
+	 * Optional group which the badge belongs to.
+	 *
+	 * Each group has a fixed period after which the the group will no longer be considered new and the badges will disappear.
+	 *
+	 * @var string
+	 */
+	private $group;
+
+	/**
 	 * An instance of the WPSEO_Admin_Asset_Manager class.
 	 *
 	 * @var WPSEO_Admin_Asset_Manager
@@ -34,12 +44,14 @@ class Badge_Presenter extends Abstract_Presenter {
 	/**
 	 * New_Badge_Presenter constructor.
 	 *
-	 * @param string $id   Id of the badge.
-	 * @param string $link Optional link of the badge.
+	 * @param string $id    Id of the badge.
+	 * @param string $link  Optional link of the badge.
+	 * @param string $group Optional group which the badge belongs to.
 	 */
-	public function __construct( $id, $link = '' ) {
+	public function __construct( $id, $link = '', $group = '' ) {
 		$this->id   = $id;
 		$this->link = $link;
+		$this->group = $group;
 
 		if ( ! $this->asset_manager ) {
 			$this->asset_manager = new WPSEO_Admin_Asset_Manager();
@@ -55,6 +67,10 @@ class Badge_Presenter extends Abstract_Presenter {
 	 * @return string The styled New Badge.
 	 */
 	public function present() {
+		if( ! $this->is_group_still_new() ) {
+			return '';
+		}
+
 		if ( $this->link !== '' ) {
 			return sprintf(
 				'<a class="yoast-badge yoast-badge__is-link yoast-new-badge" id="%1$s-new-badge" href="%2$s">%3$s</a>',
@@ -69,5 +85,20 @@ class Badge_Presenter extends Abstract_Presenter {
 			\esc_attr( $this->id ),
 			\esc_html__( 'New', 'wordpress-seo' )
 		);
+	}
+
+	/**
+	 * Check whether the new badge should be shown according to the group it is in.
+	 *
+	 * @return bool True if still new.
+	 */
+	public function is_group_still_new() {
+		// If there's no group configured, the new badge is always active
+		if( ! $this->group ) {
+			return true;
+		}
+
+		$badge_group_names  = new Badge_Group_Names();
+		return $badge_group_names->is_still_eligible_for_new_badge( $this->group );
 	}
 }

--- a/src/presenters/admin/badge-presenter.php
+++ b/src/presenters/admin/badge-presenter.php
@@ -49,15 +49,17 @@ class Badge_Presenter extends Abstract_Presenter {
 	 * @param string $group Optional group which the badge belongs to.
 	 */
 	public function __construct( $id, $link = '', $group = '' ) {
-		$this->id   = $id;
-		$this->link = $link;
+		$this->id    = $id;
+		$this->link  = $link;
 		$this->group = $group;
 
 		if ( ! $this->asset_manager ) {
 			$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 		}
 
-		$this->asset_manager->enqueue_style( 'badge' );
+		if ( $this->is_group_still_new() ) {
+			$this->asset_manager->enqueue_style( 'badge' );
+		}
 	}
 
 	/**
@@ -67,7 +69,7 @@ class Badge_Presenter extends Abstract_Presenter {
 	 * @return string The styled New Badge.
 	 */
 	public function present() {
-		if( ! $this->is_group_still_new() ) {
+		if ( ! $this->is_group_still_new() ) {
 			return '';
 		}
 
@@ -93,12 +95,12 @@ class Badge_Presenter extends Abstract_Presenter {
 	 * @return bool True if still new.
 	 */
 	public function is_group_still_new() {
-		// If there's no group configured, the new badge is always active
-		if( ! $this->group ) {
+		// If there's no group configured, the new badge is always active.
+		if ( ! $this->group ) {
 			return true;
 		}
 
-		$badge_group_names  = new Badge_Group_Names();
+		$badge_group_names = new Badge_Group_Names();
 		return $badge_group_names->is_still_eligible_for_new_badge( $this->group );
 	}
 }

--- a/tests/unit/config/badge-group-names-test.php
+++ b/tests/unit/config/badge-group-names-test.php
@@ -12,18 +12,18 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  */
 class Badge_Group_Names_Test extends TestCase {
 
-	/** We'll be testing with this existing group */
+	/* We'll be testing with this existing group. */
 	const TESTING_GROUP = Badge_Group_Names::GROUP_GLOBAL_TEMPLATES;
 
-	/** The group we're testing will no longer be considered new from this version onwards  */
+	/* The group we're testing will no longer be considered new from this version onwards. */
 	const VERSION_NO_LONGER_NEW = '16.5';
-	/** The group we're testing will no longer be considered new from this RC version onwards  */
+	/* The group we're testing will no longer be considered new from this RC version onwards. */
 	const VERSION_NO_LONGER_NEW_RC = '16.5-RC1';
-	/** The group we're testing will still be considered new on this version  */
+	/* The group we're testing will still be considered new on this version. */
 	const VERSION_STILL_NEW = '16.4';
-	/** The group we're testing is not considered new on this version  */
+	/* The group we're testing is not considered new on this version. */
 	const VERSION_NEXT_MINOR = '16.6';
-	/** The group we're testing is definitely not considered new on this version  */
+	/* The group we're testing is definitely not considered new on this version. */
 	const VERSION_NEXT_MAJOR = '17.0';
 
 	/**

--- a/tests/unit/config/badge-group-names-test.php
+++ b/tests/unit/config/badge-group-names-test.php
@@ -17,6 +17,8 @@ class Badge_Group_Names_Test extends TestCase {
 
 	/** The group we're testing will no longer be considered new from this version onwards  */
 	const VERSION_NO_LONGER_NEW = '16.5';
+	/** The group we're testing will no longer be considered new from this RC version onwards  */
+	const VERSION_NO_LONGER_NEW_RC = '16.5-RC1';
 	/** The group we're testing will still be considered new on this version  */
 	const VERSION_STILL_NEW = '16.4';
 	/** The group we're testing is not considered new on this version  */
@@ -61,6 +63,20 @@ class Badge_Group_Names_Test extends TestCase {
 	 */
 	public function test_global_templates_group_is_eligible_for_new_badge() {
 		$expiry_version = self::VERSION_NO_LONGER_NEW;
+
+		self::assertFalse(
+			$this->instance->is_still_eligible_for_new_badge( self::TESTING_GROUP, $expiry_version ),
+			sprintf( 'Group should not be "new" on version %s', $expiry_version )
+		);
+	}
+
+	/**
+	 * Tests if the global templates group is no longer eligible for a "new" badge on the set RC version.
+	 *
+	 * @covers ::is_still_eligible_for_new_badge
+	 */
+	public function test_global_templates_group_is_eligible_for_new_badge_release_candidate() {
+		$expiry_version = self::VERSION_NO_LONGER_NEW_RC;
 
 		self::assertFalse(
 			$this->instance->is_still_eligible_for_new_badge( self::TESTING_GROUP, $expiry_version ),

--- a/tests/unit/config/badge-group-names-test.php
+++ b/tests/unit/config/badge-group-names-test.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Config;
+
+use Yoast\WP\SEO\Config\Badge_Group_Names;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Badge_Group_Names_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Config\Badge_Group_Names
+ */
+class Badge_Group_Names_Test extends TestCase {
+
+	/** We'll be testing with this existing group */
+	const TESTING_GROUP = Badge_Group_Names::GROUP_GLOBAL_TEMPLATES;
+
+	/** The group we're testing will no longer be considered new from this version onwards  */
+	const VERSION_NO_LONGER_NEW = '16.5';
+	/** The group we're testing will still be considered new on this version  */
+	const VERSION_STILL_NEW = '16.4';
+	/** The group we're testing is not considered new on this version  */
+	const VERSION_NEXT_MINOR = '16.6';
+	/** The group we're testing is definitely not considered new on this version  */
+	const VERSION_NEXT_MAJOR = '17.0';
+
+	/**
+	 * The test instance.
+	 *
+	 * @var Badge_Group_Names
+	 */
+	protected $instance;
+
+	/**
+	 * Set up the test.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Badge_Group_Names();
+	}
+
+	/**
+	 * Tests whether an unknown group is eligible for a "new" badge.
+	 *
+	 * @covers ::is_still_eligible_for_new_badge
+	 */
+	public function test_unknown_group_is_eligible_for_new_badge() {
+		$unknown_group = 'unknown_group';
+
+		self::assertFalse(
+			$this->instance->is_still_eligible_for_new_badge( $unknown_group ),
+			'Group "' . $unknown_group . '" should not exist and should not be considered "new"'
+		);
+	}
+
+	/**
+	 * Tests if the global templates group is no longer eligible for a "new" badge on the set version.
+	 *
+	 * @covers ::is_still_eligible_for_new_badge
+	 */
+	public function test_global_templates_group_is_eligible_for_new_badge() {
+		$expiry_version = self::VERSION_NO_LONGER_NEW;
+
+		self::assertFalse(
+			$this->instance->is_still_eligible_for_new_badge( self::TESTING_GROUP, $expiry_version ),
+			sprintf( 'Group should not be "new" on version %s', $expiry_version )
+		);
+	}
+
+	/**
+	 * Tests if the global templates group is no longer eligible for a "new" badge on the next minor version.
+	 *
+	 * @covers ::is_still_eligible_for_new_badge
+	 */
+	public function test_global_templates_group_no_longer_eligible_for_new_badge_on_next_minor() {
+		$expiry_version = self::VERSION_NEXT_MINOR;
+
+		self::assertFalse(
+			$this->instance->is_still_eligible_for_new_badge( self::TESTING_GROUP, $expiry_version ),
+			sprintf( 'Group should not be "new" on version %s', $expiry_version )
+		);
+	}
+
+	/**
+	 * Tests if the global templates group is no longer eligible for a "new" badge on the next major version.
+	 *
+	 * @covers ::is_still_eligible_for_new_badge
+	 */
+	public function test_global_templates_group_no_longer_eligible_for_new_badge_on_next_major() {
+		$expiry_version = self::VERSION_NEXT_MAJOR;
+
+		self::assertFalse(
+			$this->instance->is_still_eligible_for_new_badge( self::TESTING_GROUP, $expiry_version ),
+			sprintf( 'Group should not be "new" on version %s', $expiry_version )
+		);
+	}
+
+	/**
+	 * Tests if the global templates group is eligible for a "new" badge on the previous version.
+	 *
+	 * @covers ::is_still_eligible_for_new_badge
+	 */
+	public function test_global_templates_group_no_longer_eligible_for_new_badge_on_previous_version() {
+		$expiry_version = self::VERSION_STILL_NEW;
+
+		self::assertTrue(
+			$this->instance->is_still_eligible_for_new_badge( self::TESTING_GROUP, $expiry_version ),
+			sprintf( 'Group should be "new" on version %s', $expiry_version )
+		);
+	}
+}

--- a/tests/unit/presenters/admin/badge-presenter-test.php
+++ b/tests/unit/presenters/admin/badge-presenter-test.php
@@ -35,10 +35,11 @@ class Badge_Presenter_Test extends TestCase {
 	public function test_construct() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
 
-		$test = new Badge_Presenter( 'test-id', 'http://example.com/' );
+		$test = new Badge_Presenter( 'test-id', 'http://example.com/', 'test-group' );
 
 		$this->assertSame( 'test-id', $this->getPropertyValue( $test, 'id' ) );
 		$this->assertSame( 'http://example.com/', $this->getPropertyValue( $test, 'link' ) );
+		$this->assertSame( 'test-group', $this->getPropertyValue( $test, 'group' ) );
 
 		$this->assertInstanceOf(
 			WPSEO_Admin_Asset_Manager::class,
@@ -74,6 +75,25 @@ class Badge_Presenter_Test extends TestCase {
 		$expected = '<span class="yoast-badge yoast-new-badge" id="test2-new-badge">New</span>';
 		Monkey\Functions\expect( 'esc_url' )->andReturn( '' );
 		Monkey\Functions\expect( 'esc_html__' )->once()->andReturn( 'New' );
+
+		$this->assertEquals( $expected, (string) $test );
+	}
+
+	/**
+	 * Tests when the badge is in an expired group.
+	 *
+	 * @covers ::present
+	 */
+	public function test_badge_with_expired_group() {
+		$test = \Mockery::mock( Badge_Presenter::class )->makePartial();
+
+		$test->expects( 'is_group_still_new' )
+			->twice()
+			->andReturnFalse();
+
+		$test->__construct( 'test2', '', 'test-group' );
+
+		$expected = '';
 
 		$this->assertEquals( $expected, (string) $test );
 	}

--- a/tests/unit/presenters/admin/badge-presenter-test.php
+++ b/tests/unit/presenters/admin/badge-presenter-test.php
@@ -35,6 +35,23 @@ class Badge_Presenter_Test extends TestCase {
 	public function test_construct() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
 
+		$test = new Badge_Presenter( 'test-id', 'http://example.com/' );
+
+		$this->assertSame( 'test-id', $this->getPropertyValue( $test, 'id' ) );
+		$this->assertSame( 'http://example.com/', $this->getPropertyValue( $test, 'link' ) );
+
+		$this->assertInstanceOf(
+			WPSEO_Admin_Asset_Manager::class,
+			$this->getPropertyValue( $test, 'asset_manager' )
+		);
+	}
+
+	/**
+	 * Test constructor with a group.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct_with_group() {
 		$test = new Badge_Presenter( 'test-id', 'http://example.com/', 'test-group' );
 
 		$this->assertSame( 'test-id', $this->getPropertyValue( $test, 'id' ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When we introduce new features and place 'New' badges next to them, we want the badges to disappear after a certain version (usually the one after the next one). For example, a badge next to features introduced in `16.3` should disappear from `16.5` on (actually from `16.5-beta1`, see below)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a framework to make 'New' badges disappear after upgrading to a chosen version.

## Relevant technical choices:

* The version number in the `Badge_Group_Names` class has to be set as (e.g.) `16.5-beta0`. This way the badges will disappear as soon as the version is bumped to `16.5-beta1`, so it can be tested in beta and RC stages. This is because `version_compare()` treats `16.5-beta*` and `16.5-RC*` as coming before `16.5` (and rightly so).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

This PR introduces a "group" for the already existing "new" badge nexty to the Frontpage setting.
* build
* visit `SEO` > `Search Appearance`, tab `Content types`, and see that there is a `New` badge below the Frontpage title
* edit `src/config/badge-group-names.php`, line 18, so it becomes:
```
		self::GROUP_GLOBAL_TEMPLATES => '16.2-beta0',
```
(If the `trunk` version has been bumped to 16.3 in the meantime, set it to 16.3-beta0)
* visit `SEO` > `Search Appearance`, tab `Content types`, and see that there is **not** a `New` badge below the Frontpage title anymore.
* **also test https://github.com/Yoast/wordpress-seo-premium/pull/3292**

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [X] I have added unittests to verify the code works as intended

Fixes [P3-472]
