### PR TITLE
Allow Free and Premium to use separate instances of the Capability Manager

### DIFF
--- a/admin/capabilities/class-capability-manager-factory.php
+++ b/admin/capabilities/class-capability-manager-factory.php
@@ -13,21 +13,23 @@ class WPSEO_Capability_Manager_Factory {
 	/**
 	 * Returns the Manager to use.
 	 *
+	 * @param string $plugin_type Whether it's Free or Premium.
+	 *
 	 * @return WPSEO_Capability_Manager Manager to use.
 	 */
-	public static function get() {
-		static $manager = null;
+	public static function get( $plugin_type = 'free' ) {
+		static $manager = [];
 
-		if ( $manager === null ) {
+		if ( ! array_key_exists( $plugin_type, $manager ) ) {
 			if ( function_exists( 'wpcom_vip_add_role_caps' ) ) {
-				$manager = new WPSEO_Capability_Manager_VIP();
+				$manager[ $plugin_type ] = new WPSEO_Capability_Manager_VIP();
 			}
 
 			if ( ! function_exists( 'wpcom_vip_add_role_caps' ) ) {
-				$manager = new WPSEO_Capability_Manager_WP();
+				$manager[ $plugin_type ] = new WPSEO_Capability_Manager_WP();
 			}
 		}
 
-		return $manager;
+		return $manager[ $plugin_type ];
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix the creation _and removal_ of the Premium-specific capabilities.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the creation and deletion of Yoast SEO user capabilities.

## Relevant technical choices:

* Adds a parameter to the `WPSEO_Capability_Manager_Factory::get` method so that Free and Premium can have separate instances of the class and thus add/remove their own capabilities independently.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Please refer to the test instructions on the companion Premium PR https://github.com/Yoast/wordpress-seo-premium/pull/3293
* This PR doesn't impact Free features.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-552]