### PR TITLE
P2-896 Load the Request helper through dependency injection

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Integrations;
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Request_Helper;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 use Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter;
@@ -38,6 +39,13 @@ class Front_End_Integration implements Integration_Interface {
 	 * @var Options_Helper
 	 */
 	protected $options;
+
+	/**
+	 * Represents the request helper.
+	 *
+	 * @var Request_Helper
+	 */
+	protected $request;
 
 	/**
 	 * The helpers surface.
@@ -179,6 +187,7 @@ class Front_End_Integration implements Integration_Interface {
 	 * @param Meta_Tags_Context_Memoizer $context_memoizer  The meta tags context memoizer.
 	 * @param ContainerInterface         $service_container The DI container.
 	 * @param Options_Helper             $options           The options helper.
+	 * @param Request_Helper             $request           The request helper.
 	 * @param Helpers_Surface            $helpers           The helpers surface.
 	 * @param WPSEO_Replace_Vars         $replace_vars      The replace vars helper.
 	 *
@@ -188,12 +197,14 @@ class Front_End_Integration implements Integration_Interface {
 		Meta_Tags_Context_Memoizer $context_memoizer,
 		ContainerInterface $service_container,
 		Options_Helper $options,
+		Request_Helper $request,
 		Helpers_Surface $helpers,
 		WPSEO_Replace_Vars $replace_vars
 	) {
 		$this->container        = $service_container;
 		$this->context_memoizer = $context_memoizer;
 		$this->options          = $options;
+		$this->request          = $request;
 		$this->helpers          = $helpers;
 		$this->replace_vars     = $replace_vars;
 	}
@@ -255,7 +266,7 @@ class Front_End_Integration implements Integration_Interface {
 			return $presenters;
 		}
 
-		if ( $this->helpers->request->is_rest_request() ) {
+		if ( $this->request->is_rest_request() ) {
 			return $presenters;
 		}
 

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -460,4 +460,35 @@ class Front_End_Integration_Test extends TestCase {
 			$this->instance->filter_robots_presenter( $presenters )
 		);
 	}
+
+	/**
+	 * Tests the filter robots presenter with having wp_robots attached to the wp_head action.
+	 *
+	 * @covers ::filter_robots_presenter
+	 */
+	public function test_rest_request_should_output_robots_presenter() {
+		Monkey\Functions\expect( 'wp_robots' )->never();
+
+		\add_action( 'wp_head', 'wp_robots' );
+
+		$this->request
+			->expects( 'is_rest_request' )
+			->once()
+			->andReturnTrue();
+
+		$presenters = [
+			'Yoast\WP\SEO\Presenters\Title_Presenter',
+			'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
+			'Yoast\WP\SEO\Presenters\Robots_Presenter',
+		];
+
+		static::assertEquals(
+			[
+				'Yoast\WP\SEO\Presenters\Title_Presenter',
+				'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
+				'Yoast\WP\SEO\Presenters\Robots_Presenter',
+			],
+			$this->instance->filter_robots_presenter( $presenters )
+		);
+	}
 }

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -8,6 +8,7 @@ use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Request_Helper;
 use Yoast\WP\SEO\Integrations\Front_End_Integration;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
@@ -46,6 +47,13 @@ class Front_End_Integration_Test extends TestCase {
 	private $options;
 
 	/**
+	 * Represents the request helper.
+	 *
+	 * @var Mockery\MockInterface|Request_Helper
+	 */
+	private $request;
+
+	/**
 	 * Represents the meta tags context memoizer.
 	 *
 	 * @var Mockery\MockInterface|Meta_Tags_Context_Memoizer
@@ -61,6 +69,7 @@ class Front_End_Integration_Test extends TestCase {
 		$this->context_memoizer = Mockery::mock( Meta_Tags_Context_Memoizer::class );
 		$this->container        = Mockery::mock( ContainerInterface::class );
 		$this->options          = Mockery::mock( Options_Helper::class );
+		$this->request          = Mockery::mock( Request_Helper::class );
 
 		$this->instance = Mockery::mock(
 			Front_End_Integration::class,
@@ -68,6 +77,7 @@ class Front_End_Integration_Test extends TestCase {
 				$this->context_memoizer,
 				$this->container,
 				$this->options,
+				$this->request,
 				Mockery::mock( Helpers_Surface::class ),
 				Mockery::mock( WPSEO_Replace_Vars::class ),
 			]
@@ -430,6 +440,11 @@ class Front_End_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_robots' )->never();
 
 		\add_action( 'wp_head', 'wp_robots' );
+
+		$this->request
+			->expects( 'is_rest_request' )
+			->once()
+			->andReturnFalse();
 
 		$presenters = [
 			'Yoast\WP\SEO\Presenters\Title_Presenter',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* [This commit](https://github.com/Yoast/wordpress-seo/commit/11693de48bfd95ab13746ed3f807d1d1dcf4b713) broke a unit test on the 16.2 release branch.
* This PR fixes that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Loads the Request helper through dependency injection rather than using the Helpers surface.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow the steps to reproduce in https://yoast.atlassian.net/browse/P2-893.
* Using this branch / an RC which contains this code, see the problem is fixed.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
