### PR TITLE
Remove all the configuration regarding the `schema-blocks` translations

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -89,7 +89,6 @@ module.exports = function( grunt ) {
 				php: {
 					yoastseojs: "<%= paths.languages %>yoast-seo-js.php",
 					yoastComponents: "<%= paths.languages %>yoast-components.php",
-					yoastSchemaBlocks: "<%= paths.languages %>yoast-schema-blocks.php",
 					wordpressSeoJs: "<%= paths.languages %>wordpress-seojs.php",
 				},
 			},

--- a/config/grunt/custom-tasks/i18n-clean-json.js
+++ b/config/grunt/custom-tasks/i18n-clean-json.js
@@ -81,7 +81,6 @@ module.exports = function( grunt ) {
 	function cleanJSONFiles() {
 		cleanJSON( "languages/yoast-seo-js.json", "languages/wordpress-seo-*.json", "wordpress-seo", "messages", "wordpress-seo" );
 		cleanJSON( "languages/yoast-components.json", "languages/yoast-components-*.json", "wordpress-seo", "messages", "yoast-components" );
-		cleanJSON( "languages/yoast-schema-blocks.json", "languages/yoast-schema-blocks-*.json", "wordpress-seo", "messages", "yoast-schema-blocks" );
 		cleanJSON( "languages/wordpress-seojs.json", "languages/wordpress-seojs-*.json", "wordpress-seo", "messages", "wordpress-seo" );
 	}
 

--- a/config/grunt/task-config/clean.js
+++ b/config/grunt/task-config/clean.js
@@ -11,7 +11,6 @@ module.exports = {
 		"<%= paths.languages %>*.po",
 		"<%= paths.languages %>*.pot",
 		"<%= paths.languages %>yoast-components.json",
-		"<%= paths.languages %>yoast-schema-blocks.json",
 		"<%= paths.languages %>yoast-seo.json",
 		"<%= paths.languages %>yoastseojsfiles.txt",
 	],

--- a/config/grunt/task-config/convert-pot-to-wp.js
+++ b/config/grunt/task-config/convert-pot-to-wp.js
@@ -11,10 +11,6 @@ module.exports = {
 		src: "<%= files.pot.yoastseojs %>",
 		dest: "<%= files.pot.php.yoastseojs %>",
 	},
-	yoastSchemaBlocks: {
-		src: "<%= files.pot.yoastSchemaBlocks %>",
-		dest: "<%= files.pot.php.yoastSchemaBlocks %>",
-	},
 	wordpressSeoJs: {
 		src: "<%= files.pot.wordpressSeoJs %>",
 		dest: "<%= files.pot.php.wordpressSeoJs %>",

--- a/config/grunt/task-config/copy.js
+++ b/config/grunt/task-config/copy.js
@@ -53,15 +53,6 @@ module.exports = {
 					return dest + src.replace( "wordpress-seo", "wordpress-seojs" );
 				},
 			},
-			{
-				expand: true,
-				cwd: "languages/",
-				src: [ "wordpress-seo-*.json" ],
-				dest: "languages/",
-				rename: ( dest, src ) => {
-					return dest + src.replace( "wordpress-seo", "yoast-schema-blocks" );
-				},
-			},
 		],
 	},
 	"makepot-wordpress-seo": {
@@ -87,10 +78,6 @@ module.exports = {
 	"makepot-yoast-js-search-metadata-previews": {
 		src: "gettext.pot",
 		dest: "<%= files.pot.yoastJsSearchMetadataPreviews %>",
-	},
-	"makepot-yoast-js-schema-blocks": {
-		src: "gettext.pot",
-		dest: "<%= files.pot.yoastSchemaBocks %>",
 	},
 
 	// The default de_CH is formal on WordPress.org, but that one is not translated enough for wordpress-seo.

--- a/config/grunt/task-config/makepot.js
+++ b/config/grunt/task-config/makepot.js
@@ -15,7 +15,6 @@ module.exports = {
 				"premium/.*",
 				"<%= files.pot.php.yoastseojs %>",
 				"<%= files.pot.php.yoastComponents %>",
-				"<%= files.pot.php.yoastSchemaBlocks %>",
 				"<%= files.artifact %>",
 				"<%= files.artifactComposer %>",
 				".wordpress-svn",

--- a/config/grunt/task-config/po2json.js
+++ b/config/grunt/task-config/po2json.js
@@ -9,7 +9,6 @@ module.exports = {
 			"<%= files.pot.yoastseojs %>",
 			"<%= files.pot.yoastComponents %>",
 			"<%= files.pot.wordpressSeoJs %>",
-			"<%= files.pot.yoastSchemaBlocks %>",
 		],
 		dest: "languages",
 	},


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* All the translation configurations for the `schema-blocks` package were removed from the `release/16.2` branch in https://github.com/Yoast/wordpress-seo/pull/16928, because we needed a quick solution to bring the zip size down (the Job Posting block will not yet be released in 16.2).
* There was already more configuration present in `trunk`, but this wasn't removed in https://github.com/Yoast/wordpress-seo/pull/16928.
* After part of the configuration was removed in https://github.com/Yoast/wordpress-seo/pull/16928, the remaining configuration in `trunk` broke the `i18n` build script.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes all the configuration regarding the `schema-blocks` translations.

## Relevant technical choices:

* I did a search in `wordpress-seo/config/grunt` on the word `schema` and removed all configuration that relates to translations. 
* Note that I did not remove the configuration regarding the installation of the `schema-blocks` package.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See that `grunt build:i18n` completes without problems.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* No need for QA to test this PR, it just removes tooling.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
