### PR TITLE
Add Grunt changelog tasks from plugin-grunt-tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ temp/
 .Trashes
 .env
 .svn
+.tmp
 
 ############
 ## Composer
@@ -95,3 +96,8 @@ test.sh
 ##############
 /javascript/
 .yoast
+
+############
+# Temp files
+############
+/.tmp

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,6 +140,8 @@ module.exports = function( grunt ) {
 				"update-changelog-with-latest-pr-texts": "@yoast/grunt-plugin-tasks",
 				"get-latest-pr-texts": "@yoast/grunt-plugin-tasks",
 				"update-changelog": "@yoast/grunt-plugin-tasks",
+				"build-qa-changelog": "@yoast/grunt-plugin-tasks",
+				"download-qa-changelog": "@yoast/grunt-plugin-tasks",
 				"register-prompt": "grunt-prompt",
 				"notify-slack": "notify-slack",
 			},

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,7 +79,6 @@ module.exports = function( grunt ) {
 				yoastJsConfigurationWizard: "<%= paths.languages %>yoast-js-configuration-wizard.pot",
 				yoastJsHelpers: "<%= paths.languages %>yoast-js-helpers.pot",
 				yoastJsSearchMetadataPreviews: "<%= paths.languages %>yoast-js-search-metadata-previews.pot",
-				yoastSchemaBlocks: "<%= paths.languages %>yoast-schema-blocks.pot",
 
 				yoastseojs: "<%= paths.languages %>yoast-seo-js.pot",
 				yoastComponents: "<%= paths.languages %>yoast-components.pot",
@@ -90,7 +89,6 @@ module.exports = function( grunt ) {
 				php: {
 					yoastseojs: "<%= paths.languages %>yoast-seo-js.php",
 					yoastComponents: "<%= paths.languages %>yoast-components.php",
-					yoastSchemaBlocks: "<%= paths.languages %>yoast-schema-blocks.php",
 					wordpressSeoJs: "<%= paths.languages %>wordpress-seojs.php",
 				},
 			},

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,6 +79,7 @@ module.exports = function( grunt ) {
 				yoastJsConfigurationWizard: "<%= paths.languages %>yoast-js-configuration-wizard.pot",
 				yoastJsHelpers: "<%= paths.languages %>yoast-js-helpers.pot",
 				yoastJsSearchMetadataPreviews: "<%= paths.languages %>yoast-js-search-metadata-previews.pot",
+				yoastSchemaBlocks: "<%= paths.languages %>yoast-schema-blocks.pot",
 
 				yoastseojs: "<%= paths.languages %>yoast-seo-js.pot",
 				yoastComponents: "<%= paths.languages %>yoast-components.pot",
@@ -89,6 +90,7 @@ module.exports = function( grunt ) {
 				php: {
 					yoastseojs: "<%= paths.languages %>yoast-seo-js.php",
 					yoastComponents: "<%= paths.languages %>yoast-components.php",
+					yoastSchemaBlocks: "<%= paths.languages %>yoast-schema-blocks.php",
 					wordpressSeoJs: "<%= paths.languages %>wordpress-seojs.php",
 				},
 			},
@@ -137,6 +139,9 @@ module.exports = function( grunt ) {
 				gitpush: "grunt-git",
 				"update-version": "@yoast/grunt-plugin-tasks",
 				"set-version": "@yoast/grunt-plugin-tasks",
+				"update-changelog-with-latest-pr-texts": "@yoast/grunt-plugin-tasks",
+				"get-latest-pr-texts": "@yoast/grunt-plugin-tasks",
+				"update-changelog": "@yoast/grunt-plugin-tasks",
 				"register-prompt": "grunt-prompt",
 				"notify-slack": "notify-slack",
 			},

--- a/config/grunt/task-config/aliases.yaml
+++ b/config/grunt/task-config/aliases.yaml
@@ -53,8 +53,6 @@
   - 'copy:makepot-yoast-js-helpers'
   - 'shell:makepot-yoast-js-search-metadata-previews'
   - 'copy:makepot-yoast-js-search-metadata-previews'
-  - 'shell:makepot-yoast-js-schema-blocks'
-  - 'copy:makepot-yoast-js-schema-blocks'
   - 'shell:makepot-yoast-components-remaining'
   - 'shell:combine-pots-yoast-components'
   - 'shell:makepot-yoastseojs'

--- a/config/grunt/task-config/aliases.yaml
+++ b/config/grunt/task-config/aliases.yaml
@@ -53,6 +53,8 @@
   - 'copy:makepot-yoast-js-helpers'
   - 'shell:makepot-yoast-js-search-metadata-previews'
   - 'copy:makepot-yoast-js-search-metadata-previews'
+  - 'shell:makepot-yoast-js-schema-blocks'
+  - 'copy:makepot-yoast-js-schema-blocks'
   - 'shell:makepot-yoast-components-remaining'
   - 'shell:combine-pots-yoast-components'
   - 'shell:makepot-yoastseojs'
@@ -162,6 +164,21 @@ release:
   - 'update-version-trunk'
   - 'artifact'
   - 'wp_deploy:trunk'
+
+'update-changelog:file':
+  - get-latest-pr-texts
+  - update-changelog-with-latest-pr-texts
+
+'update-changelog:qa':
+  - get-latest-pr-texts
+  - download-qa-changelog
+  - build-qa-changelog
+
+'update-changelog:all':
+  - get-latest-pr-texts
+  - update-changelog-with-latest-pr-texts
+  - download-qa-changelog
+  - build-qa-changelog
 
 # Default task
 default:

--- a/config/grunt/task-config/build-qa-changelog.js
+++ b/config/grunt/task-config/build-qa-changelog.js
@@ -1,0 +1,8 @@
+// Custom task
+module.exports = {
+	"wordpress-seo": {
+		options: {
+			useEditDistanceCompare: false,
+		},
+	},
+};

--- a/config/grunt/task-config/download-qa-changelog.js
+++ b/config/grunt/task-config/download-qa-changelog.js
@@ -1,0 +1,8 @@
+// Custom task
+module.exports = {
+	"wordpress-seo": {
+		options: {
+
+		},
+	},
+};

--- a/config/grunt/task-config/update-changelog-with-latest-pr-texts.js
+++ b/config/grunt/task-config/update-changelog-with-latest-pr-texts.js
@@ -1,0 +1,28 @@
+/* eslint-disable no-useless-escape */
+/* eslint-disable no-useless-concat */
+// Custom task
+module.exports = {
+	"wordpress-seo": {
+		options: {
+			// Free header:
+			// = 15.7 =
+			// Release Date: January 26th, 2021
+			//
+			// Enhancements:
+			readmeFile: "./readme.txt",
+			releaseInChangelog: /[=] \d+\.\d+(\.\d+)? =/g,
+			matchChangelogHeader: /[=]= Changelog ==\n\n/ig,
+			newHeadertemplate: "== Changelog ==\n\n" + "= " + "VERSIONNUMBER" + " =\nRelease Date: " + "DATESTRING"  + "\n\n",
+			matchCorrectHeader: "= " + "VERSIONNUMBER" + "(.|\\n)*?\\n(?=(\\w\+?:\\n|= \\d+[\.\\d]+ =|= Earlier versions =))",
+			matchCorrectLines: "= " + "VERSIONNUMBER" + "(.|\\n)*?(?=(= \\d+[\.\\d]+ =|= Earlier versions =))",
+			matchCleanedChangelog: "= " + "VERSIONNUMBER" + "(.|\\n)*= Earlier versions =",
+			replaceCleanedChangelog: "= Earlier versions =",
+			pluginSlug: "wordpress-seo",
+			defaultChangelogEntries: "",
+			useANewLineAfterHeader: true,
+			commitChangelog: true,
+			useEditDistanceComapair: true,
+		},
+	},
+
+};

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@wordpress/data": "^4.10.0",
     "@wordpress/dependency-extraction-webpack-plugin": "^2.8.0",
     "@wordpress/element": "^2.9.0",
-    "@yoast/grunt-plugin-tasks": "^2.0.0",
+    "@yoast/grunt-plugin-tasks": "^2.1",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-jest": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1621,10 +1621,10 @@
   resolved "https://registry.yarnpkg.com/@yoast/feature-flag/-/feature-flag-0.5.2.tgz#ef4cd8ddb959c5857c5d68639ab09ab75c381508"
   integrity sha512-erHel5POEyPpt1B2fToLm8caZPruiOxBRZvn7X9nWqwb0lIbxbOkDp/XQnm168bcvVEL95Dg9JMaPgQwO3rA9w==
 
-"@yoast/grunt-plugin-tasks@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@yoast/grunt-plugin-tasks/-/grunt-plugin-tasks-2.0.0.tgz#77c33c1b3fd8087075b611e49c4654b21e86ca15"
-  integrity sha512-RL2Rx0vJfITcKAYOQoMa8xa+AqBK9nW4N75ybkRMIxVcGjuHyeoWWiviy47BqLfketGWecJScVZBRg1spVBoaA==
+"@yoast/grunt-plugin-tasks@^2.1":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@yoast/grunt-plugin-tasks/-/grunt-plugin-tasks-2.1.0.tgz#255fd3d7ae434e55d54b3eea32ddf0426f7b38ea"
+  integrity sha512-vaUcMs24v9gT6OMq+x67J7prU2qg8iHqdgSaKMK4KveNGEiZbBiJ/rd8bCeDSDhRm38HZNG1MGPzXbuIDN9oUg==
   dependencies:
     "@yoast/browserslist-config" "^1.0.0"
     autoprefixer "^9.7.2"
@@ -7354,9 +7354,9 @@ grunt-git@^1.0.14:
   dependencies:
     flopmang "^1.0.0"
 
-"grunt-glotpress@https://github.com/Yoast/grunt-glotpress.git#master":
+"grunt-glotpress@git+https://github.com/Yoast/grunt-glotpress.git#master":
   version "0.3.0"
-  resolved "https://github.com/Yoast/grunt-glotpress.git#e6ccc69c2532d126f5d8a30397ffd012e55b6eec"
+  resolved "git+https://github.com/Yoast/grunt-glotpress.git#e6ccc69c2532d126f5d8a30397ffd012e55b6eec"
   dependencies:
     request "^2.88.0"
     request-promise-native "^1.0.7"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR as needed for the automation of RC/beta release process, this add changelog update taks, without the need for input during the RC/beta creation task


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Added config for RC/beta creation

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* run grunt update-changelog:file --plugin-version=XX.X-RCX (where the X represent numbers for instance: 16.3-RC2" this should update the changlog.md file with new changelog items from the "wiki" yoast-cli create:changelog command specific to this RC number and version
* run grunt update-changelog:qa --plugin-version=XX.X-betaX this should create/overwrite a file .tmp/qachangelog.md for a beta1 it will contain all entry's from the "wiki" yoast-cli create:changelog command, for a beta 2 it will only contain entries from the wiki that where not mentioned in the github release text, for a RC it will start aging. with RC1 having all items. thius file can be used during github pre release creation as the text file for a release.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* none,

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* should not effect plugin code. (I also tested that it does not do that)


## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
