### PR TITLE
Formatted post date correctly in schema replace vars helper.

### DIFF
--- a/src/helpers/schema/replace-vars-helper.php
+++ b/src/helpers/schema/replace-vars-helper.php
@@ -7,6 +7,7 @@ use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
+use Yoast\WP\SEO\Helpers\Date_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 
 /**
@@ -31,17 +32,27 @@ class Replace_Vars_Helper {
 	protected $id_helper;
 
 	/**
+	 * The date helper.
+	 *
+	 * @var Date_Helper
+	 */
+	protected $date_helper;
+
+	/**
 	 * Replace_Vars_Helper constructor.
 	 *
 	 * @param WPSEO_Replace_Vars $replace_vars The replace vars.
 	 * @param ID_Helper          $id_helper    The Schema ID helper.
+	 * @param Date_Helper        $date_helper  The date helper.
 	 */
 	public function __construct(
 		WPSEO_Replace_Vars $replace_vars,
-		ID_Helper $id_helper
+		ID_Helper $id_helper,
+		Date_Helper $date_helper
 	) {
 		$this->replace_vars = $replace_vars;
 		$this->id_helper    = $id_helper;
+		$this->date_helper  = $date_helper;
 	}
 
 	/**
@@ -86,7 +97,7 @@ class Replace_Vars_Helper {
 
 		if ( $context->post ) {
 			// Post does not always exist, e.g. on term pages.
-			$replace_vars['post_date'] = $context->post->post_date;
+			$replace_vars['post_date'] = $this->date_helper->format( $context->post->post_date, \DATE_ATOM );
 		}
 
 		foreach ( $replace_vars as $var => $value ) {

--- a/tests/unit/helpers/schema/replace-vars-helper-test.php
+++ b/tests/unit/helpers/schema/replace-vars-helper-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Helpers\Schema;
 
+use Yoast\WP\SEO\Helpers\Date_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Helpers\Schema\Replace_Vars_Helper_Double;
@@ -48,6 +49,13 @@ class Replace_Vars_Helper_Test extends TestCase {
 	protected $id_helper;
 
 	/**
+	 * Date_Helper mock.
+	 *
+	 * @var Mockery\MockInterface|Date_Helper
+	 */
+	protected $date_helper;
+
+	/**
 	 * The instance under test.
 	 *
 	 * @var Replace_Vars_Helper
@@ -62,10 +70,12 @@ class Replace_Vars_Helper_Test extends TestCase {
 
 		$this->replace_vars = Mockery::mock( WPSEO_Replace_Vars::class );
 		$this->id_helper    = Mockery::mock( ID_Helper::class );
+		$this->date_helper  = Mockery::mock( Date_Helper::class );
 
 		$this->instance = new Replace_Vars_Helper(
 			$this->replace_vars,
-			$this->id_helper
+			$this->id_helper,
+			$this->date_helper
 		);
 	}
 
@@ -94,6 +104,11 @@ class Replace_Vars_Helper_Test extends TestCase {
 			->expects( 'get_user_schema_id' )
 			->andReturn( 'https://basic.wordpress.test#/schema/person/a00dc884baa6bd52ebacc06cfd5aab21' );
 
+		$this->date_helper
+			->expects( 'format' )
+			->with( '2020-10-11 13:00:00', \DATE_ATOM )
+			->andReturn( '2020-10-11T13:00:00+00:00' );
+
 		$this->replace_vars
 			->expects( 'safe_register_replacement' )
 			->times( 8 );
@@ -116,7 +131,7 @@ class Replace_Vars_Helper_Test extends TestCase {
 			'primary_image_id' => 'https://basic.wordpress.test/schema-templates#primaryimage',
 			'webpage_id'       => 'https://basic.wordpress.test/schema-templates#webpage',
 			'website_id'       => 'https://basic.wordpress.test#website',
-			'post_date'        => '2020-10-11 13:00:00',
+			'post_date'        => '2020-10-11T13:00:00+00:00',
 			'organization_id'  => 'https://basic.wordpress.test#organization',
 		];
 
@@ -137,12 +152,18 @@ class Replace_Vars_Helper_Test extends TestCase {
 			->expects( 'get_user_schema_id' )
 			->andReturn( 'https://basic.wordpress.test#/schema/person/a00dc884baa6bd52ebacc06cfd5aab21' );
 
+		$this->date_helper
+			->expects( 'format' )
+			->with( '2020-10-11 13:00:00', \DATE_ATOM )
+			->andReturn( '2020-10-11T13:00:00+00:00' );
+
 		// Partial mock, to be able to spy on the `register_replacement` method.
 		$instance = Mockery::mock(
 			Replace_Vars_Helper::class,
 			[
 				$this->replace_vars,
 				$this->id_helper,
+				$this->date_helper,
 			]
 		)
 			->shouldAllowMockingProtectedMethods()
@@ -195,6 +216,7 @@ class Replace_Vars_Helper_Test extends TestCase {
 			[
 				$this->replace_vars,
 				$this->id_helper,
+				$this->date_helper,
 			]
 		)
 			->shouldAllowMockingProtectedMethods()
@@ -256,7 +278,8 @@ class Replace_Vars_Helper_Test extends TestCase {
 	public function test_get_identity_function() {
 		$instance = new Replace_Vars_Helper_Double(
 			$this->replace_vars,
-			$this->id_helper
+			$this->id_helper,
+			$this->date_helper
 		);
 		$value    = 'a_value';
 		$closure  = $instance->get_identity_function( $value );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The `datePosted` property of the Job posting block should be in ISO 8601 format.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Fixes a bug where the Job posting block would show an invalidly formatted `datePosted` date.

## Relevant technical choices:

* I used the `"2017-01-24T19:33:17+00:00"` format, since that is the same format we use for the other Schema pieces in the graph.
	* E.g. for the `datePublished` and `dateModified` properties of the `WebSite` and `Article` pieces.
	* It is also valid [according to Google's documentation](https://developers.google.com/search/docs/data-types/job-posting#job-posting-definition):
	  > The original date that employer posted the job in ISO 8601 format. For example, "2017-01-24" or "2017-01-24T19:33:17+00:00".

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a post.
* Add a job posting block.
* Fill in all required blocks so that Schema is generated on the frontend.
* Save the post.
* View the post on the frontend.
* Check the Schema output. 
	* It should have a `JobPosting` Schema piece with a `datePosted` property.
	* This property should be in ISO 8601 format: Like `2021-01-24T19:33:17+00:00`.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
