### PR TITLE
Prevent the displaying of an Organization schema piece if the logo is an unsupported image

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -370,7 +370,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 				 * Do not use a company without a logo.
 				 * The logic check is on `< 1` instead of `false` due to how `get_attachment_id_from_settings` works.
 				 */
-				if ( $this->company_logo_id < 1 ) {
+				if ( $this->company_logo_id < 1 || ! $this->company_logo_meta ) {
 					return false;
 				}
 

--- a/tests/unit/context/meta-tags-context-test.php
+++ b/tests/unit/context/meta-tags-context-test.php
@@ -344,13 +344,39 @@ class Meta_Tags_Context_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the generate site represents with a company with name and an unsupported logo.
+	 *
+	 * @covers ::generate_site_represents
+	 */
+	public function test_generate_site_represents_company_with_name_and_unsupported_logo() {
+		$this->instance->company_name      = 'Company';
+		$this->instance->company_logo_id   = 12;
+		$this->instance->company_logo_meta = false;
+
+		$this->options->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'company' );
+
+		$this->assertFalse( $this->instance->generate_site_represents() );
+	}
+
+	/**
 	 * Tests the generate site represents with a company with name and logo.
 	 *
 	 * @covers ::generate_site_represents
 	 */
 	public function test_generate_site_represents_company_with_name_and_logo() {
-		$this->instance->company_name    = 'Company';
-		$this->instance->company_logo_id = 12;
+		$this->instance->company_name      = 'Company';
+		$this->instance->company_logo_id   = 12;
+		$this->instance->company_logo_meta = [
+			'width'  => 640,
+			'height' => 480,
+			'url'    => 'https://basic.wordpress.test/wp-content/uploads/2021/04/WordPress4.jpg',
+			'path'   => '/var/www/html/wp-content/uploads/2021/04/WordPress4.jpg',
+			'size'   => 'full',
+			'id'     => 12,
+			'alt'    => 'Alt. Text',
+			'pixels' => 307200,
+			'type'   => 'image/jpeg',
+		];
 
 		$this->options->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'company' );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Yoast SEO only supports JPG, PNG and GIF images to be correctly displayed as logo in the Organization schema piece. We should avoid to output a badly formed piece if another image type is used.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a malformed Organization piece is added to the Schema if the company logo is an unsupported image.

## Relevant technical choices:

* This only prevents a faulty Schema output, but it doesn't address the uploading/use of unsupported images in the Image selector component.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* edit your theme's `functions.php` file and add this snippet to the bottom:
```
function my_custom_mime_types( $mimes ) {
// New allowed mime types.
   $mimes['svg'] = 'image/svg+xml';
   $mimes['svgz'] = 'image/svg+xml';
   $mimes['webp'] = 'image/webp';
   return $mimes;
}
add_filter( 'upload_mimes', 'my_custom_mime_types' );
```
* save the file
* visit `SEO` > `Search Appearance`, first tab `General`
* set the type as an Organization
* insert a name for the Organization
* click on "Select Image" (or "Replace Image" if you already have one)
   * in the modal, upload and then select an SVG image
* Save the settings
* visit the home page in the front end and inspect the schema in the source
  * check that there is no `Organization` piece and no other piece is referring to it
* visit `SEO` > `Search Appearance`, first tab `General`
* click on "Replace Image"
   * in the modal, upload and then select a WEBP image
* Save the settings
* visit the home page in the front end and inspect the schema in the source
  * check that there is no `Organization` piece and no other piece is referring to it
* visit `SEO` > `Search Appearance`, first tab `General`
* click on "Replace Image"
   * in the modal, upload and then select a BMP image
* Save the settings
* visit the home page in the front end and inspect the schema in the source
  * check that there is no `Organization` piece and no other piece is referring to it
* visit `SEO` > `Search Appearance`, first tab `General`
* click on "Replace Image"
   * in the modal, upload and then select an image of the following types: JPG, GIF, PNG
* Save the settings
* visit the home page in the front end and inspect the schema in the source
  * check that there is an `Organization` piece, that it's well formed and the `logo` property shows the URL of the image you selected, with the right `height` and `width` values.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-572]