### PR TITLE
Add url property to author schema

### DIFF
--- a/src/generators/schema/author.php
+++ b/src/generators/schema/author.php
@@ -3,12 +3,12 @@
 namespace Yoast\WP\SEO\Generators\Schema;
 
 use Yoast\WP\SEO\Config\Schema_IDs;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 
 /**
  * Returns schema Author data.
  */
 class Author extends Person {
-
 	/**
 	 * Determine whether we should return Person schema.
 	 *
@@ -53,6 +53,13 @@ class Author extends Person {
 			$data['mainEntityOfPage'] = [
 				'@id' => $this->context->canonical . Schema_IDs::WEBPAGE_HASH,
 			];
+		}
+
+		// If this is a post and the author archives are enabled, set the author archive url as the author url.
+		if ( $this->context->indexable->object_type === 'post' ) {
+			if ( YoastSEO()->helpers->options->get( 'disable-author' ) !== true ) {
+				$data['url'] = YoastSEO()->helpers->user->get_the_author_posts_url( $user_id );
+			}
 		}
 
 		return $data;

--- a/src/generators/schema/author.php
+++ b/src/generators/schema/author.php
@@ -3,12 +3,12 @@
 namespace Yoast\WP\SEO\Generators\Schema;
 
 use Yoast\WP\SEO\Config\Schema_IDs;
-use Yoast\WP\SEO\Helpers\Options_Helper;
 
 /**
  * Returns schema Author data.
  */
 class Author extends Person {
+
 	/**
 	 * Determine whether we should return Person schema.
 	 *
@@ -57,8 +57,8 @@ class Author extends Person {
 
 		// If this is a post and the author archives are enabled, set the author archive url as the author url.
 		if ( $this->context->indexable->object_type === 'post' ) {
-			if ( YoastSEO()->helpers->options->get( 'disable-author' ) !== true ) {
-				$data['url'] = YoastSEO()->helpers->user->get_the_author_posts_url( $user_id );
+			if ( $this->helpers->options->get( 'disable-author' ) !== true ) {
+				$data['url'] = $this->helpers->user->get_the_author_posts_url( $user_id );
 			}
 		}
 

--- a/src/helpers/user-helper.php
+++ b/src/helpers/user-helper.php
@@ -46,6 +46,17 @@ class User_Helper {
 	}
 
 	/**
+	 * Retrieves the archive url of the user.
+	 *
+	 * @param int|false $user_id User ID.
+	 *
+	 * @return string The author's archive url.
+	 */
+	public function get_the_author_posts_url( $user_id ) {
+		return \get_author_posts_url( $user_id );
+	}
+
+	/**
 	 * Retrieves the current user ID.
 	 *
 	 * @return int The current user's ID, or 0 if no user is logged in.


### PR DESCRIPTION
on a post with author archives enabled

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* To improve the author schema piece by adding the url property when possible.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds url property to author schema on a post when author archives are enabled.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* On a post:
  * With author archives enabled:
    * Test the author archive url is added as a url property on the person schema piece.
  * With author archives disabled:
    * Test the url property is not added to the person schema piece.
* On anything else than a post that has a person schema piece:
  * Test the url property is not added on the person schema piece. 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Schema, especially for posts. Only affects the Person schema piece.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
