### PR TITLE
Adds the table of contents accessibility feature to the article piece…

### DIFF
--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -117,15 +117,15 @@ class Schema_Generator implements Generator_Interface {
 	/**
 	 * Generates the schema graph.
 	 *
-	 * @param array             $pieces_to_generate The schema graph pieces to generate.
+	 * @param array             $graph_piece_generators The schema graph pieces to generate.
 	 * @param Meta_Tags_Context $context            The meta tags context to use.
 	 *
 	 * @return array The generated schema graph.
 	 */
-	protected function generate_graph( $pieces_to_generate, $context ) {
+	protected function generate_graph( $graph_piece_generators, $context ) {
 		$graph = [];
-		foreach ( $pieces_to_generate as $identifier => $piece ) {
-			$graph_pieces = $piece->generate();
+		foreach ( $graph_piece_generators as $identifier => $graph_piece_generator ) {
+			$graph_pieces = $graph_piece_generator->generate();
 			// If only a single graph piece was returned.
 			if ( $graph_pieces !== false && \array_key_exists( '@type', $graph_pieces ) ) {
 				$graph_pieces = [ $graph_pieces ];
@@ -142,8 +142,10 @@ class Schema_Generator implements Generator_Interface {
 				 * @api array $graph_piece The graph piece to filter.
 				 *
 				 * @param Meta_Tags_Context $context A value object with context variables.
+				 * @param Abstract_Schema_Piece $graph_piece_generator A value object with context variables.
+				 * @param Abstract_Schema_Piece[] $graph_piece_generators A value object with context variables.
 				 */
-				$graph_piece = \apply_filters( 'wpseo_schema_' . $identifier, $graph_piece, $context );
+				$graph_piece = \apply_filters( 'wpseo_schema_' . $identifier, $graph_piece, $context, $graph_piece_generator, $graph_piece_generators );
 				$graph_piece = $this->type_filter( $graph_piece, $identifier, $context );
 				$graph_piece = $this->validate_type( $graph_piece );
 

--- a/src/integrations/front-end/schema-accessibility-feature.php
+++ b/src/integrations/front-end/schema-accessibility-feature.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Front_End;
+
+use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
+use Yoast\WP\SEO\Generators\Schema\Abstract_Schema_Piece;
+use Yoast\WP\SEO\Generators\Schema\Article;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Adds the table of contents accessibility feature to the article piece with a fallback to the webpage piece.
+ */
+class Schema_Accessibility_Feature implements Integration_Interface {
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * @return array
+	 */
+	public static function get_conditionals() {
+		return [ Front_End_Conditional::class ];
+	}
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * This is the place to register hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_filter( 'wpseo_schema_webpage', [ $this, 'maybe_add_accessibility_feature' ], 10, 4 );
+		\add_filter( 'wpseo_schema_article', [ $this, 'add_accessibility_feature' ], 10, 2 );
+	}
+
+	/**
+	 * Adds the accessibility feature to the webpage if there is no article.
+	 *
+	 * @param array                   $piece         The graph piece.
+	 * @param Meta_Tags_Context       $context       The context.
+	 * @param Abstract_Schema_Piece   $the_generator The current schema generator.
+	 * @param Abstract_Schema_Piece[] $generators    The schema generators.
+	 *
+	 * @return array The graph piece.
+	 */
+	public function maybe_add_accessibility_feature( $piece, $context, $the_generator, $generators ) {
+		foreach ( $generators as $generator ) {
+			if ( is_a( $generator, Article::class ) && $generator->is_needed() ) {
+				return $piece;
+			}
+		}
+
+		return $this->add_accessibility_feature( $piece, $context );
+	}
+
+	/**
+	 * Adds the accessibility feature to a schema graph piece.
+	 *
+	 * @param array             $piece   The schema piece.
+	 * @param Meta_Tags_Context $context The context.
+	 *
+	 * @return array The graph piece.
+	 */
+	public function add_accessibility_feature( $piece, $context ) {
+		if ( empty( $context->blocks['yoast-seo/table-of-contents'] ) ) {
+			return $piece;
+		}
+
+		if ( isset( $piece['accessibilityFeature'] ) ) {
+			$piece['accessibilityFeature'][] = 'tableOfContents';
+		}
+		else {
+			$piece['accessibilityFeature'] = [
+				'tableOfContents',
+			];
+		}
+		return $piece;
+	}
+}


### PR DESCRIPTION
… with a fallback to the webpage piece.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

From the issue:
>WebPage and Article schema support an accessibilityFeature property, which can list the accessibility features contained within that piece.
>One of the valid values is tableOfContents. We should add this when a post includes our TOC block.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the table of contents accessibility feature to the article schema with a fallback to the webpage schema, when using the Yoast table of contents block.

## Relevant technical choices:

* Renamed a couple of variables to better represent their contents.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* A post without a Yoast ToC block should not add this property to the article schema or webpage schema.
* A page without a Yoast ToC block should not add this property to the article schema or webpage schema.
* A post with a Yoast ToC block should add this property to the article schema. (Make sure your organisation or person settings are set to surface article schema).
* A post with article type set to "none" with a Yoast ToC block should add this property to the webpage schema.
* A page with a Yoast ToC block should add this property to the webpage schema.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Webpage and article schema in combination with the Yoast ToC block (in Premium)

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities