### PR TITLE
P3-582 improve presentations classes

### DIFF
--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -180,16 +180,21 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	 */
 	public function generate_open_graph_description() {
 		if ( $this->model->open_graph_description ) {
-			return $this->model->open_graph_description;
+			$open_graph_description = $this->model->open_graph_description;
 		}
 
-		$open_graph_description = $this->meta_description;
+		if ( empty( $open_graph_description ) ) {
+			// The helper applies a filter, but we don't have a default value at this stage so we pass an empty string.
+			$open_graph_description = $this->values_helper->get_open_graph_description( '', $this->model->object_type, $this->model->object_sub_type );
+		}
+
+		if ( empty( $open_graph_description ) ) {
+			$open_graph_description = $this->meta_description;
+		}
 
 		if ( empty( $open_graph_description ) ) {
 			$open_graph_description = $this->post->get_the_excerpt( $this->model->object_id );
 		}
-
-		$open_graph_description = $this->values_helper->get_open_graph_description( $open_graph_description, $this->model->object_type, $this->model->object_sub_type );
 
 		return $this->post->strip_shortcodes( $open_graph_description );
 	}

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -430,10 +430,19 @@ class Indexable_Presentation extends Abstract_Presentation {
 	 */
 	public function generate_open_graph_title() {
 		if ( $this->model->open_graph_title ) {
-			return $this->model->open_graph_title;
+			$open_graph_title = $this->model->open_graph_title;
 		}
 
-		return $this->values_helper->get_open_graph_title( $this->title, $this->model->object_type, $this->model->object_sub_type );
+		if ( empty( $open_graph_title ) ) {
+			// The helper applies a filter, but we don't have a default value at this stage so we pass an empty string.
+			$open_graph_title = $this->values_helper->get_open_graph_title( '', $this->model->object_type, $this->model->object_sub_type );
+		}
+
+		if ( empty( $open_graph_title ) ) {
+			$open_graph_title = $this->title;
+		}
+
+		return $open_graph_title;
 	}
 
 	/**
@@ -443,10 +452,19 @@ class Indexable_Presentation extends Abstract_Presentation {
 	 */
 	public function generate_open_graph_description() {
 		if ( $this->model->open_graph_description ) {
-			return $this->model->open_graph_description;
+			$open_graph_description = $this->model->open_graph_description;
 		}
 
-		return $this->values_helper->get_open_graph_description( $this->meta_description, $this->model->object_type, $this->model->object_sub_type );
+		if ( empty( $open_graph_description ) ) {
+			// The helper applies a filter, but we don't have a default value at this stage so we pass an empty string.
+			$open_graph_description = $this->values_helper->get_open_graph_description( '', $this->model->object_type, $this->model->object_sub_type );
+		}
+
+		if ( empty( $open_graph_description ) ) {
+			$open_graph_description = $this->meta_description;
+		}
+
+		return $open_graph_description;
 	}
 
 	/**

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -604,6 +604,13 @@ class Indexable_Presentation extends Abstract_Presentation {
 			return $this->model->twitter_title;
 		}
 
+		if ( $this->context->open_graph_enabled === true ) {
+			$open_graph_title = $this->values_helper->get_open_graph_title( '', $this->model->object_type, $this->model->object_sub_type );
+			if ( ! empty( $open_graph_title ) ) {
+				return $open_graph_title;
+			}
+		}
+
 		if ( $this->open_graph_title && $this->context->open_graph_enabled === true ) {
 			return '';
 		}
@@ -623,6 +630,13 @@ class Indexable_Presentation extends Abstract_Presentation {
 	public function generate_twitter_description() {
 		if ( $this->model->twitter_description ) {
 			return $this->model->twitter_description;
+		}
+
+		if ( $this->context->open_graph_enabled === true ) {
+			$open_graph_description = $this->values_helper->get_open_graph_description( '', $this->model->object_type, $this->model->object_sub_type );
+			if ( ! empty( $open_graph_description ) ) {
+				return $open_graph_description;
+			}
 		}
 
 		if ( $this->open_graph_description && $this->context->open_graph_enabled === true ) {
@@ -648,6 +662,13 @@ class Indexable_Presentation extends Abstract_Presentation {
 		// When there is an image set by the user.
 		if ( $image && $this->context->indexable->twitter_image_source === 'set-by-user' ) {
 			return $image['url'];
+		}
+
+		if ( $this->context->open_graph_enabled === true ) {
+			$open_graph_image = $this->values_helper->get_open_graph_image( '', $this->model->object_type, $this->model->object_sub_type );
+			if ( ! empty( $open_graph_image ) ) {
+				return $open_graph_image;
+			}
 		}
 
 		// When there isn't a set image or there is a Open Graph image set.

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -101,17 +101,12 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	 * @return string The Open Graph description.
 	 */
 	public function generate_open_graph_description() {
-		if ( $this->model->open_graph_description ) {
-			return $this->model->open_graph_description;
+		$open_graph_description = parent::generate_open_graph_description();
+		if ( $open_graph_description ) {
+			return $open_graph_description;
 		}
 
-		$open_graph_description = $this->meta_description;
-
-		if ( empty( $open_graph_description ) ) {
-			$open_graph_description = $this->taxonomy->get_term_description( $this->model->object_id );
-		}
-
-		return $this->values_helper->get_open_graph_description( $open_graph_description, $this->model->object_type, $this->model->object_sub_type );
+		return $this->taxonomy->get_term_description( $this->model->object_id );
 	}
 
 	/**

--- a/tests/unit/presentations/indexable-post-type-presentation/open-graph-description-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/open-graph-description-test.php
@@ -52,6 +52,7 @@ class Open_Graph_Description_Test extends TestCase {
 	 * @covers ::generate_open_graph_description
 	 */
 	public function test_with_helper_fallback() {
+		$this->indexable->object_type     = 'post';
 		$this->indexable->object_sub_type = 'post';
 		$description_from_helper          = 'Description from helper';
 		$this->instance->meta_description = 'Meta description';
@@ -70,6 +71,8 @@ class Open_Graph_Description_Test extends TestCase {
 	 * @covers ::generate_open_graph_description
 	 */
 	public function test_with_meta_description() {
+		$this->indexable->object_type            = 'post';
+		$this->indexable->object_sub_type        = 'post';
 		$this->indexable->open_graph_description = '';
 		$description_from_helper                 = '';
 		$this->instance->meta_description        = 'Meta description';
@@ -88,6 +91,7 @@ class Open_Graph_Description_Test extends TestCase {
 	 * @covers ::generate_open_graph_description
 	 */
 	public function test_with_excerpt_fallback() {
+		$this->indexable->object_type     = 'post';
 		$this->indexable->object_sub_type = 'post';
 		$description_from_helper          = '';
 		$this->instance->meta_description = '';

--- a/tests/unit/presentations/indexable-post-type-presentation/open-graph-description-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/open-graph-description-test.php
@@ -23,6 +23,16 @@ class Open_Graph_Description_Test extends TestCase {
 
 		$this->set_instance();
 		$this->indexable->object_id = 1;
+
+		$this->post
+			->expects( 'strip_shortcodes' )
+			->withAnyArgs()
+			->once()
+			->andReturnUsing(
+				function( $string ) {
+					return $string;
+				}
+			);
 	}
 
 	/**
@@ -37,23 +47,37 @@ class Open_Graph_Description_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the situation where the meta_description is used.
+	 * Tests the situation where the value from the helper is used.
+	 *
+	 * @covers ::generate_open_graph_description
+	 */
+	public function test_with_helper_fallback() {
+		$this->indexable->object_sub_type = 'post';
+		$description_from_helper          = 'Description from helper';
+		$this->instance->meta_description = 'Meta description';
+
+		$this->values_helper
+			->expects( 'get_open_graph_description' )
+			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
+			->andReturn( $description_from_helper );
+
+		$this->assertSame( 'Description from helper', $this->instance->generate_open_graph_description() );
+	}
+
+	/**
+	 * Tests the situation where the fallback to meta_description is used.
 	 *
 	 * @covers ::generate_open_graph_description
 	 */
 	public function test_with_meta_description() {
 		$this->indexable->open_graph_description = '';
+		$description_from_helper                 = '';
 		$this->instance->meta_description        = 'Meta description';
 
 		$this->values_helper
 			->expects( 'get_open_graph_description' )
-			->with( $this->instance->meta_description, $this->indexable->object_type, $this->indexable->object_sub_type )
-			->andReturn( $this->instance->meta_description );
-
-		$this->post
-			->expects( 'strip_shortcodes' )
-			->with( $this->instance->meta_description )
-			->andReturn( $this->instance->meta_description );
+			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
+			->andReturn( $description_from_helper );
 
 		$this->assertSame( 'Meta description', $this->instance->generate_open_graph_description() );
 	}
@@ -65,8 +89,14 @@ class Open_Graph_Description_Test extends TestCase {
 	 */
 	public function test_with_excerpt_fallback() {
 		$this->indexable->object_sub_type = 'post';
+		$description_from_helper          = '';
 		$this->instance->meta_description = '';
 		$excerpt_description              = 'Excerpt description';
+
+		$this->values_helper
+			->expects( 'get_open_graph_description' )
+			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
+			->andReturn( $description_from_helper );
 
 		$this->post
 			->expects( 'get_the_excerpt' )
@@ -74,39 +104,6 @@ class Open_Graph_Description_Test extends TestCase {
 			->once()
 			->andReturn( $excerpt_description );
 
-		$this->values_helper
-			->expects( 'get_open_graph_description' )
-			->with( $excerpt_description, $this->indexable->object_type, $this->indexable->object_sub_type )
-			->andReturn( $excerpt_description );
-
-		$this->post
-			->expects( 'strip_shortcodes' )
-			->with( $excerpt_description )
-			->andReturn( $excerpt_description );
-
 		$this->assertSame( 'Excerpt description', $this->instance->generate_open_graph_description() );
-	}
-
-	/**
-	 * Tests the situation where the value from the helper is used.
-	 *
-	 * @covers ::generate_open_graph_description
-	 */
-	public function test_with_helper_fallback() {
-		$this->indexable->object_sub_type = 'post';
-		$this->instance->meta_description = 'Meta description';
-		$description_from_helper          = 'Description from helper';
-
-		$this->values_helper
-			->expects( 'get_open_graph_description' )
-			->with( $this->instance->meta_description, $this->indexable->object_type, $this->indexable->object_sub_type )
-			->andReturn( $description_from_helper );
-
-		$this->post
-			->expects( 'strip_shortcodes' )
-			->with( $description_from_helper )
-			->andReturn( $description_from_helper );
-
-		$this->assertSame( 'Description from helper', $this->instance->generate_open_graph_description() );
 	}
 }

--- a/tests/unit/presentations/indexable-post-type-presentation/twitter-description-test.php
+++ b/tests/unit/presentations/indexable-post-type-presentation/twitter-description-test.php
@@ -48,6 +48,10 @@ class Twitter_Description_Test extends TestCase {
 			->once()
 			->andReturn( '' );
 
+		$this->values_helper
+			->expects( 'get_open_graph_description' )
+			->andReturn( '' );
+
 		$this->post
 			->expects( 'get_the_excerpt' )
 			->with( $this->indexable->object_id )
@@ -68,6 +72,10 @@ class Twitter_Description_Test extends TestCase {
 		$this->indexable->twitter_description = '';
 		$this->instance->meta_description     = '';
 		$this->context->open_graph_enabled    = true;
+
+		$this->values_helper
+			->expects( 'get_open_graph_description' )
+			->andReturn( '' );
 
 		$this->instance
 			->expects( 'generate_open_graph_description' )
@@ -107,6 +115,10 @@ class Twitter_Description_Test extends TestCase {
 	 * @covers ::generate_twitter_description
 	 */
 	public function test_with_no_term_description() {
+		$this->values_helper
+			->expects( 'get_open_graph_description' )
+			->andReturn( '' );
+
 		$this->options
 			->expects( 'get' )
 			->once()

--- a/tests/unit/presentations/indexable-presentation/open-graph-description-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-description-test.php
@@ -32,7 +32,23 @@ class Open_Graph_Description_Test extends TestCase {
 	public function test_generate_open_graph_description_when_open_graph_description_is_given() {
 		$this->indexable->open_graph_description = 'Example of Open Graph description';
 
-		$this->assertEquals( 'Example of Open Graph description', $this->instance->generate_open_graph_description() );
+		$this->assertSame( 'Example of Open Graph description', $this->instance->generate_open_graph_description() );
+	}
+
+	/**
+	 * Tests the situation where the value from the helper is used.
+	 *
+	 * @covers ::generate_open_graph_description
+	 */
+	public function test_with_helper_fallback() {
+		$description_from_helper          = 'Description from helper';
+		$this->instance->meta_description = 'Meta description';
+
+		$this->values_helper
+			->expects( 'get_open_graph_description' )
+			->andReturn( $description_from_helper );
+
+		$this->assertSame( 'Description from helper', $this->instance->generate_open_graph_description() );
 	}
 
 	/**
@@ -45,9 +61,9 @@ class Open_Graph_Description_Test extends TestCase {
 
 		$this->values_helper
 			->expects( 'get_open_graph_description' )
-			->with( $this->indexable->description, $this->indexable->object_type, $this->indexable->object_sub_type )
-			->andReturn( $this->indexable->description );
+			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
+			->andReturn( '' );
 
-		$this->assertEquals( 'Example of meta description', $this->instance->generate_open_graph_description() );
+		$this->assertSame( 'Example of meta description', $this->instance->generate_open_graph_description() );
 	}
 }

--- a/tests/unit/presentations/indexable-presentation/open-graph-description-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-description-test.php
@@ -61,7 +61,6 @@ class Open_Graph_Description_Test extends TestCase {
 
 		$this->values_helper
 			->expects( 'get_open_graph_description' )
-			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
 			->andReturn( '' );
 
 		$this->assertSame( 'Example of meta description', $this->instance->generate_open_graph_description() );

--- a/tests/unit/presentations/indexable-presentation/open-graph-title-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-title-test.php
@@ -32,8 +32,26 @@ class Open_Graph_Title_Test extends TestCase {
 	 */
 	public function test_generate_open_graph_title_when_open_graph_title_is_set() {
 		$this->indexable->open_graph_title = 'Example of Open Graph title';
+		$this->indexable->title            = 'Example of SEO title';
 
-		$this->assertEquals( 'Example of Open Graph title', $this->instance->generate_open_graph_title() );
+		$this->assertSame( 'Example of Open Graph title', $this->instance->generate_open_graph_title() );
+	}
+
+	/**
+	 * Tests the situation where the Open Graph title is not set and the value from the helper is used.
+	 *
+	 * @covers ::generate_open_graph_title
+	 */
+	public function test_generate_open_graph_title_from_helper() {
+		$title_from_helper      = 'Example of title from the helper';
+		$this->indexable->title = 'Example of SEO title';
+
+		$this->values_helper
+			->expects( 'get_open_graph_title' )
+			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
+			->andReturn( $title_from_helper );
+
+		$this->assertSame( 'Example of title from the helper', $this->instance->generate_open_graph_title() );
 	}
 
 	/**
@@ -46,9 +64,9 @@ class Open_Graph_Title_Test extends TestCase {
 
 		$this->values_helper
 			->expects( 'get_open_graph_title' )
-			->with( $this->indexable->title, $this->indexable->object_type, $this->indexable->object_sub_type )
-			->andReturn( $this->indexable->title );
+			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
+			->andReturn( '' );
 
-		$this->assertEquals( 'Example of SEO title', $this->instance->generate_open_graph_title() );
+		$this->assertSame( 'Example of SEO title', $this->instance->generate_open_graph_title() );
 	}
 }

--- a/tests/unit/presentations/indexable-presentation/open-graph-title-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-title-test.php
@@ -48,7 +48,6 @@ class Open_Graph_Title_Test extends TestCase {
 
 		$this->values_helper
 			->expects( 'get_open_graph_title' )
-			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
 			->andReturn( $title_from_helper );
 
 		$this->assertSame( 'Example of title from the helper', $this->instance->generate_open_graph_title() );
@@ -64,7 +63,6 @@ class Open_Graph_Title_Test extends TestCase {
 
 		$this->values_helper
 			->expects( 'get_open_graph_title' )
-			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
 			->andReturn( '' );
 
 		$this->assertSame( 'Example of SEO title', $this->instance->generate_open_graph_title() );

--- a/tests/unit/presentations/indexable-presentation/twitter-description-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-description-test.php
@@ -38,6 +38,22 @@ class Twitter_Description_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the situation where no Twitter description is set, the Values Helper provides a description, and Open Graph is enabled.
+	 *
+	 * @covers ::generate_twitter_description
+	 */
+	public function test_generate_twitter_description_with_description_from_values_helper_and_open_graph_enabled() {
+		$this->context->open_graph_enabled = true;
+		$description_from_helper           = 'Description from helper';
+
+		$this->values_helper
+			->expects( 'get_open_graph_description' )
+			->andReturn( $description_from_helper );
+
+		$this->assertSame( 'Description from helper', $this->instance->generate_twitter_description() );
+	}
+
+	/**
 	 * Tests the situation where no Twitter description is set, the Open Graph description is set, and Open Graph is enabled.
 	 *
 	 * @covers ::generate_twitter_description
@@ -45,6 +61,10 @@ class Twitter_Description_Test extends TestCase {
 	public function test_generate_twitter_description_with_set_open_graph_description_and_open_graph_enabled() {
 		$this->context->open_graph_enabled       = true;
 		$this->indexable->open_graph_description = 'Open Graph description';
+
+		$this->values_helper
+			->expects( 'get_open_graph_description' )
+			->andReturn( '' );
 
 		$this->assertSame( '', $this->instance->generate_twitter_description() );
 	}
@@ -58,6 +78,10 @@ class Twitter_Description_Test extends TestCase {
 		$this->context->open_graph_enabled      = true;
 		$this->instance->open_graph_description = '';
 		$this->indexable->description           = 'SEO description';
+
+		$this->values_helper
+			->expects( 'get_open_graph_description' )
+			->andReturn( '' );
 
 		$this->assertSame( 'SEO description', $this->instance->generate_twitter_description() );
 	}
@@ -87,18 +111,25 @@ class Twitter_Description_Test extends TestCase {
 		$this->indexable->description           = 'Meta description';
 		$this->instance->open_graph_description = '';
 
+		$this->values_helper
+			->expects( 'get_open_graph_description' )
+			->andReturn( '' );
+
 		$this->assertSame( 'Meta description', $this->instance->generate_twitter_description() );
 	}
 
 	/**
 	 * Tests the situation where an empty value is returned.
 	 *
+	 * The helper is called twice: the first time from the Twitter method, the second time from the Open Graph method.
+	 *
 	 * @covers ::generate_twitter_description
 	 */
 	public function test_with_empty_return_value() {
 		$this->values_helper
 			->expects( 'get_open_graph_description' )
-			->andReturn( $this->indexable->description );
+			->twice()
+			->andReturn( '' );
 
 		$this->assertEmpty( $this->instance->generate_twitter_description() );
 	}

--- a/tests/unit/presentations/indexable-presentation/twitter-description-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-description-test.php
@@ -73,7 +73,6 @@ class Twitter_Description_Test extends TestCase {
 
 		$this->values_helper
 			->expects( 'get_open_graph_description' )
-			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
 			->andReturn( '' );
 
 		$this->assertSame( 'SEO description', $this->instance->generate_twitter_description() );
@@ -99,7 +98,6 @@ class Twitter_Description_Test extends TestCase {
 	public function test_with_empty_return_value() {
 		$this->values_helper
 			->expects( 'get_open_graph_description' )
-			->with( $this->indexable->description, $this->indexable->object_type, $this->indexable->object_sub_type )
 			->andReturn( $this->indexable->description );
 
 		$this->assertEmpty( $this->instance->generate_twitter_description() );

--- a/tests/unit/presentations/indexable-presentation/twitter-description-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-description-test.php
@@ -34,7 +34,7 @@ class Twitter_Description_Test extends TestCase {
 	public function test_with_set_twitter_description() {
 		$this->indexable->twitter_description = 'Twitter description';
 
-		$this->assertEquals( 'Twitter description', $this->instance->generate_twitter_description() );
+		$this->assertSame( 'Twitter description', $this->instance->generate_twitter_description() );
 	}
 
 	/**
@@ -46,7 +46,7 @@ class Twitter_Description_Test extends TestCase {
 		$this->context->open_graph_enabled       = true;
 		$this->indexable->open_graph_description = 'Open Graph description';
 
-		$this->assertEquals( '', $this->instance->generate_twitter_description() );
+		$this->assertSame( '', $this->instance->generate_twitter_description() );
 	}
 
 	/**
@@ -59,7 +59,7 @@ class Twitter_Description_Test extends TestCase {
 		$this->instance->open_graph_description = '';
 		$this->indexable->description           = 'SEO description';
 
-		$this->assertEquals( 'SEO description', $this->instance->generate_twitter_description() );
+		$this->assertSame( 'SEO description', $this->instance->generate_twitter_description() );
 	}
 
 	/**
@@ -73,10 +73,10 @@ class Twitter_Description_Test extends TestCase {
 
 		$this->values_helper
 			->expects( 'get_open_graph_description' )
-			->with( $this->indexable->description, $this->indexable->object_type, $this->indexable->object_sub_type )
-			->andReturn( $this->indexable->description );
+			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
+			->andReturn( '' );
 
-		$this->assertEquals( 'SEO description', $this->instance->generate_twitter_description() );
+		$this->assertSame( 'SEO description', $this->instance->generate_twitter_description() );
 	}
 
 	/**
@@ -88,7 +88,7 @@ class Twitter_Description_Test extends TestCase {
 		$this->indexable->description           = 'Meta description';
 		$this->instance->open_graph_description = '';
 
-		$this->assertEquals( 'Meta description', $this->instance->generate_twitter_description() );
+		$this->assertSame( 'Meta description', $this->instance->generate_twitter_description() );
 	}
 
 	/**

--- a/tests/unit/presentations/indexable-presentation/twitter-image-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-image-test.php
@@ -71,6 +71,10 @@ class Twitter_Image_Test extends TestCase {
 			->with( $this->context )
 			->andReturn( $image_generate );
 
+		$this->values_helper
+			->expects( 'get_open_graph_image' )
+			->andReturn( '' );
+
 		$this->instance
 			->expects( 'generate_open_graph_images' )
 			->once()

--- a/tests/unit/presentations/indexable-presentation/twitter-title-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-title-test.php
@@ -34,7 +34,7 @@ class Twitter_Title_Test extends TestCase {
 	public function test_generate_twitter_title_with_set_twitter_title() {
 		$this->indexable->twitter_title = 'Twitter title';
 
-		$this->assertEquals( 'Twitter title', $this->instance->generate_twitter_title() );
+		$this->assertSame( 'Twitter title', $this->instance->generate_twitter_title() );
 	}
 
 	/**
@@ -46,7 +46,7 @@ class Twitter_Title_Test extends TestCase {
 		$this->context->open_graph_enabled = true;
 		$this->indexable->open_graph_title = 'Open Graph title';
 
-		$this->assertEquals( '', $this->instance->generate_twitter_title() );
+		$this->assertSame( '', $this->instance->generate_twitter_title() );
 	}
 
 	/**
@@ -59,7 +59,7 @@ class Twitter_Title_Test extends TestCase {
 		$this->instance->open_graph_title  = 'Open Graph title';
 		$this->indexable->title            = 'SEO title';
 
-		$this->assertEquals( 'SEO title', $this->instance->generate_twitter_title() );
+		$this->assertSame( 'SEO title', $this->instance->generate_twitter_title() );
 	}
 
 	/**
@@ -72,7 +72,7 @@ class Twitter_Title_Test extends TestCase {
 		$this->instance->open_graph_title  = null;
 		$this->indexable->title            = 'SEO title';
 
-		$this->assertEquals( 'SEO title', $this->instance->generate_twitter_title() );
+		$this->assertSame( 'SEO title', $this->instance->generate_twitter_title() );
 	}
 
 	/**
@@ -84,7 +84,7 @@ class Twitter_Title_Test extends TestCase {
 		$this->indexable->title           = 'SEO title';
 		$this->instance->open_graph_title = '';
 
-		$this->assertEquals( 'SEO title', $this->instance->generate_twitter_title() );
+		$this->assertSame( 'SEO title', $this->instance->generate_twitter_title() );
 	}
 
 	/**
@@ -95,8 +95,8 @@ class Twitter_Title_Test extends TestCase {
 	public function test_generate_twitter_title_with_empty_return_value() {
 		$this->values_helper
 			->expects( 'get_open_graph_title' )
-			->with( $this->indexable->title, $this->indexable->object_type, $this->indexable->object_sub_type )
-			->andReturn( $this->indexable->title );
+			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
+			->andReturn( '' );
 
 		$this->assertEmpty( $this->instance->generate_twitter_title() );
 	}

--- a/tests/unit/presentations/indexable-presentation/twitter-title-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-title-test.php
@@ -95,7 +95,6 @@ class Twitter_Title_Test extends TestCase {
 	public function test_generate_twitter_title_with_empty_return_value() {
 		$this->values_helper
 			->expects( 'get_open_graph_title' )
-			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
 			->andReturn( '' );
 
 		$this->assertEmpty( $this->instance->generate_twitter_title() );

--- a/tests/unit/presentations/indexable-presentation/twitter-title-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-title-test.php
@@ -38,6 +38,22 @@ class Twitter_Title_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the situation where no Twitter title is set, the Values Helper provides a title, and Open Graph is enabled.
+	 *
+	 * @covers ::generate_twitter_title
+	 */
+	public function test_generate_twitter_title_with_title_from_values_helper_and_open_graph_enabled() {
+		$this->context->open_graph_enabled = true;
+		$title_from_helper                 = 'Example of title from the helper';
+
+		$this->values_helper
+			->expects( 'get_open_graph_title' )
+			->andReturn( $title_from_helper );
+
+		$this->assertSame( 'Example of title from the helper', $this->instance->generate_twitter_title() );
+	}
+
+	/**
 	 * Tests the situation where no Twitter title is set, the Open Graph title is set, and Open Graph is enabled.
 	 *
 	 * @covers ::generate_twitter_title
@@ -45,6 +61,10 @@ class Twitter_Title_Test extends TestCase {
 	public function test_generate_twitter_title_with_set_open_graph_title_and_open_graph_enabled() {
 		$this->context->open_graph_enabled = true;
 		$this->indexable->open_graph_title = 'Open Graph title';
+
+		$this->values_helper
+			->expects( 'get_open_graph_title' )
+			->andReturn( '' );
 
 		$this->assertSame( '', $this->instance->generate_twitter_title() );
 	}
@@ -72,6 +92,10 @@ class Twitter_Title_Test extends TestCase {
 		$this->instance->open_graph_title  = null;
 		$this->indexable->title            = 'SEO title';
 
+		$this->values_helper
+			->expects( 'get_open_graph_title' )
+			->andReturn( '' );
+
 		$this->assertSame( 'SEO title', $this->instance->generate_twitter_title() );
 	}
 
@@ -84,17 +108,24 @@ class Twitter_Title_Test extends TestCase {
 		$this->indexable->title           = 'SEO title';
 		$this->instance->open_graph_title = '';
 
+		$this->values_helper
+			->expects( 'get_open_graph_title' )
+			->andReturn( '' );
+
 		$this->assertSame( 'SEO title', $this->instance->generate_twitter_title() );
 	}
 
 	/**
 	 * Tests the situation where an empty value is returned.
 	 *
+	 * The helper is called twice: the first time from the Twitter method, the second time from the Open Graph method.
+	 *
 	 * @covers ::generate_twitter_title
 	 */
 	public function test_generate_twitter_title_with_empty_return_value() {
 		$this->values_helper
 			->expects( 'get_open_graph_title' )
+			->twice()
 			->andReturn( '' );
 
 		$this->assertEmpty( $this->instance->generate_twitter_title() );

--- a/tests/unit/presentations/indexable-term-archive-presentation/open-graph-description-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/open-graph-description-test.php
@@ -34,7 +34,30 @@ class Open_Graph_Description_Test extends TestCase {
 	public function test_with_set_open_graph_description() {
 		$this->indexable->open_graph_description = 'Open Graph description';
 
-		$this->assertEquals( 'Open Graph description', $this->instance->generate_open_graph_description() );
+		$this->assertSame( 'Open Graph description', $this->instance->generate_open_graph_description() );
+	}
+
+	/**
+	 * Tests the situation where the description from template is given.
+	 *
+	 * @covers ::generate_open_graph_description
+	 */
+	public function test_with_description_from_template() {
+		$this->indexable->open_graph_description = '';
+		$description_from_template               = 'Description from template';
+		$this->instance->meta_description        = 'Meta description';
+
+		$this->taxonomy
+			->expects( 'get_term_description' )
+			->with( $this->indexable->object_id )
+			->never();
+
+		$this->values_helper
+			->expects( 'get_open_graph_description' )
+			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
+			->andReturn( $description_from_template );
+
+		$this->assertSame( 'Description from template', $this->instance->generate_open_graph_description() );
 	}
 
 	/**
@@ -48,10 +71,10 @@ class Open_Graph_Description_Test extends TestCase {
 
 		$this->values_helper
 			->expects( 'get_open_graph_description' )
-			->with( $this->instance->meta_description, $this->indexable->object_type, $this->indexable->object_sub_type )
-			->andReturn( $this->instance->meta_description );
+			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
+			->andReturn( '' );
 
-		$this->assertEquals( 'Meta description', $this->instance->generate_open_graph_description() );
+		$this->assertSame( 'Meta description', $this->instance->generate_open_graph_description() );
 	}
 
 	/**
@@ -64,37 +87,16 @@ class Open_Graph_Description_Test extends TestCase {
 		$this->instance->meta_description        = '';
 		$term_description                        = 'Term description';
 
-		$this->taxonomy
-			->expects( 'get_term_description' )
-			->with( $this->indexable->object_id )
-			->andReturn( $term_description );
-
 		$this->values_helper
 			->expects( 'get_open_graph_description' )
-			->with( $term_description, $this->indexable->object_type, $this->indexable->object_sub_type )
-			->andReturn( $term_description );
-
-		$this->assertEquals( 'Term description', $this->instance->generate_open_graph_description() );
-	}
-
-	/**
-	 * Tests the situation where the description from template is given.
-	 *
-	 * @covers ::generate_open_graph_description
-	 */
-	public function test_with_description_from_template() {
-		$this->indexable->open_graph_description = '';
-		$this->instance->meta_description        = '';
-		$this->taxonomy
-			->expects( 'get_term_description' )
-			->with( $this->indexable->object_id )
-			->once()
+			->with( '', $this->indexable->object_type, $this->indexable->object_sub_type )
 			->andReturn( '' );
 
-		$this->values_helper
-			->expects( 'get_open_graph_description' )
-			->andReturn( 'Description from template' );
+		$this->taxonomy
+			->expects( 'get_term_description' )
+			->with( $this->indexable->object_id )
+			->andReturn( $term_description );
 
-		$this->assertEquals( 'Description from template', $this->instance->generate_open_graph_description() );
+		$this->assertSame( 'Term description', $this->instance->generate_open_graph_description() );
 	}
 }

--- a/tests/unit/presentations/indexable-term-archive-presentation/open-graph-description-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/open-graph-description-test.php
@@ -43,6 +43,8 @@ class Open_Graph_Description_Test extends TestCase {
 	 * @covers ::generate_open_graph_description
 	 */
 	public function test_with_description_from_template() {
+		$this->indexable->object_type            = 'post-type-archive';
+		$this->indexable->object_sub_type        = 'book';
 		$this->indexable->open_graph_description = '';
 		$description_from_template               = 'Description from template';
 		$this->instance->meta_description        = 'Meta description';
@@ -66,6 +68,8 @@ class Open_Graph_Description_Test extends TestCase {
 	 * @covers ::generate_open_graph_description
 	 */
 	public function test_with_meta_description() {
+		$this->indexable->object_type            = 'post-type-archive';
+		$this->indexable->object_sub_type        = 'book';
 		$this->indexable->open_graph_description = '';
 		$this->instance->meta_description        = 'Meta description';
 
@@ -83,6 +87,8 @@ class Open_Graph_Description_Test extends TestCase {
 	 * @covers ::generate_open_graph_description
 	 */
 	public function test_with_term_description() {
+		$this->indexable->object_type            = 'post-type-archive';
+		$this->indexable->object_sub_type        = 'book';
 		$this->indexable->open_graph_description = '';
 		$this->instance->meta_description        = '';
 		$term_description                        = 'Term description';

--- a/tests/unit/presentations/indexable-term-archive-presentation/twitter-description-test.php
+++ b/tests/unit/presentations/indexable-term-archive-presentation/twitter-description-test.php
@@ -47,6 +47,10 @@ class Twitter_Description_Test extends TestCase {
 		$this->instance->meta_description     = '';
 		$this->context->open_graph_enabled    = true;
 
+		$this->values_helper
+			->expects( 'get_open_graph_description' )
+			->andReturn( '' );
+
 		$this->instance
 			->expects( 'generate_open_graph_description' )
 			->once()
@@ -70,6 +74,10 @@ class Twitter_Description_Test extends TestCase {
 		$this->indexable->twitter_description = '';
 		$this->instance->meta_description     = '';
 		$this->context->open_graph_enabled    = true;
+
+		$this->values_helper
+			->expects( 'get_open_graph_description' )
+			->andReturn( '' );
 
 		$this->instance
 			->expects( 'generate_open_graph_description' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the changes in #16850 to be more clear and readable, by reducing the changes from the current state in `master` and following the hierarchy fallback order.
* We want also to address the changes in the Twitter hierarchy, where social templates should take precedence over the fallback to OG tags.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the presentations classes for readability and adherence to the current behaviour.
* Updates the presentations classes to add the Social Template in the hierarchy for the Twitter tags.

## Relevant technical choices:

* The tests have also improved to check more carefully the complete fallback mechanism.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


#### Test against regression

Basically we need to test against regressions to make sure that the code changes are not breaking the fallback hierarchy, so:

* build and activate Premium from the `release/16.3` branch
* Follow the test instructions in https://github.com/Yoast/wordpress-seo-premium/pull/3273, ignoring the part about the upgrade routine, and make sure that everything still works as expected.

#### Test the Twitter changes

* build and activate Premium from the `release/16.3` branch
* For each of the content types that have the Yoast Metabox (`Posts`, `Pages`, `Custom Types` items and `Terms`):
  * make sure you have Social Templates filled for them
  * edit the item
  * set the Facebook title, description and image
  * set the Twitter title, description and image
  * check the front end source and see that there are Twitter tags with the values you set
  * empty the Twitter fields
  * check the front end source and see that there are Twitter tags with the values from the Social Templates
  * empty the social templates (or deactivate Premium)
  * check the front end source and see that there are **no** Twitter tags, but there are OG tags following the hierarchy you checked at the previous point (without the Social Templates, obviously, because they are empty or unused)
* For each of the content types that don't have the Yoast Metabox (`Custom Types Archives`, `Date Archives`, `Author Archives`):
  * make sure you have Social Templates filled for them
  * check the front end source and see that there are Twitter tags with the values from the Social Templates
  * empty the social templates (or deactivate Premium)
  * check the front end source and see that there are **no** Twitter tags, but there are OG tags following the hierarchy you checked at the previous point (without the Social Templates, obviously, because they are empty or unused)
  
  
### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-582]
