### PR TITLE
Add support for LiteSpeed web servers

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -48,7 +48,7 @@ class WPSEO_Utils {
 	}
 
 	/**
-	 * Check if the web server is running on Apache.
+	 * Check if the web server is running on Apache or compatible (LiteSpeed).
 	 *
 	 * @since 1.8.0
 	 *
@@ -61,7 +61,15 @@ class WPSEO_Utils {
 
 		$software = sanitize_text_field( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) );
 
-		return stripos( $software, 'apache' ) !== false;
+		if ( stripos( $software, 'apache' ) !== false ) {
+			$abool = true;
+		}
+		elseif ( stripos( $software, 'litespeed' ) !== false ) {
+			$abool = true;
+		}
+		else $abool = false;
+
+		return $abool;
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -69,7 +69,7 @@ class WPSEO_Utils {
 		}
 		else $abool = false;
 
-		return $abool;
+		return stripos( $software, 'apache' ) !== false || stripos( $software, 'litespeed' ) !== false;
 	}
 
 	/**

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -61,14 +61,6 @@ class WPSEO_Utils {
 
 		$software = sanitize_text_field( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) );
 
-		if ( stripos( $software, 'apache' ) !== false ) {
-			$abool = true;
-		}
-		elseif ( stripos( $software, 'litespeed' ) !== false ) {
-			$abool = true;
-		}
-		else $abool = false;
-
 		return stripos( $software, 'apache' ) !== false || stripos( $software, 'litespeed' ) !== false;
 	}
 


### PR DESCRIPTION
Patch to expand test for Apache to also check for the Apache-compatible web server LiteSpeed and return same result

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* Add support for the only [unofficially supported but officially recognized](https://make.wordpress.org/hosting/handbook/handbook/server-environment/#web-server) web server, LiteSpeed. Without this then changes to redirects via wordpress-seo-premium are not actually applied to `.htaccess` and the Settings tab under Redirects only shows PHP & Web server instead of PHP & `.htaccess` along with a secondary option of with being able to select a separate redirect file.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Add increased compatibility for LiteSpeed web servers

## Relevant technical choices:

* Easiest to just implement this patch but would be _better to change the logic in all plugins that use this function_ where would only test if it is NGINX and if not then assume is Apache and/or compatible. This is because if an unpopular web server is used then it would either recognize & use `.htaccess` or admins would assume that they have to manually copy/convert what's listed in `.htaccess` to their server config but they can't easily do that if `.htaccess` is not even modified if their server is not recognized. They could use PHP in the meantime but that leads to major scalability problems due to reduced performance & converting redirects from an exported CSV to an acceptable server config format is more work than converting from `.htaccess` rules.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Install/activate wordpress-seo-premium on a LiteSpeed web server (Enterprise, OpenLiteSpeed, or Web ADC)
2. Look under **Settings tab > Redirects** (in UI) to see if shows `.htaccess` as a redirect method
3. Add plain redirect
4. Look under **Tools > File editor** (or **Edit Files** if multisite) > .htaccess file section to see if the new redirect is listed below `# BEGIN YOAST REDIRECTS`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Verify Apache is still recognized correctly

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
