### PR TITLE
Consistently self-close enhanced twitter meta tags

### DIFF
--- a/src/presenters/slack/enhanced-data-presenter.php
+++ b/src/presenters/slack/enhanced-data-presenter.php
@@ -20,8 +20,8 @@ class Enhanced_Data_Presenter extends Abstract_Indexable_Presenter {
 		$twitter_tags  = '';
 		$i             = 1;
 		foreach ( $enhanced_data as $label => $value ) {
-			$twitter_tags .= \sprintf( "\t" . '<meta name="twitter:label%1$d" content="%2$s">' . "\n", $i, $label );
-			$twitter_tags .= \sprintf( "\t" . '<meta name="twitter:data%1$d" content="%2$s">' . "\n", $i, $value );
+			$twitter_tags .= \sprintf( "\t" . '<meta name="twitter:label%1$d" content="%2$s" />' . "\n", $i, $label );
+			$twitter_tags .= \sprintf( "\t" . '<meta name="twitter:data%1$d" content="%2$s" />' . "\n", $i, $value );
 			++$i;
 		}
 		return \trim( $twitter_tags );

--- a/tests/unit/presenters/slack/enhanced-data-presenter-test.php
+++ b/tests/unit/presenters/slack/enhanced-data-presenter-test.php
@@ -70,10 +70,10 @@ class Enhanced_Data_Presenter_Test extends TestCase {
 		);
 
 		$this->assertEquals(
-			"<meta name=\"twitter:label1\" content=\"Written by\">\n"
-			. "\t<meta name=\"twitter:data1\" content=\"Agatha Christie\">\n"
-			. "\t<meta name=\"twitter:label2\" content=\"Est. reading time\">\n"
-			. "\t<meta name=\"twitter:data2\" content=\"40 minutes\">",
+			"<meta name=\"twitter:label1\" content=\"Written by\" />\n"
+			. "\t<meta name=\"twitter:data1\" content=\"Agatha Christie\" />\n"
+			. "\t<meta name=\"twitter:label2\" content=\"Est. reading time\" />\n"
+			. "\t<meta name=\"twitter:data2\" content=\"40 minutes\" />",
 			$this->instance->present()
 		);
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* All our meta tags are self-closing (`<meta ... />`). Our `twitter:label` and `twitter:data` are not. For consistencies' sake and to allow pages to pass some validations, we should add the self-closing indicator.

## Summary

This PR can be summarized in the following changelog entry:

* [Enhancement] Makes all twitter meta tags self-closing.

## Relevant technical choices:

* More information here: https://www.w3.org/TR/html52/syntax.html#start-tags . It isn't strictly necessary to mark the tags as self closing, but it doesn't hurt either and it allows for consistency and, according to [this issue](https://github.com/Yoast/wordpress-seo/issues/16949), ADA compliance. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check if the source-code of an article has the following meta tags:
```
	<meta name="twitter:card" content="summary_large_image" />
	<meta name="twitter:label1" content="Written by" />
	<meta name="twitter:data1" content="admin" />
	<meta name="twitter:label2" content="Est. reading time" />
	<meta name="twitter:data2" content="7 minutes" />
```

and confirm the tags are self closing: ` />`.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/16949
