### PR TITLE
Increase Ryte sitecheck timeout

### DIFF
--- a/admin/ryte/class-ryte-request.php
+++ b/admin/ryte/class-ryte-request.php
@@ -38,7 +38,7 @@ class WPSEO_Ryte_Request {
 		$url        = add_query_arg( $parameters, $this->ryte_endpoint );
 
 		// Decrease a chance of "cURL 28 (timeout)" errors by increasing the timeout to 10 seconds.
-		$args		= [ 'timeout' => 10 ];
+		$args       = [ 'timeout' => 10 ];
 		$response   = wp_remote_get( $url, $args );
 
 		return $this->process_response( $response );

--- a/admin/ryte/class-ryte-request.php
+++ b/admin/ryte/class-ryte-request.php
@@ -36,7 +36,10 @@ class WPSEO_Ryte_Request {
 
 		$parameters = array_merge( $defaults, $parameters );
 		$url        = add_query_arg( $parameters, $this->ryte_endpoint );
-		$response   = wp_remote_get( $url );
+
+		// Decrease a chance of "cURL 28 (timeout)" errors by increasing the timeout to 10 seconds.
+		$args		= [ 'timeout' => 10 ];
+		$response   = wp_remote_get( $url, $args );
 
 		return $this->process_response( $response );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Decrease the likelyhood of a site-check by Ryte to end in a timeout.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [non-user-facing] Increase the timeout for the site-health check to Ryte from 5 to 10 seconds.

## Relevant technical choices:

* When Ryte is particularly busy, responses may exceed several seconds. Combine this with WordPress / host / networking overhead may cause the Ryte check to timeout and show an `cURL 28 error`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have Query Monitor installed
* Go to Tools -> Site Health
* Check the HTTP API calls in Query Monitor
* See that the call to `https://indexability.yoast.onpage.org/` now has a timeout of 10 seconds (instead of the default 5)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/16837
