### PR TITLE
P3-584 do not restrict image types but avoid race condition

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -366,7 +366,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 				 * Do not use a company without a logo.
 				 * The logic check is on `< 1` instead of `false` due to how `get_attachment_id_from_settings` works.
 				 */
-				if ( $this->company_logo_id < 1 || ! $this->company_logo_meta ) {
+				if ( $this->company_logo_id < 1 ) {
 					return false;
 				}
 

--- a/src/generators/schema/organization.php
+++ b/src/generators/schema/organization.php
@@ -26,13 +26,20 @@ class Organization extends Abstract_Schema_Piece {
 	public function generate() {
 		$logo_schema_id = $this->context->site_url . Schema_IDs::ORGANIZATION_LOGO_HASH;
 
+		if ( $this->context->company_logo_meta ) {
+			$logo = $this->helpers->schema->image->generate_from_attachment_meta( $logo_schema_id, $this->context->company_logo_meta, $this->context->company_name );
+		}
+		else {
+			$logo = $this->helpers->schema->image->generate_from_attachment_id( $logo_schema_id, $this->context->company_logo_id, $this->context->company_name );
+		}
+
 		return [
 			'@type'  => 'Organization',
 			'@id'    => $this->context->site_url . Schema_IDs::ORGANIZATION_HASH,
 			'name'   => $this->helpers->schema->html->smart_strip_tags( $this->context->company_name ),
 			'url'    => $this->context->site_url,
 			'sameAs' => $this->fetch_social_profiles(),
-			'logo'   => $this->helpers->schema->image->generate_from_attachment_meta( $logo_schema_id, $this->context->company_logo_meta, $this->context->company_name ),
+			'logo'   => $logo,
 			'image'  => [ '@id' => $logo_schema_id ],
 		];
 	}

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -332,7 +332,9 @@ class Image_Helper {
 				// There is not an option to put a URL in an image field in the settings anymore, only to upload it through the media manager.
 				// This means an attachment always exists, so doing this is only needed once.
 				$image_meta = $this->get_best_attachment_variation( $image_id );
-				$this->options->set( $setting . '_meta', $image_meta );
+				if ( $image_meta ) {
+					$this->options->set( $setting . '_meta', $image_meta );
+				}
 			}
 		}
 

--- a/tests/unit/context/meta-tags-context-test.php
+++ b/tests/unit/context/meta-tags-context-test.php
@@ -30,7 +30,7 @@ class Meta_Tags_Context_Test extends TestCase {
 	/**
 	 * The options helper.
 	 *
-	 * @var Options_Helper
+	 * @var Options_Helper|\Mockery\Mock
 	 */
 	private $options;
 
@@ -337,21 +337,6 @@ class Meta_Tags_Context_Test extends TestCase {
 	public function test_generate_site_represents_company_without_logo() {
 		$this->instance->company_name    = 'Company';
 		$this->instance->company_logo_id = 0;
-
-		$this->options->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'company' );
-
-		$this->assertFalse( $this->instance->generate_site_represents() );
-	}
-
-	/**
-	 * Tests the generate site represents with a company with name and an unsupported logo.
-	 *
-	 * @covers ::generate_site_represents
-	 */
-	public function test_generate_site_represents_company_with_name_and_unsupported_logo() {
-		$this->instance->company_name      = 'Company';
-		$this->instance->company_logo_id   = 12;
-		$this->instance->company_logo_meta = false;
 
 		$this->options->expects( 'get' )->once()->with( 'company_or_person', false )->andReturn( 'company' );
 

--- a/tests/unit/generators/schema/organization-test.php
+++ b/tests/unit/generators/schema/organization-test.php
@@ -156,6 +156,68 @@ class Organization_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the generated schema is as expected when the logo has no meta.
+	 *
+	 * @dataProvider generate_provider
+	 * @covers       ::generate
+	 *
+	 * @param array $profiles_input    The social profiles input for the options.
+	 * @param array $profiles_expected The social profiles expected output.
+	 */
+	public function test_generate_without_logo_meta( $profiles_input, $profiles_expected ) {
+		$this->context->site_url                    = 'https://yoast.com/';
+		$this->context->company_name                = 'Yoast';
+		$this->instance->context->company_logo_meta = false;
+		$this->instance->context->company_logo_id   = 12;
+
+		$schema_id      = $this->context->site_url . Schema_IDs::ORGANIZATION_HASH;
+		$schema_logo_id = $this->context->site_url . Schema_IDs::ORGANIZATION_LOGO_HASH;
+
+		$logo = [
+			'@type' => 'ImageObject',
+			'@id'   => $schema_logo_id,
+			'url'   => 'https://yoast.com/logo.jpg',
+		];
+
+		$this->html->expects( 'smart_strip_tags' )
+			->once()
+			->with( $this->context->company_name )
+			->andReturn( $this->context->company_name );
+
+		// For the private `fetch_social_profiles` method.
+		foreach ( $profiles_input as $profile_type => $profile_value ) {
+			$this->options->expects( 'get' )
+				->once()
+				->with( $profile_type, '' )
+				->andReturn( $profile_value );
+		}
+		Filters\expectApplied( 'wpseo_schema_organization_social_profiles' )
+			->once()
+			->with( $profiles_expected )
+			->andReturn( $profiles_expected );
+
+		$this->image->expects( 'generate_from_attachment_meta' )
+			->never();
+
+		$this->image->expects( 'generate_from_attachment_id' )
+			->once()
+			->with( $schema_logo_id, $this->context->company_logo_id, $this->context->company_name )
+			->andReturn( $logo );
+
+		$expected = [
+			'@type'  => 'Organization',
+			'@id'    => $schema_id,
+			'name'   => $this->context->company_name,
+			'url'    => $this->context->site_url,
+			'sameAs' => $profiles_expected,
+			'logo'   => $logo,
+			'image'  => [ '@id' => $schema_logo_id ],
+		];
+
+		$this->assertEquals( $expected, $this->instance->generate() );
+	}
+
+	/**
 	 * Tests is needed when the site represents a company.
 	 *
 	 * @covers ::is_needed


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The fix in #16936  merely prevented to trigger notice in the frontend + put out a malformed `Organization` Schema piece, but at the cost of forbidding the usage of images for which we couldn't get an array of metadatas.
We should restore that, while avoiding to save the full `option_titles` array each time there is a new frontend request (which can raise race conditions if the options are filtered)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the complete options array could be re-saved in the database at each frontend request.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* edit your theme's `functions.php` file and add this snippet to the bottom:
```
function my_custom_mime_types( $mimes ) {
// New allowed mime types.
   $mimes['svg'] = 'image/svg+xml';
   $mimes['svgz'] = 'image/svg+xml';
   $mimes['webp'] = 'image/webp';
   return $mimes;
}
add_filter( 'upload_mimes', 'my_custom_mime_types' );
```
* save the file
* visit `SEO` > `Search Appearance`, first tab `General`
* set the type as an Organization
* insert a name for the Organization
* click on "Select Image" (or "Replace Image" if you already have one)
   * in the modal, upload and then select an SVG image
* Save the settings
* visit the home page in the front end and inspect the schema in the source
    * check that there is an `Organization` piece, that it's well formed and the `logo` property shows the URL of the image you selected, _without_ the `height` and `width` values.
* inspect the `wp_options` table in the database, find the `wpseo_titles` options
   * check that there is no `company_logo_meta` value
   _* this means that the options are not saved once more to the DB because of the frontend request with such image_
* visit `SEO` > `Search Appearance`, first tab `General`
* click on "Replace Image"
   * in the modal, upload and then select a WEBP image
* Save the settings
* visit the home page in the front end and inspect the schema in the source
    * check that there is an `Organization` piece, that it's well formed and the `logo` property shows the URL of the image you selected, _without_ the `height` and `width` values.
* inspect the `wp_options` table in the database, find the `wpseo_titles` options
   * check that there is no `company_logo_meta` value
   * _this means that the options are not saved once more to the DB because of the frontend request with such image_
* visit `SEO` > `Search Appearance`, first tab `General`
* click on "Replace Image"
   * in the modal, upload and then select a BMP image
* Save the settings
* visit the home page in the front end and inspect the schema in the source
  * check that there is an `Organization` piece, that it's well formed and the `logo` property shows the URL of the image you selected, _with the right_ `height` and `width` values.
* inspect the `wp_options` table in the database, find the `wpseo_titles` options
   * check if there is no `company_logo_meta` value: in this case, the original BMP had no metadata but the height and width were calculated anyway.
   * _this means that the options are not saved once more to the DB because of the frontend request with such image_
* visit `SEO` > `Search Appearance`, first tab `General`
* click on "Replace Image"
   * in the modal, upload and then select an image of the following types: JPG, GIF, PNG
* Save the settings
* visit the home page in the front end and inspect the schema in the source
  * check that there is an `Organization` piece, that it's well formed and the `logo` property shows the URL of the image you selected, with the right `height` and `width` values.
* inspect the `wp_options` table in the database, find the `wpseo_titles` options
   * check that there is a `company_logo_meta` item, set to an array having the right URL, the right height and width, plus other info like the image mime type
   * _this means that the options are saved once more to the DB because of the frontend request with such image_, but it will happen only on the first request, thus reducing the chances of race conditions.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-584]
