### PR TITLE
Performance: use isset()

### DIFF
--- a/admin/class-plugin-availability.php
+++ b/admin/class-plugin-availability.php
@@ -259,7 +259,7 @@ class WPSEO_Plugin_Availability {
 	 * @return bool Whether or not the dependency is available.
 	 */
 	public function is_dependency_available( $dependency ) {
-		return in_array( $dependency['slug'], array_keys( get_plugins() ), true );
+		return isset( get_plugins()[ $dependency['slug'] ] );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Code quality

## Summary

This PR can be summarized in the following changelog entry:

* Code quality

## Relevant technical choices:

Performance tweak: Use `isset()` instead of the slow combination of `in_array()` with `array_keys()`.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.