### PR TITLE
QA: don't use `join()`

### DIFF
--- a/lib/migrations/adapter.php
+++ b/lib/migrations/adapter.php
@@ -596,7 +596,7 @@ class Adapter {
 			( $unique === true ) ? 'UNIQUE ' : '',
 			$this->identifier( $index_name ),
 			$this->identifier( $table_name ),
-			\join( ', ', $cols )
+			\implode( ', ', $cols )
 		);
 
 		return $this->execute_ddl( $sql );
@@ -947,7 +947,7 @@ class Adapter {
 		$name = \preg_replace( '/\\_{2,}/', '_', $name );
 		// If the column parameter is an array then the user wants to create a multi-column index.
 		if ( \is_array( $column_name ) ) {
-			$column_str = \join( '_and_', $column_name );
+			$column_str = \implode( '_and_', $column_name );
 		}
 		else {
 			$column_str = $column_name;

--- a/lib/migrations/table.php
+++ b/lib/migrations/table.php
@@ -230,7 +230,7 @@ class Table {
 			$c        = $this->columns[ $i ];
 			$fields[] = $c->__toString();
 		}
-		return \join( ",\n", $fields );
+		return \implode( ",\n", $fields );
 	}
 
 	/**

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -1274,7 +1274,7 @@ class ORM implements \ArrayAccess {
 		}
 		$query[] = '))';
 
-		return $this->where_raw( \join( ' ', $query ), $data );
+		return $this->where_raw( \implode( ' ', $query ), $data );
 	}
 
 	/**
@@ -1749,7 +1749,7 @@ class ORM implements \ArrayAccess {
 	 */
 	protected function build_select_start() {
 		$fragment       = 'SELECT ';
-		$result_columns = \join( ', ', $this->result_columns );
+		$result_columns = \implode( ', ', $this->result_columns );
 		if ( $this->distinct ) {
 			$result_columns = 'DISTINCT ' . $result_columns;
 		}
@@ -1771,7 +1771,7 @@ class ORM implements \ArrayAccess {
 			return '';
 		}
 
-		return \join( ' ', $this->join_sources );
+		return \implode( ' ', $this->join_sources );
 	}
 
 	/**
@@ -1802,7 +1802,7 @@ class ORM implements \ArrayAccess {
 			return '';
 		}
 
-		return 'GROUP BY ' . \join( ', ', $this->group_by );
+		return 'GROUP BY ' . \implode( ', ', $this->group_by );
 	}
 
 	/**
@@ -1824,7 +1824,7 @@ class ORM implements \ArrayAccess {
 			$this->values = \array_merge( $this->values, $condition[ self::CONDITION_VALUES ] );
 		}
 
-		return \strtoupper( $type ) . ' ' . \join( ' AND ', $conditions );
+		return \strtoupper( $type ) . ' ' . \implode( ' AND ', $conditions );
 	}
 
 	/**
@@ -1835,7 +1835,7 @@ class ORM implements \ArrayAccess {
 			return '';
 		}
 
-		return 'ORDER BY ' . \join( ', ', $this->order_by );
+		return 'ORDER BY ' . \implode( ', ', $this->order_by );
 	}
 
 	/**
@@ -1879,7 +1879,7 @@ class ORM implements \ArrayAccess {
 			}
 		}
 
-		return \join( $glue, $filtered_pieces );
+		return \implode( $glue, $filtered_pieces );
 	}
 
 	/**
@@ -1894,7 +1894,7 @@ class ORM implements \ArrayAccess {
 		$parts = \explode( '.', $identifier );
 		$parts = \array_map( [ $this, 'quote_identifier_part' ], $parts );
 
-		return \join( '.', $parts );
+		return \implode( '.', $parts );
 	}
 
 	/**
@@ -1909,7 +1909,7 @@ class ORM implements \ArrayAccess {
 		if ( \is_array( $identifier ) ) {
 			$result = \array_map( [ $this, 'quote_one_identifier' ], $identifier );
 
-			return \join( ', ', $result );
+			return \implode( ', ', $result );
 		}
 		else {
 			return $this->quote_one_identifier( $identifier );
@@ -2156,7 +2156,7 @@ class ORM implements \ArrayAccess {
 			if ( empty( $values ) && empty( $this->expr_fields ) ) {
 				return true;
 			}
-			$query = \join( ' ', [ $this->build_update(), $this->add_id_column_conditions() ] );
+			$query = \implode( ' ', [ $this->build_update(), $this->add_id_column_conditions() ] );
 
 			$id = $this->id( true );
 			if ( \is_array( $id ) ) {
@@ -2234,7 +2234,7 @@ class ORM implements \ArrayAccess {
 			$query[] = '= %s';
 		}
 
-		return \join( ' ', $query );
+		return \implode( ' ', $query );
 	}
 
 	/**
@@ -2252,9 +2252,9 @@ class ORM implements \ArrayAccess {
 			}
 			$field_list[] = "{$this->quote_identifier($key)} = {$value}";
 		}
-		$query[] = \join( ', ', $field_list );
+		$query[] = \implode( ', ', $field_list );
 
-		return \join( ' ', $query );
+		return \implode( ' ', $query );
 	}
 
 	/**
@@ -2267,12 +2267,12 @@ class ORM implements \ArrayAccess {
 		$query[]      = 'INSERT INTO';
 		$query[]      = $this->quote_identifier( $this->table_name );
 		$field_list   = \array_map( [ $this, 'quote_identifier' ], \array_keys( $this->dirty_fields ) );
-		$query[]      = '(' . \join( ', ', $field_list ) . ')';
+		$query[]      = '(' . \implode( ', ', $field_list ) . ')';
 		$query[]      = 'VALUES';
 		$placeholders = $this->create_placeholders( $this->dirty_fields );
 		$query[]      = "({$placeholders})";
 
-		return \join( ' ', $query );
+		return \implode( ' ', $query );
 	}
 
 	/**
@@ -2286,7 +2286,7 @@ class ORM implements \ArrayAccess {
 	public function delete() {
 		$query = [ 'DELETE FROM', $this->quote_identifier( $this->table_name ), $this->add_id_column_conditions() ];
 
-		return self::execute( \join( ' ', $query ), \is_array( $this->id( true ) ) ? \array_values( $this->id( true ) ) : [ $this->id( true ) ] );
+		return self::execute( \implode( ' ', $query ), \is_array( $this->id( true ) ) ? \array_values( $this->id( true ) ) : [ $this->id( true ) ] );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Code quality

## Summary

This PR can be summarized in the following changelog entry:

* Code quality

## Relevant technical choices:

`join()` is an alias for `implode()`. Use the canonical function name instead.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.