### PR TITLE
Tests: minor tweaks

### DIFF
--- a/tests/unit/doubles/inc/options/option-social-double.php
+++ b/tests/unit/doubles/inc/options/option-social-double.php
@@ -12,11 +12,9 @@ class Option_Social_Double extends WPSEO_Option_Social {
 
 	/**
 	 * Adds all the actions and filters for the option.
-	 *
-	 * @return WPSEO_Option
 	 */
 	public function __construct() {
-		return parent::__construct();
+		parent::__construct();
 	}
 
 	/**

--- a/tests/unit/routes/yoast-head-rest-field-test.php
+++ b/tests/unit/routes/yoast-head-rest-field-test.php
@@ -205,8 +205,6 @@ class Yoast_Head_REST_Field_Test extends TestCase {
 	 * Tests adding the yoast_head property for the posts page.
 	 *
 	 * @covers ::for_post_type_archive
-	 *
-	 * @dataProvider method_provider
 	 */
 	public function test_adding_yoast_head_to_posts_page() {
 		$this->head_action
@@ -226,8 +224,6 @@ class Yoast_Head_REST_Field_Test extends TestCase {
 	 * Tests adding the yoast_head property for the posts page.
 	 *
 	 * @covers ::for_post_type_archive
-	 *
-	 * @dataProvider method_provider
 	 */
 	public function test_adding_yoast_head_to_post_type_without_archive() {
 		$this->post_type_helper->expects( 'has_archive' )->with( 'no-archive' )->andReturnFalse();
@@ -276,8 +272,6 @@ class Yoast_Head_REST_Field_Test extends TestCase {
 	 * Tests adding the yoast_head property for the posts page.
 	 *
 	 * @covers ::for_post_type_archive
-	 *
-	 * @dataProvider method_provider
 	 */
 	public function test_adding_yoast_head_to_posts_page_with_404() {
 		$this->head_action


### PR DESCRIPTION
## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

No functional changes.


### Tests: fix incorrect test double constructor

A constructor cannot `return`.

### Tests: remove stray dataProvider tags

These tests do not use a data provider and do not allow for parameters to be passed in, so the `@dataProvider` tag is incorrect.




## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.