### PR TITLE
QA: fix incorrect escaping

### DIFF
--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -230,7 +230,7 @@ $new_tab_message         = sprintf(
 			<?php foreach ( $extensions as $slug => $extension ) : ?>
 				<section class="yoast-promoblock secondary yoast-promo-extension">
 					<h3>
-						<img alt="" width="100" height="100" src="<?php echo esc_attr( $extension['image'] ); ?>"/>
+						<img alt="" width="100" height="100" src="<?php echo esc_url( $extension['image'] ); ?>"/>
 						<?php echo esc_html( $extension['display_title'] ); ?>
 					</h3>
 					<ul class="yoast-list--usp">


### PR DESCRIPTION
## Context

* Security hardening

## Summary

This PR can be summarized in the following changelog entry:

* Security hardening

## Relevant technical choices:

URLs should be escaped with `esc_url()`

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.