### PR TITLE
Docs: remove redundant var name

### DIFF
--- a/admin/class-admin-asset-analysis-worker-location.php
+++ b/admin/class-admin-asset-analysis-worker-location.php
@@ -13,14 +13,14 @@ final class WPSEO_Admin_Asset_Analysis_Worker_Location implements WPSEO_Admin_As
 	/**
 	 * Holds the asset's location.
 	 *
-	 * @var WPSEO_Admin_Asset_Location $asset_location.
+	 * @var WPSEO_Admin_Asset_Location
 	 */
 	private $asset_location;
 
 	/**
 	 * Holds the asset itself.
 	 *
-	 * @var WPSEO_Admin_Asset $asset.
+	 * @var WPSEO_Admin_Asset
 	 */
 	private $asset;
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -215,7 +215,7 @@ class WPSEO_Admin {
 	 * @param array  $links Array of links for the plugins, adapted when the current plugin is found.
 	 * @param string $file  The filename for the current plugin, which the filter loops through.
 	 *
-	 * @return array $links
+	 * @return array
 	 */
 	public function add_action_link( $links, $file ) {
 		if ( $file === WPSEO_BASENAME && WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) ) {
@@ -288,7 +288,7 @@ class WPSEO_Admin {
 	 *
 	 * @param array $contactmethods Currently set contactmethods.
 	 *
-	 * @return array $contactmethods with added contactmethods.
+	 * @return array Contactmethods with added contactmethods.
 	 */
 	public function update_contactmethods( $contactmethods ) {
 		$contactmethods['facebook']   = __( 'Facebook profile URL', 'wordpress-seo' );

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -636,7 +636,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 *
 	 * @param string $orderby The column by which we want to order.
 	 *
-	 * @return string $orderby
+	 * @return string
 	 */
 	protected function sanitize_orderby( $orderby ) {
 		$valid_column_names = [
@@ -658,7 +658,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	 *
 	 * @param string $order Whether we want to sort ascending or descending.
 	 *
-	 * @return string $order SQL order string (ASC, DESC).
+	 * @return string SQL order string (ASC, DESC).
 	 */
 	protected function sanitize_order( $order ) {
 		if ( in_array( strtoupper( $order ), [ 'ASC', 'DESC' ], true ) ) {

--- a/admin/class-yoast-input-validation.php
+++ b/admin/class-yoast-input-validation.php
@@ -46,7 +46,7 @@ class Yoast_Input_Validation {
 	 *
 	 * @param string $admin_title The page title, with extra context added.
 	 *
-	 * @return string $admin_title The modified or original admin title.
+	 * @return string The modified or original admin title.
 	 */
 	public static function add_yoast_admin_document_title_errors( $admin_title ) {
 		$errors      = get_settings_errors();

--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -13,7 +13,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 	/**
 	 * The options that need to be anonymized before they can be sent elsewhere.
 	 *
-	 * @var array $anonymous_settings All of the option_names which need to be
+	 * @var array All of the option_names which need to be
 	 * anonymized before they can be sent elsewhere.
 	 */
 	private $anonymous_settings = [
@@ -52,7 +52,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 	/**
 	 * The options we want to track.
 	 *
-	 * @var array $include_list The option_names for the options we want to track.
+	 * @var array The option_names for the options we want to track.
 	 */
 	private $include_list = [
 		'ms_defaults_set',

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -85,7 +85,7 @@ class WPSEO_Image_Utils {
 	 * @param array $image         Image array with URL and metadata.
 	 * @param int   $attachment_id Attachment ID.
 	 *
-	 * @return false|array $image {
+	 * @return false|array {
 	 *     Array of image data
 	 *
 	 *     @type string $alt      Image's alt text.
@@ -351,7 +351,7 @@ class WPSEO_Image_Utils {
 	/**
 	 * Retrieve the internal WP image file sizes.
 	 *
-	 * @return array $image_sizes An array of image sizes.
+	 * @return array An array of image sizes.
 	 */
 	public static function get_sizes() {
 		/**

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -73,7 +73,7 @@ class WPSEO_Meta {
 	 *   in the relevant child classes (WPSEO_Metabox and WPSEO_Social_admin) as they are only needed there.
 	 * - Beware: even though the meta keys are divided into subsets, they still have to be uniquely named!}}
 	 *
-	 * @var array $meta_fields
+	 * @var array
 	 *            Array format:
 	 *                (required)       'type'          => (string) field type. i.e. text / textarea / checkbox /
 	 *                                                    radio / select / multiselect / upload etc.

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -17,7 +17,7 @@ class WPSEO_Utils {
 	 *
 	 * @since 1.8.0
 	 *
-	 * @var bool $has_filters
+	 * @var bool
 	 */
 	public static $has_filters;
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1166,7 +1166,7 @@ class WPSEO_Utils {
 	 * @deprecated 15.0
 	 * @codeCoverageIgnore
 	 *
-	 * @return array $roles
+	 * @return array
 	 */
 	public static function get_roles() {
 		_deprecated_function( __METHOD__, '15.0', 'wp_roles()->get_names()' );
@@ -1222,7 +1222,7 @@ class WPSEO_Utils {
 	 *
 	 * @param string $text Input string that might contain shortcodes.
 	 *
-	 * @return string $text String without shortcodes.
+	 * @return string String without shortcodes.
 	 */
 	public static function strip_shortcode( $text ) {
 		_deprecated_function( __METHOD__, 'WPSEO 15.2' );

--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -41,7 +41,7 @@ class WPSEO_Sitemaps_Router {
 	 *
 	 * @param string $redirect The redirect URL currently determined.
 	 *
-	 * @return bool|string $redirect
+	 * @return bool|string
 	 */
 	public function redirect_canonical( $redirect ) {
 

--- a/inc/wpseo-non-ajax-functions.php
+++ b/inc/wpseo-non-ajax-functions.php
@@ -29,7 +29,7 @@ add_action( 'wp_loaded', 'wpseo_initialize_admin_bar' );
  * @param array $capabilities          Array of capabilities to be checked, unused here.
  * @param array $args                  List of arguments for the specific capabilities to be checked.
  *
- * @return array $required_capabilities Filtered capabilities.
+ * @return array Filtered capabilities.
  */
 function allow_custom_field_edits( $required_capabilities, $capabilities, $args ) {
 	if ( ! in_array( $args[0], [ 'edit_post_meta', 'add_post_meta' ], true ) ) {

--- a/lib/model.php
+++ b/lib/model.php
@@ -37,7 +37,7 @@ class Model implements JsonSerializable {
 	 * @example Model::$auto_prefix_models = 'MyProject_MyModels_'; //PEAR
 	 * @example Model::$auto_prefix_models = '\MyProject\MyModels\'; //Namespaces
 	 *
-	 * @var string $auto_prefix_models
+	 * @var string
 	 */
 	public static $auto_prefix_models = '\Yoast\WP\SEO\Models\\';
 
@@ -48,14 +48,14 @@ class Model implements JsonSerializable {
 	 * @example Model::$short_table_names = true;
 	 * @example Model::$short_table_names = false; // default
 	 *
-	 * @var bool $short_table_names
+	 * @var bool
 	 */
 	public static $short_table_names = false;
 
 	/**
 	 * The ORM instance used by this model instance to communicate with the database.
 	 *
-	 * @var ORM $orm
+	 * @var ORM
 	 */
 	public $orm;
 

--- a/src/deprecated/frontend/abstract-class-deprecated-schema-piece.php
+++ b/src/deprecated/frontend/abstract-class-deprecated-schema-piece.php
@@ -98,7 +98,7 @@ abstract class WPSEO_Deprecated_Graph_Piece implements WPSEO_Graph_Piece {
 	 * @codeCoverageIgnore
 	 * @deprecated 14.0
 	 *
-	 * @return array $data Article data.
+	 * @return array Article data.
 	 */
 	public function generate() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0', $this->stable_class_name . '::generate' );

--- a/src/deprecated/frontend/class-opengraph.php
+++ b/src/deprecated/frontend/class-opengraph.php
@@ -102,7 +102,7 @@ class WPSEO_OpenGraph {
 	 *
 	 * @param bool $echo Whether to echo or return the description.
 	 *
-	 * @return string $ogdesc
+	 * @return string
 	 */
 	public function description( $echo = true ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
@@ -152,7 +152,7 @@ class WPSEO_OpenGraph {
 	 *
 	 * @param boolean $echo Whether to echo or return the type.
 	 *
-	 * @return string $type
+	 * @return string
 	 */
 	public function type( $echo = true ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
@@ -173,7 +173,7 @@ class WPSEO_OpenGraph {
 	 *
 	 * @param bool $echo Whether to echo or return the locale.
 	 *
-	 * @return string $locale
+	 * @return string
 	 */
 	public function locale( $echo = true ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
@@ -189,7 +189,7 @@ class WPSEO_OpenGraph {
 	 *
 	 * @param array $meta_tags The array to fix.
 	 *
-	 * @return array $meta_tags
+	 * @return array
 	 */
 	public function facebook_filter( $meta_tags ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );

--- a/src/deprecated/frontend/schema/class-schema-faq.php
+++ b/src/deprecated/frontend/schema/class-schema-faq.php
@@ -48,7 +48,7 @@ class WPSEO_Schema_FAQ extends WPSEO_Deprecated_Graph_Piece {
 	 *
 	 * @param array|string $page_type The page type.
 	 *
-	 * @return array $page_type The page type that's now an array.
+	 * @return array The page type that's now an array.
 	 */
 	public function change_schema_page_type( $page_type ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
@@ -71,7 +71,7 @@ class WPSEO_Schema_FAQ extends WPSEO_Deprecated_Graph_Piece {
 	 * @param WP_Block_Parser_Block $block   The block data array.
 	 * @param WPSEO_Schema_Context  $context A value object with context variables.
 	 *
-	 * @return array $data Our Schema graph.
+	 * @return array Our Schema graph.
 	 */
 	public function render_schema_questions( $graph, $block, $context ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );

--- a/src/deprecated/frontend/schema/class-schema-image.php
+++ b/src/deprecated/frontend/schema/class-schema-image.php
@@ -79,7 +79,7 @@ class WPSEO_Schema_Image {
 	 * @param string $url     The image URL.
 	 * @param string $caption A caption, if set.
 	 *
-	 * @return array $data Schema ImageObject array.
+	 * @return array Schema ImageObject array.
 	 */
 	public function simple_image_object( $url, $caption = '' ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'YoastSEO()->helpers->schema->image->simple_image_object' );

--- a/src/deprecated/frontend/schema/class-schema-person.php
+++ b/src/deprecated/frontend/schema/class-schema-person.php
@@ -76,7 +76,7 @@ class WPSEO_Schema_Person extends WPSEO_Deprecated_Graph_Piece {
 	 *
 	 * @param int $user_id User ID.
 	 *
-	 * @return string[] $output A list of social profiles.
+	 * @return string[] A list of social profiles.
 	 */
 	protected function get_social_profiles( $user_id ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\Person::get_social_profiles' );
@@ -137,7 +137,7 @@ class WPSEO_Schema_Person extends WPSEO_Deprecated_Graph_Piece {
 	 * @param array   $data      The Person schema.
 	 * @param WP_User $user_data User data.
 	 *
-	 * @return array $data The Person schema.
+	 * @return array The Person schema.
 	 */
 	protected function add_image( $data, $user_data ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0', 'Yoast\WP\SEO\Generators\Schema\Person::add_image' );

--- a/src/deprecated/frontend/schema/interface-wpseo-graph-piece.php
+++ b/src/deprecated/frontend/schema/interface-wpseo-graph-piece.php
@@ -18,7 +18,7 @@ if ( ! interface_exists( 'WPSEO_Graph_Piece' ) ) {
 		/**
 		 * Add your piece of the graph.
 		 *
-		 * @return array|bool $graph A graph piece on success, false on failure.
+		 * @return array|bool A graph piece on success, false on failure.
 		 */
 		public function generate();
 

--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -41,7 +41,7 @@ class Article extends Abstract_Schema_Piece {
 	/**
 	 * Returns Article data.
 	 *
-	 * @return array $data Article data.
+	 * @return array Article data.
 	 */
 	public function generate() {
 		$data = [
@@ -81,7 +81,7 @@ class Article extends Abstract_Schema_Piece {
 	 *
 	 * @param array $data Article data.
 	 *
-	 * @return array $data Article data.
+	 * @return array Article data.
 	 */
 	private function add_keywords( $data ) {
 		/**
@@ -99,7 +99,7 @@ class Article extends Abstract_Schema_Piece {
 	 *
 	 * @param array $data Article data.
 	 *
-	 * @return array $data Article data.
+	 * @return array Article data.
 	 */
 	private function add_sections( $data ) {
 		/**
@@ -119,7 +119,7 @@ class Article extends Abstract_Schema_Piece {
 	 * @param string $key      The key in data to save the terms in.
 	 * @param string $taxonomy The taxonomy to retrieve the terms from.
 	 *
-	 * @return mixed array $data Article data.
+	 * @return mixed Article data.
 	 */
 	protected function add_terms( $data, $key, $taxonomy ) {
 		$terms = \get_the_terms( $this->context->id, $taxonomy );
@@ -148,7 +148,7 @@ class Article extends Abstract_Schema_Piece {
 	 *
 	 * @param array $data The Article data.
 	 *
-	 * @return array $data The Article data.
+	 * @return array The Article data.
 	 */
 	private function add_image( $data ) {
 		if ( $this->context->main_image_url !== null ) {
@@ -166,7 +166,7 @@ class Article extends Abstract_Schema_Piece {
 	 *
 	 * @param array $data The Article data.
 	 *
-	 * @return array $data The Article data with the potential action added.
+	 * @return array The Article data with the potential action added.
 	 */
 	private function add_potential_action( $data ) {
 		/**

--- a/src/generators/schema/faq.php
+++ b/src/generators/schema/faq.php
@@ -48,7 +48,7 @@ class FAQ extends Abstract_Schema_Piece {
 	/**
 	 * Render a list of questions, referencing them by ID.
 	 *
-	 * @return array $data Our Schema graph.
+	 * @return array Our Schema graph.
 	 */
 	public function generate() {
 		$graph = [];

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -19,7 +19,7 @@ class HowTo extends Abstract_Schema_Piece {
 	/**
 	 * Renders a list of questions, referencing them by ID.
 	 *
-	 * @return array $data Our Schema graph.
+	 * @return array Our Schema graph.
 	 */
 	public function generate() {
 		$graph = [];

--- a/src/generators/schema/main-image.php
+++ b/src/generators/schema/main-image.php
@@ -24,7 +24,7 @@ class Main_Image extends Abstract_Schema_Piece {
 	 * This can be either a social image (Open Graph or Twitter), the featured image,
 	 * or fall back to the first image in the content of the page.
 	 *
-	 * @return false|array $data Image Schema.
+	 * @return false|array Image Schema.
 	 */
 	public function generate() {
 		$image_id = $this->context->canonical . Schema_IDs::PRIMARY_IMAGE_HASH;

--- a/src/generators/schema/organization.php
+++ b/src/generators/schema/organization.php
@@ -21,7 +21,7 @@ class Organization extends Abstract_Schema_Piece {
 	/**
 	 * Returns the Organization Schema data.
 	 *
-	 * @return array $data The Organization schema.
+	 * @return array The Organization schema.
 	 */
 	public function generate() {
 		$logo_schema_id = $this->context->site_url . Schema_IDs::ORGANIZATION_LOGO_HASH;
@@ -40,7 +40,7 @@ class Organization extends Abstract_Schema_Piece {
 	/**
 	 * Retrieve the social profiles to display in the organization schema.
 	 *
-	 * @return array $profiles An array of social profiles.
+	 * @return array An array of social profiles.
 	 */
 	private function fetch_social_profiles() {
 		$profiles        = [];

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -90,7 +90,7 @@ class Person extends Abstract_Schema_Piece {
 	 * @param array $same_as_urls Array of SameAs URLs.
 	 * @param int   $user_id      User ID.
 	 *
-	 * @return string[] $same_as_urls A list of SameAs URLs.
+	 * @return string[] A list of SameAs URLs.
 	 */
 	protected function get_social_profiles( $same_as_urls, $user_id ) {
 		/**
@@ -168,7 +168,7 @@ class Person extends Abstract_Schema_Piece {
 	 * @param array   $data      The Person schema.
 	 * @param WP_User $user_data User data.
 	 *
-	 * @return array $data The Person schema.
+	 * @return array The Person schema.
 	 */
 	protected function add_image( $data, $user_data ) {
 		$schema_id = $this->context->site_url . Schema_IDs::PERSON_LOGO_HASH;

--- a/src/generators/schema/third-party/events-calendar-schema.php
+++ b/src/generators/schema/third-party/events-calendar-schema.php
@@ -52,7 +52,7 @@ class Events_Calendar_Schema extends Abstract_Schema_Piece {
 	 * Partially lifted from the 'Tribe__JSON_LD__Abstract' class.
 	 *
 	 * @see https://docs.theeventscalendar.com/reference/classes/tribe__json_ld__abstract/
-	 * @return array $graph Event Schema markup
+	 * @return array Event Schema markup
 	 */
 	public function generate() {
 		$posts = [];

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -117,7 +117,7 @@ class WebPage extends Abstract_Schema_Piece {
 	 *
 	 * @param array $data The WebPage data.
 	 *
-	 * @return array $data The WebPage data with the potential action added.
+	 * @return array The WebPage data with the potential action added.
 	 */
 	private function add_potential_action( $data ) {
 		/**

--- a/src/generators/schema/website.php
+++ b/src/generators/schema/website.php
@@ -48,7 +48,7 @@ class Website extends Abstract_Schema_Piece {
 	 *
 	 * @param array $data The website data array.
 	 *
-	 * @return array $data
+	 * @return array
 	 */
 	private function add_alternate_name( $data ) {
 		$alternate_name = $this->helpers->options->get( 'alternate_website_name', '' );
@@ -66,7 +66,7 @@ class Website extends Abstract_Schema_Piece {
 	 *
 	 * @param array $data The website data array.
 	 *
-	 * @return array $data
+	 * @return array
 	 */
 	private function internal_search_section( $data ) {
 		/**

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -208,7 +208,7 @@ class Indexing_Helper {
 	/**
 	 * Gets the start time when the indexing process has started but not completed.
 	 *
-	 * @return int|bool $start_time The start time when the indexing process has started but not completed, false otherwise.
+	 * @return int|bool The start time when the indexing process has started but not completed, false otherwise.
 	 */
 	public function get_started() {
 		return $this->options_helper->get( 'indexing_started' );

--- a/src/helpers/schema/image-helper.php
+++ b/src/helpers/schema/image-helper.php
@@ -113,7 +113,7 @@ class Image_Helper {
 	 * @param string $url       The image URL.
 	 * @param string $caption   A caption, if set.
 	 *
-	 * @return array $data Schema ImageObject array.
+	 * @return array Schema ImageObject array.
 	 */
 	public function simple_image_object( $schema_id, $url, $caption = '' ) {
 		$data = $this->generate_object( $schema_id );

--- a/src/helpers/string-helper.php
+++ b/src/helpers/string-helper.php
@@ -37,7 +37,7 @@ class String_Helper {
 	 *
 	 * @param string $text Input string that might contain shortcodes.
 	 *
-	 * @return string $text String without shortcodes.
+	 * @return string String without shortcodes.
 	 */
 	public function strip_shortcode( $text ) {
 		return \preg_replace( '`\[[^\]]+\]`s', '', \strip_shortcodes( $text ) );

--- a/src/integrations/front-end/open-graph-oembed.php
+++ b/src/integrations/front-end/open-graph-oembed.php
@@ -72,7 +72,7 @@ class Open_Graph_OEmbed implements Integration_Interface {
 	 * @param array   $data The oEmbed data.
 	 * @param WP_Post $post The current Post object.
 	 *
-	 * @return array $filter_data - An array of oEmbed data with modified values where appropriate.
+	 * @return array An array of oEmbed data with modified values where appropriate.
 	 * @link https://developer.wordpress.org/reference/hooks/oembed_response_data/ for hook info.
 	 */
 	public function set_oembed_data( $data, $post ) {

--- a/src/presenters/canonical-presenter.php
+++ b/src/presenters/canonical-presenter.php
@@ -26,7 +26,7 @@ class Canonical_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Run the canonical content through the `wpseo_canonical` filter.
 	 *
-	 * @return string $canonical The filtered canonical.
+	 * @return string The filtered canonical.
 	 */
 	public function get() {
 		if ( \in_array( 'noindex', $this->presentation->robots, true ) ) {

--- a/src/presenters/meta-description-presenter.php
+++ b/src/presenters/meta-description-presenter.php
@@ -45,7 +45,7 @@ class Meta_Description_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Run the meta description content through replace vars, the `wpseo_metadesc` filter and sanitization.
 	 *
-	 * @return string $meta_description The filtered meta description.
+	 * @return string The filtered meta description.
 	 */
 	public function get() {
 		$meta_description = $this->replace_vars( $this->presentation->meta_description );

--- a/src/presenters/open-graph/description-presenter.php
+++ b/src/presenters/open-graph/description-presenter.php
@@ -20,7 +20,7 @@ class Description_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Run the Open Graph description through replace vars and the `wpseo_opengraph_desc` filter.
 	 *
-	 * @return string $description The filtered description.
+	 * @return string The filtered description.
 	 */
 	public function get() {
 		/**

--- a/src/presenters/open-graph/locale-presenter.php
+++ b/src/presenters/open-graph/locale-presenter.php
@@ -20,7 +20,7 @@ final class Locale_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Run the locale through the `wpseo_og_locale` filter.
 	 *
-	 * @return string $locale The filtered locale.
+	 * @return string The filtered locale.
 	 */
 	public function get() {
 		/**

--- a/src/presenters/open-graph/site-name-presenter.php
+++ b/src/presenters/open-graph/site-name-presenter.php
@@ -20,7 +20,7 @@ class Site_Name_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Runs the site name through the `wpseo_opengraph_site_name` filter.
 	 *
-	 * @return string $site_name The filtered site_name.
+	 * @return string The filtered site_name.
 	 */
 	public function get() {
 		/**

--- a/src/presenters/open-graph/title-presenter.php
+++ b/src/presenters/open-graph/title-presenter.php
@@ -20,7 +20,7 @@ class Title_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Run the title content through replace vars, the `wpseo_opengraph_title` filter and sanitization.
 	 *
-	 * @return string $title The filtered title.
+	 * @return string The filtered title.
 	 */
 	public function get() {
 		$title = $this->replace_vars( $this->presentation->open_graph_title );

--- a/src/presenters/open-graph/type-presenter.php
+++ b/src/presenters/open-graph/type-presenter.php
@@ -20,7 +20,7 @@ class Type_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Run the opengraph type content through the `wpseo_opengraph_type` filter.
 	 *
-	 * @return string $type The filtered type.
+	 * @return string The filtered type.
 	 */
 	public function get() {
 		/**

--- a/src/presenters/rel-next-presenter.php
+++ b/src/presenters/rel-next-presenter.php
@@ -46,7 +46,7 @@ class Rel_Next_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Run the canonical content through the `wpseo_adjacent_rel_url` filter.
 	 *
-	 * @return string $rel_next The filtered adjacent link.
+	 * @return string The filtered adjacent link.
 	 */
 	public function get() {
 		if ( \in_array( 'noindex', $this->presentation->robots, true ) ) {

--- a/src/presenters/rel-prev-presenter.php
+++ b/src/presenters/rel-prev-presenter.php
@@ -46,7 +46,7 @@ class Rel_Prev_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Run the rel prev content through the `wpseo_adjacent_rel_url` filter.
 	 *
-	 * @return string $rel_prev The filtered adjacent link.
+	 * @return string The filtered adjacent link.
 	 */
 	public function get() {
 		if ( \in_array( 'noindex', $this->presentation->robots, true ) ) {

--- a/src/presenters/twitter/card-presenter.php
+++ b/src/presenters/twitter/card-presenter.php
@@ -20,7 +20,7 @@ class Card_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Runs the card type through the `wpseo_twitter_card_type` filter.
 	 *
-	 * @return string $card_type The filtered card type.
+	 * @return string The filtered card type.
 	 */
 	public function get() {
 		/**

--- a/src/presenters/webmaster/baidu-presenter.php
+++ b/src/presenters/webmaster/baidu-presenter.php
@@ -19,7 +19,7 @@ class Baidu_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Retrieves the webmaster tool site verification value from the settings.
 	 *
-	 * @return string $verification_value The webmaster tool site verification value.
+	 * @return string The webmaster tool site verification value.
 	 */
 	public function get() {
 		return $this->helpers->options->get( 'baiduverify', '' );

--- a/src/presenters/webmaster/bing-presenter.php
+++ b/src/presenters/webmaster/bing-presenter.php
@@ -19,7 +19,7 @@ class Bing_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Retrieves the webmaster tool site verification value from the settings.
 	 *
-	 * @return string $verification_value The webmaster tool site verification value.
+	 * @return string The webmaster tool site verification value.
 	 */
 	public function get() {
 		return $this->helpers->options->get( 'msverify', '' );

--- a/src/presenters/webmaster/google-presenter.php
+++ b/src/presenters/webmaster/google-presenter.php
@@ -19,7 +19,7 @@ class Google_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Retrieves the webmaster tool site verification value from the settings.
 	 *
-	 * @return string $verification_value The webmaster tool site verification value.
+	 * @return string The webmaster tool site verification value.
 	 */
 	public function get() {
 		return $this->helpers->options->get( 'googleverify', '' );

--- a/src/presenters/webmaster/pinterest-presenter.php
+++ b/src/presenters/webmaster/pinterest-presenter.php
@@ -19,7 +19,7 @@ class Pinterest_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Retrieves the webmaster tool site verification value from the settings.
 	 *
-	 * @return string $verification_value The webmaster tool site verification value.
+	 * @return string The webmaster tool site verification value.
 	 */
 	public function get() {
 		return $this->helpers->options->get( 'pinterestverify', '' );

--- a/src/presenters/webmaster/yandex-presenter.php
+++ b/src/presenters/webmaster/yandex-presenter.php
@@ -19,7 +19,7 @@ class Yandex_Presenter extends Abstract_Indexable_Tag_Presenter {
 	/**
 	 * Retrieves the webmaster tool site verification value from the settings.
 	 *
-	 * @return string $verification_value The webmaster tool site verification value.
+	 * @return string The webmaster tool site verification value.
 	 */
 	public function get() {
 		return $this->helpers->options->get( 'yandexverify', '' );

--- a/tests/integration/admin/import/test-class-import-aioseo.php
+++ b/tests/integration/admin/import/test-class-import-aioseo.php
@@ -246,7 +246,7 @@ class WPSEO_Import_AIOSEO_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @param bool $pre_existing_yoast_data Whether or not to insert pre-existing Yoast SEO data.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post( $pre_existing_yoast_data = false ) {
 		$post_id = $this->factory()->post->create();

--- a/tests/integration/admin/import/test-class-import-detector.php
+++ b/tests/integration/admin/import/test-class-import-detector.php
@@ -38,7 +38,7 @@ class WPSEO_Import_External_Detector_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Sets up a test post.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post() {
 		$post_id = $this->factory()->post->create();

--- a/tests/integration/admin/import/test-class-import-greg-high-performance-seo.php
+++ b/tests/integration/admin/import/test-class-import-greg-high-performance-seo.php
@@ -137,7 +137,7 @@ class WPSEO_Import_Greg_SEO_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Sets up a test post.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post() {
 		$post_id = $this->factory()->post->create();

--- a/tests/integration/admin/import/test-class-import-headspace.php
+++ b/tests/integration/admin/import/test-class-import-headspace.php
@@ -139,7 +139,7 @@ class WPSEO_Import_HeadSpace_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Sets up a test post.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post() {
 		$post_id = $this->factory()->post->create();

--- a/tests/integration/admin/import/test-class-import-jetpack.php
+++ b/tests/integration/admin/import/test-class-import-jetpack.php
@@ -134,7 +134,7 @@ class WPSEO_Import_Jetpack_SEO_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Sets up a test post.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post() {
 		$post_id = $this->factory()->post->create();

--- a/tests/integration/admin/import/test-class-import-platinum-seo-pack.php
+++ b/tests/integration/admin/import/test-class-import-platinum-seo-pack.php
@@ -144,7 +144,7 @@ class WPSEO_Import_Platinum_SEO_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Sets up a test post.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post() {
 		$post_id = $this->factory()->post->create();

--- a/tests/integration/admin/import/test-class-import-plugin.php
+++ b/tests/integration/admin/import/test-class-import-plugin.php
@@ -94,7 +94,7 @@ class WPSEO_Import_Plugin_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Sets up a test post.
 	 *
-	 * @return int $post_id
+	 * @return int
 	 */
 	private function setup_post() {
 		$post_id = $this->factory()->post->create();

--- a/tests/integration/admin/import/test-class-import-premium-seo-pack.php
+++ b/tests/integration/admin/import/test-class-import-premium-seo-pack.php
@@ -254,7 +254,7 @@ class WPSEO_Import_Premium_SEO_Pack_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @param bool $pre_existing_yoast_data Whether or not to insert pre-existing Yoast SEO data.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post( $pre_existing_yoast_data = false ) {
 		$this->create_table();

--- a/tests/integration/admin/import/test-class-import-rankmath.php
+++ b/tests/integration/admin/import/test-class-import-rankmath.php
@@ -159,7 +159,7 @@ class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Sets up a test post.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post() {
 		$post_id = $this->factory()->post->create();

--- a/tests/integration/admin/import/test-class-import-seo-framework.php
+++ b/tests/integration/admin/import/test-class-import-seo-framework.php
@@ -146,7 +146,7 @@ class WPSEO_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Sets up a test post.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post() {
 		$post_id = $this->factory()->post->create();

--- a/tests/integration/admin/import/test-class-import-seopressor.php
+++ b/tests/integration/admin/import/test-class-import-seopressor.php
@@ -146,7 +146,7 @@ class WPSEO_Import_SEOPressor_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Sets up a test post.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post() {
 		$post_id  = $this->factory()->post->create();

--- a/tests/integration/admin/import/test-class-import-smartcrawl.php
+++ b/tests/integration/admin/import/test-class-import-smartcrawl.php
@@ -289,7 +289,7 @@ class WPSEO_Import_Smartcrawl_SEO_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @param bool $pre_existing_yoast_data Whether or not to insert pre-existing Yoast SEO data.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post( $pre_existing_yoast_data = false ) {
 		$post_id = $this->factory()->post->create();

--- a/tests/integration/admin/import/test-class-import-squirrly.php
+++ b/tests/integration/admin/import/test-class-import-squirrly.php
@@ -288,7 +288,7 @@ class WPSEO_Import_Squirrly_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @param bool $pre_existing_yoast_data Whether or not to insert pre-existing Yoast SEO data.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post( $pre_existing_yoast_data = false ) {
 		$this->create_table();

--- a/tests/integration/admin/import/test-class-import-ultimate-seo.php
+++ b/tests/integration/admin/import/test-class-import-ultimate-seo.php
@@ -141,7 +141,7 @@ class WPSEO_Import_Ultimate_SEO_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Sets up a test post.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post() {
 		$post_id = $this->factory()->post->create();

--- a/tests/integration/admin/import/test-class-import-woothemes-seo.php
+++ b/tests/integration/admin/import/test-class-import-woothemes-seo.php
@@ -146,7 +146,7 @@ class WPSEO_Import_WooThemes_SEO_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Sets up a test post.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post() {
 		$post_id = $this->factory()->post->create();

--- a/tests/integration/admin/import/test-class-import-wp-meta-seo.php
+++ b/tests/integration/admin/import/test-class-import-wp-meta-seo.php
@@ -141,7 +141,7 @@ class WPSEO_Import_WP_Meta_SEO_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Sets up a test post.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_post() {
 		$post_id = $this->factory()->post->create();

--- a/tests/integration/admin/import/test-class-import-wpseo.php
+++ b/tests/integration/admin/import/test-class-import-wpseo.php
@@ -194,7 +194,7 @@ class WPSEO_Import_WPSEO_Test extends WPSEO_UnitTestCase {
 	/**
 	 * Sets up a test post.
 	 *
-	 * @return int $post_id ID for the post created.
+	 * @return int ID for the post created.
 	 */
 	private function setup_data() {
 		$post_id = $this->factory()->post->create();

--- a/tests/integration/doubles/wpseo-meta-columns-double.php
+++ b/tests/integration/doubles/wpseo-meta-columns-double.php
@@ -13,7 +13,7 @@ class WPSEO_Meta_Columns_Double extends WPSEO_Meta_Columns {
 	/**
 	 * The current post type.
 	 *
-	 * @var $current_post_type
+	 * @var string
 	 */
 	private $current_post_type;
 


### PR DESCRIPTION
## Context

* Documentation improvements

## Summary

This PR can be summarized in the following changelog entry:

* Documentation improvements

## Relevant technical choices:

No functional changes.

### Docs: remove redundant property names in @var tags

### Docs: remove redundant variable name in @return tags

`@return` tags should not contain a variable name. PHP returns a value, not a variable, so the function local name has no significance in this tag.
If needs be, use the description to explain what the value signifies.




## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.