### PR TITLE
Docs: use short form type keywords

### DIFF
--- a/admin/class-asset.php
+++ b/admin/class-asset.php
@@ -229,7 +229,7 @@ class WPSEO_Admin_Asset {
 	/**
 	 * Returns whether a script asset should be loaded in the footer of the page.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function is_in_footer() {
 		return $this->in_footer;
@@ -238,7 +238,7 @@ class WPSEO_Admin_Asset {
 	/**
 	 * Returns whether this CSS has a RTL counterpart.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function has_rtl() {
 		return $this->rtl;

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -894,7 +894,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 	/**
 	 * Parse the field where the existing meta-data value is displayed.
 	 *
-	 * @param integer    $record_id  Record ID.
+	 * @param int        $record_id  Record ID.
 	 * @param string     $attributes HTML attributes.
 	 * @param bool|array $values     Optional values data array.
 	 *

--- a/admin/class-export.php
+++ b/admin/class-export.php
@@ -96,8 +96,8 @@ class WPSEO_Export {
 	/**
 	 * Writes a line to the export.
 	 *
-	 * @param string  $line          Line string.
-	 * @param boolean $newline_first Boolean flag whether to prepend with new line.
+	 * @param string $line          Line string.
+	 * @param bool   $newline_first Boolean flag whether to prepend with new line.
 	 */
 	private function write_line( $line, $newline_first = false ) {
 		if ( $newline_first ) {

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -590,7 +590,7 @@ class WPSEO_Meta_Columns {
 	/**
 	 * Determines whether the given post ID uses the default indexing settings.
 	 *
-	 * @param integer $post_id The post ID to check.
+	 * @param int $post_id The post ID to check.
 	 *
 	 * @return bool Whether or not the default indexing is being used for the post.
 	 */
@@ -626,7 +626,7 @@ class WPSEO_Meta_Columns {
 	/**
 	 * Parses the score column.
 	 *
-	 * @param integer $post_id The ID of the post for which to show the score.
+	 * @param int $post_id The ID of the post for which to show the score.
 	 *
 	 * @return string The HTML for the SEO score indicator.
 	 */

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -26,7 +26,7 @@ class WPSEO_Primary_Term_Admin implements WPSEO_WordPress_Integration {
 	/**
 	 * Gets the current post ID.
 	 *
-	 * @return integer The post ID.
+	 * @return int The post ID.
 	 */
 	protected function get_current_id() {
 		$post_id = filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -970,7 +970,7 @@ class Yoast_Form {
 	 *
 	 * @param string $feature_setting The feature setting.
 	 *
-	 * @return boolean True if we are dealing with the Usage tracking feature on a multisite subsite.
+	 * @return bool True if we are dealing with the Usage tracking feature on a multisite subsite.
 	 */
 	protected function is_tracking_on_subsite( $feature_setting ) {
 		return ( $feature_setting === 'tracking' && ! is_network_admin() && ! is_main_site() );

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -123,7 +123,7 @@ class Yoast_Notification {
 	 *
 	 * Returns the id of the current user if not user has been sent.
 	 *
-	 * @return integer The user id
+	 * @return int The user id
 	 */
 	public function get_user_id() {
 		if ( $this->get_user() !== null ) {

--- a/admin/filters/class-cornerstone-filter.php
+++ b/admin/filters/class-cornerstone-filter.php
@@ -111,7 +111,7 @@ class WPSEO_Cornerstone_Filter extends WPSEO_Abstract_Post_Filter {
 	/**
 	 * Returns the total amount of articles marked as cornerstone content.
 	 *
-	 * @return integer
+	 * @return int
 	 */
 	protected function get_post_total() {
 		global $wpdb;

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -221,7 +221,7 @@ class WPSEO_Metabox_Formatter {
 	 * Checks if Jetpack's markdown module is enabled.
 	 * Can be extended to work with other plugins that parse markdown in the content.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	private function is_markdown_enabled() {
 		$is_markdown = false;
@@ -246,7 +246,7 @@ class WPSEO_Metabox_Formatter {
 	/**
 	 * Checks if the user is logged in to SEMrush.
 	 *
-	 * @return boolean The SEMrush login status.
+	 * @return bool The SEMrush login status.
 	 */
 	private function get_semrush_login_status() {
 		try {

--- a/admin/import/plugins/class-import-seopressor.php
+++ b/admin/import/plugins/class-import-seopressor.php
@@ -99,7 +99,7 @@ class WPSEO_Import_SEOPressor extends WPSEO_Plugin_Importer {
 	/**
 	 * Imports the focus keywords, and stores them for later use.
 	 *
-	 * @param integer $post_id Post ID.
+	 * @param int $post_id Post ID.
 	 *
 	 * @return void
 	 */
@@ -128,8 +128,8 @@ class WPSEO_Import_SEOPressor extends WPSEO_Plugin_Importer {
 	/**
 	 * Retrieves the SEOpressor robot value and map this to Yoast SEO values.
 	 *
-	 * @param string  $meta_rules The meta rules taken from the SEOpressor settings array.
-	 * @param integer $post_id    The post id of the current post.
+	 * @param string $meta_rules The meta rules taken from the SEOpressor settings array.
+	 * @param int    $post_id    The post id of the current post.
 	 *
 	 * @return void
 	 */

--- a/admin/import/plugins/class-import-wpseo.php
+++ b/admin/import/plugins/class-import-wpseo.php
@@ -174,7 +174,7 @@ class WPSEO_Import_WPSEO extends WPSEO_Plugin_Importer {
 	/**
 	 * Gets the wpSEO robot value and map this to Yoast SEO values.
 	 *
-	 * @param integer $post_id The post id of the current post.
+	 * @param int $post_id The post id of the current post.
 	 *
 	 * @return void
 	 */

--- a/admin/ryte/class-ryte-option.php
+++ b/admin/ryte/class-ryte-option.php
@@ -105,7 +105,7 @@ class WPSEO_Ryte_Option {
 	/**
 	 * Saving the last fetch timestamp to the options.
 	 *
-	 * @param integer $timestamp Timestamp with the new value.
+	 * @param int $timestamp Timestamp with the new value.
 	 */
 	public function set_last_fetch( $timestamp ) {
 		$this->ryte_option[ self::LAST_FETCH ] = $timestamp;

--- a/admin/ryte/class-ryte.php
+++ b/admin/ryte/class-ryte.php
@@ -205,7 +205,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	/**
 	 * Checks if WordFence protects the site against 'fake' Google crawlers.
 	 *
-	 * @return boolean True if WordFence protects the site.
+	 * @return bool True if WordFence protects the site.
 	 */
 	private function wordfence_protection_enabled() {
 		if ( ! class_exists( 'wfConfig' ) ) {

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -79,9 +79,9 @@ class WPSEO_Taxonomy_Columns {
 	/**
 	 * Parses the column.
 	 *
-	 * @param string  $content     The current content of the column.
-	 * @param string  $column_name The name of the column.
-	 * @param integer $term_id     ID of requested taxonomy.
+	 * @param string $content     The current content of the column.
+	 * @param string $column_name The name of the column.
+	 * @param int    $term_id     ID of requested taxonomy.
 	 *
 	 * @return string
 	 */
@@ -123,7 +123,7 @@ class WPSEO_Taxonomy_Columns {
 	/**
 	 * Parses the value for the score column.
 	 *
-	 * @param integer $term_id ID of requested term.
+	 * @param int $term_id ID of requested term.
 	 *
 	 * @return string
 	 */

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -52,7 +52,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	/**
 	 * Shows an message when a post is about to get trashed.
 	 *
-	 * @param integer $post_id The current post ID.
+	 * @param int $post_id The current post ID.
 	 *
 	 * @return void
 	 */
@@ -71,7 +71,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	/**
 	 * Shows an message when a post is about to get trashed.
 	 *
-	 * @param integer $post_id The current post ID.
+	 * @param int $post_id The current post ID.
 	 *
 	 * @return void
 	 */
@@ -90,7 +90,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 	/**
 	 * Shows a message when a term is about to get deleted.
 	 *
-	 * @param integer $term_id The term ID that will be deleted.
+	 * @param int $term_id The term ID that will be deleted.
 	 *
 	 * @return void
 	 */

--- a/config/dependency-injection/container-compiler.php
+++ b/config/dependency-injection/container-compiler.php
@@ -16,11 +16,11 @@ class Container_Compiler {
 	/**
 	 * Compiles the dependency injection container.
 	 *
-	 * @param boolean $debug                    If false the container will only be re-compiled if it does not yet already exist.
-	 * @param string  $generated_container_path The path the generated container should be written to.
-	 * @param string  $services_path            The path of the services.php.
-	 * @param string  $class_map_path           The path of the class map.
-	 * @param string  $namespace                The namespace the generated container should be in.
+	 * @param bool   $debug                    If false the container will only be re-compiled if it does not yet already exist.
+	 * @param string $generated_container_path The path the generated container should be written to.
+	 * @param string $services_path            The path of the services.php.
+	 * @param string $class_map_path           The path of the class map.
+	 * @param string $namespace                The namespace the generated container should be in.
 	 *
 	 * @throws Exception If compiling the container fails.
 	 *

--- a/config/dependency-injection/inject-from-registry-pass.php
+++ b/config/dependency-injection/inject-from-registry-pass.php
@@ -21,8 +21,8 @@ class Inject_From_Registry_Pass extends AbstractRecursivePass {
 	/**
 	 * Creates definitions for classes being injected from the container registry.
 	 *
-	 * @param mixed   $value   The value being processed.
-	 * @param boolean $is_root Whether or not the value is the root.
+	 * @param mixed $value   The value being processed.
+	 * @param bool  $is_root Whether or not the value is the root.
 	 *
 	 * @return mixed The processed value.
 	 *

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -985,8 +985,8 @@ class WPSEO_Meta {
 	/**
 	 * Counts the total of all the keywords being used for posts except the given one.
 	 *
-	 * @param string  $keyword The keyword to be counted.
-	 * @param integer $post_id The id of the post to which the keyword belongs.
+	 * @param string $keyword The keyword to be counted.
+	 * @param int    $post_id The id of the post to which the keyword belongs.
 	 *
 	 * @return array
 	 */

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1434,7 +1434,7 @@ SVG;
 	 *
 	 * @since 1.8.0
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function grant_access() {
 		_deprecated_function( __METHOD__, 'WPSEO 15.5' );

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -494,7 +494,7 @@ class WPSEO_Options {
 	 * @param string $option_name              The name for the option to set.
 	 * @param mixed  $option_value             The value for the option.
 	 *
-	 * @return boolean Returns true if the option is successfully saved in the database.
+	 * @return bool Returns true if the option is successfully saved in the database.
 	 */
 	public static function save_option( $wpseo_options_group_name, $option_name, $option_value ) {
 		$options                 = static::get_option( $wpseo_options_group_name );

--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -17,7 +17,7 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 *
 	 * @param string $type Type string to check for.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function handles_type( $type ) {
 		// If the author archives have been disabled, we don't do anything.

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -78,7 +78,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 *
 	 * @param string $type Type string to check for.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function handles_type( $type ) {
 

--- a/inc/sitemaps/class-sitemaps-cache.php
+++ b/inc/sitemaps/class-sitemaps-cache.php
@@ -74,7 +74,7 @@ class WPSEO_Sitemaps_Cache {
 	 *
 	 * @since 3.2
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function is_enabled() {
 
@@ -94,7 +94,7 @@ class WPSEO_Sitemaps_Cache {
 	 * @param string $type Sitemap type.
 	 * @param int    $page Page number to retrieve.
 	 *
-	 * @return string|boolean
+	 * @return string|bool
 	 */
 	public function get_sitemap( $type, $page ) {
 

--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -130,8 +130,8 @@ class WPSEO_Sitemaps_Renderer {
 	/**
 	 * Produce final XML output with debug information.
 	 *
-	 * @param string  $sitemap   Sitemap XML.
-	 * @param boolean $transient Transient cache flag.
+	 * @param string $sitemap   Sitemap XML.
+	 * @param bool   $transient Transient cache flag.
 	 *
 	 * @return string
 	 */

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -182,7 +182,7 @@ class WPSEO_Sitemaps {
 	 * Set the sitemap current page to allow creating partial sitemaps with WP-CLI
 	 * in a one-off process.
 	 *
-	 * @param integer $current_page The part that should be generated.
+	 * @param int $current_page The part that should be generated.
 	 */
 	public function set_n( $current_page ) {
 		if ( is_scalar( $current_page ) && intval( $current_page ) > 0 ) {

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -41,7 +41,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 *
 	 * @param string $type Type string to check for.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function handles_type( $type ) {
 
@@ -76,8 +76,8 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		/**
 		 * Filter the setting of excluding empty terms from the XML sitemap.
 		 *
-		 * @param boolean $exclude        Defaults to true.
-		 * @param array   $taxonomy_names Array of names for the taxonomies being processed.
+		 * @param bool  $exclude        Defaults to true.
+		 * @param array $taxonomy_names Array of names for the taxonomies being processed.
 		 */
 		$hide_empty = apply_filters( 'wpseo_sitemap_exclude_empty_terms', true, $taxonomy_names );
 
@@ -87,8 +87,8 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			/**
 			 * Filter the setting of excluding empty terms from the XML sitemap for a specific taxonomy.
 			 *
-			 * @param boolean $exclude       Defaults to the sitewide setting.
-			 * @param string  $taxonomy_name The name of the taxonomy being processed.
+			 * @param bool   $exclude       Defaults to the sitewide setting.
+			 * @param string $taxonomy_name The name of the taxonomy being processed.
 			 */
 			$hide_empty_tax = apply_filters( 'wpseo_sitemap_exclude_empty_terms_taxonomy', $hide_empty, $taxonomy_name );
 
@@ -296,8 +296,8 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		/**
 		 * Filter to exclude the taxonomy from the XML sitemap.
 		 *
-		 * @param boolean $exclude       Defaults to false.
-		 * @param string  $taxonomy_name Name of the taxonomy to exclude..
+		 * @param bool   $exclude       Defaults to false.
+		 * @param string $taxonomy_name Name of the taxonomy to exclude..
 		 */
 		if ( apply_filters( 'wpseo_sitemap_exclude_taxonomy', false, $taxonomy_name ) ) {
 			return false;

--- a/inc/sitemaps/interface-sitemap-provider.php
+++ b/inc/sitemaps/interface-sitemap-provider.php
@@ -15,7 +15,7 @@ interface WPSEO_Sitemap_Provider {
 	 *
 	 * @param string $type Type string to check for.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function handles_type( $type );
 

--- a/lib/migrations/adapter.php
+++ b/lib/migrations/adapter.php
@@ -108,7 +108,7 @@ class Adapter {
 	 *
 	 * @param string $table The table name.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function has_table( $table ) {
 		return $this->table_exists( $table );
@@ -193,7 +193,7 @@ class Adapter {
 	 *
 	 * @param string $database The database name.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function database_exists( $database ) {
 		$ddl    = 'SHOW DATABASES';
@@ -215,7 +215,7 @@ class Adapter {
 	 *
 	 * @param string $db The database name.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function create_database( $db ) {
 		if ( $this->database_exists( $db ) ) {
@@ -232,7 +232,7 @@ class Adapter {
 	 *
 	 * @param string $db The database name.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function drop_database( $db ) {
 		if ( ! $this->database_exists( $db ) ) {
@@ -249,7 +249,7 @@ class Adapter {
 	 *
 	 * @param string $table The table name.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function table_exists( $table ) {
 		global $wpdb;
@@ -274,7 +274,7 @@ class Adapter {
 	 *
 	 * @param string $query The query to run.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function execute( $query ) {
 		return $this->query( $query );
@@ -285,7 +285,7 @@ class Adapter {
 	 *
 	 * @param string $query The query to run.
 	 *
-	 * @return boolean Whether or not the query was performed succesfully.
+	 * @return bool Whether or not the query was performed succesfully.
 	 */
 	public function query( $query ) {
 		global $wpdb;
@@ -354,7 +354,7 @@ class Adapter {
 	 *
 	 * @param string $ddl The query to run.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function execute_ddl( $ddl ) {
 		return $this->query( $ddl );
@@ -365,7 +365,7 @@ class Adapter {
 	 *
 	 * @param string $table The table name.
 	 *
-	 * @return boolean Whether or not the table was succesfully dropped.
+	 * @return bool Whether or not the table was succesfully dropped.
 	 */
 	public function drop_table( $table ) {
 		$ddl = \sprintf( 'DROP TABLE IF EXISTS %s', $this->identifier( $table ) );
@@ -414,7 +414,7 @@ class Adapter {
 	 * @param string $name     The current table name.
 	 * @param string $new_name The new table name.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function rename_table( $name, $new_name ) {
 		if ( empty( $name ) || empty( $new_name ) ) {
@@ -433,7 +433,7 @@ class Adapter {
 	 * @param string $type        The column type.
 	 * @param array  $options     Column options.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function add_column( $table_name, $column_name, $type, $options = [] ) {
 		if ( empty( $table_name ) || empty( $column_name ) || empty( $type ) ) {
@@ -461,7 +461,7 @@ class Adapter {
 	 * @param string $table_name  The table name.
 	 * @param string $column_name The column name.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function remove_column( $table_name, $column_name ) {
 		$sql = \sprintf( 'ALTER TABLE %s DROP COLUMN %s', $this->identifier( $table_name ), $this->identifier( $column_name ) );
@@ -476,7 +476,7 @@ class Adapter {
 	 * @param string $column_name     The column name.
 	 * @param string $new_column_name The new column name.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function rename_column( $table_name, $column_name, $new_column_name ) {
 		if ( empty( $table_name ) || empty( $column_name ) || empty( $new_column_name ) ) {
@@ -498,7 +498,7 @@ class Adapter {
 	 * @param string $type        The column type.
 	 * @param array  $options     Column options.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function change_column( $table_name, $column_name, $type, $options = [] ) {
 		if ( empty( $table_name ) || empty( $column_name ) || empty( $type ) ) {
@@ -554,7 +554,7 @@ class Adapter {
 	 * @param string $column_name The column name.
 	 * @param array  $options     Index options.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function add_index( $table_name, $column_name, $options = [] ) {
 		if ( empty( $table_name ) || empty( $column_name ) ) {
@@ -609,7 +609,7 @@ class Adapter {
 	 * @param string $column_name The column name.
 	 * @param array  $options     Index options.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function remove_index( $table_name, $column_name, $options = [] ) {
 		if ( empty( $table_name ) || empty( $column_name ) ) {
@@ -635,7 +635,7 @@ class Adapter {
 	 * @param string $created_column_name Created at column name.
 	 * @param string $updated_column_name Updated at column name.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function add_timestamps( $table_name, $created_column_name, $updated_column_name ) {
 		if ( empty( $table_name ) || empty( $created_column_name ) || empty( $updated_column_name ) ) {
@@ -663,7 +663,7 @@ class Adapter {
 	 * @param string $created_column_name Created at column name.
 	 * @param string $updated_column_name Updated at column name.
 	 *
-	 * @return boolean Whether or not the timestamps were removed.
+	 * @return bool Whether or not the timestamps were removed.
 	 */
 	public function remove_timestamps( $table_name, $created_column_name, $updated_column_name ) {
 		if ( empty( $table_name ) || empty( $created_column_name ) || empty( $updated_column_name ) ) {
@@ -682,7 +682,7 @@ class Adapter {
 	 * @param string $column_name The column name.
 	 * @param array  $options     Index options.
 	 *
-	 * @return boolean Whether or not the index exists.
+	 * @return bool Whether or not the index exists.
 	 */
 	public function has_index( $table_name, $column_name, $options = [] ) {
 		if ( empty( $table_name ) || empty( $column_name ) ) {
@@ -904,7 +904,7 @@ class Adapter {
 	 *
 	 * @param string $version The version.
 	 *
-	 * @return boolean Whether or not the version was succesfully set.
+	 * @return bool Whether or not the version was succesfully set.
 	 */
 	public function add_version( $version ) {
 		$sql = \sprintf( "INSERT INTO %s (version) VALUES ('%s')", $this->get_schema_version_table_name(), $version );
@@ -917,7 +917,7 @@ class Adapter {
 	 *
 	 * @param string $version The version.
 	 *
-	 * @return boolean Whether or not the version was succesfully removed.
+	 * @return bool Whether or not the version was succesfully removed.
 	 */
 	public function remove_version( $version ) {
 		$sql = \sprintf( "DELETE FROM %s WHERE version = '%s'", $this->get_schema_version_table_name(), $version );
@@ -1000,7 +1000,7 @@ class Adapter {
 	 *
 	 * @param string $string The string.
 	 *
-	 * @return boolean Whether or not it's a SQL function call.
+	 * @return bool Whether or not it's a SQL function call.
 	 */
 	private function is_sql_method_call( $string ) {
 		$string = \trim( $string );
@@ -1013,7 +1013,7 @@ class Adapter {
 	/**
 	 * Checks if a transaction is active.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	private function in_transaction() {
 		return $this->in_transaction;

--- a/lib/migrations/migration.php
+++ b/lib/migrations/migration.php
@@ -74,7 +74,7 @@ abstract class Migration {
 	 * @param string $name    The name of the database.
 	 * @param array  $options The options.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function create_database( $name, $options = null ) {
 		return $this->adapter->create_database( $name, $options );
@@ -85,7 +85,7 @@ abstract class Migration {
 	 *
 	 * @param string $name The name of the database.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function drop_database( $name ) {
 		return $this->adapter->drop_database( $name );
@@ -96,7 +96,7 @@ abstract class Migration {
 	 *
 	 * @param string $table_name The name of the table.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function drop_table( $table_name ) {
 		return $this->adapter->drop_table( $table_name );
@@ -108,7 +108,7 @@ abstract class Migration {
 	 * @param string $name     The name of the table.
 	 * @param string $new_name The new name of the table.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function rename_table( $name, $new_name ) {
 		return $this->adapter->rename_table( $name, $new_name );
@@ -121,7 +121,7 @@ abstract class Migration {
 	 * @param string $column_name     The column name.
 	 * @param string $new_column_name The new column name.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function rename_column( $table_name, $column_name, $new_column_name ) {
 		return $this->adapter->rename_column( $table_name, $column_name, $new_column_name );
@@ -135,7 +135,7 @@ abstract class Migration {
 	 * @param string       $type        The column type.
 	 * @param array|string $options     The options.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function add_column( $table_name, $column_name, $type, $options = [] ) {
 		return $this->adapter->add_column( $table_name, $column_name, $type, $options );
@@ -147,7 +147,7 @@ abstract class Migration {
 	 * @param string $table_name  The name of the table.
 	 * @param string $column_name The column name.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function remove_column( $table_name, $column_name ) {
 		return $this->adapter->remove_column( $table_name, $column_name );
@@ -161,7 +161,7 @@ abstract class Migration {
 	 * @param string       $type        The column type.
 	 * @param array|string $options     The options.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function change_column( $table_name, $column_name, $type, $options = [] ) {
 		return $this->adapter->change_column( $table_name, $column_name, $type, $options );
@@ -174,7 +174,7 @@ abstract class Migration {
 	 * @param string       $column_name The column name.
 	 * @param array|string $options     The options.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function add_index( $table_name, $column_name, $options = [] ) {
 		return $this->adapter->add_index( $table_name, $column_name, $options );
@@ -187,7 +187,7 @@ abstract class Migration {
 	 * @param string       $column_name The column name.
 	 * @param array|string $options     The options.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function remove_index( $table_name, $column_name, $options = [] ) {
 		return $this->adapter->remove_index( $table_name, $column_name, $options );
@@ -200,7 +200,7 @@ abstract class Migration {
 	 * @param string $created_column_name Created at column name.
 	 * @param string $updated_column_name Updated at column name.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function add_timestamps( $table_name, $created_column_name = 'created_at', $updated_column_name = 'updated_at' ) {
 		return $this->adapter->add_timestamps( $table_name, $created_column_name, $updated_column_name );
@@ -213,7 +213,7 @@ abstract class Migration {
 	 * @param string $created_column_name Created at column name.
 	 * @param string $updated_column_name Updated at column name.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function remove_timestamps( $table_name, $created_column_name = 'created_at', $updated_column_name = 'updated_at' ) {
 		return $this->adapter->remove_timestamps( $table_name, $created_column_name, $updated_column_name );
@@ -258,7 +258,7 @@ abstract class Migration {
 	 *
 	 * @param string $sql The query to run.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function query( $sql ) {
 		return $this->adapter->query( $sql );

--- a/lib/migrations/table.php
+++ b/lib/migrations/table.php
@@ -172,10 +172,10 @@ class Table {
 	/**
 	 * Table definition
 	 *
-	 * @param boolean $wants_sql Whether or not to return SQL or execute the query. Defaults to false.
+	 * @param bool $wants_sql Whether or not to return SQL or execute the query. Defaults to false.
 	 *
 	 * @throws Exception If the table definition has not been intialized.
-	 * @return boolean | string
+	 * @return bool|string
 	 */
 	public function finish( $wants_sql = false ) {
 		if ( ! $this->initialized ) {

--- a/src/actions/alert-dismissal-action.php
+++ b/src/actions/alert-dismissal-action.php
@@ -32,7 +32,7 @@ class Alert_Dismissal_Action {
 	 *
 	 * @param string $alert_identifier Alert identifier.
 	 *
-	 * @return boolean Whether the dismiss was successful or not.
+	 * @return bool Whether the dismiss was successful or not.
 	 */
 	public function dismiss( $alert_identifier ) {
 		$user_id = $this->user->get_current_user_id();
@@ -66,7 +66,7 @@ class Alert_Dismissal_Action {
 	 *
 	 * @param string $alert_identifier Alert identifier.
 	 *
-	 * @return boolean Whether the reset was successful or not.
+	 * @return bool Whether the reset was successful or not.
 	 */
 	public function reset( $alert_identifier ) {
 		$user_id = $this->user->get_current_user_id();

--- a/src/builders/indexable-hierarchy-builder.php
+++ b/src/builders/indexable-hierarchy-builder.php
@@ -340,7 +340,7 @@ class Indexable_Hierarchy_Builder {
 	 * @param int       $indexable_id The indexable id we're adding ancestors for.
 	 * @param int[]     $parents      The indexable ids of the parents already added.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	private function is_invalid_ancestor( $ancestor, $indexable_id, $parents ) {
 		// If the ancestor is not an Indexable, it is invalid by default.

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -143,8 +143,8 @@ class Indexable_Post_Builder {
 	/**
 	 * Retrieves the permalink for a post with the given post type and ID.
 	 *
-	 * @param string  $post_type The post type.
-	 * @param integer $post_id   The post ID.
+	 * @param string $post_type The post type.
+	 * @param int    $post_id   The post ID.
 	 *
 	 * @return false|string|WP_Error The permalink.
 	 */

--- a/src/conditionals/admin-conditional.php
+++ b/src/conditionals/admin-conditional.php
@@ -10,7 +10,7 @@ class Admin_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		return \is_admin();

--- a/src/conditionals/admin/estimated-reading-time-conditional.php
+++ b/src/conditionals/admin/estimated-reading-time-conditional.php
@@ -38,7 +38,7 @@ class Estimated_Reading_Time_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		// Check if we are in our Elementor ajax request (for saving).

--- a/src/conditionals/admin/post-conditional.php
+++ b/src/conditionals/admin/post-conditional.php
@@ -12,7 +12,7 @@ class Post_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		global $pagenow;

--- a/src/conditionals/admin/posts-overview-or-ajax-conditional.php
+++ b/src/conditionals/admin/posts-overview-or-ajax-conditional.php
@@ -12,7 +12,7 @@ class Posts_Overview_Or_Ajax_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		global $pagenow;

--- a/src/conditionals/conditional-interface.php
+++ b/src/conditionals/conditional-interface.php
@@ -10,7 +10,7 @@ interface Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met();
 }

--- a/src/conditionals/development-conditional.php
+++ b/src/conditionals/development-conditional.php
@@ -12,7 +12,7 @@ class Development_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		return WPSEO_Utils::is_development_mode();

--- a/src/conditionals/feature-flag-conditional.php
+++ b/src/conditionals/feature-flag-conditional.php
@@ -10,7 +10,7 @@ abstract class Feature_Flag_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		$feature_flag = \strtoupper( $this->get_feature_flag() );

--- a/src/conditionals/front-end-conditional.php
+++ b/src/conditionals/front-end-conditional.php
@@ -10,7 +10,7 @@ class Front_End_Conditional implements Conditional {
 	/**
 	 * Returns `true` when NOT on an admin page.
 	 *
-	 * @return boolean `true` when NOT on an admin page.
+	 * @return bool `true` when NOT on an admin page.
 	 */
 	public function is_met() {
 		return ! \is_admin();

--- a/src/conditionals/get-request-conditional.php
+++ b/src/conditionals/get-request-conditional.php
@@ -10,7 +10,7 @@ class Get_Request_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		if ( isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'GET' ) {

--- a/src/conditionals/headless-rest-endpoints-enabled-conditional.php
+++ b/src/conditionals/headless-rest-endpoints-enabled-conditional.php
@@ -28,7 +28,7 @@ class Headless_Rest_Endpoints_Enabled_Conditional implements Conditional {
 	/**
 	 * Returns `true` whether the headless REST endpoints have been enabled.
 	 *
-	 * @return boolean `true` when the headless REST endpoints have been enabled.
+	 * @return bool `true` when the headless REST endpoints have been enabled.
 	 */
 	public function is_met() {
 		return $this->options->get( 'enable_headless_rest_endpoints' );

--- a/src/conditionals/jetpack-conditional.php
+++ b/src/conditionals/jetpack-conditional.php
@@ -11,7 +11,7 @@ class Jetpack_Conditional implements Conditional {
 	 * Returns `true` when the Jetpack plugin exists on this
 	 * WordPress installation.
 	 *
-	 * @return boolean `true` when the Jetpack plugin exists on this WordPress installation.
+	 * @return bool `true` when the Jetpack plugin exists on this WordPress installation.
 	 */
 	public function is_met() {
 		return \class_exists( 'Jetpack' );

--- a/src/conditionals/migrations-conditional.php
+++ b/src/conditionals/migrations-conditional.php
@@ -28,7 +28,7 @@ class Migrations_Conditional implements Conditional {
 	/**
 	 * Returns `true` when all database migrations have been run.
 	 *
-	 * @return boolean `true` when all database migrations have been run.
+	 * @return bool `true` when all database migrations have been run.
 	 */
 	public function is_met() {
 		return $this->migration_status->is_version( 'free', \WPSEO_VERSION );

--- a/src/conditionals/open-graph-conditional.php
+++ b/src/conditionals/open-graph-conditional.php
@@ -28,7 +28,7 @@ class Open_Graph_Conditional implements Conditional {
 	/**
 	 * Returns `true` when the Open Graph feature is enabled.
 	 *
-	 * @return boolean `true` when the Open Graph feature is enabled.
+	 * @return bool `true` when the Open Graph feature is enabled.
 	 */
 	public function is_met() {
 		return $this->options->get( 'opengraph' ) === true;

--- a/src/conditionals/primary-category-conditional.php
+++ b/src/conditionals/primary-category-conditional.php
@@ -29,7 +29,7 @@ class Primary_Category_Conditional implements Conditional {
 	 * Returns `true` when on the frontend,
 	 * or when on the post overview, post edit or new post admin page.
 	 *
-	 * @return boolean `true` when on the frontend, or when on the post overview,
+	 * @return bool `true` when on the frontend, or when on the post overview,
 	 *          post edit or new post admin page.
 	 */
 	public function is_met() {

--- a/src/conditionals/semrush-enabled-conditional.php
+++ b/src/conditionals/semrush-enabled-conditional.php
@@ -28,7 +28,7 @@ class SEMrush_Enabled_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		return $this->options->get( 'semrush_integration_active', false );

--- a/src/conditionals/should-index-links-conditional.php
+++ b/src/conditionals/should-index-links-conditional.php
@@ -28,7 +28,7 @@ class Should_Index_Links_Conditional implements Conditional {
 	/**
 	 * Returns `true` when the links on this website should be indexed.
 	 *
-	 * @return boolean `true` when the links on this website should be indexed.
+	 * @return bool `true` when the links on this website should be indexed.
 	 */
 	public function is_met() {
 		$should_index_links = $this->options_helper->get( 'enable_text_link_counter' );

--- a/src/conditionals/the-events-calendar-conditional.php
+++ b/src/conditionals/the-events-calendar-conditional.php
@@ -10,7 +10,7 @@ class The_Events_Calendar_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		return \defined( 'TRIBE_EVENTS_FILE' );

--- a/src/conditionals/third-party/elementor-edit-conditional.php
+++ b/src/conditionals/third-party/elementor-edit-conditional.php
@@ -13,7 +13,7 @@ class Elementor_Edit_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		global $pagenow;

--- a/src/conditionals/third-party/w3-total-cache-conditional.php
+++ b/src/conditionals/third-party/w3-total-cache-conditional.php
@@ -12,7 +12,7 @@ class W3_Total_Cache_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		if ( ! \defined( 'W3TC_DIR' ) ) {

--- a/src/conditionals/third-party/wpml-conditional.php
+++ b/src/conditionals/third-party/wpml-conditional.php
@@ -12,7 +12,7 @@ class WPML_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		return \defined( 'WPML_PLUGIN_FILE' );

--- a/src/conditionals/third-party/wpml-wpseo-conditional.php
+++ b/src/conditionals/third-party/wpml-wpseo-conditional.php
@@ -20,7 +20,7 @@ class WPML_WPSEO_Conditional implements Conditional {
 	/**
 	 * Returns whether or not the Yoast SEO Multilingual plugin is active.
 	 *
-	 * @return boolean Whether or not the Yoast SEO Multilingual plugin is active.
+	 * @return bool Whether or not the Yoast SEO Multilingual plugin is active.
 	 */
 	public function is_met() {
 		return \is_plugin_active( self::PATH_TO_WPML_WPSEO_PLUGIN_FILE );

--- a/src/conditionals/web-stories-conditional.php
+++ b/src/conditionals/web-stories-conditional.php
@@ -10,7 +10,7 @@ class Web_Stories_Conditional implements Conditional {
 	/**
 	 * Returns `true` when the Web Stories plugins is installed and active.
 	 *
-	 * @return boolean `true` when the Web Stories plugins is installed and active.
+	 * @return bool `true` when the Web Stories plugins is installed and active.
 	 */
 	public function is_met() {
 		return \function_exists( '\Google\Web_Stories\get_plugin_instance' );

--- a/src/conditionals/woocommerce-conditional.php
+++ b/src/conditionals/woocommerce-conditional.php
@@ -10,7 +10,7 @@ class WooCommerce_Conditional implements Conditional {
 	/**
 	 * Returns `true` when the WooCommerce plugin is installed and activated.
 	 *
-	 * @return boolean `true` when the WooCommerce plugin is installed and activated.
+	 * @return bool `true` when the WooCommerce plugin is installed and activated.
 	 */
 	public function is_met() {
 		return \class_exists( 'WooCommerce' );

--- a/src/conditionals/xmlrpc-conditional.php
+++ b/src/conditionals/xmlrpc-conditional.php
@@ -10,7 +10,7 @@ class XMLRPC_Conditional implements Conditional {
 	/**
 	 * Returns whether the current request is an XML-RPC request.
 	 *
-	 * @return boolean `true` when the current request is an XML-RPC request, `false` if not.
+	 * @return bool `true` when the current request is an XML-RPC request, `false` if not.
 	 */
 	public function is_met() {
 		return ( \defined( 'XMLRPC_REQUEST' ) && \XMLRPC_REQUEST );

--- a/src/conditionals/yoast-tools-page-conditional.php
+++ b/src/conditionals/yoast-tools-page-conditional.php
@@ -10,7 +10,7 @@ class Yoast_Tools_Page_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		global $pagenow;

--- a/src/deprecated/admin/recalculate/class-recalculate-posts.php
+++ b/src/deprecated/admin/recalculate/class-recalculate-posts.php
@@ -43,7 +43,7 @@ class WPSEO_Recalculate_Posts extends WPSEO_Recalculate {
 	 * @deprecated 14.4
 	 * @codeCoverageIgnore
 	 *
-	 * @param integer $paged The page.
+	 * @param int $paged The page.
 	 *
 	 * @return array
 	 */

--- a/src/deprecated/admin/recalculate/class-recalculate-terms.php
+++ b/src/deprecated/admin/recalculate/class-recalculate-terms.php
@@ -43,7 +43,7 @@ class WPSEO_Recalculate_Terms extends WPSEO_Recalculate {
 	 * @deprecated 14.4
 	 * @codeCoverageIgnore
 	 *
-	 * @param integer $paged The page.
+	 * @param int $paged The page.
 	 *
 	 * @return array
 	 */

--- a/src/deprecated/frontend/class-opengraph.php
+++ b/src/deprecated/frontend/class-opengraph.php
@@ -43,7 +43,7 @@ class WPSEO_OpenGraph {
 	 * @param string $property Property attribute value.
 	 * @param string $content  Content attribute value.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function og_tag( $property, $content ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
@@ -68,7 +68,7 @@ class WPSEO_OpenGraph {
 	 *
 	 * @link https://ogp.me/#type_article
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function url() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
@@ -86,7 +86,7 @@ class WPSEO_OpenGraph {
 	 *
 	 * @param bool $echo Whether or not to echo the output.
 	 *
-	 * @return string|boolean
+	 * @return string|bool
 	 */
 	public function og_title( $echo = true ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
@@ -119,7 +119,7 @@ class WPSEO_OpenGraph {
 	 * @link https://developers.facebook.com/blog/post/2013/06/19/platform-updates--new-open-graph-tags-for-media-publishers-and-more/
 	 * @link https://ogp.me/#type_article
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function article_author_facebook() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
@@ -136,7 +136,7 @@ class WPSEO_OpenGraph {
 	 * @link https://developers.facebook.com/blog/post/2013/06/19/platform-updates--new-open-graph-tags-for-media-publishers-and-more/
 	 * @link https://ogp.me/#type_article
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function website_facebook() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
@@ -150,7 +150,7 @@ class WPSEO_OpenGraph {
 	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
-	 * @param boolean $echo Whether to echo or return the type.
+	 * @param bool $echo Whether to echo or return the type.
 	 *
 	 * @return string
 	 */
@@ -217,7 +217,7 @@ class WPSEO_OpenGraph {
 	 *
 	 * @link https://ogp.me/#type_article
 	 *
-	 * @return boolean;
+	 * @return bool ;
 	 */
 	public function publish_date() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
@@ -259,7 +259,7 @@ class WPSEO_OpenGraph {
 	 *
 	 * @link https://ogp.me/#type_article
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public function tags() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
@@ -275,7 +275,7 @@ class WPSEO_OpenGraph {
 	 *
 	 * @link https://ogp.me/#type_article
 	 *
-	 * @return boolean;
+	 * @return bool ;
 	 */
 	public function category() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );

--- a/src/helpers/language-helper.php
+++ b/src/helpers/language-helper.php
@@ -12,7 +12,7 @@ class Language_Helper {
 	 *
 	 * @param string $language The used language.
 	 *
-	 * @return boolean Whether word form recognition is active for the used language.
+	 * @return bool Whether word form recognition is active for the used language.
 	 */
 	public function is_word_form_recognition_active( $language ) {
 		$supported_languages = [ 'de', 'en', 'es', 'fr', 'it', 'nl', 'ru', 'id', 'pt', 'pl', 'ar', 'sv', 'he', 'hu', 'nb', 'tr' ];

--- a/src/helpers/request-helper.php
+++ b/src/helpers/request-helper.php
@@ -10,7 +10,7 @@ class Request_Helper {
 	/**
 	 * Checks if the current request is a REST request.
 	 *
-	 * @return boolean True when the current request is a REST request.
+	 * @return bool True when the current request is a REST request.
 	 */
 	public function is_rest_request() {
 		return \defined( 'REST_REQUEST' ) && REST_REQUEST === true;

--- a/src/integrations/front-end/comment-link-fixer.php
+++ b/src/integrations/front-end/comment-link-fixer.php
@@ -96,7 +96,7 @@ class Comment_Link_Fixer implements Integration_Interface {
 	/**
 	 * Redirects out the ?replytocom variables.
 	 *
-	 * @return boolean True when redirect has been done.
+	 * @return bool True when redirect has been done.
 	 */
 	public function replytocom_redirect() {
 		if ( isset( $_GET['replytocom'] ) && \is_singular() ) {

--- a/src/integrations/front-end/indexing-controls.php
+++ b/src/integrations/front-end/indexing-controls.php
@@ -69,7 +69,7 @@ class Indexing_Controls implements Integration_Interface {
 	 * Sends a Robots HTTP header preventing URL from being indexed in the search results while allowing search engines
 	 * to follow the links in the object at the URL.
 	 *
-	 * @return boolean Boolean indicating whether the noindex header was sent.
+	 * @return bool Boolean indicating whether the noindex header was sent.
 	 */
 	public function noindex_robots() {
 		if ( ! \is_robots() ) {

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -7,74 +7,74 @@ use Yoast\WP\Lib\Model;
 /**
  * Indexable table definition.
  *
- * @property int     $id
- * @property int     $object_id
- * @property string  $object_type
- * @property string  $object_sub_type
+ * @property int    $id
+ * @property int    $object_id
+ * @property string $object_type
+ * @property string $object_sub_type
  *
- * @property int     $author_id
- * @property int     $post_parent
+ * @property int    $author_id
+ * @property int    $post_parent
  *
- * @property string  $created_at
- * @property string  $updated_at
+ * @property string $created_at
+ * @property string $updated_at
  *
- * @property string  $permalink
- * @property string  $permalink_hash
- * @property string  $canonical
+ * @property string $permalink
+ * @property string $permalink_hash
+ * @property string $canonical
  *
- * @property boolean $is_robots_noindex
- * @property boolean $is_robots_nofollow
- * @property boolean $is_robots_noarchive
- * @property boolean $is_robots_noimageindex
- * @property boolean $is_robots_nosnippet
+ * @property bool   $is_robots_noindex
+ * @property bool   $is_robots_nofollow
+ * @property bool   $is_robots_noarchive
+ * @property bool   $is_robots_noimageindex
+ * @property bool   $is_robots_nosnippet
  *
- * @property string  $title
- * @property string  $description
- * @property string  $breadcrumb_title
+ * @property string $title
+ * @property string $description
+ * @property string $breadcrumb_title
  *
- * @property boolean $is_cornerstone
+ * @property bool   $is_cornerstone
  *
- * @property string  $primary_focus_keyword
- * @property int     $primary_focus_keyword_score
+ * @property string $primary_focus_keyword
+ * @property int    $primary_focus_keyword_score
  *
- * @property int     $readability_score
+ * @property int    $readability_score
  *
- * @property int     $link_count
- * @property int     $incoming_link_count
- * @property int     $number_of_pages
+ * @property int    $link_count
+ * @property int    $incoming_link_count
+ * @property int    $number_of_pages
  *
- * @property string  $open_graph_title
- * @property string  $open_graph_description
- * @property string  $open_graph_image
- * @property string  $open_graph_image_id
- * @property string  $open_graph_image_source
- * @property string  $open_graph_image_meta
+ * @property string $open_graph_title
+ * @property string $open_graph_description
+ * @property string $open_graph_image
+ * @property string $open_graph_image_id
+ * @property string $open_graph_image_source
+ * @property string $open_graph_image_meta
  *
- * @property string  $twitter_title
- * @property string  $twitter_description
- * @property string  $twitter_image
- * @property string  $twitter_image_id
- * @property string  $twitter_image_source
- * @property string  $twitter_card
+ * @property string $twitter_title
+ * @property string $twitter_description
+ * @property string $twitter_image
+ * @property string $twitter_image_id
+ * @property string $twitter_image_source
+ * @property string $twitter_card
  *
- * @property int     $prominent_words_version
+ * @property int    $prominent_words_version
  *
- * @property boolean $is_public
- * @property boolean $is_protected
- * @property string  $post_status
- * @property boolean $has_public_posts
+ * @property bool   $is_public
+ * @property bool   $is_protected
+ * @property string $post_status
+ * @property bool   $has_public_posts
  *
- * @property int     $blog_id
+ * @property int    $blog_id
  *
- * @property string  $language
- * @property string  $region
+ * @property string $language
+ * @property string $region
  *
- * @property string  $schema_page_type
- * @property string  $schema_article_type
+ * @property string $schema_page_type
+ * @property string $schema_article_type
  *
- * @property bool    $has_ancestors
+ * @property bool   $has_ancestors
  *
- * @property int     $estimated_reading_time_minutes
+ * @property int    $estimated_reading_time_minutes
  */
 class Indexable extends Model {
 
@@ -154,7 +154,7 @@ class Indexable extends Model {
 	/**
 	 * Enhances the save method.
 	 *
-	 * @return boolean True on success.
+	 * @return bool True on success.
 	 */
 	public function save() {
 		if ( $this->permalink ) {

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -705,7 +705,7 @@ class Indexable_Presentation extends Abstract_Presentation {
 	/**
 	 * Generates the estimated reading time.
 	 *
-	 * @return integer The estimated reading time.
+	 * @return int The estimated reading time.
 	 *
 	 * @codeCoverageIgnore Wrapper method.
 	 */

--- a/src/routes/alert-dismissal-route.php
+++ b/src/routes/alert-dismissal-route.php
@@ -96,7 +96,7 @@ class Alert_Dismissal_Route implements Route_Interface {
 	/**
 	 * Whether or not the current user is allowed to dismiss alerts.
 	 *
-	 * @return boolean Whether or not the current user is allowed to dismiss alerts.
+	 * @return bool Whether or not the current user is allowed to dismiss alerts.
 	 */
 	public function can_dismiss() {
 		return \current_user_can( 'edit_posts' );

--- a/src/routes/indexables-head-route.php
+++ b/src/routes/indexables-head-route.php
@@ -91,7 +91,7 @@ class Indexables_Head_Route implements Route_Interface {
 	 *
 	 * @param string $url The url to check.
 	 *
-	 * @return boolean Whether or not the url is valid.
+	 * @return bool Whether or not the url is valid.
 	 */
 	public function is_valid_url( $url ) {
 		if ( \filter_var( $url, \FILTER_VALIDATE_URL ) === false ) {

--- a/src/routes/indexing-route.php
+++ b/src/routes/indexing-route.php
@@ -401,7 +401,7 @@ class Indexing_Route extends Abstract_Indexation_Route {
 	/**
 	 * Whether or not the current user is allowed to index.
 	 *
-	 * @return boolean Whether or not the current user is allowed to index.
+	 * @return bool Whether or not the current user is allowed to index.
 	 */
 	public function can_index() {
 		return \current_user_can( 'edit_posts' );

--- a/src/routes/semrush-route.php
+++ b/src/routes/semrush-route.php
@@ -191,7 +191,7 @@ class SEMrush_Route implements Route_Interface {
 	 *
 	 * @param string $code The code to check.
 	 *
-	 * @return boolean Whether or not the code is valid.
+	 * @return bool Whether or not the code is valid.
 	 */
 	public function has_valid_code( $code ) {
 		return $code !== '';
@@ -202,7 +202,7 @@ class SEMrush_Route implements Route_Interface {
 	 *
 	 * @param string $keyphrase The keyphrase to check.
 	 *
-	 * @return boolean Whether or not the keyphrase is valid.
+	 * @return bool Whether or not the keyphrase is valid.
 	 */
 	public function has_valid_keyphrase( $keyphrase ) {
 		return \trim( $keyphrase ) !== '';

--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -341,7 +341,7 @@ class Meta_Surface {
 	 *
 	 * @param string $url The url.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	protected function is_date_archive_url( $url ) {
 		$path = \wp_parse_url( $url, \PHP_URL_PATH );

--- a/tests/integration/doubles/wpseo-meta-columns-double.php
+++ b/tests/integration/doubles/wpseo-meta-columns-double.php
@@ -92,7 +92,7 @@ class WPSEO_Meta_Columns_Double extends WPSEO_Meta_Columns {
 	/**
 	 * Determines whether the given post ID uses the default indexing settings.
 	 *
-	 * @param integer $post_id The post ID to check.
+	 * @param int $post_id The post ID to check.
 	 *
 	 * @return bool Whether or not the default indexing is being used for the post.
 	 */

--- a/tests/integration/frontend/test-class-wpseo-image-utils.php
+++ b/tests/integration/frontend/test-class-wpseo-image-utils.php
@@ -77,10 +77,10 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @covers \WPSEO_Image_Utils::get_data
 	 *
-	 * @param mixed   $image         The image data.
-	 * @param mixed   $expected      Expected value.
-	 * @param integer $attachment_id The attachment id.
-	 * @param string  $message       Message to show when test fails.
+	 * @param mixed  $image         The image data.
+	 * @param mixed  $expected      Expected value.
+	 * @param int    $attachment_id The attachment id.
+	 * @param string $message       Message to show when test fails.
 	 */
 	public function test_get_data( $image, $expected, $attachment_id, $message ) {
 		$this->assertEquals(
@@ -97,10 +97,10 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @covers \WPSEO_Image_Utils::filter_usable_dimensions
 	 *
-	 * @param int     $width       Width of the image.
-	 * @param int     $height      Height of the image.
-	 * @param boolean $is_usable   If these dimensions are usable or not.
-	 * @param string  $description Description for the data being tested.
+	 * @param int    $width       Width of the image.
+	 * @param int    $height      Height of the image.
+	 * @param bool   $is_usable   If these dimensions are usable or not.
+	 * @param string $description Description for the data being tested.
 	 */
 	public function test_get_usable_dimensions( $width, $height, $is_usable, $description = '' ) {
 		$expected = [];

--- a/tests/unit/doubles/builders/indexable-post-builder-double.php
+++ b/tests/unit/doubles/builders/indexable-post-builder-double.php
@@ -69,8 +69,8 @@ class Indexable_Post_Builder_Double extends Indexable_Post_Builder {
 	/**
 	 * Retrieves the permalink for a post with the given post type and ID.
 	 *
-	 * @param string  $post_type The post type.
-	 * @param integer $post_id   The post ID.
+	 * @param string $post_type The post type.
+	 * @param int    $post_id   The post ID.
 	 *
 	 * @return false|string|WP_Error The permalink.
 	 */

--- a/tests/unit/generators/schema/article-test.php
+++ b/tests/unit/generators/schema/article-test.php
@@ -191,9 +191,9 @@ class Article_Test extends TestCase {
 	/**
 	 * Tests the generate method.
 	 *
-	 * @param array   $values_to_test The values that need to vary in order to test all the paths.
-	 * @param boolean $expected_value The expected generated article schema.
-	 * @param string  $message        The message to show in case a test fails.
+	 * @param array  $values_to_test The values that need to vary in order to test all the paths.
+	 * @param bool   $expected_value The expected generated article schema.
+	 * @param string $message        The message to show in case a test fails.
 	 *
 	 * @covers ::generate
 	 * @covers ::add_image

--- a/tests/unit/generators/schema/webpage-test.php
+++ b/tests/unit/generators/schema/webpage-test.php
@@ -186,9 +186,9 @@ class WebPage_Test extends TestCase {
 	 * @covers ::add_breadcrumbs
 	 * @covers ::add_potential_action
 	 *
-	 * @param array   $values_to_test The values that need to vary in order to test all the paths.
-	 * @param boolean $expected       The expected generated webpage schema.
-	 * @param string  $message        The message to show in case a test fails.
+	 * @param array  $values_to_test The values that need to vary in order to test all the paths.
+	 * @param bool   $expected       The expected generated webpage schema.
+	 * @param string $message        The message to show in case a test fails.
 	 *
 	 * @dataProvider provider_for_generate
 	 */

--- a/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
@@ -458,7 +458,7 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 	/**
 	 * Sets the expectations for the get_object_ids_for term method.
 	 *
-	 * @param integer ...$object_ids The object ids.
+	 * @param int ...$object_ids The object ids.
 	 */
 	private function set_expectations_for_get_object_ids_for_term( ...$object_ids ) {
 		$this->wpdb->term_taxonomy      = 'wp_term_taxonomy';


### PR DESCRIPTION
## Context

* Documentation improvements

## Summary

This PR can be summarized in the following changelog entry:

* Documentation improvements

## Relevant technical choices:

### Use short form type keywords

Includes re-aligning the parameter names and descriptions.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.
