### PR TITLE
Docs: improve type order

### DIFF
--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -159,7 +159,7 @@ class WPSEO_Database_Proxy {
 	 * Deletes a record from the database.
 	 *
 	 * @param array      $where  Where clauses for the query.
-	 * @param null|array $format Formats for the data.
+	 * @param array|null $format Formats for the data.
 	 *
 	 * @return false|int
 	 */
@@ -178,7 +178,7 @@ class WPSEO_Database_Proxy {
 	 *
 	 * @param string $query The query to execute.
 	 *
-	 * @return array|null|object The resultset
+	 * @return array|object|null The resultset
 	 */
 	public function get_results( $query ) {
 		$this->pre_execution();

--- a/admin/class-option-tabs.php
+++ b/admin/class-option-tabs.php
@@ -71,7 +71,7 @@ class WPSEO_Option_Tabs {
 	/**
 	 * Get active tab.
 	 *
-	 * @return null|WPSEO_Option_Tab Get the active tab.
+	 * @return WPSEO_Option_Tab|null Get the active tab.
 	 */
 	public function get_active_tab() {
 		if ( empty( $this->active_tab ) ) {

--- a/admin/class-remote-request.php
+++ b/admin/class-remote-request.php
@@ -102,7 +102,7 @@ class WPSEO_Remote_Request {
 	/**
 	 * Returns the value of the response error.
 	 *
-	 * @return null|WP_Error The response error.
+	 * @return WP_Error|null The response error.
 	 */
 	public function get_response_error() {
 		return $this->response_error;

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -124,7 +124,7 @@ class Yoast_Notification_Center {
 	 * Check if the user has dismissed a notification.
 	 *
 	 * @param Yoast_Notification $notification The notification to check for dismissal.
-	 * @param null|int           $user_id      User ID to check on.
+	 * @param int|null           $user_id      User ID to check on.
 	 *
 	 * @return bool
 	 */
@@ -329,7 +329,7 @@ class Yoast_Notification_Center {
 	 * @param string $notification_id The ID of the notification to search for.
 	 * @param int    $user_id         The ID of the user.
 	 *
-	 * @return null|Yoast_Notification
+	 * @return Yoast_Notification|null
 	 */
 	public function get_notification_by_id( $notification_id, $user_id = null ) {
 		$user_id = self::get_user_id( $user_id );

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -135,7 +135,7 @@ class Yoast_Notification {
 	/**
 	 * Retrieve nonce identifier.
 	 *
-	 * @return null|string Nonce for this Notification.
+	 * @return string|null Nonce for this Notification.
 	 */
 	public function get_nonce() {
 		if ( $this->options['id'] && empty( $this->options['nonce'] ) ) {

--- a/admin/class-yoast-notifications.php
+++ b/admin/class-yoast-notifications.php
@@ -216,7 +216,7 @@ class Yoast_Notifications {
 	/**
 	 * Extract the Yoast Notification from the AJAX request.
 	 *
-	 * @return null|Yoast_Notification
+	 * @return Yoast_Notification|null
 	 */
 	private function get_notification_from_ajax_request() {
 

--- a/admin/config-ui/class-configuration-options-adapter.php
+++ b/admin/config-ui/class-configuration-options-adapter.php
@@ -178,7 +178,7 @@ class WPSEO_Configuration_Options_Adapter {
 	 *
 	 * @param string $class_name Class to get the type of.
 	 *
-	 * @return null|string
+	 * @return string|null
 	 */
 	protected function get_option_type( $class_name ) {
 		if ( ! isset( $this->lookup[ $class_name ] ) ) {
@@ -193,7 +193,7 @@ class WPSEO_Configuration_Options_Adapter {
 	 *
 	 * @param string $class_name Class to get the option of.
 	 *
-	 * @return null|string|array
+	 * @return string|array|null
 	 */
 	protected function get_option( $class_name ) {
 		if ( ! isset( $this->lookup[ $class_name ] ) ) {

--- a/admin/config-ui/fields/class-field-multiple-authors.php
+++ b/admin/config-ui/fields/class-field-multiple-authors.php
@@ -40,7 +40,7 @@ class WPSEO_Config_Field_Multiple_Authors extends WPSEO_Config_Field_Choice {
 	/**
 	 * Get the data from the stored options.
 	 *
-	 * @return null|string
+	 * @return string|null
 	 */
 	public function get_data() {
 

--- a/admin/config-ui/fields/class-field-site-name.php
+++ b/admin/config-ui/fields/class-field-site-name.php
@@ -37,7 +37,7 @@ class WPSEO_Config_Field_Site_Name extends WPSEO_Config_Field {
 	/**
 	 * Get the data from the stored options.
 	 *
-	 * @return null|string
+	 * @return string|null
 	 */
 	public function get_data() {
 		if ( WPSEO_Options::get( 'website_name', false ) ) {

--- a/admin/roles/class-abstract-role-manager.php
+++ b/admin/roles/class-abstract-role-manager.php
@@ -22,7 +22,7 @@ abstract class WPSEO_Abstract_Role_Manager implements WPSEO_Role_Manager {
 	 *
 	 * @param string      $role         Role to register.
 	 * @param string      $display_name Display name to use.
-	 * @param null|string $template     Optional. Role to base the new role on.
+	 * @param string|null $template     Optional. Role to base the new role on.
 	 *
 	 * @return void
 	 */

--- a/admin/roles/class-role-manager.php
+++ b/admin/roles/class-role-manager.php
@@ -15,7 +15,7 @@ interface WPSEO_Role_Manager {
 	 *
 	 * @param string      $role         Role to register.
 	 * @param string      $display_name Display name to use.
-	 * @param null|string $template     Optional. Role to base the new role on.
+	 * @param string|null $template     Optional. Role to base the new role on.
 	 *
 	 * @return void
 	 */

--- a/admin/tracking/class-tracking-theme-data.php
+++ b/admin/tracking/class-tracking-theme-data.php
@@ -37,7 +37,7 @@ class WPSEO_Tracking_Theme_Data implements WPSEO_Collection {
 	 *
 	 * @param WP_Theme $theme The theme object.
 	 *
-	 * @return null|string The name of the parent theme or null.
+	 * @return string|null The name of the parent theme or null.
 	 */
 	private function get_parent_theme( WP_Theme $theme ) {
 		if ( is_child_theme() ) {

--- a/inc/class-upgrade-history.php
+++ b/inc/class-upgrade-history.php
@@ -22,7 +22,7 @@ class WPSEO_Upgrade_History {
 	/**
 	 * WPSEO_Upgrade_History constructor.
 	 *
-	 * @param null|string $option_name Optional. Custom option to use to store/retrieve history from.
+	 * @param string|null $option_name Optional. Custom option to use to store/retrieve history from.
 	 */
 	public function __construct( $option_name = null ) {
 		if ( $option_name !== null ) {

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -563,7 +563,7 @@ class WPSEO_Meta {
 	 * @param string $meta_value New meta value.
 	 * @param string $prev_value The old meta value.
 	 *
-	 * @return null|bool True = stop saving, null = continue saving.
+	 * @return bool|null True = stop saving, null = continue saving.
 	 */
 	public static function remove_meta_if_default( $check, $object_id, $meta_key, $meta_value, $prev_value = '' ) {
 		/* If it's one of our meta fields, check against default. */
@@ -589,7 +589,7 @@ class WPSEO_Meta {
 	 * @param string $meta_key   The full meta key (including prefix).
 	 * @param string $meta_value New meta value.
 	 *
-	 * @return null|bool True = stop saving, null = continue saving.
+	 * @return bool|null True = stop saving, null = continue saving.
 	 */
 	public static function dont_save_meta_if_default( $check, $object_id, $meta_key, $meta_value ) {
 		/* If it's one of our meta fields, check against default. */

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -971,7 +971,7 @@ class WPSEO_Replace_Vars {
 	/**
 	 * Retrieve the post/page/cpt author's users description for use as a replacement string.
 	 *
-	 * @return null|string
+	 * @return string|null
 	 */
 	private function retrieve_user_description() {
 		$replacement = null;

--- a/inc/sitemaps/class-sitemaps-cache-validator.php
+++ b/inc/sitemaps/class-sitemaps-cache-validator.php
@@ -42,7 +42,7 @@ class WPSEO_Sitemaps_Cache_Validator {
 	 *
 	 * @since 3.2
 	 *
-	 * @param null|string $type The type to get the key for. Null or self::SITEMAP_INDEX_TYPE for index cache.
+	 * @param string|null $type The type to get the key for. Null or self::SITEMAP_INDEX_TYPE for index cache.
 	 * @param int         $page The page of cache to get the key for.
 	 *
 	 * @return bool|string The key where the cache is stored on. False if the key could not be generated.
@@ -131,7 +131,7 @@ class WPSEO_Sitemaps_Cache_Validator {
 	 *
 	 * @since 3.2
 	 *
-	 * @param null|string $type The type to get the key for. Null for all caches.
+	 * @param string|null $type The type to get the key for. Null for all caches.
 	 *
 	 * @return void
 	 */
@@ -161,8 +161,8 @@ class WPSEO_Sitemaps_Cache_Validator {
 	 *
 	 * @since 3.2
 	 *
-	 * @param null|string $type      The type of sitemap to clear cache for.
-	 * @param null|string $validator The validator to clear cache of.
+	 * @param string|null $type      The type of sitemap to clear cache for.
+	 * @param string|null $validator The validator to clear cache of.
 	 *
 	 * @return void
 	 */
@@ -207,7 +207,7 @@ class WPSEO_Sitemaps_Cache_Validator {
 	 *
 	 * @param string $type Provide a type for a specific type validator, empty for global validator.
 	 *
-	 * @return null|string The validator for the supplied type.
+	 * @return string|null The validator for the supplied type.
 	 */
 	public static function get_validator( $type = '' ) {
 

--- a/inc/sitemaps/class-sitemaps-cache.php
+++ b/inc/sitemaps/class-sitemaps-cache.php
@@ -112,7 +112,7 @@ class WPSEO_Sitemaps_Cache {
 	 * @param string $type Sitemap type.
 	 * @param int    $page Page number to retrieve.
 	 *
-	 * @return null|WPSEO_Sitemap_Cache_Data Null on no cache found otherwise object containing sitemap and meta data.
+	 * @return WPSEO_Sitemap_Cache_Data|null Null on no cache found otherwise object containing sitemap and meta data.
 	 */
 	public function get_sitemap_data( $type, $page ) {
 

--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -38,7 +38,7 @@ if ( ! function_exists( 'yoast_get_primary_term_id' ) ) {
 	 * Get the primary term ID.
 	 *
 	 * @param string           $taxonomy Optional. The taxonomy to get the primary term ID for. Defaults to category.
-	 * @param null|int|WP_Post $post     Optional. Post to get the primary term ID for.
+	 * @param int|WP_Post|null $post     Optional. Post to get the primary term ID for.
 	 *
 	 * @return bool|int
 	 */
@@ -55,7 +55,7 @@ if ( ! function_exists( 'yoast_get_primary_term' ) ) {
 	 * Get the primary term name.
 	 *
 	 * @param string           $taxonomy Optional. The taxonomy to get the primary term for. Defaults to category.
-	 * @param null|int|WP_Post $post     Optional. Post to get the primary term for.
+	 * @param int|WP_Post|null $post     Optional. Post to get the primary term for.
 	 *
 	 * @return string Name of the primary term.
 	 */

--- a/lib/abstract-main.php
+++ b/lib/abstract-main.php
@@ -85,7 +85,7 @@ abstract class Abstract_Main {
 	 *
 	 * @throws Exception If something goes wrong generating the DI container.
 	 *
-	 * @return null|ContainerInterface The DI container.
+	 * @return ContainerInterface|null The DI container.
 	 */
 	abstract protected function get_container();
 

--- a/lib/model.php
+++ b/lib/model.php
@@ -156,7 +156,7 @@ class Model implements JsonSerializable {
 	 *
 	 * @param string      $class_name The target class name.
 	 * @param string      $property   The property to get the value for.
-	 * @param null|string $default    Default value when property does not exist.
+	 * @param string|null $default    Default value when property does not exist.
 	 *
 	 * @return string The value of the property.
 	 */
@@ -315,8 +315,8 @@ class Model implements JsonSerializable {
 	 * the method chain.
 	 *
 	 * @param string      $associated_class_name                    The associated class name.
-	 * @param null|string $foreign_key_name                         The foreign key name in the associated table.
-	 * @param null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
+	 * @param string|null $foreign_key_name                         The foreign key name in the associated table.
+	 * @param string|null $foreign_key_name_in_current_models_table The foreign key in the current models table.
 	 *
 	 * @throws \Exception When ID of current model has a null value.
 	 *
@@ -347,8 +347,8 @@ class Model implements JsonSerializable {
 	 * key is on the associated table.
 	 *
 	 * @param string      $associated_class_name                    The associated class name.
-	 * @param null|string $foreign_key_name                         The foreign key name in the associated table.
-	 * @param null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
+	 * @param string|null $foreign_key_name                         The foreign key name in the associated table.
+	 * @param string|null $foreign_key_name_in_current_models_table The foreign key in the current models table.
 	 *
 	 * @throws \Exception  When ID of current model has a null value.
 	 *
@@ -363,8 +363,8 @@ class Model implements JsonSerializable {
 	 * key is on the associated table.
 	 *
 	 * @param string      $associated_class_name                    The associated class name.
-	 * @param null|string $foreign_key_name                         The foreign key name in the associated table.
-	 * @param null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
+	 * @param string|null $foreign_key_name                         The foreign key name in the associated table.
+	 * @param string|null $foreign_key_name_in_current_models_table The foreign key in the current models table.
 	 *
 	 * @throws \Exception When ID has a null value.
 	 *
@@ -381,8 +381,8 @@ class Model implements JsonSerializable {
 	 * the foreign key is on the base table.
 	 *
 	 * @param string      $associated_class_name                       The associated class name.
-	 * @param null|string $foreign_key_name                            The foreign key in the current models table.
-	 * @param null|string $foreign_key_name_in_associated_models_table The foreign key in the associated table.
+	 * @param string|null $foreign_key_name                            The foreign key in the current models table.
+	 * @param string|null $foreign_key_name_in_associated_models_table The foreign key in the associated table.
 	 *
 	 * @return $this|null Instance of the foreign model.
 	 */
@@ -412,11 +412,11 @@ class Model implements JsonSerializable {
 	 * README for a full explanation of the parameters.
 	 *
 	 * @param string      $associated_class_name   The associated class name.
-	 * @param null|string $join_class_name         The class name to join.
-	 * @param null|string $key_to_base_table       The key to the the current models table.
-	 * @param null|string $key_to_associated_table The key to the associated table.
-	 * @param null|string $key_in_base_table       The key in the current models table.
-	 * @param null|string $key_in_associated_table The key in the associated table.
+	 * @param string|null $join_class_name         The class name to join.
+	 * @param string|null $key_to_base_table       The key to the the current models table.
+	 * @param string|null $key_to_associated_table The key to the associated table.
+	 * @param string|null $key_in_base_table       The key in the current models table.
+	 * @param string|null $key_in_associated_table The key in the associated table.
 	 *
 	 * @return ORM Instance of the ORM.
 	 */

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -372,7 +372,7 @@ class ORM implements \ArrayAccess {
 	 * instance of the ORM class, or false if no rows were returned. As a shortcut, you may supply an ID as a parameter
 	 * to this method. This will perform a primary key lookup on the table.
 	 *
-	 * @param null|int $id An (optional) ID.
+	 * @param int|null $id An (optional) ID.
 	 *
 	 * @return bool|Model
 	 */
@@ -609,7 +609,7 @@ class ORM implements \ArrayAccess {
 	 * Adds an unquoted expression to the set of columns returned by the SELECT query. Internal method.
 	 *
 	 * @param string      $expr  The expression.
-	 * @param null|string $alias The alias to return the expression as. Defaults to null.
+	 * @param string|null $alias The alias to return the expression as. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -649,7 +649,7 @@ class ORM implements \ArrayAccess {
 	 * Adds a column to the list of columns returned by the SELECT query.
 	 *
 	 * @param string      $column The column. Defaults to '*'.
-	 * @param null|string $alias  The alias to return the column as. Defaults to null.
+	 * @param string|null $alias  The alias to return the column as. Defaults to null.
 	 *
 	 * @return ORM
 	 */
@@ -663,7 +663,7 @@ class ORM implements \ArrayAccess {
 	 * Adds an unquoted expression to the list of columns returned by the SELECT query.
 	 *
 	 * @param string      $expr  The expression.
-	 * @param null|string $alias The alias to return the column as. Defaults to null.
+	 * @param string|null $alias The alias to return the column as. Defaults to null.
 	 *
 	 * @return ORM
 	 */

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -272,7 +272,7 @@ class Indexable_Post_Builder {
 	 * @param string $keyword The focus keyword that is set.
 	 * @param int    $score   The score saved on the meta data.
 	 *
-	 * @return null|int Score to use.
+	 * @return int|null Score to use.
 	 */
 	protected function get_keyword_score( $keyword, $score ) {
 		if ( empty( $keyword ) ) {

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -126,7 +126,7 @@ class Indexable_Term_Builder {
 	 * @param string $keyword The focus keyword that is set.
 	 * @param int    $score   The score saved on the meta data.
 	 *
-	 * @return null|int Score to use.
+	 * @return int|null Score to use.
 	 */
 	protected function get_keyword_score( $keyword, $score ) {
 		if ( empty( $keyword ) ) {
@@ -166,7 +166,7 @@ class Indexable_Term_Builder {
 	 * @param string $meta_key  The key to extract.
 	 * @param array  $term_meta The meta data.
 	 *
-	 * @return null|string The meta value.
+	 * @return string|null The meta value.
 	 */
 	protected function get_meta_value( $meta_key, $term_meta ) {
 		if ( ! $term_meta || ! \array_key_exists( $meta_key, $term_meta ) ) {

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -549,7 +549,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	/**
 	 * Gets the main image ID.
 	 *
-	 * @return int|null|false The main image ID.
+	 * @return int|false|null The main image ID.
 	 */
 	public function generate_main_image_id() {
 		if ( ! \has_post_thumbnail( $this->id ) ) {

--- a/src/deprecated/admin/extension-manager.php
+++ b/src/deprecated/admin/extension-manager.php
@@ -52,7 +52,7 @@ class WPSEO_Extension_Manager {
 	 *
 	 * @param string $extension_name The name of the extension to get.
 	 *
-	 * @return null|WPSEO_Extension The extension object or null when it doesn't exist.
+	 * @return WPSEO_Extension|null The extension object or null when it doesn't exist.
 	 */
 	public function get( $extension_name ) {
 		_deprecated_function( __METHOD__, '15.4' );

--- a/src/deprecated/frontend/class-opengraph-image.php
+++ b/src/deprecated/frontend/class-opengraph-image.php
@@ -29,7 +29,7 @@ class WPSEO_OpenGraph_Image extends Images {
 	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
-	 * @param null|string     $image     Optional. The Image to use.
+	 * @param string|null     $image     Optional. The Image to use.
 	 * @param WPSEO_OpenGraph $opengraph Optional. The OpenGraph object.
 	 */
 	public function __construct( $image = null, WPSEO_OpenGraph $opengraph = null ) {

--- a/src/deprecated/frontend/class-primary-category.php
+++ b/src/deprecated/frontend/class-primary-category.php
@@ -29,7 +29,7 @@ class WPSEO_Frontend_Primary_Category implements WPSEO_WordPress_Integration {
 	 * @codeCoverageIgnore
 	 * @deprecated 14.0
 	 *
-	 * @return array|null|object|WP_Error The category we want to use for the post link.
+	 * @return array|object|WP_Error|null The category we want to use for the post link.
 	 */
 	public function post_link_category( $category, $categories = null, $post = null ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );

--- a/src/helpers/indexable-helper.php
+++ b/src/helpers/indexable-helper.php
@@ -112,7 +112,7 @@ class Indexable_Helper {
 	 * Resets the permalinks of the indexables.
 	 *
 	 * @param string      $type    The type of the indexable.
-	 * @param null|string $subtype The subtype. Can be null.
+	 * @param string|null $subtype The subtype. Can be null.
 	 * @param string      $reason  The reason that the permalink has been changed.
 	 */
 	public function reset_permalink_indexables( $type = null, $subtype = null, $reason = Indexing_Reasons::REASON_PERMALINK_SETTINGS ) {

--- a/src/integrations/primary-category.php
+++ b/src/integrations/primary-category.php
@@ -40,7 +40,7 @@ class Primary_Category implements Integration_Interface {
 	 * @param array    $categories This parameter is not used.
 	 * @param WP_Post  $post       The post in question.
 	 *
-	 * @return array|null|object|WP_Error The category we want to use for the post link.
+	 * @return array|object|WP_Error|null The category we want to use for the post link.
 	 */
 	public function post_link_category( $category, $categories = null, $post = null ) {
 		$post = \get_post( $post );

--- a/src/integrations/watchers/indexable-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-permalink-watcher.php
@@ -280,7 +280,7 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 	 * @codeCoverageIgnore
 	 *
 	 * @param string      $type    The type of the indexable.
-	 * @param null|string $subtype The subtype. Can be null.
+	 * @param string|null $subtype The subtype. Can be null.
 	 * @param string      $reason  The reason that the permalink has been changed.
 	 */
 	public function reset_permalink_indexables( $type, $subtype = null, $reason = Indexing_Reasons::REASON_PERMALINK_SETTINGS ) {

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -514,7 +514,7 @@ class Indexable_Repository {
 	 * Resets the permalinks of the passed object type and subtype.
 	 *
 	 * @param string      $type    The type of the indexable. Can be null.
-	 * @param null|string $subtype The subtype. Can be null.
+	 * @param string|null $subtype The subtype. Can be null.
 	 *
 	 * @return int|bool The number of permalinks changed if the query was succesful. False otherwise.
 	 */

--- a/src/values/images.php
+++ b/src/values/images.php
@@ -101,7 +101,7 @@ class Images {
 	 *
 	 * @param string $url The given URL.
 	 *
-	 * @return null|number Returns the found image ID if it exists. Otherwise -1.
+	 * @return number|null Returns the found image ID if it exists. Otherwise -1.
 	 *                     If the URL is empty we return null.
 	 */
 	public function add_image_by_url( $url ) {

--- a/tests/integration/doubles/wpseo-configuration-service-mock.php
+++ b/tests/integration/doubles/wpseo-configuration-service-mock.php
@@ -15,7 +15,7 @@ class WPSEO_Configuration_Service_Mock extends WPSEO_Configuration_Service {
 	 *
 	 * @param string $item Property to get.
 	 *
-	 * @return null|mixed
+	 * @return mixed|null
 	 */
 	public function get( $item ) {
 		if ( isset( $this->{$item} ) ) {

--- a/tests/unit/doubles/builders/indexable-post-builder-double.php
+++ b/tests/unit/doubles/builders/indexable-post-builder-double.php
@@ -84,7 +84,7 @@ class Indexable_Post_Builder_Double extends Indexable_Post_Builder {
 	 * @param string $keyword The focus keyword that is set.
 	 * @param int    $score   The score saved on the meta data.
 	 *
-	 * @return null|int Score to use.
+	 * @return int|null Score to use.
 	 */
 	public function get_keyword_score( $keyword, $score ) {
 		return parent::get_keyword_score( $keyword, $score );

--- a/tests/unit/doubles/builders/indexable-term-builder-double.php
+++ b/tests/unit/doubles/builders/indexable-term-builder-double.php
@@ -38,7 +38,7 @@ class Indexable_Term_Builder_Double extends Indexable_Term_Builder {
 	 * @param string $keyword The focus keyword that is set.
 	 * @param int    $score   The score saved on the meta data.
 	 *
-	 * @return null|int Score to use.
+	 * @return int|null Score to use.
 	 */
 	public function get_keyword_score( $keyword, $score ) {
 		return parent::get_keyword_score( $keyword, $score );
@@ -50,7 +50,7 @@ class Indexable_Term_Builder_Double extends Indexable_Term_Builder {
 	 * @param string $meta_key  The key to extract.
 	 * @param array  $term_meta The meta data.
 	 *
-	 * @return null|string The meta value.
+	 * @return string|null The meta value.
 	 */
 	public function get_meta_value( $meta_key, $term_meta ) {
 		return parent::get_meta_value( $meta_key, $term_meta );

--- a/tests/unit/doubles/models/indexable-double.php
+++ b/tests/unit/doubles/models/indexable-double.php
@@ -14,7 +14,7 @@ class Indexable_Double extends Indexable_Model {
 	/**
 	 * Holds the return value for has_one. Making it possible to mock that.
 	 *
-	 * @var null|MockInterface
+	 * @var MockInterface|null
 	 */
 	public $mock_has_one = null;
 
@@ -40,10 +40,10 @@ class Indexable_Double extends Indexable_Model {
 	 * key is on the associated table.
 	 *
 	 * @param string      $associated_class_name                    The associated class name.
-	 * @param null|string $foreign_key_name                         The foreign key name in the associated table.
-	 * @param null|string $foreign_key_name_in_current_models_table The foreign key in the current models table.
+	 * @param string|null $foreign_key_name                         The foreign key name in the associated table.
+	 * @param string|null $foreign_key_name_in_current_models_table The foreign key in the current models table.
 	 *
-	 * @return null|MockInterface
+	 * @return MockInterface|null
 	 */
 	public function has_one( $associated_class_name, $foreign_key_name = null, $foreign_key_name_in_current_models_table = null ) {
 		return $this->mock_has_one;


### PR DESCRIPTION
## Context

* Documentation improvements

## Summary

This PR can be summarized in the following changelog entry:

* Documentation improvements

## Relevant technical choices:

`null` should always be listed last.




## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.