### PR TITLE
Docs: fix missing/incorrect types in `@return` tags

### DIFF
--- a/admin/class-admin-asset-yoast-components-l10n.php
+++ b/admin/class-admin-asset-yoast-components-l10n.php
@@ -44,7 +44,7 @@ final class WPSEO_Admin_Asset_Yoast_Components_L10n {
 	 * Returns translations necessary for JS files.
 	 *
 	 * @param string $component The component to retrieve the translations for.
-	 * @return object The translations in a Jed format for JS files.
+	 * @return object|null The translations in a Jed format for JS files.
 	 */
 	protected function get_translations( $component ) {
 		$locale = \get_user_locale();

--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -144,7 +144,7 @@ class WPSEO_Admin_Init {
 	/**
 	 * Gets the latest released major WordPress version from the WordPress stable-check api.
 	 *
-	 * @return float The latest released major WordPress version. 0 The stable-check api doesn't respond.
+	 * @return float|int The latest released major WordPress version. 0 when the stable-check API doesn't respond.
 	 */
 	private function get_latest_major_wordpress_version() {
 		$core_updates = get_core_updates( [ 'dismissed' => true ] );

--- a/admin/class-asset.php
+++ b/admin/class-asset.php
@@ -207,7 +207,7 @@ class WPSEO_Admin_Asset {
 	/**
 	 * Returns the asset version.
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	public function get_version() {
 		if ( ! empty( $this->version ) ) {

--- a/admin/class-product-upsell-notice.php
+++ b/admin/class-product-upsell-notice.php
@@ -176,7 +176,7 @@ class WPSEO_Product_Upsell_Notice {
 	/**
 	 * Dismisses the notice.
 	 *
-	 * @return string
+	 * @return bool
 	 */
 	protected function is_notice_dismissed() {
 		return get_user_meta( get_current_user_id(), self::USER_META_DISMISSED, true ) === '1';
@@ -192,7 +192,7 @@ class WPSEO_Product_Upsell_Notice {
 	/**
 	 * Returns the set options.
 	 *
-	 * @return mixed|void
+	 * @return mixed
 	 */
 	protected function get_options() {
 		return get_option( self::OPTION_NAME );

--- a/admin/class-yoast-input-validation.php
+++ b/admin/class-yoast-input-validation.php
@@ -192,7 +192,7 @@ class Yoast_Input_Validation {
 	 *
 	 * @param string $error_code Code of the error set via `add_settings_error()`, normally the variable name.
 	 *
-	 * @return string The error description.
+	 * @return string|null The error description.
 	 */
 	public static function get_error_description( $error_code ) {
 		if ( ! isset( self::$error_descriptions[ $error_code ] ) ) {

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -665,11 +665,11 @@ class Yoast_Notification_Center {
 	}
 
 	/**
-	 * Retrieve the notifications from storage.
+	 * Retrieve the notifications from storage and fill the relevant property.
 	 *
 	 * @param int $user_id The ID of the user to retrieve notifications for.
 	 *
-	 * @return array|void Yoast_Notification[] Notifications.
+	 * @return void
 	 */
 	private function retrieve_notifications_from_storage( $user_id ) {
 

--- a/admin/config-ui/components/class-component-mailchimp-signup.php
+++ b/admin/config-ui/components/class-component-mailchimp-signup.php
@@ -29,7 +29,7 @@ class WPSEO_Config_Component_Mailchimp_Signup implements WPSEO_Config_Component 
 	/**
 	 * Gets the field.
 	 *
-	 * @return WPSEO_Config_Field
+	 * @return WPSEO_Config_Field_Mailchimp_Signup
 	 */
 	public function get_field() {
 		return new WPSEO_Config_Field_Mailchimp_Signup();

--- a/admin/filters/class-cornerstone-filter.php
+++ b/admin/filters/class-cornerstone-filter.php
@@ -90,7 +90,7 @@ class WPSEO_Cornerstone_Filter extends WPSEO_Abstract_Post_Filter {
 	/**
 	 * Returns a text explaining this filter.
 	 *
-	 * @return string The explanation.
+	 * @return string|null The explanation.
 	 */
 	protected function get_explanation() {
 		$post_type_object = get_post_type_object( $this->get_current_post_type() );

--- a/admin/metabox/class-metabox-null-tab.php
+++ b/admin/metabox/class-metabox-null-tab.php
@@ -13,7 +13,7 @@ class WPSEO_Metabox_Null_Tab implements WPSEO_Metabox_Tab {
 	/**
 	 * Returns the html for the tab link.
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	public function link() {
 		return null;
@@ -22,7 +22,7 @@ class WPSEO_Metabox_Null_Tab implements WPSEO_Metabox_Tab {
 	/**
 	 * Returns the html for the tab content.
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	public function content() {
 		return null;

--- a/admin/ryte/class-ryte.php
+++ b/admin/ryte/class-ryte.php
@@ -117,7 +117,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	/**
 	 * Fetches the data from Ryte.
 	 *
-	 * @return bool Whether the request ran.
+	 * @return bool|null Whether the request ran.
 	 */
 	public function fetch_from_ryte() {
 		// Don't do anything when the WordPress environment type isn't "production".

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -596,7 +596,7 @@ class WPSEO_Addon_Manager {
 	 *
 	 * @param object $site_information Site information as received from the API.
 	 *
-	 * @return object Mapped site information.
+	 * @return stdClass Mapped site information.
 	 */
 	protected function map_site_information( $site_information ) {
 		return (object) [
@@ -610,7 +610,7 @@ class WPSEO_Addon_Manager {
 	 *
 	 * @param object $subscription Subscription information as received from the API.
 	 *
-	 * @return object Mapped subscription.
+	 * @return stdClass Mapped subscription.
 	 */
 	protected function map_subscription( $subscription ) {
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Not our properties.

--- a/inc/class-wpseo-shortlinker.php
+++ b/inc/class-wpseo-shortlinker.php
@@ -142,7 +142,7 @@ class WPSEO_Shortlinker {
 	/**
 	 * Gets the user's language.
 	 *
-	 * @return string The user's language.
+	 * @return string|false The user's language or `false` when it couldn't be retrieved.
 	 */
 	private function get_user_language() {
 		if ( function_exists( 'get_user_locale' ) ) {

--- a/lib/dependency-injection/container-registry.php
+++ b/lib/dependency-injection/container-registry.php
@@ -38,7 +38,7 @@ class Container_Registry {
 	 * @param string $id                The ID of the service.
 	 * @param int    $invalid_behaviour The behaviour when the service could not be found.
 	 *
-	 * @return object The service.
+	 * @return object|null The service.
 	 *
 	 * @throws ServiceCircularReferenceException When a circular reference is detected.
 	 * @throws ServiceNotFoundException          When the service is not defined.

--- a/lib/migrations/adapter.php
+++ b/lib/migrations/adapter.php
@@ -319,7 +319,7 @@ class Adapter {
 	 *
 	 * @param string $query The query to run.
 	 *
-	 * @return array An associative array of the result.
+	 * @return array|false An associative array of the result.
 	 */
 	public function select_one( $query ) {
 		global $wpdb;
@@ -378,7 +378,7 @@ class Adapter {
 	 * @param string $table_name The table name.
 	 * @param array  $options    The options.
 	 *
-	 * @return bool|Table
+	 * @return Table
 	 */
 	public function create_table( $table_name, $options = [] ) {
 		return new Table( $this, $table_name, $options );
@@ -527,7 +527,7 @@ class Adapter {
 	 * @param string $table  The table name.
 	 * @param string $column The column name.
 	 *
-	 * @return array
+	 * @return array|null
 	 */
 	public function column_info( $table, $column ) {
 		if ( empty( $table ) || empty( $column ) ) {

--- a/lib/migrations/migration.php
+++ b/lib/migrations/migration.php
@@ -49,7 +49,7 @@ abstract class Migration {
 	 *
 	 * @param Adapter $adapter The adapter to set.
 	 *
-	 * @return $this
+	 * @return $this|null
 	 */
 	public function set_adapter( $adapter ) {
 		if ( ! $adapter instanceof Adapter ) {

--- a/lib/model.php
+++ b/lib/model.php
@@ -494,7 +494,7 @@ class Model implements JsonSerializable {
 	 *
 	 * @param string $property The property to get.
 	 *
-	 * @return null|string The value of the property
+	 * @return mixed The value of the property
 	 */
 	public function __get( $property ) {
 		$value = $this->orm->get( $property );

--- a/src/actions/alert-dismissal-action.php
+++ b/src/actions/alert-dismissal-action.php
@@ -134,7 +134,8 @@ class Alert_Dismissal_Action {
 	/**
 	 * Returns an object with all alerts dismissed by current user.
 	 *
-	 * @return array An array with the keys of all Alerts that have been dismissed by the current user.
+	 * @return array|false An array with the keys of all Alerts that have been dismissed
+	 *                     by the current user or `false`.
 	 */
 	public function all_dismissed() {
 		$user_id = $this->user->get_current_user_id();

--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -60,7 +60,8 @@ abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interf
 	/**
 	 * Returns the total number of unindexed links.
 	 *
-	 * @return int The total number of unindexed links.
+	 * @return int|false The total number of unindexed links or `false` when there
+	 *                   are no unindexes links.
 	 */
 	public function get_total_unindexed() {
 		$transient = \get_transient( static::UNINDEXED_COUNT_TRANSIENT );

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -90,7 +90,7 @@ class Indexable_Author_Builder {
 	 * @param int    $user_id The user to retrieve the indexable for.
 	 * @param string $key     The meta entry to retrieve.
 	 *
-	 * @return string The value of the meta field.
+	 * @return string|null The value of the meta field.
 	 */
 	protected function get_author_meta( $user_id, $key ) {
 		$value = \get_the_author_meta( $key, $user_id );

--- a/src/deprecated/admin/class-social-admin.php
+++ b/src/deprecated/admin/class-social-admin.php
@@ -46,7 +46,7 @@ class WPSEO_Social_Admin extends WPSEO_Metabox {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @return WPSEO_Metabox_Collapsibles_Sections
+	 * @return WPSEO_Metabox_Collapsibles_Sections|null
 	 */
 	public function get_meta_section() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.6' );

--- a/src/deprecated/admin/links/class-link-compatibility-notifier.php
+++ b/src/deprecated/admin/links/class-link-compatibility-notifier.php
@@ -39,7 +39,7 @@ class WPSEO_Link_Compatibility_Notifier {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @return Yoast_Notification The notification.
+	 * @return Yoast_Notification|null The notification.
 	 */
 	protected function get_notification() {
 		_deprecated_function( __METHOD__, 'WPSEO 13.1' );

--- a/src/deprecated/admin/links/class-link-table-accessible-notifier.php
+++ b/src/deprecated/admin/links/class-link-table-accessible-notifier.php
@@ -39,7 +39,7 @@ class WPSEO_Link_Table_Accessible_Notifier {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @return Yoast_Notification The notification.
+	 * @return Yoast_Notification|null The notification.
 	 */
 	protected function get_notification() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.1' );

--- a/src/deprecated/admin/notifiers/class-post-type-archive-notification-handler.php
+++ b/src/deprecated/admin/notifiers/class-post-type-archive-notification-handler.php
@@ -24,8 +24,6 @@ class WPSEO_Post_Type_Archive_Notification_Handler extends WPSEO_Dismissible_Not
 	 *
 	 * @deprecated 14.1
 	 * @codeCoverageIgnore
-	 *
-	 * @return void
 	 */
 	public function __construct() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.1' );
@@ -37,7 +35,7 @@ class WPSEO_Post_Type_Archive_Notification_Handler extends WPSEO_Dismissible_Not
 	 * @deprecated 14.1
 	 * @codeCoverageIgnore
 	 *
-	 * @return Yoast_Notification The notification for the notification center.
+	 * @return Yoast_Notification|null The notification for the notification center.
 	 */
 	protected function get_notification() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.1' );

--- a/src/deprecated/frontend/class-twitter.php
+++ b/src/deprecated/frontend/class-twitter.php
@@ -54,7 +54,7 @@ class WPSEO_Twitter {
 	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
-	 * @return object
+	 * @return object|null
 	 */
 	public static function get_instance() {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );

--- a/src/helpers/author-archive-helper.php
+++ b/src/helpers/author-archive-helper.php
@@ -28,7 +28,7 @@ class Author_Archive_Helper {
 	 *
 	 * @param int $author_id The author ID.
 	 *
-	 * @return bool Whether the author has at least one public post.
+	 * @return bool|null Whether the author has at least one public post.
 	 */
 	public function author_has_public_posts( $author_id ) {
 		// First check if the author has at least one public post.

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -705,7 +705,7 @@ class Indexable_Presentation extends Abstract_Presentation {
 	/**
 	 * Generates the estimated reading time.
 	 *
-	 * @return int The estimated reading time.
+	 * @return int|null The estimated reading time.
 	 *
 	 * @codeCoverageIgnore Wrapper method.
 	 */

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -111,7 +111,7 @@ class Yoast_Head_REST_Field implements Route_Interface {
 	 *
 	 * @param array $params The rest request params.
 	 *
-	 * @return string The head.
+	 * @return string|null The head.
 	 */
 	public function for_post( $params ) {
 		if ( ! isset( $params['id'] ) ) {
@@ -135,7 +135,7 @@ class Yoast_Head_REST_Field implements Route_Interface {
 	 *
 	 * @param array $params The rest request params.
 	 *
-	 * @return string The head.
+	 * @return string|null The head.
 	 */
 	public function for_term( $params ) {
 		$obj = $this->head_action->for_term( $params['id'] );
@@ -152,7 +152,7 @@ class Yoast_Head_REST_Field implements Route_Interface {
 	 *
 	 * @param array $params The rest request params.
 	 *
-	 * @return string The head.
+	 * @return string|null The head.
 	 */
 	public function for_author( $params ) {
 		$obj = $this->head_action->for_author( $params['id'] );
@@ -169,7 +169,7 @@ class Yoast_Head_REST_Field implements Route_Interface {
 	 *
 	 * @param array $params The rest request params.
 	 *
-	 * @return string The head.
+	 * @return string|null The head.
 	 */
 	public function for_post_type_archive( $params ) {
 		if ( $params['slug'] === 'post' ) {


### PR DESCRIPTION
## Context

* Documentation improvements

## Summary

This PR can be summarized in the following changelog entry:

* Documentation improvements

## Relevant technical choices:

All types which can be returned should be listed in the `@return` tag.




## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.
