### PR TITLE
Docs: fix incorrect param types

### DIFF
--- a/admin/class-admin-asset-dev-server-location.php
+++ b/admin/class-admin-asset-dev-server-location.php
@@ -27,7 +27,7 @@ final class WPSEO_Admin_Asset_Dev_Server_Location implements WPSEO_Admin_Asset_L
 	/**
 	 * Class constructor.
 	 *
-	 * @param string $url Where the dev server is located.
+	 * @param string|null $url Where the dev server is located.
 	 */
 	public function __construct( $url = null ) {
 		if ( $url === null ) {

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -37,8 +37,8 @@ class WPSEO_Admin_Asset_Manager {
 	/**
 	 * Constructs a manager of assets. Needs a location to know where to register assets at.
 	 *
-	 * @param WPSEO_Admin_Asset_Location $asset_location The provider of the asset location.
-	 * @param string                     $prefix         The prefix for naming assets.
+	 * @param WPSEO_Admin_Asset_Location|null $asset_location The provider of the asset location.
+	 * @param string                          $prefix         The prefix for naming assets.
 	 */
 	public function __construct( WPSEO_Admin_Asset_Location $asset_location = null, $prefix = self::PREFIX ) {
 		if ( $asset_location === null ) {

--- a/admin/class-customizer.php
+++ b/admin/class-customizer.php
@@ -199,13 +199,13 @@ class WPSEO_Customizer {
 	/**
 	 * Adds the customizer setting and control.
 	 *
-	 * @param string $index           Array key index to use for the customizer setting.
-	 * @param array  $control_args    Customizer control object arguments.
-	 *                                Only those different from the default need to be passed.
-	 * @param string $id              Optional. Customizer control object ID.
-	 *                                Will default to 'wpseo-' . $index.
-	 * @param array  $custom_settings Optional. Customizer setting arguments.
-	 *                                Only those different from the default need to be passed.
+	 * @param string      $index           Array key index to use for the customizer setting.
+	 * @param array       $control_args    Customizer control object arguments.
+	 *                                     Only those different from the default need to be passed.
+	 * @param string|null $id              Optional. Customizer control object ID.
+	 *                                     Will default to 'wpseo-' . $index.
+	 * @param array       $custom_settings Optional. Customizer setting arguments.
+	 *                                     Only those different from the default need to be passed.
 	 */
 	private function add_setting_and_control( $index, $control_args, $id = null, $custom_settings = [] ) {
 		$setting                  = sprintf( $this->setting_template, $index );

--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -113,10 +113,10 @@ class WPSEO_Database_Proxy {
 	 *
 	 * Performs an insert into and if key is duplicate it will update the existing record.
 	 *
-	 * @param array $data         Data to update on the table.
-	 * @param array $where        Unused. Where condition as key => value array.
-	 * @param null  $format       Optional. Data prepare format.
-	 * @param null  $where_format Deprecated. Where prepare format.
+	 * @param array      $data         Data to update on the table.
+	 * @param array|null $where        Unused. Where condition as key => value array.
+	 * @param null       $format       Optional. Data prepare format.
+	 * @param null       $where_format Deprecated. Where prepare format.
 	 *
 	 * @return false|int False when the upsert request is invalid, int on number of rows changed.
 	 */

--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -697,7 +697,7 @@ class WPSEO_Meta_Columns {
 	 *
 	 * @since 7.0
 	 *
-	 * @param string $post_type Optional. The post type to test, defaults to the current post post_type.
+	 * @param string|null $post_type Optional. The post type to test, defaults to the current post post_type.
 	 *
 	 * @return bool Whether or not the meta box (and associated columns etc) should be hidden.
 	 */

--- a/admin/class-paper-presenter.php
+++ b/admin/class-paper-presenter.php
@@ -34,10 +34,10 @@ class WPSEO_Paper_Presenter {
 	/**
 	 * WPSEO_presenter_paper constructor.
 	 *
-	 * @param string $title     The title of the paper.
-	 * @param string $view_file Optional. The path to the view file. Use the content setting if you do not wish to use
-	 *                          a view file.
-	 * @param array  $settings  Optional. Settings for the paper.
+	 * @param string      $title     The title of the paper.
+	 * @param string|null $view_file Optional. The path to the view file. Use the content setting
+	 *                               if do not wish to use a view file.
+	 * @param array       $settings  Optional. Settings for the paper.
 	 */
 	public function __construct( $title, $view_file = null, array $settings = [] ) {
 		$defaults = [

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -169,7 +169,7 @@ class WPSEO_Primary_Term_Admin implements WPSEO_WordPress_Integration {
 	/**
 	 * Returns all the taxonomies for which the primary term selection is enabled.
 	 *
-	 * @param int $post_id Default current post ID.
+	 * @param int|null $post_id Default current post ID.
 	 * @return array
 	 */
 	protected function get_primary_term_taxonomies( $post_id = null ) {

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -909,8 +909,8 @@ class Yoast_Form {
 	/**
 	 * Retrieves the value for the form field.
 	 *
-	 * @param string $field_name    The field name to retrieve the value for.
-	 * @param string $default_value The default value, when field has no value.
+	 * @param string      $field_name    The field name to retrieve the value for.
+	 * @param string|null $default_value The default value, when field has no value.
 	 *
 	 * @return mixed|null The retrieved value.
 	 */

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -149,8 +149,8 @@ class Yoast_Notification_Center {
 	/**
 	 * Checks if the notification is being dismissed.
 	 *
-	 * @param string|Yoast_Notification $notification Notification to check dismissal of.
-	 * @param string                    $meta_value   Value to set the meta value to if dismissed.
+	 * @param Yoast_Notification $notification Notification to check dismissal of.
+	 * @param string             $meta_value   Value to set the meta value to if dismissed.
 	 *
 	 * @return bool True if dismissed.
 	 */
@@ -326,8 +326,8 @@ class Yoast_Notification_Center {
 	/**
 	 * Get the notification by ID and user ID.
 	 *
-	 * @param string $notification_id The ID of the notification to search for.
-	 * @param int    $user_id         The ID of the user.
+	 * @param string   $notification_id The ID of the notification to search for.
+	 * @param int|null $user_id         The ID of the user.
 	 *
 	 * @return Yoast_Notification|null
 	 */

--- a/admin/menu/class-base-menu.php
+++ b/admin/menu/class-base-menu.php
@@ -36,10 +36,10 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * Creates a submenu formatted array.
 	 *
-	 * @param string     $page_title Page title to use.
-	 * @param string     $page_slug  Page slug to use.
-	 * @param callable   $callback   Optional. Callback which handles the page request.
-	 * @param callable[] $hook       Optional. Hook to trigger when the page is registered.
+	 * @param string          $page_title Page title to use.
+	 * @param string          $page_slug  Page slug to use.
+	 * @param callable|null   $callback   Optional. Callback which handles the page request.
+	 * @param callable[]|null $hook       Optional. Hook to trigger when the page is registered.
 	 *
 	 * @return array Formatted submenu.
 	 */

--- a/admin/taxonomy/class-taxonomy-columns.php
+++ b/admin/taxonomy/class-taxonomy-columns.php
@@ -237,7 +237,7 @@ class WPSEO_Taxonomy_Columns {
 	 *
 	 * @since 7.0
 	 *
-	 * @param string $taxonomy Optional. The taxonomy to test, defaults to the current taxonomy.
+	 * @param string|null $taxonomy Optional. The taxonomy to test, defaults to the current taxonomy.
 	 *
 	 * @return bool Whether or not the meta box (and associated columns etc) should be hidden.
 	 */

--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -65,10 +65,10 @@ class Custom_Loader extends PhpFileLoader {
 	/**
 	 * Registers a set of classes as services using PSR-4 for discovery.
 	 *
-	 * @param Definition $prototype A definition to use as template.
-	 * @param string     $namespace The namespace prefix of classes in the scanned directory.
-	 * @param string     $resource  The directory to look for classes, glob-patterns allowed.
-	 * @param string     $exclude   A globed path of files to exclude.
+	 * @param Definition  $prototype A definition to use as template.
+	 * @param string      $namespace The namespace prefix of classes in the scanned directory.
+	 * @param string      $resource  The directory to look for classes, glob-patterns allowed.
+	 * @param string|null $exclude   A globed path of files to exclude.
 	 *
 	 * @throws InvalidArgumentException If invalid arguments are supplied.
 	 *

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -129,7 +129,7 @@ class WPSEO_Upgrade {
 	/**
 	 * Runs the needed cleanup after an update, setting the DB version to latest version, flushing caches etc.
 	 *
-	 * @param string $previous_version The previous version.
+	 * @param string|null $previous_version The previous version.
 	 *
 	 * @return void
 	 */

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -57,7 +57,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 *
 	 * Sets the asset manager to use.
 	 *
-	 * @param WPSEO_Admin_Asset_Manager $asset_manager Optional. Asset manager to use.
+	 * @param WPSEO_Admin_Asset_Manager|null $asset_manager Optional. Asset manager to use.
 	 */
 	public function __construct( WPSEO_Admin_Asset_Manager $asset_manager = null ) {
 		if ( ! $asset_manager ) {

--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -13,8 +13,8 @@ class WPSEO_Content_Images {
 	/**
 	 * Retrieves images from the post content.
 	 *
-	 * @param int      $post_id The post ID.
-	 * @param \WP_Post $post    The post object.
+	 * @param int           $post_id The post ID.
+	 * @param \WP_Post|null $post    The post object.
 	 *
 	 * @return array An array of images found in this post.
 	 */

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -398,7 +398,7 @@ class WPSEO_Image_Utils {
 	/**
 	 * Gets the post's first usable content image. Null if none is available.
 	 *
-	 * @param int $post_id The post id.
+	 * @param int|null $post_id The post id.
 	 *
 	 * @return string|null The image URL.
 	 */

--- a/inc/language-utils.php
+++ b/inc/language-utils.php
@@ -15,7 +15,7 @@ class WPSEO_Language_Utils {
 	/**
 	 * Returns the language part of a given locale, defaults to english when the $locale is empty.
 	 *
-	 * @param string $locale The locale to get the language of.
+	 * @param string|null $locale The locale to get the language of.
 	 *
 	 * @return string The language part of the locale.
 	 */

--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -211,12 +211,12 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	/**
 	 * Clean a given option value.
 	 *
-	 * @param array  $option_value          Old (not merged with defaults or filtered) option value to
-	 *                                      clean according to the rules for this option.
-	 * @param string $current_version       Optional. Version from which to upgrade, if not set,
-	 *                                      version specific upgrades will be disregarded.
-	 * @param array  $all_old_option_values Optional. Only used when importing old options to have
-	 *                                      access to the real old values, in contrast to the saved ones.
+	 * @param array       $option_value          Old (not merged with defaults or filtered) option value to
+	 *                                           clean according to the rules for this option.
+	 * @param string|null $current_version       Optional. Version from which to upgrade, if not set,
+	 *                                           version specific upgrades will be disregarded.
+	 * @param array|null  $all_old_option_values Optional. Only used when importing old options to have
+	 *                                           access to the real old values, in contrast to the saved ones.
 	 *
 	 * @return array Cleaned option.
 	 */

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -700,12 +700,12 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	/**
 	 * Clean a given option value.
 	 *
-	 * @param array  $option_value          Old (not merged with defaults or filtered) option value to
-	 *                                      clean according to the rules for this option.
-	 * @param string $current_version       Optional. Version from which to upgrade, if not set,
-	 *                                      version specific upgrades will be disregarded.
-	 * @param array  $all_old_option_values Optional. Only used when importing old options to have
-	 *                                      access to the real old values, in contrast to the saved ones.
+	 * @param array       $option_value          Old (not merged with defaults or filtered) option value to
+	 *                                           clean according to the rules for this option.
+	 * @param string|null $current_version       Optional. Version from which to upgrade, if not set,
+	 *                                           version specific upgrades will be disregarded.
+	 * @param array|null  $all_old_option_values Optional. Only used when importing old options to have
+	 *                                           access to the real old values, in contrast to the saved ones.
 	 *
 	 * @return array Cleaned option.
 	 */

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -448,12 +448,12 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 	/**
 	 * Clean a given option value.
 	 *
-	 * @param array  $option_value          Old (not merged with defaults or filtered) option value to
-	 *                                      clean according to the rules for this option.
-	 * @param string $current_version       Optional. Version from which to upgrade, if not set,
-	 *                                      version specific upgrades will be disregarded.
-	 * @param array  $all_old_option_values Optional. Only used when importing old options to have
-	 *                                      access to the real old values, in contrast to the saved ones.
+	 * @param array       $option_value          Old (not merged with defaults or filtered) option value to
+	 *                                           clean according to the rules for this option.
+	 * @param string|null $current_version       Optional. Version from which to upgrade, if not set,
+	 *                                           version specific upgrades will be disregarded.
+	 * @param array|null  $all_old_option_values Optional. Only used when importing old options to have
+	 *                                           access to the real old values, in contrast to the saved ones.
 	 *
 	 * @return array Cleaned option.
 	 */

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -736,8 +736,8 @@ abstract class WPSEO_Option {
 	 * @uses WPSEO_Option::get_original_option()
 	 * @uses WPSEO_Option::import()
 	 *
-	 * @param string $current_version Optional. Version from which to upgrade, if not set,
-	 *                                version specific upgrades will be disregarded.
+	 * @param string|null $current_version Optional. Version from which to upgrade, if not set,
+	 *                                     version specific upgrades will be disregarded.
 	 *
 	 * @return void
 	 */
@@ -760,12 +760,12 @@ abstract class WPSEO_Option {
 	 *    once the admin has dismissed the message (add ajax function)
 	 * Important: all validation routines which add_settings_errors would need to be changed for this to work
 	 *
-	 * @param array  $option_value          Option value to be imported.
-	 * @param string $current_version       Optional. Version from which to upgrade, if not set,
-	 *                                      version specific upgrades will be disregarded.
-	 * @param array  $all_old_option_values Optional. Only used when importing old options to
-	 *                                      have access to the real old values, in contrast to
-	 *                                      the saved ones.
+	 * @param array       $option_value          Option value to be imported.
+	 * @param string|null $current_version       Optional. Version from which to upgrade, if not set,
+	 *                                           version specific upgrades will be disregarded.
+	 * @param array|null  $all_old_option_values Optional. Only used when importing old options to
+	 *                                           have access to the real old values, in contrast to
+	 *                                           the saved ones.
 	 *
 	 * @return void
 	 */
@@ -825,8 +825,8 @@ abstract class WPSEO_Option {
 	 * @todo [JRF] - shouldn't this be a straight array merge ? at the end of the day, the validation
 	 * removes any invalid keys on save.
 	 *
-	 * @param array $options Optional. Current options. If not set, the option defaults
-	 *                       for the $option_key will be returned.
+	 * @param array|null $options Optional. Current options. If not set, the option defaults
+	 *                            for the $option_key will be returned.
 	 *
 	 * @return array Combined and filtered options array.
 	 */

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -345,11 +345,11 @@ class WPSEO_Options {
 	/**
 	 * Run the clean up routine for one or all options.
 	 *
-	 * @param array|string $option_name     Optional. the option you want to clean or an array of
-	 *                                      option names for the options you want to clean.
-	 *                                      If not set, all options will be cleaned.
-	 * @param string       $current_version Optional. Version from which to upgrade, if not set,
-	 *                                      version specific upgrades will be disregarded.
+	 * @param array|string|null $option_name     Optional. the option you want to clean or an array of
+	 *                                           option names for the options you want to clean.
+	 *                                           If not set, all options will be cleaned.
+	 * @param string|null       $current_version Optional. Version from which to upgrade, if not set,
+	 *                                           version specific upgrades will be disregarded.
 	 *
 	 * @return void
 	 */

--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -302,12 +302,12 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 * - Convert old option values to new
 	 * - Fixes strings which were escaped (should have been sanitized - escaping is for output)
 	 *
-	 * @param array  $option_value          Old (not merged with defaults or filtered) option value to
-	 *                                      clean according to the rules for this option.
-	 * @param string $current_version       Optional. Version from which to upgrade, if not set,
-	 *                                      version specific upgrades will be disregarded.
-	 * @param array  $all_old_option_values Optional. Only used when importing old options to have
-	 *                                      access to the real old values, in contrast to the saved ones.
+	 * @param array       $option_value          Old (not merged with defaults or filtered) option value to
+	 *                                           clean according to the rules for this option.
+	 * @param string|null $current_version       Optional. Version from which to upgrade, if not set,
+	 *                                           version specific upgrades will be disregarded.
+	 * @param array|null  $all_old_option_values Optional. Only used when importing old options to have
+	 *                                           access to the real old values, in contrast to the saved ones.
 	 *
 	 * @return array Cleaned option.
 	 */
@@ -373,10 +373,10 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	/**
 	 * Retrieve a taxonomy term's meta value(s).
 	 *
-	 * @param mixed  $term     Term to get the meta value for
-	 *                         either (string) term name, (int) term id or (object) term.
-	 * @param string $taxonomy Name of the taxonomy to which the term is attached.
-	 * @param string $meta     Optional. Meta value to get (without prefix).
+	 * @param mixed       $term     Term to get the meta value for
+	 *                              either (string) term name, (int) term id or (object) term.
+	 * @param string      $taxonomy Name of the taxonomy to which the term is attached.
+	 * @param string|null $meta     Optional. Meta value to get (without prefix).
 	 *
 	 * @return mixed|bool Value for the $meta if one is given, might be the default.
 	 *                    If no meta is given, an array of all the meta data for the term.

--- a/lib/migrations/adapter.php
+++ b/lib/migrations/adapter.php
@@ -176,9 +176,9 @@ class Adapter {
 	/**
 	 * Return the SQL definition of a column.
 	 *
-	 * @param string $column_name The column name.
-	 * @param string $type        The type of the column.
-	 * @param array  $options     Column options.
+	 * @param string     $column_name The column name.
+	 * @param string     $type        The type of the column.
+	 * @param array|null $options     Column options.
 	 *
 	 * @return string
 	 */

--- a/lib/migrations/migration.php
+++ b/lib/migrations/migration.php
@@ -71,8 +71,8 @@ abstract class Migration {
 	/**
 	 * Creates a database.
 	 *
-	 * @param string $name    The name of the database.
-	 * @param array  $options The options.
+	 * @param string     $name    The name of the database.
+	 * @param array|null $options The options.
 	 *
 	 * @return bool
 	 */

--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -122,8 +122,8 @@ class Index_Command implements Command_Interface {
 	 *
 	 * @when after_wp_load
 	 *
-	 * @param array $args       The arguments.
-	 * @param array $assoc_args The associative arguments.
+	 * @param array|null $args       The arguments.
+	 * @param array|null $assoc_args The associative arguments.
 	 *
 	 * @return void
 	 */

--- a/src/config/badge-group-names.php
+++ b/src/config/badge-group-names.php
@@ -29,7 +29,7 @@ class Badge_Group_Names {
 	/**
 	 * Badge_Group_Names constructor.
 	 *
-	 * @param string $version Optional: the current plugin version.
+	 * @param string|null $version Optional: the current plugin version.
 	 */
 	public function __construct( $version = null ) {
 		if ( ! $version ) {
@@ -41,8 +41,8 @@ class Badge_Group_Names {
 	/**
 	 * Check whether a group of badges is still eligible for a "new" badge.
 	 *
-	 * @param string $group           One of the GROUP_* constants.
-	 * @param string $current_version The current version of the plugin that's being checked.
+	 * @param string      $group           One of the GROUP_* constants.
+	 * @param string|null $current_version The current version of the plugin that's being checked.
 	 *
 	 * @return bool Whether a group of badges is still eligible for a "new" badge.
 	 */

--- a/src/deprecated/admin/extension-manager.php
+++ b/src/deprecated/admin/extension-manager.php
@@ -21,8 +21,8 @@ class WPSEO_Extension_Manager {
 	 * @deprecated 15.4
 	 * @codeCoverageIgnore
 	 *
-	 * @param string          $extension_name The extension name.
-	 * @param WPSEO_Extension $extension      The extension value object.
+	 * @param string               $extension_name The extension name.
+	 * @param WPSEO_Extension|null $extension      The extension value object.
 	 *
 	 * @return void
 	 */

--- a/src/deprecated/frontend/class-opengraph-image.php
+++ b/src/deprecated/frontend/class-opengraph-image.php
@@ -29,8 +29,8 @@ class WPSEO_OpenGraph_Image extends Images {
 	 * @deprecated 14.0
 	 * @codeCoverageIgnore
 	 *
-	 * @param string|null     $image     Optional. The Image to use.
-	 * @param WPSEO_OpenGraph $opengraph Optional. The OpenGraph object.
+	 * @param string|null          $image     Optional. The Image to use.
+	 * @param WPSEO_OpenGraph|null $opengraph Optional. The OpenGraph object.
 	 */
 	public function __construct( $image = null, WPSEO_OpenGraph $opengraph = null ) {
 		_deprecated_function( __METHOD__, 'WPSEO 14.0' );

--- a/src/deprecated/frontend/class-primary-category.php
+++ b/src/deprecated/frontend/class-primary-category.php
@@ -22,9 +22,9 @@ class WPSEO_Frontend_Primary_Category implements WPSEO_WordPress_Integration {
 	/**
 	 * Filters post_link_category to change the category to the chosen category by the user.
 	 *
-	 * @param stdClass $category   The category that is now used for the post link.
-	 * @param array    $categories This parameter is not used.
-	 * @param WP_Post  $post       The post in question.
+	 * @param stdClass     $category   The category that is now used for the post link.
+	 * @param array|null   $categories This parameter is not used.
+	 * @param WP_Post|null $post       The post in question.
 	 *
 	 * @codeCoverageIgnore
 	 * @deprecated 14.0

--- a/src/deprecated/frontend/schema/class-schema-article.php
+++ b/src/deprecated/frontend/schema/class-schema-article.php
@@ -26,7 +26,7 @@ class WPSEO_Schema_Article extends WPSEO_Deprecated_Graph_Piece {
 	/**
 	 * WPSEO_Schema_Article constructor.
 	 *
-	 * @param array $context The context. No longer used but present for BC.
+	 * @param array|null $context The context. No longer used but present for BC.
 	 *
 	 * @codeCoverageIgnore
 	 * @deprecated 14.0
@@ -43,7 +43,7 @@ class WPSEO_Schema_Article extends WPSEO_Deprecated_Graph_Piece {
 	 * @codeCoverageIgnore
 	 * @deprecated 14.0
 	 *
-	 * @param string $post_type Post type to check.
+	 * @param string|null $post_type Post type to check.
 	 *
 	 * @return bool True if it has article schema, false if not.
 	 */

--- a/src/helpers/indexable-helper.php
+++ b/src/helpers/indexable-helper.php
@@ -111,7 +111,7 @@ class Indexable_Helper {
 	/**
 	 * Resets the permalinks of the indexables.
 	 *
-	 * @param string      $type    The type of the indexable.
+	 * @param string|null $type    The type of the indexable.
 	 * @param string|null $subtype The subtype. Can be null.
 	 * @param string      $reason  The reason that the permalink has been changed.
 	 */

--- a/src/helpers/meta-helper.php
+++ b/src/helpers/meta-helper.php
@@ -39,10 +39,10 @@ class Meta_Helper {
 	/**
 	 * Retrieve a taxonomy term's meta value(s).
 	 *
-	 * @param mixed  $term     Term to get the meta value for
-	 *                         either (string) term name, (int) term id or (object) term.
-	 * @param string $taxonomy Name of the taxonomy to which the term is attached.
-	 * @param string $meta     Optional. Meta value to get (without prefix).
+	 * @param mixed       $term     Term to get the meta value for
+	 *                              either (string) term name, (int) term id or (object) term.
+	 * @param string      $taxonomy Name of the taxonomy to which the term is attached.
+	 * @param string|null $meta     Optional. Meta value to get (without prefix).
 	 *
 	 * @return mixed|bool Value for the $meta if one is given, might be the default.
 	 *                    If no meta is given, an array of all the meta data for the term.

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -75,7 +75,7 @@ class Post_Helper {
 	/**
 	 * Retrieves the post type of the current post.
 	 *
-	 * @param WP_Post $post The post.
+	 * @param WP_Post|null $post The post.
 	 *
 	 * @codeCoverageIgnore It only wraps a WordPress function.
 	 *

--- a/src/helpers/schema/article-helper.php
+++ b/src/helpers/schema/article-helper.php
@@ -10,7 +10,7 @@ class Article_Helper {
 	/**
 	 * Determines whether a given post type should have Article schema.
 	 *
-	 * @param string $post_type Post type to check.
+	 * @param string|null $post_type Post type to check.
 	 *
 	 * @return bool True if it has Article schema, false if not.
 	 */

--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -109,7 +109,7 @@ class Url_Helper {
 	/**
 	 * Parse the home URL setting to find the base URL for relative URLs.
 	 *
-	 * @param string $path Optional path string.
+	 * @param string|null $path Optional path string.
 	 *
 	 * @return string
 	 */
@@ -129,9 +129,9 @@ class Url_Helper {
 	/**
 	 * Returns the link type.
 	 *
-	 * @param array $url      The URL, as parsed by wp_parse_url.
-	 * @param array $home_url Optional. The home URL, as parsed by wp_parse_url. Used to avoid reparsing the home_url.
-	 * @param bool  $is_image Whether or not the link is an image.
+	 * @param array      $url      The URL, as parsed by wp_parse_url.
+	 * @param array|null $home_url Optional. The home URL, as parsed by wp_parse_url. Used to avoid reparsing the home_url.
+	 * @param bool       $is_image Whether or not the link is an image.
 	 *
 	 * @return string The link type.
 	 */

--- a/src/integrations/primary-category.php
+++ b/src/integrations/primary-category.php
@@ -36,9 +36,9 @@ class Primary_Category implements Integration_Interface {
 	/**
 	 * Filters post_link_category to change the category to the chosen category by the user.
 	 *
-	 * @param stdClass $category   The category that is now used for the post link.
-	 * @param array    $categories This parameter is not used.
-	 * @param WP_Post  $post       The post in question.
+	 * @param stdClass     $category   The category that is now used for the post link.
+	 * @param array|null   $categories This parameter is not used.
+	 * @param WP_Post|null $post       The post in question.
 	 *
 	 * @return array|object|WP_Error|null The category we want to use for the post link.
 	 */

--- a/src/integrations/third-party/woocommerce.php
+++ b/src/integrations/third-party/woocommerce.php
@@ -170,8 +170,8 @@ class WooCommerce implements Integration_Interface {
 	/**
 	 * Handles the title.
 	 *
-	 * @param string                 $title        The title.
-	 * @param Indexable_Presentation $presentation The indexable presentation.
+	 * @param string                      $title        The title.
+	 * @param Indexable_Presentation|null $presentation The indexable presentation.
 	 *
 	 * @return string The title to use.
 	 */
@@ -206,8 +206,8 @@ class WooCommerce implements Integration_Interface {
 	/**
 	 * Handles the meta description.
 	 *
-	 * @param string                 $description  The title.
-	 * @param Indexable_Presentation $presentation The indexable presentation.
+	 * @param string                      $description  The title.
+	 * @param Indexable_Presentation|null $presentation The indexable presentation.
 	 *
 	 * @return string The description to use.
 	 */

--- a/src/memoizers/meta-tags-context-memoizer.php
+++ b/src/memoizers/meta-tags-context-memoizer.php
@@ -132,7 +132,7 @@ class Meta_Tags_Context_Memoizer {
 	/**
 	 * Clears the memoization of either a specific indexable or all indexables.
 	 *
-	 * @param Indexable|int|string $indexable Optional. The indexable or indexable id to clear the memoization of.
+	 * @param Indexable|int|string|null $indexable Optional. The indexable or indexable id to clear the memoization of.
 	 */
 	public function clear( $indexable = null ) {
 		if ( $indexable instanceof Indexable ) {

--- a/src/memoizers/presentation-memoizer.php
+++ b/src/memoizers/presentation-memoizer.php
@@ -69,7 +69,7 @@ class Presentation_Memoizer {
 	/**
 	 * Clears the memoization of either a specific indexable or all indexables.
 	 *
-	 * @param Indexable|int $indexable Optional. The indexable or indexable id to clear the memoization of.
+	 * @param Indexable|int|null $indexable Optional. The indexable or indexable id to clear the memoization of.
 	 */
 	public function clear( $indexable = null ) {
 		if ( $indexable instanceof Indexable ) {

--- a/src/presentations/indexable-author-archive-presentation.php
+++ b/src/presentations/indexable-author-archive-presentation.php
@@ -31,7 +31,8 @@ class Indexable_Author_Archive_Presentation extends Indexable_Presentation {
 	/**
 	 * Indexable_Author_Archive_Presentation constructor.
 	 *
-	 * @param Post_Type_Helper $post_type The post type helper.
+	 * @param Post_Type_Helper      $post_type      The post type helper.
+	 * @param Author_Archive_Helper $author_archive The author archive helper.
 	 *
 	 * @codeCoverageIgnore
 	 */

--- a/src/presenters/admin/badge-presenter.php
+++ b/src/presenters/admin/badge-presenter.php
@@ -53,10 +53,10 @@ class Badge_Presenter extends Abstract_Presenter {
 	/**
 	 * Badge_Presenter constructor.
 	 *
-	 * @param string            $id                Id of the badge.
-	 * @param string            $link              Optional link of the badge.
-	 * @param string            $group             Optional group which the badge belongs to.
-	 * @param Badge_Group_Names $badge_group_names Optional object storing the group names.
+	 * @param string                 $id                Id of the badge.
+	 * @param string                 $link              Optional link of the badge.
+	 * @param string                 $group             Optional group which the badge belongs to.
+	 * @param Badge_Group_Names|null $badge_group_names Optional object storing the group names.
 	 */
 	public function __construct( $id, $link = '', $group = '', $badge_group_names = null ) {
 		$this->id    = $id;

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -513,7 +513,7 @@ class Indexable_Repository {
 	/**
 	 * Resets the permalinks of the passed object type and subtype.
 	 *
-	 * @param string      $type    The type of the indexable. Can be null.
+	 * @param string|null $type    The type of the indexable. Can be null.
 	 * @param string|null $subtype The subtype. Can be null.
 	 *
 	 * @return int|bool The number of permalinks changed if the query was succesful. False otherwise.

--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -141,7 +141,7 @@ class Meta_Surface {
 	/**
 	 * Returns the meta tags context for a post type archive.
 	 *
-	 * @param string $post_type Optional. The post type to get the archive meta for. Defaults to the current post type.
+	 * @param string|null $post_type Optional. The post type to get the archive meta for. Defaults to the current post type.
 	 *
 	 * @return Meta|false The meta values. False if none could be found.
 	 */
@@ -266,8 +266,8 @@ class Meta_Surface {
 	/**
 	 * Returns the meta for an indexable.
 	 *
-	 * @param Indexable $indexable The indexable.
-	 * @param string    $page_type Optional. The page type if already known.
+	 * @param Indexable   $indexable The indexable.
+	 * @param string|null $page_type Optional. The page type if already known.
 	 *
 	 * @return Meta|false The meta values. False if none could be found.
 	 */
@@ -283,7 +283,7 @@ class Meta_Surface {
 	 * Returns the meta for an indexable.
 	 *
 	 * @param Indexable[] $indexables The indexables.
-	 * @param string      $page_type  Optional. The page type if already known.
+	 * @param string|null $page_type  Optional. The page type if already known.
 	 *
 	 * @return Meta|false The meta values. False if none could be found.
 	 */

--- a/tests/integration/doubles/class-upgrade-double.php
+++ b/tests/integration/doubles/class-upgrade-double.php
@@ -55,7 +55,7 @@ class WPSEO_Upgrade_Double extends WPSEO_Upgrade {
 	/**
 	 * Test double. Runs the needed cleanup after an update, setting the DB version to latest version, flushing caches etc.
 	 *
-	 * @param string $previous_version The previous version.
+	 * @param string|null $previous_version The previous version.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
## Context

* Documentation improvements

## Summary

This PR can be summarized in the following changelog entry:

* Documentation improvements

## Relevant technical choices:

### Docs: fix missing/incorrect types in @param tags

All types which are accepted should be listed in the `@param` tag.

### Docs: add missing param tag 



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.
