### PR TITLE
Docs: various minor tweaks

### DIFF
--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -93,7 +93,7 @@ class WPSEO_Database_Proxy {
 	 *
 	 * @param array $data         Data to update on the table.
 	 * @param array $where        Where condition as key => value array.
-	 * @param null  $format       Optional. data prepare format.
+	 * @param null  $format       Optional. Data prepare format.
 	 * @param null  $where_format Optional. Where prepare format.
 	 *
 	 * @return false|int False when the update request is invalid, int on number of rows changed.

--- a/admin/config-ui/class-configuration-page.php
+++ b/admin/config-ui/class-configuration-page.php
@@ -54,7 +54,7 @@ class WPSEO_Configuration_Page {
 	}
 
 	/**
-	 *  Registers the page for the wizard.
+	 * Registers the page for the wizard.
 	 */
 	public function add_wizard_page() {
 		add_dashboard_page( '', '', 'wpseo_manage_options', self::PAGE_IDENTIFIER, '' );

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -252,7 +252,7 @@ class WPSEO_Metabox_Formatter {
 		try {
 			$semrush_client = YoastSEO()->classes->get( SEMrush_Client::class );
 		} catch ( Empty_Property_Exception $e ) {
-			// return false if token is malformed (empty property).
+			// Return false if token is malformed (empty property).
 			return false;
 		}
 

--- a/admin/import/plugins/class-import-jetpack.php
+++ b/admin/import/plugins/class-import-jetpack.php
@@ -27,7 +27,7 @@ class WPSEO_Import_Jetpack_SEO extends WPSEO_Plugin_Importer {
 	protected $meta_key = 'advanced_seo_description';
 
 	/**
-	 *  Array of meta keys to detect and import.
+	 * Array of meta keys to detect and import.
 	 *
 	 * @var array
 	 */

--- a/admin/views/tabs/dashboard/webmaster-tools.php
+++ b/admin/views/tabs/dashboard/webmaster-tools.php
@@ -42,6 +42,7 @@ echo '<p class="desc label">';
 printf(
 	/* translators: %1$s expands to a link start tag to the Baidu Webmaster Tools site add page, %2$s is the link closing tag. */
 	esc_html__( 'Get your Baidu verification code in %1$sBaidu Webmaster Tools%2$s.', 'wordpress-seo' ),
+
 	/*
 	 * Get the Baidu Webmaster Tools site add link from this 3rd party article.
 	 * {@link http://www.dragonmetrics.com/how-to-optimize-your-site-with-baidu-webmaster-tools/}

--- a/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
+++ b/admin/views/tabs/metas/paper-content/general/knowledge-graph.php
@@ -30,6 +30,7 @@ $knowledge_graph_help = new WPSEO_Admin_Help_Panel(
 	<?php
 	// phpcs:ignore WordPress.Security.EscapeOutput -- get_panel_html() output is properly escaped.
 	echo $knowledge_graph_help->get_panel_html();
+
 	/**
 	 * Filter: 'wpseo_knowledge_graph_setting_msg' - Allows adding a message above these settings.
 	 *

--- a/config/dependency-injection/interface-injection-pass.php
+++ b/config/dependency-injection/interface-injection-pass.php
@@ -104,7 +104,7 @@ class Interface_Injection_Pass implements CompilerPassInterface {
 		$constructor_arguments = $class_constructor->getParameters();
 		$splat_argument        = \end( $constructor_arguments );
 
-		// isVariadic means "is it a 'splat' argument".
+		// The isVariadic check means "is it a 'splat' argument".
 		if ( ! $splat_argument || ! $splat_argument->isVariadic() ) {
 			return null;
 		}

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -55,7 +55,7 @@ class WPSEO_Upgrade {
 			'9.0-RC0'    => 'upgrade_90',
 			'10.0-RC0'   => 'upgrade_100',
 			'11.1-RC0'   => 'upgrade_111',
-			/** Reset notifications because we removed the AMP Glue plugin notification */
+			// Reset notifications because we removed the AMP Glue plugin notification.
 			'12.1-RC0'   => 'clean_all_notifications',
 			'12.3-RC0'   => 'upgrade_123',
 			'12.4-RC0'   => 'upgrade_124',

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -275,11 +275,13 @@ class WPSEO_Replace_Vars {
 			elseif ( strpos( $var, 'ct_' ) === 0 ) {
 				$single      = ( isset( $matches[2][ $k ] ) && $matches[2][ $k ] !== '' );
 				$replacement = $this->retrieve_ct_custom_tax_name( $var, $single );
-			} // Deal with non-variable variable names.
+			}
+			// Deal with non-variable variable names.
 			elseif ( method_exists( $this, 'retrieve_' . $var ) ) {
 				$method_name = 'retrieve_' . $var;
 				$replacement = $this->$method_name();
-			} // Deal with externally defined variable names.
+			}
+			// Deal with externally defined variable names.
 			elseif ( isset( self::$external_replacements[ $var ] ) && ! is_null( self::$external_replacements[ $var ] ) ) {
 				$replacement = call_user_func( self::$external_replacements[ $var ], $var, $this->args );
 			}

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -43,7 +43,6 @@ class WPSEO_Utils {
 		 *
 		 * @api bool $allowed Whether file editing is allowed.
 		 */
-
 		return apply_filters( 'wpseo_allow_system_file_edit', $allowed );
 	}
 

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -93,7 +93,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		'og_frontpage_image'               => '', // Text field.
 		'og_frontpage_image_id'            => 0,
 
-		/**
+		/*
 		 * Uses enrich_defaults to add more along the lines of:
 		 * - 'title-' . $pt->name                => ''; // Text field.
 		 * - 'metadesc-' . $pt->name             => ''; // Text field.

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -439,6 +439,7 @@ abstract class WPSEO_Option {
 			$url = 'https://graph.facebook.com/' . $dirty[ $key ];
 
 			$response = wp_remote_get( $url );
+
 			/**
 			 * Filter: 'validate_facebook_app_id_api_response_code' - Allows to filter the Faceboook API response code.
 			 *
@@ -447,6 +448,7 @@ abstract class WPSEO_Option {
 			 * @api int $response_code The Facebook API response header code.
 			 */
 			$response_code = apply_filters_deprecated( 'validate_facebook_app_id_api_response_code', wp_remote_retrieve_response_code( $response ), 'WPSEO 15.5' );
+
 			/**
 			 * Filter: 'validate_facebook_app_id_api_response_body' - Allows to filter the Faceboook API response body.
 			 *

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -327,11 +327,11 @@ class WPSEO_Sitemap_Image_Parser {
 		 * Filter image data to be included in XML sitemap for the post.
 		 *
 		 * @param array  $image {
-		 *                      Array of image data.
+		 *     Array of image data.
 		 *
-		 * @type string  $src   Image URL.
-		 * @type string  $title Image title attribute (optional).
-		 * @type string  $alt   Image alt attribute (optional).
+		 *     @type string  $src   Image URL.
+		 *     @type string  $title Image title attribute (optional).
+		 *     @type string  $alt   Image alt attribute (optional).
 		 * }
 		 *
 		 * @param object $post  Post object.

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -73,6 +73,7 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		$taxonomies     = array_intersect_key( $taxonomies, array_flip( $taxonomy_names ) );
 
 		// Retrieve all the taxonomies and their terms so we can do a proper count on them.
+
 		/**
 		 * Filter the setting of excluding empty terms from the XML sitemap.
 		 *

--- a/src/conditionals/admin/doing-post-quick-edit-save-conditional.php
+++ b/src/conditionals/admin/doing-post-quick-edit-save-conditional.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Conditionals\Admin;
 use Yoast\WP\SEO\Conditionals\Conditional;
 
 // phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
+
 /**
  * Checks if the post is saved by inline-save. This is the case when doing quick edit.
  */

--- a/src/deprecated/admin/extension.php
+++ b/src/deprecated/admin/extension.php
@@ -6,6 +6,7 @@
  */
 
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Reason: The class is deprecated.
+
 /**
  * Represents the values for a single Yoast Premium extension plugin.
  *

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -228,9 +228,11 @@ class Elementor implements Integration_Interface {
 	/**
 	 * Saves the WP SEO metadata for posts.
 	 *
+	 * Outputs JSON via wp_send_json then stops code execution.
+	 *
 	 * {@internal $_POST parameters are validated via sanitize_post_meta().}}
 	 *
-	 * @return void Outputs JSON via wp_send_json then stops code execution.
+	 * @return void
 	 */
 	public function save_postdata() {
 		global $post;

--- a/src/integrations/watchers/primary-category-quick-edit-watcher.php
+++ b/src/integrations/watchers/primary-category-quick-edit-watcher.php
@@ -10,6 +10,7 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 
 // phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
+
 /**
  * Class Primary_Category_Quick_Edit_Watcher
  */

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -166,7 +166,6 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 		 *
 		 * @api string $link_output The output string.
 		 */
-
 		return \apply_filters( 'wpseo_breadcrumb_single_link', $link, $breadcrumb );
 	}
 

--- a/src/presenters/meta-description-presenter.php
+++ b/src/presenters/meta-description-presenter.php
@@ -49,6 +49,7 @@ class Meta_Description_Presenter extends Abstract_Indexable_Tag_Presenter {
 	 */
 	public function get() {
 		$meta_description = $this->replace_vars( $this->presentation->meta_description );
+
 		/**
 		 * Filter: 'wpseo_metadesc' - Allow changing the Yoast SEO meta description sentence.
 		 *

--- a/src/presenters/title-presenter.php
+++ b/src/presenters/title-presenter.php
@@ -43,6 +43,7 @@ class Title_Presenter extends Abstract_Indexable_Tag_Presenter {
 	 */
 	public function get_title() {
 		$title = $this->replace_vars( $this->presentation->title );
+
 		/**
 		 * Filter: 'wpseo_title' - Allow changing the Yoast SEO generated title.
 		 *

--- a/src/values/open-graph/images.php
+++ b/src/values/open-graph/images.php
@@ -20,7 +20,7 @@ class Images extends Base_Images {
 	/**
 	 * Sets the helpers.
 	 *
-	 *  @required
+	 * @required
 	 *
 	 * @codeCoverageIgnore - Is handled by DI-container.
 	 *

--- a/tests/unit/conditionals/admin/doing-post-quick-edit-save-conditional-test.php
+++ b/tests/unit/conditionals/admin/doing-post-quick-edit-save-conditional-test.php
@@ -7,6 +7,7 @@ use Yoast\WP\SEO\Conditionals\Admin\Doing_Post_Quick_Edit_Save_Conditional;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 // phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
+
 /**
  * Class Doing_Post_Quick_Edit_Save_Conditional
  *

--- a/tests/unit/conditionals/estimated-reading-time-conditional-test.php
+++ b/tests/unit/conditionals/estimated-reading-time-conditional-test.php
@@ -10,6 +10,7 @@ use Yoast\WP\SEO\Helpers\Input_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 // phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
+
 /**
  * Class Estimated_Reading_Time_Conditional.
  *

--- a/tests/unit/integrations/watchers/primary-category-quick-edit-watcher-test.php
+++ b/tests/unit/integrations/watchers/primary-category-quick-edit-watcher-test.php
@@ -13,6 +13,7 @@ use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 // phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Base class can't be written shorter without abbreviating.
+
 /**
  * Class Admin_Columns_Cache_Integration_Test.
  *

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -212,6 +212,7 @@ function _wpseo_activate() {
 
 	do_action( 'wpseo_activate' );
 }
+
 /**
  * On deactivation, flush the rewrite rules so XML sitemaps stop working.
  */
@@ -460,6 +461,7 @@ if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
 
 	// Initializes the Yoast indexables for the first time.
 	YoastSEO();
+
 	/**
 	 * Action called when the Yoast SEO plugin file has loaded.
 	 */


### PR DESCRIPTION
## Context

* Documentation improvements

## Summary

This PR can be summarized in the following changelog entry:

* Documentation improvements

## Relevant technical choices:


### Docs: various minor fixes

* Move a function description for a `void` function to the "description" part of the docblock. The `void` return type cannot have a description attached to it.

### Docs: minor spacing fixes

### Docs: minor capitalization and punctuation fixes

... picked up along the way.

### Docs: use correct comment format

### Docs: comply with whitespace requirements 



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a documentation-only change and should have no effect on the functionality.
