### PR TITLE
Fix path of the Yoast SEO icon image

### DIFF
--- a/admin/class-premium-popup.php
+++ b/admin/class-premium-popup.php
@@ -89,7 +89,7 @@ class WPSEO_Premium_Popup {
 
 		$popup = <<<EO_POPUP
 <div id="wpseo-{$this->identifier}-popup" class="wpseo-premium-popup wp-clearfix$classes">
-	<img class="alignright wpseo-premium-popup-icon" src="{$assets_uri}images/Yoast_SEO_Icon.svg" width="150" height="150" alt="Yoast SEO"/>
+	<img class="alignright wpseo-premium-popup-icon" src="{$assets_uri}packages/js/images/Yoast_SEO_Icon.svg" width="150" height="150" alt="Yoast SEO"/>
 	<{$this->heading_level} id="wpseo-contact-support-popup-title" class="wpseo-premium-popup-title">{$this->title}</{$this->heading_level}>
 	{$this->content}
 	<a id="wpseo-{$this->identifier}-popup-button" class="yoast-button-upsell" href="{$this->url}" target="_blank">

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -354,7 +354,7 @@ class Yoast_Notification {
 	private function wrap_yoast_seo_icon( $message ) {
 		$out  = sprintf(
 			'<img src="%1$s" height="%2$d" width="%3$d" class="yoast-seo-icon" />',
-			esc_url( plugin_dir_url( WPSEO_FILE ) . 'images/Yoast_SEO_Icon.svg' ),
+			esc_url( plugin_dir_url( WPSEO_FILE ) . 'packages/js/images/Yoast_SEO_Icon.svg' ),
 			60,
 			60
 		);

--- a/css/src/dashboard.css
+++ b/css/src/dashboard.css
@@ -61,7 +61,7 @@
   content: "";
   width: 40px;
   height: 40px;
-  background-image: url("../../images/Yoast_SEO_Icon.svg");
+  background-image: url("../../packages/js/images/Yoast_SEO_Icon.svg");
   margin: 25px auto;
   -webkit-animation: rotate 2s infinite linear;
   animation: rotate 2s infinite linear;

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -503,7 +503,7 @@ textarea.wpseo-new-metadesc {
 
 /* Yoast SEO credits page. */
 body.toplevel_page_wpseo_dashboard .wp-badge {
-  background: transparent url(../../images/Yoast_SEO_Icon.svg) no-repeat 50% 10px;
+  background: transparent url(../../packages/js/images/Yoast_SEO_Icon.svg) no-repeat 50% 10px;
   background-size: 140px 140px;
   box-shadow: none;
 }

--- a/css/src/yst_plugin_tools.scss
+++ b/css/src/yst_plugin_tools.scss
@@ -501,7 +501,7 @@ textarea.wpseo-new-metadesc {
 
 /* Yoast SEO credits page. */
 body.toplevel_page_wpseo_dashboard .wp-badge {
-	background: transparent url(../../images/Yoast_SEO_Icon.svg) no-repeat 50% 10px;
+	background: transparent url(../../packages/js/images/Yoast_SEO_Icon.svg) no-repeat 50% 10px;
 	background-size: 140px 140px;
 	box-shadow: none;
 }

--- a/inc/health-check.php
+++ b/inc/health-check.php
@@ -206,7 +206,7 @@ abstract class WPSEO_Health_Check {
 		$this->actions .= sprintf(
 			/* translators: 1: Start of a paragraph beginning with the Yoast icon, 2: Expands to 'Yoast SEO', 3: Paragraph closing tag. */
 			esc_html__( '%1$sThis was reported by the %2$s plugin%3$s', 'wordpress-seo' ),
-			'<p class="yoast-site-health__signature"><img src="' . esc_url( plugin_dir_url( WPSEO_FILE ) . 'images/Yoast_SEO_Icon.svg' ) . '" alt="" height="20" width="20" class="yoast-site-health__signature-icon">',
+			'<p class="yoast-site-health__signature"><img src="' . esc_url( plugin_dir_url( WPSEO_FILE ) . 'packages/js/images/Yoast_SEO_Icon.svg' ) . '" alt="" height="20" width="20" class="yoast-site-health__signature-icon">',
 			'Yoast SEO',
 			'</p>'
 		);

--- a/tests/unit/inc/health-check-test.php
+++ b/tests/unit/inc/health-check-test.php
@@ -126,7 +126,7 @@ class Health_Check_Test extends TestCase {
 					'color' => 'green',
 				],
 				'description' => '',
-				'actions'     => '<p class="yoast-site-health__signature"><img src="images/Yoast_SEO_Icon.svg" alt="" height="20" width="20" class="yoast-site-health__signature-icon">This was reported by the Yoast SEO plugin</p>',
+				'actions'     => '<p class="yoast-site-health__signature"><img src="packages/js/images/Yoast_SEO_Icon.svg" alt="" height="20" width="20" class="yoast-site-health__signature-icon">This was reported by the Yoast SEO plugin</p>',
 				'test'        => '',
 			],
 			$this->instance->get_test_result()


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The `Yoast_SEO_Icon` image was moved from the root `images` directory to `packages/js/images`, but the path in the files where this image is used has not been changed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an incorrect path that caused the Yoast SEO Icon to not be found.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Make sure there are no console errors when:
* Clicking on the Dashboard
* Clicking on an SEO suggestion under Tools -> Site Health, e.g.
<img width="817" alt="Screenshot 2021-05-07 at 11 48 57" src="https://user-images.githubusercontent.com/32479012/117432151-54230300-af2a-11eb-93f9-73a7f7c9634d.png">
* Additionally, the Yoast icon should be visible under the Site Health tabs as shown in the screenshot above.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-808
