### PR TITLE
Added cooking time instruction

### DIFF
--- a/css/src/schema-blocks.css
+++ b/css/src/schema-blocks.css
@@ -1,1 +1,26 @@
 @import '@yoast/schema-blocks/css/schema-blocks.css';
+
+.yoast-schema-flex {
+	display: flex;
+}
+
+.yoast-schema-select select.components-select-control__input {
+	height: 100%;
+	padding: 6px 33px 6px 8px;
+}
+
+.yoast-schema-select div.components-input-control__backdrop,
+.components-text-control__input {
+	border: #CCCCCC 1px solid;
+	border-radius: 0;
+}
+
+.wp-block-yoast-cooking-time .yoast-schema-flex {
+	align-items: baseline;
+	overflow: visible;
+}
+
+.wp-block-yoast-cooking-time .yoast-schema-flex * {
+	margin-top: 0;
+    white-space: pre;
+}

--- a/css/src/schema-blocks.css
+++ b/css/src/schema-blocks.css
@@ -1,7 +1,9 @@
 @import '@yoast/schema-blocks/css/schema-blocks.css';
 
+/* General styling for all blocks (including premium) */
 .yoast-schema-flex {
 	display: flex;
+	line-height: 1.25;
 }
 
 .yoast-schema-select select.components-select-control__input {
@@ -10,11 +12,12 @@
 }
 
 .yoast-schema-select div.components-input-control__backdrop,
-.components-text-control__input {
+.yoast-schema-flex .components-text-control__input {
 	border: #CCCCCC 1px solid;
 	border-radius: 0;
 }
 
+/* Cooking time block */
 .wp-block-yoast-cooking-time .yoast-schema-flex {
 	align-items: baseline;
 	overflow: visible;

--- a/css/src/schema-blocks.css
+++ b/css/src/schema-blocks.css
@@ -16,14 +16,3 @@
 	border: #CCCCCC 1px solid;
 	border-radius: 0;
 }
-
-/* Cooking time block */
-.wp-block-yoast-cooking-time .yoast-schema-flex {
-	align-items: baseline;
-	overflow: visible;
-}
-
-.wp-block-yoast-cooking-time .yoast-schema-flex * {
-	margin-top: 0;
-    white-space: pre;
-}

--- a/packages/schema-blocks/css/schema-blocks.css
+++ b/packages/schema-blocks/css/schema-blocks.css
@@ -157,3 +157,21 @@
 .yoast-schema-analysis {
 	margin-bottom: 24px;
 }
+
+/* Duration instruction */
+.yoast-schema-flex.yoast-schema-duration {
+	align-items: baseline;
+	overflow: visible;
+}
+
+.yoast-schema-flex.yoast-schema-duration p {
+	margin-top: 0;
+    white-space: pre;
+}
+
+.yoast-schema-duration .minutes-input {
+	display: inline-block;
+	max-width: 100px;
+	min-width: 40px;
+}
+

--- a/packages/schema-blocks/src/core/blocks/BlockDefinition.tsx
+++ b/packages/schema-blocks/src/core/blocks/BlockDefinition.tsx
@@ -25,6 +25,7 @@ export interface RenderEditProps extends BlockEditProps<Record<string, unknown>>
 
 export interface RenderSaveProps extends BlockSaveProps<Record<string, unknown>> {
 	clientId?: string;
+	className?: string;
 }
 
 export type MutableBlockConfiguration = {

--- a/packages/schema-blocks/src/instructions/blocks/Duration.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/Duration.tsx
@@ -33,7 +33,7 @@ export default class Duration extends BlockInstruction {
 		const value = props.attributes.value as number || 0;
 
 		/* translators: %d will be replaced with the number of minutes. */
-		return <p className={ props.className }>{ sprintf( __( "%d minutes", "yoast-schema-block" ), value ) }</p>;
+		return <p className={ props.className }>{ sprintf( __( "%d minutes", "yoast-schema-blocks" ), value ) }</p>;
 	}
 
 	/**
@@ -59,12 +59,12 @@ export default class Duration extends BlockInstruction {
 				<TextControl
 					type="number"
 					placeholder="#"
-					aria-label={ __( "Cooking time", "yoast-schema-block" ) }
+					aria-label={ __( "Cooking time", "yoast-schema-blocks" ) }
 					className="minutes-input"
 					onChange={ onChange }
 					value={ props.attributes.value as number || "" }
 				/>
-				<p> { __( "minutes", "yoast-schema-block" ) }</p>
+				<p> { __( "minutes", "yoast-schema-blocks" ) }</p>
 			</div>
 		);
 	}

--- a/packages/schema-blocks/src/instructions/blocks/Duration.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/Duration.tsx
@@ -1,0 +1,91 @@
+import { BlockConfiguration } from "@wordpress/blocks";
+import { __, sprintf } from "@wordpress/i18n";
+import { TextControl } from "@wordpress/components";
+import moment from "moment";
+
+import { ReactElement, createElement, useCallback } from "react";
+import BlockInstruction from "../../core/blocks/BlockInstruction";
+import { RenderEditProps, RenderSaveProps } from "../../core/blocks/BlockDefinition";
+
+/**
+ * Duration instruction.
+ */
+export default class Duration extends BlockInstruction {
+	public options: {
+		/**
+		 * The attribute name the value selected in the select control should be saved as.
+		 */
+		name: string;
+		/**
+		 * If it is required that a value is selected.
+		 */
+		required?: boolean;
+	};
+
+	/**
+	 * Renders saving the element.
+	 *
+	 * @param props The props.
+	 *
+	 * @returns {JSX.Element} The element to render.
+	 */
+	save( props: RenderSaveProps ): ReactElement | string {
+		const value = props.attributes.value as number || 0;
+
+		/* translators: %d will be replaced with the number of minutes. */
+		return <p className={ props.className }>{ sprintf( __( "%d minutes", "yoast-schema-block" ), value ) }</p>;
+	}
+
+	/**
+	 * Renders editing the element.
+	 *
+	 * @param props The props.
+	 *
+	 * @returns {JSX.Element} The element to render.
+	 */
+	edit( props: RenderEditProps ): ReactElement | string {
+		const onChange = useCallback(
+			( value = 0 ) => {
+				props.setAttributes( {
+					value,
+					iso8601Duration: moment.duration( value, "minutes" ).toISOString(),
+				} );
+			},
+			[ props.attributes.value ],
+		);
+
+		return (
+			<div className="yoast-schema-flex yoast-schema-duration">
+				<TextControl
+					type="number"
+					placeholder="#"
+					aria-label={ __( "Cooking time", "yoast-schema-block" ) }
+					className="minutes-input"
+					onChange={ onChange }
+					value={ props.attributes.value as number || "" }
+				/>
+				<p> { __( "minutes", "yoast-schema-block" ) }</p>
+			</div>
+		);
+	}
+
+	/**
+	 * Adds the select to the block configuration.
+	 *
+	 * @returns The block configuration.
+	 */
+	configuration(): Partial<BlockConfiguration> {
+		return {
+			attributes: {
+				value: {
+					type: "number",
+				},
+				iso8601Duration: {
+					type: "string",
+				},
+			},
+		};
+	}
+}
+
+BlockInstruction.register( "duration", Duration );

--- a/packages/schema-blocks/src/instructions/blocks/index.ts
+++ b/packages/schema-blocks/src/instructions/blocks/index.ts
@@ -15,3 +15,4 @@ import "./TextInput";
 import "./Title";
 import "./Variation";
 import "./VariationPicker";
+import "./Duration";

--- a/src/schema-templates/assets/icons.php
+++ b/src/schema-templates/assets/icons.php
@@ -1,0 +1,277 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+// phpcs:disable Yoast.NamingConventions.NamespaceName.Invalid
+namespace Yoast\WP\SEO\Schema_Templates\Assets;
+
+/**
+ * Class Icons.
+ *
+ * Provides SVG icons as strings.
+ */
+class Icons {
+
+	/**
+	 * Represents the start of the SVG tag.
+	 */
+	const SVG_START_TAG = "<svg xmlns='http://www.w3.org/2000/svg' fill='none' style='fill:none' viewBox='0 0 24 24' stroke='currentColor' height='%SIZE%' width='%SIZE%' >";
+
+	/**
+	 * The default height and width of an icon.
+	 */
+	const SIZE_DEFAULT = 24;
+
+	/**
+	 * The height and width of an icon in a variation picker.
+	 */
+	const SIZE_VARIATION = 36;
+
+	/**
+	 * The Heroicons academic cap svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_academic_cap( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path fill='#fff' d='M12 14l9-5-9-5-9 5 9 5z' />" .
+			"<path fill='#fff' d='M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z' />" .
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons annotation svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_annotation( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons ban svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_ban( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons briefcase svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_briefcase( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons calendar svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_calendar( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons clipboard check svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_clipboard_check( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons clipboard copy svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_clipboard_copy( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons clipboard list svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_clipboard_list( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons clock svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_clock( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons currency dollar svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_currency_dollar( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons cursor_click svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_cursor_click( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons document text svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_document_text( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons globe svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_globe( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons identification svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_identification( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V5a2 2 0 114 0v1m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons location marker svg icon
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_location_marker( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z' />" .
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M15 11a3 3 0 11-6 0 3 3 0 016 0z' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons office building svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_office_building( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path d='M19 21V5C19 3.89543 18.1046 3 17 3H7C5.89543 3 5 3.89543 5 5V21M19 21L21 21M19 21H14M5 21L3 21M5 21H10M9 6.99998H10M9 11H10M14 6.99998H15M14 11H15M10 21V16C10 15.4477 10.4477 15 11 15H13C13.5523 15 14 15.4477 14 16V21M10 21H14' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/>",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons photograph svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_photograph( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z' />",
+			$size
+		);
+	}
+
+	/**
+	 * The Heroicons switch horizontal svg icon.
+	 *
+	 * @param integer $size The Height and Width of the SVG icon.
+	 * @return string
+	 */
+	public static function heroicons_switch_horizontal( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4' />",
+			$size
+		);
+	}
+
+	/**
+	 * Generates the SVG based on given path.
+	 *
+	 * @param string  $path     The path to generate svg for.
+	 * @param integer $svg_size The Height and Width of the SVG icon.
+	 *
+	 * @return string The generated icon svg.
+	 */
+	protected static function svg( $path, $svg_size = self::SIZE_DEFAULT ) {
+		$start = \str_replace( '%SIZE%', $svg_size, self::SVG_START_TAG );
+		return $start . $path . '</svg>';
+	}
+}

--- a/src/schema-templates/assets/icons.php
+++ b/src/schema-templates/assets/icons.php
@@ -1,4 +1,5 @@
 <?php
+
 // phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 // phpcs:disable Yoast.NamingConventions.NamespaceName.Invalid
 namespace Yoast\WP\SEO\Schema_Templates\Assets;
@@ -28,14 +29,14 @@ class Icons {
 	/**
 	 * The Heroicons academic cap svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_academic_cap( $size = self::SIZE_DEFAULT ) {
 		return self::svg(
-			"<path fill='#fff' d='M12 14l9-5-9-5-9 5 9 5z' />" .
-			"<path fill='#fff' d='M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z' />" .
-			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222' />",
+			"<path fill='#fff' d='M12 14l9-5-9-5-9 5 9 5z' />"
+			. "<path fill='#fff' d='M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z' />"
+			. "<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14zm-4 6v-7.5l4-2.222' />",
 			$size
 		);
 	}
@@ -43,7 +44,7 @@ class Icons {
 	/**
 	 * The Heroicons annotation svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_annotation( $size = self::SIZE_DEFAULT ) {
@@ -56,7 +57,7 @@ class Icons {
 	/**
 	 * The Heroicons ban svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_ban( $size = self::SIZE_DEFAULT ) {
@@ -69,7 +70,7 @@ class Icons {
 	/**
 	 * The Heroicons briefcase svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_briefcase( $size = self::SIZE_DEFAULT ) {
@@ -82,7 +83,7 @@ class Icons {
 	/**
 	 * The Heroicons calendar svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_calendar( $size = self::SIZE_DEFAULT ) {
@@ -95,7 +96,7 @@ class Icons {
 	/**
 	 * The Heroicons clipboard check svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_clipboard_check( $size = self::SIZE_DEFAULT ) {
@@ -108,7 +109,7 @@ class Icons {
 	/**
 	 * The Heroicons clipboard copy svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_clipboard_copy( $size = self::SIZE_DEFAULT ) {
@@ -121,7 +122,7 @@ class Icons {
 	/**
 	 * The Heroicons clipboard list svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_clipboard_list( $size = self::SIZE_DEFAULT ) {
@@ -134,7 +135,7 @@ class Icons {
 	/**
 	 * The Heroicons clock svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_clock( $size = self::SIZE_DEFAULT ) {
@@ -147,7 +148,7 @@ class Icons {
 	/**
 	 * The Heroicons currency dollar svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_currency_dollar( $size = self::SIZE_DEFAULT ) {
@@ -160,7 +161,7 @@ class Icons {
 	/**
 	 * The Heroicons cursor_click svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_cursor_click( $size = self::SIZE_DEFAULT ) {
@@ -173,7 +174,7 @@ class Icons {
 	/**
 	 * The Heroicons document text svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_document_text( $size = self::SIZE_DEFAULT ) {
@@ -186,7 +187,7 @@ class Icons {
 	/**
 	 * The Heroicons globe svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_globe( $size = self::SIZE_DEFAULT ) {
@@ -199,7 +200,7 @@ class Icons {
 	/**
 	 * The Heroicons identification svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_identification( $size = self::SIZE_DEFAULT ) {
@@ -212,13 +213,13 @@ class Icons {
 	/**
 	 * The Heroicons location marker svg icon
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_location_marker( $size = self::SIZE_DEFAULT ) {
 		return self::svg(
-			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z' />" .
-			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M15 11a3 3 0 11-6 0 3 3 0 016 0z' />",
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z' />"
+			. "<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M15 11a3 3 0 11-6 0 3 3 0 016 0z' />",
 			$size
 		);
 	}
@@ -226,7 +227,7 @@ class Icons {
 	/**
 	 * The Heroicons office building svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_office_building( $size = self::SIZE_DEFAULT ) {
@@ -239,7 +240,7 @@ class Icons {
 	/**
 	 * The Heroicons photograph svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_photograph( $size = self::SIZE_DEFAULT ) {
@@ -252,7 +253,7 @@ class Icons {
 	/**
 	 * The Heroicons switch horizontal svg icon.
 	 *
-	 * @param integer $size The Height and Width of the SVG icon.
+	 * @param int $size The Height and Width of the SVG icon.
 	 * @return string
 	 */
 	public static function heroicons_switch_horizontal( $size = self::SIZE_DEFAULT ) {
@@ -263,10 +264,24 @@ class Icons {
 	}
 
 	/**
+	 * The Heroicons grid svg icon.
+	 *
+	 * @param int $size The Height and Width of the SVG icon.
+	 *
+	 * @return string The generated icon.
+	 */
+	public static function heroicons_grid( $size = self::SIZE_DEFAULT ) {
+		return self::svg(
+			"<path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z' />",
+			$size
+		);
+	}
+
+	/**
 	 * Generates the SVG based on given path.
 	 *
-	 * @param string  $path     The path to generate svg for.
-	 * @param integer $svg_size The Height and Width of the SVG icon.
+	 * @param string $path     The path to generate svg for.
+	 * @param int    $svg_size The Height and Width of the SVG icon.
 	 *
 	 * @return string The generated icon svg.
 	 */

--- a/src/schema-templates/cooking-time.block.php
+++ b/src/schema-templates/cooking-time.block.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Recipe cooking time block schema template.
+ *
+ * @package Yoast\WP\SEO\Schema_Templates
+ */
+
+use Yoast\WP\SEO\Schema_Templates\Assets\Icons;
+// phpcs:disable WordPress.Security.EscapeOutput -- Reason: The Icons contains safe svg.
+?>
+{{block name="yoast/cooking-time" title="<?php esc_attr_e( 'Cooking time', 'wordpress-seo' ); ?>" category="yoast-structured-data-blocks" parent=[ "yoast/recipe" ] description="<?php esc_html_e( 'The recipe\'s cooking time', 'wordpress-seo' ); ?>" icon="<?php echo Icons::heroicons_clock(); ?>" supports={"multiple": false} }}
+<div class={{class-name}}>
+	{{heading name="title" default-heading-level=3 tags=[ "h2", "h3", "h4", "h5", "h6", "strong" ] default="<?php esc_attr_e( 'Cooking time', 'wordpress-seo' ); ?>" }}
+	{{duration name="cooking-time" }}
+</div>

--- a/src/schema-templates/cooking-time.schema.php
+++ b/src/schema-templates/cooking-time.schema.php
@@ -1,3 +1,3 @@
 <?php // phpcs:ignore Internal.NoCodeFound ?>
 {{schema name="yoast/cooking-time" only-nested=true }}
-{{attribute name="iso8601Value" }}
+{{attribute name="iso8601Duration" }}

--- a/src/schema-templates/cooking-time.schema.php
+++ b/src/schema-templates/cooking-time.schema.php
@@ -1,0 +1,3 @@
+<?php // phpcs:ignore Internal.NoCodeFound ?>
+{{schema name="yoast/cooking-time" only-nested=true }}
+{{attribute name="iso8601Value" }}

--- a/src/schema-templates/recipe.block.php
+++ b/src/schema-templates/recipe.block.php
@@ -24,13 +24,12 @@ $yoast_seo_required_blocks = [
 
 $yoast_seo_recommended_blocks = [
 	[ 'name' => 'core/paragraph' ],
+	[ 'name' => 'yoast/cooking-time' ],
 ];
 
 // phpcs:disable WordPress.Security.EscapeOutput -- Reason: WPSEO_Utils::format_json_encode is safe.
 ?>
 {{block name="yoast/recipe" title="<?php echo esc_attr( $yoast_seo_block_title ); ?>" category="yoast-structured-data-blocks" keywords=[ "SEO", "Schema"] description="<?php esc_attr_e( 'Create a Recipe in an SEO-friendly way. You can only use one Recipe block per post.', 'wordpress-seo' ); ?>" supports={"multiple": false} }}
-{{sidebar-duration name="cook-time" output=false label="<?php esc_attr_e( 'Cook time', 'wordpress-seo' ); ?>" }}
-{{sidebar-duration name="prep-time" output=false label="<?php esc_attr_e( 'Preparation time', 'wordpress-seo' ); ?>" }}
 {{sidebar-input name="yield" output=false type="number" label="<?php esc_attr_e( 'Serves #', 'wordpress-seo' ); ?>" }}
 <div class={{class-name}}>
 	{{inner-blocks template=<?php echo WPSEO_Utils::format_json_encode( $yoast_seo_block_template ); ?> required-blocks=<?php echo WPSEO_Utils::format_json_encode( $yoast_seo_required_blocks ); ?> recommended-blocks=<?php echo WPSEO_Utils::format_json_encode( $yoast_seo_recommended_blocks ); ?> appender="button" appenderLabel="<?php esc_attr_e( 'Add a block to your recipe...', 'wordpress-seo' ); ?>" }}

--- a/src/schema-templates/recipe.schema.php
+++ b/src/schema-templates/recipe.schema.php
@@ -12,7 +12,7 @@
 		"@id": "%%author_id%%"
 	},
 	"description": {{inner-blocks-html blocks={ "core/paragraph": "content" } null-when-empty=true allowed-tags=[ "h1","h2","h3","h4","h5","h6","br","a","p","b","strong","i","em" ] }},
-	"cookTime": {{attribute name="cook-time" }},
+	"cookTime": {{inner-blocks allowed-blocks=[ "yoast/cooking-time" ] only-first=true }},
 	"prepTime": {{attribute name="prep-time" }},
 	"recipeInstructions": {{inner-blocks allowed-blocks=[ "yoast/steps" ] only-first=true }},
 	"recipeIngredient": {{inner-blocks allowed-blocks=[ "yoast/ingredients" ] only-first=true }},

--- a/tests/unit/dependency-injection/schema-templates-loader-test.php
+++ b/tests/unit/dependency-injection/schema-templates-loader-test.php
@@ -39,6 +39,8 @@ class Schema_Templates_Loader_Test extends TestCase {
 		$schema_directory = 'src/schema-templates/';
 
 		$expected_schema_blocks = [
+			$schema_directory . 'cooking-time.block.php',
+			$schema_directory . 'cooking-time.schema.php',
 			$schema_directory . 'image.schema.php',
 			$schema_directory . 'ingredients.block.php',
 			$schema_directory . 'ingredients.schema.php',

--- a/yarn.lock
+++ b/yarn.lock
@@ -12883,14 +12883,6 @@ grunt-git@^1.0.14:
   dependencies:
     flopmang "^1.0.0"
 
-"grunt-glotpress@git+https://github.com/Yoast/grunt-glotpress.git#master":
-  version "0.3.0"
-  uid e6ccc69c2532d126f5d8a30397ffd012e55b6eec
-  resolved "git+https://github.com/Yoast/grunt-glotpress.git#e6ccc69c2532d126f5d8a30397ffd012e55b6eec"
-  dependencies:
-    request "^2.88.0"
-    request-promise-native "^1.0.7"
-
 "grunt-glotpress@https://github.com/Yoast/grunt-glotpress.git#master":
   version "0.3.0"
   resolved "https://github.com/Yoast/grunt-glotpress.git#e6ccc69c2532d126f5d8a30397ffd012e55b6eec"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a cooking time block for the recipe block.

## Relevant technical choices:

* Moved Icons to free from premium, along with some general CSS rules that apply to certain elements that are shared between free and premium.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure the `YOAST_SEO_SCHEMA_BLOCK` feature flag is enabled.
* Create a new post.
* Add a new recipe block.
* Inside the recipe block add a `Cooking Time` block.
* Fill in a number of minutes.
* Save the post.
* On the front-end inspect the schema output. In the recipe schema block, the cooking time attribute should be formatted as a ISO 8601 duration string. https://en.wikipedia.org/wiki/ISO_8601

* Also check out `P2-223-move-schema-assets-for-free` in premium. Activate premium and make sure the block icons are working as expected in both the cooking time block (clock-icon) and the jobs-posting block.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
