### PR TITLE
Add a feature flag for the addon installation project

### DIFF
--- a/src/conditionals/Addon_Installation_Conditional.php
+++ b/src/conditionals/Addon_Installation_Conditional.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Checks if the Addon_Installation constant is set.
+ */
+class Addon_Installation_Conditional extends Feature_Flag_Conditional {
+	/**
+	 * Returns the name of the feature flag.
+	 * 'YOAST_SEO_' is automatically prepended to it and it will be uppercased.
+	 *
+	 * @return string the name of the feature flag.
+	 */
+	protected function get_feature_flag() {
+		return 'ADDON_INSTALLATION';
+	}
+}

--- a/src/conditionals/addon-installation-conditional.php
+++ b/src/conditionals/addon-installation-conditional.php
@@ -6,6 +6,7 @@ namespace Yoast\WP\SEO\Conditionals;
  * Checks if the Addon_Installation constant is set.
  */
 class Addon_Installation_Conditional extends Feature_Flag_Conditional {
+
 	/**
 	 * Returns the name of the feature flag.
 	 * 'YOAST_SEO_' is automatically prepended to it and it will be uppercased.

--- a/src/routes/supported-features-route.php
+++ b/src/routes/supported-features-route.php
@@ -36,8 +36,9 @@ class Supported_Features_Route implements Route_Interface {
 	 */
 	public function register_routes() {
 		$supported_features_route = [
-			'methods'  => 'GET',
-			'callback' => [ $this, 'get_supported_features' ],
+			'methods'             => 'GET',
+			'callback'            => [ $this, 'get_supported_features' ],
+			'permission_callback' => '__return_true',
 		];
 
 		\register_rest_route( Main::API_V1_NAMESPACE, self::SUPPORTED_FEATURES_ROUTE, $supported_features_route );

--- a/src/routes/supported-features-route.php
+++ b/src/routes/supported-features-route.php
@@ -6,6 +6,9 @@ use WP_REST_Response;
 use Yoast\WP\SEO\Conditionals\Addon_Installation_Conditional;
 use Yoast\WP\SEO\Main;
 
+/**
+ * Supported_Features_Route class.
+ */
 class Supported_Features_Route implements Route_Interface {
 
 	/**
@@ -14,7 +17,6 @@ class Supported_Features_Route implements Route_Interface {
 	 * @var string
 	 */
 	const SUPPORTED_FEATURES_ROUTE = '/supported-features';
-
 
 	/**
 	 * Returns the conditionals based in which this loadable should be active.

--- a/src/routes/supported-features-route.php
+++ b/src/routes/supported-features-route.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Yoast\WP\SEO\Routes;
+
+use WP_REST_Response;
+use Yoast\WP\SEO\Conditionals\Addon_Installation_Conditional;
+use Yoast\WP\SEO\Main;
+
+class Supported_Features_Route implements Route_Interface {
+
+	/**
+	 * Represents the supported features route.
+	 *
+	 * @var string
+	 */
+	const SUPPORTED_FEATURES_ROUTE = '/supported-features';
+
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * @return array
+	 */
+	public static function get_conditionals() {
+		return [
+			Addon_Installation_Conditional::class,
+		];
+	}
+
+	/**
+	 * Registers routes with WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		$supported_features_route = [
+			'methods'  => 'GET',
+			'callback' => [ $this, 'get_supported_features' ],
+		];
+
+		\register_rest_route( Main::API_V1_NAMESPACE, self::SUPPORTED_FEATURES_ROUTE, $supported_features_route );
+	}
+
+	/**
+	 * Returns a list of features supported by this yoast seo installation.
+	 *
+	 * @return WP_REST_Response a list of features supported by this yoast seo installation.
+	 */
+	public function get_supported_features() {
+		return new WP_REST_Response(
+			[
+				'addon-installation' => 1,
+			]
+		);
+	}
+}

--- a/tests/unit/routes/supported-features-route-test.php
+++ b/tests/unit/routes/supported-features-route-test.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Routes;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Addon_Installation_Conditional;
+use Yoast\WP\SEO\Routes\Supported_Features_Route;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Supported_Features_Route_Test.
+ *
+ * @group routes
+ * @group addon-installation
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Routes\Supported_Features_Route
+ */
+class Supported_Features_Route_Test extends TestCase {
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Supported_Features_Route
+	 */
+	protected $instance;
+
+	/**
+	 * Set up the test fixtures.
+	 */
+	protected function set_up() {
+		$this->instance = new Supported_Features_Route();
+	}
+
+	/**
+	 * Tests the retrieval of the conditionals.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals(
+			[ Addon_Installation_Conditional::class ],
+			Supported_Features_Route::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the registration of the routes.
+	 *
+	 * @covers ::register_routes
+	 */
+	public function test_register_routes() {
+		Monkey\Functions\expect( 'register_rest_route' )
+			->with(
+				'yoast/v1',
+				'/supported-features',
+				[
+					'methods'  => 'GET',
+					'callback' => [ $this, 'get_supported_features' ],
+				]
+			)
+			->once();
+
+		$this->instance->register_routes();
+	}
+
+	/**
+	 * Tests the get_supported_features route.
+	 *
+	 * @covers ::get_supported_features
+	 */
+	public function test_get_supported_features() {
+		Mockery::mock( 'overload:WP_REST_Response' );
+		$actual = $this->instance->get_supported_features();
+
+		$expected = new \WP_REST_Response(
+			[
+				'addon-installation' => 1,
+			]
+		);
+
+		$this->assertInstanceOf( 'WP_REST_Response', $actual );
+		$this->assertEquals( $expected, $actual );
+	}
+}
+

--- a/tests/unit/routes/supported-features-route-test.php
+++ b/tests/unit/routes/supported-features-route-test.php
@@ -55,8 +55,9 @@ class Supported_Features_Route_Test extends TestCase {
 				'yoast/v1',
 				'/supported-features',
 				[
-					'methods'  => 'GET',
-					'callback' => [ $this, 'get_supported_features' ],
+					'methods'             => 'GET',
+					'callback'            => [ $this, 'get_supported_features' ],
+					'permission_callback' => '__return_true',
 				]
 			)
 			->once();
@@ -83,4 +84,3 @@ class Supported_Features_Route_Test extends TestCase {
 		$this->assertEquals( $expected, $actual );
 	}
 }
-

--- a/tests/unit/routes/supported-features-route-test.php
+++ b/tests/unit/routes/supported-features-route-test.php
@@ -17,6 +17,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @coversDefaultClass \Yoast\WP\SEO\Routes\Supported_Features_Route
  */
 class Supported_Features_Route_Test extends TestCase {
+
 	/**
 	 * Represents the instance to test.
 	 *


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We need to know whether we can install an addon from outside.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a rest route which gives information about the features which are supported by the plugin.

## Relevant technical choices:

* We've kept it simple. The rest route returns the needed information immediately.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

use the `basic.wordpress.test` local setup to follow along these test instructions.

* Checkout this pr's branch;
* Set the `YOAST_SEO_ADDON_INSTALLATION` feature flag to true.
   * Go to your plugin development docker environment.
   * go to `config/basic-wordpress-config.php` for example. line 40;
   * add `define( 'YOAST_SEO_ADDON_INSTALLATION', true );`
* Run `composer install`. ( for the DI. )
* Go to http://basic.wordpress.test/wp-json/yoast/v1/supported-features. It should return:
```
{
    "addon-installation": 1
}
```
* Set the feature flag from step 2, to false.
* Visit the same address, you should not get any output.

It should still work, whether logged in or logged out ( no authorisation required ).


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* None, it only adds a route and feature flag.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
