### PR TITLE
Add extra path in grunt-task config for images inside the js package

### DIFF
--- a/config/grunt/task-config/copy.js
+++ b/config/grunt/task-config/copy.js
@@ -106,6 +106,7 @@ module.exports = {
 					"deprecated/**",
 					"frontend/**",
 					"images/**",
+					"packages/js/images/**",
 					"inc/**",
 					"<%= paths.jsDist %>/**/*.js",
 					"languages/**",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The `Yoast_SEO_Icon` image was moved from the root images directory to `packages/js/images`, but the path in the files where this image is used has not been changed. [This PR ](https://github.com/Yoast/wordpress-seo/pull/16994) fixes the problem in the development version. However, it doesn't fix the issue in the production version.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an extra path inside `copy.js` file for images inside the js package.

## Relevant technical choices:

* Delete the empty `premium-configuration` branch with the same name after this PR is merged

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
* The development version can be tested via docker.
* The production version can be tested by making a zip first.

Make sure there are no console errors both in the development and in the production version when:
* Clicking on the Dashboard
* Clicking on an SEO suggestion under Tools -> Site Health, e.g.
<img width="817" alt="Screenshot 2021-05-07 at 11 48 57" src="https://user-images.githubusercontent.com/32479012/117432151-54230300-af2a-11eb-93f9-73a7f7c9634d.png">

* Additionally, the Yoast icon should be visible under the Site Health tabs as shown in the screenshot above.

* Deleting a post, page, or a CPT and the Yoast SEO icon should be visible in the premium pop up
<img width="1330" alt="Screenshot 2021-05-10 at 14 07 29" src="https://user-images.githubusercontent.com/48715883/117656868-28f21b00-b199-11eb-8612-740322579f7a.png">


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-817
