### PR TITLE
LINGO-819 Fix failing schema blocks tests

### DIFF
--- a/packages/schema-blocks/tests/functions/blocks/getParentSidebar.test.ts
+++ b/packages/schema-blocks/tests/functions/blocks/getParentSidebar.test.ts
@@ -1,3 +1,4 @@
+import "../../matchMedia.mock";
 import { BlockEditProps, BlockInstance } from "@wordpress/blocks";
 import * as renderer from "react-test-renderer";
 import getParentSidebar from "../../../src/functions/blocks/getParentSidebar";
@@ -55,7 +56,7 @@ jest.mock( "../../../src/core/blocks/BlockDefinitionRepository", () => {
 	};
 } );
 
-describe.skip( "The getParentSidebar function", () => {
+describe( "The getParentSidebar function", () => {
 	it( "receives the parents argument as null", () => {
 		const props: BlockEditProps<unknown> = {
 			className: "",

--- a/packages/schema-blocks/tests/functions/presenters/BlockSuggestionsPresenter.test.ts
+++ b/packages/schema-blocks/tests/functions/presenters/BlockSuggestionsPresenter.test.ts
@@ -1,3 +1,4 @@
+import "../../matchMedia.mock";
 import { mount } from "enzyme";
 import * as renderer from "react-test-renderer";
 import { createBlock } from "@wordpress/blocks";


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* After merging `develop` in `javascript` to `feature/language-split` in `wordpress-seo`, there are two `schema-blocks` test that are failing. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds `matchMedia.mock` to ` BlockSuggestionsPresenter` and `getParentSidebar` test files, and unskips `getParentSidebar` test.

## Relevant technical choices:

* `getParentSidebar` test was skipped in [this PR](https://github.com/Yoast/wordpress-seo/pull/17017) and it's unskipped in this PR.
* The empty `premium-configuration` branch with the same name should be deleted after this PR is merged.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run `yarn test` and make sure that all tests pass.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-819
