### PR TITLE
Change prop type that was causing a console error in the configuration wizard

### DIFF
--- a/packages/configuration-wizard/src/Choice.js
+++ b/packages/configuration-wizard/src/Choice.js
@@ -99,7 +99,7 @@ Choice.propTypes = {
 	value: PropTypes.string,
 	properties: PropTypes.shape( {
 		label: PropTypes.string,
-		choices: PropTypes.array,
+		choices: PropTypes.object,
 		explanation: PropTypes.string,
 		description: PropTypes.string,
 		type: PropTypes.string,
@@ -114,7 +114,7 @@ Choice.defaultProps = {
 	value: "",
 	properties: {
 		label: "",
-		choices: [],
+		choices: {},
 		description: "",
 	},
 	onChange: () => null,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The prop type for the `choices` component was changed from object to array in this [commit](https://github.com/Yoast/javascript/commit/737d588e7f8c6742e7806c7e58e65ee95782c3f9). This wasn't causing any errors in the previous plugin versions, but in this version we get an error saying that an array was expected but received an object. Changing the prop type back to Object fixes the error, and seems more logical as the function in `Choice.js` uses object-specific methods such as `Object.keys`. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes prop type for `choices` from array to object.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open the configuration wizard and make sure this error does not appear:
<img width="975" alt="Screenshot 2021-05-12 at 11 21 31" src="https://user-images.githubusercontent.com/32479012/117952104-1e5c9080-b315-11eb-8bcf-9432f4d747b8.png">


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
