### PR TITLE
Use mb_substr instead of substr to avoid multibyte character truncation

### DIFF
--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -162,7 +162,7 @@ class Indexable extends Model {
 			$this->permalink_hash = \strlen( $this->permalink ) . ':' . \md5( $this->permalink );
 		}
 		if ( \strlen( $this->primary_focus_keyword ) > 191 ) {
-			$this->primary_focus_keyword = \substr( $this->primary_focus_keyword, 0, 191 );
+			$this->primary_focus_keyword = \mb_substr($this->primary_focus_keyword, 0, 191, 'UTF-8');
 		}
 
 		return parent::save();


### PR DESCRIPTION
## Context

This fixes an issue where multibyte characters can be truncated part-way through a character in the `primary_focus_keyword` field on an Indexable. The potential knock-on effect is invalid characters in a mysql insert/update, which then fails.

## Summary

This PR can be summarized in the following changelog entry:

* Improved the truncation of the `primary_focus_keyword` field to handle multibyte characters.

## Relevant technical choices:

* Changed the string truncation method to use `mb_substr()` instead of `substr()`

## Test instructions

Use some strings (longer than 191 characters) containing multibyte characters in the keywords field of a page or post - check that they are saved correctly to `wp_yoast_indexables`.

This is the exact keywords string where we first spotted the issue, with some Malayalam characters toward the end:-

```
kuldeep yadav, kuldeep yadav india, ms dhoni, kuldeep yadav world cup, india vs australia, kuldeep yadav wickets, india cricket team, cricket news, sports news, ie malayalam, കുൽദീപ് യാദവ്, എംഎസ് ധോണി, ധോണി സ്റ്റംപിങ്, ഐഇ മലയാളം
```

The result was that after mysql insert failure (in this case silent, with wpdb returning 'success',) the Indexable object had an ID of zero, which had knock-on effects.

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
