### PR TITLE
QAK-2892 Ensure robots values are always congruent if noindex and or nofollow is set

### DIFF
--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -71,7 +71,7 @@ class WP_Robots_Integration implements Integration_Interface {
 		}
 
 		$merged_robots   = array_merge( $robots, $this->get_robots_value() );
-		$filtered_robots = $this->filter_robots_noindex_nofollow( $merged_robots );
+		$filtered_robots = $this->enforce_robots_congruence( $merged_robots );
 		$sorted_robots   = $this->sort_robots( $filtered_robots );
 
 		// Filter all falsy-null robot values.
@@ -147,11 +147,19 @@ class WP_Robots_Integration implements Integration_Interface {
 	 *
 	 * @return array The filtered robots.
 	 */
-	protected function filter_robots_noindex_nofollow( $robots ) {
+	protected function enforce_robots_congruence( $robots ) {
 		if ( isset( $robots['nofollow'] ) ) {
 			$robots['follow'] = null;
 		}
-
+		if ( isset( $robots['noarchive'] ) ) {
+			$robots['archive'] = null;
+		}
+		if ( isset( $robots['noimageindex'] ) ) {
+			$robots['imageindex'] = null;
+		}
+		if ( isset( $robots['nosnippet'] ) ) {
+			$robots['snippet'] = null;
+		}
 		if ( isset( $robots['noindex'] ) ) {
 			$robots['index']             = null;
 			$robots['imageindex']        = null;

--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -71,7 +71,7 @@ class WP_Robots_Integration implements Integration_Interface {
 		}
 
 		$merged_robots   = array_merge( $robots, $this->get_robots_value() );
-		$filtered_robots = $this->filter_robots_no_index( $merged_robots );
+		$filtered_robots = $this->filter_robots_noindex_nofollow( $merged_robots );
 		$sorted_robots   = $this->sort_robots( $filtered_robots );
 
 		// Filter all falsy-null robot values.
@@ -97,7 +97,6 @@ class WP_Robots_Integration implements Integration_Interface {
 
 		$robots_presenter               = new Robots_Presenter();
 		$robots_presenter->presentation = $context->presentation;
-
 		return $this->format_robots( $robots_presenter->get() );
 	}
 
@@ -139,7 +138,7 @@ class WP_Robots_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Filters robots value when page is set noindex.
+	 * Ensures all other possible robots values are congruent with nofollow and or noindex.
 	 *
 	 * WordPress might add some robot values again.
 	 * When the page is set to noindex we want to filter out these values.
@@ -148,20 +147,23 @@ class WP_Robots_Integration implements Integration_Interface {
 	 *
 	 * @return array The filtered robots.
 	 */
-	protected function filter_robots_no_index( $robots ) {
-		if ( ! isset( $robots['noindex'] ) ) {
-			return $robots;
+	protected function filter_robots_noindex_nofollow( $robots ) {
+		if ( isset( $robots['nofollow'] ) ) {
+			$robots['follow'] = null;
 		}
 
-		$robots['imageindex']        = null;
-		$robots['noimageindex']      = null;
-		$robots['archive']           = null;
-		$robots['noarchive']         = null;
-		$robots['snippet']           = null;
-		$robots['nosnippet']         = null;
-		$robots['max-snippet']       = null;
-		$robots['max-image-preview'] = null;
-		$robots['max-video-preview'] = null;
+		if ( isset( $robots['noindex'] ) ) {
+			$robots['index']             = null;
+			$robots['imageindex']        = null;
+			$robots['noimageindex']      = null;
+			$robots['archive']           = null;
+			$robots['noarchive']         = null;
+			$robots['snippet']           = null;
+			$robots['nosnippet']         = null;
+			$robots['max-snippet']       = null;
+			$robots['max-image-preview'] = null;
+			$robots['max-video-preview'] = null;
+		}
 
 		return $robots;
 	}

--- a/tests/unit/integrations/front-end/wp-robots-integration-test.php
+++ b/tests/unit/integrations/front-end/wp-robots-integration-test.php
@@ -198,7 +198,6 @@ class WP_Robots_Integration_Test extends TestCase {
 		);
 	}
 
-
 	/**
 	 * Tests the add robots with having the robots input being overwritten by our data.
 	 *

--- a/tests/unit/integrations/front-end/wp-robots-integration-test.php
+++ b/tests/unit/integrations/front-end/wp-robots-integration-test.php
@@ -120,7 +120,7 @@ class WP_Robots_Integration_Test extends TestCase {
 	 * @covers ::add_robots
 	 * @covers ::get_robots_value
 	 * @covers ::format_robots
-	 * @covers ::filter_robots_no_index
+	 * @covers ::enforce_robots_congruence
 	 */
 	public function test_add_robots() {
 		$context = (object) [
@@ -163,7 +163,7 @@ class WP_Robots_Integration_Test extends TestCase {
 	 * @covers ::add_robots
 	 * @covers ::get_robots_value
 	 * @covers ::format_robots
-	 * @covers ::filter_robots_no_index
+	 * @covers ::enforce_robots_congruence
 	 */
 	public function test_add_robots_with_noindex_set() {
 		$context = (object) [
@@ -193,6 +193,55 @@ class WP_Robots_Integration_Test extends TestCase {
 				[
 					'index'  => true,
 					'follow' => true,
+				]
+			)
+		);
+	}
+
+
+	/**
+	 * Tests the add robots with having the robots input being overwritten by our data.
+	 *
+	 * @covers ::add_robots
+	 * @covers ::get_robots_value
+	 * @covers ::format_robots
+	 * @covers ::enforce_robots_congruence
+	 */
+	public function test_enforce_robots_congruence() {
+		$context = (object) [
+			'presentation' => (object) [
+				'robots' => [
+					'follow'     => 'nofollow',
+					'imageindex' => 'noimageindex',
+					'archive'    => 'noarchive',
+					'snippet'    => 'nosnippet',
+					'index'      => 'index',
+				],
+			],
+		];
+
+		Monkey\Functions\expect( 'wp_reset_query' )->once();
+
+		$this->context_memoizer
+			->expects( 'for_current_page' )
+			->once()
+			->andReturn( $context );
+
+		static::assertEquals(
+			[
+				'index'        => true,
+				'nofollow'     => true,
+				'noarchive'    => true,
+				'noimageindex' => true,
+				'nosnippet'    => true,
+			],
+			$this->instance->add_robots(
+				[
+					'index'      => true,
+					'follow'     => true,
+					'archive'    => true,
+					'imageindex' => true,
+					'snippet'    => true,
 				]
 			)
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In a very limited set of cases it was possible that WordPress pages (WP 5.7+) in combination with our plugin would show combinations of `index, noindex` or `follow, nofollow` as robots meta values. While noindex / nofollow directives generally take precedence over their index / follow counterparts, this is of course highly unwanted behavior. This PR ensures that this could never happen again. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where both noindex and index values could be added to the robots meta tag on the WP login screen. 

## Relevant technical choices:

* Enforces that `index` is always removed from robots if `noindex` is included.
* Enforces that `follow` is always removed from robots meta if `nofollow` is included.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Scenario 1: wp-login.php
  * Go to /wp-login.php on your local wordpress install with Yoast SEO active on WP 5.7+.
  * Notice the robots meta tag contains the following incongruent value: `index, noindex, follow`
  * Notice how the fix corrects that to `noindex, follow`
* Scenario 2: Global discourage search engines
  * Enable the setting  "Discourage search engines from indexing this site" in your global WordPress reading settings.
  * Go to a random page on your site.
  * Notice the robots meta tag contains the following incongruent value: `noindex, follow, nofollow`
  * Notice how the fix corrects that to `noindex, nofollow`


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Robots meta tag on any page on the site. I would argue the scope of this to be limited in the following way: All this does is check a robots tag for incongruent values and unset those. We already did this for other values related to noindex. When we detected `noindex`, we already ensured a robots meta tag could never contain `imageindex`, `noimageindex`, `archive`, `noarchive`, `snippet`, `nosnippet`, `max-snippet`, `max-image-preview`, `max-video-preview`. All we've added to this, is the following extra (very logical) restrictions:
  * When a robots tag contains `nofollow`, it can now never contain `follow`.
  * When a robots tag contains `noindex`, it can never contain `index`.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities