### PR TITLE
Always reset the query before retrieving the current page context

### DIFF
--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -84,16 +84,7 @@ class WP_Robots_Integration implements Integration_Interface {
 	 * @returns array The robots key-value pairs.
 	 */
 	protected function get_robots_value() {
-		global $wp_query;
-
-		$old_wp_query = $wp_query;
-		// phpcs:ignore WordPress.WP.DiscouragedFunctions.wp_reset_query_wp_reset_query -- Reason: The recommended function, wp_reset_postdata, doesn't reset wp_query.
-		\wp_reset_query();
-
 		$context = $this->context_memoizer->for_current_page();
-
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Reason: we have to restore the query.
-		$GLOBALS['wp_query'] = $old_wp_query;
 
 		$robots_presenter               = new Robots_Presenter();
 		$robots_presenter->presentation = $context->presentation;

--- a/src/memoizers/meta-tags-context-memoizer.php
+++ b/src/memoizers/meta-tags-context-memoizer.php
@@ -93,8 +93,14 @@ class Meta_Tags_Context_Memoizer {
 			// phpcs:ignore WordPress.WP.DiscouragedFunctions.wp_reset_query_wp_reset_query -- Reason: The recommended function, wp_reset_postdata, doesn't reset wp_query.
 			\wp_reset_query();
 
-			$indexable                   = $this->repository->for_current_page();
-			$page_type                   = $this->current_page->get_page_type();
+			$indexable = $this->repository->for_current_page();
+			$page_type = $this->current_page->get_page_type();
+
+			if ( $page_type === 'Fallback' ) {
+				// Do not cache the context if it's a fallback page.
+				// The likely cause for this is that this function was called before the query was loaded.
+				return $this->get( $indexable, $page_type );
+			}
 			$this->cache['current_page'] = $this->get( $indexable, $page_type );
 
 			// Restore the previous query.

--- a/src/memoizers/meta-tags-context-memoizer.php
+++ b/src/memoizers/meta-tags-context-memoizer.php
@@ -86,9 +86,20 @@ class Meta_Tags_Context_Memoizer {
 	 */
 	public function for_current_page() {
 		if ( ! isset( $this->cache['current_page'] ) ) {
+			// First reset the query to ensure we actually have the current page.
+			global $wp_query;
+
+			$old_wp_query = $wp_query;
+			// phpcs:ignore WordPress.WP.DiscouragedFunctions.wp_reset_query_wp_reset_query -- Reason: The recommended function, wp_reset_postdata, doesn't reset wp_query.
+			\wp_reset_query();
+
 			$indexable                   = $this->repository->for_current_page();
 			$page_type                   = $this->current_page->get_page_type();
 			$this->cache['current_page'] = $this->get( $indexable, $page_type );
+
+			// Restore the previous query.
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Reason: we have to restore the query.
+			$GLOBALS['wp_query'] = $old_wp_query;
 		}
 
 		return $this->cache['current_page'];

--- a/tests/unit/integrations/front-end/wp-robots-integration-test.php
+++ b/tests/unit/integrations/front-end/wp-robots-integration-test.php
@@ -98,8 +98,6 @@ class WP_Robots_Integration_Test extends TestCase {
 			],
 		];
 
-		Monkey\Functions\expect( 'wp_reset_query' )->once();
-
 		$this->context_memoizer
 			->expects( 'for_current_page' )
 			->once()
@@ -133,8 +131,6 @@ class WP_Robots_Integration_Test extends TestCase {
 				],
 			],
 		];
-
-		Monkey\Functions\expect( 'wp_reset_query' )->once();
 
 		$this->context_memoizer
 			->expects( 'for_current_page' )
@@ -177,8 +173,6 @@ class WP_Robots_Integration_Test extends TestCase {
 			],
 		];
 
-		Monkey\Functions\expect( 'wp_reset_query' )->once();
-
 		$this->context_memoizer
 			->expects( 'for_current_page' )
 			->once()
@@ -218,8 +212,6 @@ class WP_Robots_Integration_Test extends TestCase {
 				],
 			],
 		];
-
-		Monkey\Functions\expect( 'wp_reset_query' )->once();
 
 		$this->context_memoizer
 			->expects( 'for_current_page' )

--- a/tests/unit/memoizers/meta-tags-context-memoizer-test.php
+++ b/tests/unit/memoizers/meta-tags-context-memoizer-test.php
@@ -161,6 +161,8 @@ class Meta_Tags_Context_Memoizer_Test extends TestCase {
 			->withNoArgs()
 			->andReturn( 'the_page_type' );
 
+		Monkey\Functions\expect( 'wp_reset_query' )->once();
+
 		$this->mock_get();
 
 		$this->assertEquals( $this->meta_tags_context_mock, $this->instance->for_current_page() );
@@ -267,6 +269,8 @@ class Meta_Tags_Context_Memoizer_Test extends TestCase {
 			->once()
 			->andReturn( 'the_page_type' );
 
+		Monkey\Functions\expect( 'wp_reset_query' )->once();
+
 		$this->mock_get();
 
 		$this->instance->for_current_page();
@@ -292,6 +296,8 @@ class Meta_Tags_Context_Memoizer_Test extends TestCase {
 			->once()
 			->andReturn( 'the_page_type' );
 
+		Monkey\Functions\expect( 'wp_reset_query' )->once();
+
 		$this->mock_get();
 
 		$this->instance->for_current_page();
@@ -316,6 +322,8 @@ class Meta_Tags_Context_Memoizer_Test extends TestCase {
 			->expects( 'get_page_type' )
 			->once()
 			->andReturn( 'the_page_type' );
+
+		Monkey\Functions\expect( 'wp_reset_query' )->once();
 
 		$this->mock_get();
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Flows were possible where the current page context was fetched without first resetting the query, possibly leading to situation where the wrong object would be set as the current page leading to, among other things, incorrect schema.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a rare issue where the name property would be missing in the breadcrumb schema due to plugin conflicts.

## Relevant technical choices:

* The query is always reset when creating the current page context, this ensures the main query is always used and whether or not the loop is active no longer has any impact on what is seen as the current page.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add the following code somewhere ( functions.php or wp-seo-main.php ): `add_action( 'init', 'wp_title' );`
* This will call wp_title causing our plugin to load the current page at a time this is not yet available.
* The schema should be correct.
* Please also regression test https://github.com/Yoast/wordpress-seo/pull/16790 specifically as it's been touched by this PR.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Schema and meta tag output when another plugin manipulates the query or calls certain functions before the query is set.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #17006
