### PR TITLE
P3-590 Change defaults for social title templates

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -824,9 +824,6 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_163() {
 		$this->copy_og_settings_from_social_to_titles();
-
-		// Run after the WPSEO_Options::enrich_defaults method which has priority 99.
-		\add_action( 'init', [ $this, 'set_og_settings_from_seo_values' ], 100 );
 	}
 
 	/**
@@ -1170,78 +1167,5 @@ class WPSEO_Upgrade {
 		$wpseo_titles = \array_merge( $wpseo_titles, $copied_options );
 
 		\update_option( 'wpseo_titles', $wpseo_titles );
-	}
-
-	/**
-	 * Overwrites the social options defaults with the values from the matching SEO options.
-	 *
-	 * @return void
-	 */
-	public function set_og_settings_from_seo_values() {
-		$wpseo_titles    = get_option( 'wpseo_titles' );
-		$updated_options = [];
-
-		$options = [
-			'title-author-wpseo'     => 'social-title-author-wpseo',
-			'title-archive-wpseo'    => 'social-title-archive-wpseo',
-			'metadesc-author-wpseo'  => 'social-description-author-wpseo',
-			'metadesc-archive-wpseo' => 'social-description-archive-wpseo',
-		];
-
-		$options_templates_post_types = [
-			'title-'    => 'social-title-',
-			'metadesc-' => 'social-description-',
-		];
-
-		$options_templates_post_types_archive = [
-			'title-ptarchive-'    => 'social-title-ptarchive-',
-			'metadesc-ptarchive-' => 'social-description-ptarchive-',
-		];
-
-		$options_templates_term_archive = [
-			'title-tax-'    => 'social-title-tax-',
-			'metadesc-tax-' => 'social-description-tax-',
-		];
-
-		foreach ( $options as $seo => $social ) {
-			if ( isset( $wpseo_titles[ $seo ] ) ) {
-				$updated_options[ $social ] = $wpseo_titles[ $seo ];
-			}
-		}
-
-		$post_type_objects = get_post_types( [ 'public' => true ], 'objects' );
-
-		if ( $post_type_objects ) {
-			foreach ( $post_type_objects as $pt ) {
-				// Post types.
-				foreach ( $options_templates_post_types as $seo => $social ) {
-					if ( isset( $wpseo_titles[ $seo . $pt->name ] ) ) {
-						$updated_options[ $social . $pt->name ] = $wpseo_titles[ $seo . $pt->name ];
-					}
-				}
-				// Post type archives.
-				foreach ( $options_templates_post_types_archive as $seo_archive => $social_archive ) {
-					if ( isset( $wpseo_titles[ $seo_archive . $pt->name ] ) ) {
-						$updated_options[ $social_archive . $pt->name ] = $wpseo_titles[ $seo_archive . $pt->name ];
-					}
-				}
-			}
-		}
-
-		$taxonomy_objects = get_taxonomies( [ 'public' => true ], 'object' );
-
-		if ( $taxonomy_objects ) {
-			foreach ( $taxonomy_objects as $tax ) {
-				foreach ( $options_templates_term_archive as $seo => $social ) {
-					if ( isset( $wpseo_titles[ $seo . $tax->name ] ) ) {
-						$updated_options[ $social . $tax->name ] = $wpseo_titles[ $seo . $tax->name ];
-					}
-				}
-			}
-		}
-
-		$wpseo_titles = array_merge( $wpseo_titles, $updated_options );
-
-		update_option( 'wpseo_titles', $wpseo_titles );
 	}
 }

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -38,8 +38,8 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		'title-search-wpseo'               => '', // Text field.
 		'title-404-wpseo'                  => '', // Text field.
 
-		'social-title-author-wpseo'        => '', // Text field.
-		'social-title-archive-wpseo'       => '%%date%% %%page%% %%sep%% %%sitename%%', // Text field.
+		'social-title-author-wpseo'        => '%%name%%', // Text field.
+		'social-title-archive-wpseo'       => '%%date%%', // Text field.
 		'social-description-author-wpseo'  => '', // Text area.
 		'social-description-archive-wpseo' => '', // Text area.
 		'social-image-url-author-wpseo'    => '', // Hidden input field.
@@ -245,8 +245,6 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	public function translate_defaults() {
 		/* translators: 1: Author name; 2: Site name. */
 		$this->defaults['title-author-wpseo'] = sprintf( __( '%1$s, Author at %2$s', 'wordpress-seo' ), '%%name%%', '%%sitename%%' ) . ' %%page%% ';
-		/* translators: 1: Author name, 2: Site name. */
-		$this->defaults['social-title-author-wpseo'] = sprintf( __( '%1$s, Author at %2$s', 'wordpress-seo' ), '%%name%%', '%%sitename%%' ) . ' %%page%% ';
 		/* translators: %s expands to the search phrase. */
 		$this->defaults['title-search-wpseo'] = sprintf( __( 'You searched for %s', 'wordpress-seo' ), '%%searchphrase%%' ) . ' %%page%% %%sep%% %%sitename%%';
 		$this->defaults['title-404-wpseo']    = __( 'Page not found', 'wordpress-seo' ) . ' %%sep%% %%sitename%%';
@@ -293,7 +291,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				$enriched_defaults[ 'post_types-' . $pt->name . '-maintax' ] = 0; // Select box.
 				$enriched_defaults[ 'schema-page-type-' . $pt->name ]        = 'WebPage';
 				$enriched_defaults[ 'schema-article-type-' . $pt->name ]     = ( YoastSEO()->helpers->schema->article->is_article_post_type( $pt->name ) ) ? 'Article' : 'None';
-				$enriched_defaults[ 'social-title-' . $pt->name ]            = '%%title%% %%page%% %%sep%% %%sitename%%'; // Text field.
+				$enriched_defaults[ 'social-title-' . $pt->name ]            = '%%title%%'; // Text field.
 				$enriched_defaults[ 'social-description-' . $pt->name ]      = ''; // Text area.
 				$enriched_defaults[ 'social-image-url-' . $pt->name ]        = ''; // Hidden input field.
 				$enriched_defaults[ 'social-image-id-' . $pt->name ]         = 0; // Hidden input field.
@@ -303,7 +301,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 					$enriched_defaults[ 'metadesc-ptarchive-' . $pt->name ]           = ''; // Text area.
 					$enriched_defaults[ 'bctitle-ptarchive-' . $pt->name ]            = ''; // Text field.
 					$enriched_defaults[ 'noindex-ptarchive-' . $pt->name ]            = false;
-					$enriched_defaults[ 'social-title-ptarchive-' . $pt->name ]       = $archive . ' %%page%% %%sep%% %%sitename%%'; // Text field.
+					$enriched_defaults[ 'social-title-ptarchive-' . $pt->name ]       = $archive; // Text field.
 					$enriched_defaults[ 'social-description-ptarchive-' . $pt->name ] = ''; // Text area.
 					$enriched_defaults[ 'social-image-url-ptarchive-' . $pt->name ]   = ''; // Hidden input field.
 					$enriched_defaults[ 'social-image-id-ptarchive-' . $pt->name ]    = 0; // Hidden input field.
@@ -324,7 +322,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 
 				$enriched_defaults[ 'noindex-tax-' . $tax->name ] = ( $tax->name === 'post_format' );
 
-				$enriched_defaults[ 'social-title-tax-' . $tax->name ]       = $archives . ' %%page%% %%sep%% %%sitename%%'; // Text field.
+				$enriched_defaults[ 'social-title-tax-' . $tax->name ]       = $archives; // Text field.
 				$enriched_defaults[ 'social-description-tax-' . $tax->name ] = ''; // Text area.
 				$enriched_defaults[ 'social-image-url-tax-' . $tax->name ]   = ''; // Hidden input field.
 				$enriched_defaults[ 'social-image-id-tax-' . $tax->name ]    = 0; // Hidden input field.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the defaults for the social templates do be distinct from the ones used for the SEO templates

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets the default values for the Social Title templates.
* Removes the upgrade routine that copied the SEO templates defaults into the Social templates defaults.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* activate Yoast SEO switched to this branch and built
* use the Yoast Test Helper plugin to register the `Book` and `Movie` custom post types
* manually inspect the database by using your tool of choice (e.g. Sequel Pro on macOS)
* in the `wp_options` table, delete the option with name `wpseo_titles`
* _To test the following bullet point, install and activate Premium from `trunk` and enable the Social Templates feature flag_
* go to WordPress > SEO > Search Appearance, check that the social title fields display the expected default:
   * `Content Types tab`, Single Post: "`Title`"  (%%title%%)
     * this should happen for all the post types
   * `Content Types tab`, Archives for the custom post types: "`Post type (plural)` Archive"  (%%pt_plural%% Archive)
     * this should happen for all the custom post types
   * `Taxonomy tab`: “`Term title` Archives” (%%term_title%% Archives)
     * this should happen for all the taxonomies
  * `Archive` tab:
    * Author archive: "`Name`" (%%name%%)
    * Date archive: "`Date`" (%%date%%)
* do not touch anything and hit "Save Changes"
  * this way you just saved again the whole array of serialized options in the `wpseo_titles` value
* inspect the database and check the `wpseo_titles` value
  * hint: copy and paste the entire serialized array in your editor of choice
* check that in the serialized array of options the following options have the expected default values:
```
  'social-title-author-wpseo' => '%%name%%',
  'social-title-archive-wpseo' => '%%date%%',
  'social-title-post' => '%%title%%',
  'social-title-page' => '%%title%%',
  'social-title-attachment' => '%%title%%',
  'social-title-tax-category' => '%%term_title%% Archives',
  'social-title-tax-post_tag' => '%%term_title%% Archives',
  'social-title-tax-post_format' => '%%term_title%% Archives',
  'social-title-book' => '%%title%%',
  'social-title-ptarchive-book' => '%%pt_plural%% Archive',
  'social-title-movie' => '%%title%%',
  'social-title-ptarchive-movie' => '%%pt_plural%% Archive',
  'social-title-tax-book-category' => '%%term_title%% Archives',
  'social-title-tax-book-genre' => '%%term_title%% Archives',
  'social-title-tax-movie-category' => '%%term_title%% Archives',
  'social-title-tax-movie-genre' => '%%term_title%% Archives',
```

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-590]
