### PR TITLE
A page is only a static posts page if it is a page

### DIFF
--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
-use WP_Post;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
 /**

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
+use WP_Post;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
 /**
@@ -230,7 +231,7 @@ class Current_Page_Helper {
 
 		$page_for_posts = (int) \get_option( 'page_for_posts' );
 
-		return ( $page_for_posts > 0 && $page_for_posts === $wp_query->get_queried_object_id() );
+		return ( $page_for_posts > 0 && $wp_query->is_page( $page_for_posts ) );
 	}
 
 	/**

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -227,11 +227,13 @@ class Current_Page_Helper {
 	 * @return bool Whether or not the current page is a static posts page.
 	 */
 	public function is_static_posts_page() {
-		$wp_query = $this->wp_query_wrapper->get_main_query();
+		$wp_query       = $this->wp_query_wrapper->get_main_query();
+		$queried_object = $wp_query->get_queried_object();
 
 		return (
 			$wp_query->is_posts_page &&
-			\is_a( $wp_query->get_queried_object(), WP_Post::class )
+			\is_a( $queried_object, WP_Post::class ) &&
+			$queried_object->post_type === 'page'
 		);
 	}
 

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
+use WP_Post;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
 /**
@@ -228,9 +229,10 @@ class Current_Page_Helper {
 	public function is_static_posts_page() {
 		$wp_query = $this->wp_query_wrapper->get_main_query();
 
-		$page_for_posts = (int) \get_option( 'page_for_posts' );
-
-		return ( $page_for_posts > 0 && $wp_query->is_page( $page_for_posts ) );
+		return (
+			$wp_query->is_posts_page &&
+			\is_a( $wp_query->get_queried_object(), WP_Post::class )
+		);
 	}
 
 	/**

--- a/src/memoizers/meta-tags-context-memoizer.php
+++ b/src/memoizers/meta-tags-context-memoizer.php
@@ -99,7 +99,13 @@ class Meta_Tags_Context_Memoizer {
 			if ( $page_type === 'Fallback' ) {
 				// Do not cache the context if it's a fallback page.
 				// The likely cause for this is that this function was called before the query was loaded.
-				return $this->get( $indexable, $page_type );
+				$context = $this->get( $indexable, $page_type );
+
+				// Restore the previous query.
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Reason: we have to restore the query.
+				$GLOBALS['wp_query'] = $old_wp_query;
+
+				return $context;
 			}
 			$this->cache['current_page'] = $this->get( $indexable, $page_type );
 

--- a/tests/unit/helpers/current-page-helper-test.php
+++ b/tests/unit/helpers/current-page-helper-test.php
@@ -454,9 +454,10 @@ class Current_Page_Helper_Test extends TestCase {
 	public function test_is_static_posts_page_same_object_id() {
 		$wp_query = Mockery::mock( 'WP_Query' );
 		$wp_query
-			->expects( 'get_queried_object_id' )
+			->expects( 'is_page' )
 			->once()
-			->andReturn( 1 );
+			->with( 1 )
+			->andReturn( true );
 
 		$this->wp_query_wrapper
 			->expects( 'get_main_query' )
@@ -480,9 +481,10 @@ class Current_Page_Helper_Test extends TestCase {
 	public function test_is_static_posts_page_different_object_id() {
 		$wp_query = Mockery::mock( 'WP_Query' );
 		$wp_query
-			->expects( 'get_queried_object_id' )
+			->expects( 'is_page' )
 			->once()
-			->andReturn( 2 );
+			->with( 1 )
+			->andReturn( false );
 
 		$this->wp_query_wrapper
 			->expects( 'get_main_query' )

--- a/tests/unit/helpers/current-page-helper-test.php
+++ b/tests/unit/helpers/current-page-helper-test.php
@@ -461,11 +461,14 @@ class Current_Page_Helper_Test extends TestCase {
 			->once()
 			->andReturn( $wp_query );
 
+		$post_mock            = Mockery::mock( WP_Post::class );
+		$post_mock->post_type = 'page';
+
 		$wp_query->is_posts_page = true;
 		$wp_query
 			->expects( 'get_queried_object' )
 			->once()
-			->andReturn( Mockery::mock( WP_Post::class ) );
+			->andReturn( $post_mock );
 
 		$this->assertTrue( $this->instance->is_static_posts_page() );
 	}
@@ -484,6 +487,10 @@ class Current_Page_Helper_Test extends TestCase {
 			->andReturn( $wp_query );
 
 		$wp_query->is_posts_page = false;
+		$wp_query
+			->expects( 'get_queried_object' )
+			->once()
+			->andReturn( null );
 
 		$this->assertFalse( $this->instance->is_static_posts_page() );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Ensures we no longer trigger the static posts page on any object with the same ID.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the schema output could be incorrect on terms with the same ID as the static posts page.

## Relevant technical choices:

* Uses the built in `is_page` function of `WP_Query`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

To reproduce the issue:
1. Install Yoast free 16.3
2. Go to the WordPress Reading settings, and set your Sample page as the `Posts page` (in my case, the sample page has the ID of 2, this is important).
3. Go to your post categories and create categories until you create one with the same ID as the page in the previous step, so in this case ID 2.
4. Create a post and assign the category from the previous step (ID 2)
5. Go to the archive page of the category (in admin, go to Posts -> Categories and click `view` on the category)
6. Inspect the source of the archive page, and note that the `name` of the `CollectionPage` is empty, as in this example:
```json
	        {
	            "@type": "CollectionPage",
	            "@id": "http://basic.wordpress.test/category/exclusive-discrete-access/#webpage",
	            "url": "http://basic.wordpress.test/category/exclusive-discrete-access/",
	            "name": "", <===============
	            "isPartOf": {
	                "@id": "http://basic.wordpress.test/#website"
	            },
	            "breadcrumb": {
	                "@id": "http://basic.wordpress.test/category/exclusive-discrete-access/#breadcrumb"
	            },
	            "inLanguage": "en-US",
	            "potentialAction": [
	                {
	                    "@type": "ReadAction",
	                    "target": [
	                        "http://basic.wordpress.test/category/exclusive-discrete-access/"
	                    ]
	                }
	            ]
	        },
```

To test if this PR fixes the issue, make sure that the name is filled in / correct.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The schema output on term and author archives that have the same ID as the static posts page.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #17006
