### PR TITLE
change the way we get the locale for the researcher

### DIFF
--- a/src/helpers/language-helper.php
+++ b/src/helpers/language-helper.php
@@ -44,7 +44,7 @@ class Language_Helper {
 	 * @return string The language to use to select a researcher.
 	 */
 	public function get_researcher_language() {
-		$researcher_language = WPSEO_Language_Utils::get_language( \get_user_locale() );
+		$researcher_language = WPSEO_Language_Utils::get_language( get_locale() );
 		if ( ! \in_array( $researcher_language, Researcher_Languages::SUPPORTED_LANGUAGES, true ) ) {
 			$researcher_language = 'default';
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Previously (up to 16.3), your site language determined the analysis, regardless of what language you set in your user profile. Now, the user profile seems to overwrite the site language.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the function to retrieve the locale for language researcher from `get_user_locale()` to `get_locale()`

## Relevant technical choices:

* The empty premium-configuration branch with the same name should be deleted after this PR is merged.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Do the following in default and in Classic editor:
* Set your site language to English. Make sure your user language (under `Profiles` is set to `default`).
* Create a post with the following content: 
> Het huis werd gebouwd. The house was built.

* The passive voice assessment should say there is one passive sentence. When you click on the marker, `The house was built.` should be highlighted.
* Set your user language to Dutch.
* Go back to the post you created.
* The passive voice assessment should say there is one passive sentence. When you click on the marker, `The house was built.` should be highlighted. (no change to when your user language was default).

In Elementor:
* Set your site language to English. Make sure your user language (under `Profiles` is set to `default`).
* Create/edit a post in Elementor editor
* In your console, type `window.yoast.Researcher` and hit enter.
* Confirm that the researcher file starts with `en`.
<img width="650" alt="Screenshot 2021-05-20 at 13 45 06" src="https://user-images.githubusercontent.com/48715883/118973419-f357e980-b971-11eb-9b65-60747546d8dc.png">

* Set your user language to Dutch.
* Go back to the post you created in Elementor editor.
* Confirm that you get the same result when typing `window.yoast.Researcher`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-839
