### PR TITLE
P3 622 fix unsafe redirect in redirect helper

### DIFF
--- a/src/helpers/redirect-helper.php
+++ b/src/helpers/redirect-helper.php
@@ -16,6 +16,7 @@ class Redirect_Helper {
 	 * @param int    $status   The status code to use.
 	 */
 	public function do_unsafe_redirect( $location, $status = 302 ) {
+		// phpcs:ignore WordPress.Security.SafeRedirect -- intentional, function has been renamed to make unsafe more clear.
 		\wp_redirect( $location, $status, 'Yoast SEO' );
 		exit;
 	}

--- a/src/helpers/redirect-helper.php
+++ b/src/helpers/redirect-helper.php
@@ -15,7 +15,7 @@ class Redirect_Helper {
 	 * @param string $location The path to redirect to.
 	 * @param int    $status   The status code to use.
 	 */
-	public function do_redirect( $location, $status = 302 ) {
+	public function do_unsafe_redirect( $location, $status = 302 ) {
 		\wp_redirect( $location, $status, 'Yoast SEO' );
 		exit;
 	}
@@ -31,5 +31,20 @@ class Redirect_Helper {
 	public function do_safe_redirect( $location, $status = 302 ) {
 		\wp_safe_redirect( $location, $status, 'Yoast SEO' );
 		exit;
+	}
+
+	/**
+	 * Wraps wp_redirect to allow testing for redirects.
+	 *
+	 * @deprecated 16.x
+	 * @codeCoverageIgnore It only wraps a WordPress function.
+	 *
+	 * @param string $location The path to redirect to.
+	 * @param int    $status   The status code to use.
+	 */
+	public function do_redirect( $location, $status = 302 ) {
+		\_deprecated_function( __METHOD__, 'WPSEO 16.x', 'Yoast\WP\SEO\Helpers\Redirect_Helper::do_unsafe_redirect' );
+
+		$this->do_unsafe_redirect( $location, $status );
 	}
 }

--- a/src/integrations/front-end/redirects.php
+++ b/src/integrations/front-end/redirects.php
@@ -108,7 +108,7 @@ class Redirects implements Integration_Interface {
 			return;
 		}
 
-		$this->redirect->do_redirect( $redirect, 301 );
+		$this->redirect->do_unsafe_redirect( $redirect, 301 );
 	}
 
 	/**
@@ -128,7 +128,7 @@ class Redirects implements Integration_Interface {
 			return;
 		}
 
-		$this->redirect->do_redirect( $url, 301 );
+		$this->redirect->do_unsafe_redirect( $url, 301 );
 	}
 
 	/**

--- a/src/integrations/front-end/redirects.php
+++ b/src/integrations/front-end/redirects.php
@@ -108,7 +108,7 @@ class Redirects implements Integration_Interface {
 			return;
 		}
 
-		$this->redirect->do_unsafe_redirect( $redirect, 301 );
+		$this->redirect->do_safe_redirect( $redirect, 301 );
 	}
 
 	/**

--- a/tests/unit/integrations/front-end/redirects-test.php
+++ b/tests/unit/integrations/front-end/redirects-test.php
@@ -166,7 +166,7 @@ class Redirects_Test extends TestCase {
 			->andReturnTrue();
 
 		$this->redirect
-			->shouldNotReceive( 'do_redirect' );
+			->shouldNotReceive( 'do_safe_redirect' );
 
 		$this->instance->page_redirect();
 	}
@@ -192,7 +192,7 @@ class Redirects_Test extends TestCase {
 			->andReturn( '' );
 
 		$this->redirect
-			->shouldNotReceive( 'do_redirect' );
+			->shouldNotReceive( 'do_safe_redirect' );
 
 		$this->instance->page_redirect();
 	}
@@ -218,7 +218,7 @@ class Redirects_Test extends TestCase {
 			->andReturn( 'https://example.org/redirect' );
 
 		$this->redirect
-			->expects( 'do_redirect' )
+			->expects( 'do_safe_redirect' )
 			->once()
 			->with( 'https://example.org/redirect', 301 );
 
@@ -237,7 +237,7 @@ class Redirects_Test extends TestCase {
 			->andReturnFalse();
 
 		$this->redirect
-			->shouldNotReceive( 'do_redirect' );
+			->shouldNotReceive( 'do_unsafe_redirect' );
 
 		$this->instance->attachment_redirect();
 	}
@@ -260,7 +260,7 @@ class Redirects_Test extends TestCase {
 			->andReturnFalse();
 
 		$this->redirect
-			->shouldNotReceive( 'do_redirect' );
+			->shouldNotReceive( 'do_unsafe_redirect' );
 
 		$this->instance->attachment_redirect();
 	}
@@ -288,7 +288,7 @@ class Redirects_Test extends TestCase {
 			->andReturn( '' );
 
 		$this->redirect
-			->shouldNotReceive( 'do_redirect' );
+			->shouldNotReceive( 'do_unsafe_redirect' );
 
 		$this->instance->attachment_redirect();
 	}
@@ -316,7 +316,7 @@ class Redirects_Test extends TestCase {
 			->andReturn( 'https://example.org/redirect' );
 
 		$this->redirect
-			->expects( 'do_redirect' )
+			->expects( 'do_unsafe_redirect' )
 			->once()
 			->with( 'https://example.org/redirect', 301 );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Using `wp_safe_redirect()` instead of `wp_redirect()`, along with the allowed_redirect_hosts filter if needed, can help avoid any chances of malicious redirects within code.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*  Improve unsafe redirects in Redirect_Helper.

## Relevant technical choices:

* The `do_redirect` function (in  Redirect_Helper) has been renamed to `do_unsafe_redirect`, to keep the option, but make it more clear that someone is consciously choosing the unsafer option (instead of the `do_safe_redirect` function).
* The unsafe redirect in the `page_redirect` has been changed to a safe redirect.
* It still needs to be discussed whether the unsafe redirect in `attachment_redirect` can also safely be replaced with a safe redirect. **-- Please update this comment with the decisions made --**

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In SEO > Search Appearance > Archives, set the `Author archives` and `Date archives` to `Disabled`.
* Navigate to an author / date archive page on the frontend, e.g. http://basic.wordpress.test/2021/. 
* Make sure you are redirected to the home page. 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #P3-622
