### PR TITLE
P3 546 set max-image-preview to none when noimageindex is set

### DIFF
--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -147,6 +147,11 @@ class WP_Robots_Integration implements Integration_Interface {
 		}
 		if ( isset( $robots['noimageindex'] ) ) {
 			$robots['imageindex'] = null;
+
+			// max-image-preview should be to none when noimageindex is present.
+			if ( isset( $robots['max-image-preview'] ) ) {
+				$robots['max-image-preview'] = 'none';
+			}
 		}
 		if ( isset( $robots['nosnippet'] ) ) {
 			$robots['snippet'] = null;

--- a/tests/unit/integrations/front-end/wp-robots-integration-test.php
+++ b/tests/unit/integrations/front-end/wp-robots-integration-test.php
@@ -127,6 +127,45 @@ class WP_Robots_Integration_Test extends TestCase {
 					'index'             => 'index',
 					'follow'            => 'follow',
 					'max-image-preview' => 'max-image-preview:large',
+				],
+			],
+		];
+
+		$this->context_memoizer
+			->expects( 'for_current_page' )
+			->once()
+			->andReturn( $context );
+
+		static::assertEquals(
+			[
+				'follow'            => true,
+				'index'             => true,
+				'max-image-preview' => 'large',
+			],
+			$this->instance->add_robots(
+				[
+					'index'  => true,
+					'follow' => true,
+				]
+			)
+		);
+	}
+
+	/**
+	 * Tests the add robots with having the robots input being overwritten by our data.
+	 *
+	 * @covers ::add_robots
+	 * @covers ::get_robots_value
+	 * @covers ::format_robots
+	 * @covers ::enforce_robots_congruence
+	 */
+	public function test_add_robots_with_noimageindex() {
+		$context = (object) [
+			'presentation' => (object) [
+				'robots' => [
+					'index'             => 'index',
+					'follow'            => 'follow',
+					'max-image-preview' => 'max-image-preview:large',
 					'imageindex'        => 'noimageindex',
 				],
 			],
@@ -142,7 +181,7 @@ class WP_Robots_Integration_Test extends TestCase {
 				'follow'            => true,
 				'index'             => true,
 				'noimageindex'      => true,
-				'max-image-preview' => 'large',
+				'max-image-preview' => 'none',
 			],
 			$this->instance->add_robots(
 				[


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* With WP 5.6 when user sets post to noimage, then `max-image-preview:large` is not output. With 5.7 where we build our settings to core robots settings `max-image-preview:large` was still being output.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where `max-image-preview:large` is still output when a post is set `noimage`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Within the post configure Advanced settings to:
* Allow search engines to show this Post in search results? : Yes (current default for Posts)
* Should search engines follow links on this Post? : No
* Meta robots advanced : No Image Index & No Archive
* Check the meta tag robots output contains `max-image-preview:none`.
* Edit the post and in Meta robots advanced: remove No Image Index. 
* Check the meta tag robots output contains `max-image-preview:large`.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #P3-546
