### PR TITLE
P1-542 Replace Jed with WP i18n in YoastSEO.js

### DIFF
--- a/packages/js/src/analysis/PostDataCollector.js
+++ b/packages/js/src/analysis/PostDataCollector.js
@@ -1,6 +1,7 @@
 /* global wpseoScriptData */
 
 /* External dependencies */
+import { __ } from "@wordpress/i18n";
 import { get } from "lodash-es";
 import { markers } from "yoastseo";
 import { select } from "@wordpress/data";
@@ -11,14 +12,11 @@ import { update as updateAdminBar } from "../ui/adminBar";
 import * as publishBox from "../ui/publishBox";
 import { update as updateTrafficLight } from "../ui/trafficLight";
 import * as tmceHelper from "../lib/tinymce";
-import getI18n from "./getI18n";
 import getIndicatorForScore from "./getIndicatorForScore";
 import isKeywordAnalysisActive from "./isKeywordAnalysisActive";
 
 const { tmceId } = tmceHelper;
 const $ = jQuery;
-const i18n = getI18n();
-
 /**
  * Show warning in console when the unsupported CkEditor is used
  *
@@ -385,9 +383,9 @@ PostDataCollector.prototype.saveScores = function( score, keyword ) {
 
 	if ( "" === keyword ) {
 		indicator.className = "na";
-		indicator.screenReaderText = i18n.dgettext(
-			"js-text-analysis",
-			"Enter a focus keyphrase to calculate the SEO score"
+		indicator.screenReaderText = __(
+			"Enter a focus keyphrase to calculate the SEO score",
+			"wordpress-seo"
 		);
 	}
 

--- a/packages/yoastseo/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
+++ b/packages/yoastseo/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
@@ -2,8 +2,6 @@ import PreviouslyUsedKeywords from "../../src/bundledPlugins/previouslyUsedKeywo
 
 var usedKeywords = { keyword: [ 1 ], test: [ 2, 3, 4 ] };
 import Paper from "../../src/values/Paper.js";
-import Factory from "../specHelpers/factory.js";
-var i18n = Factory.buildJed();
 
 var app = {};
 
@@ -20,25 +18,25 @@ describe( "checks for keyword doubles", function() {
 	it( "returns array with keyword", function() {
 		var paper = new Paper( "text", { keyword: "keyword" } );
 
-		var plugin = new PreviouslyUsedKeywords( app, args, i18n );
-		expect( plugin.scoreAssessment( { id: 1, count: 1 }, paper, i18n ).score ).toBe( 6 );
-		expect( plugin.scoreAssessment( { id: 1, count: 1 }, paper, i18n ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: " +
+		var plugin = new PreviouslyUsedKeywords( app, args );
+		expect( plugin.scoreAssessment( { id: 1, count: 1 }, paper ).score ).toBe( 6 );
+		expect( plugin.scoreAssessment( { id: 1, count: 1 }, paper ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: " +
 			"You've used this keyphrase <a href='http://post?1' target='_blank'>once before</a>. " +
 			"<a href='https://yoa.st/33y' target='_blank'>Do not use your keyphrase more than once</a>." );
 
-		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper, i18n ).score ).toBe( 1 );
-		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper, i18n ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: " +
+		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper ).score ).toBe( 1 );
+		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: " +
 			"You've used this keyphrase <a href='http://search?keyword' target='_blank'>2 times before</a>. " +
 			"<a href='https://yoa.st/33y' target='_blank'>Do not use your keyphrase more than once</a>." );
 
-		expect( plugin.scoreAssessment( { id: 0, count: 0 }, paper, i18n ).score ).toBe( 9 );
-		expect( plugin.scoreAssessment( { id: 0, count: 0 }, paper, i18n ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: You've not used this keyphrase before, very good." );
+		expect( plugin.scoreAssessment( { id: 0, count: 0 }, paper ).score ).toBe( 9 );
+		expect( plugin.scoreAssessment( { id: 0, count: 0 }, paper ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: You've not used this keyphrase before, very good." );
 	} );
 
 	it( "escapes the keyword's special characters in the url", function() {
 		var paper = new Paper( "text", { keyword: "keyword/bla" } );
-		var plugin = new PreviouslyUsedKeywords( app, args, i18n );
-		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper, i18n ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: " +
+		var plugin = new PreviouslyUsedKeywords( app, args );
+		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper ).text ).toBe( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: " +
 			"You've used this keyphrase <a href='http://search?keyword%2Fbla' target='_blank'>2 times before</a>. " +
 			"<a href='https://yoa.st/33y' target='_blank'>Do not use your keyphrase more than once</a>." );
 	} );
@@ -46,7 +44,7 @@ describe( "checks for keyword doubles", function() {
 
 describe( "checks for keyword doubles", function() {
 	it( "returns array with keyword", function() {
-		var plugin = new PreviouslyUsedKeywords( app, undefined, i18n ); // eslint-disable-line no-undefined
+		var plugin = new PreviouslyUsedKeywords( app, undefined ); // eslint-disable-line no-undefined
 		expect( plugin.searchUrl ).toBe( "" );
 	} );
 } );
@@ -61,7 +59,7 @@ describe( "replaces keyword usage", function() {
 			postUrl: postUrl,
 		};
 
-		const plugin = new PreviouslyUsedKeywords( app, args, i18n );
+		const plugin = new PreviouslyUsedKeywords( app, args );
 		expect( plugin.usedKeywords ).not.toBeDefined();
 		plugin.updateKeywordUsage(  { keyword: [ 1 ], test: [ 2, 3, 4 ] } );
 		expect( plugin.usedKeywords.keyword ).toContain( 1 );

--- a/packages/yoastseo/spec/fullTextTests/runFullTextTests.js
+++ b/packages/yoastseo/spec/fullTextTests/runFullTextTests.js
@@ -1,6 +1,4 @@
 import getLanguage from "../../src/languageProcessing/helpers/language/getLanguage";
-import factory from "../specHelpers/factory.js";
-const i18n = factory.buildJed();
 import getResearcher from "../specHelpers/getResearcher";
 import getMorphologyData from "../specHelpers/getMorphologyData";
 
@@ -73,7 +71,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.introductionKeyword.isApplicable );
 
 			if ( isApplicable ) {
-				result.introductionKeyword = introductionKeywordAssessment.getResult( paper, researcher, i18n );
+				result.introductionKeyword = introductionKeywordAssessment.getResult( paper, researcher );
 				expect( result.introductionKeyword.getScore() ).toBe( expectedResults.introductionKeyword.score );
 				expect( result.introductionKeyword.getText() ).toBe( expectedResults.introductionKeyword.resultText );
 			}
@@ -84,7 +82,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.keyphraseLength.isApplicable );
 
 			if ( isApplicable ) {
-				result.keyphraseLength = keyphraseLengthAssessment.getResult( paper, researcher, i18n );
+				result.keyphraseLength = keyphraseLengthAssessment.getResult( paper, researcher );
 				expect( result.keyphraseLength.getScore() ).toBe( expectedResults.keyphraseLength.score );
 				expect( result.keyphraseLength.getText() ).toBe( expectedResults.keyphraseLength.resultText );
 			}
@@ -98,8 +96,7 @@ testPapers.forEach( function( testPaper ) {
 				result.keywordDensity = keywordDensityAssessment.getResult(
 					paper,
 					researcher,
-					i18n
-				);
+					);
 				expect( result.keywordDensity.getScore() ).toBe( expectedResults.keywordDensity.score );
 				expect( result.keywordDensity.getText() ).toBe( expectedResults.keywordDensity.resultText );
 			}
@@ -110,7 +107,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.metaDescriptionKeyword.isApplicable );
 
 			if ( isApplicable ) {
-				result.metaDescriptionKeyword = metaDescriptionKeywordAssessment.getResult( paper, researcher, i18n );
+				result.metaDescriptionKeyword = metaDescriptionKeywordAssessment.getResult( paper, researcher );
 				expect( result.metaDescriptionKeyword.getScore() ).toBe( expectedResults.metaDescriptionKeyword.score );
 				expect( result.metaDescriptionKeyword.getText() ).toBe( expectedResults.metaDescriptionKeyword.resultText );
 			}
@@ -121,7 +118,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.metaDescriptionLength.isApplicable );
 
 			if ( isApplicable ) {
-				result.metaDescriptionLength = metaDescriptionLengthAssessment.getResult( paper, researcher, i18n );
+				result.metaDescriptionLength = metaDescriptionLengthAssessment.getResult( paper, researcher );
 				expect( result.metaDescriptionLength.getScore() ).toBe( expectedResults.metaDescriptionLength.score );
 				expect( result.metaDescriptionLength.getText() ).toBe( expectedResults.metaDescriptionLength.resultText );
 			}
@@ -132,7 +129,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.subheadingsKeyword.isApplicable );
 
 			if ( isApplicable ) {
-				result.subheadingsKeyword = subheadingsKeywordAssessment.getResult( paper, researcher, i18n );
+				result.subheadingsKeyword = subheadingsKeywordAssessment.getResult( paper, researcher );
 				expect( result.subheadingsKeyword.getScore() ).toBe( expectedResults.subheadingsKeyword.score );
 				expect( result.subheadingsKeyword.getText() ).toBe( expectedResults.subheadingsKeyword.resultText );
 			}
@@ -143,7 +140,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.textCompetingLinks.isApplicable );
 
 			if ( isApplicable ) {
-				result.textCompetingLinks = textCompetingLinksAssessment.getResult( paper, researcher, i18n );
+				result.textCompetingLinks = textCompetingLinksAssessment.getResult( paper, researcher );
 				expect( result.textCompetingLinks.getScore() ).toBe( expectedResults.textCompetingLinks.score );
 				expect( result.textCompetingLinks.getText() ).toBe( expectedResults.textCompetingLinks.resultText );
 			}
@@ -154,7 +151,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.textImages.isApplicable );
 
 			if ( isApplicable ) {
-				result.textImages = textImagesAssessment.getResult( paper, researcher, i18n );
+				result.textImages = textImagesAssessment.getResult( paper, researcher );
 				expect( result.textImages.getScore() ).toBe( expectedResults.textImages.score );
 				expect( result.textImages.getText() ).toBe( expectedResults.textImages.resultText );
 			}
@@ -165,7 +162,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.textLength.isApplicable );
 
 			if ( isApplicable ) {
-				result.textLength = textLengthAssessment.getResult( paper, researcher, i18n );
+				result.textLength = textLengthAssessment.getResult( paper, researcher );
 				expect( result.textLength.getScore() ).toBe( expectedResults.textLength.score );
 				expect( result.textLength.getText() ).toBe( expectedResults.textLength.resultText );
 			}
@@ -176,7 +173,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.externalLinks.isApplicable );
 
 			if ( isApplicable ) {
-				result.externalLinks = outboundLinksAssessment.getResult( paper, researcher, i18n );
+				result.externalLinks = outboundLinksAssessment.getResult( paper, researcher );
 				expect( result.externalLinks.getScore() ).toBe( expectedResults.externalLinks.score );
 				expect( result.externalLinks.getText() ).toBe( expectedResults.externalLinks.resultText );
 			}
@@ -187,7 +184,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.internalLinks.isApplicable );
 
 			if ( isApplicable ) {
-				result.internalLinks = internalLinksAssessment.getResult( paper, researcher, i18n );
+				result.internalLinks = internalLinksAssessment.getResult( paper, researcher );
 				expect( result.internalLinks.getScore() ).toBe( expectedResults.internalLinks.score );
 				expect( result.internalLinks.getText() ).toBe( expectedResults.internalLinks.resultText );
 			}
@@ -198,7 +195,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.titleKeyword.isApplicable );
 
 			if ( isApplicable ) {
-				result.titleKeyword = titleKeywordAssessment.getResult( paper, researcher, i18n );
+				result.titleKeyword = titleKeywordAssessment.getResult( paper, researcher );
 				expect( result.titleKeyword.getScore() ).toBe( expectedResults.titleKeyword.score );
 				expect( result.titleKeyword.getText() ).toBe( expectedResults.titleKeyword.resultText );
 			}
@@ -209,7 +206,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.titleWidth.isApplicable );
 
 			if ( isApplicable ) {
-				result.titleWidth = titleWidthAssessment.getResult( paper, researcher, i18n );
+				result.titleWidth = titleWidthAssessment.getResult( paper, researcher );
 				expect( result.titleWidth.getScore() ).toBe( expectedResults.titleWidth.score );
 				expect( result.titleWidth.getText() ).toBe( expectedResults.titleWidth.resultText );
 			}
@@ -220,7 +217,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.urlKeyword.isApplicable );
 
 			if ( isApplicable ) {
-				result.urlKeyword = urlKeywordAssessment.getResult( paper, researcher, i18n );
+				result.urlKeyword = urlKeywordAssessment.getResult( paper, researcher );
 				expect( result.urlKeyword.getScore() ).toBe( expectedResults.urlKeyword.score );
 				expect( result.urlKeyword.getText() ).toBe( expectedResults.urlKeyword.resultText );
 			}
@@ -231,7 +228,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.keyphraseDistribution.isApplicable );
 
 			if ( isApplicable ) {
-				result.keyphraseDistribution = keyphraseDistributionAssessment.getResult( paper, researcher, i18n );
+				result.keyphraseDistribution = keyphraseDistributionAssessment.getResult( paper, researcher );
 				expect( result.keyphraseDistribution.getScore() ).toBe( expectedResults.keyphraseDistribution.score );
 				expect( result.keyphraseDistribution.getText() ).toBe( expectedResults.keyphraseDistribution.resultText );
 			}
@@ -243,7 +240,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.fleschReadingEase.isApplicable );
 
 			if ( isApplicable ) {
-				result.fleschReadingEase = fleschReadingAssessment.getResult( paper, researcher, i18n );
+				result.fleschReadingEase = fleschReadingAssessment.getResult( paper, researcher );
 				expect( result.fleschReadingEase.getScore() ).toBe( expectedResults.fleschReadingEase.score );
 				expect( result.fleschReadingEase.getText() ).toBe( expectedResults.fleschReadingEase.resultText );
 			}
@@ -254,7 +251,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.subheadingsTooLong.isApplicable );
 
 			if ( isApplicable ) {
-				result.subheadingsTooLong = subheadingDistributionTooLongAssessment.getResult( paper, researcher, i18n );
+				result.subheadingsTooLong = subheadingDistributionTooLongAssessment.getResult( paper, researcher );
 				expect( result.subheadingsTooLong.getScore() ).toBe( expectedResults.subheadingsTooLong.score );
 				expect( result.subheadingsTooLong.getText() ).toBe( expectedResults.subheadingsTooLong.resultText );
 			}
@@ -265,7 +262,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.textParagraphTooLong.isApplicable );
 
 			if ( isApplicable ) {
-				result.textParagraphTooLong = paragraphTooLongAssessment.getResult( paper, researcher, i18n );
+				result.textParagraphTooLong = paragraphTooLongAssessment.getResult( paper, researcher );
 				expect( result.textParagraphTooLong.getScore() ).toBe( expectedResults.textParagraphTooLong.score );
 				expect( result.textParagraphTooLong.getText() ).toBe( expectedResults.textParagraphTooLong.resultText );
 			}
@@ -276,7 +273,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.textSentenceLength.isApplicable );
 
 			if ( isApplicable ) {
-				result.textSentenceLength = sentenceLengthInTextAssessment.getResult( paper, researcher, i18n );
+				result.textSentenceLength = sentenceLengthInTextAssessment.getResult( paper, researcher );
 				expect( result.textSentenceLength.getScore() ).toBe( expectedResults.textSentenceLength.score );
 				expect( result.textSentenceLength.getText() ).toBe( expectedResults.textSentenceLength.resultText );
 			}
@@ -287,7 +284,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.textTransitionWords.isApplicable );
 
 			if ( isApplicable ) {
-				result.textTransitionWords = transitionWordsAssessment.getResult( paper, researcher, i18n );
+				result.textTransitionWords = transitionWordsAssessment.getResult( paper, researcher );
 				expect( result.textTransitionWords.getScore() ).toBe( expectedResults.textTransitionWords.score );
 				expect( result.textTransitionWords.getText() ).toBe( expectedResults.textTransitionWords.resultText );
 			}
@@ -298,14 +295,14 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.passiveVoice.isApplicable );
 
 			if ( isApplicable ) {
-				result.passiveVoice = passiveVoiceAssessment.getResult( paper, researcher, i18n );
+				result.passiveVoice = passiveVoiceAssessment.getResult( paper, researcher );
 				expect( result.passiveVoice.getScore() ).toBe( expectedResults.passiveVoice.score );
 				expect( result.passiveVoice.getText() ).toBe( expectedResults.passiveVoice.resultText );
 			}
 		} );
 
 		it( "returns a score and the associated feedback text for the textPresence assessment", function() {
-			result.textPresence = textPresenceAssessment.getResult( paper, researcher, i18n );
+			result.textPresence = textPresenceAssessment.getResult( paper, researcher );
 			expect( result.textPresence.getScore() ).toBe( expectedResults.textPresence.score );
 			expect( result.textPresence.getText() ).toBe( expectedResults.textPresence.resultText );
 		} );
@@ -315,7 +312,7 @@ testPapers.forEach( function( testPaper ) {
 			expect( isApplicable ).toBe( expectedResults.sentenceBeginnings.isApplicable );
 
 			if ( isApplicable ) {
-				result.sentenceBeginnings = sentenceBeginningsAssessment.getResult( paper, researcher, i18n );
+				result.sentenceBeginnings = sentenceBeginningsAssessment.getResult( paper, researcher );
 				expect( result.sentenceBeginnings.getScore() ).toBe( expectedResults.sentenceBeginnings.score );
 				expect( result.sentenceBeginnings.getText() ).toBe( expectedResults.sentenceBeginnings.resultText );
 			}

--- a/packages/yoastseo/spec/parsedPaper/assess/TreeAssessorSpec.js
+++ b/packages/yoastseo/spec/parsedPaper/assess/TreeAssessorSpec.js
@@ -3,13 +3,11 @@ import TreeBuilder from "../../../src/parsedPaper/build/tree";
 import { TreeResearcher } from "../../../src/parsedPaper/research";
 import Paper from "../../../src/values/Paper";
 
-import factory from "../../specHelpers/factory.js";
 import TestAggregator from "../../specHelpers/tree/TestAggregator";
 import TestAssessment from "../../specHelpers/tree/TestAssessment";
 import TestResearch from "../../specHelpers/tree/TestResearch";
 
 describe( "TreeAssessor", () => {
-	const i18n = factory.buildJed();
 	let treeBuilder;
 
 	beforeEach( () => {
@@ -23,13 +21,11 @@ describe( "TreeAssessor", () => {
 			const assessor = new TreeAssessor( {
 				researcher,
 				scoreAggregator,
-				i18n,
 			} );
 
 			expect( assessor.getAssessments() ).toEqual( [] );
 			expect( assessor.scoreAggregator ).toEqual( scoreAggregator );
 			expect( assessor.researcher ).toEqual( researcher );
-			expect( assessor.i18n ).toEqual( i18n );
 		} );
 
 		it( "creates a new TreeAssessor with assessments", () => {
@@ -42,14 +38,12 @@ describe( "TreeAssessor", () => {
 			const assessor = new TreeAssessor( {
 				researcher,
 				scoreAggregator,
-				i18n,
 				assessments,
 			} );
 
 			expect( assessor.getAssessments() ).toEqual( assessments );
 			expect( assessor.scoreAggregator ).toEqual( scoreAggregator );
 			expect( assessor.researcher ).toEqual( researcher );
-			expect( assessor.i18n ).toEqual( i18n );
 		} );
 	} );
 
@@ -64,7 +58,6 @@ describe( "TreeAssessor", () => {
 			const assessor = new TreeAssessor( {
 				researcher,
 				scoreAggregator,
-				i18n,
 				assessments,
 			} );
 
@@ -94,7 +87,6 @@ describe( "TreeAssessor", () => {
 			const assessor = new TreeAssessor( {
 				researcher,
 				scoreAggregator,
-				i18n,
 				assessments,
 			} );
 
@@ -141,7 +133,6 @@ describe( "TreeAssessor", () => {
 			const assessor = new TreeAssessor( {
 				researcher,
 				scoreAggregator,
-				i18n,
 				assessments,
 			} );
 
@@ -190,7 +181,6 @@ describe( "TreeAssessor", () => {
 			const assessor = new TreeAssessor( {
 				researcher,
 				scoreAggregator,
-				i18n,
 				assessments,
 			} );
 
@@ -219,7 +209,6 @@ describe( "TreeAssessor", () => {
 			const assessor = new TreeAssessor( {
 				researcher,
 				scoreAggregator,
-				i18n,
 				assessments,
 			} );
 
@@ -244,7 +233,6 @@ describe( "TreeAssessor", () => {
 			const assessor = new TreeAssessor( {
 				researcher,
 				scoreAggregator,
-				i18n,
 				assessments,
 			} );
 
@@ -273,7 +261,6 @@ describe( "TreeAssessor", () => {
 			const assessor = new TreeAssessor( {
 				researcher,
 				scoreAggregator,
-				i18n,
 				assessments,
 			} );
 
@@ -297,7 +284,6 @@ describe( "TreeAssessor", () => {
 			const assessor = new TreeAssessor( {
 				researcher,
 				scoreAggregator,
-				i18n,
 				assessments,
 			} );
 
@@ -319,7 +305,6 @@ describe( "TreeAssessor", () => {
 			const assessor = new TreeAssessor( {
 				researcher,
 				scoreAggregator,
-				i18n,
 				assessments,
 			} );
 

--- a/packages/yoastseo/spec/parsedPaper/assess/assessorFactoriesSpec.js
+++ b/packages/yoastseo/spec/parsedPaper/assess/assessorFactoriesSpec.js
@@ -1,6 +1,5 @@
 import { ReadabilityScoreAggregator, SEOScoreAggregator } from "../../../src/parsedPaper/assess/scoreAggregators";
 import { TreeResearcher } from "../../../src/parsedPaper/research";
-import factory from "../../specHelpers/factory.js";
 
 import {
 	constructReadabilityAssessor,
@@ -8,18 +7,16 @@ import {
 } from "../../../src/parsedPaper/assess/assessorFactories";
 
 describe( "assessorFactories", () => {
-	let i18n;
 	let researcher;
 
 	beforeEach( () => {
-		i18n = factory.buildJed();
 		researcher = new TreeResearcher();
 	} );
 
 	describe( "constructSEOAssessor", () => {
 		it( "can create an SEO Assessor", () => {
 			const config = {};
-			const assessor = constructSEOAssessor( i18n, researcher, config );
+			const assessor = constructSEOAssessor( researcher, config );
 
 			const expectedAssessments = [];
 			const expectedResearcher = researcher;
@@ -34,7 +31,7 @@ describe( "assessorFactories", () => {
 			const config = {
 				taxonomy: true,
 			};
-			const assessor = constructSEOAssessor( i18n, researcher, config );
+			const assessor = constructSEOAssessor( researcher, config );
 
 			const expectedAssessments = [];
 			const expectedResearcher = researcher;
@@ -49,7 +46,7 @@ describe( "assessorFactories", () => {
 			const config = {
 				relatedKeyphrase: true,
 			};
-			const assessor = constructSEOAssessor( i18n, researcher, config );
+			const assessor = constructSEOAssessor( researcher, config );
 
 			const expectedAssessments = [];
 			const expectedResearcher = researcher;
@@ -65,7 +62,7 @@ describe( "assessorFactories", () => {
 				taxonomy: true,
 				relatedKeyphrase: true,
 			};
-			const assessor = constructSEOAssessor( i18n, researcher, config );
+			const assessor = constructSEOAssessor( researcher, config );
 
 			const expectedAssessments = [];
 			const expectedResearcher = researcher;
@@ -80,7 +77,7 @@ describe( "assessorFactories", () => {
 			const config = {
 				cornerstone: true,
 			};
-			const assessor = constructSEOAssessor( i18n, researcher, config );
+			const assessor = constructSEOAssessor( researcher, config );
 
 			const expectedAssessments = [];
 			const expectedResearcher = researcher;
@@ -96,7 +93,7 @@ describe( "assessorFactories", () => {
 				cornerstone: true,
 				relatedKeyphrase: true,
 			};
-			const assessor = constructSEOAssessor( i18n, researcher, config );
+			const assessor = constructSEOAssessor( researcher, config );
 
 			const expectedAssessments = [];
 			const expectedResearcher = researcher;
@@ -113,13 +110,13 @@ describe( "assessorFactories", () => {
 				taxonomy: true,
 			};
 
-			expect( () => constructSEOAssessor( i18n, researcher, config ) ).toThrow();
+			expect( () => constructSEOAssessor( researcher, config ) ).toThrow();
 		} );
 	} );
 
 	describe( "constructReadabilityAssessor", () => {
 		it( "construct a readability assessor", () => {
-			const assessor = constructReadabilityAssessor( i18n, researcher );
+			const assessor = constructReadabilityAssessor( researcher );
 
 			const expectedAssessments = [];
 			const expectedResearcher = researcher;
@@ -131,7 +128,7 @@ describe( "assessorFactories", () => {
 		} );
 
 		it( "construct a cornerstone readability assessor", () => {
-			const assessor = constructReadabilityAssessor( i18n, researcher, true );
+			const assessor = constructReadabilityAssessor( researcher, true );
 
 			const expectedAssessments = [];
 			const expectedResearcher = researcher;

--- a/packages/yoastseo/spec/pluggableSpec.js
+++ b/packages/yoastseo/spec/pluggableSpec.js
@@ -2,8 +2,6 @@ import DefaultResearcher from "../src/languageProcessing/languages/_default/Rese
 import Pluggable from "../src/pluggable";
 import InvalidTypeError from "../src/errors/invalidType";
 import Assessor from "../src/scoring/assessor.js";
-import factory from "./specHelpers/factory.js";
-const i18n = factory.buildJed();
 
 describe( "the pluggable interface", function() {
 	var app, pluggable;
@@ -43,7 +41,7 @@ describe( "the pluggable interface", function() {
 		} );
 
 		it( "should be able to add an assessment", function() {
-			var assessor = new Assessor( i18n, new DefaultResearcher() );
+			var assessor = new Assessor( new DefaultResearcher() );
 			expect( pluggable._registerAssessment( assessor, "name", function() {}, "test-plugin" ) ).toEqual( true );
 		} );
 	} );

--- a/packages/yoastseo/spec/scoring/assessments/readability/fleschReadingEaseAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/fleschReadingEaseAssessmentSpec.js
@@ -3,14 +3,13 @@ import DefaultResearcher from "../../../../src/languageProcessing/languages/_def
 import fleschReadingAssessment from "../../../../src/scoring/assessments/readability/fleschReadingEaseAssessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import factory from "../../../specHelpers/factory.js";
-const i18n = factory.buildJed();
 import russianConfig from "../../../../src/languageProcessing/languages/ru/config/fleschReadingEaseScores";
 
 describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns an 'easy' score and the associated feedback text for a paper using the default config when the score is" +
 		" between 80 and 90.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 80.5 ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 80.5 ) );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 80.5 in the test," +
@@ -20,7 +19,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns a 'fairly easy' score and the associated feedback text for a paper using the default config when the score is" +
 		" between 70 and 80.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 70.1 ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 70.1 ) );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 70.1 in the test," +
@@ -30,7 +29,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns an 'okay' score and the associated feedback text for a paper using the default config when the score is" +
 		" between 60 and 70.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 69.9 ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 69.9 ) );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 69.9 in the test," +
@@ -40,7 +39,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns an 'fairly difficult' score and the associated feedback text for a paper using the default config when the score is" +
 		" between 50 and 60.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 50.9 ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 50.9 ) );
 
 		expect( result.getScore() ).toBe( 6 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 50.9 in" +
@@ -51,7 +50,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns a 'difficult' score and the associated feedback text for a paper using the default config when the score is" +
 		" between 30 and 50.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 49.1 ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 49.1 ) );
 
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 49.1 in the test," +
@@ -62,7 +61,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns an 'very difficult' score and the associated feedback text for a paper using the default config when the score is" +
 		" between 0 and 30.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 1.2 ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 1.2 ) );
 
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 1.2 in the test," +
@@ -71,7 +70,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	} );
 	it( "returns a 'very easy' score and the associated feedback text for a paper using the default config when the score is 100.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 100 ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 100 ) );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 100 in the test," +
@@ -81,7 +80,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns a 'very easy' score and the associated feedback text for a paper using the default config when the score is" +
 		" exactly 90.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 90 ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 90 ) );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 90 in the test," +
@@ -90,7 +89,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 
 	it( "returns a 'very easy' score and the associated feedback text for a paper using the Russian config when the score is 100.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 100, false, false, russianConfig ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 100, false, false, russianConfig ) );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 100 in the test," +
@@ -100,7 +99,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns a 'very easy' score and the associated feedback text for a paper using the Russian config when the score is" +
 		" exactly 80.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 80, false, false, russianConfig ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 80, false, false, russianConfig ) );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 80 in the test," +
@@ -110,7 +109,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns a 'very easy' score and the associated feedback text for a paper using the Russian config when the score is" +
 		" between 80 and 90.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 85.6, false, false, russianConfig ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 85.6, false, false, russianConfig ) );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 85.6 in the test," +
@@ -120,7 +119,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns a 'easy' score and the associated feedback text for a paper using the Russian config when the score is" +
 		" between 70 and 80.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 72.9, false, false, russianConfig ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 72.9, false, false, russianConfig ) );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 72.9 in the test," +
@@ -130,7 +129,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns a 'fairly easy' score and the associated feedback text for a paper using the Russian config when the score is" +
 		" between 60 and 70.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 66.6, false, false, russianConfig ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 66.6, false, false, russianConfig ) );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 66.6 in the test," +
@@ -140,7 +139,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns an 'okay' score and the associated feedback text for a paper using the Russian config when the score is" +
 		" between 50 and 60.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 55.5, false, false, russianConfig ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 55.5, false, false, russianConfig ) );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 55.5 in the test," +
@@ -150,7 +149,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns a 'fairly difficult' score and the associated feedback text for a paper using the Russian config when the score is" +
 		" between 40 and 50.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 40.9, false, false, russianConfig ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 40.9, false, false, russianConfig ) );
 
 		expect( result.getScore() ).toBe( 6 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 40.9 in the test," +
@@ -161,7 +160,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns a 'difficult' score and the associated feedback text for a paper using the Russian config when the score is" +
 		" between 30 and 40.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 30, false, false, russianConfig ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 30, false, false, russianConfig ) );
 
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 30 in the test," +
@@ -172,7 +171,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 	it( "returns a 'very difficult' score and the associated feedback text for a paper using the Russian config when the score is" +
 		" below 30.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 11.2, false, false, russianConfig ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 11.2, false, false, russianConfig ) );
 
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 11.2 in the" +
@@ -182,7 +181,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 
 	it( "returns a feedback text containing '100' for a paper with a Flesch score above 100.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 103.0, false, false, russianConfig ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( 103.0, false, false, russianConfig ) );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 100" +
@@ -191,7 +190,7 @@ describe( "An assessment for the Flesch reading ease test", function() {
 
 	it( "returns a feedback text containing '0' for a paper with a Flesch score under 0.", function() {
 		const paper = new Paper( "This is a very interesting paper" );
-		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( -3.0 ), i18n );
+		const result = fleschReadingAssessment.getResult( paper, factory.buildMockResearcher( -3.0 ) );
 
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 0" +

--- a/packages/yoastseo/spec/scoring/assessments/readability/paragraphTooLongAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/paragraphTooLongAssessmentSpec.js
@@ -1,21 +1,20 @@
 import paragraphTooLongAssessment from "../../../../src/scoring/assessments/readability/paragraphTooLongAssessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
-const i18n = Factory.buildJed();
 import Mark from "../../../../src/values/Mark.js";
 import Researcher from "../../../../src/languageProcessing/languages/en/Researcher";
 
 describe( "An assessment for scoring too long paragraphs.", function() {
 	const paper = new Paper();
 	it( "scores 1 paragraph with ok length", function() {
-		const assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 60, text: "" } ] ), i18n );
+		const assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 60, text: "" } ] ) );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: None of the paragraphs" +
 			" are too long. Great job!" );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 	it( "scores 1 slightly too long paragraph", function() {
-		const assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 160, text: "" } ] ), i18n );
+		const assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 160, text: "" } ] ) );
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs" +
 			" contains more than the recommended maximum of 150 words." +
@@ -23,7 +22,7 @@ describe( "An assessment for scoring too long paragraphs.", function() {
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "scores 1 extremely long paragraph", function() {
-		const assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 6000, text: "" } ] ), i18n );
+		const assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 6000, text: "" } ] ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs" +
 			" contains more than the recommended maximum of 150 words." +
@@ -32,7 +31,7 @@ describe( "An assessment for scoring too long paragraphs.", function() {
 	} );
 	it( "scores 3 paragraphs with ok length", function() {
 		const assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 60, text: "" },
-			{ wordCount: 71, text: "" }, { wordCount: 83, text: "" } ] ), i18n );
+			{ wordCount: 71, text: "" }, { wordCount: 83, text: "" } ] ) );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: None of the paragraphs" +
 			" are too long. Great job!" );
@@ -40,7 +39,7 @@ describe( "An assessment for scoring too long paragraphs.", function() {
 	} );
 	it( "scores 3 paragraphs, one of which is too long", function() {
 		const assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 60, text: "" },
-			{ wordCount: 71, text: "" }, { wordCount: 183, text: "" } ] ), i18n );
+			{ wordCount: 71, text: "" }, { wordCount: 183, text: "" } ] ) );
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs" +
 			" contains more than the recommended maximum of 150 words." +
@@ -49,7 +48,7 @@ describe( "An assessment for scoring too long paragraphs.", function() {
 	} );
 	it( "scores 3 paragraphs, two of which are too long", function() {
 		const assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { wordCount: 60, text: "" },
-			{ wordCount: 191, text: "" }, { wordCount: 183, text: "" } ] ), i18n );
+			{ wordCount: 191, text: "" }, { wordCount: 183, text: "" } ] ) );
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 2 of the paragraphs" +
 			" contain more than the recommended maximum of 150 words." +
@@ -57,7 +56,7 @@ describe( "An assessment for scoring too long paragraphs.", function() {
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 	it( "returns an empty assessment result for a paper without paragraphs.", function() {
-		const assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ ] ), i18n );
+		const assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ ] ) );
 		expect( assessment.getScore() ).toBe( 0 );
 		expect( assessment.getText() ).toBe( "" );
 	} );
@@ -67,13 +66,13 @@ describe( "Applicability of the assessment.", function() {
 	it( "returns true for isApplicable on a paper with text.", function() {
 		const paper = new Paper( "This is a very interesting paper.", { locale: "en_US" } );
 		const researcher = new Researcher( paper );
-		paragraphTooLongAssessment.getResult( paper, researcher, i18n );
+		paragraphTooLongAssessment.getResult( paper, researcher );
 		expect( paragraphTooLongAssessment.isApplicable( paper, researcher ) ).toBe( true );
 	} );
 	it( "returns false for isApplicable on a paper without text.", function() {
 		const paper = new Paper( "", { locale: "en_US" } );
 		const researcher = new Researcher( paper );
-		paragraphTooLongAssessment.getResult( paper, researcher, i18n );
+		paragraphTooLongAssessment.getResult( paper, researcher );
 		expect( paragraphTooLongAssessment.isApplicable( paper, researcher ) ).toBe( false );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/assessments/readability/passiveVoiceAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/passiveVoiceAssessmentSpec.js
@@ -1,7 +1,6 @@
 import passiveVoiceAssessment from "../../../../src/scoring/assessments/readability/passiveVoiceAssessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
-const i18n = Factory.buildJed();
 import Mark from "../../../../src/values/Mark.js";
 import DefaultResearcher from "../../../../src/languageProcessing/languages/_default/Researcher";
 import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
@@ -9,21 +8,21 @@ import EnglishResearcher from "../../../../src/languageProcessing/languages/en/R
 describe( "An assessment for scoring passive voice.", function() {
 	const paper = new Paper();
 	it( "returns result when the text is empty", function() {
-		const assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 0, passives: [] } ), i18n );
+		const assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 0, passives: [] } ) );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough" +
 			" active voice. That's great!" );
 	} );
 
 	it( "scores 0 passive sentences - 0%", function() {
-		const assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [] } ), i18n );
+		const assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [] } ) );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough" +
 			" active voice. That's great!" );
 	} );
 
 	it( "scores 1 passive sentence - 5%", function() {
-		const assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [ 1 ] } ), i18n );
+		const assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [ 1 ] } ) );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough" +
 			" active voice. That's great!" );
@@ -31,7 +30,7 @@ describe( "An assessment for scoring passive voice.", function() {
 	} );
 
 	it( "scores 2 passive sentences - 10%", function() {
-		const assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [ 1, 2 ] } ), i18n );
+		const assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [ 1, 2 ] } ) );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough" +
 			" active voice. That's great!" );
@@ -40,7 +39,7 @@ describe( "An assessment for scoring passive voice.", function() {
 
 	it( "scores 10 passive sentence - 50%", function() {
 		const assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 20,
-			passives: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ] } ), i18n );
+			passives: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ] } ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 50% of the sentences" +
 			" contain passive voice, which is more than the recommended maximum of 10%. " +
@@ -49,7 +48,7 @@ describe( "An assessment for scoring passive voice.", function() {
 	} );
 
 	it( "scores 5 passive sentences - 25%", function() {
-		const assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [ 1, 2, 3, 4, 5 ] } ), i18n );
+		const assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [ 1, 2, 3, 4, 5 ] } ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 25% of the sentences" +
 			" contain passive voice, which is more than the recommended maximum of 10%. " +
@@ -58,7 +57,7 @@ describe( "An assessment for scoring passive voice.", function() {
 	} );
 
 	it( "scores 5 passive sentences - 13.3%", function() {
-		const assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 30, passives: [ 1, 2, 3, 4 ] } ), i18n );
+		const assessment = passiveVoiceAssessment.getResult( paper, Factory.buildMockResearcher( { total: 30, passives: [ 1, 2, 3, 4 ] } ) );
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 13.3% of the sentences" +
 			" contain passive voice, which is more than the recommended maximum of 10%. " +

--- a/packages/yoastseo/spec/scoring/assessments/readability/sentenceBeginningsAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/sentenceBeginningsAssessmentSpec.js
@@ -15,7 +15,6 @@ import TurkishResearcher from "../../../../src/languageProcessing/languages/tr/R
 import sentenceBeginningsAssessment from "../../../../src/scoring/assessments/readability/sentenceBeginningsAssessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
-const i18n = Factory.buildJed();
 import Mark from "../../../../src/values/Mark.js";
 
 let paper = new Paper();
@@ -25,7 +24,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hey", count: 2 },
 			{ word: "cup", count: 2 },
 			{ word: "laptop", count: 1 },
-			{ word: "table", count: 4 } ] ), i18n );
+			{ word: "table", count: 4 } ] ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>:" +
 			" The text contains 4 consecutive sentences starting with the same word." +
@@ -35,7 +34,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 	it( "scores two instance with too many consecutive English sentences starting with the same word, 5 being the lowest count.", function() {
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hey", count: 2 },
 			{ word: "banana", count: 6 }, { word: "pencil", count: 1 },
-			{ word: "bottle", count: 5 } ] ), i18n );
+			{ word: "bottle", count: 5 } ] ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
 			"The text contains 2 instances where 5 or more consecutive sentences start with the same word. <a href='https://yoa.st/35g' " +
@@ -45,7 +44,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 	it( "scores zero instance with too many consecutive English sentences starting with the same word.", function() {
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hey", count: 1 },
 			{ word: "telephone", count: 2 }, { word: "towel", count: 2 },
-			{ word: "couch", count: 1 } ] ), i18n );
+			{ word: "couch", count: 1 } ] ) );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
 			"There is enough variety in your sentences. That's great!" );
@@ -54,7 +53,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 	it( "scores one instance with 4 consecutive German sentences starting with the same word.", function() {
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hallo", count: 2 },
 			{ word: "Stuhl", count: 2 }, { word: "Banane", count: 1 },
-			{ word: "Tafel", count: 4 } ] ), i18n );
+			{ word: "Tafel", count: 4 } ] ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: T" +
 			"he text contains 4 consecutive sentences starting with the same word." +
@@ -64,7 +63,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 	it( "scores two instance with too many consecutive German sentences starting with the same word, 5 being the lowest count.", function() {
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hallo", count: 2 },
 			{ word: "Banane", count: 6 }, { word: "Blatt", count: 1 },
-			{ word: "Schloss", count: 5 } ] ), i18n );
+			{ word: "Schloss", count: 5 } ] ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
 			"The text contains 2 instances where 5 or more consecutive sentences start with the same word. <a href='https://yoa.st/35g' " +
@@ -74,7 +73,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 	it( "scores zero instance with too many consecutive German sentences starting with the same word.", function() {
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hallo", count: 1 },
 			{ word: "Telefon", count: 2 }, { word: "Hund", count: 2 },
-			{ word: "Haus", count: 1 } ] ), i18n );
+			{ word: "Haus", count: 1 } ] ) );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
 			"There is enough variety in your sentences. That's great!" );
@@ -83,7 +82,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 	it( "scores one instance with 4 consecutive Indonesian sentences starting with the same word.", function() {
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "halo", count: 2 },
 			{ word: "cangkir", count: 2 }, { word: "pisang", count: 1 },
-			{ word: "meja", count: 4 } ] ), i18n );
+			{ word: "meja", count: 4 } ] ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
 			"The text contains 4 consecutive sentences starting with the same word." +
@@ -93,7 +92,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 	it( "scores two instance with too many consecutive Indonesian sentences starting with the same word, 5 being the lowest count.", function() {
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "halo", count: 2 },
 			{ word: "cangkir", count: 6 }, { word: "pisang", count: 1 },
-			{ word: "botol", count: 5 } ] ), i18n );
+			{ word: "botol", count: 5 } ] ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
 			"The text contains 2 instances where 5 or more consecutive sentences start with the same word. <a href='https://yoa.st/35g' " +
@@ -103,7 +102,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 	it( "scores zero instance with too many consecutive Indonesian sentences starting with the same word.", function() {
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "halo", count: 1 },
 			{ word: "pensil", count: 2 }, { word: "kopi", count: 2 },
-			{ word: "sofa", count: 1 } ] ), i18n );
+			{ word: "sofa", count: 1 } ] ) );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
 			"There is enough variety in your sentences. That's great!" );
@@ -112,7 +111,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 	it( "scores one instance with 4 consecutive Hungarian sentences starting with the same word.", function() {
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hé", count: 2 },
 			{ word: "csésze", count: 2 }, { word: "laptop", count: 1 },
-			{ word: "asztal", count: 4 } ] ), i18n );
+			{ word: "asztal", count: 4 } ] ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
 			"The text contains 4 consecutive sentences starting with the same word." +
@@ -122,7 +121,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 	it( "scores two instance with too many consecutive Hungarian sentences starting with the same word, 5 being the lowest count.", function() {
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hé", count: 2 },
 			{ word: "banán", count: 6 }, { word: "ceruza", count: 1 },
-			{ word: "üveg", count: 5 } ] ), i18n );
+			{ word: "üveg", count: 5 } ] ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
 			"The text contains 2 instances where 5 or more consecutive sentences start with the same word. <a href='https://yoa.st/35g' " +
@@ -132,7 +131,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 	it( "scores zero instance with too many consecutive Hungarian sentences starting with the same word.", function() {
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "helló", count: 1 },
 			{ word: "ceruza", count: 2 }, { word: "kávé", count: 2 },
-			{ word: "kanapé", count: 1 } ] ), i18n );
+			{ word: "kanapé", count: 1 } ] ) );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
 			"There is enough variety in your sentences. That's great!" );
@@ -141,7 +140,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 	it( "scores one instance with 4 consecutive Turkish sentences starting with the same word.", function() {
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "merhaba", count: 2 },
 			{ word: "bilgisayar", count: 2 }, { word: "köpek", count: 1 },
-			{ word: "kedi", count: 4 } ] ), i18n );
+			{ word: "kedi", count: 4 } ] ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
 			"The text contains 4 consecutive sentences starting with the same word." +
@@ -151,7 +150,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 	it( "scores two instance with too many consecutive Turkish sentences starting with the same word, 5 being the lowest count.", function() {
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hayvan", count: 2 },
 			{ word: "muz", count: 6 }, { word: "makyaj", count: 1 },
-			{ word: "çay", count: 5 } ] ), i18n );
+			{ word: "çay", count: 5 } ] ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
 			"The text contains 2 instances where 5 or more consecutive sentences start with the same word. <a href='https://yoa.st/35g' " +
@@ -161,7 +160,7 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 	it( "scores zero instance with too many consecutive Turkish sentences starting with the same word.", function() {
 		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "hoşgeldiniz", count: 1 },
 			{ word: "ayakkabı", count: 2 }, { word: "kayıt", count: 2 },
-			{ word: "ceket", count: 1 } ] ), i18n );
+			{ word: "ceket", count: 1 } ] ) );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
 			"There is enough variety in your sentences. That's great!" );

--- a/packages/yoastseo/spec/scoring/assessments/readability/sentenceLengthInTextAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/sentenceLengthInTextAssessmentSpec.js
@@ -3,7 +3,6 @@ import SentenceLengthInTextAssessment from "../../../../src/scoring/assessments/
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
 import Mark from "../../../../src/values/Mark.js";
-const i18n = Factory.buildJed();
 import spanishConfig from "../../../../src/languageProcessing/languages/es/config/sentenceLength";
 import polishConfig from "../../../../src/languageProcessing/languages/pl/config/sentenceLength";
 import hebrewConfig from "../../../../src/languageProcessing/languages/he/config/sentenceLength";
@@ -25,7 +24,7 @@ describe( "An assessment for sentence length", function() {
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
-		] ), i18n );
+		] ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -38,7 +37,7 @@ describe( "An assessment for sentence length", function() {
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 30 },
 			{ sentence: "", sentenceLength: 1 },
-		] ), i18n );
+		] ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -52,7 +51,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 30 },
-		] ), i18n );
+		] ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -69,7 +68,7 @@ describe( "An assessment for sentence length", function() {
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
-		] ), i18n );
+		] ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -90,7 +89,7 @@ describe( "An assessment for sentence length", function() {
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
-		] ), i18n );
+		] ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -104,7 +103,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 16 },
-		], false, false, russianConfig ), i18n );
+		], false, false, russianConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -125,7 +124,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 26 },
-		], false, false, italianConfig ), i18n );
+		], false, false, italianConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -139,7 +138,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 24 },
-		], false, false, italianConfig ), i18n );
+		], false, false, italianConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -151,7 +150,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 26 },
-		], false, false, spanishConfig ), i18n );
+		], false, false, spanishConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -165,7 +164,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 24 },
-		], false, false, spanishConfig ), i18n );
+		], false, false, spanishConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -177,7 +176,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 26 },
-		], false, false, catalanConfig ), i18n );
+		], false, false, catalanConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -191,7 +190,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 24 },
-		], false, false, catalanConfig ), i18n );
+		], false, false, catalanConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -203,7 +202,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 19 },
-		], false, false, polishConfig.regularConfig ), i18n );
+		], false, false, polishConfig.regularConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -215,7 +214,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 21 },
-		], false, false, polishConfig.regularConfig ), i18n );
+		], false, false, polishConfig.regularConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -238,7 +237,7 @@ describe( "An assessment for sentence length", function() {
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
-		], false, false, polishConfig.regularConfig ), i18n );
+		], false, false, polishConfig.regularConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -253,7 +252,7 @@ describe( "An assessment for sentence length", function() {
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
-		], false, false, polishConfig.regularConfig ), i18n );
+		], false, false, polishConfig.regularConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -286,7 +285,7 @@ describe( "An assessment for sentence length", function() {
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
-		], false, false, polishConfig.regularConfig ), i18n );
+		], false, false, polishConfig.regularConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -300,7 +299,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 26 },
-		], false, false, portugueseConfig ), i18n );
+		], false, false, portugueseConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -314,7 +313,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 24 },
-		], false, false, portugueseConfig ), i18n );
+		], false, false, portugueseConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -329,7 +328,7 @@ describe( "An assessment for sentence length", function() {
 			{ sentence: "", sentenceLength: 20 },
 			{ sentence: "", sentenceLength: 27 },
 			{ sentence: "", sentenceLength: 24 },
-		], false, false, portugueseConfig ), i18n );
+		], false, false, portugueseConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -341,7 +340,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 16 },
-		], false, false, hebrewConfig ), i18n );
+		], false, false, hebrewConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -358,7 +357,7 @@ describe( "An assessment for sentence length", function() {
 			{ sentence: "", sentenceLength: 15 },
 			{ sentence: "", sentenceLength: 15 },
 			{ sentence: "", sentenceLength: 15 },
-		], false, false, hebrewConfig ), i18n );
+		], false, false, hebrewConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -370,7 +369,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 14 },
-		], false, false, hebrewConfig ), i18n );
+		], false, false, hebrewConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -382,7 +381,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 14 },
-		], false, false, turkishConfig ), i18n );
+		], false, false, turkishConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -397,7 +396,7 @@ describe( "An assessment for sentence length", function() {
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
-		], false, false, turkishConfig ), i18n );
+		], false, false, turkishConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -411,7 +410,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 14 },
-		], false, false, turkishConfig ), i18n );
+		], false, false, turkishConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -423,7 +422,7 @@ describe( "An assessment for sentence length", function() {
 		const mockPaper = new Paper( "text", { locale: "hu_HU" } );
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 21 },
-		] ), i18n );
+		] ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -438,7 +437,7 @@ describe( "An assessment for sentence length", function() {
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 21 },
 			{ sentence: "", sentenceLength: 13 },
-		] ), i18n );
+		] ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -455,7 +454,7 @@ describe( "An assessment for sentence length", function() {
 			{ sentence: "", sentenceLength: 20 },
 			{ sentence: "", sentenceLength: 20 },
 			{ sentence: "", sentenceLength: 20 },
-		] ), i18n );
+		] ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -468,7 +467,7 @@ describe( "An assessment for sentence length", function() {
 
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 19 },
-		] ), i18n );
+		] ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -528,7 +527,7 @@ describe( "An assessment for sentence length for cornerstone content", function(
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment( true ).getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 19 },
-		], false, false, polishConfig.cornerstoneConfig ), i18n );
+		], false, false, polishConfig.cornerstoneConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -540,7 +539,7 @@ describe( "An assessment for sentence length for cornerstone content", function(
 		const mockPaper = new Paper();
 		const assessment = new SentenceLengthInTextAssessment( true ).getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 21 },
-		], false, false, polishConfig.cornerstoneConfig ), i18n );
+		], false, false, polishConfig.cornerstoneConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -557,7 +556,7 @@ describe( "An assessment for sentence length for cornerstone content", function(
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
-		], false, false, polishConfig.cornerstoneConfig ), i18n );
+		], false, false, polishConfig.cornerstoneConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -590,7 +589,7 @@ describe( "An assessment for sentence length for cornerstone content", function(
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
-		], false, false, polishConfig.cornerstoneConfig ), i18n );
+		], false, false, polishConfig.cornerstoneConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -607,7 +606,7 @@ describe( "An assessment for sentence length for cornerstone content", function(
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
 			{ sentence: "", sentenceLength: 1 },
-		] ), i18n );
+		] ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 6 );

--- a/packages/yoastseo/spec/scoring/assessments/readability/subheadingDistributionTooLongAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/subheadingDistributionTooLongAssessmentSpec.js
@@ -2,7 +2,6 @@ import SubheadingDistributionTooLong from "../../../../src/scoring/assessments/r
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
 import Mark from "../../../../src/values/Mark.js";
-const i18n = Factory.buildJed();
 
 const subheadingDistributionTooLong = new SubheadingDistributionTooLong();
 
@@ -15,8 +14,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 	it( "Scores a short text (<300 words), which does not have subheadings.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( shortText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 200 } ] ),
-			i18n
+			Factory.buildMockResearcher( [ { text: "", wordCount: 200 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
@@ -26,8 +24,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 	it( "Scores a short text (<300 words), which has subheadings.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( "a " + subheading + shortText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 1 }, { text: "", wordCount: 200 } ] ),
-			i18n
+			Factory.buildMockResearcher( [ { text: "", wordCount: 1 }, { text: "", wordCount: 200 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: Great job!" );
@@ -36,8 +33,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 	it( "Scores a long text (>300 words), which does not have subheadings.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( longText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 330 } ] ),
-			i18n
+			Factory.buildMockResearcher( [ { text: "", wordCount: 330 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 2 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
@@ -48,8 +44,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 	it( "Scores a long text (>300 words), which has subheadings and all sections of the text are <300 words.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( shortText + subheading + shortText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 200 } ] ),
-			i18n
+			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 200 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: Great job!" );
@@ -59,8 +54,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 		"which is between 300 and 350 words long.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( shortText + subheading + longText + subheading + shortText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 330 }, { text: "", wordCount: 200 } ] ),
-			i18n
+			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 330 }, { text: "", wordCount: 200 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
@@ -72,8 +66,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 		"which are between 300 and 350 words long.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( shortText + subheading + longText + subheading + longText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 330 }, { text: "", wordCount: 330 } ] ),
-			i18n
+			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 330 }, { text: "", wordCount: 330 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
@@ -85,8 +78,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 		"which is above 350 words long.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( shortText + subheading + veryLongText + subheading + shortText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 360 }, { text: "", wordCount: 200 } ] ),
-			i18n
+			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 360 }, { text: "", wordCount: 200 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
@@ -97,8 +89,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 	it( "Scores a long text (>300 words), which has subheadings and some sections of the text are above 350 words long.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( shortText + subheading + longText + subheading + longText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 360 }, { text: "", wordCount: 330 } ] ),
-			i18n
+			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 360 }, { text: "", wordCount: 330 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
@@ -146,12 +137,12 @@ describe.skip( "A test for marking too long text segments not separated by a sub
 				marked: "<yoastmark class='yoast-text-mark'>This is a too long fragment. It contains 330 words.</yoastmark>",
 			} ),
 		];
-		expect( subheadingDistributionTooLong.getResult( paper, textFragment, i18n )._marker ).toEqual( expected );
+		expect( subheadingDistributionTooLong.getResult( paper, textFragment )._marker ).toEqual( expected );
 	} );
 
 	it( "returns no markers if no text segments is too long", function() {
 		const paper = new Paper( shortText );
 		const textFragment = Factory.buildMockResearcher( [ { text: "This is a short segment.", wordCount: 200 } ] );
-		expect( subheadingDistributionTooLong.getResult( paper, textFragment, i18n )._hasMarks ).toEqual( false );
+		expect( subheadingDistributionTooLong.getResult( paper, textFragment )._hasMarks ).toEqual( false );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/assessments/readability/textPresenceAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/textPresenceAssessmentSpec.js
@@ -1,12 +1,11 @@
 import textPresence from "../../../../src/scoring/assessments/readability/textPresenceAssessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
-const i18n = Factory.buildJed();
 
 describe( "Assesses presence of text", function() {
 	it( "returns a score of 3 and a feedback string for a text under 50 words", function() {
 		const mockPaper = new Paper( "Hallo" );
-		const assessment = textPresence.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
+		const assessment = textPresence.getResult( mockPaper, Factory.buildMockResearcher( 0 ) );
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/35h' target='_blank'>Not enough content</a>:" +
@@ -17,7 +16,7 @@ describe( "Assesses presence of text", function() {
 		const mockPaper = new Paper( "Hello. This is a text with over 50 words. We want to see if this assessment is working well." +
 			" What do you think? This is a very interesting paper, with a lot of words. More words are better, don't you think?" +
 			" I am almost done. This is word number fifty. Yay!" );
-		const assessment = textPresence.getResult( mockPaper, Factory.buildMockResearcher( 1 ), i18n );
+		const assessment = textPresence.getResult( mockPaper, Factory.buildMockResearcher( 1 ) );
 
 		expect( assessment.getScore() ).toEqual( 0 );
 		expect( assessment.getText() ).toEqual( "" );
@@ -27,7 +26,7 @@ describe( "Assesses presence of text", function() {
 		const mockPaper = new Paper( "Hello. This is a text with exactly 50 words. We want to see if this assessment is working well." +
 			" What do you think? This is a very interesting paper, with a lot of words. More words are better, don't you think?" +
 			" I am almost done. This is word number fifty. Yay!" );
-		const assessment = textPresence.getResult( mockPaper, Factory.buildMockResearcher( 4 ), i18n );
+		const assessment = textPresence.getResult( mockPaper, Factory.buildMockResearcher( 4 ) );
 
 		expect( assessment.getScore() ).toEqual( 0 );
 		expect( assessment.getText() ).toEqual( "" );

--- a/packages/yoastseo/spec/scoring/assessments/readability/transitionWordsAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/transitionWordsAssessmentSpec.js
@@ -4,13 +4,12 @@ import transitionWordsAssessment from "../../../../src/scoring/assessments/reada
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
 import Mark from "../../../../src/values/Mark.js";
-const i18n = Factory.buildJed();
 
 describe( "An assessment for transition word percentage", function() {
 	it( "returns the score for 0% of the sentences with transition words", function() {
 		const mockPaper = new Paper();
 		const assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 10,
-			transitionWordSentences: 0 } ), i18n );
+			transitionWordSentences: 0 } ) );
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: " +
@@ -21,7 +20,7 @@ describe( "An assessment for transition word percentage", function() {
 	it( "returns the score for a paper with text but no sentences (e.g. only images)", function() {
 		const mockPaper = new Paper();
 		const assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 0,
-			transitionWordSentences: 0 } ), i18n );
+			transitionWordSentences: 0 } ) );
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: " +
@@ -32,7 +31,7 @@ describe( "An assessment for transition word percentage", function() {
 	it( "returns the score for 10.0% of the sentences with transition words", function() {
 		const mockPaper = new Paper();
 		const assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 10,
-			transitionWordSentences: 1 } ), i18n );
+			transitionWordSentences: 1 } ) );
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: " +
@@ -43,7 +42,7 @@ describe( "An assessment for transition word percentage", function() {
 	it( "returns the score for 20.0% of the sentences with transition words", function() {
 		const mockPaper = new Paper();
 		const assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 5,
-			transitionWordSentences: 1 } ), i18n );
+			transitionWordSentences: 1 } ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: " +
@@ -54,7 +53,7 @@ describe( "An assessment for transition word percentage", function() {
 	it( "returns the score for 25.0% of the sentences with transition words", function() {
 		const mockPaper = new Paper();
 		const assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 4,
-			transitionWordSentences: 1 } ), i18n );
+			transitionWordSentences: 1 } ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: " +
@@ -65,7 +64,7 @@ describe( "An assessment for transition word percentage", function() {
 	it( "returns the score for 35.0% of the sentences with transition words", function() {
 		const mockPaper = new Paper();
 		const assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 20,
-			transitionWordSentences: 7 } ), i18n );
+			transitionWordSentences: 7 } ) );
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!" );
 		expect( assessment.hasMarks() ).toBe( true );
@@ -73,7 +72,7 @@ describe( "An assessment for transition word percentage", function() {
 	it( "returns the score for 40% sentences with transition words", function() {
 		const mockPaper = new Paper();
 		const assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 10,
-			transitionWordSentences: 4 } ), i18n );
+			transitionWordSentences: 4 } ) );
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!" );
 		expect( assessment.hasMarks() ).toBe( true );
@@ -82,7 +81,7 @@ describe( "An assessment for transition word percentage", function() {
 	it( "returns the score for 47% sentences with transition words", function() {
 		const mockPaper = new Paper();
 		const assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 100,
-			transitionWordSentences: 47 } ), i18n );
+			transitionWordSentences: 47 } ) );
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!" );
 		expect( assessment.hasMarks() ).toBe( true );
@@ -91,7 +90,7 @@ describe( "An assessment for transition word percentage", function() {
 	it( "returns the score for 66.7% of the sentences with transition words", function() {
 		const mockPaper = new Paper();
 		const assessment = transitionWordsAssessment.getResult( mockPaper, Factory.buildMockResearcher( { totalSentences: 3,
-			transitionWordSentences: 2 } ), i18n );
+			transitionWordSentences: 2 } ) );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!" );

--- a/packages/yoastseo/spec/scoring/assessments/readability/wordComplexityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/wordComplexityAssessmentSpec.js
@@ -3,12 +3,11 @@ import DefaultResearcher from "../../../../src/languageProcessing/languages/_def
 import wordComplexityAssessment from "../../../../src/scoring/assessments/readability/wordComplexityAssessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import factory from "../../../specHelpers/factory.js";
-const i18n = factory.buildJed();
 
 describe( "an assessment returning complex words", function() {
 	it( "runs a test with an empty text", function() {
 		const mockPaper = new Paper( "" );
-		const result = wordComplexityAssessment.getResult( mockPaper, factory.buildMockResearcher( [] ), i18n );
+		const result = wordComplexityAssessment.getResult( mockPaper, factory.buildMockResearcher( [] ) );
 
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "0% of the words contain <a href='https://yoa.st/difficult-words' target='_blank'>" +
@@ -31,7 +30,7 @@ describe( "an assessment returning complex words", function() {
 				{ word: "", complexity: 1 },
 				{ word: "", complexity: 10 } ],
 			} ]
-		), i18n );
+		) );
 
 		expect( result.getScore() ).toBe( 3 );
 		expect( result.getText() ).toBe( "30% of the words contain <a href='https://yoa.st/difficult-words' target='_blank'>over 3 syllables</a>, " +
@@ -63,7 +62,7 @@ describe( "an assessment returning complex words", function() {
 				{ word: "", complexity: 1 },
 				{ word: "", complexity: 10 },
 			] } ]
-		), i18n );
+		) );
 		expect( result.getScore() ).toBe( 6.8 );
 		expect( result.getText() ).toBe( "5.3% of the words contain <a href='https://yoa.st/difficult-words' target='_blank'>over 3 syllables</a>, " +
 			"which is more than the recommended maximum of 5%." );
@@ -95,7 +94,7 @@ describe( "an assessment returning complex words", function() {
 				{ word: "", complexity: 1 },
 				{ word: "", complexity: 10 } ] },
 		]
-		), i18n );
+		) );
 		expect( result.getScore() ).toBe( 7 );
 		expect( result.getText() ).toBe( "5% of the words contain <a href='https://yoa.st/difficult-words' target='_blank'>over 3 syllables</a>, " +
 			"which is less than or equal to the recommended maximum of 5%." );
@@ -141,7 +140,7 @@ describe( "an assessment returning complex words", function() {
 				{ word: "", complexity: 3 },
 				{ word: "", complexity: 10 } ],
 			} ]
-		), i18n );
+		) );
 		expect( result.getScore() ).toBe( 8.3 );
 		expect( result.getText() ).toBe( "2.9% of the words contain <a href='https://yoa.st/difficult-words' target='_blank'>over 3 syllables</a>, " +
 			"which is less than or equal to the recommended maximum of 5%." );
@@ -163,7 +162,7 @@ describe( "an assessment returning complex words", function() {
 				{ word: "", complexity: 1 },
 				{ word: "", complexity: 1 } ],
 			} ]
-		), i18n );
+		) );
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "0% of the words contain <a href='https://yoa.st/difficult-words' target='_blank'>over 3 syllables</a>, " +
 			"which is less than or equal to the recommended maximum of 5%." );

--- a/packages/yoastseo/spec/scoring/assessments/seo/FunctionWordsInKeyphraseAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/FunctionWordsInKeyphraseAssessmentSpec.js
@@ -4,14 +4,11 @@ import Factory from "../../../specHelpers/factory";
 import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
 import DefaultResearcher from "../../../../src/languageProcessing/languages/_default/Researcher";
 
-const i18n = Factory.buildJed();
-
 describe( "An assessment for checking if the keyphrase contains function words only", function() {
 	it( "returns a consideration feedback if there are only function words in the keyphrase", function() {
 		const assessment = new FunctionWordsInKeyphraseAssessment().getResult(
 			new Paper( "", { keyword: "someone was here" } ),
 			Factory.buildMockResearcher( true ),
-			i18n
 		);
 		expect( assessment.getScore() ).toBe( 0 );
 		expect( assessment.getText() ).toBe(
@@ -24,8 +21,7 @@ describe( "An assessment for checking if the keyphrase contains function words o
 	it( "returns nothing if there are also content words in the keyphrase", function() {
 		const assessment = new FunctionWordsInKeyphraseAssessment().getResult(
 			new Paper( "", { keyword: "someone smart was here" } ),
-			Factory.buildMockResearcher( false ),
-			i18n
+			Factory.buildMockResearcher( false )
 		);
 		expect( assessment.hasScore() ).toBe( false );
 	} );

--- a/packages/yoastseo/spec/scoring/assessments/seo/InternalLinksAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/InternalLinksAssessmentSpec.js
@@ -2,14 +2,13 @@ import InternalLinksAssessment from "../../../../src/scoring/assessments/seo/Int
 
 import Paper from "../../../../src/values/Paper.js";
 import factory from "../../../specHelpers/factory.js";
-const i18n = factory.buildJed();
 
 describe( "An assessor running the linkStatistics for internal links", function() {
 	it( "A paper with one internal link, which is do-follow", function() {
 		const mockPaper = new Paper( "some text" );
 
 		const assessment = new InternalLinksAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalDofollow: 1,
-			internalNofollow: 0, internalTotal: 1 } ), i18n );
+			internalNofollow: 0, internalTotal: 1 } ) );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: You have enough" +
@@ -20,7 +19,7 @@ describe( "An assessor running the linkStatistics for internal links", function(
 		const mockPaper = new Paper( "some text" );
 
 		const assessment = new InternalLinksAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalDofollow: 1,
-			internalNofollow: 1, internalTotal: 2 } ), i18n );
+			internalNofollow: 1, internalTotal: 2 } ) );
 
 		expect( assessment.getScore() ).toEqual( 8 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: There are both" +
@@ -31,7 +30,7 @@ describe( "An assessor running the linkStatistics for internal links", function(
 		const mockPaper = new Paper( "some text" );
 
 		const assessment = new InternalLinksAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalDofollow: 0,
-			internalNofollow: 1, internalTotal: 1 } ), i18n );
+			internalNofollow: 1, internalTotal: 1 } ) );
 
 		expect( assessment.getScore() ).toEqual( 7 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: " +
@@ -40,7 +39,7 @@ describe( "An assessor running the linkStatistics for internal links", function(
 
 	it( "A paper without internal links", function() {
 		const mockPaper = new Paper( "some text" );
-		const assessment = new InternalLinksAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalTotal: 0 } ), i18n );
+		const assessment = new InternalLinksAssessment().getResult( mockPaper, factory.buildMockResearcher( { internalTotal: 0 } ) );
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33z' target='_blank'>Internal links</a>: " +

--- a/packages/yoastseo/spec/scoring/assessments/seo/IntroductionKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/IntroductionKeywordAssessmentSpec.js
@@ -2,8 +2,6 @@ import IntroductionKeywordAssessment from "../../../../src/scoring/assessments/s
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";
 
-const i18n = Factory.buildJed();
-
 describe( "An assessment for finding the keyword in the first paragraph", function() {
 	it( "returns keyphrase words found in one sentence of the first paragraph", function() {
 		const assessment = new IntroductionKeywordAssessment().getResult(
@@ -12,8 +10,7 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 				foundInOneSentence: true,
 				foundInParagraph: true,
 				keyphraseOrSynonym: "keyphrase",
-			} ),
-			i18n
+			} )
 		);
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>: Well done!" );
@@ -26,8 +23,7 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 				foundInOneSentence: true,
 				foundInParagraph: true,
 				keyphraseOrSynonym: "synonym",
-			} ),
-			i18n
+			} )
 		);
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>: Well done!" );
@@ -40,8 +36,7 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 				foundInOneSentence: false,
 				foundInParagraph: true,
 				keyphraseOrSynonym: "keyphrase",
-			} ),
-			i18n
+			} )
 		);
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>:" +
@@ -57,8 +52,7 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 				foundInOneSentence: false,
 				foundInParagraph: true,
 				keyphraseOrSynonym: "synonym",
-			} ),
-			i18n
+			} )
 		);
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>:" +
@@ -74,8 +68,7 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 				foundInOneSentence: false,
 				foundInParagraph: false,
 				keyphraseOrSynonym: "",
-			} ),
-			i18n
+			} )
 		);
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>:" +

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseDistributionAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseDistributionAssessmentSpec.js
@@ -1,7 +1,6 @@
 import KeyphraseDistributionAssessment from "../../../../src/scoring/assessments/seo/KeyphraseDistributionAssessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
-const i18n = Factory.buildJed();
 import Mark from "../../../../src/values/Mark.js";
 
 const keyphraseDistributionAssessment = new KeyphraseDistributionAssessment();
@@ -14,8 +13,7 @@ describe( "An assessment to check your keyphrase distribution", function() {
 			Factory.buildMockResearcher( {
 				keyphraseDistributionScore: 100,
 				sentencesToHighlight: [],
-			} ),
-			i18n
+			} )
 		);
 
 		expect( assessment.getScore() ).toEqual( 0 );
@@ -31,8 +29,7 @@ describe( "An assessment to check your keyphrase distribution", function() {
 			Factory.buildMockResearcher( {
 				keyphraseDistributionScore: 60,
 				sentencesToHighlight: [],
-			} ),
-			i18n
+			} )
 		);
 
 		expect( assessment.getScore() ).toEqual( 1 );
@@ -48,8 +45,7 @@ describe( "An assessment to check your keyphrase distribution", function() {
 			Factory.buildMockResearcher( {
 				keyphraseDistributionScore: 40,
 				sentencesToHighlight: [],
-			} ),
-			i18n
+			} )
 		);
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -65,8 +61,7 @@ describe( "An assessment to check your keyphrase distribution", function() {
 			Factory.buildMockResearcher( {
 				keyphraseDistributionScore: 25,
 				sentencesToHighlight: [],
-			} ),
-			i18n
+			} )
 		);
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -140,8 +135,7 @@ describe( "A test for marking keywords in the text", function() {
 							marked: "<yoastmark class='yoast-text-mark'>Another sentence.</yoastmark>",
 						} ),
 					],
-				} ),
-			i18n
+				} )
 		);
 		const expected = [
 			new Mark( {

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseLengthAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseLengthAssessmentSpec.js
@@ -1,7 +1,6 @@
 import KeyphraseLengthAssessment from "../../../../src/scoring/assessments/seo/KeyphraseLengthAssessment";
 import Paper from "../../../../src/values/Paper.js";
 import factory from "../../../specHelpers/factory.js";
-const i18n = factory.buildJed();
 import { all as englishFunctionWords } from "../../../../src/languageProcessing/languages/en/config/functionWords";
 
 describe( "the keyphrase length assessment", function() {
@@ -9,7 +8,7 @@ describe( "the keyphrase length assessment", function() {
 		const paper = new Paper();
 		const researcher = factory.buildMockResearcher( { keyphraseLength: 0, functionWords: [] } );
 
-		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher );
 
 		expect( result.getScore() ).toEqual( -999 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
@@ -20,7 +19,7 @@ describe( "the keyphrase length assessment", function() {
 		const paper = new Paper();
 		const researcher = factory.buildMockResearcher( { keyphraseLength: 0, functionWords: englishFunctionWords } );
 
-		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher );
 
 		expect( result.getScore() ).toEqual( -999 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
@@ -32,7 +31,7 @@ describe( "the keyphrase length assessment", function() {
 		const paper = new Paper();
 		const researcher = factory.buildMockResearcher( { keyphraseLength: 0, functionWords: englishFunctionWords } );
 
-		const result = new KeyphraseLengthAssessment( { isRelatedKeyphrase: true } ).getResult( paper, researcher, i18n );
+		const result = new KeyphraseLengthAssessment( { isRelatedKeyphrase: true } ).getResult( paper, researcher );
 
 		expect( result.getScore() ).toEqual( -999 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
@@ -43,7 +42,7 @@ describe( "the keyphrase length assessment", function() {
 		const paper = new Paper( "", { keyword: "keyword" } );
 		const researcher = factory.buildMockResearcher( { keyphraseLength: 11, functionWords: englishFunctionWords } );
 
-		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher );
 
 		expect( result.getScore() ).toEqual( 3 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
@@ -55,7 +54,7 @@ describe( "the keyphrase length assessment", function() {
 		const paper = new Paper( "", { keyword: "keyword" } );
 		const researcher = factory.buildMockResearcher( { keyphraseLength: 3, functionWords: englishFunctionWords } );
 
-		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher );
 
 		expect( result.getScore() ).toEqual( 9 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: Good job!" );
@@ -65,7 +64,7 @@ describe( "the keyphrase length assessment", function() {
 		const paper = new Paper( "", { keyword: "keyword keyword keyword keyword keyword" } );
 		const researcher = factory.buildMockResearcher( { keyphraseLength: 5, functionWords: englishFunctionWords } );
 
-		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher );
 
 		expect( result.getScore() ).toEqual( 6 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +
@@ -77,7 +76,7 @@ describe( "the keyphrase length assessment", function() {
 		const paper = new Paper( "", { keyword: "1 2 3 4 5 6" } );
 		const researcher = factory.buildMockResearcher( { keyphraseLength: 5, functionWords: [] } );
 
-		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher );
 
 		expect( result.getScore() ).toEqual( 9 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: Good job!" );
@@ -87,7 +86,7 @@ describe( "the keyphrase length assessment", function() {
 		const paper = new Paper( "", { keyword: "1 2 3 4 5 6 7 8 9" } );
 		const researcher = factory.buildMockResearcher( { keyphraseLength: 9, functionWords: [] } );
 
-		const result = new KeyphraseLengthAssessment().getResult( paper, researcher, i18n );
+		const result = new KeyphraseLengthAssessment().getResult( paper, researcher );
 
 		expect( result.getScore() ).toEqual( 6 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/33i' target='_blank'>Keyphrase length</a>: " +

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
@@ -5,11 +5,8 @@ import GermanResearcher from "../../../../src/languageProcessing/languages/de/Re
 import DefaultResearcher from "../../../../src/languageProcessing/languages/_default/Researcher";
 import Paper from "../../../../src/values/Paper.js";
 import Mark from "../../../../src/values/Mark.js";
-import factory from "../../../specHelpers/factory.js";
 import getMorphologyData from "../../../specHelpers/getMorphologyData";
 
-
-const i18n = factory.buildJed();
 const morphologyData = getMorphologyData( "en" );
 const morphologyDataDe = getMorphologyData( "de" );
 const nonkeyword = "nonkeyword, ";
@@ -19,7 +16,7 @@ describe( "Tests for the keywordDensity assessment for languages without morphol
 	it( "runs the keywordDensity on the paper without keyword in the text", function() {
 		const paper = new Paper( nonkeyword.repeat( 1000 ), { keyword: "keyword" } );
 		const researcher = new DefaultResearcher( paper );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
 		expect( result.getScore() ).toBe( 4 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 5 times for a text of this length." +
@@ -29,7 +26,7 @@ describe( "Tests for the keywordDensity assessment for languages without morphol
 	it( "runs the keywordDensity on the paper with a low keyphrase density (0.1%)", function() {
 		const paper = new Paper( nonkeyword.repeat( 999 ) + keyword, { keyword: "keyword" } );
 		const researcher = new DefaultResearcher( paper );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
 		expect( result.getScore() ).toBe( 4 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 1 time. That's less than the recommended minimum of 5 times for a text of this length." +
@@ -39,7 +36,7 @@ describe( "Tests for the keywordDensity assessment for languages without morphol
 	it( "runs the keywordDensity on the paper with a good keyphrase density (0.5%)", function() {
 		const paper = new Paper( nonkeyword.repeat( 995 ) + keyword.repeat( 5 ), { keyword: "keyword" } );
 		const researcher = new DefaultResearcher( paper );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 5 times. This is great!" );
@@ -48,7 +45,7 @@ describe( "Tests for the keywordDensity assessment for languages without morphol
 	it( "runs the keywordDensity on the paper with a good keyphrase density (2%)", function() {
 		const paper = new Paper( nonkeyword.repeat( 980 ) + keyword.repeat( 20 ), { keyword: "keyword" } );
 		const researcher = new DefaultResearcher( paper );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 20 times. This is great!" );
@@ -57,7 +54,7 @@ describe( "Tests for the keywordDensity assessment for languages without morphol
 	it( "runs the keywordDensity on the paper with a slightly too high keyphrase density (3.5%)", function() {
 		const paper = new Paper( nonkeyword.repeat( 965 ) + keyword.repeat( 35 ), { keyword: "keyword" } );
 		const researcher = new DefaultResearcher( paper );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
 		expect( result.getScore() ).toBe( -10 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 35 times. That's more than the recommended maximum of 29 times " +
@@ -67,7 +64,7 @@ describe( "Tests for the keywordDensity assessment for languages without morphol
 	it( "runs the keywordDensity on the paper with a very high keyphrase density (10%)", function() {
 		const paper = new Paper( nonkeyword.repeat( 900 ) + keyword.repeat( 100 ), { keyword: "keyword" } );
 		const researcher = new DefaultResearcher( paper );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
 		expect( result.getScore() ).toBe( -50 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 100 times. That's way more than the recommended maximum of 29 times " +
@@ -78,7 +75,7 @@ describe( "Tests for the keywordDensity assessment for languages without morphol
 	it( "adjusts the keyphrase density based on the length of the keyword with the actual density remaining at 2% - short keyphrase", function() {
 		const paper = new Paper( nonkeyword.repeat( 960 ) + "b c, ".repeat( 20 ), { keyword: "b c" } );
 		const researcher = new DefaultResearcher( paper );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 20 times. This is great!" );
@@ -87,7 +84,7 @@ describe( "Tests for the keywordDensity assessment for languages without morphol
 	it( "adjusts the keyphrase density based on the length of the keyword with the actual density remaining at 2% - long keyphrase", function() {
 		const paper = new Paper( nonkeyword.repeat( 900 ) + "b c d e f, ".repeat( 20 ), { keyword: "b c d e f" } );
 		const researcher = new DefaultResearcher( paper );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
 		expect( result.getScore() ).toBe( -50 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 20 times. That's way more than the recommended maximum of 12 times " +
@@ -97,7 +94,7 @@ describe( "Tests for the keywordDensity assessment for languages without morphol
 	it( "returns a bad result if the keyword is only used once, regardless of the density", function() {
 		const paper = new Paper( nonkeyword.repeat( 100 ) + keyword, { keyword: "keyword" } );
 		const researcher = new DefaultResearcher( paper );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
 		expect( result.getScore() ).toBe( 4 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 1 time. That's less than the recommended minimum of 2 times " +
@@ -108,7 +105,7 @@ describe( "Tests for the keywordDensity assessment for languages without morphol
 		"the recommended count is smaller than or equal to 2, regardless of the density", function() {
 		const paper = new Paper( nonkeyword.repeat( 100 ) + "a b c, a b c", { keyword: "a b c", locale: "xx_XX" } );
 		const researcher = new DefaultResearcher( paper );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 2 times. This is great!" );
@@ -140,7 +137,7 @@ describe( "Tests for the keywordDensity assessment for languages with morphology
 		const paper = new Paper( nonkeyword.repeat( 968 ) + keyword.repeat( 32 ), { keyword: "keyword", locale: "en_EN" } );
 		const researcher = new EnglishResearcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 32 times. This is great!" );
@@ -150,7 +147,7 @@ describe( "Tests for the keywordDensity assessment for languages with morphology
 		const paper = new Paper( nonkeyword.repeat( 968 ) + keyword.repeat( 32 ), { keyword: "keyword", locale: "de_DE" } );
 		const researcher = new GermanResearcher( paper );
 		researcher.addResearchData( "morphology", morphologyDataDe );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
 		expect( result.getScore() ).toBe( 9 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 32 times. This is great!" );
@@ -159,7 +156,7 @@ describe( "Tests for the keywordDensity assessment for languages with morphology
 	it( "gives a BAD result when keyword density is between 3 and 3.5%, if morphology support is added, but there is no morphology data", function() {
 		const paper = new Paper( nonkeyword.repeat( 968 ) + keyword.repeat( 32 ), { keyword: "keyword", locale: "de_DE" } );
 		const researcher = new GermanResearcher( paper );
-		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
 		expect( result.getScore() ).toBe( -10 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 32 times. That's more than the recommended maximum of 29 times for a text of this length. " +
@@ -171,7 +168,7 @@ describe( "A test for marking the keyword", function() {
 		const keywordDensityAssessment = new KeywordDensityAssessment();
 		const paper = new Paper( "This is a very interesting paper with a keyword and another keyword.", { keyword: "keyword" }  );
 		const researcher = new DefaultResearcher( paper );
-		keywordDensityAssessment.getResult( paper, researcher, i18n );
+		keywordDensityAssessment.getResult( paper, researcher );
 		const expected = [
 			new Mark( {
 				marked: "This is a very interesting paper with a " +
@@ -186,7 +183,7 @@ describe( "A test for marking the keyword", function() {
 		const keywordDensityAssessment = new KeywordDensityAssessment();
 		const paper = new Paper( "This is the release of YoastSEO 9.3.", { keyword: "YoastSEO 9.3" }  );
 		const researcher = new DefaultResearcher( paper );
-		keywordDensityAssessment.getResult( paper, researcher, i18n );
+		keywordDensityAssessment.getResult( paper, researcher );
 		const expected = [
 			new Mark( { marked: "This is the release of <yoastmark class='yoast-text-mark'>YoastSEO 9.3</yoastmark>.",
 				original: "This is the release of YoastSEO 9.3." } ) ];

--- a/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionKeywordAssessmentSpec.js
@@ -2,8 +2,6 @@ import MetaDescriptionKeywordAssessment from "../../../../src/scoring/assessment
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";
 
-const i18n = Factory.buildJed();
-
 const mockResearcherNoMatches = Factory.buildMockResearcher( 0 );
 const mockResearcherOneMatch = Factory.buildMockResearcher( 1 );
 const mockResearcherTwoMatches = Factory.buildMockResearcher( 2 );
@@ -12,7 +10,7 @@ const mockResearcherThreeMatches = Factory.buildMockResearcher( 3 );
 describe( "the metadescription keyword assessment", function() {
 	it( "returns a bad result when the meta description doesn't contain the keyword", function() {
 		const mockPaper = new Paper();
-		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherNoMatches, i18n );
+		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherNoMatches );
 
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: " +
@@ -23,7 +21,7 @@ describe( "the metadescription keyword assessment", function() {
 	it( "returns a good result and an appropriate feedback message when at least one sentence contains every keyword term " +
 		"at least once in the same sentence.", function() {
 		const mockPaper = new Paper();
-		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherOneMatch, i18n );
+		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherOneMatch );
 
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta description</a>: " +
@@ -33,7 +31,7 @@ describe( "the metadescription keyword assessment", function() {
 	it( "returns a good result and an appropriate feedback message when the meta description contains the keyword " +
 		"two times in the same sentence", function() {
 		const mockPaper = new Paper();
-		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherTwoMatches, i18n );
+		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherTwoMatches );
 
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta " +
@@ -42,7 +40,7 @@ describe( "the metadescription keyword assessment", function() {
 
 	it( "returns a bad result when the meta description contains the keyword three times in the same sentence", function() {
 		const mockPaper = new Paper();
-		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherThreeMatches, i18n );
+		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherThreeMatches );
 
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta " +

--- a/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionLengthAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionLengthAssessmentSpec.js
@@ -1,14 +1,13 @@
 import MetaDescriptionLengthAssessment from "../../../../src/scoring/assessments/seo/MetaDescriptionLengthAssessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
-const i18n = Factory.buildJed();
 
 const descriptionLengthAssessment = new MetaDescriptionLengthAssessment();
 
 describe( "the meta description length assessment", function() {
 	it( "assesses an empty description", function() {
 		const mockPaper = new Paper();
-		const assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 0 ), i18n );
+		const assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 0 ) );
 
 		expect( assessment.getScore() ).toEqual( 1 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length" +
@@ -18,7 +17,7 @@ describe( "the meta description length assessment", function() {
 
 	it( "assesses a short description", function() {
 		const mockPaper = new Paper();
-		const assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ), i18n );
+		const assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 20 ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: " +
@@ -28,7 +27,7 @@ describe( "the meta description length assessment", function() {
 
 	it( "assesses a too long description", function() {
 		const mockPaper = new Paper();
-		const assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 400 ), i18n );
+		const assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 400 ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( descriptionLengthAssessment.getMaximumLength() ).toEqual( 156 );
@@ -39,7 +38,7 @@ describe( "the meta description length assessment", function() {
 
 	it( "assesses a good description", function() {
 		const mockPaper = new Paper();
-		const assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 140 ), i18n );
+		const assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 140 ) );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: Well done!" );

--- a/packages/yoastseo/spec/scoring/assessments/seo/OutboundLinksAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/OutboundLinksAssessmentSpec.js
@@ -1,8 +1,6 @@
 import OutboundLinksAssessment from "../../../../src/scoring/assessments/seo/OutboundLinksAssessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import factory from "../../../specHelpers/factory.js";
-const i18n = factory.buildJed();
-
 const linkStatisticAssessment = new OutboundLinksAssessment();
 
 const attributes = {
@@ -27,7 +25,7 @@ describe( "Tests outbound links assessment", function() {
 			totalKeyword: 0,
 			totalNaKeyword: 0 };
 
-		const assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
+		const assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ) );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: Good job!" );
@@ -49,7 +47,7 @@ describe( "Tests outbound links assessment", function() {
 			totalKeyword: 0,
 			totalNaKeyword: 1 };
 
-		const assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
+		const assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ) );
 
 		expect( assessment.getScore() ).toEqual( 8 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: " +
@@ -72,7 +70,7 @@ describe( "Tests outbound links assessment", function() {
 			totalKeyword: 0,
 			totalNaKeyword: 0 };
 
-		const assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
+		const assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ) );
 
 		expect( assessment.getScore() ).toEqual( 7 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: " +
@@ -96,20 +94,20 @@ describe( "Tests outbound links assessment", function() {
 			totalKeyword: 0,
 			totalNaKeyword: 0 };
 
-		const assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ), i18n );
+		const assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( mockResult ) );
 
 		expect( assessment.getScore() ).toEqual( 0 );
 	} );
 
 	it( "Tests a paper without outbound links", function() {
 		const mockPaper = new Paper( "" );
-		let assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( { externalTotal: 0 } ), i18n );
+		let assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( { externalTotal: 0 } ) );
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34f' target='_blank'>Outbound links</a>: " +
 			"No outbound links appear in this page. <a href='https://yoa.st/34g' target='_blank'>Add some</a>!" );
 
-		assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( {} ), i18n );
+		assessment = linkStatisticAssessment.getResult( mockPaper, factory.buildMockResearcher( {} ) );
 		expect( assessment.getScore() ).toEqual( 0 );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/assessments/seo/PageTitleWidthAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/PageTitleWidthAssessmentSpec.js
@@ -1,14 +1,12 @@
 import PageTitleLengthAssessment from "../../../../src/scoring/assessments/seo/PageTitleWidthAssessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import factory from "../../../specHelpers/factory.js";
-const i18n = factory.buildJed();
-
 const pageTitleLengthAssessment = new PageTitleLengthAssessment();
 
 describe( "the SEO title length assessment", function() {
 	it( "should assess a paper without an SEO title", function() {
 		const paper = new Paper( "" );
-		const result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 0 ), i18n );
+		const result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 0 ) );
 
 		expect( result.getScore() ).toEqual( 1 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: " +
@@ -17,7 +15,7 @@ describe( "the SEO title length assessment", function() {
 
 	it( "should assess a paper with an SEO title that's under the recommended value", function() {
 		const paper = new Paper( "", { title: "The Title" } );
-		const result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 9 ), i18n );
+		const result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 9 ) );
 		expect( result.getScore() ).toEqual( 6 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: " +
 			"The SEO title is too short. <a href='https://yoa.st/34i' target='_blank'>Use the space to add keyphrase variations " +
@@ -26,21 +24,21 @@ describe( "the SEO title length assessment", function() {
 
 	it( "should assess a paper with an SEO title that's in range of the recommended value", function() {
 		const paper = new Paper( "", { title: "The Title That Is At Least As Long As It Should Be To Pass" } );
-		const result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 450 ), i18n );
+		const result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 450 ) );
 		expect( result.getScore() ).toEqual( 9 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: Good job!" );
 	} );
 
 	it( "should assess a paper with an SEO title that's in range of the recommended value", function() {
 		const paper = new Paper( "", { title: "The Title That Is At Least As Long As It Should Be To Pass" } );
-		const result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 600 ), i18n );
+		const result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 600 ) );
 		expect( result.getScore() ).toEqual( 9 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: Good job!" );
 	} );
 
 	it( "should assess a paper with an SEO title that's longer than the recommended value", function() {
 		const paper = new Paper( "", { title: "The Title That Is Too Long Long To Pass" } );
-		const result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 620 ), i18n );
+		const result = pageTitleLengthAssessment.getResult( paper, factory.buildMockResearcher( 620 ) );
 		expect( result.getScore() ).toEqual( 3 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: " +
 			"The SEO title is wider than the viewable limit. <a href='https://yoa.st/34i' target='_blank'>Try to make it shorter</a>." );

--- a/packages/yoastseo/spec/scoring/assessments/seo/SingleH1AssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/SingleH1AssessmentSpec.js
@@ -1,7 +1,6 @@
 import SingleH1Assessment from "../../../../src/scoring/assessments/seo/SingleH1Assessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
-const i18n = Factory.buildJed();
 import Mark from "../../../../src/values/Mark.js";
 
 const h1Assessment = new SingleH1Assessment();
@@ -9,7 +8,7 @@ const h1Assessment = new SingleH1Assessment();
 describe( "An assessment to check whether there is more than one H1 in the text", function() {
 	it( "returns the default result when the paper doesn't contain an H1", function() {
 		const mockPaper = new Paper( "<p>a paragraph</p>" );
-		const assessment = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [] ), i18n );
+		const assessment = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [] ) );
 
 		expect( assessment.getScore() ).toEqual( 0 );
 		expect( assessment.getText() ).toEqual( "" );
@@ -19,7 +18,7 @@ describe( "An assessment to check whether there is more than one H1 in the text"
 	it( "returns the default result when there's an H1 at the beginning of the body", function() {
 		const mockPaper = new Paper( "<h1>heading</h1><p>a paragraph</p>" );
 		const assessment = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher(
-			[ { tag: "h1", content: "heading", position: 0 } ] ), i18n );
+			[ { tag: "h1", content: "heading", position: 0 } ] ) );
 
 		expect( assessment.getScore() ).toEqual( 0 );
 		expect( assessment.getText() ).toEqual( "" );
@@ -29,7 +28,7 @@ describe( "An assessment to check whether there is more than one H1 in the text"
 	it( "returns a bad score and appropriate feedback when there is one superfluous (i.e., non-title) H1s in the body of the text", function() {
 		const mockPaper = new Paper( "<p>a paragraph</p><h1>heading</h1>" );
 		const assessment = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher(
-			[ { tag: "h1", content: "heading", position: 2 } ] ), i18n );
+			[ { tag: "h1", content: "heading", position: 2 } ] ) );
 
 		expect( assessment.getScore() ).toEqual( 1 );
 		expect( assessment.getText() ).toEqual(  "<a href='https://yoa.st/3a6' target='_blank'>Single title</a>: " +
@@ -43,7 +42,7 @@ describe( "An assessment to check whether there is more than one H1 in the text"
 		const assessment = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [
 			{ tag: "h1", content: "heading 1", position: 2 },
 			{ tag: "h1", content: "heading 2", position: 4 },
-		] ), i18n );
+		] ) );
 
 		expect( assessment.getScore() ).toEqual( 1 );
 		expect( assessment.getText() ).toEqual(  "<a href='https://yoa.st/3a6' target='_blank'>Single title</a>: " +
@@ -56,7 +55,7 @@ describe( "A test for marking incorrect H1s in the body", function() {
 	it( "returns markers for incorrect H1s in the body", function() {
 		const mockPaper = new Paper( "<p>a paragraph</p><h1>heading</h1>" );
 		const assessment = h1Assessment;
-		assessment.getResult( mockPaper, Factory.buildMockResearcher( [ { tag: "h1", content: "heading", position: 2 } ] ), i18n );
+		assessment.getResult( mockPaper, Factory.buildMockResearcher( [ { tag: "h1", content: "heading", position: 2 } ] ) );
 
 		const expected = [
 			new Mark( { original: "<h1>heading</h1>",
@@ -68,7 +67,7 @@ describe( "A test for marking incorrect H1s in the body", function() {
 
 	it( "doesn't return markers for H1s in the first position of the body", function() {
 		const mockPaper = new Paper( "<h1>heading</h1><p>a paragraph</p>" );
-		const results = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [ { tag: "h1", content: "heading", position: 0 } ] ), i18n );
+		const results = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [ { tag: "h1", content: "heading", position: 0 } ] ) );
 
 		expect( results._hasMarks ).toEqual( false );
 		expect( h1Assessment.getMarks() ).toEqual( [] );
@@ -76,7 +75,7 @@ describe( "A test for marking incorrect H1s in the body", function() {
 
 	it( "doesn't return markers when there are no H1s in the body", function() {
 		const mockPaper = new Paper( "<p>a paragraph</p>" );
-		const results = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [] ), i18n );
+		const results = h1Assessment.getResult( mockPaper, Factory.buildMockResearcher( [] ) );
 
 		expect( results._hasMarks ).toEqual( false );
 	} );

--- a/packages/yoastseo/spec/scoring/assessments/seo/SubHeadingsKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/SubHeadingsKeywordAssessmentSpec.js
@@ -2,7 +2,6 @@ import SubheadingsKeywordAssessment from "../../../../src/scoring/assessments/se
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";
 
-const i18n = Factory.buildJed();
 const matchKeywordAssessment = new SubheadingsKeywordAssessment();
 
 describe( "An assessment for matching keywords in subheadings", () => {
@@ -10,8 +9,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 		const mockPaper = new Paper();
 		const assessment = matchKeywordAssessment.getResult(
 			mockPaper,
-			Factory.buildMockResearcher( { count: 1, matches: 0, percentReflectingTopic: 0 } ),
-			i18n
+			Factory.buildMockResearcher( { count: 1, matches: 0, percentReflectingTopic: 0 } )
 		);
 
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -25,8 +23,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 		const mockPaper = new Paper();
 		const assessment = matchKeywordAssessment.getResult(
 			mockPaper,
-			Factory.buildMockResearcher( { count: 8, matches: 2, percentReflectingTopic: 25 } ),
-			i18n
+			Factory.buildMockResearcher( { count: 8, matches: 2, percentReflectingTopic: 25 } )
 		);
 
 		expect( assessment.getScore() ).toEqual( 3 );
@@ -41,8 +38,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 		const mockPaper = new Paper();
 		const assessment = matchKeywordAssessment.getResult(
 			mockPaper,
-			Factory.buildMockResearcher( { count: 1, matches: 1, percentReflectingTopic: 100 } ),
-			i18n
+			Factory.buildMockResearcher( { count: 1, matches: 1, percentReflectingTopic: 100 } )
 		);
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -57,8 +53,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 		const mockPaper = new Paper();
 		const assessment = matchKeywordAssessment.getResult(
 			mockPaper,
-			Factory.buildMockResearcher( { count: 2, matches: 1, percentReflectingTopic: 50 } ),
-			i18n
+			Factory.buildMockResearcher( { count: 2, matches: 1, percentReflectingTopic: 50 } )
 		);
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -73,8 +68,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 		const mockPaper = new Paper();
 		const assessment = matchKeywordAssessment.getResult(
 			mockPaper,
-			Factory.buildMockResearcher( { count: 4, matches: 2, percentReflectingTopic: 50 } ),
-			i18n
+			Factory.buildMockResearcher( { count: 4, matches: 2, percentReflectingTopic: 50 } )
 		);
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -89,8 +83,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 		const mockPaper = new Paper();
 		const assessment = matchKeywordAssessment.getResult(
 			mockPaper,
-			Factory.buildMockResearcher( { count: 8, matches: 7, percentReflectingTopic: 87.5 } ),
-			i18n
+			Factory.buildMockResearcher( { count: 8, matches: 7, percentReflectingTopic: 87.5 } )
 		);
 
 		expect( assessment.getScore() ).toEqual( 3 );

--- a/packages/yoastseo/spec/scoring/assessments/seo/TextCompetingLinksAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/TextCompetingLinksAssessmentSpec.js
@@ -3,8 +3,6 @@ import TextCompetingLinksAssessment from "../../../../src/scoring/assessments/se
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";
 
-const i18n = Factory.buildJed();
-
 describe( "An assessment for competing links in the text", function() {
 	it( "returns a 'bad' score if a paper is referring to another paper with the same keyword", function() {
 		const paper = new Paper( "This is a very interesting paper", { keyword: "some keyword" } );
@@ -29,8 +27,7 @@ describe( "An assessment for competing links in the text", function() {
 					otherNofollow: 0,
 				}
 			),
-			i18n
-		);
+			);
 
 		expect( result.getScore() ).toBe( 2 );
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/34l' target='_blank'>Link keyphrase</a>: " +
@@ -40,7 +37,7 @@ describe( "An assessment for competing links in the text", function() {
 
 	it( "returns the score when the paper is empty", function() {
 		const paper = new Paper( "" );
-		const result = new TextCompetingLinksAssessment( {} ).getResult( paper, new DefaultResearcher( paper ), i18n );
+		const result = new TextCompetingLinksAssessment( {} ).getResult( paper, new DefaultResearcher( paper ) );
 		expect( result.score ).toBe(  0 );
 	} );
 

--- a/packages/yoastseo/spec/scoring/assessments/seo/TextImagesAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/TextImagesAssessmentSpec.js
@@ -1,7 +1,6 @@
 import ImageCountAssessment from "../../../../src/scoring/assessments/seo/TextImagesAssessment";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
-const i18n = Factory.buildJed();
 
 const imageCountAssessment = new ImageCountAssessment();
 
@@ -17,7 +16,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 0,
 				withAltNonKeyword: 0,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: " +
@@ -35,7 +34,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 0,
 				withAltNonKeyword: 0,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: " +
@@ -54,7 +53,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 0,
 				withAltNonKeyword: 0,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: " +
@@ -74,7 +73,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 0,
 				withAltNonKeyword: 0,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: " +
@@ -95,7 +94,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 0,
 				withAltNonKeyword: 1,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: " +
@@ -117,7 +116,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 0,
 				withAltNonKeyword: 4,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: " +
@@ -138,7 +137,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 1,
 				withAltNonKeyword: 0,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: " +
@@ -158,7 +157,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 1,
 				withAltNonKeyword: 1,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Good job!" );
@@ -178,7 +177,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 2,
 				withAltNonKeyword: 1,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Good job!" );
@@ -197,7 +196,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 6,
 				withAltNonKeyword: 0,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: " +
@@ -219,7 +218,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 1,
 				withAltNonKeyword: 4,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: " +
@@ -242,7 +241,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 2,
 				withAltNonKeyword: 1,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Good job!" );
@@ -261,7 +260,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 4,
 				withAltNonKeyword: 0,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: Good job!" );
@@ -280,7 +279,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 5,
 				withAltNonKeyword: 0,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: " +
@@ -302,7 +301,7 @@ describe( "An image count assessment", function() {
 				withAltKeyword: 1,
 				withAltNonKeyword: 3,
 			},
-		}, true ), i18n );
+		}, true ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33c' target='_blank'>Image alt attributes</a>: " +

--- a/packages/yoastseo/spec/scoring/assessments/seo/TextLengthAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/TextLengthAssessmentSpec.js
@@ -1,14 +1,13 @@
 import TextLengthAssessment from "../../../../src/scoring/assessments/seo/TextLengthAssessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
-const i18n = Factory.buildJed();
 
 const wordCountAssessment = new TextLengthAssessment();
 
 describe( "A word count assessment", function() {
 	it( "assesses a single word", function() {
 		const mockPaper = new Paper( "sample" );
-		const assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 1 ), i18n );
+		const assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 1 ) );
 
 		expect( assessment.getScore() ).toEqual( -20 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -18,7 +17,7 @@ describe( "A word count assessment", function() {
 
 	it( "assesses a low word count", function() {
 		const mockPaper = new Paper( "These are just five words" );
-		const assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 5 ), i18n );
+		const assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 5 ) );
 
 		expect( assessment.getScore() ).toEqual( -20 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -28,7 +27,7 @@ describe( "A word count assessment", function() {
 
 	it( "assesses a medium word count", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 150 ) );
-		const assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 150 ), i18n );
+		const assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 150 ) );
 
 		expect( assessment.getScore() ).toEqual( -10 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -38,7 +37,7 @@ describe( "A word count assessment", function() {
 
 	it( "assesses a slightly higher than medium word count", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 225 ) );
-		const assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 225 ), i18n );
+		const assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 225 ) );
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -48,7 +47,7 @@ describe( "A word count assessment", function() {
 
 	it( "assesses an almost at the recommended amount, word count", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 275 ) );
-		const assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 275 ), i18n );
+		const assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 275 ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -59,7 +58,7 @@ describe( "A word count assessment", function() {
 
 	it( "assesses high word count", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 325 ) );
-		const assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 325 ), i18n );
+		const assessment = wordCountAssessment.getResult( mockPaper, Factory.buildMockResearcher( 325 ) );
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -83,7 +82,7 @@ describe( "A word count assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 25 ) );
 		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
 
-		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 25 ), i18n );
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 25 ) );
 
 		expect( results.getScore() ).toEqual( -20 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -95,7 +94,7 @@ describe( "A word count assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 125 ) );
 		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
 
-		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 125 ), i18n );
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 125 ) );
 
 		expect( results.getScore() ).toEqual( -20 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -107,7 +106,7 @@ describe( "A word count assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 325 ) );
 		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
 
-		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 325 ), i18n );
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 325 ) );
 
 		expect( results.getScore() ).toEqual( -20 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -119,7 +118,7 @@ describe( "A word count assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 425 ) );
 		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
 
-		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 425 ), i18n );
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 425 ) );
 
 		expect( results.getScore() ).toEqual( 6 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
@@ -131,7 +130,7 @@ describe( "A word count assessment", function() {
 		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 925 ) );
 		const assessmentCornerstone = new TextLengthAssessment( cornerstoneConfig );
 
-		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 925 ), i18n );
+		const results = assessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 925 ) );
 
 		expect( results.getScore() ).toEqual( 9 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 925 words. Good job!" );

--- a/packages/yoastseo/spec/scoring/assessments/seo/TitleKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/TitleKeywordAssessmentSpec.js
@@ -2,8 +2,6 @@ import TitleKeywordAssessment from "../../../../src/scoring/assessments/seo/Titl
 import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";
 
-const i18n = Factory.buildJed();
-
 describe( "an assessment to check if the keyword is in the pageTitle", function() {
 	it( "returns an assementresult with keyword not found", function() {
 		const paper = new Paper( "", {
@@ -13,7 +11,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		const assessment = new TitleKeywordAssessment().getResult(
 			paper,
 			Factory.buildMockResearcher( { exactMatchFound: false, allWordsFound: false, position: -1, exactMatchKeyphrase: false } ),
-			i18n );
+		);
 
 		expect( assessment.getScore() ).toBe( 2 );
 		expect( assessment.getText() ).toBe(
@@ -31,7 +29,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		const assessment = new TitleKeywordAssessment().getResult(
 			paper,
 			Factory.buildMockResearcher( { exactMatchFound: true, allWordsFound: true, position: 0, exactMatchKeyphrase: false } ),
-			i18n );
+		);
 
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe(
@@ -48,7 +46,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		const assessment = new TitleKeywordAssessment().getResult(
 			paper,
 			Factory.buildMockResearcher( { exactMatchFound: true, allWordsFound: true, position: 41, exactMatchKeyphrase: false } ),
-			i18n );
+		);
 
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe(
@@ -66,7 +64,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		const assessment = new TitleKeywordAssessment().getResult(
 			paper,
 			Factory.buildMockResearcher( { exactMatchFound: false, allWordsFound: true, position: -1, exactMatchKeyphrase: false  } ),
-			i18n );
+		);
 
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe(
@@ -84,7 +82,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		const assessment = new TitleKeywordAssessment().getResult(
 			paper,
 			Factory.buildMockResearcher( { exactMatchFound: false, allWordsFound: false, position: 0, exactMatchKeyphrase: true } ),
-			i18n );
+		);
 
 		expect( assessment.getScore() ).toBe( 2 );
 		expect( assessment.getText() ).toBe(

--- a/packages/yoastseo/spec/scoring/assessments/seo/UrlKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/UrlKeywordAssessmentSpec.js
@@ -1,7 +1,6 @@
 import UrlKeywordAssessment from "../../../../src/scoring/assessments/seo/UrlKeywordAssessment";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
-const i18n = Factory.buildJed();
 
 const keywordInUrl = new UrlKeywordAssessment();
 
@@ -14,8 +13,7 @@ describe( "A keyword in url count assessment", function() {
 	it( "assesses no keyword was found in the url: short keyphrase", function() {
 		const assessment = keywordInUrl.getResult(
 			mockPaper,
-			Factory.buildMockResearcher( { keyphraseLength: 1, percentWordMatches: 0 } ),
-			i18n
+			Factory.buildMockResearcher( { keyphraseLength: 1, percentWordMatches: 0 } )
 		);
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -26,8 +24,7 @@ describe( "A keyword in url count assessment", function() {
 	it( "assesses a keyword was found in the url: short keyphrase", function() {
 		const assessment = keywordInUrl.getResult(
 			mockPaper,
-			Factory.buildMockResearcher( { keyphraseLength: 1, percentWordMatches: 100 } ),
-			i18n
+			Factory.buildMockResearcher( { keyphraseLength: 1, percentWordMatches: 100 } )
 		);
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -37,8 +34,7 @@ describe( "A keyword in url count assessment", function() {
 	it( "assesses no keyword was found in the url: long keyphrase", function() {
 		const assessment = keywordInUrl.getResult(
 			mockPaper,
-			Factory.buildMockResearcher( { keyphraseLength: 3, percentWordMatches: 0 } ),
-			i18n
+			Factory.buildMockResearcher( { keyphraseLength: 3, percentWordMatches: 0 } )
 		);
 
 		expect( assessment.getScore() ).toEqual( 6 );
@@ -49,8 +45,7 @@ describe( "A keyword in url count assessment", function() {
 	it( "assesses a keyword was found in the url: long keyphrase", function() {
 		const assessment = keywordInUrl.getResult(
 			mockPaper,
-			Factory.buildMockResearcher( { keyphraseLength: 3, percentWordMatches: 100 } ),
-			i18n
+			Factory.buildMockResearcher( { keyphraseLength: 3, percentWordMatches: 100 } )
 		);
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -61,8 +56,7 @@ describe( "A keyword in url count assessment", function() {
 	it( "assesses part of the keyphrase was found in the url: long keyphrase", function() {
 		const assessment = keywordInUrl.getResult(
 			mockPaper,
-			Factory.buildMockResearcher( { keyphraseLength: 3, percentWordMatches: 67 } ),
-			i18n
+			Factory.buildMockResearcher( { keyphraseLength: 3, percentWordMatches: 67 } )
 		);
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -73,8 +67,7 @@ describe( "A keyword in url count assessment", function() {
 	it( "assesses a keyword was found in the url: in double quotes", function() {
 		const assessment = keywordInUrl.getResult(
 			mockPaper,
-			Factory.buildMockResearcher( { keyphraseLength: 1, percentWordMatches: 100 } ),
-			i18n
+			Factory.buildMockResearcher( { keyphraseLength: 1, percentWordMatches: 100 } )
 		);
 
 		expect( assessment.getScore() ).toEqual( 9 );
@@ -84,8 +77,7 @@ describe( "A keyword in url count assessment", function() {
 	it( "assesses part of the keyphrase was not found in the url: in double quotes", function() {
 		const assessment = keywordInUrl.getResult(
 			mockPaper,
-			Factory.buildMockResearcher( { keyphraseLength: 1, percentWordMatches: 0 } ),
-			i18n
+			Factory.buildMockResearcher( { keyphraseLength: 1, percentWordMatches: 0 } )
 		);
 
 		expect( assessment.getScore() ).toEqual( 6 );

--- a/packages/yoastseo/spec/scoring/assessments/seo/taxonomyTextLengthSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/taxonomyTextLengthSpec.js
@@ -4,17 +4,15 @@ import { getTextLengthAssessment } from "../../../../src/scoring/taxonomyAssesso
 
 describe( "A taxonomy page text length assessment.", function() {
 	let assessment;
-	let i18n;
 
 	beforeEach( () => {
 		// Taxonomy assessor has a text length assessment with specific boundaries.
 		assessment = getTextLengthAssessment();
-		i18n = Factory.buildJed();
 	} );
 
 	it( "assesses a single word", function() {
 		const mockPaper = new Paper( "sample" );
-		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 1 ), i18n );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 1 ) );
 
 		expect( result.getScore() ).toEqual( -20 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 1 word. " +
@@ -23,7 +21,7 @@ describe( "A taxonomy page text length assessment.", function() {
 
 	it( "assesses a couple of words", function() {
 		const mockPaper = new Paper( "sample" );
-		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 5 ), i18n );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 5 ) );
 
 		expect( result.getScore() ).toEqual( -20 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 5 words. " +
@@ -32,7 +30,7 @@ describe( "A taxonomy page text length assessment.", function() {
 
 	it( "assesses words far below the minimum.", function() {
 		const mockPaper = new Paper( "sample" );
-		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 51 ), i18n );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 51 ) );
 
 		expect( result.getScore() ).toEqual( -10 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 51 words. " +
@@ -41,7 +39,7 @@ describe( "A taxonomy page text length assessment.", function() {
 
 	it( "assesses words below the minimum.", function() {
 		const mockPaper = new Paper( "sample" );
-		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 101 ), i18n );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 101 ) );
 
 		expect( result.getScore() ).toEqual( 3 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 101 words. " +
@@ -50,7 +48,7 @@ describe( "A taxonomy page text length assessment.", function() {
 
 	it( "assesses words slightly below the minimum.", function() {
 		const mockPaper = new Paper( "sample" );
-		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 201 ), i18n );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 201 ) );
 
 		expect( result.getScore() ).toEqual( 6 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 201 words. " +
@@ -59,7 +57,7 @@ describe( "A taxonomy page text length assessment.", function() {
 
 	it( "assesses words above the minimum.", function() {
 		const mockPaper = new Paper( "sample" );
-		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 251 ), i18n );
+		const result = assessment.getResult( mockPaper, Factory.buildMockResearcher( 251 ) );
 
 		expect( result.getScore() ).toEqual( 9 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34j' target='_blank'>Text length</a>: The text contains 251 words. Good job!" );

--- a/packages/yoastseo/spec/scoring/assessorSpec.js
+++ b/packages/yoastseo/spec/scoring/assessorSpec.js
@@ -3,8 +3,6 @@ import Assessor from "../../src/scoring/assessor.js";
 import Paper from "../../src/values/Paper.js";
 import AssessmentResult from "../../src/values/AssessmentResult.js";
 import MissingArgument from "../../src/errors/missingArgument";
-import factory from "../specHelpers/factory.js";
-var i18n = factory.buildJed();
 
 global.window = {};
 
@@ -18,13 +16,13 @@ describe( "an assessor object", function() {
 
 		it( "throws an error when no researcher argument is provided", function() {
 			expect( function() {
-				new Assessor( i18n );
+				new Assessor();
 			} ).toThrowError( MissingArgument );
 		} );
 
 		it( "creates an assessor", function() {
-			expect( new Assessor( i18n, new DefaultResearcher() ) ).toBeDefined();
-			expect( Object.keys( new Assessor( i18n, new DefaultResearcher() ).getAvailableAssessments() ) ).toEqual( [] );
+			expect( new Assessor( new DefaultResearcher() ) ).toBeDefined();
+			expect( Object.keys( new Assessor( new DefaultResearcher() ).getAvailableAssessments() ) ).toEqual( [] );
 		} );
 	} );
 
@@ -42,7 +40,7 @@ describe( "an assessor object", function() {
 
 	describe( "returning the overall score", function() {
 		it( "returns the overall score", function() {
-			var assessor = new Assessor( i18n, new DefaultResearcher() );
+			var assessor = new Assessor( new DefaultResearcher() );
 			assessor.getValidResults = function() {
 				return [ result5, result4, result8 ];
 			};
@@ -63,7 +61,7 @@ describe( "an assessor object", function() {
 
 	describe( "adding an assessment", function() {
 		it( "adds an assessment", function() {
-			var assessor = new Assessor( i18n, new DefaultResearcher() );
+			var assessor = new Assessor( new DefaultResearcher() );
 			assessor.addAssessment( "testname", mockAssessment );
 
 			var result = assessor.getAssessment( "testname" );
@@ -74,7 +72,7 @@ describe( "an assessor object", function() {
 
 	describe( "removing an assessment", function() {
 		it( "removes an assessment", function() {
-			var assessor = new Assessor( i18n, new DefaultResearcher() );
+			var assessor = new Assessor( new DefaultResearcher() );
 			assessor.removeAssessment( "testname" );
 
 			var result = assessor.getAssessment( "testname" );
@@ -86,7 +84,7 @@ describe( "an assessor object", function() {
 	describe( "assess", function() {
 		it( "should add the marker to the assessment result", function() {
 			var paper = new Paper();
-			var assessor = new Assessor( i18n, new DefaultResearcher(), {
+			var assessor = new Assessor( new DefaultResearcher(), {
 				/**
 				 * A mock marker function.
 				 *
@@ -132,7 +130,7 @@ describe( "an assessor object", function() {
 		var assessor;
 
 		beforeEach( function() {
-			assessor = new Assessor( i18n, new DefaultResearcher(), {} );
+			assessor = new Assessor( new DefaultResearcher(), {} );
 		} );
 
 		it( "should return true when we have a global marker and a getMarks function", function() {
@@ -180,7 +178,7 @@ describe( "an assessor object", function() {
 		var assessor;
 
 		beforeEach( function() {
-			assessor = new Assessor( i18n, {} );
+			assessor = new Assessor( {} );
 		} );
 
 		it( "should compose the global marker and the getMarks function", function() {

--- a/packages/yoastseo/spec/scoring/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/contentAssessorSpec.js
@@ -2,12 +2,9 @@ import EnglishResearcher from "../../src/languageProcessing/languages/en/Researc
 import DefaultResearcher from "../../src/languageProcessing/languages/_default/Researcher";
 import ContentAssessor from "../../src/scoring/contentAssessor.js";
 import AssessmentResult from "../../src/values/AssessmentResult.js";
-import Factory from "../specHelpers/factory.js";
 import Paper from "../../src/values/Paper.js";
 
 import { forEach } from "lodash-es";
-
-const i18n = Factory.buildJed();
 
 describe( "A content assessor", function() {
 	describe( "calculatePenaltyPoints", function() {
@@ -15,7 +12,7 @@ describe( "A content assessor", function() {
 		let results;
 		const paper = new Paper();
 		beforeEach( function() {
-			contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ) );
+			contentAssessor = new ContentAssessor( new EnglishResearcher( paper ) );
 			contentAssessor.getValidResults = function() {
 				return results;
 			};
@@ -101,7 +98,7 @@ describe( "A content assessor", function() {
 		let points, results, contentAssessor;
 
 		beforeEach( function() {
-			contentAssessor = new ContentAssessor( i18n, new EnglishResearcher() );
+			contentAssessor = new ContentAssessor( new EnglishResearcher() );
 			contentAssessor.getValidResults = function() {
 				return results;
 			};
@@ -155,7 +152,7 @@ describe( "A content assessor", function() {
 		let points, results, contentAssessor;
 
 		beforeEach( function() {
-			contentAssessor = new ContentAssessor( i18n, new EnglishResearcher() );
+			contentAssessor = new ContentAssessor( new EnglishResearcher() );
 			contentAssessor.getValidResults = function() {
 				return results;
 			};
@@ -192,7 +189,7 @@ describe( "A content assessor", function() {
 	describe( "Checks the applicable assessments", function() {
 		it( "Should have 8 available assessments for a fully supported language", function() {
 			const paper = new Paper( "test", { locale: "en_US" } );
-			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ) );
+			const contentAssessor = new ContentAssessor( new EnglishResearcher( paper ) );
 
 			contentAssessor.getPaper = function() {
 				return paper;
@@ -204,7 +201,7 @@ describe( "A content assessor", function() {
 
 		it( "Should have 4 available assessments for a basic supported language", function() {
 			const paper = new Paper( "test", { locale: "xx_XX" } );
-			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ) );
+			const contentAssessor = new ContentAssessor( new DefaultResearcher( paper ) );
 
 			contentAssessor.getPaper = function() {
 				return paper;

--- a/packages/yoastseo/spec/scoring/cornerstone/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/cornerstone/contentAssessorSpec.js
@@ -6,9 +6,6 @@ import DutchResearcher from "../../../src/languageProcessing/languages/nl/Resear
 import ContentAssessor from "../../../src/scoring/cornerstone/contentAssessor";
 import AssessmentResult from "../../../src/values/AssessmentResult";
 import Paper from "../../../src/values/Paper";
-import Factory from "../../specHelpers/factory";
-
-const i18n = Factory.buildJed();
 
 describe( "A content assessor", function() {
 	describe( "calculatePenaltyPoints", function() {
@@ -16,7 +13,7 @@ describe( "A content assessor", function() {
 		let results;
 		const paper = new Paper();
 		beforeEach( function() {
-			contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ) );
+			contentAssessor = new ContentAssessor( new EnglishResearcher( paper ) );
 			contentAssessor.getValidResults = function() {
 				return results;
 			};
@@ -104,7 +101,7 @@ describe( "A content assessor", function() {
 		let points, results, contentAssessor;
 
 		beforeEach( function() {
-			contentAssessor = new ContentAssessor( i18n );
+			contentAssessor = new ContentAssessor();
 			contentAssessor.getValidResults = function() {
 				return results;
 			};
@@ -158,7 +155,7 @@ describe( "A content assessor", function() {
 		let points, results, contentAssessor;
 
 		beforeEach( function() {
-			contentAssessor = new ContentAssessor( i18n, { researcher: new DutchResearcher() } );
+			contentAssessor = new ContentAssessor( { researcher: new DutchResearcher() } );
 			contentAssessor.getValidResults = function() {
 				return results;
 			};
@@ -195,7 +192,7 @@ describe( "A content assessor", function() {
 	describe( "Checks the applicable assessments", function() {
 		const paper = new Paper( "test" );
 		it( "Should have 8 available assessments for a fully supported language", function() {
-			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ) );
+			const contentAssessor = new ContentAssessor( new EnglishResearcher( paper ) );
 			contentAssessor.getPaper = function() {
 				return paper;
 			};
@@ -206,7 +203,7 @@ describe( "A content assessor", function() {
 		} );
 
 		it( "Should have 4 available assessments for a basic supported language", function() {
-			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ) );
+			const contentAssessor = new ContentAssessor( new DefaultResearcher( paper ) );
 			contentAssessor.getPaper = function() {
 				return paper;
 			};
@@ -218,7 +215,7 @@ describe( "A content assessor", function() {
 	} );
 
 	describe( "has configuration overrides", () => {
-		const assessor = new ContentAssessor( i18n );
+		const assessor = new ContentAssessor();
 
 		test( "SubheadingsDistributionTooLong", () => {
 			const assessment = assessor.getAssessment( "subheadingsTooLong" );

--- a/packages/yoastseo/spec/scoring/cornerstone/relatedKeywordAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/cornerstone/relatedKeywordAssessorSpec.js
@@ -1,10 +1,8 @@
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
 import Assessor from "../../../src/scoring/cornerstone/relatedKeywordAssessor.js";
 import Paper from "../../../src/values/Paper.js";
-import factory from "../../specHelpers/factory.js";
 import getResults from "../../specHelpers/getListOfAssessmentResults";
-const i18n = factory.buildJed();
-const assessor = new Assessor( i18n, new EnglishResearcher() );
+const assessor = new Assessor( new EnglishResearcher() );
 
 describe( "running assessments in the assessor", function() {
 	it( "runs assessments without any specific requirements", function() {

--- a/packages/yoastseo/spec/scoring/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/cornerstone/seoAssessorSpec.js
@@ -1,16 +1,13 @@
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
 import Assessor from "../../../src/scoring/cornerstone/seoAssessor.js";
 import Paper from "../../../src/values/Paper.js";
-import factory from "../../specHelpers/factory.js";
 import getResults from "../../specHelpers/getAssessorResults";
-
-const i18n = factory.buildJed();
 
 describe( "running assessments in the assessor", function() {
 	let assessor;
 
 	beforeEach( () => {
-		assessor = new Assessor( i18n, new EnglishResearcher() );
+		assessor = new Assessor( new EnglishResearcher() );
 	} );
 
 	it( "runs assessments without any specific requirements", function() {

--- a/packages/yoastseo/spec/scoring/relatedKeywordAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/relatedKeywordAssessorSpec.js
@@ -1,10 +1,8 @@
 import EnglishResearcher from "../../src/languageProcessing/languages/en/Researcher";
 import Assessor from "../../src/scoring/relatedKeywordAssessor";
 import Paper from "../../src/values/Paper";
-import factory from "../specHelpers/factory";
 import getResults from "../specHelpers/getListOfAssessmentResults";
-const i18n = factory.buildJed();
-const assessor = new Assessor( i18n, new EnglishResearcher() );
+const assessor = new Assessor( new EnglishResearcher() );
 
 describe( "running assessments in the assessor", function() {
 	it( "runs assessments without any specific requirements", function() {

--- a/packages/yoastseo/spec/scoring/relatedKeywordTaxonomyAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/relatedKeywordTaxonomyAssessorSpec.js
@@ -1,9 +1,7 @@
 import EnglishResearcher from "../../src/languageProcessing/languages/en/Researcher";
 import Assessor from "../../src/scoring/relatedKeywordTaxonomyAssessor.js";
 import Paper from "../../src/values/Paper.js";
-import factory from "../specHelpers/factory.js";
-const i18n = factory.buildJed();
-const assessor = new Assessor( i18n, new EnglishResearcher() );
+const assessor = new Assessor( new EnglishResearcher() );
 import getResults from "../specHelpers/getAssessorResults";
 
 describe( "running assessments in the assessor", function() {

--- a/packages/yoastseo/spec/scoring/renderers/AssessorPresenterSpec.js
+++ b/packages/yoastseo/spec/scoring/renderers/AssessorPresenterSpec.js
@@ -1,19 +1,15 @@
 import AssessorPresenter from "../../../src/scoring/renderers/AssessorPresenter.js";
 import AssessmentResult from "../../../src/values/AssessmentResult";
-import Factory from "../../specHelpers/factory.js";
 
 describe( "an AssessorPresenter", function() {
-	let i18n;
 	let assessorPresenter;
 
 	beforeEach( function() {
-		i18n = Factory.buildJed();
 		assessorPresenter = new AssessorPresenter( {
 			scorer: { __score: [], __totalScore: 0 },
 			targets: { output: "", overall: "" },
 			keyword: "",
 			assessor: {},
-			i18n: i18n,
 		} );
 	} );
 

--- a/packages/yoastseo/spec/scoring/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/seoAssessorSpec.js
@@ -1,15 +1,13 @@
 import DefaultResearcher from "../../src/languageProcessing/languages/_default/Researcher";
 import Assessor from "../../src/scoring/seoAssessor.js";
 import Paper from "../../src/values/Paper.js";
-import factory from "../specHelpers/factory.js";
 import getResults from "../specHelpers/getAssessorResults";
-const i18n = factory.buildJed();
 
 describe( "running assessments in the assessor", function() {
 	let assessor;
 
 	beforeEach( () => {
-		assessor = new Assessor( i18n, new DefaultResearcher() );
+		assessor = new Assessor( new DefaultResearcher() );
 	} );
 
 	it( "runs assessments without any specific requirements", function() {

--- a/packages/yoastseo/spec/scoring/taxonomyAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/taxonomyAssessorSpec.js
@@ -1,15 +1,13 @@
 import DefaultResearcher from "../../src/languageProcessing/languages/_default/Researcher";
 import Assessor from "../../src/scoring/taxonomyAssessor.js";
 import Paper from "../../src/values/Paper.js";
-import factory from "../specHelpers/factory.js";
-const i18n = factory.buildJed();
 import getResults from "../specHelpers/getAssessorResults";
 
 describe( "running assessments in the assessor", function() {
 	let assessor;
 
 	beforeEach( () => {
-		assessor = new Assessor( i18n, new DefaultResearcher() );
+		assessor = new Assessor( new DefaultResearcher() );
 	} );
 
 	it( "runs assessments without any specific requirements", function() {

--- a/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
+++ b/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
@@ -19,7 +19,6 @@ import { StructuredNode } from "../../src/parsedPaper/structure/tree";
 import testTexts from "../fullTextTests/testTexts";
 
 // Test helpers
-import Factory from "../specHelpers/factory.js";
 import TestResearch from "../specHelpers/tree/TestResearch";
 import getMorphologyData from "../specHelpers/getMorphologyData";
 import TestAssessment from "../specHelpers/tree/TestAssessment";
@@ -271,9 +270,6 @@ describe( "AnalysisWebWorker", () => {
 						},
 					},
 				} ) );
-
-				expect( worker._i18n ).toBeDefined();
-				expect( worker._i18n.gettext( "test" ) ).toBe( "1234" );
 			} );
 
 			test( "sets the locale", () => {
@@ -1512,10 +1508,8 @@ describe( "AnalysisWebWorker", () => {
 			scope = createScope();
 			worker = new AnalysisWebWorker( scope, researcher );
 
-			const i18n = Factory.buildJed();
-
 			// Build the different kinds of assessors and aggregator to use.
-			assessor = new SEOAssessor( i18n, { marker: {} } );
+			assessor = new SEOAssessor( { marker: {} } );
 			treeAssessor = worker.createSEOTreeAssessor( {} );
 			scoreAggregator = new SEOScoreAggregator();
 

--- a/packages/yoastseo/src/bundledPlugins/previouslyUsedKeywords.js
+++ b/packages/yoastseo/src/bundledPlugins/previouslyUsedKeywords.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { isUndefined } from "lodash-es";
 
 import MissingArgument from "../errors/missingArgument";
@@ -69,19 +70,18 @@ PreviouslyUsedKeyword.prototype.updateKeywordUsage = function( usedKeywords ) {
  *
  * @param {object} previouslyUsedKeywords The result of the previously used keywords research
  * @param {Paper} paper The paper object to research.
- * @param {Jed} i18n The i18n object.
  * @returns {object} the scoreobject with text and score.
  */
-PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywords, paper, i18n ) {
+PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywords, paper ) {
 	var count = previouslyUsedKeywords.count;
 	var id = previouslyUsedKeywords.id;
 	if ( count === 0 ) {
 		return {
-			text: i18n.sprintf(
+			text: sprintf(
 				/* Translators:
 				%1$s expands to a link to an article on yoast.com,
 				%2$s expands to an anchor tag. */
-				i18n.dgettext( "js-text-analysis", "%1$sPreviously used keyphrase%2$s: You've not used this keyphrase before, very good." ),
+				__( "%1$sPreviously used keyphrase%2$s: You've not used this keyphrase before, very good.", "wordpress-seo" ),
 				this.urlTitle,
 				"</a>"
 			),
@@ -93,9 +93,9 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 		return {
 			/* Translators: %1$s and %2$s expand to an admin link where the keyword is already used. %3$s and %4$s
 			expand to links on yoast.com, %4$s expands to the anchor end tag. */
-			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "%3$sPreviously used keyphrase%5$s: " +
+			text: sprintf( __( "%3$sPreviously used keyphrase%5$s: " +
 				"You've used this keyphrase %1$sonce before%2$s. " +
-				"%4$sDo not use your keyphrase more than once%5$s." ),
+				"%4$sDo not use your keyphrase more than once%5$s.", "wordpress-seo" ),
 			url,
 			"</a>",
 			this.urlTitle,
@@ -111,9 +111,9 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 			/* Translators: %1$s and $3$s expand to the admin search page for the keyword, %2$d expands to the number
 			of times this keyword has been used before, %4$s and %5$s expand to links to yoast.com, %6$s expands to
 			the anchor end tag */
-			text: i18n.sprintf( i18n.dgettext( "js-text-analysis", "%4$sPreviously used keyphrase%6$s: " +
+			text: sprintf( __( "%4$sPreviously used keyphrase%6$s: " +
 				"You've used this keyphrase %1$s%2$d times before%3$s. " +
-				"%5$sDo not use your keyphrase more than once%6$s." ),
+				"%5$sDo not use your keyphrase more than once%6$s.", "wordpress-seo" ),
 			url,
 			count,
 			"</a>",
@@ -153,12 +153,11 @@ PreviouslyUsedKeyword.prototype.researchPreviouslyUsedKeywords = function( paper
  *
  * @param {Paper} paper The Paper object to assess.
  * @param {Researcher} researcher The Researcher object containing all available researches.
- * @param {object} i18n The locale object.
  * @returns {AssessmentResult} The assessment result of the assessment
  */
-PreviouslyUsedKeyword.prototype.assess = function( paper, researcher, i18n ) {
+PreviouslyUsedKeyword.prototype.assess = function( paper, researcher ) {
 	var previouslyUsedKeywords = this.researchPreviouslyUsedKeywords( paper );
-	var previouslyUsedKeywordsResult = this.scoreAssessment( previouslyUsedKeywords, paper, i18n );
+	var previouslyUsedKeywordsResult = this.scoreAssessment( previouslyUsedKeywords, paper );
 
 	var assessmentResult =  new AssessmentResult();
 	assessmentResult.setScore( previouslyUsedKeywordsResult.score );

--- a/packages/yoastseo/src/config/presenter.js
+++ b/packages/yoastseo/src/config/presenter.js
@@ -1,34 +1,35 @@
+import { __ } from "@wordpress/i18n";
+
 /**
  * Returns the configuration used for score ratings and the AssessorPresenter.
- * @param {Jed} i18n The translator object.
  * @returns {Object} The config object.
  */
-export default function( i18n ) {
-	const contentOptimizationLabel = i18n.dgettext( "js-text-analysis", "Content optimization:" );
+export default function() {
+	const contentOptimizationLabel = __( "Content optimization:", "wordpress-seo" );
 	return {
 		feedback: {
 			className: "na",
-			screenReaderText: i18n.dgettext( "js-text-analysis", "Feedback" ),
-			fullText: `${ contentOptimizationLabel } ${ i18n.dgettext( "js-text-analysis", "Has feedback" ) }`,
+			screenReaderText: __( "Feedback", "wordpress-seo" ),
+			fullText: `${ contentOptimizationLabel } ${ __( "Has feedback", "wordpress-seo" ) }`,
 			screenReaderReadabilityText: "",
 		},
 		bad: {
 			className: "bad",
-			screenReaderText: i18n.dgettext( "js-text-analysis", "Needs improvement" ),
-			fullText: `${ contentOptimizationLabel } ${ i18n.dgettext( "js-text-analysis", "Needs improvement" ) }`,
-			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "Needs improvement" ),
+			screenReaderText: __( "Needs improvement", "wordpress-seo" ),
+			fullText: `${ contentOptimizationLabel } ${ __( "Needs improvement", "wordpress-seo" ) }`,
+			screenReaderReadabilityText: __( "Needs improvement", "wordpress-seo" ),
 		},
 		ok: {
 			className: "ok",
-			screenReaderText: i18n.dgettext( "js-text-analysis", "OK SEO score" ),
-			fullText: `${ contentOptimizationLabel } ${ i18n.dgettext( "js-text-analysis", "OK SEO score" ) }`,
-			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "OK" ),
+			screenReaderText: __( "OK SEO score", "wordpress-seo" ),
+			fullText: `${ contentOptimizationLabel } ${ __( "OK SEO score", "wordpress-seo" ) }`,
+			screenReaderReadabilityText: __( "OK", "wordpress-seo" ),
 		},
 		good: {
 			className: "good",
-			screenReaderText: i18n.dgettext( "js-text-analysis", "Good SEO score" ),
-			fullText: `${ contentOptimizationLabel } ${ i18n.dgettext( "js-text-analysis", "Good SEO score" ) }`,
-			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "Good" ),
+			screenReaderText: __( "Good SEO score", "wordpress-seo" ),
+			fullText: `${ contentOptimizationLabel } ${ __( "Good SEO score", "wordpress-seo" ) }`,
+			screenReaderReadabilityText: __( "Good", "wordpress-seo" ),
 		},
 	};
 }

--- a/packages/yoastseo/src/parsedPaper/assess/TreeAssessor.js
+++ b/packages/yoastseo/src/parsedPaper/assess/TreeAssessor.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import AssessmentResult from "../../values/AssessmentResult";
 
 /**
@@ -13,18 +14,12 @@ class TreeAssessor {
 	 * Creates a new assessor.
 	 *
 	 * @param {Object}                                     options                 Assessor options.
-	 * @param {Jed}                                        options.i18n            A Jed object to use for translations.
 	 * @param {module:parsedPaper/research.TreeResearcher} options.researcher      Supplies the assessments with researches and their
 	 *                                                                             (cached) results.
 	 * @param {module:parsedPaper/assess.ScoreAggregator}  options.scoreAggregator Aggregates the scores on the individual assessments into one.
 	 * @param {module:parsedPaper/assess.Assessment[]}     [options.assessments]   The list of assessments to apply.
 	 */
 	constructor( options ) {
-		/**
-		 * A Jed object to use for translations.
-		 * @type {Jed}
-		 */
-		this.i18n = options.i18n;
 		/**
 		 * Supplies the assessments with researches and their (cached) results.
 		 * @type {module:parsedPaper/research.TreeResearcher}
@@ -93,9 +88,9 @@ class TreeAssessor {
 		return assessment.apply( paper, node ).catch(
 			() => {
 				return new AssessmentResult( {
-					text: this.i18n.sprintf(
+					text: sprintf(
 						/* Translators: %1$s expands to the name of the assessment. */
-						this.i18n.dgettext( "js-text-analysis", "An error occurred in the '%1$s' assessment" ),
+						__( "An error occurred in the '%1$s' assessment", "wordpress-seo" ),
 						assessment.name
 					),
 					score: -1,

--- a/packages/yoastseo/src/parsedPaper/assess/assessorFactories.js
+++ b/packages/yoastseo/src/parsedPaper/assess/assessorFactories.js
@@ -41,7 +41,6 @@ const SEO_ASSESSMENTS_MAP = {
 /**
  * Constructs a new SEO assessor.
  *
- * @param {Jed}                                 i18n       The Jed object to use for localization / internalization.
  * @param {module:parsedPaper/research.TreeResearcher} researcher The researcher the assessments need to use to get information about the text.
  *
  * @param {Object}                              config                    The assessor configuration.
@@ -55,7 +54,7 @@ const SEO_ASSESSMENTS_MAP = {
  *
  * @memberOf module:parsedPaper/assess
  */
-const constructSEOAssessor = function( i18n, researcher, config ) {
+const constructSEOAssessor = function( researcher, config ) {
 	/*
 	 * Construct the key to retrieve the right assessment list factory.
 	 * E.g. "RelatedKeyphraseTaxonomy" for related keyphrase + taxonomy;
@@ -78,13 +77,12 @@ const constructSEOAssessor = function( i18n, researcher, config ) {
 	// Construct assessor.
 	const assessments = assessmentFactory();
 	const scoreAggregator = new SEOScoreAggregator();
-	return new TreeAssessor( { i18n, researcher, assessments, scoreAggregator } );
+	return new TreeAssessor( { researcher, assessments, scoreAggregator } );
 };
 
 /**
  * Constructs a new readability assessor.
  *
- * @param {Jed}                                        i18n                 The Jed object to use for localization / internalization.
  * @param {module:parsedPaper/research.TreeResearcher} researcher           The researcher the assessments need to use to
  *                                                                          get information about the text.
  * @param {boolean}                                    isCornerstoneContent If the to be analyzed content is considered cornerstone content
@@ -94,10 +92,10 @@ const constructSEOAssessor = function( i18n, researcher, config ) {
  *
  * @memberOf module:parsedPaper/assess
  */
-const constructReadabilityAssessor = function( i18n, researcher, isCornerstoneContent = false ) {
+const constructReadabilityAssessor = function( researcher, isCornerstoneContent = false ) {
 	const assessments = isCornerstoneContent ? constructReadabilityAssessments() : constructCornerstoneReadabilityAssessments();
 	const scoreAggregator = new ReadabilityScoreAggregator();
-	return new TreeAssessor( { i18n, researcher, assessments, scoreAggregator } );
+	return new TreeAssessor( { researcher, assessments, scoreAggregator } );
 };
 
 export {

--- a/packages/yoastseo/src/scoring/assessments/assessment.js
+++ b/packages/yoastseo/src/scoring/assessments/assessment.js
@@ -8,11 +8,10 @@ class Assessment {
 	 *
 	 * @param {Paper}       paper       The paper to run this assessment on.
 	 * @param {Researcher}  researcher  The researcher used for the assessment.
-	 * @param {object}      i18n        The i18n-object used for parsing translations.
 	 *
 	 * @returns {AssessmentResult} The result of the assessment.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		throw "The method getResult is not implemented";
 	}
 

--- a/packages/yoastseo/src/scoring/assessments/readability/fleschReadingEaseAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/fleschReadingEaseAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { inRange } from "lodash-es";
 
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
@@ -8,11 +9,10 @@ import AssessmentResult from "../../../values/AssessmentResult";
  *
  * @param {Object} fleschReadingScore   The Flesch reading ease score.
  * @param {Object} scoresConfig         The Flesch reading ease assessment scores and borders.
- * @param {Object} i18n                 The i18n-object used for parsing translations.
  *
  * @returns {Object} Object with score and resultText.
  */
-const calculateFleschReadingResult = function( fleschReadingScore, scoresConfig, i18n ) {
+const calculateFleschReadingResult = function( fleschReadingScore, scoresConfig ) {
 	// Results must be between 0 and 100;
 	if ( fleschReadingScore < 0 ) {
 		fleschReadingScore = 0;
@@ -24,49 +24,49 @@ const calculateFleschReadingResult = function( fleschReadingScore, scoresConfig,
 
 	let score;
 	let feedback = "";
-	let note = i18n.dgettext( "js-text-analysis", "Good job!" );
+	let note = __( "Good job!", "wordpress-seo" );
 	const urlTitle = createAnchorOpeningTag( "https://yoa.st/34r" );
 	const urlCallToAction = createAnchorOpeningTag( "https://yoa.st/34s" );
 
 	if ( fleschReadingScore >= scoresConfig.borders.veryEasy ) {
 		score = scoresConfig.scores.veryEasy;
-		feedback = i18n.dgettext( "js-text-analysis", "very easy" );
+		feedback = __( "very easy", "wordpress-seo" );
 	} else if ( inRange( fleschReadingScore, scoresConfig.borders.easy, scoresConfig.borders.veryEasy ) ) {
 		score = scoresConfig.scores.easy;
-		feedback = i18n.dgettext( "js-text-analysis", "easy" );
+		feedback = __( "easy", "wordpress-seo" );
 	} else if ( inRange( fleschReadingScore, scoresConfig.borders.fairlyEasy, scoresConfig.borders.easy ) ) {
 		score = scoresConfig.scores.fairlyEasy;
-		feedback = i18n.dgettext( "js-text-analysis", "fairly easy" );
+		feedback = __( "fairly easy", "wordpress-seo" );
 	} else if ( inRange( fleschReadingScore, scoresConfig.borders.okay, scoresConfig.borders.fairlyEasy ) ) {
 		score = scoresConfig.scores.okay;
-		feedback = i18n.dgettext( "js-text-analysis", "ok" );
+		feedback = __( "ok", "wordpress-seo" );
 	} else if ( inRange( fleschReadingScore, scoresConfig.borders.fairlyDifficult, scoresConfig.borders.okay ) ) {
 		score = scoresConfig.scores.fairlyDifficult;
-		feedback = i18n.dgettext( "js-text-analysis", "fairly difficult" );
-		note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences to improve readability" );
+		feedback = __( "fairly difficult", "wordpress-seo" );
+		note = __( "Try to make shorter sentences to improve readability", "wordpress-seo" );
 	} else if ( inRange( fleschReadingScore, scoresConfig.borders.difficult, scoresConfig.borders.fairlyDifficult ) ) {
 		score = scoresConfig.scores.difficult;
-		feedback = i18n.dgettext( "js-text-analysis", "difficult" );
-		note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences, using less difficult words to improve readability" );
+		feedback = __( "difficult", "wordpress-seo" );
+		note = __( "Try to make shorter sentences, using less difficult words to improve readability", "wordpress-seo" );
 	} else {
 		score = scoresConfig.scores.veryDifficult;
-		feedback = i18n.dgettext( "js-text-analysis", "very difficult" );
-		note = i18n.dgettext( "js-text-analysis", "Try to make shorter sentences, using less difficult words to improve readability" );
+		feedback = __( "very difficult", "wordpress-seo" );
+		note = __( "Try to make shorter sentences, using less difficult words to improve readability", "wordpress-seo" );
 	}
 
 	// If the score is good, add a "Good job" message without a link to the Call-to-action article.
 	if ( score >= scoresConfig.scores.okay ) {
 		return {
 			score: score,
-			resultText: i18n.sprintf(
+			resultText: sprintf(
 				/* Translators: %1$s expands to a link on yoast.com,
 					%2$s to the anchor end tag,
 					%3$s expands to the numeric Flesch reading ease score,
 					%4$s to the easiness of reading,
 					%5$s expands to a call to action based on the score */
-				i18n.dgettext(
-					"js-text-analysis",
-					"%1$sFlesch Reading Ease%2$s: The copy scores %3$s in the test, which is considered %4$s to read. %5$s"
+				__(
+					"%1$sFlesch Reading Ease%2$s: The copy scores %3$s in the test, which is considered %4$s to read. %5$s",
+					"wordpress-seo"
 				),
 				urlTitle,
 				"</a>",
@@ -79,16 +79,16 @@ const calculateFleschReadingResult = function( fleschReadingScore, scoresConfig,
 	// If the score is not good, add a Call-to-action message with a link to the Call-to-action article.
 	return {
 		score: score,
-		resultText: i18n.sprintf(
+		resultText: sprintf(
 			/* Translators: %1$s and %5$s expand to a link on yoast.com,
 				%2$s to the anchor end tag,
 				%7$s expands to the anchor end tag and a full stop,
 				%3$s expands to the numeric Flesch reading ease score,
 				%4$s to the easiness of reading,
 				%6$s expands to a call to action based on the score */
-			i18n.dgettext(
-				"js-text-analysis",
-				"%1$sFlesch Reading Ease%2$s: The copy scores %3$s in the test, which is considered %4$s to read. %5$s%6$s%7$s"
+			__(
+				"%1$sFlesch Reading Ease%2$s: The copy scores %3$s in the test, which is considered %4$s to read. %5$s%6$s%7$s",
+				"wordpress-seo"
 			),
 			urlTitle,
 			"</a>",
@@ -107,11 +107,10 @@ const calculateFleschReadingResult = function( fleschReadingScore, scoresConfig,
  *
  * @param {Paper}       paper       The paper to run this assessment on.
  * @param {Researcher}  researcher  The researcher used for the assessment.
- * @param {Object}      i18n        The i18n-object used for parsing translations.
  *
  * @returns {Object} An assessmentResult with the score and formatted text.
  */
-const getFleschReadingResult = function( paper, researcher, i18n ) {
+const getFleschReadingResult = function( paper, researcher ) {
 	const fleschReadingScore = researcher.getResearch( "getFleschReadingScore" );
 	const languageSpecificConfig = researcher.getConfig( "fleschReadingEaseScores" );
 	const defaultConfig = {
@@ -136,7 +135,7 @@ const getFleschReadingResult = function( paper, researcher, i18n ) {
 	};
 	const config = languageSpecificConfig ? languageSpecificConfig : defaultConfig;
 
-	const fleschReadingResult = calculateFleschReadingResult( fleschReadingScore, config, i18n );
+	const fleschReadingResult = calculateFleschReadingResult( fleschReadingScore, config );
 
 	const assessmentResult =  new AssessmentResult();
 

--- a/packages/yoastseo/src/scoring/assessments/readability/paragraphTooLongAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/paragraphTooLongAssessment.js
@@ -1,3 +1,4 @@
+import { __, _n, sprintf } from "@wordpress/i18n";
 import { filter, map } from "lodash-es";
 import { stripBlockTagsAtStartEnd as stripHTMLTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
 import marker from "../../../markers/addMark";
@@ -26,11 +27,10 @@ const getTooLongParagraphs = function( paragraphsLength  ) {
  *
  * @param {array} paragraphsLength  The array containing the lengths of individual paragraphs.
  * @param {array} tooLongParagraphs The number of too long paragraphs.
- * @param {object} i18n             The i18n object used for translations.
  *
  * @returns {{score: number, text: string }} the assessmentResult.
  */
-const calculateParagraphLengthResult = function( paragraphsLength, tooLongParagraphs, i18n ) {
+const calculateParagraphLengthResult = function( paragraphsLength, tooLongParagraphs ) {
 	let score;
 	const urlTitle = createAnchorOpeningTag( "https://yoa.st/35d" );
 	const urlCallToAction = createAnchorOpeningTag( "https://yoa.st/35e" );
@@ -61,10 +61,12 @@ const calculateParagraphLengthResult = function( paragraphsLength, tooLongParagr
 			score: score,
 			hasMarks: false,
 
-			text: i18n.sprintf(
+			text: sprintf(
 				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis",
-					"%1$sParagraph length%2$s: None of the paragraphs are too long. Great job!" ),
+				__(
+					"%1$sParagraph length%2$s: None of the paragraphs are too long. Great job!",
+					"wordpress-seo"
+				),
 				urlTitle,
 				"</a>"
 			),
@@ -73,13 +75,17 @@ const calculateParagraphLengthResult = function( paragraphsLength, tooLongParagr
 	return {
 		score: score,
 		hasMarks: true,
-		text: i18n.sprintf(
+		text: sprintf(
 			/* Translators: %1$s and %5$s expand to a link on yoast.com, %2$s expands to the anchor end tag, %3$d expands to the
 			number of paragraphs over the recommended word limit, %4$d expands to the word limit */
-			i18n.dngettext( "js-text-analysis",
+			_n(
 				"%1$sParagraph length%2$s: %3$d of the paragraphs contains more than the recommended maximum of %4$d words." +
-				" %5$sShorten your paragraphs%2$s!", "%1$sParagraph length%2$s: %3$d of the paragraphs contain more than the " +
-				"recommended maximum of %4$d words. %5$sShorten your paragraphs%2$s!", tooLongParagraphs.length ),
+				" %5$sShorten your paragraphs%2$s!",
+				"%1$sParagraph length%2$s: %3$d of the paragraphs contain more than the " +
+				"recommended maximum of %4$d words. %5$sShorten your paragraphs%2$s!",
+				tooLongParagraphs.length,
+				"wordpress-seo"
+			),
 			urlTitle,
 			"</a>",
 			tooLongParagraphs.length,
@@ -130,17 +136,16 @@ const paragraphLengthMarker = function( paper, researcher ) {
  *
  * @param {object} paper        The paper to use for the assessment.
  * @param {object} researcher   The researcher used for calling research.
- * @param {object} i18n         The object used for translations.
  *
  * @returns {object} the Assessmentresult
  */
-const paragraphLengthAssessment = function( paper, researcher, i18n ) {
+const paragraphLengthAssessment = function( paper, researcher ) {
 	let paragraphsLength = researcher.getResearch( "getParagraphLength" );
 
 	paragraphsLength = sortParagraphs( paragraphsLength );
 
 	const tooLongParagraphs = getTooLongParagraphs( paragraphsLength );
-	const paragraphLengthResult = calculateParagraphLengthResult( paragraphsLength, tooLongParagraphs, i18n );
+	const paragraphLengthResult = calculateParagraphLengthResult( paragraphsLength, tooLongParagraphs );
 	const assessmentResult = new AssessmentResult();
 
 	assessmentResult.setScore( paragraphLengthResult.score );

--- a/packages/yoastseo/src/scoring/assessments/readability/passiveVoiceAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/passiveVoiceAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { map } from "lodash-es";
 
 import formatNumber from "../../../helpers/formatNumber";
@@ -12,11 +13,10 @@ import Mark from "../../../values/Mark";
  * Calculates the result based on the number of sentences and passives.
  *
  * @param {object} passiveVoice     The object containing the number of sentences and passives.
- * @param {object} i18n             The object used for translations.
  *
  * @returns {{score: number, text}} resultobject with score and text.
  */
-const calculatePassiveVoiceResult = function( passiveVoice, i18n ) {
+const calculatePassiveVoiceResult = function( passiveVoice ) {
 	let score;
 	let percentage = 0;
 	const recommendedValue = 10;
@@ -49,11 +49,9 @@ const calculatePassiveVoiceResult = function( passiveVoice, i18n ) {
 		return {
 			score: score,
 			hasMarks: hasMarks,
-			text: i18n.sprintf(
+			text: sprintf(
 				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
-				i18n.dgettext(
-					"js-text-analysis",
-					"%1$sPassive voice%2$s: You're using enough active voice. That's great!" ),
+				__( "%1$sPassive voice%2$s: You're using enough active voice. That's great!", "wordpress-seo" ),
 				urlTitle,
 				"</a>"
 			),
@@ -62,13 +60,13 @@ const calculatePassiveVoiceResult = function( passiveVoice, i18n ) {
 	return {
 		score: score,
 		hasMarks: hasMarks,
-		text: i18n.sprintf(
+		text: sprintf(
 			/* Translators: %1$s and %5$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
 			%3$s expands to the percentage of sentences in passive voice, %4$s expands to the recommended value. */
-			i18n.dgettext(
-				"js-text-analysis",
+			__(
 				"%1$sPassive voice%2$s: %3$s of the sentences contain passive voice, which is more than the recommended maximum of %4$s. " +
-				"%5$sTry to use their active counterparts%2$s."
+				"%5$sTry to use their active counterparts%2$s.",
+				"wordpress-seo"
 
 			),
 			urlTitle,
@@ -105,14 +103,13 @@ const passiveVoiceMarker = function( paper, researcher ) {
  *
  * @param {object} paper        The paper to use for the assessment.
  * @param {object} researcher   The researcher used for calling research.
- * @param {object} i18n         The object used for translations.
  *
  * @returns {object} the Assessmentresult
  */
-const passiveVoiceAssessment = function( paper, researcher, i18n ) {
+const passiveVoiceAssessment = function( paper, researcher ) {
 	const passiveVoice = researcher.getResearch( "getPassiveVoice" );
 
-	const passiveVoiceResult = calculatePassiveVoiceResult( passiveVoice, i18n );
+	const passiveVoiceResult = calculatePassiveVoiceResult( passiveVoice );
 
 	const assessmentResult = new AssessmentResult();
 

--- a/packages/yoastseo/src/scoring/assessments/readability/sentenceBeginningsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/sentenceBeginningsAssessment.js
@@ -1,3 +1,4 @@
+import { __, _n, sprintf } from "@wordpress/i18n";
 import { filter, flatten, map, partition, sortBy } from "lodash-es";
 
 import marker from "../../../markers/addMark";
@@ -35,11 +36,10 @@ const groupSentenceBeginnings = function( sentenceBeginnings ) {
  * Calculates the score based on sentence beginnings.
  *
  * @param {object} groupedSentenceBeginnings    The object with grouped sentence beginnings.
- * @param {object} i18n                         The object used for translations.
  *
  * @returns {{score: number, text: string, hasMarks: boolean}} result object with score and text.
  */
-const calculateSentenceBeginningsResult = function( groupedSentenceBeginnings, i18n ) {
+const calculateSentenceBeginningsResult = function( groupedSentenceBeginnings ) {
 	const urlTitle = createAnchorOpeningTag( "https://yoa.st/35f" );
 	const urlCallToAction = createAnchorOpeningTag( "https://yoa.st/35g" );
 
@@ -47,16 +47,17 @@ const calculateSentenceBeginningsResult = function( groupedSentenceBeginnings, i
 		return {
 			score: 3,
 			hasMarks: true,
-			text: i18n.sprintf(
+			text: sprintf(
 				/* Translators: %1$s and %5$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
 				%3$d expands to the number of consecutive sentences starting with the same word,
 				%4$d expands to the number of instances where 3 or more consecutive sentences start with the same word. */
-				i18n.dngettext(
-					"js-text-analysis",
+				_n(
 					"%1$sConsecutive sentences%2$s: The text contains %3$d consecutive sentences starting with the same word." +
-					" %5$sTry to mix things up%2$s!", "%1$sConsecutive sentences%2$s: The text contains %4$d instances where" +
+					" %5$sTry to mix things up%2$s!",
+					"%1$sConsecutive sentences%2$s: The text contains %4$d instances where" +
 					" %3$d or more consecutive sentences start with the same word. %5$sTry to mix things up%2$s!",
-					groupedSentenceBeginnings.total
+					groupedSentenceBeginnings.total,
+					"wordpress-seo"
 				),
 				urlTitle,
 				"</a>",
@@ -69,10 +70,12 @@ const calculateSentenceBeginningsResult = function( groupedSentenceBeginnings, i
 	return {
 		score: 9,
 		hasMarks: false,
-		text: i18n.sprintf(
+		text: sprintf(
 			/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-			i18n.dgettext( "js-text-analysis",
-				"%1$sConsecutive sentences%2$s: There is enough variety in your sentences. That's great!" ),
+			__(
+				"%1$sConsecutive sentences%2$s: There is enough variety in your sentences. That's great!",
+				"wordpress-seo"
+			),
 			urlTitle,
 			"</a>"
 		),
@@ -112,14 +115,13 @@ const sentenceBeginningMarker = function( paper, researcher ) {
  *
  * @param {object} paper        The paper to use for the assessment.
  * @param {object} researcher   The researcher used for calling research.
- * @param {object} i18n         The object used for translations.
  *
  * @returns {object} The Assessment result
  */
-const sentenceBeginningsAssessment = function( paper, researcher, i18n ) {
+const sentenceBeginningsAssessment = function( paper, researcher ) {
 	const sentenceBeginnings = researcher.getResearch( "getSentenceBeginnings" );
 	const groupedSentenceBeginnings = groupSentenceBeginnings( sentenceBeginnings );
-	const sentenceBeginningsResult = calculateSentenceBeginningsResult( groupedSentenceBeginnings, i18n );
+	const sentenceBeginningsResult = calculateSentenceBeginningsResult( groupedSentenceBeginnings );
 	const assessmentResult = new AssessmentResult();
 
 	assessmentResult.setScore( sentenceBeginningsResult.score );

--- a/packages/yoastseo/src/scoring/assessments/readability/sentenceLengthInTextAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/sentenceLengthInTextAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { map } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -32,10 +33,10 @@ class SentenceLengthInTextAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper The paper to use for the assessment.
 	 * @param {Researcher} researcher The researcher used for calling research.
-	 * @param {object} i18n The object used for translations.
+	 *
 	 * @returns {AssessmentResult} The Assessment result.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		const sentences = researcher.getResearch( "countSentencesFromText" );
 		this._config = this.getConfig( researcher );
 		const percentage = this.calculatePercentage( sentences );
@@ -44,7 +45,7 @@ class SentenceLengthInTextAssessment extends Assessment {
 		const assessmentResult = new AssessmentResult();
 
 		assessmentResult.setScore( score );
-		assessmentResult.setText( this.translateScore( score, percentage, i18n ) );
+		assessmentResult.setText( this.translateScore( score, percentage ) );
 		assessmentResult.setHasMarks( ( percentage > 0 ) );
 
 		return assessmentResult;
@@ -131,30 +132,33 @@ class SentenceLengthInTextAssessment extends Assessment {
 	 *
 	 * @param {number} score The score.
 	 * @param {number} percentage The percentage.
-	 * @param {object} i18n The object used for translations.
 	 *
 	 * @returns {string} A string.
 	 */
-	translateScore( score, percentage,  i18n ) {
+	translateScore( score, percentage ) {
 		const urlTitle = createAnchorOpeningTag( "https://yoa.st/34v" );
 		const urlCallToAction = createAnchorOpeningTag( "https://yoa.st/34w" );
 		if ( score >= 7 ) {
-			return i18n.sprintf(
+			return sprintf(
 				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis",
-					"%1$sSentence length%2$s: Great!" ),
+				__(
+					"%1$sSentence length%2$s: Great!",
+					"wordpress-seo"
+				),
 				urlTitle,
 				"</a>"
 			);
 		}
 
-		return i18n.sprintf(
+		return sprintf(
 			/* Translators: %1$s and %6$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
 			%3$d expands to percentage of sentences, %4$s expands to the recommended maximum sentence length,
 			%5$s expands to the recommended maximum percentage. */
-			i18n.dgettext( "js-text-analysis",
+			__(
 				"%1$sSentence length%2$s: %3$s of the sentences contain more than %4$s words, which is more than the recommended maximum of %5$s." +
-				" %6$sTry to shorten the sentences%2$s." ),
+				" %6$sTry to shorten the sentences%2$s.",
+				"wordpress-seo"
+			),
 			urlTitle,
 			"</a>",
 			percentage + "%",

--- a/packages/yoastseo/src/scoring/assessments/readability/subheadingDistributionTooLongAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/subheadingDistributionTooLongAssessment.js
@@ -1,3 +1,4 @@
+import { __, _n, sprintf } from "@wordpress/i18n";
 import { filter, merge } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -48,11 +49,10 @@ class SubheadingsDistributionTooLong extends Assessment {
 	 *
 	 * @param {Paper}       paper       The paper to use for the assessment.
 	 * @param {Researcher}  researcher  The researcher used for calling research.
-	 * @param {Object}      i18n        The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The assessment result.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		this._subheadingTextsLength = researcher.getResearch( "getSubheadingTextLengths" );
 
 		this._subheadingTextsLength = this._subheadingTextsLength.sort( function( a, b ) {
@@ -68,7 +68,7 @@ class SubheadingsDistributionTooLong extends Assessment {
 
 		this._textLength = getWords( paper.getText() ).length;
 
-		const calculatedResult = this.calculateResult( i18n );
+		const calculatedResult = this.calculateResult();
 		calculatedResult.resultTextPlural = calculatedResult.resultTextPlural || "";
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
@@ -113,11 +113,9 @@ class SubheadingsDistributionTooLong extends Assessment {
 	/**
 	 * Calculates the score and creates a feedback string based on the subheading texts length.
 	 *
-	 * @param {Object} i18n The object used for translations.
-	 *
 	 * @returns {Object} The calculated result.
 	 */
-	calculateResult( i18n ) {
+	calculateResult() {
 		if ( this._textLength > 300 ) {
 			if ( this._hasSubheadings ) {
 				const longestSubheadingTextLength = this._subheadingTextsLength[ 0 ].wordCount;
@@ -125,11 +123,11 @@ class SubheadingsDistributionTooLong extends Assessment {
 					// Green indicator.
 					return {
 						score: this._config.scores.goodSubheadings,
-						resultText: i18n.sprintf(
+						resultText: sprintf(
 							// Translators: %1$s expands to a link to https://yoa.st/headings, %2$s expands to the link closing tag.
-							i18n.dgettext(
-								"js-text-analysis",
-								"%1$sSubheading distribution%2$s: Great job!"
+							__(
+								"%1$sSubheading distribution%2$s: Great job!",
+								"wordpress-seo"
 							),
 							this._config.urlTitle,
 							"</a>"
@@ -141,19 +139,20 @@ class SubheadingsDistributionTooLong extends Assessment {
 					// Orange indicator.
 					return {
 						score: this._config.scores.okSubheadings,
-						resultText: i18n.sprintf(
+						resultText: sprintf(
 							/*
 							 * Translators: %1$s and %5$s expand to a link on yoast.com, %3$d to the number of text sections
 							 * not separated by subheadings, %4$d expands to the recommended number of words following a
 							 * subheading, %2$s expands to the link closing tag.
 							 */
-							i18n.dngettext(
-								"js-text-analysis",
+							_n(
 								"%1$sSubheading distribution%2$s: %3$d section of your text is longer than %4$d words and" +
 								" is not separated by any subheadings. %5$sAdd subheadings to improve readability%2$s.",
 								"%1$sSubheading distribution%2$s: %3$d sections of your text are longer than %4$d words " +
 								"and are not separated by any subheadings. %5$sAdd subheadings to improve readability%2$s.",
-								this._tooLongTextsNumber ),
+								this._tooLongTextsNumber,
+								"wordpress-seo"
+							),
 							this._config.urlTitle,
 							"</a>",
 							this._tooLongTextsNumber,
@@ -166,17 +165,18 @@ class SubheadingsDistributionTooLong extends Assessment {
 				// Red indicator.
 				return {
 					score: this._config.scores.badSubheadings,
-					resultText: i18n.sprintf(
+					resultText: sprintf(
 						/* Translators: %1$s and %5$s expand to a link on yoast.com, %3$d to the number of text sections
 						not separated by subheadings, %4$d expands to the recommended number of words following a
 						subheading, %2$s expands to the link closing tag. */
-						i18n.dngettext(
-							"js-text-analysis",
+						_n(
 							"%1$sSubheading distribution%2$s: %3$d section of your text is longer than %4$d words and" +
 							" is not separated by any subheadings. %5$sAdd subheadings to improve readability%2$s.",
 							"%1$sSubheading distribution%2$s: %3$d sections of your text are longer than %4$d words " +
 							"and are not separated by any subheadings. %5$sAdd subheadings to improve readability%2$s.",
-							this._tooLongTextsNumber ),
+							this._tooLongTextsNumber,
+							"wordpress-seo"
+						),
 						this._config.urlTitle,
 						"</a>",
 						this._tooLongTextsNumber,
@@ -188,12 +188,12 @@ class SubheadingsDistributionTooLong extends Assessment {
 			// Red indicator, use '2' so we can differentiate in external analysis.
 			return {
 				score: this._config.scores.badLongTextNoSubheadings,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %3$s expand to a link to https://yoa.st/headings, %2$s expands to the link closing tag. */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sSubheading distribution%2$s: You are not using any subheadings, although your text is rather long." +
-						" %3$sTry and add some subheadings%2$s."
+						" %3$sTry and add some subheadings%2$s.",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					"</a>",
@@ -205,11 +205,11 @@ class SubheadingsDistributionTooLong extends Assessment {
 			// Green indicator.
 			return {
 				score: this._config.scores.goodSubheadings,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s expands to a link to https://yoa.st/headings, %2$s expands to the link closing tag. */
-					i18n.dgettext(
-						"js-text-analysis",
-						"%1$sSubheading distribution%2$s: Great job!"
+					__(
+						"%1$sSubheading distribution%2$s: Great job!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					"</a>"
@@ -219,12 +219,12 @@ class SubheadingsDistributionTooLong extends Assessment {
 		// Green indicator.
 		return {
 			score: this._config.scores.goodShortTextNoSubheadings,
-			resultText: i18n.sprintf(
+			resultText: sprintf(
 				/* Translators: %1$s expands to a link to https://yoa.st/headings, %2$s expands to the link closing tag. */
-				i18n.dgettext(
-					"js-text-analysis",
+				__(
 					"%1$sSubheading distribution%2$s: You are not using any subheadings, but your text is short enough" +
-					" and probably doesn't need them."
+					" and probably doesn't need them.",
+					"wordpress-seo"
 				),
 				this._config.urlTitle,
 				"</a>"

--- a/packages/yoastseo/src/scoring/assessments/readability/textPresenceAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/textPresenceAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import { stripFullTags as stripHTMLTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
 import AssessmentResult from "../../../values/AssessmentResult";
@@ -7,11 +8,10 @@ import AssessmentResult from "../../../values/AssessmentResult";
  *
  * @param {Paper}       paper       The paper to assess.
  * @param {Researcher}  researcher  The researcher.
- * @param {Jed}         i18n        The translations object.
  *
  * @returns {AssessmentResult} The result of this assessment.
  */
-function textPresenceAssessment( paper, researcher, i18n ) {
+function textPresenceAssessment( paper, researcher ) {
 	const text = stripHTMLTags( paper.getText() );
 	const urlTitle = createAnchorOpeningTag( "https://yoa.st/35h" );
 	const urlCallToAction = createAnchorOpeningTag( "https://yoa.st/35i" );
@@ -19,11 +19,13 @@ function textPresenceAssessment( paper, researcher, i18n ) {
 	if ( text.length < 50 ) {
 		const result = new AssessmentResult();
 
-		result.setText( i18n.sprintf(
+		result.setText( sprintf(
 			/* Translators: %1$s and %3$s expand to links to articles on Yoast.com,
 			%2$s expands to the anchor end tag*/
-			i18n.dgettext( "js-text-analysis",
-				"%1$sNot enough content%2$s: %3$sPlease add some content to enable a good analysis%2$s." ),
+			__(
+				"%1$sNot enough content%2$s: %3$sPlease add some content to enable a good analysis%2$s.",
+				"wordpress-seo"
+			),
 			urlTitle,
 			"</a>",
 			urlCallToAction ) );

--- a/packages/yoastseo/src/scoring/assessments/readability/transitionWordsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/transitionWordsAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { map } from "lodash-es";
 
 import formatNumber from "../../../helpers/formatNumber";
@@ -51,11 +52,10 @@ const calculateScoreFromPercentage = function( percentage ) {
  *
  * @param {object} transitionWordSentences  The object containing the total number of sentences and the number of sentences containing
  *                                          a transition word.
- * @param {object} i18n                     The object used for translations.
  *
  * @returns {object} Object containing score and text.
  */
-const calculateTransitionWordResult = function( transitionWordSentences, i18n ) {
+const calculateTransitionWordResult = function( transitionWordSentences ) {
 	const percentage = calculateTransitionWordPercentage( transitionWordSentences );
 	const score = calculateScoreFromPercentage( percentage );
 	const hasMarks   = ( percentage > 0 );
@@ -66,10 +66,11 @@ const calculateTransitionWordResult = function( transitionWordSentences, i18n ) 
 		return {
 			score: formatNumber( score ),
 			hasMarks: hasMarks,
-			text: i18n.sprintf(
+			text: sprintf(
 				/* Translators: %1$s and %3$s expand to a link to yoast.com, %2$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis",
-					"%1$sTransition words%2$s: None of the sentences contain transition words. %3$sUse some%2$s."
+				__(
+					"%1$sTransition words%2$s: None of the sentences contain transition words. %3$sUse some%2$s.",
+					"wordpress-seo"
 				),
 				urlTitle,
 				"</a>",
@@ -81,11 +82,12 @@ const calculateTransitionWordResult = function( transitionWordSentences, i18n ) 
 		return {
 			score: formatNumber( score ),
 			hasMarks: hasMarks,
-			text: i18n.sprintf(
+			text: sprintf(
 				/* Translators: %1$s and %4$s expand to a link to yoast.com, %2$s expands to the anchor end tag,
 				%3$s expands to the percentage of sentences containing transition words */
-				i18n.dgettext( "js-text-analysis",
-					"%1$sTransition words%2$s: Only %3$s of the sentences contain transition words, which is not enough. %4$sUse more of them%2$s."
+				__(
+					"%1$sTransition words%2$s: Only %3$s of the sentences contain transition words, which is not enough. %4$sUse more of them%2$s.",
+					"wordpress-seo"
 				),
 				urlTitle,
 				"</a>",
@@ -97,10 +99,11 @@ const calculateTransitionWordResult = function( transitionWordSentences, i18n ) 
 	return {
 		score: formatNumber( score ),
 		hasMarks: hasMarks,
-		text: i18n.sprintf(
+		text: sprintf(
 			/* Translators: %1$s expands to a link on yoast.com, %3$s expands to the anchor end tag. */
-			i18n.dgettext( "js-text-analysis",
-				"%1$sTransition words%2$s: Well done!"
+			__(
+				"%1$sTransition words%2$s: Well done!",
+				"wordpress-seo"
 			),
 			urlTitle,
 			"</a>" ),
@@ -112,13 +115,12 @@ const calculateTransitionWordResult = function( transitionWordSentences, i18n ) 
  *
  * @param {object} paper        The paper to use for the assessment.
  * @param {object} researcher   The researcher used for calling research.
- * @param {object} i18n         The object used for translations.
  *
  * @returns {object} The Assessment result.
  */
-const transitionWordsAssessment = function( paper, researcher, i18n ) {
+const transitionWordsAssessment = function( paper, researcher ) {
 	const transitionWordSentences = researcher.getResearch( "findTransitionWords" );
-	const transitionWordResult = calculateTransitionWordResult( transitionWordSentences, i18n );
+	const transitionWordResult = calculateTransitionWordResult( transitionWordSentences );
 	const assessmentResult = new AssessmentResult();
 
 	assessmentResult.setScore( transitionWordResult.score );

--- a/packages/yoastseo/src/scoring/assessments/readability/wordComplexityAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/wordComplexityAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { filter, flatMap, flatten, forEach, zip } from "lodash-es";
 
 import formatNumber from "../../../helpers/formatNumber";
@@ -28,11 +29,10 @@ const filterComplexity = function( words ) {
  *
  * @param {number}  wordCount       The number of words used.
  * @param {Array}   wordComplexity  The list of words with their syllable count.
- * @param {Object}  i18n            The object used for translations.
  *
  * @returns {{score: number, text}} resultobject with score and text.
  */
-const calculateComplexity = function( wordCount, wordComplexity, i18n ) {
+const calculateComplexity = function( wordCount, wordComplexity ) {
 	let percentage = 0;
 	const tooComplexWords = filterComplexity( wordComplexity ).length;
 
@@ -54,15 +54,15 @@ const calculateComplexity = function( wordCount, wordComplexity, i18n ) {
 		return {
 			score: score,
 			hasMarks: hasMarks,
-			text: i18n.sprintf(
-				i18n.dgettext(
-					"js-text-analysis",
-
-					// Translators: %1$s expands to the percentage of complex words, %2$s expands to a link on yoast.com,
-					// %3$d expands to the recommended maximum number of syllables,
-					// %4$s expands to the anchor end tag, %5$s expands to the recommended maximum number of syllables.
+			text: sprintf(
+				// Translators: %1$s expands to the percentage of complex words, %2$s expands to a link on yoast.com,
+				// %3$d expands to the recommended maximum number of syllables,
+				// %4$s expands to the anchor end tag, %5$s expands to the recommended maximum number of syllables.
+				__(
 					"%1$s of the words contain %2$sover %3$s syllables%4$s, " +
-					"which is less than or equal to the recommended maximum of %5$s." ),
+					"which is less than or equal to the recommended maximum of %5$s.",
+					"wordpress-seo"
+				),
 				percentage + "%", wordComplexityURL, recommendedValue, "</a>", recommendedMaximum + "%"  ),
 		};
 	}
@@ -70,15 +70,15 @@ const calculateComplexity = function( wordCount, wordComplexity, i18n ) {
 	return {
 		score: score,
 		hasMarks: hasMarks,
-		text: i18n.sprintf(
-			i18n.dgettext(
-				"js-text-analysis",
-
-				// Translators: %1$s expands to the percentage of complex words, %2$s expands to a link on yoast.com,
-				// %3$d expands to the recommended maximum number of syllables,
-				// %4$s expands to the anchor end tag, %5$s expands to the recommended maximum number of syllables.
+		text: sprintf(
+			// Translators: %1$s expands to the percentage of complex words, %2$s expands to a link on yoast.com,
+			// %3$d expands to the recommended maximum number of syllables,
+			// %4$s expands to the anchor end tag, %5$s expands to the recommended maximum number of syllables.
+			__(
 				"%1$s of the words contain %2$sover %3$s syllables%4$s, " +
-				"which is more than the recommended maximum of %5$s." ),
+				"which is more than the recommended maximum of %5$s.",
+				"wordpress-seo"
+			),
 			percentage + "%", wordComplexityURL, recommendedValue, "</a>", recommendedMaximum + "%"  ),
 	};
 };
@@ -164,18 +164,17 @@ const wordComplexityMarker = function( paper, researcher ) {
  *
  * @param {Paper}       paper       The Paper object to assess.
  * @param {Researcher}  researcher  The Researcher object containing all available researches.
- * @param {object}      i18n        The object used for translations.
  *
  * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
  */
-const wordComplexityAssessment = function( paper, researcher, i18n ) {
+const wordComplexityAssessment = function( paper, researcher ) {
 	let wordComplexity = researcher.getResearch( "wordComplexity" );
 	wordComplexity = flatMap( wordComplexity, function( sentence ) {
 		return sentence.words;
 	} );
 	const wordCount = wordComplexity.length;
 
-	const complexityResult = calculateComplexity( wordCount, wordComplexity, i18n );
+	const complexityResult = calculateComplexity( wordCount, wordComplexity );
 	const assessmentResult = new AssessmentResult();
 	assessmentResult.setScore( complexityResult.score );
 	assessmentResult.setText( complexityResult.text );

--- a/packages/yoastseo/src/scoring/assessments/seo/FunctionWordsInKeyphraseAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/FunctionWordsInKeyphraseAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { escape, merge } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -39,27 +40,27 @@ class FunctionWordsInKeyphraseAssessment extends Assessment {
 	 * @param {Paper} 		paper 		The paper to use for the assessment.
 	 * @param {Researcher} 	researcher 	The researcher used for calling research.
 	 *
-	 * @param {Jed} i18n The object used for translations.
-	 *
 	 * @returns {AssessmentResult} The result of the assessment.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		this._functionWordsInKeyphrase = researcher.getResearch( "functionWordsInKeyphrase" );
 		this._keyword = escape( paper.getKeyword() );
 		const assessmentResult = new AssessmentResult();
 
 		if ( this._functionWordsInKeyphrase ) {
 			assessmentResult.setScore( this._config.scores.onlyFunctionWords );
-			assessmentResult.setText( i18n.sprintf(
+			assessmentResult.setText( sprintf(
 				/**
 				 * Translators:
 				 * %1$s and %2$s expand to links on yoast.com,
 				 * %3$s expands to the anchor end tag,
 				 * %4$s expands to the focus keyphrase of the article.
 				 */
-				i18n.dgettext( "js-text-analysis", "%1$sFunction words in keyphrase%3$s: " +
-					"Your keyphrase \"%4$s\" contains function words only. " +
-					"%2$sLearn more about what makes a good keyphrase.%3$s" ),
+				__(
+					"%1$sFunction words in keyphrase%3$s: Your keyphrase \"%4$s\" contains function words only. " +
+					"%2$sLearn more about what makes a good keyphrase.%3$s",
+					"wordpress-seo"
+				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,
 				"</a>",

--- a/packages/yoastseo/src/scoring/assessments/seo/InternalLinksAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/InternalLinksAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { merge } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -47,15 +48,14 @@ class InternalLinksAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper The paper to use for the assessment.
 	 * @param {Researcher} researcher The researcher used for calling research.
-	 * @param {Jed} i18n The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The result of the assessment.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		this.linkStatistics = researcher.getResearch( "getLinkStatistics" );
 		const assessmentResult = new AssessmentResult();
 
-		const calculatedResult = this.calculateResult( i18n );
+		const calculatedResult = this.calculateResult();
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
 
@@ -76,18 +76,18 @@ class InternalLinksAssessment extends Assessment {
 	/**
 	 * Returns a score and text based on the linkStatistics object.
 	 *
-	 * @param {Jed} i18n The object used for translations.
-	 *
 	 * @returns {Object} ResultObject with score and text
 	 */
-	calculateResult( i18n ) {
+	calculateResult() {
 		if ( this.linkStatistics.internalTotal === 0 ) {
 			return {
 				score: this._config.scores.noInternal,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-					i18n.dgettext( "js-text-analysis", "%1$sInternal links%3$s: " +
-						"No internal links appear in this page, %2$smake sure to add some%3$s!" ),
+					__(
+						"%1$sInternal links%3$s: No internal links appear in this page, %2$smake sure to add some%3$s!",
+						"wordpress-seo"
+					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
 					"</a>"
@@ -98,10 +98,12 @@ class InternalLinksAssessment extends Assessment {
 		if ( this.linkStatistics.internalNofollow === this.linkStatistics.internalTotal ) {
 			return {
 				score: this._config.scores.noneInternalFollow,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-					i18n.dgettext( "js-text-analysis", "%1$sInternal links%3$s: " +
-						"The internal links in this page are all nofollowed. %2$sAdd some good internal links%3$s." ),
+					__(
+						"%1$sInternal links%3$s: The internal links in this page are all nofollowed. %2$sAdd some good internal links%3$s.",
+						"wordpress-seo"
+					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
 					"</a>"
@@ -112,9 +114,9 @@ class InternalLinksAssessment extends Assessment {
 		if ( this.linkStatistics.internalDofollow === this.linkStatistics.internalTotal ) {
 			return {
 				score: this._config.scores.allInternalFollow,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-					i18n.dgettext( "js-text-analysis", "%1$sInternal links%2$s: You have enough internal links. Good job!" ),
+					__( "%1$sInternal links%2$s: You have enough internal links. Good job!", "wordpress-seo" ),
 					this._config.urlTitle,
 					"</a>"
 				),
@@ -122,11 +124,11 @@ class InternalLinksAssessment extends Assessment {
 		}
 		return {
 			score: this._config.scores.someInternalFollow,
-			resultText: i18n.sprintf(
+			resultText: sprintf(
 				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-				i18n.dgettext(
-					"js-text-analysis",
-					"%1$sInternal links%2$s: There are both nofollowed and normal internal links on this page. Good job!"
+				__(
+					"%1$sInternal links%2$s: There are both nofollowed and normal internal links on this page. Good job!",
+					"wordpress-seo"
 				),
 				this._config.urlTitle,
 				"</a>"

--- a/packages/yoastseo/src/scoring/assessments/seo/IntroductionKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/IntroductionKeywordAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { merge } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -41,15 +42,14 @@ class IntroductionKeywordAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper The paper to use for the assessment.
 	 * @param {Researcher} researcher The researcher used for calling research.
-	 * @param {Jed} i18n The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The result of this assessment.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		const assessmentResult = new AssessmentResult();
 
 		this._firstParagraphMatches = researcher.getResearch( "findKeywordInFirstParagraph" );
-		const calculatedResult = this.calculateResult( i18n );
+		const calculatedResult = this.calculateResult();
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
@@ -71,19 +71,17 @@ class IntroductionKeywordAssessment extends Assessment {
 	/**
 	 * Returns a result based on the number of occurrences of keyphrase in the first paragraph.
 	 *
-	 * @param {Jed} i18n The object used for translations.
-	 *
 	 * @returns {Object} result object with a score and translation text.
 	 */
-	calculateResult( i18n ) {
+	calculateResult() {
 		if ( this._firstParagraphMatches.foundInOneSentence ) {
 			return {
 				score: this._config.scores.good,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
-					i18n.dgettext(
-						"js-text-analysis",
-						"%1$sKeyphrase in introduction%2$s: Well done!"
+					__(
+						"%1$sKeyphrase in introduction%2$s: Well done!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					"</a>"
@@ -94,12 +92,12 @@ class IntroductionKeywordAssessment extends Assessment {
 		if ( this._firstParagraphMatches.foundInParagraph ) {
 			return {
 				score: this._config.scores.okay,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag. */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sKeyphrase in introduction%3$s:" +
-						"Your keyphrase or its synonyms appear in the first paragraph of the copy, but not within one sentence. %2$sFix that%3$s!"
+						"Your keyphrase or its synonyms appear in the first paragraph of the copy, but not within one sentence. %2$sFix that%3$s!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -110,12 +108,12 @@ class IntroductionKeywordAssessment extends Assessment {
 
 		return {
 			score: this._config.scores.bad,
-			resultText: i18n.sprintf(
+			resultText: sprintf(
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag. */
-				i18n.dgettext(
-					"js-text-analysis",
+				__(
 					"%1$sKeyphrase in introduction%3$s: Your keyphrase or its synonyms do not appear in the first paragraph. " +
-					"%2$sMake sure the topic is clear immediately%3$s."
+					"%2$sMake sure the topic is clear immediately%3$s.",
+					"wordpress-seo"
 				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,

--- a/packages/yoastseo/src/scoring/assessments/seo/KeyphraseDistributionAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/KeyphraseDistributionAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { merge } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -53,16 +54,15 @@ class KeyphraseDistributionAssessment extends Assessment {
 	 *
 	 * @param {Paper}      paper      The paper to use for the assessment.
 	 * @param {Researcher} researcher The researcher used for calling research.
-	 * @param {Jed}        i18n       The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The assessment result.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		this._keyphraseDistribution = researcher.getResearch( "keyphraseDistribution" );
 
 		const assessmentResult = new AssessmentResult();
 
-		const calculatedResult = this.calculateResult( i18n );
+		const calculatedResult = this.calculateResult();
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
@@ -74,23 +74,21 @@ class KeyphraseDistributionAssessment extends Assessment {
 	/**
 	 * Calculates the result based on the keyphraseDistribution research.
 	 *
-	 * @param {Jed} i18n The object used for translations.
-	 *
 	 * @returns {Object} Object with score and feedback text.
 	 */
-	calculateResult( i18n ) {
+	calculateResult() {
 		const distributionScore = this._keyphraseDistribution.keyphraseDistributionScore;
 
 		if ( distributionScore === 100 ) {
 			return {
 				score: this._config.scores.consideration,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to links to Yoast.com articles,
 					%3$s expands to the anchor end tag */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sKeyphrase distribution%3$s: " +
-						"%2$sInclude your keyphrase or its synonyms in the text so that we can check keyphrase distribution%3$s."
+						"%2$sInclude your keyphrase or its synonyms in the text so that we can check keyphrase distribution%3$s.",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -102,13 +100,13 @@ class KeyphraseDistributionAssessment extends Assessment {
 		if ( distributionScore > this._config.parameters.acceptableDistributionScore ) {
 			return {
 				score: this._config.scores.bad,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to links to Yoast.com articles,
 					%3$s expands to the anchor end tag */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sKeyphrase distribution%3$s: " +
-						"Very uneven. Large parts of your text do not contain the keyphrase or its synonyms. %2$sDistribute them more evenly%3$s."
+						"Very uneven. Large parts of your text do not contain the keyphrase or its synonyms. %2$sDistribute them more evenly%3$s.",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -122,13 +120,13 @@ class KeyphraseDistributionAssessment extends Assessment {
 		) {
 			return {
 				score: this._config.scores.okay,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to links to Yoast.com articles,
 					%3$s expands to the anchor end tag */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sKeyphrase distribution%3$s: " +
-						"Uneven. Some parts of your text do not contain the keyphrase or its synonyms. %2$sDistribute them more evenly%3$s."
+						"Uneven. Some parts of your text do not contain the keyphrase or its synonyms. %2$sDistribute them more evenly%3$s.",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -139,11 +137,11 @@ class KeyphraseDistributionAssessment extends Assessment {
 
 		return {
 			score: this._config.scores.good,
-			resultText: i18n.sprintf(
+			resultText: sprintf(
 				/* Translators: %1$s expands to links to Yoast.com articles, %2$s expands to the anchor end tag */
-				i18n.dgettext(
-					"js-text-analysis",
-					"%1$sKeyphrase distribution%2$s: Good job!"
+				__(
+					"%1$sKeyphrase distribution%2$s: Good job!",
+					"wordpress-seo"
 				),
 				this._config.urlTitle,
 				"</a>"
@@ -167,7 +165,7 @@ class KeyphraseDistributionAssessment extends Assessment {
 	 *
 	 * @returns {boolean} True when there is a keyword and a text with 15 sentences or more.
 	 */
-	isApplicable( paper ) {
+	isApplicable( paper) {
 		return paper.hasText() && paper.hasKeyword() && getSentences( paper.getText() ).length >= 15;
 	}
 }

--- a/packages/yoastseo/src/scoring/assessments/seo/KeyphraseLengthAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/KeyphraseLengthAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { merge, inRange } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -52,11 +53,10 @@ class KeyphraseLengthAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper The paper to use for the assessment.
 	 * @param {Researcher} researcher The researcher used for calling research.
-	 * @param {Jed} i18n The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The result of this assessment.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		this._keyphraseLengthData = researcher.getResearch( "keyphraseLength" );
 		const assessmentResult = new AssessmentResult();
 		this._boundaries = this._config.parameters;
@@ -66,7 +66,7 @@ class KeyphraseLengthAssessment extends Assessment {
 			this._boundaries = merge( {}, this._config.parameters, this._config.parametersNoFunctionWordSupport  );
 		}
 
-		const calculatedResult = this.calculateResult( i18n );
+		const calculatedResult = this.calculateResult();
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
@@ -77,21 +77,19 @@ class KeyphraseLengthAssessment extends Assessment {
 	/**
 	 * Calculates the result based on the keyphraseLength research.
 	 *
-	 * @param {Jed} i18n The object used for translations.
-	 *
 	 * @returns {Object} Object with score and text.
 	 */
-	calculateResult( i18n ) {
+	calculateResult() {
 		if ( this._keyphraseLengthData.keyphraseLength < this._boundaries.recommendedMinimum ) {
 			if ( this._config.isRelatedKeyphrase ) {
 				return {
 					score: this._config.scores.veryBad,
-					resultText: i18n.sprintf(
+					resultText: sprintf(
 						/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-						i18n.dgettext(
-							"js-text-analysis",
+						__(
 							"%1$sKeyphrase length%3$s: " +
-							"%2$sSet a keyphrase in order to calculate your SEO score%3$s."
+							"%2$sSet a keyphrase in order to calculate your SEO score%3$s.",
+							"wordpress-seo"
 						),
 						this._config.urlTitle,
 						this._config.urlCallToAction,
@@ -101,12 +99,12 @@ class KeyphraseLengthAssessment extends Assessment {
 			}
 			return {
 				score: this._config.scores.veryBad,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sKeyphrase length%3$s: No focus keyphrase was set for this page. " +
-						"%2$sSet a keyphrase in order to calculate your SEO score%3$s."
+						"%2$sSet a keyphrase in order to calculate your SEO score%3$s.",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -118,11 +116,11 @@ class KeyphraseLengthAssessment extends Assessment {
 		if ( inRange( this._keyphraseLengthData.keyphraseLength, this._boundaries.recommendedMinimum, this._boundaries.recommendedMaximum + 1 ) ) {
 			return {
 				score: this._config.scores.good,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
-					i18n.dgettext(
-						"js-text-analysis",
-						"%1$sKeyphrase length%2$s: Good job!"
+					__(
+						"%1$sKeyphrase length%2$s: Good job!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					"</a>"
@@ -133,16 +131,16 @@ class KeyphraseLengthAssessment extends Assessment {
 		if ( inRange( this._keyphraseLengthData.keyphraseLength, this._boundaries.recommendedMaximum + 1, this._boundaries.acceptableMaximum + 1 ) ) {
 			return {
 				score: this._config.scores.okay,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators:
 					%1$d expands to the number of words in the keyphrase,
 					%2$d expands to the recommended maximum of words in the keyphrase,
 					%3$s and %4$s expand to links on yoast.com,
 					%5$s expands to the anchor end tag. */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%3$sKeyphrase length%5$s: The keyphrase is %1$d words long. That's more than the recommended maximum of %2$d words. " +
-							"%4$sMake it shorter%5$s!"
+							"%4$sMake it shorter%5$s!",
+						"wordpress-seo"
 					),
 					this._keyphraseLengthData.keyphraseLength,
 					this._boundaries.recommendedMaximum,
@@ -155,16 +153,16 @@ class KeyphraseLengthAssessment extends Assessment {
 
 		return {
 			score: this._config.scores.bad,
-			resultText: i18n.sprintf(
+			resultText: sprintf(
 				/* Translators:
 				%1$d expands to the number of words in the keyphrase,
 				%2$d expands to the recommended maximum of words in the keyphrase,
 				%3$s and %4$s expand to links on yoast.com,
 				%5$s expands to the anchor end tag. */
-				i18n.dgettext(
-					"js-text-analysis",
+				__(
 					"%3$sKeyphrase length%5$s: The keyphrase is %1$d words long. That's way more than the recommended maximum of %2$d words. " +
-					"%4$sMake it shorter%5$s!"
+					"%4$sMake it shorter%5$s!",
+					"wordpress-seo"
 				),
 				this._keyphraseLengthData.keyphraseLength,
 				this._boundaries.recommendedMaximum,

--- a/packages/yoastseo/src/scoring/assessments/seo/KeywordDensityAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/KeywordDensityAssessment.js
@@ -1,3 +1,4 @@
+import { __, _n, sprintf } from "@wordpress/i18n";
 import { merge } from "lodash-es";
 
 import recommendedKeywordCount from "../../helpers/assessments/recommendedKeywordCount.js";
@@ -93,13 +94,11 @@ class KeywordDensityAssessment extends Assessment {
 	 * result with score.
 	 *
 	 * @param {Paper} paper The paper to use for the assessment.
-	 * @param {Researcher} researcher The researcher used for calling the
-	 *                                research.
-	 * @param {Jed} i18n The object used for translations.
+	 * @param {Researcher} researcher The researcher used for calling the research.
 	 *
 	 * @returns {AssessmentResult} The result of the assessment.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		this._keywordCount = researcher.getResearch( "keywordCount" );
 		const keyphraseLength = this._keywordCount.length;
 
@@ -113,7 +112,7 @@ class KeywordDensityAssessment extends Assessment {
 		this.setBoundaries( paper.getText(), keyphraseLength );
 
 		this._keywordDensity = this._keywordDensityData.keywordDensity * keyphraseLengthFactor( keyphraseLength );
-		const calculatedScore = this.calculateResult( i18n );
+		const calculatedScore = this.calculateResult();
 
 		assessmentResult.setScore( calculatedScore.score );
 		assessmentResult.setText( calculatedScore.resultText );
@@ -178,24 +177,22 @@ class KeywordDensityAssessment extends Assessment {
 	/**
 	 * Returns the score for the keyphrase density.
 	 *
-	 * @param {Jed} i18n The object used for translations.
-	 *
 	 * @returns {Object} The object with calculated score and resultText.
 	 */
-	calculateResult( i18n ) {
+	calculateResult() {
 		if ( this.hasNoMatches() ) {
 			return {
 				score: this._config.scores.underMinimum,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators:
 					%1$s and %4$s expand to links to Yoast.com,
 					%2$s expands to the anchor end tag,
 					%3$d expands to the recommended minimal number of times the keyphrase should occur in the text. */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sKeyphrase density%2$s: The focus keyphrase was found 0 times. " +
 						"That's less than the recommended minimum of %3$d times for a text of this length. " +
-						"%4$sFocus on your keyphrase%2$s!"
+						"%4$sFocus on your keyphrase%2$s!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					"</a>",
@@ -208,19 +205,19 @@ class KeywordDensityAssessment extends Assessment {
 		if ( this.hasTooFewMatches() ) {
 			return {
 				score: this._config.scores.underMinimum,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators:
 					%1$s and %4$s expand to links to Yoast.com,
 					%2$s expands to the anchor end tag,
 					%3$d expands to the recommended minimal number of times the keyphrase should occur in the text,
 					%5$d expands to the number of times the keyphrase occurred in the text. */
-					i18n.dngettext(
-						"js-text-analysis",
+					_n(
 						"%1$sKeyphrase density%2$s: The focus keyphrase was found %5$d time. That's less than the " +
 						"recommended minimum of %3$d times for a text of this length. %4$sFocus on your keyphrase%2$s!",
 						"%1$sKeyphrase density%2$s: The focus keyphrase was found %5$d times. That's less than the " +
 						"recommended minimum of %3$d times for a text of this length. %4$sFocus on your keyphrase%2$s!",
-						this._keywordCount.count
+						this._keywordCount.count,
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					"</a>",
@@ -234,16 +231,16 @@ class KeywordDensityAssessment extends Assessment {
 		if ( this.hasGoodNumberOfMatches()  ) {
 			return {
 				score: this._config.scores.correctDensity,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators:
 					%1$s expands to a link to Yoast.com,
 					%2$s expands to the anchor end tag,
 					%3$d expands to the number of times the keyphrase occurred in the text. */
-					i18n.dngettext(
-						"js-text-analysis",
+					_n(
 						"%1$sKeyphrase density%2$s: The focus keyphrase was found %3$d time. This is great!",
 						"%1$sKeyphrase density%2$s: The focus keyphrase was found %3$d times. This is great!",
-						this._keywordCount.count
+						this._keywordCount.count,
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					"</a>",
@@ -255,19 +252,19 @@ class KeywordDensityAssessment extends Assessment {
 		if ( this.hasTooManyMatches() ) {
 			return {
 				score: this._config.scores.overMaximum,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators:
 					%1$s and %4$s expand to links to Yoast.com,
 					%2$s expands to the anchor end tag,
 					%3$d expands to the recommended maximal number of times the keyphrase should occur in the text,
 					%5$d expands to the number of times the keyphrase occurred in the text. */
-					i18n.dngettext(
-						"js-text-analysis",
+					_n(
 						"%1$sKeyphrase density%2$s: The focus keyphrase was found %5$d time. That's more than the " +
 						"recommended maximum of %3$d times for a text of this length. %4$sDon't overoptimize%2$s!",
 						"%1$sKeyphrase density%2$s: The focus keyphrase was found %5$d times. That's more than the " +
 						"recommended maximum of %3$d times for a text of this length. %4$sDon't overoptimize%2$s!",
-						this._keywordCount.count
+						this._keywordCount.count,
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					"</a>",
@@ -281,19 +278,19 @@ class KeywordDensityAssessment extends Assessment {
 		// Implicitly returns this if the rounded keyphrase density is higher than overMaximum.
 		return {
 			score: this._config.scores.wayOverMaximum,
-			resultText: i18n.sprintf(
+			resultText: sprintf(
 				/* Translators:
 				%1$s and %4$s expand to links to Yoast.com,
 				%2$s expands to the anchor end tag,
 				%3$d expands to the recommended maximal number of times the keyphrase should occur in the text,
 				%5$d expands to the number of times the keyphrase occurred in the text. */
-				i18n.dngettext(
-					"js-text-analysis",
+				_n(
 					"%1$sKeyphrase density%2$s: The focus keyphrase was found %5$d time. That's way more than the " +
 					"recommended maximum of %3$d times for a text of this length. %4$sDon't overoptimize%2$s!",
 					"%1$sKeyphrase density%2$s: The focus keyphrase was found %5$d times. That's way more than the " +
 					"recommended maximum of %3$d times for a text of this length. %4$sDon't overoptimize%2$s!",
-					this._keywordCount.count
+					this._keywordCount.count,
+					"wordpress-seo"
 				),
 				this._config.urlTitle,
 				"</a>",

--- a/packages/yoastseo/src/scoring/assessments/seo/MetaDescriptionKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/MetaDescriptionKeywordAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { merge } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -44,14 +45,13 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	 *
 	 * @param {Paper}      paper      The paper to use for the assessment.
 	 * @param {Researcher} researcher The researcher used for calling research.
-	 * @param {Jed}        i18n       The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The assessment result.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		this._keyphraseCounts = researcher.getResearch( "metaDescriptionKeyword" );
 		const assessmentResult = new AssessmentResult();
-		const calculatedResult = this.calculateResult( i18n );
+		const calculatedResult = this.calculateResult();
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
@@ -62,20 +62,18 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	/**
 	 * Returns the result object based on the number of keyword matches in the meta description.
 	 *
-	 * @param {Jed} i18n The object used for translations.
-	 *
 	 * @returns {Object} Result object with score and text.
 	 */
-	calculateResult( i18n ) {
+	calculateResult() {
 		// GOOD result when the meta description contains a keyphrase or synonym 1 or 2 times.
 		if ( this._keyphraseCounts === 1 || this._keyphraseCounts === 2 ) {
 			return {
 				score: this._config.scores.good,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
-					i18n.dgettext(
-						"js-text-analysis",
-						"%1$sKeyphrase in meta description%2$s: Keyphrase or synonym appear in the meta description. Well done!"
+					__(
+						"%1$sKeyphrase in meta description%2$s: Keyphrase or synonym appear in the meta description. Well done!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					"</a>"
@@ -87,17 +85,17 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 		if ( this._keyphraseCounts >= 3 ) {
 			return {
 				score: this._config.scores.bad,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/**
 					 * Translators:
 					 * %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag,
 					 * %3$s expands to the number of sentences containing the keyphrase,
 					 * %4$s expands to a link on yoast.com, %5$s expands to the anchor end tag.
 					 */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sKeyphrase in meta description%2$s: The meta description contains the keyphrase %3$s times, " +
-						"which is over the advised maximum of 2 times. %4$sLimit that%5$s!"
+						"which is over the advised maximum of 2 times. %4$sLimit that%5$s!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					"</a>",
@@ -111,16 +109,16 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 		// BAD if the keyphrases is not contained in the meta description.
 		return {
 			score: this._config.scores.bad,
-			resultText: i18n.sprintf(
+			resultText: sprintf(
 				/**
 				 * Translators:
 				 * %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag.
 				 * %3$s expands to a link on yoast.com, %4$s expands to the anchor end tag.
 				 */
-				i18n.dgettext(
-					"js-text-analysis",
+				__(
 					"%1$sKeyphrase in meta description%2$s: The meta description has been specified, " +
-					"but it does not contain the keyphrase. %3$sFix that%4$s!"
+					"but it does not contain the keyphrase. %3$sFix that%4$s!",
+					"wordpress-seo"
 				),
 				this._config.urlTitle,
 				"</a>",

--- a/packages/yoastseo/src/scoring/assessments/seo/MetaDescriptionLengthAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/MetaDescriptionLengthAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { merge } from "lodash-es";
 import Assessment from "../assessment";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
@@ -48,16 +49,15 @@ export default class MetaDescriptionLengthAssessment extends Assessment {
 	 *
 	 * @param {Paper}       paper       The paper to use for the assessment.
 	 * @param {Researcher}  researcher  The researcher used for calling research.
-	 * @param {Jed}         i18n        The object used for translations
 	 *
 	 * @returns {AssessmentResult} The assessment result.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		const descriptionLength = researcher.getResearch( "metaDescriptionLength" );
 		const assessmentResult = new AssessmentResult();
 
 		assessmentResult.setScore( this.calculateScore( descriptionLength ) );
-		assessmentResult.setText( this.translateScore( descriptionLength, i18n ) );
+		assessmentResult.setText( this.translateScore( descriptionLength ) );
 
 		// Max and actual are used in the snippet editor progress bar.
 		assessmentResult.max = this._config.maximumLength;
@@ -93,16 +93,15 @@ export default class MetaDescriptionLengthAssessment extends Assessment {
 	 * Translates the descriptionLength to a message the user can understand.
 	 *
 	 * @param {number} descriptionLength    The length of the metadescription.
-	 * @param {object} i18n                 The object used for translations.
 	 *
 	 * @returns {string} The translated string.
 	 */
-	translateScore( descriptionLength, i18n ) {
+	translateScore( descriptionLength ) {
 		if ( descriptionLength === 0 ) {
-			return i18n.sprintf(
+			return sprintf(
 				/* Translators:  %1$s and %2$s expand to a links on yoast.com, %3$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis", "%1$sMeta description length%3$s:  No meta description has been specified. " +
-					"Search engines will display copy from the page instead. %2$sMake sure to write one%3$s!" ),
+				__( "%1$sMeta description length%3$s:  No meta description has been specified. " +
+					"Search engines will display copy from the page instead. %2$sMake sure to write one%3$s!", "wordpress-seo" ),
 				this._config.urlTitle,
 				this._config.urlCallToAction,
 				"</a>"
@@ -110,12 +109,12 @@ export default class MetaDescriptionLengthAssessment extends Assessment {
 		}
 
 		if ( descriptionLength <= this._config.recommendedMaximumLength ) {
-			return i18n.sprintf(
+			return sprintf(
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag,
 				%4$d expands to the number of characters in the meta description, %5$d expands to
 				the total available number of characters in the meta description */
-				i18n.dgettext( "js-text-analysis", "%1$sMeta description length%3$s: The meta description is too short (under %4$d characters). " +
-				"Up to %5$d characters are available. %2$sUse the space%3$s!" ),
+				__( "%1$sMeta description length%3$s: The meta description is too short (under %4$d characters). " +
+				"Up to %5$d characters are available. %2$sUse the space%3$s!", "wordpress-seo" ),
 				this._config.urlTitle,
 				this._config.urlCallToAction,
 				"</a>",
@@ -125,11 +124,11 @@ export default class MetaDescriptionLengthAssessment extends Assessment {
 		}
 
 		if ( descriptionLength > this._config.maximumLength ) {
-			return i18n.sprintf(
+			return sprintf(
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag,
 				%4$d expands to	the total available number of characters in the meta description */
-				i18n.dgettext( "js-text-analysis", "%1$sMeta description length%3$s: The meta description is over %4$d characters. " +
-				"To ensure the entire description will be visible, %2$syou should reduce the length%3$s!" ),
+				__( "%1$sMeta description length%3$s: The meta description is over %4$d characters. " +
+				"To ensure the entire description will be visible, %2$syou should reduce the length%3$s!", "wordpress-seo" ),
 				this._config.urlTitle,
 				this._config.urlCallToAction,
 				"</a>",
@@ -137,9 +136,9 @@ export default class MetaDescriptionLengthAssessment extends Assessment {
 			);
 		}
 
-		return i18n.sprintf(
+		return sprintf(
 			/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-			i18n.dgettext( "js-text-analysis", "%1$sMeta description length%2$s: Well done!" ),
+			__( "%1$sMeta description length%2$s: Well done!", "wordpress-seo" ),
 			this._config.urlTitle,
 			"</a>"
 		);

--- a/packages/yoastseo/src/scoring/assessments/seo/OutboundLinksAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/OutboundLinksAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { isEmpty, merge } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -38,16 +39,15 @@ export default class OutboundLinksAssessment extends Assessment {
 	 *
 	 * @param {Paper}       paper       The paper to use for the assessment.
 	 * @param {Researcher}  researcher  The researcher used for calling research.
-	 * @param {Jed}         i18n        The object used for translations
 	 *
 	 * @returns {AssessmentResult} The assessment result.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		const linkStatistics = researcher.getResearch( "getLinkStatistics" );
 		const assessmentResult = new AssessmentResult();
 		if ( ! isEmpty( linkStatistics ) ) {
 			assessmentResult.setScore( this.calculateScore( linkStatistics ) );
-			assessmentResult.setText( this.translateScore( linkStatistics, i18n ) );
+			assessmentResult.setText( this.translateScore( linkStatistics ) );
 		}
 		return assessmentResult;
 	}
@@ -94,17 +94,17 @@ export default class OutboundLinksAssessment extends Assessment {
 	 * Translates the score to a message the user can understand.
 	 *
 	 * @param {Object}  linkStatistics  The object with all link statistics.
-	 * @param {Jed}     i18n            The object used for translations.
 	 *
 	 * @returns {string} The translated string.
 	 */
-	translateScore( linkStatistics, i18n ) {
+	translateScore( linkStatistics ) {
 		if ( linkStatistics.externalTotal === 0 ) {
-			return i18n.sprintf(
+			return sprintf(
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis", "%1$sOutbound links%3$s: " +
-					"No outbound links appear in this page. " +
-					"%2$sAdd some%3$s!" ),
+				__(
+					"%1$sOutbound links%3$s: No outbound links appear in this page. %2$sAdd some%3$s!",
+					"wordpress-seo"
+				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,
 				"</a>"
@@ -112,11 +112,12 @@ export default class OutboundLinksAssessment extends Assessment {
 		}
 
 		if ( linkStatistics.externalNofollow === linkStatistics.externalTotal ) {
-			return i18n.sprintf(
+			return sprintf(
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis", "%1$sOutbound links%3$s: " +
-					"All outbound links on this page are nofollowed. " +
-					"%2$sAdd some normal links%3$s." ),
+				__(
+					"%1$sOutbound links%3$s: All outbound links on this page are nofollowed. %2$sAdd some normal links%3$s.",
+					"wordpress-seo"
+				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,
 				"</a>"
@@ -124,21 +125,24 @@ export default class OutboundLinksAssessment extends Assessment {
 		}
 
 		if ( linkStatistics.externalDofollow === linkStatistics.externalTotal ) {
-			return i18n.sprintf(
+			return sprintf(
 				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis", "%1$sOutbound links%2$s: " +
-					"Good job!" ),
+				__(
+					"%1$sOutbound links%2$s: Good job!",
+					"wordpress-seo"
+				),
 				this._config.urlTitle,
 				"</a>"
 			);
 		}
 
 		if ( linkStatistics.externalDofollow < linkStatistics.externalTotal ) {
-			return i18n.sprintf(
+			return sprintf(
 				/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis", "%1$sOutbound links%2$s: " +
-					"There are both nofollowed and normal outbound links on this page. " +
-					"Good job!" ),
+				__(
+					"%1$sOutbound links%2$s: There are both nofollowed and normal outbound links on this page. Good job!",
+					"wordpress-seo"
+				),
 				this._config.urlTitle,
 				"</a>"
 			);

--- a/packages/yoastseo/src/scoring/assessments/seo/PageTitleWidthAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/PageTitleWidthAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { merge } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -51,16 +52,15 @@ export default class PageTitleWidthAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper The paper to use for the assessment.
 	 * @param {Researcher} researcher The researcher used for calling research.
-	 * @param {Jed} i18n The object used for translations
 	 *
 	 * @returns {AssessmentResult} The assessment result.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		const pageTitleWidth = researcher.getResearch( "pageTitleWidth" );
 		const assessmentResult = new AssessmentResult();
 
 		assessmentResult.setScore( this.calculateScore( pageTitleWidth ) );
-		assessmentResult.setText( this.translateScore( pageTitleWidth, i18n ) );
+		assessmentResult.setText( this.translateScore( pageTitleWidth ) );
 
 		// Max and actual are used in the snippet editor progress bar.
 		assessmentResult.max = this._config.maxLength;
@@ -95,18 +95,17 @@ export default class PageTitleWidthAssessment extends Assessment {
 	 * Translates the pageTitleWidth score to a message the user can understand.
 	 *
 	 * @param {number} pageTitleWidth The width of the pageTitle.
-	 * @param {Jed} i18n The object used for translations.
 	 *
 	 * @returns {string} The translated string.
 	 */
-	translateScore( pageTitleWidth, i18n ) {
+	translateScore( pageTitleWidth ) {
 		if ( inRange( pageTitleWidth, 1, 400 ) ) {
-			return i18n.sprintf(
+			return sprintf(
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-				i18n.dgettext(
-					"js-text-analysis",
+				__(
 					"%1$sSEO title width%3$s: The SEO title is too short. " +
-					"%2$sUse the space to add keyphrase variations or create compelling call-to-action copy%3$s."
+					"%2$sUse the space to add keyphrase variations or create compelling call-to-action copy%3$s.",
+					"wordpress-seo"
 				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,
@@ -115,11 +114,11 @@ export default class PageTitleWidthAssessment extends Assessment {
 		}
 
 		if ( inRange( pageTitleWidth, this._config.minLength, this._config.maxLength ) ) {
-			return i18n.sprintf(
+			return sprintf(
 				/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-				i18n.dgettext(
-					"js-text-analysis",
-					"%1$sSEO title width%2$s: Good job!"
+				__(
+					"%1$sSEO title width%2$s: Good job!",
+					"wordpress-seo"
 				),
 				this._config.urlTitle,
 				"</a>"
@@ -127,11 +126,11 @@ export default class PageTitleWidthAssessment extends Assessment {
 		}
 
 		if ( pageTitleWidth > this._config.maxLength ) {
-			return i18n.sprintf(
+			return sprintf(
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-				i18n.dgettext(
-					"js-text-analysis",
-					"%1$sSEO title width%3$s: The SEO title is wider than the viewable limit. %2$sTry to make it shorter%3$s."
+				__(
+					"%1$sSEO title width%3$s: The SEO title is wider than the viewable limit. %2$sTry to make it shorter%3$s.",
+					"wordpress-seo"
 				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,
@@ -139,9 +138,9 @@ export default class PageTitleWidthAssessment extends Assessment {
 			);
 		}
 
-		return i18n.sprintf(
+		return sprintf(
 			/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-			i18n.dgettext( "js-text-analysis", "%1$sSEO title width%3$s: %2$sPlease create an SEO title%3$s." ),
+			__( "%1$sSEO title width%3$s: %2$sPlease create an SEO title%3$s.", "wordpress-seo" ),
 			this._config.urlTitle,
 			this._config.urlCallToAction,
 			"</a>"

--- a/packages/yoastseo/src/scoring/assessments/seo/SingleH1Assessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/SingleH1Assessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { map } from "lodash-es";
 import { merge } from "lodash-es";
 import { isUndefined } from "lodash-es";
@@ -40,16 +41,15 @@ class singleH1Assessment extends Assessment {
 	 *
 	 * @param {Paper}       paper       The paper to use for the assessment.
 	 * @param {Researcher}  researcher  The researcher used for calling the research.
-	 * @param {Jed}         i18n        The object used for translations
 	 *
 	 * @returns {AssessmentResult} The assessment result.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		this._h1s = researcher.getResearch( "h1s" );
 
 		const assessmentResult = new AssessmentResult();
 
-		const calculatedResult = this.calculateResult( i18n );
+		const calculatedResult = this.calculateResult();
 
 		if ( ! isUndefined( calculatedResult ) ) {
 			assessmentResult.setScore( calculatedResult.score );
@@ -72,11 +72,9 @@ class singleH1Assessment extends Assessment {
 	/**
 	 * Returns the score and the feedback string for the single H1 assessment.
 	 *
-	 * @param {Jed} i18n The object used for translations.
-	 *
 	 * @returns {Object|null} The calculated score and the feedback string.
 	 */
-	calculateResult( i18n ) {
+	calculateResult() {
 		// Returns the default assessment result if there are no H1s in the body.
 		if ( this._h1s.length === 0 ) {
 			return;
@@ -89,12 +87,12 @@ class singleH1Assessment extends Assessment {
 
 		return {
 			score: this._config.scores.textContainsSuperfluousH1,
-			resultText: i18n.sprintf(
+			resultText: sprintf(
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-				i18n.dgettext(
-					"js-text-analysis",
+				__(
 					"%1$sSingle title%3$s: H1s should only be used as your main title. Find all H1s in your text " +
-					"that aren't your main title and %2$schange them to a lower heading level%3$s!"
+					"that aren't your main title and %2$schange them to a lower heading level%3$s!",
+					"wordpress-seo"
 				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,

--- a/packages/yoastseo/src/scoring/assessments/seo/SubHeadingsKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/SubHeadingsKeywordAssessment.js
@@ -1,3 +1,4 @@
+import { __, _n, sprintf } from "@wordpress/i18n";
 import { merge } from "lodash-es";
 import { getSubheadingsTopLevel } from "../../../languageProcessing/helpers/html/getSubheadings";
 import Assessment from "../assessment";
@@ -43,18 +44,17 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 	 *
 	 * @param {Paper} paper             The paper to use for the assessment.
 	 * @param {Researcher} researcher   The researcher used for calling research.
-	 * @param {Object} i18n             The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The assessment result.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		this._subHeadings = researcher.getResearch( "matchKeywordInSubheadings" );
 
 		const assessmentResult = new AssessmentResult();
 
 		this._minNumberOfSubheadings = Math.ceil( this._subHeadings.count * this._config.parameters.lowerBoundary );
 		this._maxNumberOfSubheadings = Math.floor( this._subHeadings.count * this._config.parameters.upperBoundary );
-		const calculatedResult = this.calculateResult( i18n );
+		const calculatedResult = this.calculateResult();
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
@@ -139,19 +139,17 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 	/**
 	 * Determines the score and the Result text for the subheadings.
 	 *
-	 * @param {Object} i18n The object used for translations.
-	 *
 	 * @returns {Object} The object with the calculated score and the result text.
 	 */
-	calculateResult( i18n ) {
+	calculateResult() {
 		if ( this.hasTooFewMatches() ) {
 			return {
 				score: this._config.scores.tooFewMatches,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to a link on yoast.com, %3$s expands to the anchor end tag. */
-					i18n.dgettext(
-						"js-text-analysis",
-						"%1$sKeyphrase in subheading%3$s: %2$sUse more keyphrases or synonyms in your H2 and H3 subheadings%3$s!"
+					__(
+						"%1$sKeyphrase in subheading%3$s: %2$sUse more keyphrases or synonyms in your H2 and H3 subheadings%3$s!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -163,12 +161,12 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 		if ( this.hasTooManyMatches() ) {
 			return {
 				score: this._config.scores.tooManyMatches,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to a link on yoast.com, %3$s expands to the anchor end tag. */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sKeyphrase in subheading%3$s: More than 75%% of your H2 and H3 subheadings reflect the topic of your copy. " +
-						"That's too much. %2$sDon't over-optimize%3$s!"
+						"That's too much. %2$sDon't over-optimize%3$s!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -180,16 +178,16 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 		if ( this.isOneOfOne() ) {
 			return {
 				score: this._config.scores.goodNumberOfMatches,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag,
 					%3$d expands to the number of subheadings containing the keyphrase. */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sKeyphrase in subheading%2$s: Your H2 or H3 subheading reflects the topic of your copy. Good job!",
-						this._subHeadings.matches
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
-					"</a>"
+					"</a>",
+					this._subHeadings.matches
 				),
 			};
 		}
@@ -197,14 +195,14 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 		if ( this.hasGoodNumberOfMatches() ) {
 			return {
 				score: this._config.scores.goodNumberOfMatches,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag,
 					%3$d expands to the number of subheadings containing the keyphrase. */
-					i18n.dngettext(
-						"js-text-analysis",
+					_n(
 						"%1$sKeyphrase in subheading%2$s: %3$s of your H2 and H3 subheadings reflects the topic of your copy. Good job!",
 						"%1$sKeyphrase in subheading%2$s: %3$s of your H2 and H3 subheadings reflect the topic of your copy. Good job!",
-						this._subHeadings.matches
+						this._subHeadings.matches,
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					"</a>",
@@ -215,11 +213,11 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 
 		return {
 			score: this._config.scores.noMatches,
-			resultText: i18n.sprintf(
+			resultText: sprintf(
 				/* Translators: %1$s and %2$s expand to a link on yoast.com, %3$s expands to the anchor end tag. */
-				i18n.dgettext(
-					"js-text-analysis",
-					"%1$sKeyphrase in subheading%3$s: %2$sUse more keyphrases or synonyms in your H2 and H3 subheadings%3$s!"
+				__(
+					"%1$sKeyphrase in subheading%3$s: %2$sUse more keyphrases or synonyms in your H2 and H3 subheadings%3$s!",
+					"wordpress-seo"
 				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,

--- a/packages/yoastseo/src/scoring/assessments/seo/TextCompetingLinksAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/TextCompetingLinksAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { isUndefined, merge } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -41,16 +42,15 @@ class TextCompetingLinksAssessment extends Assessment {
 	 *
 	 * @param {Paper}       paper       The paper to use for the assessment.
 	 * @param {Researcher}  researcher  The researcher used for calling research.
-	 * @param {Jed}         i18n        The object used for translations.
 	 *
 	 * @returns {Object} The AssessmentResult.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		const assessmentResult = new AssessmentResult();
 
 		this.linkCount = researcher.getResearch( "getLinkStatistics" );
 
-		const calculatedResult = this.calculateResult( i18n );
+		const calculatedResult = this.calculateResult();
 
 		if ( isUndefined( calculatedResult ) ) {
 			return assessmentResult;
@@ -77,21 +77,19 @@ class TextCompetingLinksAssessment extends Assessment {
 	/**
 	 * Returns a result based on the number of links.
 	 *
-	 * @param {Jed} i18n The object used for translations.
-	 *
 	 * @returns {Object} ResultObject with score and text.
 	 */
-	calculateResult( i18n ) {
+	calculateResult() {
 		if ( this.linkCount.keyword.totalKeyword > this._config.parameters.recommendedMaximum ) {
 			return {
 				score: this._config.scores.bad,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators:  %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sLink keyphrase%3$s: " +
 						"You're linking to another page with the words you want this page to rank for. " +
-						"%2$sDon't do that%3$s!"
+						"%2$sDon't do that%3$s!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,

--- a/packages/yoastseo/src/scoring/assessments/seo/TextImagesAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/TextImagesAssessment.js
@@ -1,3 +1,4 @@
+import { __, _n, sprintf } from "@wordpress/i18n";
 import { merge } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -46,18 +47,17 @@ export default class TextImagesAssessment extends Assessment {
 	 *
 	 * @param {Paper}       paper       The Paper object to assess.
 	 * @param {Researcher}  researcher  The Researcher object containing all available researches.
-	 * @param {Jed}         i18n        The locale object.
 	 *
 	 * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		this.imageCount = researcher.getResearch( "imageCount" );
 		this.altProperties = researcher.getResearch( "altTagCount" );
 
 		this._minNumberOfKeywordMatches = Math.ceil( this.imageCount * this._config.parameters.lowerBoundary );
 		this._maxNumberOfKeywordMatches = Math.floor( this.imageCount * this._config.parameters.upperBoundary );
 
-		const calculatedScore = this.calculateResult( i18n );
+		const calculatedScore = this.calculateResult();
 
 		const assessmentResult = new AssessmentResult();
 		assessmentResult.setScore( calculatedScore.score );
@@ -117,20 +117,18 @@ export default class TextImagesAssessment extends Assessment {
 	/**
 	 * Calculate the result based on the current image count and current image alt-tag count.
 	 *
-	 * @param {Object} i18n The object used for translations.
-	 *
 	 * @returns {Object} The calculated result.
 	 */
-	calculateResult( i18n ) {
+	calculateResult() {
 		// No images.
 		if ( this.imageCount === 0 ) {
 			return {
 				score: this._config.scores.noImages,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-					i18n.dgettext(
-						"js-text-analysis",
-						"%1$sImage alt attributes%3$s: No images appear on this page. %2$sAdd some%3$s!"
+					__(
+						"%1$sImage alt attributes%3$s: No images appear on this page. %2$sAdd some%3$s!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -143,12 +141,12 @@ export default class TextImagesAssessment extends Assessment {
 		if ( this.altProperties.withAlt > 0 ) {
 			return {
 				score: this._config.scores.withAlt,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sImage alt attributes%3$s: " +
-						"Images on this page have alt attributes, but you have not set your keyphrase. %2$sFix that%3$s!"
+						"Images on this page have alt attributes, but you have not set your keyphrase. %2$sFix that%3$s!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -161,13 +159,13 @@ export default class TextImagesAssessment extends Assessment {
 		if ( this.altProperties.withAltNonKeyword > 0 && this.altProperties.withAltKeyword === 0 ) {
 			return {
 				score: this._config.scores.withAltNonKeyword,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sImage alt attributes%3$s: " +
 						"Images on this page do not have alt attributes that reflect the topic of your text. " +
-						"%2$sAdd your keyphrase or synonyms to the alt tags of relevant images%3$s!"
+						"%2$sAdd your keyphrase or synonyms to the alt tags of relevant images%3$s!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -180,19 +178,19 @@ export default class TextImagesAssessment extends Assessment {
 		if ( this.hasTooFewMatches() ) {
 			return {
 				score: this._config.scores.withAltTooFewKeywordMatches,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$d expands to the number of images containing an alt attribute with the keyword,
 					 * %2$d expands to the total number of images, %3$s and %4$s expand to links on yoast.com,
 					 * %5$s expands to the anchor end tag. */
-					i18n.dngettext(
-						"js-text-analysis",
+					_n(
 						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, only %1$d has an alt attribute that " +
 						"reflects the topic of your text. " +
 						"%4$sAdd your keyphrase or synonyms to the alt tags of more relevant images%5$s!",
 						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, only %1$d have alt attributes that " +
 						"reflect the topic of your text. " +
 						"%4$sAdd your keyphrase or synonyms to the alt tags of more relevant images%5$s!",
-						this.altProperties.withAltKeyword
+						this.altProperties.withAltKeyword,
+						"wordpress-seo"
 					),
 					this.altProperties.withAltKeyword,
 					this.imageCount,
@@ -210,12 +208,12 @@ export default class TextImagesAssessment extends Assessment {
 		if ( this.hasGoodNumberOfMatches() ) {
 			return {
 				score: this._config.scores.withAltGoodNumberOfKeywordMatches,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s expands to a link on yoast.com,
 					 * %2$s expands to the anchor end tag. */
-					i18n.dgettext(
-						"js-text-analysis",
-						"%1$sImage alt attributes%2$s: Good job!"
+					__(
+						"%1$sImage alt attributes%2$s: Good job!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					"</a>"
@@ -226,15 +224,15 @@ export default class TextImagesAssessment extends Assessment {
 		if ( this.hasTooManyMatches() ) {
 			return {
 				score: this._config.scores.withAltTooManyKeywordMatches,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$d expands to the number of images containing an alt attribute with the keyword,
                      * %2$d expands to the total number of images, %3$s and %4$s expand to a link on yoast.com,
 					 * %5$s expands to the anchor end tag. */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%3$sImage alt attributes%5$s: Out of %2$d images on this page, %1$d have alt attributes with " +
 						"words from your keyphrase or synonyms. " +
-						"That's a bit much. %4$sOnly include the keyphrase or its synonyms when it really fits the image%5$s."
+						"That's a bit much. %4$sOnly include the keyphrase or its synonyms when it really fits the image%5$s.",
+						"wordpress-seo"
 					),
 					this.altProperties.withAltKeyword,
 					this.imageCount,
@@ -248,11 +246,14 @@ export default class TextImagesAssessment extends Assessment {
 		// Images, but no alt tags.
 		return {
 			score: this._config.scores.noAlt,
-			resultText: i18n.sprintf(
+			resultText: sprintf(
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-				i18n.dgettext( "js-text-analysis", "%1$sImage alt attributes%3$s: " +
+				__(
+					"%1$sImage alt attributes%3$s: " +
 					"Images on this page do not have alt attributes that reflect the topic of your text. " +
-					"%2$sAdd your keyphrase or synonyms to the alt tags of relevant images%3$s!" ),
+					"%2$sAdd your keyphrase or synonyms to the alt tags of relevant images%3$s!",
+					"wordpress-seo"
+				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,
 				"</a>"

--- a/packages/yoastseo/src/scoring/assessments/seo/TextLengthAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/TextLengthAssessment.js
@@ -1,3 +1,4 @@
+import { _n, sprintf } from "@wordpress/i18n";
 import { inRange, merge } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -46,14 +47,13 @@ export default class TextLengthAssessment extends Assessment {
 	 *
 	 * @param {Paper}       paper       The Paper object to assess.
 	 * @param {Researcher}  researcher  The Researcher object containing all available researches.
-	 * @param {Jed}         i18n        The locale object.
 	 *
 	 * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		const wordCount = researcher.getResearch( "wordCountInText" );
 		const assessmentResult = new AssessmentResult();
-		const calculatedResult = this.calculateResult( wordCount, i18n );
+		const calculatedResult = this.calculateResult( wordCount );
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
@@ -65,22 +65,22 @@ export default class TextLengthAssessment extends Assessment {
 	 * Returns the score and the appropriate feedback string based on the current word count.
 	 *
 	 * @param {number}  wordCount   The amount of words to be checked against.
-	 * @param {Jed}     i18n        The locale object.
 	 *
 	 * @returns {Object} The score and the feedback string.
 	 */
-	calculateResult( wordCount, i18n ) {
+	calculateResult( wordCount ) {
 		if ( wordCount >= this._config.recommendedMinimum ) {
 			return {
 				score: this._config.scores.recommendedMinimum,
-				resultText: i18n.sprintf(
-					i18n.dngettext(
-						"js-text-analysis",
-						/* Translators: %1$d expands to the number of words in the text,
-						%2$s expands to a link on yoast.com, %3$s expands to the anchor end tag */
+				resultText: sprintf(
+					/* Translators: %1$d expands to the number of words in the text,
+					%2$s expands to a link on yoast.com, %3$s expands to the anchor end tag */
+					_n(
 						"%2$sText length%3$s: The text contains %1$d word. Good job!",
 						"%2$sText length%3$s: The text contains %1$d words. Good job!",
-						wordCount ),
+						wordCount,
+						"wordpress-seo"
+					),
 					wordCount,
 					this._config.urlTitle,
 					"</a>"
@@ -97,23 +97,24 @@ export default class TextLengthAssessment extends Assessment {
 
 			return {
 				score: badScore,
-				resultText: i18n.sprintf(
-					i18n.dngettext(
-						"js-text-analysis",
-						/* Translators: %1$d expands to the number of words in the text,
-						%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+				resultText: sprintf(
+					/* Translators: %1$d expands to the number of words in the text,
+					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					_n(
 						"%2$sText length%4$s: The text contains %1$d word.",
 						"%2$sText length%4$s: The text contains %1$d words.",
-						wordCount
-					) + " " + i18n.dngettext(
-						"js-text-analysis",
-						/* Translators: The preceding sentence is "Text length: The text contains x words.",
-						%3$s expands to a link on yoast.com,
-						%4$s expands to the anchor end tag,
-						%5$d expands to the recommended minimum of words. */
+						wordCount,
+						"wordpress-seo"
+					) + " " +
+					/* Translators: The preceding sentence is "Text length: The text contains x words.",
+					%3$s expands to a link on yoast.com,
+					%4$s expands to the anchor end tag,
+					%5$d expands to the recommended minimum of words. */
+					_n(
 						"This is far below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
 						"This is far below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
-						this._config.recommendedMinimum
+						this._config.recommendedMinimum,
+						"wordpress-seo"
 					),
 					wordCount,
 					this._config.urlTitle,
@@ -128,23 +129,24 @@ export default class TextLengthAssessment extends Assessment {
 			if ( this._config.cornerstoneContent === false ) {
 				return {
 					score: this._config.scores.slightlyBelowMinimum,
-					resultText: i18n.sprintf(
-						i18n.dngettext(
-							"js-text-analysis",
-							/* Translators: %1$d expands to the number of words in the text,
-							%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					resultText: sprintf(
+						/* Translators: %1$d expands to the number of words in the text,
+						%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+						_n(
 							"%2$sText length%4$s: The text contains %1$d word.",
 							"%2$sText length%4$s: The text contains %1$d words.",
-							wordCount
-						) + " " + i18n.dngettext(
-							"js-text-analysis",
-							/* Translators: The preceding sentence is "Text length: The text contains x words.",
-							%3$s expands to a link on yoast.com,
-							%4$s expands to the anchor end tag,
-							%5$d expands to the recommended minimum of words. */
+							wordCount,
+							"wordpress-seo"
+						) + " " +
+						/* Translators: The preceding sentence is "Text length: The text contains x words.",
+						%3$s expands to a link on yoast.com,
+						%4$s expands to the anchor end tag,
+						%5$d expands to the recommended minimum of words. */
+						_n(
 							"This is slightly below the recommended minimum of %5$d word. %3$sAdd a bit more copy%4$s.",
 							"This is slightly below the recommended minimum of %5$d words. %3$sAdd a bit more copy%4$s.",
-							this._config.recommendedMinimum
+							this._config.recommendedMinimum,
+							"wordpress-seo"
 						),
 						wordCount,
 						this._config.urlTitle,
@@ -157,23 +159,24 @@ export default class TextLengthAssessment extends Assessment {
 
 			return {
 				score: this._config.scores.slightlyBelowMinimum,
-				resultText: i18n.sprintf(
-					i18n.dngettext(
-						"js-text-analysis",
-						/* Translators: %1$d expands to the number of words in the text,
-						%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+				resultText: sprintf(
+					/* Translators: %1$d expands to the number of words in the text,
+					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
+					_n(
 						"%2$sText length%4$s: The text contains %1$d word.",
 						"%2$sText length%4$s: The text contains %1$d words.",
-						wordCount
-					) + " " + i18n.dngettext(
-						"js-text-analysis",
-						/* Translators: The preceding sentence is "Text length: The text contains x words.",
-						%3$s expands to a link on yoast.com,
-						%4$s expands to the anchor end tag,
-						%5$d expands to the recommended minimum of words. */
+						wordCount,
+						"wordpress-seo"
+					) + " " +
+					/* Translators: The preceding sentence is "Text length: The text contains x words.",
+					%3$s expands to a link on yoast.com,
+					%4$s expands to the anchor end tag,
+					%5$d expands to the recommended minimum of words. */
+					_n(
 						"This is below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
 						"This is below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
-						this._config.recommendedMinimum
+						this._config.recommendedMinimum,
+						"wordpress-seo"
 					),
 					wordCount,
 					this._config.urlTitle,
@@ -186,23 +189,24 @@ export default class TextLengthAssessment extends Assessment {
 
 		return {
 			score: this._config.scores.belowMinimum,
-			resultText: i18n.sprintf(
-				i18n.dngettext(
-					"js-text-analysis",
+			resultText: sprintf(
+				_n(
 					/* Translators: %1$d expands to the number of words in the text,
 					%2$s expands to a link on yoast.com, %4$s expands to the anchor end tag. */
 					"%2$sText length%4$s: The text contains %1$d word.",
 					"%2$sText length%4$s: The text contains %1$d words.",
-					wordCount
-				) + " " + i18n.dngettext(
-					"js-text-analysis",
-					/* Translators: The preceding sentence is "Text length: The text contains x words.",
-					%3$s expands to a link on yoast.com,
-					%4$s expands to the anchor end tag,
-					%5$d expands to the recommended minimum of words. */
+					wordCount,
+					"wordpress-seo"
+				) + " " +
+				/* Translators: The preceding sentence is "Text length: The text contains x words.",
+				%3$s expands to a link on yoast.com,
+				%4$s expands to the anchor end tag,
+				%5$d expands to the recommended minimum of words. */
+				_n(
 					"This is below the recommended minimum of %5$d word. %3$sAdd more content%4$s.",
 					"This is below the recommended minimum of %5$d words. %3$sAdd more content%4$s.",
-					this._config.recommendedMinimum
+					this._config.recommendedMinimum,
+					"wordpress-seo"
 				),
 				wordCount,
 				this._config.urlTitle,

--- a/packages/yoastseo/src/scoring/assessments/seo/TitleKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/TitleKeywordAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { escape, merge } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -45,17 +46,16 @@ class TitleKeywordAssessment extends Assessment {
 	 *
 	 * @param {Paper}       paper       The Paper object to assess.
 	 * @param {Researcher}  researcher  The Researcher object containing all available researches.
-	 * @param {Jed}         i18n        The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The result of the assessment with text and score.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		this._keywordMatches = researcher.getResearch( "findKeywordInPageTitle" );
 		this._keyword = escape( paper.getKeyword() );
 
 		const assessmentResult = new AssessmentResult();
 
-		const calculatedResult = this.calculateResult( i18n, this._keyword );
+		const calculatedResult = this.calculateResult( this._keyword );
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
 
@@ -78,12 +78,11 @@ class TitleKeywordAssessment extends Assessment {
 	 * an exact match of the keyword is found in the beginning of the title. Returns OK results if all content words
 	 * from the keyphrase are in the title (in any form). Returns BAD otherwise.
 	 *
-	 * @param {Jed}     i18n        The object used for translations.
 	 * @param {string}  keyword     The keyword of the paper (to be returned in the feedback strings).
 	 *
 	 * @returns {Object} Object with score and text.
 	 */
-	calculateResult( i18n, keyword ) {
+	calculateResult( keyword ) {
 		const exactMatchFound = this._keywordMatches.exactMatchFound;
 		const position = this._keywordMatches.position;
 		const allWordsFound = this._keywordMatches.allWordsFound;
@@ -93,13 +92,13 @@ class TitleKeywordAssessment extends Assessment {
 			if ( position === 0 ) {
 				return {
 					score: this._config.scores.good,
-					resultText: i18n.sprintf(
+					resultText: sprintf(
 						/* Translators: %1$s expands to a link on yoast.com,
 						%2$s expands to the anchor end tag. */
-						i18n.dgettext(
-							"js-text-analysis",
+						__(
 							"%1$sKeyphrase in title%2$s: The exact match of the focus keyphrase appears at the beginning " +
-							"of the SEO title. Good job!"
+							"of the SEO title. Good job!",
+							"wordpress-seo"
 						),
 						this._config.urlTitle,
 						"</a>"
@@ -108,13 +107,13 @@ class TitleKeywordAssessment extends Assessment {
 			}
 			return {
 				score: this._config.scores.okay,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to a link on yoast.com,
 					%3$s expands to the anchor end tag. */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sKeyphrase in title%3$s: The exact match of the focus keyphrase appears in the SEO title, but not " +
-						"at the beginning. %2$sMove it to the beginning for the best results%3$s."
+						"at the beginning. %2$sMove it to the beginning for the best results%3$s.",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -126,13 +125,13 @@ class TitleKeywordAssessment extends Assessment {
 		if ( allWordsFound ) {
 			return {
 				score: this._config.scores.okay,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to a link on yoast.com,
 					%3$s expands to the anchor end tag. */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sKeyphrase in title%3$s: Does not contain the exact match. %2$sTry to write the exact match of " +
-						"your keyphrase in the SEO title and put it at the beginning of the title%3$s."
+						"your keyphrase in the SEO title and put it at the beginning of the title%3$s.",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -144,13 +143,13 @@ class TitleKeywordAssessment extends Assessment {
 		if ( exactMatchKeyphrase ) {
 			return {
 				score: this._config.scores.bad,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators: %1$s and %2$s expand to a link on yoast.com,
 					%3$s expands to the anchor end tag. */
-					i18n.dgettext(
-						"js-text-analysis",
+					__(
 						"%1$sKeyphrase in title%3$s: Does not contain the exact match. %2$sTry to write the exact match of " +
-						"your keyphrase in the SEO title and put it at the beginning of the title%3$s."
+						"your keyphrase in the SEO title and put it at the beginning of the title%3$s.",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -162,14 +161,14 @@ class TitleKeywordAssessment extends Assessment {
 
 		return {
 			score: this._config.scores.bad,
-			resultText: i18n.sprintf(
+			resultText: sprintf(
 				/* Translators: %1$s and %2$s expand to a link on yoast.com,
 				%3$s expands to the anchor end tag, %4$s expands to the keyword of the article. */
-				i18n.dgettext(
-					"js-text-analysis",
+				__(
 					"%1$sKeyphrase in title%3$s: Not all the words from your keyphrase \"%4$s\" appear in the SEO title. " +
 					"%2$sFor the best SEO results write the exact match of your keyphrase in the SEO title, and put " +
-					"the keyphrase at the beginning of the title%3$s."
+					"the keyphrase at the beginning of the title%3$s.",
+					"wordpress-seo"
 				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,

--- a/packages/yoastseo/src/scoring/assessments/seo/UrlKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/UrlKeywordAssessment.js
@@ -1,3 +1,4 @@
+import { __, sprintf } from "@wordpress/i18n";
 import { merge } from "lodash-es";
 
 import Assessment from "../assessment";
@@ -39,16 +40,15 @@ class UrlKeywordAssessment extends Assessment {
 	 *
 	 * @param {Paper}       paper       The Paper object to assess.
 	 * @param {Researcher}  researcher  The Researcher object containing all available researches.
-	 * @param {Jed}         i18n        The object used for translations.
 	 *
 	 * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
 	 */
-	getResult( paper, researcher, i18n ) {
+	getResult( paper, researcher ) {
 		this._keywordInURL = researcher.getResearch( "keywordCountInUrl" );
 
 		const assessmentResult = new AssessmentResult();
 
-		const calculatedResult = this.calculateResult( i18n );
+		const calculatedResult = this.calculateResult();
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
 
@@ -69,20 +69,19 @@ class UrlKeywordAssessment extends Assessment {
 	/**
 	 * Determines the score and the result text based on whether or not there's a keyword in the url.
 	 *
-	 * @param {Jed} i18n The object used for translations.
 	 *
 	 * @returns {Object} The object with calculated score and resultText.
 	 */
-	calculateResult( i18n ) {
+	calculateResult() {
 		if ( this._keywordInURL.keyphraseLength < 3 ) {
 			if ( this._keywordInURL.percentWordMatches === 100 ) {
 				return {
 					score: this._config.scores.good,
-					resultText: i18n.sprintf(
+					resultText: sprintf(
 						/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-						i18n.dgettext(
-							"js-text-analysis",
-							"%1$sKeyphrase in slug%2$s: Great work!"
+						__(
+							"%1$sKeyphrase in slug%2$s: Great work!",
+							"wordpress-seo"
 						),
 						this._config.urlTitle,
 						"</a>"
@@ -92,11 +91,11 @@ class UrlKeywordAssessment extends Assessment {
 
 			return {
 				score: this._config.scores.okay,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators:  %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-					i18n.dgettext(
-						"js-text-analysis",
-						"%1$sKeyphrase in slug%3$s: (Part of) your keyphrase does not appear in the slug. %2$sChange that%3$s!"
+					__(
+						"%1$sKeyphrase in slug%3$s: (Part of) your keyphrase does not appear in the slug. %2$sChange that%3$s!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -108,11 +107,11 @@ class UrlKeywordAssessment extends Assessment {
 		if ( this._keywordInURL.percentWordMatches > 50 ) {
 			return {
 				score: this._config.scores.good,
-				resultText: i18n.sprintf(
+				resultText: sprintf(
 					/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
-					i18n.dgettext(
-						"js-text-analysis",
-						"%1$sKeyphrase in slug%2$s: More than half of your keyphrase appears in the slug. That's great!"
+					__(
+						"%1$sKeyphrase in slug%2$s: More than half of your keyphrase appears in the slug. That's great!",
+						"wordpress-seo"
 					),
 					this._config.urlTitle,
 					"</a>"
@@ -121,11 +120,11 @@ class UrlKeywordAssessment extends Assessment {
 		}
 		return {
 			score: this._config.scores.okay,
-			resultText: i18n.sprintf(
+			resultText: sprintf(
 				/* Translators:  %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
-				i18n.dgettext(
-					"js-text-analysis",
-					"%1$sKeyphrase in slug%3$s: (Part of) your keyphrase does not appear in the slug. %2$sChange that%3$s!"
+				__(
+					"%1$sKeyphrase in slug%3$s: (Part of) your keyphrase does not appear in the slug. %2$sChange that%3$s!",
+					"wordpress-seo"
 				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,

--- a/packages/yoastseo/src/scoring/assessor.js
+++ b/packages/yoastseo/src/scoring/assessor.js
@@ -3,6 +3,7 @@ import removeDuplicateMarks from "../markers/removeDuplicateMarks";
 import AssessmentResult from "../values/AssessmentResult.js";
 import { showTrace } from "../helpers/errors.js";
 
+import { __, sprintf } from "@wordpress/i18n";
 import { isUndefined } from "lodash-es";
 import { isFunction } from "lodash-es";
 import { forEach } from "lodash-es";
@@ -16,34 +17,18 @@ const ScoreRating = 9;
 /**
  * Creates the Assessor.
  *
- * @param {Object} i18n             The i18n object used for translations.
  * @param {Object} researcher       The researcher to use in the assessor.
  * @param {Object} options          The options for this assessor.
  * @param {Object} options.marker   The marker to pass the list of marks to.
  *
  * @constructor
  */
-const Assessor = function( i18n, researcher, options ) {
+const Assessor = function( researcher, options ) {
 	this.type = "Assessor";
-	this.setI18n( i18n );
 	this.setResearcher( researcher );
 	this._assessments = [];
 
 	this._options = options || {};
-};
-
-/**
- * Checks if the i18n object is defined and sets it.
- *
- * @param {Object} i18n The i18n object used for translations.
- * @throws {MissingArgument} Parameter needs to be a valid i18n object.
- * @returns {void}
- */
-Assessor.prototype.setI18n = function( i18n ) {
-	if ( isUndefined( i18n ) ) {
-		throw new MissingArgument( "The assessor requires an i18n object." );
-	}
-	this.i18n = i18n;
 };
 
 /**
@@ -185,7 +170,7 @@ Assessor.prototype.executeAssessment = function( paper, researcher, assessment )
 	var result;
 
 	try {
-		result = assessment.getResult( paper, researcher, this.i18n );
+		result = assessment.getResult( paper, researcher );
 		result.setIdentifier( assessment.identifier );
 
 		if ( result.hasMarks() ) {
@@ -204,9 +189,9 @@ Assessor.prototype.executeAssessment = function( paper, researcher, assessment )
 		result = new AssessmentResult();
 
 		result.setScore( -1 );
-		result.setText( this.i18n.sprintf(
+		result.setText( sprintf(
 			/* Translators: %1$s expands to the name of the assessment. */
-			this.i18n.dgettext( "js-text-analysis", "An error occurred in the '%1$s' assessment" ),
+			__( "An error occurred in the '%1$s' assessment", "wordpress-seo" ),
 			assessment.identifier,
 			assessmentError
 		) );

--- a/packages/yoastseo/src/scoring/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/contentAssessor.js
@@ -23,15 +23,14 @@ import { sum } from "lodash-es";
 /**
  * Creates the Assessor
  *
- * @param {object}  i18n            The i18n object used for translations.
  * @param {object}  researcher      The researcher to use for the analysis.
  * @param {Object}  options         The options for this assessor.
  * @param {Object}  options.marker  The marker to pass the list of marks to.
  *
  * @constructor
  */
-const ContentAssessor = function( i18n, researcher, options = {} ) {
-	Assessor.call( this, i18n, researcher, options );
+const ContentAssessor = function( researcher, options = {} ) {
+	Assessor.call( this, researcher, options );
 	this.type = "ContentAssessor";
 	this._assessments = [
 

--- a/packages/yoastseo/src/scoring/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/cornerstone/contentAssessor.js
@@ -19,14 +19,13 @@ import textPresence from "../assessments/readability/textPresenceAssessment.js";
 /**
  * Creates the Assessor
  *
- * @param {object} i18n The i18n object used for translations.
  * @param {Object} options The options for this assessor.
  * @param {Object} options.marker The marker to pass the list of marks to.
  *
  * @constructor
  */
-const CornerStoneContentAssessor = function( i18n, options = {} ) {
-	Assessor.call( this, i18n, options );
+const CornerStoneContentAssessor = function( options = {} ) {
+	Assessor.call( this, options );
 	this.type = "CornerstoneContentAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/scoring/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/cornerstone/relatedKeywordAssessor.js
@@ -12,14 +12,13 @@ import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphras
 /**
  * Creates the Assessor
  *
- * @param {object} i18n The i18n object used for translations.
  * @param {Object} options The options for this assessor.
  * @param {Object} options.marker The marker to pass the list of marks to.
  *
  * @constructor
  */
-const relatedKeywordAssessor = function( i18n, options ) {
-	Assessor.call( this, i18n, options );
+const relatedKeywordAssessor = function( options ) {
+	Assessor.call( this, options );
 
 	this._assessments = [
 		new IntroductionKeyword(),

--- a/packages/yoastseo/src/scoring/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/cornerstone/seoAssessor.js
@@ -22,14 +22,13 @@ import SingleH1Assessment from "../assessments/seo/SingleH1Assessment";
 /**
  * Creates the Assessor
  *
- * @param {Object} i18n The i18n object used for translations.
  * @param {Object} options The options for this assessor.
  * @param {Object} options.marker The marker to pass the list of marks to.
  *
  * @constructor
  */
-const CornerstoneSEOAssessor = function( i18n, options ) {
-	Assessor.call( this, i18n, options );
+const CornerstoneSEOAssessor = function( options ) {
+	Assessor.call( this, options );
 	this.type = "CornerstoneSEOAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/scoring/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/relatedKeywordAssessor.js
@@ -12,15 +12,14 @@ import FunctionWordsInKeyphrase from "./assessments/seo/FunctionWordsInKeyphrase
 /**
  * Creates the Assessor
  *
- * @param {object}  i18n            The i18n object used for translations.
  * @param {object}  researcher      The researcher to use for the analysis.
  * @param {Object}  options         The options for this assessor.
  * @param {Object}  options.marker  The marker to pass the list of marks to.
  *
  * @constructor
  */
-const relatedKeywordAssessor = function( i18n, researcher, options ) {
-	Assessor.call( this, i18n, researcher, options );
+const relatedKeywordAssessor = function( researcher, options ) {
+	Assessor.call( this, researcher, options );
 
 	this._assessments = [
 		new IntroductionKeyword(),

--- a/packages/yoastseo/src/scoring/relatedKeywordTaxonomyAssessor.js
+++ b/packages/yoastseo/src/scoring/relatedKeywordTaxonomyAssessor.js
@@ -10,14 +10,13 @@ import FunctionWordsInKeyphrase from "./assessments/seo/FunctionWordsInKeyphrase
 /**
  * Creates the Assessor used for taxonomy pages.
  *
- * @param {object}  i18n        The i18n object used for translations.
  * @param {object}  researcher  The researcher to use for the analysis.
  * @param {Object}  options     The options for this assessor.
  *
  * @constructor
  */
-const RelatedKeywordTaxonomyAssessor = function( i18n, researcher, options ) {
-	Assessor.call( this, i18n, researcher, options );
+const RelatedKeywordTaxonomyAssessor = function( researcher, options ) {
+	Assessor.call( this, researcher, options );
 	this.type = "RelatedKeywordsTaxonomyAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/scoring/renderers/AssessorPresenter.js
+++ b/packages/yoastseo/src/scoring/renderers/AssessorPresenter.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { forEach } from "lodash-es";
 import { isNumber } from "lodash-es";
 import { isObject } from "lodash-es";
@@ -16,17 +17,15 @@ import createConfig from "../../config/presenter.js";
  * @param {string} args.targets.overall The HTML element to render the overall rating out to.
  * @param {string} args.keyword The keyword to use for checking, when calculating the overall rating.
  * @param {SEOAssessor} args.assessor The Assessor object to retrieve assessment results from.
- * @param {Jed} args.i18n The translation object.
  *
  * @constructor
  */
 var AssessorPresenter = function( args ) {
 	this.keyword = args.keyword;
 	this.assessor = args.assessor;
-	this.i18n = args.i18n;
 	this.output = args.targets.output;
 	this.overall = args.targets.overall || "overallScore";
-	this.presenterConfig = createConfig( args.i18n );
+	this.presenterConfig = createConfig();
 
 	this._disableMarkerButtons = false;
 
@@ -347,9 +346,9 @@ AssessorPresenter.prototype.renderIndividualRatings = function() {
 	outputTarget.innerHTML = template( {
 		scores: scores,
 		i18n: {
-			disabledMarkText: this.i18n.dgettext( "js-text-analysis", "Marks are disabled in current view" ),
-			markInText: this.i18n.dgettext( "js-text-analysis", "Mark this result in the text" ),
-			removeMarksInText: this.i18n.dgettext( "js-text-analysis", "Remove marks in the text" ),
+			disabledMarkText: __( "Marks are disabled in current view", "wordpress-seo" ),
+			markInText: __( "Mark this result in the text", "wordpress-seo" ),
+			removeMarksInText: __( "Remove marks in the text", "wordpress-seo" ),
 		},
 		activeMarker: this._activeMarker,
 		markerButtonsDisabled: this._disableMarkerButtons,

--- a/packages/yoastseo/src/scoring/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/seoAssessor.js
@@ -20,15 +20,14 @@ import SingleH1Assessment from "./assessments/seo/SingleH1Assessment";
 /**
  * Creates the Assessor
  *
- * @param {object}  i18n            The i18n object used for translations.
  * @param {object}  researcher      The researcher to use for the analysis.
  * @param {Object}  options         The options for this assessor.
  * @param {Object}  options.marker  The marker to pass the list of marks to.
  *
  * @constructor
  */
-const SEOAssessor = function( i18n, researcher,  options ) {
-	Assessor.call( this, i18n, researcher, options );
+const SEOAssessor = function( researcher,  options ) {
+	Assessor.call( this, researcher, options );
 	this.type = "SEOAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/scoring/taxonomyAssessor.js
+++ b/packages/yoastseo/src/scoring/taxonomyAssessor.js
@@ -34,13 +34,12 @@ export const getTextLengthAssessment = function() {
 /**
  * Creates the Assessor used for taxonomy pages.
  *
- * @param {object} i18n         The i18n object used for translations.
  * @param {object} researcher   The researcher used for the analysis.
  * @param {Object} options      The options for this assessor.
  * @constructor
  */
-const TaxonomyAssessor = function( i18n, researcher, options ) {
-	Assessor.call( this, i18n, researcher, options );
+const TaxonomyAssessor = function( researcher, options ) {
+	Assessor.call( this, researcher, options );
 	this.type = "TaxonomyAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/snippetPreview/snippetPreview.js
+++ b/packages/yoastseo/src/snippetPreview/snippetPreview.js
@@ -1,3 +1,4 @@
+import { __ } from "@wordpress/i18n";
 import { isEmpty } from "lodash-es";
 import { isElement } from "lodash-es";
 import { isUndefined } from "lodash-es";
@@ -265,12 +266,9 @@ function updateProgressBar( element, value, maximum, rating ) {
  * @param {boolean}        opts.addTrailingSlash          - Whether or not to add a trailing slash to the URL.
  * @param {string}         opts.metaDescriptionDate       - The date to display before the meta description.
  *
- * @param {Jed}            opts.i18n                      - The translation object.
- *
  * @param {string}         opts.previewMode               - The current preview mode.
  *
  * @property {App}         refObj                         - The connected app object.
- * @property {Jed}         i18n                           - The translation object.
  *
  * @property {HTMLElement} targetElement                  - The target element that contains this snippet editor.
  *
@@ -313,7 +311,6 @@ var SnippetPreview = function( opts ) {
 
 	if ( ! isUndefined( opts.analyzerApp ) ) {
 		this.refObj = opts.analyzerApp;
-		this.i18n = this.refObj.i18n;
 
 		this.data = {
 			title: this.refObj.rawData.snippetTitle || "",
@@ -325,10 +322,6 @@ var SnippetPreview = function( opts ) {
 		if ( ! isEmpty( this.refObj.rawData.metaTitle ) ) {
 			opts.placeholder.title = this.refObj.rawData.metaTitle;
 		}
-	}
-
-	if ( ! isUndefined( opts.i18n ) ) {
-		this.i18n = opts.i18n;
 	}
 
 	if ( ! isElement( opts.targetElement ) ) {
@@ -377,22 +370,22 @@ SnippetPreview.prototype.renderTemplate = function() {
 		metaDescriptionDate: this.opts.metaDescriptionDate,
 		placeholder: this.opts.placeholder,
 		i18n: {
-			edit: this.i18n.dgettext( "js-text-analysis", "Edit snippet" ),
-			title: this.i18n.dgettext( "js-text-analysis", "SEO title" ),
-			slug: this.i18n.dgettext( "js-text-analysis", "Slug" ),
-			metaDescription: this.i18n.dgettext( "js-text-analysis", "Meta description" ),
-			save: this.i18n.dgettext( "js-text-analysis", "Close snippet editor" ),
-			snippetPreview: this.i18n.dgettext( "js-text-analysis", "Google preview" ),
-			titleLabel: this.i18n.dgettext( "js-text-analysis", "SEO title preview:" ),
-			slugLabel: this.i18n.dgettext( "js-text-analysis", "Slug preview:" ),
-			metaDescriptionLabel: this.i18n.dgettext( "js-text-analysis", "Meta description preview:" ),
-			snippetPreviewDescription: this.i18n.dgettext(
-				"js-text-analysis",
-				"You can click on each element in the preview to jump to the Snippet Editor."
+			edit: __( "Edit snippet", "wordpress-seo" ),
+			title: __( "SEO title", "wordpress-seo" ),
+			slug: __( "Slug", "wordpress-seo" ),
+			metaDescription: __( "Meta description", "wordpress-seo" ),
+			save: __( "Close snippet editor", "wordpress-seo" ),
+			snippetPreview: __( "Google preview", "wordpress-seo" ),
+			titleLabel: __( "SEO title preview:", "wordpress-seo" ),
+			slugLabel: __( "Slug preview:", "wordpress-seo" ),
+			metaDescriptionLabel: __( "Meta description preview:", "wordpress-seo" ),
+			snippetPreviewDescription: __(
+				"You can click on each element in the preview to jump to the Snippet Editor.",
+				"wordpress-seo"
 			),
-			desktopPreviewMode: this.i18n.dgettext( "js-text-analysis", "Desktop preview" ),
-			mobilePreviewMode: this.i18n.dgettext( "js-text-analysis", "Mobile preview" ),
-			isScrollableHint: this.i18n.dgettext( "js-text-analysis", "Scroll to see the preview content." ),
+			desktopPreviewMode: __( "Desktop preview", "wordpress-seo" ),
+			mobilePreviewMode: __( "Mobile preview", "wordpress-seo" ),
+			isScrollableHint: __( "Scroll to see the preview content.", "wordpress-seo" ),
 		},
 	} );
 
@@ -607,7 +600,7 @@ SnippetPreview.prototype.formatTitle = function() {
 
 	// As an ultimate fallback provide the user with a helpful message.
 	if ( isEmpty( title ) ) {
-		title = this.i18n.dgettext( "js-text-analysis", "Please provide an SEO title by editing the snippet below." );
+		title = __( "Please provide an SEO title by editing the snippet below.", "wordpress-seo" );
 	}
 
 	return title;
@@ -685,7 +678,7 @@ SnippetPreview.prototype.formatMeta = function() {
 
 	// As an ultimate fallback provide the user with a helpful message.
 	if ( isEmpty( meta ) ) {
-		meta = this.i18n.dgettext( "js-text-analysis", "Please provide a meta description by editing the snippet below." );
+		meta = __( "Please provide a meta description by editing the snippet below.", "wordpress-seo" );
 	}
 
 	return meta;

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -1,7 +1,7 @@
 // External dependencies.
 import { autop } from "@wordpress/autop";
 import { enableFeatures } from "@yoast/feature-flag";
-import Jed from "jed";
+import { __, sprintf } from "@wordpress/i18n";
 import { forEach, has, includes, isNull, isObject, isString, isUndefined, merge, pickBy, isEmpty } from "lodash-es";
 import { getLogger } from "loglevel";
 
@@ -68,7 +68,6 @@ export default class AnalysisWebWorker {
 		this._paper = null;
 		this._relatedKeywords = {};
 
-		this._i18n = AnalysisWebWorker.createI18n();
 		this._researcher = researcher;
 
 		this._contentAssessor = null;
@@ -317,8 +316,8 @@ export default class AnalysisWebWorker {
 		}
 
 		const assessor = useCornerstone === true
-			? new CornerstoneContentAssessor( this._i18n, this._researcher )
-			: new ContentAssessor( this._i18n, this._researcher );
+			? new CornerstoneContentAssessor( this._researcher )
+			: new ContentAssessor( this._researcher );
 
 		return assessor;
 	}
@@ -345,11 +344,11 @@ export default class AnalysisWebWorker {
 		let assessor;
 
 		if ( useTaxonomy === true ) {
-			assessor = new TaxonomyAssessor( this._i18n, this._researcher );
+			assessor = new TaxonomyAssessor( this._researcher );
 		} else {
 			assessor = useCornerstone === true
-				? new CornerstoneSEOAssessor( this._i18n, this._researcher )
-				: new SEOAssessor( this._i18n, this._researcher );
+				? new CornerstoneSEOAssessor( this._researcher )
+				: new SEOAssessor( this._researcher );
 		}
 
 
@@ -387,11 +386,11 @@ export default class AnalysisWebWorker {
 		let assessor;
 
 		if ( useTaxonomy === true ) {
-			assessor = new RelatedKeywordTaxonomyAssessor( this._i18n, this._researcher );
+			assessor = new RelatedKeywordTaxonomyAssessor( this._researcher );
 		} else {
 			assessor = useCornerstone === true
-				? new CornerstoneRelatedKeywordAssessor( this._i18n, this._researcher )
-				: new RelatedKeywordAssessor( this._i18n, this._researcher );
+				? new CornerstoneRelatedKeywordAssessor( this._researcher )
+				: new RelatedKeywordAssessor( this._researcher );
 		}
 
 		this._registeredAssessments.forEach( ( { name, assessment } ) => {
@@ -416,7 +415,7 @@ export default class AnalysisWebWorker {
 	/*
 	 * Disabled code:
 	 * createSEOTreeAssessor( assessorConfig ) {
-	 * 	 return constructSEOAssessor( this._i18n, this._treeResearcher, assessorConfig );
+	 * 	 return constructSEOAssessor( this._treeResearcher, assessorConfig );
 	 * }
 	 */
 
@@ -483,11 +482,6 @@ export default class AnalysisWebWorker {
 	initialize( id, configuration ) {
 		const update = AnalysisWebWorker.shouldAssessorsUpdate( configuration, this._contentAssessor, this._seoAssessor );
 
-		if ( has( configuration, "translations" ) ) {
-			this._i18n = AnalysisWebWorker.createI18n( configuration.translations );
-			delete configuration.translations;
-		}
-
 		if ( has( configuration, "researchData" ) ) {
 			forEach( configuration.researchData, ( data, research ) => {
 				this._researcher.addResearchData( research, data );
@@ -517,7 +511,7 @@ export default class AnalysisWebWorker {
 			this._contentAssessor = this.createContentAssessor();
 			/*
 			 * Disabled code:
-			 * this._contentTreeAssessor = constructReadabilityAssessor( this._i18n, this._treeResearcher, configuration.useCornerstone );
+			 * this._contentTreeAssessor = constructReadabilityAssessor( this._treeResearcher, configuration.useCornerstone );
 			 */
 			this._contentTreeAssessor = null;
 		}
@@ -880,9 +874,9 @@ export default class AnalysisWebWorker {
 		const result = new AssessmentResult();
 
 		result.setScore( -1 );
-		result.setText( this._i18n.sprintf(
+		result.setText( sprintf(
 			/* Translators: %1$s expands to the name of the assessment. */
-			this._i18n.dgettext( "js-text-analysis", "An error occurred in the '%1$s' assessment" ),
+			__( "An error occurred in the '%1$s' assessment", "wordpress-seo" ),
 			assessment.name
 		) );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* First pass at replacing Jed with WP i18n. This is still work in progress.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allows for the content analysis JavaScript strings to be uploaded automatically to translate.wordpress.org via the JS translations pipeline.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
