### PR TITLE
P3-623 Add Premium badge to social templates forms

### DIFF
--- a/admin/menu/class-replacevar-editor.php
+++ b/admin/menu/class-replacevar-editor.php
@@ -30,6 +30,7 @@ class WPSEO_Replacevar_Editor {
 	 *      @type string $label_description       Optional. The label to use for the description field.
 	 *      @type string $description_placeholder Optional. The placeholder text to use for the description field.
 	 *      @type bool   $has_new_badge           Optional. Whether to show the "New" badge.
+	 *      @type bool   $has_premium_badge       Optional. Whether to show the "Premium" badge.
 	 * }
 	 */
 	private $arguments;
@@ -50,6 +51,7 @@ class WPSEO_Replacevar_Editor {
 	 *      @type string $label_description       Optional. The label to use for the description field.
 	 *      @type string $description_placeholder Optional. The placeholder text to use for the description field.
 	 *      @type bool   $has_new_badge           Optional. Whether to show the "New" badge.
+	 *      @type bool   $has_premium_badge       Optional. Whether to show the "Premium" badge.
 	 * }
 	 */
 	public function __construct( Yoast_Form $yform, $arguments ) {
@@ -61,7 +63,8 @@ class WPSEO_Replacevar_Editor {
 				'label_description'       => '',
 				'description_placeholder' => '',
 				'has_new_badge'           => false,
-				'is_disabled'             => false
+				'is_disabled'             => false,
+				'has_premium_badge'       => false,
 			]
 		);
 
@@ -79,6 +82,7 @@ class WPSEO_Replacevar_Editor {
 			'description_placeholder' => (string) $arguments['description_placeholder'],
 			'has_new_badge'           => (bool) $arguments['has_new_badge'],
 			'is_disabled'             => (bool) $arguments['is_disabled'],
+			'has_premium_badge'       => (bool) $arguments['has_premium_badge'],
 		];
 	}
 
@@ -105,7 +109,9 @@ class WPSEO_Replacevar_Editor {
 				data-react-replacevar-label-description="%7$s"
 				data-react-replacevar-description-placeholder="%8$s"
 				data-react-replacevar-has-new-badge="%9$s"
-				data-react-replacevar-is-disabled="%10$s"></div>',
+				data-react-replacevar-is-disabled="%10$s"
+				data-react-replacevar-has-premium-badge="%11$s"
+			></div>',
 			esc_attr( $this->arguments['title'] ),
 			esc_attr( $this->arguments['description'] ),
 			esc_attr( $this->arguments['page_type_recommended'] ),
@@ -115,7 +121,8 @@ class WPSEO_Replacevar_Editor {
 			esc_attr( $this->arguments['label_description'] ),
 			esc_attr( $this->arguments['description_placeholder'] ),
 			esc_attr( $this->arguments['has_new_badge'] ),
-			esc_attr( $this->arguments['is_disabled'] )
+			esc_attr( $this->arguments['is_disabled'] ),
+			esc_attr( $this->arguments['has_premium_badge'] )
 		);
 	}
 

--- a/packages/components/src/Label.js
+++ b/packages/components/src/Label.js
@@ -6,8 +6,6 @@ import styled from "styled-components";
  * A div element that looks like it can be interacted with like a label.
  */
 export const SimulatedLabel = styled.div`
-	flex: 1 1 200px;
-	min-width: 200px;
 	cursor: pointer;
 	font-size: 14px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;

--- a/packages/components/src/badges/badge.css
+++ b/packages/components/src/badges/badge.css
@@ -1,0 +1,14 @@
+.yoast-badge {
+	display: inline-block;
+	min-height: 16px;
+	padding: 0 8px;
+	border-radius: 8px;
+	font-weight: 600;
+	font-size: 10px;
+	line-height: 1.6;
+}
+
+.yoast-badge__in-label {
+	margin-left: 8px;
+	vertical-align: text-top;
+}

--- a/packages/components/src/field-group/FieldGroup.js
+++ b/packages/components/src/field-group/FieldGroup.js
@@ -23,7 +23,18 @@ import PremiumBadge from "../premium-badge/PremiumBadge";
  *
  * @returns {React.Component} A div with a label, icon and optional description that renders all children.
  */
-const FieldGroup = ( { htmlFor, label, linkTo, linkText, description, children, wrapperClassName, titleClassName, hasNewBadge, hasPremiumBadge } ) => {
+const FieldGroup = ( {
+	htmlFor,
+	label,
+	linkTo,
+	linkText,
+	description,
+	children,
+	wrapperClassName,
+	titleClassName,
+	hasNewBadge,
+	hasPremiumBadge,
+} ) => {
 	const titleComponent = htmlFor
 		? <label htmlFor={ htmlFor }>{ label }</label>
 		: <b>{ label }</b>;

--- a/packages/components/src/field-group/FieldGroup.js
+++ b/packages/components/src/field-group/FieldGroup.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import "./field-group.css";
 import HelpIcon, { helpIconDefaultProps, helpIconProps } from "../help-icon/HelpIcon";
 import NewBadge from "../new-badge/NewBadge";
+import PremiumBadge from "../premium-badge/PremiumBadge";
 
 /**
  * FieldGroup component that can be used to wrap our form elements in.
@@ -18,10 +19,11 @@ import NewBadge from "../new-badge/NewBadge";
  * @param {string} wrapperClassName Optional: A classname for the FieldGroup's outer div. Default is "yoast-field-group".
  * @param {string} titleClassName   Optional: A classname for the FieldGroup's title div. Default is "yoast-field-group__title".
  * @param {bool}   hasNewBadge      Optional: Whether the FieldGroup has a 'New' Badge.
+ * @param {bool}   hasPremiumBadge  Optional: Whether the FieldGroup has a 'Premium' Badge.
  *
  * @returns {React.Component} A div with a label, icon and optional description that renders all children.
  */
-const FieldGroup = ( { htmlFor, label, linkTo, linkText, description, children, wrapperClassName, titleClassName, hasNewBadge } ) => {
+const FieldGroup = ( { htmlFor, label, linkTo, linkText, description, children, wrapperClassName, titleClassName, hasNewBadge, hasPremiumBadge } ) => {
 	const titleComponent = htmlFor
 		? <label htmlFor={ htmlFor }>{ label }</label>
 		: <b>{ label }</b>;
@@ -29,6 +31,7 @@ const FieldGroup = ( { htmlFor, label, linkTo, linkText, description, children, 
 		<div className={ wrapperClassName }>
 			{ label !== "" && <div className={ titleClassName }>
 				{ titleComponent }
+				{ hasPremiumBadge && <PremiumBadge inLabel={ true } /> }
 				{ hasNewBadge && <NewBadge inLabel={ true } /> }
 				{ linkTo !== "" && <HelpIcon
 					linkTo={ linkTo }

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -39,6 +39,7 @@ function ImageSelect( props ) {
 			<FieldGroup
 				label={ props.label }
 				hasNewBadge={ props.hasNewBadge }
+				hasPremiumBadge={ props.hasPremiumBadge }
 			>
 				{ props.hasPreview &&
 					<button
@@ -82,6 +83,7 @@ ImageSelect.propTypes = {
 	warnings: PropTypes.arrayOf( PropTypes.string ),
 	hasNewBadge: PropTypes.bool,
 	isDisabled: PropTypes.bool,
+	hasPremiumBadge: PropTypes.bool,
 };
 
 ImageSelect.defaultProps = {
@@ -98,4 +100,5 @@ ImageSelect.defaultProps = {
 	warnings: [],
 	hasNewBadge: false,
 	isDisabled: false,
+	hasPremiumBadge: false,
 };

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -17,6 +17,7 @@ export * from "./star-rating";
 export * from "./help-icon";
 export * from "./tables";
 export * from "./new-badge";
+export * from "./premium-badge";
 
 // Referenced index.js explicitly due to case-sensitive path conflicts.
 export * from "./toggle/index.js";

--- a/packages/components/src/new-badge/NewBadge.js
+++ b/packages/components/src/new-badge/NewBadge.js
@@ -5,7 +5,7 @@ import { __ } from "@wordpress/i18n";
 /**
  * Function for the NewBadge component.
  *
- * @param {bool} inLabel Whether the NewBadge is within a Label.
+ * @param {bool} inLabel Whether the NewBadge is displayed close to a Label.
  *
  * @returns {React.Component} The NewBadge.
  */

--- a/packages/components/src/new-badge/index.js
+++ b/packages/components/src/new-badge/index.js
@@ -1,2 +1,3 @@
+import "../badges/badge.css";
 import "./new-badge.css";
 export { default as NewBadge } from "./NewBadge";

--- a/packages/components/src/new-badge/new-badge.css
+++ b/packages/components/src/new-badge/new-badge.css
@@ -1,19 +1,4 @@
-.yoast-badge {
-	display: inline-block;
-	min-height: 16px;
-	padding: 0 8px;
-	border-radius: 8px;
-	font-weight: 600;
-	font-size: 10px;
-	line-height: 1.6;
-}
-
 .yoast-new-badge {
 	background-color: #cce5ff;
 	color: #004973;
-}
-
-.yoast-badge__in-label {
-	margin-left: 8px;
-	vertical-align: text-top;
 }

--- a/packages/components/src/premium-badge/PremiumBadge.js
+++ b/packages/components/src/premium-badge/PremiumBadge.js
@@ -1,0 +1,26 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+/**
+ * Function for the PremiumBadge component.
+ *
+ * @param {bool} inLabel Whether the PremiumBadge is within a Label.
+ *
+ * @returns {React.Component} The PremiumBadge.
+ */
+const PremiumBadge = ( { inLabel } ) => (
+	<span className={ inLabel ? "yoast-badge yoast-badge__in-label yoast-premium-badge" : "yoast-badge yoast-premium-badge" }>
+		{ /* We don't want this string to be translatable. */ }
+		Premium
+	</span>
+);
+
+PremiumBadge.propTypes = {
+	inLabel: PropTypes.bool,
+};
+
+PremiumBadge.defaultProps = {
+	inLabel: false,
+};
+
+export default PremiumBadge;

--- a/packages/components/src/premium-badge/PremiumBadge.js
+++ b/packages/components/src/premium-badge/PremiumBadge.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 /**
  * Function for the PremiumBadge component.
  *
- * @param {bool} inLabel Whether the PremiumBadge is within a Label.
+ * @param {bool} inLabel Whether the PremiumBadge is displayed close to a Label.
  *
  * @returns {React.Component} The PremiumBadge.
  */

--- a/packages/components/src/premium-badge/index.js
+++ b/packages/components/src/premium-badge/index.js
@@ -1,0 +1,2 @@
+import "./premium-badge.css";
+export { default as PremiumBadge } from "./PremiumBadge";

--- a/packages/components/src/premium-badge/index.js
+++ b/packages/components/src/premium-badge/index.js
@@ -1,2 +1,3 @@
+import "../badges/badge.css";
 import "./premium-badge.css";
 export { default as PremiumBadge } from "./PremiumBadge";

--- a/packages/components/src/premium-badge/premium-badge.css
+++ b/packages/components/src/premium-badge/premium-badge.css
@@ -1,0 +1,19 @@
+.yoast-badge {
+	display: inline-block;
+	min-height: 16px;
+	padding: 0 8px;
+	border-radius: 8px;
+	font-weight: 600;
+	font-size: 10px;
+	line-height: 1.6;
+}
+
+.yoast-premium-badge {
+	background-color: #fff3cd;
+	color: #674e00;
+}
+
+.yoast-badge__in-label {
+	margin-left: 8px;
+	vertical-align: text-top;
+}

--- a/packages/components/src/premium-badge/premium-badge.css
+++ b/packages/components/src/premium-badge/premium-badge.css
@@ -1,19 +1,4 @@
-.yoast-badge {
-	display: inline-block;
-	min-height: 16px;
-	padding: 0 8px;
-	border-radius: 8px;
-	font-weight: 600;
-	font-size: 10px;
-	line-height: 1.6;
-}
-
 .yoast-premium-badge {
 	background-color: #fff3cd;
 	color: #674e00;
-}
-
-.yoast-badge__in-label {
-	margin-left: 8px;
-	vertical-align: text-top;
 }

--- a/packages/js/src/components/ImageSelectComponent.js
+++ b/packages/js/src/components/ImageSelectComponent.js
@@ -136,6 +136,7 @@ class ImageSelectComponent extends Component {
 				removeImageButtonId={ this.props.removeImageButtonId }
 				hasNewBadge={ this.props.hasNewBadge }
 				isDisabled={ this.props.isDisabled }
+				hasPremiumBadge={ this.props.hasPremiumBadge }
 			/>
 		);
 	}
@@ -151,6 +152,7 @@ ImageSelectComponent.propTypes = {
 	removeImageButtonId: PropTypes.string,
 	hasNewBadge: PropTypes.bool,
 	isDisabled: PropTypes.bool,
+	hasPremiumBadge: PropTypes.bool,
 };
 
 ImageSelectComponent.defaultProps = {
@@ -162,6 +164,7 @@ ImageSelectComponent.defaultProps = {
 	removeImageButtonId: "",
 	hasNewBadge: false,
 	isDisabled: false,
+	hasPremiumBadge: false,
 };
 
 export default ImageSelectComponent;

--- a/packages/js/src/components/SettingsReplacementVariableEditor.js
+++ b/packages/js/src/components/SettingsReplacementVariableEditor.js
@@ -33,6 +33,7 @@ class SettingsReplacementVariableEditor extends Component {
 			descriptionPlaceholder,
 			hasNewBadge,
 			isDisabled,
+			hasPremiumBadge,
 		} = this.props;
 
 		const placeholder = descriptionPlaceholder || __( "Modify your meta description by editing it right here", "wordpress-seo" );
@@ -67,6 +68,7 @@ class SettingsReplacementVariableEditor extends Component {
 					labels={ labels }
 					hasNewBadge={ hasNewBadge }
 					isDisabled={ isDisabled }
+					hasPremiumBadge={ hasPremiumBadge }
 				/>
 			</SnippetPreviewSection>
 		);
@@ -89,12 +91,14 @@ SettingsReplacementVariableEditor.propTypes = {
 	descriptionPlaceholder: PropTypes.string,
 	hasNewBadge: PropTypes.bool,
 	isDisabled: PropTypes.bool,
+	hasPremiumBadge: PropTypes.bool,
 };
 
 SettingsReplacementVariableEditor.defaultProps = {
 	hasPaperStyle: true,
 	hasNewBadge: false,
 	isDisabled: false,
+	hasPremiumBadge: false,
 };
 
 export default linkHiddenFields( props => {

--- a/packages/js/src/components/SettingsReplacementVariableEditors.js
+++ b/packages/js/src/components/SettingsReplacementVariableEditors.js
@@ -72,6 +72,7 @@ class SettingsReplacementVariableEditors extends Component {
 				reactReplacevarDescriptionPlaceholder,
 				reactReplacevarHasNewBadge,
 				reactReplacevarIsDisabled,
+				reactReplacevarHasPremiumBadge,
 			} = targetElement.dataset;
 
 			const filteredReplacementVariables = this.filterEditorSpecificReplaceVars(
@@ -97,6 +98,7 @@ class SettingsReplacementVariableEditors extends Component {
 					descriptionPlaceholder={ reactReplacevarDescriptionPlaceholder }
 					hasNewBadge={ reactReplacevarHasNewBadge === "1" }
 					isDisabled={ reactReplacevarIsDisabled === "1" }
+					hasPremiumBadge={ reactReplacevarHasPremiumBadge === "1" }
 				/>
 			);
 		} );

--- a/packages/js/src/components/portals/ImageSelectPortal.js
+++ b/packages/js/src/components/portals/ImageSelectPortal.js
@@ -15,6 +15,7 @@ import Portal from "./Portal";
  * @param {string} removeImageButtonId  The ID for the image remove button.
  * @param {bool}   hasNewBadge          Optional. Whether the ImageSelectComponent has a 'New' badge.
  * @param {bool}   isDisabled           Optional. Whether the ImageSelectComponent is disabled.
+ * @param {bool}   hasPremiumBadge      Optional. Whether the ImageSelectComponent has a 'Premium' badge.
  *
  * @returns {null|wp.Element} The element.
  * @constructor
@@ -30,6 +31,7 @@ export default function ImageSelectPortal(
 		removeImageButtonId,
 		hasNewBadge,
 		isDisabled,
+		hasPremiumBadge,
 	} ) {
 	return (
 		<Portal target={ target }>
@@ -43,6 +45,7 @@ export default function ImageSelectPortal(
 				removeImageButtonId={ removeImageButtonId }
 				hasNewBadge={ hasNewBadge }
 				isDisabled={ isDisabled }
+				hasPremiumBadge={ hasPremiumBadge }
 			/>
 		</Portal>
 	);
@@ -59,6 +62,7 @@ ImageSelectPortal.propTypes = {
 	removeImageButtonId: PropTypes.string,
 	hasNewBadge: PropTypes.bool,
 	isDisabled: PropTypes.bool,
+	hasPremiumBadge: PropTypes.bool,
 };
 
 ImageSelectPortal.defaultProps = {
@@ -68,4 +72,5 @@ ImageSelectPortal.defaultProps = {
 	removeImageButtonId: "",
 	hasNewBadge: false,
 	isDisabled: false,
+	hasPremiumBadge: false,
 };

--- a/packages/js/src/components/portals/SettingsEditorPortal.js
+++ b/packages/js/src/components/portals/SettingsEditorPortal.js
@@ -10,16 +10,17 @@ import Portal from "./Portal";
 /**
  * Renders a portal for the editors in the search appearance settings.
  *
- * @param {object} target A target element or element ID in which to render the portal.
- * @param {object[]} replacementVariables the replacement variables for the editor.
- * @param {string[]} recommendedReplacementVariables the recommended replacement variables for the editor.
- * @param {string} titleTarget The ID of the title field.
- * @param {string} descriptionTarget The id of the description field.
- * @param {boolean} hasPaperStyle Whether the editor should be styled as a paper.
- * @param {object} labels The labels for the editor fields.
- * @param {string} descriptionPlaceholder the placeholder for the description field.
- * @param {bool} hasNewBadge Whether the editor should have a 'New' badge.
- * @param {bool} isDisabled Whether the editor should be disabled.
+ * @param {object}   target                          A target element or element ID in which to render the portal.
+ * @param {object[]} replacementVariables            The replacement variables for the editor.
+ * @param {string[]} recommendedReplacementVariables The recommended replacement variables for the editor.
+ * @param {string}   titleTarget                     The ID of the title field.
+ * @param {string}   descriptionTarget               The id of the description field.
+ * @param {boolean}  hasPaperStyle                   Whether the editor should be styled as a paper.
+ * @param {object}   labels                          The labels for the editor fields.
+ * @param {string}   descriptionPlaceholder          The placeholder for the description field.
+ * @param {bool}     hasNewBadge                     Whether the editor should have a 'New' badge.
+ * @param {bool}     isDisabled                      Whether the editor should be disabled.
+ * @param {bool}     hasPremiumBadge                 Whether the editor should have a 'Premium' badge.
  *
  * @returns {null|wp.Element} The element.
  */
@@ -34,6 +35,7 @@ export default function SettingsEditorPortal( {
 	descriptionPlaceholder,
 	hasNewBadge,
 	isDisabled,
+	hasPremiumBadge,
 } ) {
 	return (
 		<Portal target={ target }>
@@ -47,6 +49,7 @@ export default function SettingsEditorPortal( {
 				descriptionPlaceholder={ descriptionPlaceholder }
 				hasNewBadge={ hasNewBadge }
 				isDisabled={ isDisabled }
+				hasPremiumBadge={ hasPremiumBadge }
 			/>
 		</Portal>
 	);
@@ -66,9 +69,11 @@ SettingsEditorPortal.propTypes = {
 	descriptionPlaceholder: PropTypes.string,
 	hasNewBadge: PropTypes.bool,
 	isDisabled: PropTypes.bool,
+	hasPremiumBadge: PropTypes.bool,
 };
 
 SettingsEditorPortal.defaultProps = {
 	hasNewBadge: false,
 	isDisabled: false,
+	hasPremiumBadge: false,
 };

--- a/packages/js/src/initializers/search-appearance.js
+++ b/packages/js/src/initializers/search-appearance.js
@@ -85,6 +85,7 @@ export default function initSearchAppearance() {
 						removeImageButtonId={ portal.id + "-remove-button" }
 						hasNewBadge={ portal.dataset.reactImagePortalHasNewBadge === "1" }
 						isDisabled={ portal.dataset.reactImagePortalIsDisabled === "1" }
+						hasPremiumBadge={ portal.dataset.reactImagePortalHasPremiumBadge === "1" }
 					/> );
 				} ) }
 

--- a/packages/replacement-variable-editor/src/ReplacementVariableEditor.js
+++ b/packages/replacement-variable-editor/src/ReplacementVariableEditor.js
@@ -32,7 +32,7 @@ class ReplacementVariableEditor extends React.Component {
 	constructor( props ) {
 		super( props );
 
-		this.uniqueId = uniqueId();
+		this.uniqueId = uniqueId( "replacement-variable-editor-field-" );
 
 		switch ( props.type ) {
 			case "description":
@@ -106,9 +106,9 @@ class ReplacementVariableEditor extends React.Component {
 					onClick={ onFocus }
 				>
 					{ label }
-					{ hasPremiumBadge && <PremiumBadge inLabel={ true } /> }
-					{ hasNewBadge && <NewBadge inLabel={ true } /> }
 				</SimulatedLabel>
+				{ hasPremiumBadge && <PremiumBadge inLabel={ true } /> }
+				{ hasNewBadge && <NewBadge inLabel={ true } /> }
 				{ addVariableButton }
 				<InputContainer
 					onClick={ onFocus }

--- a/packages/replacement-variable-editor/src/ReplacementVariableEditor.js
+++ b/packages/replacement-variable-editor/src/ReplacementVariableEditor.js
@@ -18,7 +18,7 @@ import {
 	replacementVariablesShape,
 	recommendedReplacementVariablesShape,
 } from "./constants";
-import { NewBadge, SimulatedLabel } from "@yoast/components";
+import { NewBadge, SimulatedLabel, PremiumBadge } from "@yoast/components";
 
 /**
  * The replacement variable editor.
@@ -84,6 +84,7 @@ class ReplacementVariableEditor extends React.Component {
 			onMouseLeave,
 			hasNewBadge,
 			isDisabled,
+			hasPremiumBadge,
 		} = this.props;
 
 		const InputContainer = this.InputContainer;
@@ -105,6 +106,7 @@ class ReplacementVariableEditor extends React.Component {
 					onClick={ onFocus }
 				>
 					{ label }
+					{ hasPremiumBadge && <PremiumBadge inLabel={ true } /> }
 					{ hasNewBadge && <NewBadge inLabel={ true } /> }
 				</SimulatedLabel>
 				{ addVariableButton }
@@ -154,6 +156,7 @@ ReplacementVariableEditor.propTypes = {
 	onMouseLeave: PropTypes.func,
 	hasNewBadge: PropTypes.bool,
 	isDisabled: PropTypes.bool,
+	hasPremiumBadge: PropTypes.bool,
 };
 
 ReplacementVariableEditor.defaultProps = {
@@ -172,6 +175,7 @@ ReplacementVariableEditor.defaultProps = {
 	onMouseLeave: () => {},
 	hasNewBadge: false,
 	isDisabled: false,
+	hasPremiumBadge: false,
 };
 
 export default ReplacementVariableEditor;

--- a/packages/replacement-variable-editor/src/SettingsSnippetEditor.js
+++ b/packages/replacement-variable-editor/src/SettingsSnippetEditor.js
@@ -18,31 +18,23 @@ class SettingsSnippetEditor extends React.Component {
 	/**
 	 * Constructs the snippet editor.
 	 *
-	 * @param {Object} props                             The props for the snippet
-	 *                                                   editor.
-	 * @param {Object} props.replacementVariables        The replacement variables
-	 *                                                   for this editor.
-	 * @param {Object} props.data                        The initial editor data.
-	 * @param {string} props.keyword                     The focus keyword.
-	 * @param {string} props.data.title                  The initial title.
-	 * @param {string} props.data.slug                   The initial slug.
-	 * @param {string} props.data.description            The initial description.
-	 * @param {string} props.baseUrl                     The base URL to use for the
-	 *                                                   preview.
-	 * @param {string} props.mode                        The mode the editor should
-	 *                                                   be in.
-	 * @param {Function} props.onChange                  Called when the data
-	 *                                                   changes.
-	 * @param {Object} props.titleLengthProgress         The values for the title
-	 *                                                   length assessment.
-	 * @param {Object} props.descriptionLengthProgress   The values for the
-	 *                                                   description length
-	 *                                                   assessment.
-	 * @param {Function} props.mapDataToPreview          Function to map the editor
-	 *                                                   data to data for the preview.
-	 * @param {string} props.locale                      The locale of the page.
-	 * @param {bool}   props.hasPaperStyle               Whether or not it has paper style.
-	 * @param {bool}   props.hasNewBadge                 Optional. Whether or not it has a 'New' badge.
+	 * @param {Object}   props                           The props for the snippet editor.
+	 * @param {Object}   props.replacementVariables      The replacement variables for this editor.
+	 * @param {Object}   props.data                      The initial editor data.
+	 * @param {string}   props.keyword                   The focus keyword.
+	 * @param {string}   props.data.title                The initial title.
+	 * @param {string}   props.data.slug                 The initial slug.
+	 * @param {string}   props.data.description          The initial description.
+	 * @param {string}   props.baseUrl                   The base URL to use for the preview.
+	 * @param {string}   props.mode                      The mode the editor should be in.
+	 * @param {Function} props.onChange                  Called when the data changes.
+	 * @param {Object}   props.titleLengthProgress       The values for the title length assessment.
+	 * @param {Object}   props.descriptionLengthProgress The values for the description length assessment.
+	 * @param {Function} props.mapDataToPreview          Function to map the editor data to data for the preview.
+	 * @param {string}   props.locale                    The locale of the page.
+	 * @param {bool}     props.hasPaperStyle             Whether or not it has paper style.
+	 * @param {bool}     props.hasNewBadge               Optional. Whether or not it has a 'New' badge.
+	 * @param {bool}     props.hasPremiumBadge           Optional. Whether or not it has a 'Premium' badge.
 	 *
 	 * @returns {void}
 	 */
@@ -126,6 +118,7 @@ class SettingsSnippetEditor extends React.Component {
 			labels,
 			hasNewBadge,
 			isDisabled,
+			hasPremiumBadge,
 		} = this.props;
 
 		const { activeField, hoveredField } = this.state;
@@ -147,6 +140,7 @@ class SettingsSnippetEditor extends React.Component {
 					labels={ labels }
 					hasNewBadge={ hasNewBadge }
 					isDisabled={ isDisabled }
+					hasPremiumBadge={ hasPremiumBadge }
 				/>
 			</ErrorBoundary>
 		);
@@ -173,6 +167,7 @@ SettingsSnippetEditor.propTypes = {
 	} ),
 	hasNewBadge: PropTypes.bool,
 	isDisabled: PropTypes.bool,
+	hasPremiumBadge: PropTypes.bool,
 };
 
 SettingsSnippetEditor.defaultProps = {
@@ -183,6 +178,7 @@ SettingsSnippetEditor.defaultProps = {
 	labels: {},
 	hasNewBadge: false,
 	isDisabled: false,
+	hasPremiumBadge: false,
 };
 
 export default SettingsSnippetEditor;

--- a/packages/replacement-variable-editor/src/SettingsSnippetEditorFields.js
+++ b/packages/replacement-variable-editor/src/SettingsSnippetEditorFields.js
@@ -21,22 +21,17 @@ class SettingsSnippetEditorFields extends React.Component {
 	/**
 	 * Constructs the snippet editor fields.
 	 *
-	 * @param {Object}   props                             The props for the editor
-	 *                                                     fields.
-	 * @param {Object}   props.replacementVariables        The replacement variables
-	 *                                                     for this editor.
-	 * @param {Object}   props.data                        The initial editor data.
-	 * @param {string}   props.data.title                  The initial title.
-	 * @param {string}   props.data.description            The initial description.
-	 * @param {Function} props.onChange                    Called when the data
-	 *                                                     changes.
-	 * @param {Function} props.onFocus                     Called when a field is
-	 *                                                     focused.
-	 * @param {string}   props.activeField                 The field that is
-	 *                                                     currently active.
-	 * @param {string}   props.hoveredField                The field that is
-	 *                                                     currently hovered.
-	 * @param {bool}     props.hasNewBadge                 Optional. Whether or not it has a 'New' badge.
+	 * @param {Object}   props                      The props for the editor fields.
+	 * @param {Object}   props.replacementVariables The replacement variables for this editor.
+	 * @param {Object}   props.data                 The initial editor data.
+	 * @param {string}   props.data.title           The initial title.
+	 * @param {string}   props.data.description     The initial description.
+	 * @param {Function} props.onChange             Called when the data changes.
+	 * @param {Function} props.onFocus              Called when a field is focused.
+	 * @param {string}   props.activeField          The field that is currently active.
+	 * @param {string}   props.hoveredField         The field that is currently hovered.
+	 * @param {bool}     props.hasNewBadge          Optional. Whether or not it has a 'New' badge.
+	 * @param {bool}     props.hasPremiumBadge      Optional. Whether or not it has a 'Premium' badge.
 	 *
 	 * @returns {void}
 	 */
@@ -128,6 +123,7 @@ class SettingsSnippetEditorFields extends React.Component {
 			labels,
 			hasNewBadge,
 			isDisabled,
+			hasPremiumBadge,
 		} = this.props;
 
 		return (
@@ -149,6 +145,7 @@ class SettingsSnippetEditorFields extends React.Component {
 					fieldId={ fieldIds.title }
 					hasNewBadge={ hasNewBadge }
 					isDisabled={ isDisabled }
+					hasPremiumBadge={ hasPremiumBadge }
 				/>
 				<ReplacementVariableEditor
 					type="description"
@@ -166,6 +163,7 @@ class SettingsSnippetEditorFields extends React.Component {
 					fieldId={ fieldIds.description }
 					hasNewBadge={ hasNewBadge }
 					isDisabled={ isDisabled }
+					hasPremiumBadge={ hasPremiumBadge }
 				/>
 			</StyledEditor>
 		);
@@ -196,6 +194,7 @@ SettingsSnippetEditorFields.propTypes = {
 	} ),
 	hasNewBadge: PropTypes.bool,
 	isDisabled: PropTypes.bool,
+	hasPremiumBadge: PropTypes.bool,
 };
 
 SettingsSnippetEditorFields.defaultProps = {
@@ -207,6 +206,7 @@ SettingsSnippetEditorFields.defaultProps = {
 	labels: {},
 	hasNewBadge: false,
 	isDisabled: false,
+	hasPremiumBadge: false,
 };
 
 export default SettingsSnippetEditorFields;

--- a/packages/replacement-variable-editor/src/shared.js
+++ b/packages/replacement-variable-editor/src/shared.js
@@ -41,7 +41,6 @@ export const FormSection = styled.div`
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
-	justify-content: space-between;
 	margin: 16px 0 0 0;
 `;
 
@@ -65,6 +64,7 @@ export const TriggerReplacementVariableSuggestionsButton = styled( StandardButto
 	font-size: 13px;
 	width: 103px;
 	height: 28px;
+	margin-left: auto;
 	& svg {
 		${ getDirectionalStyle( "margin-right", "margin-left" ) }: 7px;
 		fill: ${ colors.$color_grey_dark };

--- a/packages/social-metadata-forms/tests/__snapshots__/ImageSelectTest.js.snap
+++ b/packages/social-metadata-forms/tests/__snapshots__/ImageSelectTest.js.snap
@@ -112,10 +112,6 @@ exports[`The ImageSelect component displays warnings 1`] = `
 }
 
 .c1 {
-  -webkit-flex: 1 1 200px;
-  -ms-flex: 1 1 200px;
-  flex: 1 1 200px;
-  min-width: 200px;
   cursor: pointer;
   font-size: 14px;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
@@ -366,10 +362,6 @@ exports[`The ImageSelect component renders 1`] = `
 }
 
 .c1 {
-  -webkit-flex: 1 1 200px;
-  -ms-flex: 1 1 200px;
-  flex: 1 1 200px;
-  min-width: 200px;
   cursor: pointer;
   font-size: 14px;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -174,12 +174,14 @@ class Social_Templates_Integration implements Integration_Interface {
 				data-react-image-portal-target-image-id="%3$s"
 				data-react-image-portal-has-new-badge="%4$s"
 				data-react-image-portal-is-disabled="%5$s"
+				data-react-image-portal-has-premium-badge="%6$s"
 			></div>',
 			\esc_attr( 'yoast-social-' . $identifier . '-image-select' ),
 			\esc_attr( $image_url_field_id ),
 			\esc_attr( $image_id_field_id ),
 			\esc_attr( $is_premium && $badge_group_names->is_still_eligible_for_new_badge( $this->group ) ),
-			\esc_attr( ! $is_premium )
+			\esc_attr( ! $is_premium ),
+			\esc_attr( $is_premium )
 		);
 
 		$editor = new WPSEO_Replacevar_Editor(
@@ -195,6 +197,7 @@ class Social_Templates_Integration implements Integration_Interface {
 				'description_placeholder' => \__( 'Modify your social description by editing it right here.', 'wordpress-seo' ),
 				'has_new_badge'           => $is_premium && $badge_group_names->is_still_eligible_for_new_badge( $this->group ),
 				'is_disabled'             => ! $is_premium,
+				'has_premium_badge'       => $is_premium,
 			]
 		);
 		$editor->render();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to display a "Premium" badge for the social templates forms, only when Premium is activated.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a "Premium" badge to the social templates forms.

## Relevant technical choices:

* For consistency, the ability to display the "Premium" badge is added to all the places where the "New" badge was added.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- activate Yoast SEO Free, switched to this branch and build it as usual 
- activate Yoast SEO Premium and SEO Local 
- go to SEO > Search Appearance > Content Types and check _all_ the Social image, Social Title, and Social description display a "Premium" badge before the "New" badge (check also the Locations and Locations archive)
- check the "Premium" badge matches the design https://www.sketch.com/s/6b4efaeb-fcab-4e48-8314-0d532488e164/a/g00MDDd/play
- same for SEO > Search Appearance > Taxonomies 
- same for SEO > Search Appearance > Archives 
- go to SEO > Search Appearance > General > Homepage and check the Social image, Social Title, and Social description do NOT display the "Premium" badge 
- deactivate Premium 
- check again the Content Types, Taxonomies, and Archive tabs and verify that:
  - they appear "greyed out" below an overlay with a "Unlock with Premium" button as per P3-616
  - the forms below the overlay do NOT display the "Premium" badge (not even the "New" one)
- Update: check the alignment of the label / badges / "Insert variable" buttons is okay for all the SEO / Social forms, even in the places where badges aren't used


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
