### PR TITLE
Add classes for styling in other implementations

### DIFF
--- a/packages/replacement-variable-editor/src/Mention.js
+++ b/packages/replacement-variable-editor/src/Mention.js
@@ -2,6 +2,7 @@
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
+import classNames from "classnames";
 
 // Yoast dependencies.
 import { colors } from "@yoast/style-guide";
@@ -29,7 +30,7 @@ const StyledMention = styled.span`
  */
 export const Mention = ( { children, className } ) => {
 	return <StyledMention
-		className={ className }
+		className={ classNames( "yst-replacevar__mention", className ) }
 		spellCheck={ false }
 	>
 		{ children }

--- a/packages/replacement-variable-editor/src/ReplacementVariableEditor.js
+++ b/packages/replacement-variable-editor/src/ReplacementVariableEditor.js
@@ -88,6 +88,7 @@ class ReplacementVariableEditor extends React.Component {
 		const InputContainer = this.InputContainer;
 
 		const addVariableButton = <TriggerReplacementVariableSuggestionsButton
+			className="yst-replacevar__button-insert"
 			onClick={ this.triggerReplacementVariableSuggestions }
 		>
 			{ __( "Insert variable", "yoast-components" ) }
@@ -95,10 +96,12 @@ class ReplacementVariableEditor extends React.Component {
 
 		return (
 			<FormSection
+				className="yst-replacevar"
 				onMouseEnter={ onMouseEnter }
 				onMouseLeave={ onMouseLeave }
 			>
 				<SimulatedLabel
+					className="yst-replacevar__label"
 					id={ this.uniqueId }
 					onClick={ onFocus }
 				>
@@ -107,6 +110,7 @@ class ReplacementVariableEditor extends React.Component {
 				</SimulatedLabel>
 				{ addVariableButton }
 				<InputContainer
+					className="yst-replacevar__editor"
 					onClick={ onFocus }
 					isActive={ isActive }
 					isHovered={ isHovered }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Since the `replacement-variable-editor` package is used in a range of products. To allow for different styling of the `ReplacementVariableEditor` in differing implementations, CSS-classes are needed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/replacement-variable-editor] Adds classes to the main elements of the `ReplacementVariableEditor` and `Mention` components to allow for individual styling.

## Relevant technical choices:

* Prefixed with `yst-` like we do in the Settings UI App

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In a page or post editor, get to the replacement variable editors
* Verify that the replacement variable editors function and look the same as before
* Inspect the HTML and verify that the following classes are added to various parts of the replacement variable editor:
** `yst-replacevar`
** `yst-replacevar__label`
** `yst-replacevar__editor`
** `yst-replacevar__button-insert`
** `yst-replacevar__mention`
* Repeat the steps from above for a (set of) replacement variable editor(s) in the Settings

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-534
