### PR TITLE
P3-639 Allow to save an empty Homepage Social title and trigger the fallback.

### DIFF
--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -405,11 +405,13 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				 *  'social-title-ptarchive-' . $pt->name
 				 *  'social-title-tax-' . $tax->name
 				 *  'social-title-author-wpseo', 'social-title-archive-wpseo'
+				 *  'open_graph_frontpage_title'
 				 */
 				case 'website_name':
 				case 'alternate_website_name':
 				case 'title-':
 				case 'social-title-':
+				case 'open_graph_frontpage_title':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( $dirty[ $key ] );
 					}
@@ -463,7 +465,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				 *  'social-description-ptarchive-' . $pt->name
 				 *  'social-description-tax-' . $tax->name
 				 *  'social-description-author-wpseo', 'social-description-archive-wpseo'
-				 *  'open_graph_frontpage_desc', 'open_graph_frontpage_title'
+				 *  'open_graph_frontpage_desc'
 				 */
 				case 'metadesc-':
 				case 'bctitle-ptarchive-':
@@ -471,7 +473,6 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				case 'person_name':
 				case 'social-description-':
 				case 'open_graph_frontpage_desc':
-				case 'open_graph_frontpage_title':
 					if ( isset( $dirty[ $key ] ) && $dirty[ $key ] !== '' ) {
 						$clean[ $key ] = WPSEO_Utils::sanitize_text_field( $dirty[ $key ] );
 					}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the Homepage Social title to fallback to the SEO title (when the Social title is emptied) so that we have a fallback mechanism that is consistent with the other social titles. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the Homepage Social title implementation by allowing a fallback to the Homepage SEO title.

## Relevant technical choices:

* Changed validation method for the `open_graph_frontpage_title` setting in `WPSEO_Option_Titles` so that it's now possible to save an empty string.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* activate Yoast Free, switched to this branch, and build it as usual
* use a clean database, or empty the value of the `wpseo_titles` option in the database table `wp_options`
* go to SEO > Search appearance > General > Homepage
* check the SEO title has the default value `%%sitename%% %%page%% %%sep%% %%sitedesc%% `
* check the Social title has the default value `%%sitename%%` (it's displayed as "Site title")
* check the source of the homepage on the front end
* check the SEO title is something like this (example from the Docker environment):

```
<title>Basic - Just another WordPress site</title>
```

- check the og:title value is only the site title e.g.:

```
<meta property="og:title" content="Basic" />
```

* go to the admin, empty the Homepage Social title field and save
* after the page reloads, check the field has been actually saved as empty
* check the Homepage source on the front end 
* check that the og:title now fallbacks to the SEO title, e.g.:

```
<meta property="og:title" content="Basic - Just another WordPress site" />
```

* go to the admin and change the Homepage **SEO title**
* check the Homepage source on the front end 
* check the Social title fallbacks to the SEO title you just edited
* go to the admin and empty the Homepage **SEO title**: it will be saved as empty but keep in mind it does have its own default value `%%sitename%% %%page%% %%sep%% %%sitedesc%%` 
* check the Homepage source on the front end 
* check the Social title fallbacks to the SEO title default value


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-639]