### PR TITLE
Escape attributes in Search Appearance tabs

### DIFF
--- a/admin/views/tabs/metas/general.php
+++ b/admin/views/tabs/metas/general.php
@@ -23,7 +23,7 @@ $wpseo_title_separator_presenter = new WPSEO_Paper_Presenter(
 		'class'       => 'search-appearance',
 	]
 );
-// phpcs:ignore WordPress.Security.EscapeOutput -- after contains HTMl and we assume it's properly escape on object creation.
+// phpcs:ignore WordPress.Security.EscapeOutput -- output contains HTML and we assume it's properly escape on object creation.
 echo $wpseo_title_separator_presenter->get_output();
 
 if ( get_option( 'show_on_front' ) === 'posts' ) {
@@ -44,7 +44,7 @@ $wpseo_homepage_presenter = new WPSEO_Paper_Presenter(
 		'class'       => 'search-appearance',
 	]
 );
-// phpcs:ignore WordPress.Security.EscapeOutput -- after contains HTMl and we assume it's properly escape on object creation.
+// phpcs:ignore WordPress.Security.EscapeOutput -- output contains HTML and we assume it's properly escape on object creation.
 echo $wpseo_homepage_presenter->get_output();
 
 $wpseo_knowledge_graph_title     = esc_html__( 'Knowledge Graph & Schema.org', 'wordpress-seo' );
@@ -59,5 +59,5 @@ $wpseo_knowledge_graph_presenter = new WPSEO_Paper_Presenter(
 		'class'       => 'search-appearance',
 	]
 );
-// phpcs:ignore WordPress.Security.EscapeOutput -- after contains HTMl and we assume it's properly escape on object creation.
+// phpcs:ignore WordPress.Security.EscapeOutput -- output contains HTML and we assume it's properly escape on object creation.
 echo $wpseo_knowledge_graph_presenter->get_output();

--- a/admin/views/tabs/metas/general.php
+++ b/admin/views/tabs/metas/general.php
@@ -23,6 +23,7 @@ $wpseo_title_separator_presenter = new WPSEO_Paper_Presenter(
 		'class'       => 'search-appearance',
 	]
 );
+// phpcs:ignore WordPress.Security.EscapeOutput -- after contains HTMl and we assume it's properly escape on object creation.
 echo $wpseo_title_separator_presenter->get_output();
 
 if ( get_option( 'show_on_front' ) === 'posts' ) {
@@ -43,6 +44,7 @@ $wpseo_homepage_presenter = new WPSEO_Paper_Presenter(
 		'class'       => 'search-appearance',
 	]
 );
+// phpcs:ignore WordPress.Security.EscapeOutput -- after contains HTMl and we assume it's properly escape on object creation.
 echo $wpseo_homepage_presenter->get_output();
 
 $wpseo_knowledge_graph_title     = esc_html__( 'Knowledge Graph & Schema.org', 'wordpress-seo' );
@@ -57,4 +59,5 @@ $wpseo_knowledge_graph_presenter = new WPSEO_Paper_Presenter(
 		'class'       => 'search-appearance',
 	]
 );
+// phpcs:ignore WordPress.Security.EscapeOutput -- after contains HTMl and we assume it's properly escape on object creation.
 echo $wpseo_knowledge_graph_presenter->get_output();

--- a/admin/views/tabs/metas/paper-content/front-page-content.php
+++ b/admin/views/tabs/metas/paper-content/front-page-content.php
@@ -37,7 +37,7 @@ else {
 		'yoast-og-frontpage-image-select',
 		'open_graph_frontpage_image',
 		'open_graph_frontpage_image_id',
-		$show_new_badge
+		esc_attr( $show_new_badge )
 	);
 
 	$yform->hidden( 'open_graph_frontpage_image', 'open_graph_frontpage_image' );

--- a/admin/views/tabs/metas/paper-content/post_type/post-type.php
+++ b/admin/views/tabs/metas/paper-content/post_type/post-type.php
@@ -68,12 +68,12 @@ if ( $wpseo_post_type->name !== 'page' && $article_helper->is_author_supported( 
 }
 printf(
 	'<div class="yoast-schema-settings-container" data-schema-settings data-schema-settings-post-type="%1$s" data-schema-settings-post-type-name="%2$s" data-schema-settings-page-type-field-id="%3$s" data-schema-settings-article-type-field-id="%4$s" data-schema-settings-page-type-default="%5$s" data-schema-settings-article-type-default="%6$s"></div>',
-	$wpseo_post_type->name,
-	$wpseo_post_type->labels->name,
-	'hidden_' . $schema_page_type_option,
-	'hidden_' . $schema_article_type_option,
-	WPSEO_Options::get_default( 'wpseo_titles', $schema_page_type_option ),
-	WPSEO_Options::get_default( 'wpseo_titles', $schema_article_type_option )
+	esc_attr( $wpseo_post_type->name ),
+	esc_attr( $wpseo_post_type->labels->name ),
+	esc_attr( 'hidden_' . $schema_page_type_option ),
+	esc_attr( 'hidden_' . $schema_article_type_option ),
+	esc_attr( WPSEO_Options::get_default( 'wpseo_titles', $schema_page_type_option ) ),
+	esc_attr( WPSEO_Options::get_default( 'wpseo_titles', $schema_article_type_option ) )
 );
 
 echo '</div>';

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=309",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=303",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=223",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix the feature branch crossing the CS error threshold

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes some CS errors by escaping attributes in Search Appearance tabs

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* N/A


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
