### PR TITLE
P3-638 Add image validation warnings for social templates

### DIFF
--- a/admin/views/tabs/metas/paper-content/front-page-content.php
+++ b/admin/views/tabs/metas/paper-content/front-page-content.php
@@ -33,11 +33,13 @@ else {
 				data-react-image-portal-target-image="%2$s"
 				data-react-image-portal-target-image-id="%3$s"
 				data-react-image-portal-has-new-badge="%4$s"
+				data-react-image-portal-has-image-validation="%5$s"
 			></div>',
 		'yoast-og-frontpage-image-select',
 		'open_graph_frontpage_image',
 		'open_graph_frontpage_image_id',
-		esc_attr( $show_new_badge )
+		esc_attr( $show_new_badge ),
+		true
 	);
 
 	$yform->hidden( 'open_graph_frontpage_image', 'open_graph_frontpage_image' );

--- a/admin/views/tabs/social/facebook.php
+++ b/admin/views/tabs/social/facebook.php
@@ -53,7 +53,7 @@ $yform->light_switch( 'opengraph', __( 'Add Open Graph meta data', 'wordpress-se
 	<p>
 		<?php esc_html_e( 'This image is used if the post/page being shared does not contain any images.', 'wordpress-seo' ); ?>
 	</p>
-	<div id="yoast-og-default-image-select"></div>
+	<div id="yoast-og-default-image-select" class="yoast-measure"></div>
 </div>
 <?php
 

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -55,10 +55,13 @@ function ImageSelect( props ) {
 					</button>
 				}
 				{
-					showWarnings &&
-					props.warnings.map( ( warning, index ) => <Alert key={ `warning${ index }` } type="warning">
-						{ warning }
-					</Alert> )
+					showWarnings && <div role="alert">
+						{
+							props.warnings.map( ( warning, index ) => <Alert key={ `warning${ index }` } type="warning">
+								{ warning }
+							</Alert> )
+						}
+					</div>
 				}
 				<ImageSelectButtons { ...imageSelectButtonsProps } />
 			</FieldGroup>

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -54,7 +54,7 @@ function ImageSelect( props ) {
 					</button>
 				}
 				{
-					props.hasImageValidation && props.warnings.length > 0 && imageSelected &&
+					props.warnings.length > 0 && imageSelected &&
 					props.warnings.map( ( warning, index ) => <Alert key={ `warning${ index }` } type="warning">
 						{ warning }
 					</Alert> )
@@ -84,7 +84,6 @@ ImageSelect.propTypes = {
 	hasNewBadge: PropTypes.bool,
 	isDisabled: PropTypes.bool,
 	hasPremiumBadge: PropTypes.bool,
-	hasImageValidation: PropTypes.bool,
 };
 
 ImageSelect.defaultProps = {
@@ -102,5 +101,4 @@ ImageSelect.defaultProps = {
 	hasNewBadge: false,
 	isDisabled: false,
 	hasPremiumBadge: false,
-	hasImageValidation: false,
 };

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -54,7 +54,7 @@ function ImageSelect( props ) {
 					</button>
 				}
 				{
-					props.warnings.length > 0 && imageSelected &&
+					props.hasImageValidation && props.warnings.length > 0 && imageSelected &&
 					props.warnings.map( ( warning, index ) => <Alert key={ `warning${ index }` } type="warning">
 						{ warning }
 					</Alert> )
@@ -84,6 +84,7 @@ ImageSelect.propTypes = {
 	hasNewBadge: PropTypes.bool,
 	isDisabled: PropTypes.bool,
 	hasPremiumBadge: PropTypes.bool,
+	hasImageValidation: PropTypes.bool,
 };
 
 ImageSelect.defaultProps = {
@@ -101,4 +102,5 @@ ImageSelect.defaultProps = {
 	hasNewBadge: false,
 	isDisabled: false,
 	hasPremiumBadge: false,
+	hasImageValidation: false,
 };

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -14,8 +14,9 @@ import Alert from "../Alert";
 function ImageSelect( props ) {
 	const imageSelected = props.imageUrl !== "";
 	const previewImageUrl = props.imageUrl || props.defaultImageUrl || "";
+	const showWarnings = props.warnings.length > 0 && imageSelected;
 
-	let imageClassName = "yoast-image-select__preview";
+	let imageClassName = showWarnings ? "yoast-image-select__preview yoast-image-select__preview-has-warnings" : "yoast-image-select__preview";
 	if ( previewImageUrl === "" ) {
 		imageClassName = "yoast-image-select__preview yoast-image-select__preview--no-preview";
 	}
@@ -54,7 +55,7 @@ function ImageSelect( props ) {
 					</button>
 				}
 				{
-					props.warnings.length > 0 && imageSelected &&
+					showWarnings &&
 					props.warnings.map( ( warning, index ) => <Alert key={ `warning${ index }` } type="warning">
 						{ warning }
 					</Alert> )

--- a/packages/components/src/image-select/image-select.css
+++ b/packages/components/src/image-select/image-select.css
@@ -15,6 +15,10 @@
 	background: var(--yoast-color-inactive-grey-light) var(--yoast-svg-icon-image) no-repeat center center /64px 64px;
 }
 
+.yoast-image-select__preview.yoast-image-select__preview-has-warnings {
+	margin-bottom: 16px;
+}
+
 .yoast-image-select__preview .yoast-image-select__preview--image {
 	max-width: 100%;
 	height: 100%;

--- a/packages/js/src/components/ImageSelectComponent.js
+++ b/packages/js/src/components/ImageSelectComponent.js
@@ -103,7 +103,9 @@ class ImageSelectComponent extends Component {
 		 * @returns {void}
 		 */
 		const imageCallback = ( image ) => {
-			this.setWarnings( validateFacebookImage( image ) );
+			if ( this.props.hasImageValidation ) {
+				this.setWarnings( validateFacebookImage( image ) );
+			}
 
 			this.setMyImageUrl( image.url );
 			if ( this.hiddenFieldImageId !== null ) {

--- a/packages/js/src/components/ImageSelectComponent.js
+++ b/packages/js/src/components/ImageSelectComponent.js
@@ -161,7 +161,6 @@ class ImageSelectComponent extends Component {
 				isDisabled={ this.props.isDisabled }
 				hasPremiumBadge={ this.props.hasPremiumBadge }
 				warnings={ this.state.warnings }
-				hasImageValidation={ this.props.hasImageValidation }
 			/>
 		);
 	}

--- a/packages/js/src/components/ImageSelectComponent.js
+++ b/packages/js/src/components/ImageSelectComponent.js
@@ -1,8 +1,14 @@
-import { ImageSelect } from "@yoast/components";
+/* External dependencies */
+import PropTypes from "prop-types";
 import { Component } from "@wordpress/element";
 
+/* Yoast dependencies */
+import { ImageSelect } from "@yoast/components";
+import { validateFacebookImage } from "@yoast/helpers";
+
+/* Internal dependencies */
 import { openMedia } from "../helpers/selectMedia";
-import PropTypes from "prop-types";
+
 
 /**
  * Renders the ImageSelect.
@@ -21,12 +27,14 @@ class ImageSelectComponent extends Component {
 		this.state = {
 			imageUrl: this.getInitialValue(),
 			imageId: this.getInitialId(),
+			warnings: [],
 		};
 
 		this.setMyImageUrl = this.setMyImageUrl.bind( this );
 		this.setMyImageId = this.setMyImageId.bind( this );
 		this.onClick = this.onClick.bind( this );
 		this.removeImage = this.removeImage.bind( this );
+		this.setWarnings = this.setWarnings.bind( this );
 	}
 
 	/**
@@ -95,6 +103,8 @@ class ImageSelectComponent extends Component {
 		 * @returns {void}
 		 */
 		const imageCallback = ( image ) => {
+			this.setWarnings( validateFacebookImage( image ) );
+
 			this.setMyImageUrl( image.url );
 			if ( this.hiddenFieldImageId !== null ) {
 				this.setMyImageId( image.id );
@@ -118,6 +128,17 @@ class ImageSelectComponent extends Component {
 	}
 
 	/**
+	 * Sets the image warnings.
+	 *
+	 * @param {array} warnings The validation warnings.
+	 *
+	 * @returns {void} Void.
+	 */
+	setWarnings( warnings ) {
+		this.setState( { warnings: warnings } );
+	}
+
+	/**
 	 * Renders the ImageSelect component.
 	 *
 	 * @returns {wp.Element} The rendered component.
@@ -137,6 +158,8 @@ class ImageSelectComponent extends Component {
 				hasNewBadge={ this.props.hasNewBadge }
 				isDisabled={ this.props.isDisabled }
 				hasPremiumBadge={ this.props.hasPremiumBadge }
+				warnings={ this.state.warnings }
+				hasImageValidation={ this.props.hasImageValidation }
 			/>
 		);
 	}
@@ -153,6 +176,7 @@ ImageSelectComponent.propTypes = {
 	hasNewBadge: PropTypes.bool,
 	isDisabled: PropTypes.bool,
 	hasPremiumBadge: PropTypes.bool,
+	hasImageValidation: PropTypes.bool,
 };
 
 ImageSelectComponent.defaultProps = {
@@ -165,6 +189,7 @@ ImageSelectComponent.defaultProps = {
 	hasNewBadge: false,
 	isDisabled: false,
 	hasPremiumBadge: false,
+	hasImageValidation: false,
 };
 
 export default ImageSelectComponent;

--- a/packages/js/src/components/portals/ImageSelectPortal.js
+++ b/packages/js/src/components/portals/ImageSelectPortal.js
@@ -16,6 +16,7 @@ import Portal from "./Portal";
  * @param {bool}   hasNewBadge          Optional. Whether the ImageSelectComponent has a 'New' badge.
  * @param {bool}   isDisabled           Optional. Whether the ImageSelectComponent is disabled.
  * @param {bool}   hasPremiumBadge      Optional. Whether the ImageSelectComponent has a 'Premium' badge.
+ * @param {bool}   hasImageValidation   Optional. Whether the uploaded image uses validation.
  *
  * @returns {null|wp.Element} The element.
  * @constructor
@@ -32,6 +33,7 @@ export default function ImageSelectPortal(
 		hasNewBadge,
 		isDisabled,
 		hasPremiumBadge,
+		hasImageValidation,
 	} ) {
 	return (
 		<Portal target={ target }>
@@ -46,6 +48,7 @@ export default function ImageSelectPortal(
 				hasNewBadge={ hasNewBadge }
 				isDisabled={ isDisabled }
 				hasPremiumBadge={ hasPremiumBadge }
+				hasImageValidation={ hasImageValidation }
 			/>
 		</Portal>
 	);
@@ -63,6 +66,7 @@ ImageSelectPortal.propTypes = {
 	hasNewBadge: PropTypes.bool,
 	isDisabled: PropTypes.bool,
 	hasPremiumBadge: PropTypes.bool,
+	hasImageValidation: PropTypes.bool,
 };
 
 ImageSelectPortal.defaultProps = {
@@ -73,4 +77,5 @@ ImageSelectPortal.defaultProps = {
 	hasNewBadge: false,
 	isDisabled: false,
 	hasPremiumBadge: false,
+	hasImageValidation: false,
 };

--- a/packages/js/src/initializers/search-appearance.js
+++ b/packages/js/src/initializers/search-appearance.js
@@ -86,6 +86,7 @@ export default function initSearchAppearance() {
 						hasNewBadge={ portal.dataset.reactImagePortalHasNewBadge === "1" }
 						isDisabled={ portal.dataset.reactImagePortalIsDisabled === "1" }
 						hasPremiumBadge={ portal.dataset.reactImagePortalHasPremiumBadge === "1" }
+						hasImageValidation={ portal.dataset.reactImagePortalHasImageValidation === "1" }
 					/> );
 				} ) }
 

--- a/packages/js/src/initializers/social-settings.js
+++ b/packages/js/src/initializers/social-settings.js
@@ -21,6 +21,7 @@ export default function initSocialSettings() {
 				selectImageButtonId="yoast-og-default-image-select-button"
 				replaceImageButtonId="yoast-og-default-image-replace-button"
 				removeImageButtonId="yoast-og-default-image-remove-button"
+				hasImageValidation={ true }
 			/>
 		</Fragment>,
 		element

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -199,7 +199,6 @@ class SocialMetadataPreviewForm extends Component {
 					selectImageButtonId={ join( [ lowerCaseSocialMediumName, "select-button", idSuffix ] ) }
 					replaceImageButtonId={ join( [ lowerCaseSocialMediumName, "replace-button", idSuffix ] ) }
 					removeImageButtonId={ join( [ lowerCaseSocialMediumName, "remove-button", idSuffix ] ) }
-					hasImageValidation={ true }
 				/>
 				<ReplacementVariableEditor
 					onChange={ onTitleChange }

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -199,6 +199,7 @@ class SocialMetadataPreviewForm extends Component {
 					selectImageButtonId={ join( [ lowerCaseSocialMediumName, "select-button", idSuffix ] ) }
 					replaceImageButtonId={ join( [ lowerCaseSocialMediumName, "replace-button", idSuffix ] ) }
 					removeImageButtonId={ join( [ lowerCaseSocialMediumName, "remove-button", idSuffix ] ) }
+					hasImageValidation={ true }
 				/>
 				<ReplacementVariableEditor
 					onChange={ onTitleChange }

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -175,13 +175,15 @@ class Social_Templates_Integration implements Integration_Interface {
 				data-react-image-portal-has-new-badge="%4$s"
 				data-react-image-portal-is-disabled="%5$s"
 				data-react-image-portal-has-premium-badge="%6$s"
+				data-react-image-portal-has-image-validation="%7$s"
 			></div>',
 			\esc_attr( 'yoast-social-' . $identifier . '-image-select' ),
 			\esc_attr( $image_url_field_id ),
 			\esc_attr( $image_id_field_id ),
 			\esc_attr( $is_premium && $badge_group_names->is_still_eligible_for_new_badge( $this->group ) ),
 			\esc_attr( ! $is_premium ),
-			\esc_attr( $is_premium )
+			\esc_attr( $is_premium ),
+			true
 		);
 
 		$editor = new WPSEO_Replacevar_Editor(


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to show validation warnings for the images set in the Social Templates, for consistency with the validation that is in place in the Yoast meta box for Facebook and Twitter images.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

- Adds image validation warnings to the Social templates images.
- [@yoast/components] Improves the accessibility of the Select Image validation warnings.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- activate Yoast SEO Free, switched to this branch and build it as usual 
- activate Yoast SEO Premium 
- upload the attached image to the WordPress media library (unzip it first)

[bmp-image-small.bmp.zip](https://github.com/Yoast/wordpress-seo/files/6561323/bmp-image-small.bmp.zip)

- when using this image for the social image, it will produce two warnings:
  - for the image type, because it's a BMP image (not supported by Facebook and Twitter)
  - for the image size, because it's a small image 
- go to SEO > Search Appearance > Content Types 
- set the BMP image as social image for one of the post types (posts, pages, and custom post types if you have a plugin that adds CPTs)
- check that once the image is set, two warnings appear below the image preview:
  - Your image dimensions are not suitable ...
  - The format of the uploaded image is not supported ...
- check there's a 16px margin between the image preview and the first warning
- replace the image with an image that doesn't trigger warnings (e.g. a .jpg image that is big enough)
- check the warnings disappear
- set again the BPM image and check the warnings appear again 
- remove the image and check the warnings disappear 
- repeat for Taxonomies 
- repeat for Archives 
- go to SEO > Search Appearance > General > Homepage 
- set the BMP image as the Homepage Social image 
- check that the warnings do appear
- go to SEO > Search Appearance > General > Knowledge Graph & Schema.org 
- set the BMP image as the Organization (or Person) logo
- check that the warnings do **NOT** appear
- go to SEO > Social > Facebook 
- set the BMP image as the Default image
- check that the warnings do appear

**Test there are no regressions in the edit post and edit term meta boxes**
- edit a post with Gutenberg 
- go to the Yoast meta box > Social tab 
- set the BMP image as Facebook or Twitter image 
- check the warnings do appear 
- repeat with Classic Editor 
- repeat with Elementor 
- edit a term, e.g. a category term 
- go to the Yoast meta box > Social tab 
- set the BMP image as Facebook or Twitter image 
- check the warnings do appear 

**Optionally test with a screen reader:**
- on macOS, you can test with **Safari** (not Chrome) and VoiceOver (press Cmd+F5 to enable/disable VoiceOver)
- go in any of the locations where the warnings are supposed to appear 
- set the BMP image as Social image 
- check that _both_ warnings are automatically announced by VoiceOver when they appear 
- see screenshot below:
<img width="976" alt="Screenshot 2021-05-28 at 15 11 27" src="https://user-images.githubusercontent.com/1682452/119995609-0e5bd680-bfce-11eb-8584-6326cfceb55c.png">



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-638]
