### PR TITLE
LINGO-748 implement norwegian readability feature flag

### DIFF
--- a/packages/yoastseo/src/languageProcessing/languages/nb/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nb/Researcher.js
@@ -1,10 +1,6 @@
 import { languageProcessing } from "yoastseo";
 const { AbstractResearcher } = languageProcessing;
-import { enableFeatures, isFeatureEnabled } from "@yoast/feature-flag";
-import firstWordExceptions from "../en/config/firstWordExceptions";
-import getSentenceParts from "../hu/helpers/getSentenceParts";
-import isPassiveSentence from "../hu/helpers/isPassiveSentence";
-import isPassiveSentencePart from "../hu/helpers/isPassiveSentencePart";
+import { enableFeatures, isFeatureEnabled, enabledFeatures } from "@yoast/feature-flag";
 
 // All config
 import functionWords from "./config/functionWords";
@@ -33,10 +29,9 @@ export default class Researcher extends AbstractResearcher {
 		// Enable the other Norwegian readability features
 		enableFeatures( [ 'NORWEGIAN_READABILITY' ] );
 
-		// Delete the transition words, passive voice and getSentenceBeginning researches if the Norwegian readability is not enabled
 		if ( isFeatureEnabled( 'NORWEGIAN_READABILITY' ) ) {
 			Object.assign( this.config, {
-				passiveConstructionType,
+				passiveConstructionType: "morphologicalAndPeriphrastic",
 				transitionWords,
 				twoPartTransitionWords,
 				firstWordExceptions,
@@ -47,6 +42,7 @@ export default class Researcher extends AbstractResearcher {
 				isPassiveSentence,
 			} );
 		} else {
+			// Delete the researches for other readability assessments when the feature is not enabled.
 			delete this.defaultResearches.findTransitionWords;
 			delete this.defaultResearches.getPassiveVoice;
 			delete this.defaultResearches.getSentenceBeginnings;

--- a/packages/yoastseo/src/languageProcessing/languages/nb/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nb/Researcher.js
@@ -1,15 +1,11 @@
 import { languageProcessing } from "yoastseo";
 const { AbstractResearcher } = languageProcessing;
-import { enableFeatures, isFeatureEnabled, enabledFeatures } from "@yoast/feature-flag";
 
 // All config
 import functionWords from "./config/functionWords";
 
 // All helpers
 import getStemmer from "./helpers/getStemmer";
-
-// // The list of the feature flag names
-// const featureNames = [ 'NORWEGIAN_READABILITY' ];
 
 /**
  * The researches contains all the researches
@@ -25,28 +21,6 @@ export default class Researcher extends AbstractResearcher {
 
 		// Delete Flesch Reading Ease research since Norwegian doesn't have the support for it
 		delete this.defaultResearches.getFleschReadingScore;
-
-		// Enable the other Norwegian readability features
-		//enableFeatures( [ 'NORWEGIAN_READABILITY' ] );
-
-		if ( isFeatureEnabled("norwegian-readability" ) ) {
-			Object.assign( this.config, {
-				passiveConstructionType: "morphologicalAndPeriphrastic",
-				transitionWords: ["of"],
-				twoPartTransitionWords: [["of", "and"]],
-				firstWordExceptions: ["the"],
-			} );
-		/*	Object.assign( this.helpers, {
-				getSentenceParts,
-				isPassiveSentencePart,
-				isPassiveSentence,
-			} );*/
-		} else {
-			// Delete the researches for other readability assessments when the feature is not enabled.
-			delete this.defaultResearches.findTransitionWords;
-			delete this.defaultResearches.getPassiveVoice;
-			delete this.defaultResearches.getSentenceBeginnings;
-		}
 
 		Object.assign( this.config, {
 			language: "nb",

--- a/packages/yoastseo/src/languageProcessing/languages/nb/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nb/Researcher.js
@@ -27,20 +27,20 @@ export default class Researcher extends AbstractResearcher {
 		delete this.defaultResearches.getFleschReadingScore;
 
 		// Enable the other Norwegian readability features
-		enableFeatures( [ 'NORWEGIAN_READABILITY' ] );
+		//enableFeatures( [ 'NORWEGIAN_READABILITY' ] );
 
-		if ( isFeatureEnabled( 'NORWEGIAN_READABILITY' ) ) {
+		if ( isFeatureEnabled("norwegian-readability" ) ) {
 			Object.assign( this.config, {
 				passiveConstructionType: "morphologicalAndPeriphrastic",
-				transitionWords,
-				twoPartTransitionWords,
-				firstWordExceptions,
+				transitionWords: ["of"],
+				twoPartTransitionWords: [["of", "and"]],
+				firstWordExceptions: ["the"],
 			} );
-			Object.assign( this.helpers, {
+		/*	Object.assign( this.helpers, {
 				getSentenceParts,
 				isPassiveSentencePart,
 				isPassiveSentence,
-			} );
+			} );*/
 		} else {
 			// Delete the researches for other readability assessments when the feature is not enabled.
 			delete this.defaultResearches.findTransitionWords;

--- a/packages/yoastseo/src/languageProcessing/languages/nb/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nb/Researcher.js
@@ -1,11 +1,19 @@
 import { languageProcessing } from "yoastseo";
 const { AbstractResearcher } = languageProcessing;
+import { enableFeatures, isFeatureEnabled } from "@yoast/feature-flag";
+import firstWordExceptions from "../en/config/firstWordExceptions";
+import getSentenceParts from "../hu/helpers/getSentenceParts";
+import isPassiveSentence from "../hu/helpers/isPassiveSentence";
+import isPassiveSentencePart from "../hu/helpers/isPassiveSentencePart";
 
 // All config
 import functionWords from "./config/functionWords";
 
 // All helpers
 import getStemmer from "./helpers/getStemmer";
+
+// // The list of the feature flag names
+// const featureNames = [ 'NORWEGIAN_READABILITY' ];
 
 /**
  * The researches contains all the researches
@@ -19,10 +27,30 @@ export default class Researcher extends AbstractResearcher {
 	constructor( paper ) {
 		super( paper );
 
+		// Delete Flesch Reading Ease research since Norwegian doesn't have the support for it
 		delete this.defaultResearches.getFleschReadingScore;
-		delete this.defaultResearches.getPassiveVoice;
-		delete this.defaultResearches.getSentenceBeginnings;
-		delete this.defaultResearches.findTransitionWords;
+
+		// Enable the other Norwegian readability features
+		enableFeatures( [ 'NORWEGIAN_READABILITY' ] );
+
+		// Delete the transition words, passive voice and getSentenceBeginning researches if the Norwegian readability is not enabled
+		if ( isFeatureEnabled( 'NORWEGIAN_READABILITY' ) ) {
+			Object.assign( this.config, {
+				passiveConstructionType,
+				transitionWords,
+				twoPartTransitionWords,
+				firstWordExceptions,
+			} );
+			Object.assign( this.helpers, {
+				getSentenceParts,
+				isPassiveSentencePart,
+				isPassiveSentence,
+			} );
+		} else {
+			delete this.defaultResearches.findTransitionWords;
+			delete this.defaultResearches.getPassiveVoice;
+			delete this.defaultResearches.getSentenceBeginnings;
+		}
 
 		Object.assign( this.config, {
 			language: "nb",

--- a/packages/yoastseo/src/scoring/assessments/readability/passiveVoiceAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/passiveVoiceAssessment.js
@@ -112,7 +112,7 @@ const passiveVoiceMarker = function( paper, researcher ) {
  */
 const passiveVoiceAssessment = function( paper, researcher, i18n ) {
 	// Check if the Norwegian readability feature is enabled and return the default result if it isn't.
-	if ( ! isFeatureEnabled( "norwegian-readability" ) ) {
+	if ( researcher.getConfig( "language" ) === "nb" && ! isFeatureEnabled( "norwegian-readability" ) ) {
 		return new AssessmentResult();
 	}
 

--- a/packages/yoastseo/src/scoring/assessments/readability/passiveVoiceAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/passiveVoiceAssessment.js
@@ -7,6 +7,7 @@ import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import { stripIncompleteTags as stripTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
 import AssessmentResult from "../../../values/AssessmentResult";
 import Mark from "../../../values/Mark";
+import { isFeatureEnabled } from "@yoast/feature-flag";
 
 /**
  * Calculates the result based on the number of sentences and passives.
@@ -110,6 +111,11 @@ const passiveVoiceMarker = function( paper, researcher ) {
  * @returns {object} the Assessmentresult
  */
 const passiveVoiceAssessment = function( paper, researcher, i18n ) {
+	// Check if the Norwegian readability feature is enabled and return the default result if it isn't.
+	if ( ! isFeatureEnabled( "norwegian-readability" ) ) {
+		return new AssessmentResult();
+	}
+
 	const passiveVoice = researcher.getResearch( "getPassiveVoice" );
 
 	const passiveVoiceResult = calculatePassiveVoiceResult( passiveVoice, i18n );

--- a/packages/yoastseo/src/scoring/assessments/readability/sentenceBeginningsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/sentenceBeginningsAssessment.js
@@ -1,3 +1,4 @@
+import { isFeatureEnabled } from "@yoast/feature-flag";
 import { filter, flatten, map, partition, sortBy } from "lodash-es";
 
 import marker from "../../../markers/addMark";
@@ -117,6 +118,11 @@ const sentenceBeginningMarker = function( paper, researcher ) {
  * @returns {object} The Assessment result
  */
 const sentenceBeginningsAssessment = function( paper, researcher, i18n ) {
+	// Check if the Norwegian readability feature is enabled and return the default result if it isn't.
+	if ( ! isFeatureEnabled( "norwegian-readability" ) ) {
+		return new AssessmentResult();
+	}
+
 	const sentenceBeginnings = researcher.getResearch( "getSentenceBeginnings" );
 	const groupedSentenceBeginnings = groupSentenceBeginnings( sentenceBeginnings );
 	const sentenceBeginningsResult = calculateSentenceBeginningsResult( groupedSentenceBeginnings, i18n );

--- a/packages/yoastseo/src/scoring/assessments/readability/sentenceBeginningsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/sentenceBeginningsAssessment.js
@@ -119,7 +119,7 @@ const sentenceBeginningMarker = function( paper, researcher ) {
  */
 const sentenceBeginningsAssessment = function( paper, researcher, i18n ) {
 	// Check if the Norwegian readability feature is enabled and return the default result if it isn't.
-	if ( ! isFeatureEnabled( "norwegian-readability" ) ) {
+	if ( researcher.getConfig( "language" ) === "nb" && ! isFeatureEnabled( "norwegian-readability" ) ) {
 		return new AssessmentResult();
 	}
 

--- a/packages/yoastseo/src/scoring/assessments/readability/transitionWordsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/transitionWordsAssessment.js
@@ -119,7 +119,7 @@ const calculateTransitionWordResult = function( transitionWordSentences, i18n ) 
  */
 const transitionWordsAssessment = function( paper, researcher, i18n ) {
 	// Check if the Norwegian readability feature is enabled and return the default result if it isn't.
-	if ( ! isFeatureEnabled( "norwegian-readability" ) ) {
+	if ( researcher.getConfig( "language" ) === "nb" && ! isFeatureEnabled( "norwegian-readability" ) ) {
 		return new AssessmentResult();
 	}
 

--- a/packages/yoastseo/src/scoring/assessments/readability/transitionWordsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/transitionWordsAssessment.js
@@ -1,3 +1,4 @@
+import { isFeatureEnabled } from "@yoast/feature-flag";
 import { map } from "lodash-es";
 
 import formatNumber from "../../../helpers/formatNumber";
@@ -117,6 +118,11 @@ const calculateTransitionWordResult = function( transitionWordSentences, i18n ) 
  * @returns {object} The Assessment result.
  */
 const transitionWordsAssessment = function( paper, researcher, i18n ) {
+	// Check if the Norwegian readability feature is enabled and return the default result if it isn't.
+	if ( ! isFeatureEnabled( "norwegian-readability" ) ) {
+		return new AssessmentResult();
+	}
+
 	const transitionWordSentences = researcher.getResearch( "findTransitionWords" );
 	const transitionWordResult = calculateTransitionWordResult( transitionWordSentences, i18n );
 	const assessmentResult = new AssessmentResult();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to release Norwegian readability assessments (i.e. Passive Voice, Sentence Beginning, and Transition Words Assessments) under feature flag.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds a check in Passive Voice, Sentence Beginning, and Transition Words Assessments whether `norwegian-readability` feature is enabled, and returns the default result if it's disabled.

## Relevant technical choices:

* The empty `premium-configuration` branch with the same name should be deleted after this PR is merged.
* Currently, when we enable the feature, there are going to be errors in the console related to the fact that at this point we haven't added the necessary configs and helpers for the assessments in the Norwegian Researcher. These errors will be fixed when we implement the the related assessments.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run `yarn test` and make sure everything passes
* Add this statement `define( 'YOAST_SEO_ENABLED_FEATURES', 'norwegian-readability' );` to `plugin-development-docker/config/basic-wordpress-config.php` file
* Set your site language to Norwegian (Norsk bokmål)
* Open a post
* Confirm that the Passive Voice, Sentence Beginning, and Transition Words Assessments are being loaded in the metabox
<img width="280" alt="Screenshot 2021-05-31 at 11 57 55" src="https://user-images.githubusercontent.com/48715883/120176411-89f49800-c207-11eb-9b2a-5d8574338b4e.png">

* Delete `define( 'YOAST_SEO_ENABLED_FEATURES', 'norwegian-readability' );` from `plugin-development-docker/config/basic-wordpress-config.php` file
* Reload your post
* Confirm that the Passive Voice, Sentence Beginning, and Transition Words Assessments are NOT being loaded in the metabox anymore
* Change the site language to English
* Confirm that the Passive Voice, Sentence Beginning, and Transition Words Assessments are always being loaded in the metabox regardless whether `define( 'YOAST_SEO_ENABLED_FEATURES', 'norwegian-readability' );` is in the config file or not

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-748
