### PR TITLE
Add Grunt `build:ts` command for compiling TypeScript in the plugin

### DIFF
--- a/config/grunt/task-config/aliases.yaml
+++ b/config/grunt/task-config/aliases.yaml
@@ -163,19 +163,19 @@ release:
   - 'wp_deploy:trunk'
 
 'update-changelog:file':
-  - get-latest-pr-texts
-  - update-changelog-with-latest-pr-texts
+  - 'get-latest-pr-texts'
+  - 'update-changelog-with-latest-pr-texts'
 
 'update-changelog:qa':
-  - get-latest-pr-texts
-  - download-qa-changelog
-  - build-qa-changelog
+  - 'get-latest-pr-texts'
+  - 'download-qa-changelog'
+  - 'build-qa-changelog'
 
 'update-changelog:all':
-  - get-latest-pr-texts
-  - update-changelog-with-latest-pr-texts
-  - download-qa-changelog
-  - build-qa-changelog
+  - 'get-latest-pr-texts'
+  - 'update-changelog-with-latest-pr-texts'
+  - 'download-qa-changelog'
+  - 'build-qa-changelog'
 
 # Default task
 default:

--- a/config/grunt/task-config/aliases.yaml
+++ b/config/grunt/task-config/aliases.yaml
@@ -1,6 +1,7 @@
 # Grunt aliases
 ---
 'build':
+  - 'build:ts'
   - 'build:js'
   - 'build:css'
   - 'build:images'
@@ -14,13 +15,17 @@
 
 # Grunt command to only build CSS and JS
 'build:dev':
+  - 'build:ts'
   - 'build:js'
   - 'build:css'
+
+# Compile the TypeScript in the `schema-blocks` package
+'build:ts':
+  - 'shell:install-schema-blocks'
 
 # Build JavaScript from assets to production
 'build:js':
   - 'clean:build-assets-js'
-  - 'shell:install-schema-blocks'
   - 'copy:js-dependencies'
   - 'shell:webpack'
 
@@ -136,11 +141,13 @@ clean:build-assets:
 release:
   - 'clean:build-assets'
   - 'build:images'
+  - 'release:ts'
   - 'release:js'
   - 'release:css'
   - 'build:i18n'
-'release:js':
+'release:ts':
   - 'shell:install-schema-blocks'
+'release:js':
   - 'copy:js-dependencies'
   - 'shell:webpack-prod'
 

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -140,7 +140,7 @@ module.exports = function( grunt ) {
 		},
 
 		webpack: {
-			command: "NODE_ENV=development yarn run wp-scripts build --config config/webpack/webpack.config.js",
+			command: "cross-env NODE_ENV=development yarn run wp-scripts build --config config/webpack/webpack.config.js",
 		},
 
 		"webpack-prod": {

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -192,10 +192,7 @@ module.exports = function( grunt ) {
 		},
 
 		"install-schema-blocks": {
-			// If a src directory exists in the schema-blocks but not dist directory then it needs to be built.
-			command: "if [ -d node_modules/@yoast/schema-blocks/src ] && [ ! -d node_modules/@yoast/schema-blocks/dist ]; then " +
-					 "cd node_modules/@yoast/schema-blocks && yarn install && yarn build; " +
-					 "fi",
+			command: "cd packages/schema-blocks && yarn build",
 		},
 
 		"check-for-uncommitted-changes": {

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -192,7 +192,7 @@ module.exports = function( grunt ) {
 		},
 
 		"install-schema-blocks": {
-			command: "cd packages/schema-blocks && yarn build",
+			command: "cd packages/schema-blocks && yarn build && cd ../..",
 		},
 
 		"check-for-uncommitted-changes": {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The Core team regularly gets questions from other devs about their builds breaking due to the `schema-blocks` package. It isn't common knowledge that `yarn build` should be run every time the TypeScript code in the `schema-blocks` package has changed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces the Grunt `build:ts` command to compile the TypeScript in our `schema-blocks` package.

## Relevant technical choices:

* I changed the `install-schema-blocks` shell command to run `yarn build` in `packages/schema-blocks` rather than in `node_modules/@yoast/schema-blocks`. I believe this should have happened after we merged the monorepo, but was forgotten.
* I also removed the conditional from the `install-schema-blocks` shell command. The TypeScript in the plugin should be recompiled every time it changes, so just checking for the existence of the `dist` folder is not enough.
* Unrelated: I fixed some quotes in `aliases.yaml`. This has no impact on the functioning of the plugin.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Remove your `node_modules` folder.
* Build the plugin as usual (`composer install && yarn install && grunt build:dev`).
* Create a new post and see that the Job blocks are working as expected.
* Make a change in the TypeScript code, for example add `console.log( "hello" )` in `watch.ts`.
* Run `grunt build:ts` followed by `grunt build:js`.
* Open the post editor in the Plugin and see `hello` in your console.
* Change the `console.log` statement (for example now log `"hello2"`).
* Run `grunt build:dev`.
* Open the post editor in the Plugin and see `hello2` in your console.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* No need for QA to test this PR, it concerns build tooling. If the Job blocks are working (roughly) as expected in your RC, you can conclude that building was OK.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The Schema blocks.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P2-1000
