### PR TITLE
Revert "Remove the Addon installation feature flag"

### DIFF
--- a/src/conditionals/addon-installation-conditional.php
+++ b/src/conditionals/addon-installation-conditional.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Checks if the Addon_Installation constant is set.
+ */
+class Addon_Installation_Conditional extends Feature_Flag_Conditional {
+
+	/**
+	 * Returns the name of the feature flag.
+	 * 'YOAST_SEO_' is automatically prepended to it and it will be uppercased.
+	 *
+	 * @return string the name of the feature flag.
+	 */
+	protected function get_feature_flag() {
+		return 'ADDON_INSTALLATION';
+	}
+}

--- a/src/integrations/admin/addon-installation/dialog-integration.php
+++ b/src/integrations/admin/addon-installation/dialog-integration.php
@@ -5,6 +5,7 @@
 namespace Yoast\WP\SEO\Integrations\Admin\Addon_Installation;
 
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Addon_Installation_Conditional;
 use Yoast\WP\SEO\Conditionals\Admin\Licenses_Page_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
@@ -34,6 +35,7 @@ class Dialog_Integration implements Integration_Interface {
 		return [
 			Admin_Conditional::class,
 			Licenses_Page_Conditional::class,
+			Addon_Installation_Conditional::class,
 		];
 	}
 

--- a/src/integrations/admin/addon-installation/installation-integration.php
+++ b/src/integrations/admin/addon-installation/installation-integration.php
@@ -7,6 +7,7 @@ namespace Yoast\WP\SEO\Integrations\Admin\Addon_Installation;
 use Yoast\WP\SEO\Actions\Addon_Installation\Addon_Activate_Action;
 use Yoast\WP\SEO\Actions\Addon_Installation\Addon_Install_Action;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Addon_Installation_Conditional;
 use Yoast\WP\SEO\Conditionals\Admin\Licenses_Page_Conditional;
 use Yoast\WP\SEO\Exceptions\Addon_Installation\Addon_Activation_Error_Exception;
 use Yoast\WP\SEO\Exceptions\Addon_Installation\Addon_Already_Installed_Exception;
@@ -48,6 +49,7 @@ class Installation_Integration implements Integration_Interface {
 		return [
 			Admin_Conditional::class,
 			Licenses_Page_Conditional::class,
+			Addon_Installation_Conditional::class,
 		];
 	}
 

--- a/src/routes/supported-features-route.php
+++ b/src/routes/supported-features-route.php
@@ -3,7 +3,7 @@
 namespace Yoast\WP\SEO\Routes;
 
 use WP_REST_Response;
-use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Conditionals\Addon_Installation_Conditional;
 use Yoast\WP\SEO\Main;
 
 /**
@@ -11,14 +11,23 @@ use Yoast\WP\SEO\Main;
  */
 class Supported_Features_Route implements Route_Interface {
 
-	use No_Conditionals;
-
 	/**
 	 * Represents the supported features route.
 	 *
 	 * @var string
 	 */
 	const SUPPORTED_FEATURES_ROUTE = '/supported-features';
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * @return array
+	 */
+	public static function get_conditionals() {
+		return [
+			Addon_Installation_Conditional::class,
+		];
+	}
 
 	/**
 	 * Registers routes with WordPress.

--- a/tests/unit/routes/supported-features-route-test.php
+++ b/tests/unit/routes/supported-features-route-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Routes;
 
 use Brain\Monkey;
 use Mockery;
+use Yoast\WP\SEO\Conditionals\Addon_Installation_Conditional;
 use Yoast\WP\SEO\Routes\Supported_Features_Route;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -38,7 +39,7 @@ class Supported_Features_Route_Test extends TestCase {
 	 */
 	public function test_get_conditionals() {
 		$this->assertEquals(
-			[],
+			[ Addon_Installation_Conditional::class ],
 			Supported_Features_Route::get_conditionals()
 		);
 	}


### PR DESCRIPTION
Reverts Yoast/wordpress-seo#17046

Reintroduces the addon installation flow feature flag.