### PR TITLE
P2-969 Salary range block editor css

### DIFF
--- a/css/src/schema-blocks.css
+++ b/css/src/schema-blocks.css
@@ -16,3 +16,11 @@
 	border: #CCCCCC 1px solid;
 	border-radius: 0;
 }
+
+.yoast-job-block__salary .wp-block-yoast-job-salary-range {
+	max-width: 25%;
+}
+
+.yoast-job-block__salary .wp-block-yoast-job-salary-range input[type=number] {
+	-moz-appearance: textfield;
+}

--- a/css/src/schema-blocks.css
+++ b/css/src/schema-blocks.css
@@ -24,3 +24,8 @@
 .yoast-job-block__salary .wp-block-yoast-job-salary-range input[type=number] {
 	-moz-appearance: textfield;
 }
+
+.editor-styles-wrapper .wp-block-yoast-job-salary [data-block] {
+	margin-top: 0;
+	margin-bottom: 0;
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Style the salary range block in the editor so it aligns better with the rest of the content.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Build the plugin in docker.
2. Add the jobs block pattern to a post.
3. Check if the Salary range block aligns with the Employment block.
4. Check if the Salary range block select elements are readable.
5. Check if the `-` and the `/` align vertical with in the rest in the Salary range block.

Note by @johannadevos: This PR should solve both P2-969 and P2-988. Please check whether this is the case. If so, close both tickets after merging.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
