### PR TITLE
Move social settings below schema settings and restore New badges

### DIFF
--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -73,6 +73,12 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 
 	echo '</div>';
 
+	if ( WPSEO_Options::get( 'breadcrumbs-enable' ) === true ) {
+		/* translators: %s is the plural version of the post type's name. */
+		echo '<h4>' . esc_html( sprintf( __( 'Breadcrumb settings for %s archive', 'wordpress-seo' ), $plural_label ) ) . '</h4>';
+		$yform->textinput( 'bctitle-ptarchive-' . $wpseo_post_type->name, __( 'Breadcrumbs title', 'wordpress-seo' ) );
+	}
+
 	/**
 	 * Allow adding custom fields to the admin meta page at the end of the archive settings for a post type - Content Types tab.
 	 *
@@ -80,12 +86,6 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 	 * @param string     $name  The post type name.
 	 */
 	do_action( 'Yoast\WP\SEO\admin_post_types_archive', $yform, $wpseo_post_type->name );
-
-	if ( WPSEO_Options::get( 'breadcrumbs-enable' ) === true ) {
-		/* translators: %s is the plural version of the post type's name. */
-		echo '<h4>' . esc_html( sprintf( __( 'Breadcrumb settings for %s archive', 'wordpress-seo' ), $plural_label ) ) . '</h4>';
-		$yform->textinput( 'bctitle-ptarchive-' . $wpseo_post_type->name, __( 'Breadcrumbs title', 'wordpress-seo' ) );
-	}
 }
 
 /**

--- a/admin/views/tabs/metas/paper-content/post_type/post-type.php
+++ b/admin/views/tabs/metas/paper-content/post_type/post-type.php
@@ -48,14 +48,6 @@ $editor->render();
 
 echo '</div>';
 
-/**
- * Allow adding custom fields to the admin meta page - Content Types tab.
- *
- * @param Yoast_Form $yform The Yoast_Form object.
- * @param string     $name  The post type name.
- */
-do_action( 'Yoast\WP\SEO\admin_post_types_meta', $yform, $wpseo_post_type->name );
-
 echo '<div class="yoast-settings-section">';
 
 // Schema settings.

--- a/src/config/badge-group-names.php
+++ b/src/config/badge-group-names.php
@@ -16,7 +16,7 @@ class Badge_Group_Names {
 	 * Constant describing when certain groups of new badges will no longer be shown.
 	 */
 	const GROUP_NAMES = [
-		self::GROUP_GLOBAL_TEMPLATES => '16.5-beta0',
+		self::GROUP_GLOBAL_TEMPLATES => '16.7-beta0',
 	];
 
 	/**

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -66,7 +66,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	public function register_hooks() {
 		\add_action( 'Yoast\WP\SEO\admin_author_archives_meta', [ $this, 'social_author_archives' ] );
 		\add_action( 'Yoast\WP\SEO\admin_date_archives_meta', [ $this, 'social_date_archives' ] );
-		\add_action( 'Yoast\WP\SEO\admin_post_types_meta', [ $this, 'social_post_type' ], 8, 2 );
+		\add_action( 'Yoast\WP\SEO\admin_post_types_beforearchive', [ $this, 'social_post_type' ], \PHP_INT_MAX, 2 );
 		\add_action( 'Yoast\WP\SEO\admin_post_types_archive', [ $this, 'social_post_types_archive' ], 10, 2 );
 		\add_action( 'Yoast\WP\SEO\admin_taxonomies_meta', [ $this, 'social_taxonomies' ], 10, 2 );
 	}

--- a/tests/unit/config/badge-group-names-test.php
+++ b/tests/unit/config/badge-group-names-test.php
@@ -16,16 +16,16 @@ class Badge_Group_Names_Test extends TestCase {
 	const TESTING_GROUP = Badge_Group_Names::GROUP_GLOBAL_TEMPLATES;
 
 	/* The group we're testing will no longer be considered new from this version onwards. */
-	const VERSION_NO_LONGER_NEW = '16.5';
+	const VERSION_NO_LONGER_NEW = '16.7';
 
 	/* The group we're testing will no longer be considered new from this RC version onwards. */
-	const VERSION_NO_LONGER_NEW_RC = '16.5-RC1';
+	const VERSION_NO_LONGER_NEW_RC = '16.7-RC1';
 
 	/* The group we're testing will still be considered new on this version. */
-	const VERSION_STILL_NEW = '16.4';
+	const VERSION_STILL_NEW = '16.6';
 
 	/* The group we're testing is not considered new on this version. */
-	const VERSION_NEXT_MINOR = '16.6';
+	const VERSION_NEXT_MINOR = '16.8';
 
 	/* The group we're testing is definitely not considered new on this version. */
 	const VERSION_NEXT_MAJOR = '17.0';


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to move the Social templates forms at the end of the expandable panels in the settings pages so that they're displayed as last thing within the panels.
* We want to fix a bug that prevented the "New" badges from being displayed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Moves the Social templates forms at the end of the settings sections.
* Fixes a bug where the "New" badges were not displayed for the Social templates forms.

## Relevant technical choices:

- Removes the `Yoast\WP\SEO\admin_post_types_meta` since it's now unused
- Note: This PR is a UI-change compared to the PR that merged the Global Social Templates feature https://github.com/Yoast/wordpress-seo/pull/17095 as now the Social template forms will be displayed in a different position in the settings pages 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- activate Yoast SEO Free, switched to this branch, and build it as usual 
- activate Yoast SEO Premium, Local SEO, and WooCommerce 
- make sure to enable the Location custom post type:
  - go to SEO > Local SEO > Business info, and set "My business has multiple locations" to Yes
- in the following places, check the Social image, Social title, and Social description are displayed as last thing within the expandable panels, even after "Custom fields to include in page analysis" and the "Breadcrumbs title" (when displayed)
  - SEO > Search appearance > Content Types > Posts 
  - SEO > Search appearance > Content Types > Pages 
  - SEO > Search appearance > Content Types > Locations has two sections:
    - "Single Location settings": check the social templates forms are the last thing in this section 
    - "Locations archive settings": check the social templates forms are the last thing in this section 
  - SEO > Search appearance > Content Types > Products has two sections:
    - "Single Product settings": check the social templates forms are the last thing in this section 
    - "Settings for Products archive": check there's just the following text with a link: "You can edit the SEO meta-data for this custom type on the Shop page."
  - SEO > Search appearance > Taxonomies > all taxonomies:
    - no functional changes here: the Social templates form were already the last thing within the panels   
  - SEO > Search appearance > Archives 
    - no functional changes for Author and Date archives: the Social templates form were already the last thing within the panels   
- deactivate Yoast SEO Premium 
- check again all the above places 
- check the Social templates forms appear disabled with the "upsell" button and they're still the last thing within panels 

**Test the "New" Badges:**
- activate Yoast SEO Premium again 
- check the "New" badges appear to the right of the "Premium" badges for Social Image, title, and description in all the following places:
  - SEO > Search appearance > General > Homepage
  - SEO > Search appearance > Content Types: all the post types and CPTs archives
  - SEO > Search appearance > Taxonomies: all the taxonomies 
  - SEO > Search appearance > Archives: Author and Date archives



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-665]
