### PR TITLE
P3-666 Remove ads

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -231,10 +231,13 @@ class WPSEO_Admin_Init {
 			// For backwards compatabilty, this still needs a global, for now...
 			$GLOBALS['wpseo_admin_pages'] = new WPSEO_Admin_Pages();
 
+			$page = filter_input( INPUT_GET, 'page' );
 			// Only register the yoast i18n when the page is a Yoast SEO page.
-			if ( WPSEO_Utils::is_yoast_seo_free_page( filter_input( INPUT_GET, 'page' ) ) ) {
+			if ( WPSEO_Utils::is_yoast_seo_free_page( $page ) ) {
 				$this->register_i18n_promo_class();
-				$this->register_premium_upsell_admin_block();
+				if ( $page !== 'wpseo_titles' ) {
+					$this->register_premium_upsell_admin_block();
+				}
 			}
 		}
 	}

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -48,7 +48,8 @@ class WPSEO_Premium_Upsell_Admin_Block {
 	 * @return void
 	 */
 	public function render() {
-		$url = WPSEO_Shortlinker::get( 'https://yoa.st/17h' );
+		$page = filter_input( INPUT_GET, 'page' );
+		$url  = add_query_arg( [ 'screen' => $page ], WPSEO_Shortlinker::get( 'https://yoa.st/17h' ) );
 
 		$arguments = [
 			'<strong>' . esc_html__( 'Multiple keyphrases', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Increase your SEO reach', 'wordpress-seo' ),

--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -7,7 +7,7 @@
 
 $wpseo_plugin_dir_url = plugin_dir_url( WPSEO_FILE );
 $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
-
+$wpseo_page           = filter_input( INPUT_GET, 'page' );
 ?>
 <div class="wpseo_content_cell" id="sidebar-container">
 	<div id="sidebar" class="yoast-sidebar">
@@ -40,7 +40,7 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 			</ul>
 
 			<a id="wpseo-premium-button" class="yoast-button-upsell"
-				href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jj' ); ?>" target="_blank">
+				href="<?php echo esc_url( add_query_arg( [ 'screen' => $wpseo_page ], WPSEO_Shortlinker::get( 'https://yoa.st/jj' ) ) ); ?>" target="_blank">
 				<?php
 				/* translators: %s expands to Yoast SEO Premium */
 				printf( esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
@@ -58,7 +58,7 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 			</h2>
 			<p>
 				<?php
-				$url = WPSEO_Shortlinker::get( 'https://yoa.st/3t6' );
+				$url = add_query_arg( [ 'screen' => $wpseo_page ], WPSEO_Shortlinker::get( 'https://yoa.st/3t6' ) );
 
 				/* translators: %1$s expands to Yoast SEO academy, which is a clickable link. */
 				printf( esc_html__( 'Want to learn SEO from Team Yoast? Check out our %1$s!', 'wordpress-seo' ), '<a href="' . esc_url( $url ) . '"><strong>Yoast SEO academy</strong></a>' );
@@ -67,7 +67,7 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 				?>
 			</p>
 			<p>
-				<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/3t6' ); ?>" target="_blank">
+				<a href="<?php echo esc_url( $url ); ?>" target="_blank">
 					<?php
 					/* translators: %1$s expands to Yoast SEO academy */
 					printf( esc_html__( 'Check out %1$s', 'wordpress-seo' ), 'Yoast SEO academy' );

--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -50,74 +50,6 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 				?>
 			</a><br>
 		</div>
-		<div class="yoast-sidebar__product-list">
-			<div class="yoast-sidebar__section">
-				<h2>
-					<?php
-					/* translators: %s expands to Yoast SEO */
-					printf( esc_html__( 'Extend %s', 'wordpress-seo' ), 'Yoast SEO' );
-					?>
-				</h2>
-				<div class="wp-clearfix">
-					<p>
-						<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jq' ); ?>" target="_blank">
-							<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/local_plugin_assistant.svg' ); ?>"
-								alt="">
-							<strong>Be found on Google Maps!</strong>
-							<?php
-							// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $new_tab_message is properly escaped.
-							echo $new_tab_message;
-							?>
-						</a><br>
-						<?php esc_html_e( 'Our Local SEO plugin will help you rank in Google Maps and local results.', 'wordpress-seo' ); ?>
-					</p>
-				</div>
-				<div class="wp-clearfix">
-					<p>
-						<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jo' ); ?>" target="_blank">
-							<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/video_plugin_assistant.svg' ); ?>"
-								class="alignleft"
-								alt="">
-							<strong>Rank in Google Video</strong>
-							<?php
-							// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $new_tab_message is properly escaped.
-							echo $new_tab_message;
-							?>
-						</a><br>
-						<?php esc_html_e( 'Make sure your videos rank and are easy to share with our Video SEO plugin.', 'wordpress-seo' ); ?>
-					</p>
-				</div>
-				<div class="wp-clearfix">
-					<p>
-						<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jp' ); ?>" target="_blank">
-							<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/woo_plugin_assistant.svg' ); ?>"
-								alt="">
-							<strong>WooCommerce SEO</strong>
-							<?php
-							// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $new_tab_message is properly escaped.
-							echo $new_tab_message;
-							?>
-						</a><br>
-						<?php esc_html_e( 'Optimize your shop\'s SEO and sell more products!', 'wordpress-seo' ); ?>
-					</p>
-				</div>
-				<div class="wp-clearfix">
-					<p>
-						<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jr' ); ?>" target="_blank">
-							<img src="<?php echo esc_url( $wpseo_plugin_dir_url . 'images/news_plugin_assistant.svg' ); ?>"
-								class="alignleft"
-								alt="">
-							<strong>Rank in Google News</strong>
-							<?php
-							// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $new_tab_message is properly escaped.
-							echo $new_tab_message;
-							?>
-						</a><br>
-						<?php esc_html_e( 'Start to optimize your site for Google News traffic today!', 'wordpress-seo' ); ?>
-					</p>
-				</div>
-			</div>
-		</div>
 		<div class="yoast-sidebar__section">
 			<h2>
 				<?php
@@ -139,19 +71,6 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 					<?php
 					/* translators: %1$s expands to Yoast SEO academy */
 					printf( esc_html__( 'Check out %1$s', 'wordpress-seo' ), 'Yoast SEO academy' );
-					?>
-				</a>
-			</p>
-		</div>
-		<div class="yoast-sidebar__section">
-			<h2><?php esc_html_e( 'Remove these ads?', 'wordpress-seo' ); ?></h2>
-			<p>
-				<a href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jy' ); ?>" target="_blank">
-					<?php
-					/* translators: %s expands to Yoast SEO Premium */
-					printf( esc_html__( 'Upgrade to %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: $new_tab_message is properly escaped.
-					echo $new_tab_message;
 					?>
 				</a>
 			</p>

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -205,9 +205,11 @@ class Social_Templates_Integration implements Integration_Interface {
 		$editor->render();
 
 		if ( ! $is_premium ) {
+			$wpseo_page = filter_input( INPUT_GET, 'page' );
+
 			echo '<div class="yoast-settings-section-upsell">';
 
-			echo '<a class="yoast-button-upsell" href="' . \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/4e0' ) ) . '" target="_blank">'
+			echo '<a class="yoast-button-upsell" href="' . \esc_url( \add_query_arg( [ 'screen' => $wpseo_page ], WPSEO_Shortlinker::get( 'https://yoa.st/4e0' ) ) ) . '" target="_blank">'
 			. \esc_html__( 'Unlock with Premium', 'wordpress-seo' )
 			// phpcs:ignore WordPress.Security.EscapeOutput -- Already escapes correctly.
 			. WPSEO_Admin_Utils::get_new_tab_message()


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* With adding more contextual upsells, we become less dependant on our ads. In this PR I'm removing about half the ads that were listed in the sidebar of the Yoast SEO admin screens. Also, we've removed the ad box at the bottom on the search appearance settings. 
### Before
![screencapture-basic-wordpress-test-wp-admin-admin-php-2021-06-02-17_01_08](https://user-images.githubusercontent.com/1488816/120504946-d507da00-c3c4-11eb-9c8d-08ae16222744.png)

### After
![screencapture-basic-wordpress-test-wp-admin-admin-php-2021-06-02-16_46_14](https://user-images.githubusercontent.com/1488816/120504979-dcc77e80-c3c4-11eb-9122-3751dad40331.png)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Less is more: removes a whole bunch of ads from the Yoast SEO admin screens.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* On every Yoast SEO admin/settings screen the following ads should be gone:
  * "Extend Yoast SEO"
  * "Remove these ads?"
* On the search appearance settings screen the following ad should be gone:
  * The upgrade box at the bottom
* On every admin screen, the links in the ads should now have a `screen` parameter which resembles the `page` attribute in the url of that screen.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Just some read only HTML in the settings screens.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities