### PR TITLE
P3-671 Move rewrite titles to separate paper

### DIFF
--- a/admin/views/tabs/metas/general.php
+++ b/admin/views/tabs/metas/general.php
@@ -24,9 +24,9 @@ if ( ! current_theme_supports( 'title-tag' ) ) {
 			'class'       => 'search-appearance',
 		]
 	);
+	// phpcs:ignore WordPress.Security.EscapeOutput -- output contains HTML and we assume it's properly escape on object creation.
+	echo $wpseo_rewrite_titles_presenter->get_output();
 }
-// phpcs:ignore WordPress.Security.EscapeOutput -- output contains HTML and we assume it's properly escape on object creation.
-echo $wpseo_rewrite_titles_presenter->get_output();
 
 $wpseo_title_separator_title     = esc_html__( 'Title Separator', 'wordpress-seo' );
 $wpseo_title_separator_presenter = new WPSEO_Paper_Presenter(

--- a/admin/views/tabs/metas/general.php
+++ b/admin/views/tabs/metas/general.php
@@ -11,6 +11,23 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 	exit();
 }
 
+if ( ! current_theme_supports( 'title-tag' ) ) {
+	$wpseo_rewrite_titles_title     = esc_html__( 'Rewrite titles', 'wordpress-seo' );
+	$wpseo_rewrite_titles_presenter = new WPSEO_Paper_Presenter(
+		$wpseo_rewrite_titles_title,
+		__DIR__ . '/paper-content/general/force-rewrite-title.php',
+		[
+			'collapsible' => true,
+			'expanded'    => true,
+			'paper_id'    => 'settings-general-rewrite-titles',
+			'title'       => $wpseo_rewrite_titles_title,
+			'class'       => 'search-appearance',
+		]
+	);
+}
+// phpcs:ignore WordPress.Security.EscapeOutput -- output contains HTML and we assume it's properly escape on object creation.
+echo $wpseo_rewrite_titles_presenter->get_output();
+
 $wpseo_title_separator_title     = esc_html__( 'Title Separator', 'wordpress-seo' );
 $wpseo_title_separator_presenter = new WPSEO_Paper_Presenter(
 	$wpseo_title_separator_title,

--- a/admin/views/tabs/metas/paper-content/general/force-rewrite-title.php
+++ b/admin/views/tabs/metas/paper-content/general/force-rewrite-title.php
@@ -7,13 +7,11 @@
  * @uses Yoast_Form $yform Form object.
  */
 
-if ( ! current_theme_supports( 'title-tag' ) ) {
-	$yform->light_switch( 'forcerewritetitle', __( 'Force rewrite titles', 'wordpress-seo' ) );
-	echo '<p class="description">';
-	printf(
-		/* translators: %1$s expands to Yoast SEO */
-		esc_html__( '%1$s has auto-detected whether it needs to force rewrite the titles for your pages, if you think it\'s wrong and you know what you\'re doing, you can change the setting here.', 'wordpress-seo' ),
-		'Yoast SEO'
-	);
-	echo '</p>';
-}
+$yform->light_switch( 'forcerewritetitle', __( 'Force rewrite titles', 'wordpress-seo' ) );
+echo '<p class="description">';
+printf(
+	/* translators: %1$s expands to Yoast SEO */
+	esc_html__( '%1$s has auto-detected whether it needs to force rewrite the titles for your pages, if you think it\'s wrong and you know what you\'re doing, you can change the setting here.', 'wordpress-seo' ),
+	'Yoast SEO'
+);
+echo '</p>';

--- a/admin/views/tabs/metas/paper-content/general/title-separator.php
+++ b/admin/views/tabs/metas/paper-content/general/title-separator.php
@@ -13,5 +13,3 @@ $legend      = __( 'Title separator symbol', 'wordpress-seo' );
 $legend_attr = [ 'class' => 'radiogroup screen-reader-text' ];
 $yform->radio( 'separator', WPSEO_Option_Titles::get_instance()->get_separator_options_for_display(), $legend, $legend_attr );
 
-require __DIR__ . '/force-rewrite-title.php';
-


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

When the `Force rewrite titles` setting is present, we need to make sure it appears in a paper at the top of the Search Appearance > General tab.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Moves the 'Force rewrite titles' toggle into a separate paper in the General Search Appearance settings.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure the theme does not register support for title-tag. To do this, remove or comment out the `add_theme_support( 'title-tag' );` line from your theme's functions.php file and click `Update file`.. 
* Navigate to SEO > Search Appearance > General and see there is a separate 'Rewrite titles' paper with the 'Force rewrite titles' toggle. Make sure it matches [the design](https://www.sketch.com/s/6b4efaeb-fcab-4e48-8314-0d532488e164/a/Om2Rxg8/play).
* Put the `add_theme_support( 'title-tag' );` line back into your theme's functions.php file and click `Update file`.
* Navigate to SEO > Search Appearance > General and see there is no separate 'Rewrite titles' paper and everything looks as expected. 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Use Twenty Twenty-One as your WordPress theme.
* Navigate to Appearance > Theme Editor and choose the `functions.php` as the Theme File. On line 46, comment out `add_theme_support( 'title-tag' );`, i.e. change it to `// add_theme_support( 'title-tag' );` click `Update file`.. 
* Navigate to SEO > Search Appearance > General and see there is a separate 'Rewrite titles' paper with the 'Force rewrite titles' toggle. Make sure it matches [the design](https://www.sketch.com/s/6b4efaeb-fcab-4e48-8314-0d532488e164/a/Om2Rxg8/play).
* Uncomment the `add_theme_support( 'title-tag' );` line from your theme's functions.php file and click `Update file`.
* Navigate to SEO > Search Appearance > General and see there is no separate 'Rewrite titles' paper and everything looks as expected. 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P3-671
