### PR TITLE
Fix composer 21 autoload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ jobs:
       before_install: skip
       before_script: skip
       install:
+      #force old version of composer until the --no-scripts flag in 21.0 is fixed
+        - composer self-update 2.0.14
         - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
         - travis_retry composer install --no-interaction
       script:

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -156,8 +156,7 @@ module.exports = function( grunt ) {
 		},
 
 		"composer-install-production": {
-			command: "composer install --prefer-dist --optimize-autoloader --no-dev --no-scripts && " +
-					 "composer du --optimize --no-dev",
+			command: "composer install --prefer-dist --optimize-autoloader --no-dev --no-scripts",
 		},
 
 		"composer-install": {

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -156,7 +156,8 @@ module.exports = function( grunt ) {
 		},
 
 		"composer-install-production": {
-			command: "composer install --prefer-dist --optimize-autoloader --no-dev --no-scripts",
+			command: "composer install --prefer-dist --optimize-autoloader --no-dev --no-scripts && " +
+					 "composer du --optimize --no-dev",
 		},
 
 		"composer-install": {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* downgrade composer as a temporary workaround for a problem in the latest version.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* force use of composer v2.0.14 to work around problems in the latest 21.0 version

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
