### PR TITLE
P3-674 do not output Twitter tag if OG tag already existing

### DIFF
--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -604,10 +604,11 @@ class Indexable_Presentation extends Abstract_Presentation {
 			return $this->model->twitter_title;
 		}
 
+		// Do not output tag if the helper returns a values, since it will be already in the og: tag.
 		if ( $this->context->open_graph_enabled === true ) {
 			$open_graph_title = $this->values_helper->get_open_graph_title( '', $this->model->object_type, $this->model->object_sub_type );
 			if ( ! empty( $open_graph_title ) ) {
-				return $open_graph_title;
+				return '';
 			}
 		}
 
@@ -632,10 +633,11 @@ class Indexable_Presentation extends Abstract_Presentation {
 			return $this->model->twitter_description;
 		}
 
+		// Do not output tag if the helper returns a values, since it will be already in the og: tag.
 		if ( $this->context->open_graph_enabled === true ) {
 			$open_graph_description = $this->values_helper->get_open_graph_description( '', $this->model->object_type, $this->model->object_sub_type );
 			if ( ! empty( $open_graph_description ) ) {
-				return $open_graph_description;
+				return '';
 			}
 		}
 

--- a/src/presentations/indexable-presentation.php
+++ b/src/presentations/indexable-presentation.php
@@ -604,16 +604,20 @@ class Indexable_Presentation extends Abstract_Presentation {
 			return $this->model->twitter_title;
 		}
 
-		// Do not output tag if the helper returns a values, since it will be already in the og: tag.
 		if ( $this->context->open_graph_enabled === true ) {
-			$open_graph_title = $this->values_helper->get_open_graph_title( '', $this->model->object_type, $this->model->object_sub_type );
+			$social_template_title = $this->values_helper->get_open_graph_title( '', $this->model->object_type, $this->model->object_sub_type );
+			$open_graph_title      = $this->open_graph_title;
+
+			// If the helper returns a value and it's different from the OG value in the indexable,
+			// output it in a twitter: tag.
+			if ( ! empty( $social_template_title ) && $social_template_title !== $open_graph_title ) {
+				return $social_template_title;
+			}
+
+			// If the OG title is set, let og: tag take care of this.
 			if ( ! empty( $open_graph_title ) ) {
 				return '';
 			}
-		}
-
-		if ( $this->open_graph_title && $this->context->open_graph_enabled === true ) {
-			return '';
 		}
 
 		if ( $this->title ) {
@@ -633,16 +637,20 @@ class Indexable_Presentation extends Abstract_Presentation {
 			return $this->model->twitter_description;
 		}
 
-		// Do not output tag if the helper returns a values, since it will be already in the og: tag.
 		if ( $this->context->open_graph_enabled === true ) {
-			$open_graph_description = $this->values_helper->get_open_graph_description( '', $this->model->object_type, $this->model->object_sub_type );
+			$social_template_description = $this->values_helper->get_open_graph_description( '', $this->model->object_type, $this->model->object_sub_type );
+			$open_graph_description      = $this->open_graph_description;
+
+			// If the helper returns a value and it's different from the OG value in the indexable,
+			// output it in a twitter: tag.
+			if ( ! empty( $social_template_description ) && $social_template_description !== $open_graph_description ) {
+				return $social_template_description;
+			}
+
+			// If the OG description is set, let og: tag take care of this.
 			if ( ! empty( $open_graph_description ) ) {
 				return '';
 			}
-		}
-
-		if ( $this->open_graph_description && $this->context->open_graph_enabled === true ) {
-			return '';
 		}
 
 		if ( $this->meta_description ) {

--- a/tests/unit/presentations/indexable-presentation/twitter-description-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-description-test.php
@@ -50,7 +50,7 @@ class Twitter_Description_Test extends TestCase {
 			->expects( 'get_open_graph_description' )
 			->andReturn( $description_from_helper );
 
-		$this->assertSame( 'Description from helper', $this->instance->generate_twitter_description() );
+		$this->assertSame( '', $this->instance->generate_twitter_description() );
 	}
 
 	/**

--- a/tests/unit/presentations/indexable-presentation/twitter-description-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-description-test.php
@@ -38,13 +38,39 @@ class Twitter_Description_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the situation where no Twitter description is set, the Values Helper provides a description, and Open Graph is enabled.
+	 * Tests the situation where
+	 * - no Twitter description is set
+	 * - Open Graph is enabled
+	 * - the Values Helper provides a description
+	 * - this is different from the OG description
 	 *
 	 * @covers ::generate_twitter_description
 	 */
 	public function test_generate_twitter_description_with_description_from_values_helper_and_open_graph_enabled() {
-		$this->context->open_graph_enabled = true;
-		$description_from_helper           = 'Description from helper';
+		$this->context->open_graph_enabled       = true;
+		$this->indexable->open_graph_description = 'Open Graph description';
+		$description_from_helper                 = 'Description from helper';
+
+		$this->values_helper
+			->expects( 'get_open_graph_description' )
+			->andReturn( $description_from_helper );
+
+		$this->assertSame( 'Description from helper', $this->instance->generate_twitter_description() );
+	}
+
+	/**
+	 * Tests the situation where
+	 * - no Twitter description is set
+	 * - Open Graph is enabled
+	 * - the Values Helper provides a description
+	 * - this is the same as the OG description
+	 *
+	 * @covers ::generate_twitter_description
+	 */
+	public function test_generate_twitter_description_with_description_from_values_helper_same_as_og_description() {
+		$this->context->open_graph_enabled       = true;
+		$this->indexable->open_graph_description = 'Open Graph description';
+		$description_from_helper                 = 'Open Graph description';
 
 		$this->values_helper
 			->expects( 'get_open_graph_description' )
@@ -94,10 +120,6 @@ class Twitter_Description_Test extends TestCase {
 	public function test_generate_twitter_description_with_set_open_graph_description_and_open_graph_disabled() {
 		$this->context->open_graph_enabled = false;
 		$this->indexable->description      = 'SEO description';
-
-		$this->values_helper
-			->expects( 'get_open_graph_description' )
-			->andReturn( '' );
 
 		$this->assertSame( 'SEO description', $this->instance->generate_twitter_description() );
 	}

--- a/tests/unit/presentations/indexable-presentation/twitter-title-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-title-test.php
@@ -38,13 +38,39 @@ class Twitter_Title_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the situation where no Twitter title is set, the Values Helper provides a title, and Open Graph is enabled.
+	 * Tests the situation where
+	 * - no Twitter title is set
+	 * - Open Graph is enabled
+	 * - the Values Helper provides a title
+	 * - this is different from the OG title
 	 *
 	 * @covers ::generate_twitter_title
 	 */
 	public function test_generate_twitter_title_with_title_from_values_helper_and_open_graph_enabled() {
 		$this->context->open_graph_enabled = true;
+		$this->indexable->open_graph_title = 'Open Graph title';
 		$title_from_helper                 = 'Example of title from the helper';
+
+		$this->values_helper
+			->expects( 'get_open_graph_title' )
+			->andReturn( $title_from_helper );
+
+		$this->assertSame( 'Example of title from the helper', $this->instance->generate_twitter_title() );
+	}
+
+	/**
+	 * Tests the situation where
+	 * - no Twitter title is set
+	 * - Open Graph is enabled
+	 * - the Values Helper provides a title
+	 * - this is different from the OG title
+	 *
+	 * @covers ::generate_twitter_title
+	 */
+	public function test_generate_twitter_title_with_title_from_values_helper_same_as_og_title() {
+		$this->context->open_graph_enabled = true;
+		$this->indexable->open_graph_title = 'Open Graph title';
+		$title_from_helper                 = 'Open Graph title';
 
 		$this->values_helper
 			->expects( 'get_open_graph_title' )

--- a/tests/unit/presentations/indexable-presentation/twitter-title-test.php
+++ b/tests/unit/presentations/indexable-presentation/twitter-title-test.php
@@ -50,7 +50,7 @@ class Twitter_Title_Test extends TestCase {
 			->expects( 'get_open_graph_title' )
 			->andReturn( $title_from_helper );
 
-		$this->assertSame( 'Example of title from the helper', $this->instance->generate_twitter_title() );
+		$this->assertSame( '', $this->instance->generate_twitter_title() );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to output `twitter:` tags if a matching `og:` tag is being output from the Social Templates

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a `twitter:title` and `twitter:description` tag were sent to the output even if matching `og:` tags from the Social Templates were already in place.

## Relevant technical choices:

* We still need to send out a `twitter:` tag with the value from the social template if the indexable has a different value for the open graph tag

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* activate Premium
* visit `SEO` > `Search appearance` and set values for `Social title` and `Social description` for a single post
  * eg: "Template %%title%%" and "Template %%excerpt%%"
* create a new post, add a title and some content (or an excerpt) to it
* set a FB title and a FB description
  * eg: "FB %%title%%" and "FB %%excerpt%%"
* set a Twitter title and a Twitter description
   * eg: "Twitter %%title%%" and "Twitter %%excerpt%%"
* Publish the post and check the source in the frontend
  * check that you have `og:title`, `og:description`, `twitter:title`, `twitter:description` tags and they have the right values
* Edit the post and empty the "Twitter" fields
* Update the post and check the source in the frontend
  * check that you have `og:title`, `og:description` tags with the FB values from the metabox
  * check that you have `twitter:title`, `twitter:description` tags and they have the Social template values
* Edit the post and set the "FB" fields to match the Social template values
  * eg: "Template %%title%%" and "Template %%excerpt%%"
* Update the post and check the source in the frontend
  * check that you have `og:title`, `og:description` tags with the values from the metabox
  * check that you don't have `twitter:title` nor `twitter:description` tags
* visit `SEO` > `Search appearance` and empty the values for `Social title` and `Social description` for a single post
* Edit the post and set the "FB" fields to the original values
  * eg: "FB %%title%%" and "FB %%excerpt%%"
* Update the post and check the source in the frontend
  * check that you have `og:title`, `og:description` tags with the values from the metabox
  * check that you don't have `twitter:title` nor `twitter:description` tags
* Edit the post and empty the "FB" fields
* Update the post and check the source in the frontend
  * check that you have `og:title`, `og:description` tags with the values from the SEO title and the Meta description
  * check that you don't have `twitter:title` nor `twitter:description` tags
* visit `SEO` > `Social`, `Facebook` tab and disable Open Graph, then save
* Visit the post and check the source in the frontend
  * check that you have `twitter:title`, `twitter:description` tags with the values from the SEO title and the Meta description
  * check that you don't have `og:title` nor `og:description` tags


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes [P3-674]
