### PR TITLE
LINGO-728 Add Norwegian consecutive sentences assessment

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/languages/nb/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/nb/ResearcherSpec.js
@@ -2,7 +2,7 @@ import Researcher from "../../../../src/languageProcessing/languages/nb/Research
 import Paper from "../../../../src/values/Paper.js";
 import getMorphologyData from "../../../specHelpers/getMorphologyData";
 import functionWords from "../../../../src/languageProcessing/languages/nb/config/functionWords";
-import firstWordExceptions from "../../../../src/languageProcessing/languages/en/config/firstWordExceptions";
+import firstWordExceptions from "../../../../src/languageProcessing/languages/nb/config/firstWordExceptions";
 
 const morphologyDataNB = getMorphologyData( "nb" );
 

--- a/packages/yoastseo/spec/languageProcessing/languages/nb/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/nb/ResearcherSpec.js
@@ -2,6 +2,7 @@ import Researcher from "../../../../src/languageProcessing/languages/nb/Research
 import Paper from "../../../../src/values/Paper.js";
 import getMorphologyData from "../../../specHelpers/getMorphologyData";
 import functionWords from "../../../../src/languageProcessing/languages/nb/config/functionWords";
+import firstWordExceptions from "../../../../src/languageProcessing/languages/en/config/firstWordExceptions";
 
 const morphologyDataNB = getMorphologyData( "nb" );
 
@@ -22,6 +23,10 @@ describe( "a test for Norwegian Researcher", function() {
 
 	it( "returns the Norwegian function words", function() {
 		expect( researcher.getConfig( "functionWords" ) ).toEqual( functionWords );
+	} );
+
+	it( "returns the Norwegian first word exceptions", function() {
+		expect( researcher.getConfig( "firstWordExceptions" ) ).toEqual( firstWordExceptions );
 	} );
 
 	it( "returns the Norwegian locale", function() {

--- a/packages/yoastseo/src/languageProcessing/languages/nb/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nb/Researcher.js
@@ -28,7 +28,7 @@ export default class Researcher extends AbstractResearcher {
 		Object.assign( this.config, {
 			language: "nb",
 			functionWords,
-			firstWordExceptions
+			firstWordExceptions,
 		} );
 
 		Object.assign( this.helpers, {

--- a/packages/yoastseo/src/languageProcessing/languages/nb/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nb/Researcher.js
@@ -2,6 +2,7 @@ import { languageProcessing } from "yoastseo";
 const { AbstractResearcher } = languageProcessing;
 
 // All config
+import firstWordExceptions from "./config/firstWordExceptions";
 import functionWords from "./config/functionWords";
 
 // All helpers
@@ -22,12 +23,12 @@ export default class Researcher extends AbstractResearcher {
 		// Delete Flesch Reading Ease research since Norwegian doesn't have the support for it
 		delete this.defaultResearches.getFleschReadingScore;
 		delete this.defaultResearches.getPassiveVoiceResult;
-		delete this.defaultResearches.getSentenceBeginnings;
 		delete this.defaultResearches.findTransitionWords;
 
 		Object.assign( this.config, {
 			language: "nb",
 			functionWords,
+			firstWordExceptions
 		} );
 
 		Object.assign( this.helpers, {

--- a/packages/yoastseo/src/languageProcessing/languages/nb/config/firstWordExceptions.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nb/config/firstWordExceptions.js
@@ -1,0 +1,12 @@
+/**
+ *  Returns an array with exceptions for the sentence beginning researcher.
+ *  @returns {Array} The array filled with exceptions.
+ *  */
+export default [
+	// Indefinite articles:
+	"ei", "et",
+	// Numbers 1-10:
+	"en", "ett", "to", "tre", "fire", "fem", "seks", "sju", "syv", "åtte", "ni", "ti",
+	// Demonstrative pronouns:
+	"denne", "dette", "disse", "den", "det", "de",
+];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the consecutive sentences assessment for Norwegian.
* [yoastseo] Activates the consecutive sentences assessment for Norwegian and adds a list of exception words to exclude from the assessment.


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set your site to Norwegian (Norsk bokmål)
* Open a new post and add the following sentence 4 times in the editor: `Katter er søte.`
* Make sure the consecutive sentences assessment returns a red bullet and that the sentences are highlighted.
* Remove the sentences and add the following text: `En katt. En hund. En hest. En enhjørning.`.
* Make sure the consecutive sentences assessment returns a green bullet.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-728
