### PR TITLE
P3-676 Improve ImageSelect support for 16:9 images

### DIFF
--- a/packages/components/src/image-select/image-select.css
+++ b/packages/components/src/image-select/image-select.css
@@ -5,7 +5,8 @@
 	overflow: hidden;
 	width: 300px;
 	max-width: 100%;
-	height: 165px;
+	min-height: 165px;
+	max-height: 200px;
 	border: 1px solid rgba(0,0,0,0.2);
 	background-color: transparent;
 	padding: 0;

--- a/packages/components/src/image-select/image-select.css
+++ b/packages/components/src/image-select/image-select.css
@@ -5,7 +5,7 @@
 	overflow: hidden;
 	width: 300px;
 	max-width: 100%;
-	height: 200px;
+	height: 165px;
 	border: 1px solid rgba(0,0,0,0.2);
 	background-color: transparent;
 	padding: 0;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the Social image buttons which display an image to support a ~16:9 aspect ratio, to avoid white bars above and below when an image with the right size for social sharing has been loaded.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/components] Improves the support for 16:9 images by the ImageSelect component.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* For each one of the following instances of the ImageSelect component, check that:
  * the size when empty is 300x165px
  * if you upload a 16:9 image, you don't see any white padding bars above and below the image
![Screenshot 2021-06-07 at 11-35-35 Search Appearance - Yoast SEO ‹ Basic — WordPress](https://user-images.githubusercontent.com/15989132/120994169-88d1e680-c784-11eb-8969-0ac6c3503a00.png)
* The list of the instances:
  * `SEO` > `Social`, `Facebook` tab
  * `SEO` > `Search Appearance`:
    * `General` tab (for the Homepage social settings and for the Schema settings)
    * `Content types` tab (with Premium active)
    * `Taxonomies` tab (with Premium active)
    * `Archives` tab (with Premium active)
  * in the Yoast Metabox while editing a post, in the  `Social` tab (with Premium disabled)
  * in the modal popups when clicking on "Facebook Preview" and "Twitter Preview" in the Yoast sidebar while editing a post (with Premium disabled) 
  
### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-676]
