### PR TITLE
Add social settings heading.

### DIFF
--- a/admin/views/tabs/metas/paper-content/front-page-content.php
+++ b/admin/views/tabs/metas/paper-content/front-page-content.php
@@ -25,7 +25,7 @@ else {
 	echo '<div class="social-settings-heading-container">';
 	echo '<h3 class="social-settings-heading">' . \esc_html__( 'Social settings', 'wordpress-seo' ) . '</h3>';
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Is correctly escaped in the Badge_Presenter.
-	echo new Badge_Presenter( 'global-templates', '', 'global-templates' );
+	echo new Badge_Presenter( 'global-templates-homepage', '', 'global-templates' );
 	echo '</div>';
 
 	echo '<p>' . esc_html__( 'These are the image, title and description used when a link to your homepage is shared on social media.', 'wordpress-seo' ) . '</p>';

--- a/admin/views/tabs/metas/paper-content/front-page-content.php
+++ b/admin/views/tabs/metas/paper-content/front-page-content.php
@@ -24,10 +24,8 @@ else {
 
 	echo '<div class="social-settings-heading-container">';
 	echo '<h3 class="social-settings-heading">' . \esc_html__( 'Social settings', 'wordpress-seo' ) . '</h3>';
-	if ( YoastSEO()->helpers->product->is_premium() ) {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Is correctly escaped in the Badge_Presenter.
-		echo new Badge_Presenter( 'global-templates', '', 'global-templates' );
-	}
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Is correctly escaped in the Badge_Presenter.
+	echo new Badge_Presenter( 'global-templates', '', 'global-templates' );
 	echo '</div>';
 
 	echo '<p>' . esc_html__( 'These are the image, title and description used when a link to your homepage is shared on social media.', 'wordpress-seo' ) . '</p>';

--- a/admin/views/tabs/metas/paper-content/front-page-content.php
+++ b/admin/views/tabs/metas/paper-content/front-page-content.php
@@ -10,7 +10,7 @@
  * @uses WPSEO_Admin_Recommended_Replace_Vars $recommended_replace_vars
  */
 
-use Yoast\WP\SEO\Config\Badge_Group_Names;
+use Yoast\WP\SEO\Presenters\Admin\Badge_Presenter;
 
 $view_utils               = new Yoast_View_Utils();
 $opengraph_disabled_alert = $view_utils->generate_opengraph_disabled_alert( 'homepage' );
@@ -20,10 +20,16 @@ if ( ! empty( $opengraph_disabled_alert ) ) {
 	echo $opengraph_disabled_alert;
 }
 else {
-	$badge_group_names = new Badge_Group_Names();
-	$show_new_badge    = $badge_group_names->is_still_eligible_for_new_badge( 'global-templates' );
-
 	echo '<div class="yoast-settings-section">';
+
+	echo '<div class="social-settings-heading-container">';
+	echo '<h3 class="social-settings-heading">' . \esc_html__( 'Social settings', 'wordpress-seo' ) . '</h3>';
+	if ( YoastSEO()->helpers->product->is_premium() ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Is correctly escaped in the Badge_Presenter.
+		echo new Badge_Presenter( 'global-templates', '', 'global-templates' );
+	}
+	echo '</div>';
+
 	echo '<p>' . esc_html__( 'These are the image, title and description used when a link to your homepage is shared on social media.', 'wordpress-seo' ) . '</p>';
 
 	printf(
@@ -32,13 +38,11 @@ else {
 				data-react-image-portal
 				data-react-image-portal-target-image="%2$s"
 				data-react-image-portal-target-image-id="%3$s"
-				data-react-image-portal-has-new-badge="%4$s"
-				data-react-image-portal-has-image-validation="%5$s"
+				data-react-image-portal-has-image-validation="%4$s"
 			></div>',
 		'yoast-og-frontpage-image-select',
 		'open_graph_frontpage_image',
 		'open_graph_frontpage_image_id',
-		esc_attr( $show_new_badge ),
 		true
 	);
 
@@ -56,7 +60,6 @@ else {
 			'label_title'             => __( 'Social title', 'wordpress-seo' ),
 			'label_description'       => __( 'Social description', 'wordpress-seo' ),
 			'description_placeholder' => __( 'Modify your social description by editing it right here.', 'wordpress-seo' ),
-			'has_new_badge'           => $show_new_badge,
 		]
 	);
 	$editor->render();

--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -74,9 +74,11 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 	echo '</div>';
 
 	if ( WPSEO_Options::get( 'breadcrumbs-enable' ) === true ) {
-		/* translators: %s is the plural version of the post type's name. */
-		echo '<h4>' . esc_html( sprintf( __( 'Breadcrumb settings for %s archive', 'wordpress-seo' ), $plural_label ) ) . '</h4>';
-		$yform->textinput( 'bctitle-ptarchive-' . $wpseo_post_type->name, __( 'Breadcrumbs title', 'wordpress-seo' ) );
+		echo '<div class="yoast-settings-section">';
+
+		$yform->textinput_extra_content( 'bctitle-ptarchive-' . $wpseo_post_type->name, __( 'Breadcrumbs title', 'wordpress-seo' ) );
+
+		echo '</div>';
 	}
 
 	/**

--- a/admin/views/tabs/metas/paper-content/post-type-content.php
+++ b/admin/views/tabs/metas/paper-content/post-type-content.php
@@ -15,7 +15,7 @@ $single_label = $wpseo_post_type->labels->singular_name;
 $paper_style  = false;
 
 /* translators: %s is the singular version of the post type's name. */
-echo '<h3 class="h2">' . esc_html( sprintf( __( 'Single %s settings', 'wordpress-seo' ), $wpseo_post_type->labels->singular_name ) ) . '</h3>';
+echo '<h3>' . esc_html( sprintf( __( 'Single %s settings', 'wordpress-seo' ), $wpseo_post_type->labels->singular_name ) ) . '</h3>';
 
 require __DIR__ . '/post_type/post-type.php';
 
@@ -37,7 +37,7 @@ if ( WPSEO_Post_Type::has_archive( $wpseo_post_type ) ) {
 	$plural_label = $wpseo_post_type->labels->name;
 
 	/* translators: %s is the plural version of the post type's name. */
-	echo '<h3 class="h2">' . esc_html( sprintf( __( '%s archive settings', 'wordpress-seo' ), $plural_label ) ) . '</h3>';
+	echo '<h3>' . esc_html( sprintf( __( '%s archive settings', 'wordpress-seo' ), $plural_label ) ) . '</h3>';
 
 	echo '<div class="yoast-settings-section">';
 

--- a/css/src/badge.css
+++ b/css/src/badge.css
@@ -13,6 +13,12 @@
 	color: #004973;
 }
 
+.yoast-premium-badge {
+	background-color: #fff3cd;
+	color: #674e00;
+}
+
+
 .yoast-badge__is-link {
 	text-decoration: none;
 }

--- a/css/src/search-appearance.css
+++ b/css/src/search-appearance.css
@@ -50,6 +50,20 @@
 	margin-bottom: 0;
 }
 
+.social-settings-heading-container {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+}
+
+.social-settings-heading-container .social-settings-heading {
+	margin: 0;
+}
+
+.social-settings-heading-container .yoast-badge {
+	margin-left: 8px;
+}
+
 .draftJsMentionPlugin__mention__29BEd, .draftJsMentionPlugin__mention__29BEd:visited {
   color: #575f67;
   cursor: pointer;

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -241,7 +241,7 @@ tr.yst_row.even {
 .wpseo_content_wrapper .paper.tab-block button.toggleable-container-trigger {
   width: 100%;
   padding: 16px;
-  font-size: 1rem;
+  font-size: 1.0625rem;
 }
 
 .wpseo_content_wrapper .paper.tab-block button.toggleable-container-trigger:focus {
@@ -915,7 +915,7 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 
 .yoast-settings-section.yoast-settings-section-disabled {
   position: relative;
-  padding: 0 16px 16px;
+  padding: 16px;
   border: solid 1px #cccccc;
 }
 

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -155,7 +155,6 @@ class Social_Templates_Integration implements Integration_Interface {
 	protected function build_social_fields( Yoast_Form $yform, $identifier, $page_type_recommended, $page_type_specific ) {
 		$image_url_field_id = 'social-image-url-' . $identifier;
 		$image_id_field_id  = 'social-image-id-' . $identifier;
-		$badge_group_names  = new Badge_Group_Names();
 		$is_premium         = YoastSEO()->helpers->product->is_premium();
 
 		$section_class = 'yoast-settings-section';
@@ -170,9 +169,9 @@ class Social_Templates_Integration implements Integration_Interface {
 		echo '<h3 class="social-settings-heading">' . \esc_html__( 'Social settings', 'wordpress-seo' ) . '</h3>';
 		if ( $is_premium ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Is correctly escaped in the Premium_Badge_Presenter.
-			echo new Premium_Badge_Presenter( 'global-templates' );
+			echo new Premium_Badge_Presenter( 'global-templates-' . $identifier );
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Is correctly escaped in the Badge_Presenter.
-			echo new Badge_Presenter( 'global-templates', '', $this->group );
+			echo new Badge_Presenter( 'global-templates-' . $identifier, '', $this->group );
 		}
 		echo '</div>';
 

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -9,6 +9,8 @@ use WPSEO_Admin_Utils;
 use WPSEO_Replacevar_Editor;
 use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Conditionals\Open_Graph_Conditional;
+use Yoast\WP\SEO\Presenters\Admin\Badge_Presenter;
+use Yoast\WP\SEO\Presenters\Admin\Premium_Badge_Presenter;
 use Yoast\WP\SEO\Config\Badge_Group_Names;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast_Form;
@@ -164,6 +166,16 @@ class Social_Templates_Integration implements Integration_Interface {
 
 		\printf( '<div class="%s">', \esc_attr( $section_class ) );
 
+		echo '<div class="social-settings-heading-container">';
+		echo '<h3 class="social-settings-heading">' . \esc_html__( 'Social settings', 'wordpress-seo' ) . '</h3>';
+		if ( $is_premium ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Is correctly escaped in the Premium_Badge_Presenter.
+			echo new Premium_Badge_Presenter( 'global-templates' );
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Is correctly escaped in the Badge_Presenter.
+			echo new Badge_Presenter( 'global-templates', '', $this->group );
+		}
+		echo '</div>';
+
 		$yform->hidden( $image_url_field_id, $image_url_field_id );
 		$yform->hidden( $image_id_field_id, $image_id_field_id );
 		\printf(
@@ -172,17 +184,13 @@ class Social_Templates_Integration implements Integration_Interface {
 				data-react-image-portal
 				data-react-image-portal-target-image="%2$s"
 				data-react-image-portal-target-image-id="%3$s"
-				data-react-image-portal-has-new-badge="%4$s"
-				data-react-image-portal-is-disabled="%5$s"
-				data-react-image-portal-has-premium-badge="%6$s"
-				data-react-image-portal-has-image-validation="%7$s"
+				data-react-image-portal-is-disabled="%4$s"
+				data-react-image-portal-has-image-validation="%5$s"
 			></div>',
 			\esc_attr( 'yoast-social-' . $identifier . '-image-select' ),
 			\esc_attr( $image_url_field_id ),
 			\esc_attr( $image_id_field_id ),
-			\esc_attr( $is_premium && $badge_group_names->is_still_eligible_for_new_badge( $this->group ) ),
 			\esc_attr( ! $is_premium ),
-			\esc_attr( $is_premium ),
 			true
 		);
 
@@ -197,9 +205,7 @@ class Social_Templates_Integration implements Integration_Interface {
 				'label_title'             => \__( 'Social title', 'wordpress-seo' ),
 				'label_description'       => \__( 'Social description', 'wordpress-seo' ),
 				'description_placeholder' => \__( 'Modify your social description by editing it right here.', 'wordpress-seo' ),
-				'has_new_badge'           => $is_premium && $badge_group_names->is_still_eligible_for_new_badge( $this->group ),
 				'is_disabled'             => ! $is_premium,
-				'has_premium_badge'       => $is_premium,
 			]
 		);
 		$editor->render();

--- a/src/presenters/admin/premium-badge-presenter.php
+++ b/src/presenters/admin/premium-badge-presenter.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Yoast\WP\SEO\Presenters\Admin;
+
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Presenters\Abstract_Presenter;
+
+/**
+ * Represents the presenter class for "Premium" badges.
+ */
+class Premium_Badge_Presenter extends Abstract_Presenter {
+
+	/**
+	 * Identifier of the badge.
+	 *
+	 * @var string
+	 */
+	private $id;
+
+	/**
+	 * Optional link of the badge.
+	 *
+	 * @var string
+	 */
+	private $link;
+
+	/**
+	 * An instance of the WPSEO_Admin_Asset_Manager class.
+	 *
+	 * @var WPSEO_Admin_Asset_Manager
+	 */
+	private $asset_manager;
+
+	/**
+	 * Premium_Badge_Presenter constructor.
+	 *
+	 * @param string $id   Id of the badge.
+	 * @param string $link Optional link of the badge.
+	 */
+	public function __construct( $id, $link = '' ) {
+		$this->id   = $id;
+		$this->link = $link;
+
+		if ( ! $this->asset_manager ) {
+			$this->asset_manager = new WPSEO_Admin_Asset_Manager();
+		}
+
+		$this->asset_manager->enqueue_style( 'badge' );
+	}
+
+	/**
+	 * Presents the Premium Badge. If a link has been passed, the badge is presented with the link.
+	 * Otherwise a static badge is presented.
+	 *
+	 * @return string The styled Premium Badge.
+	 */
+	public function present() {
+		if ( $this->link !== '' ) {
+			return \sprintf(
+				'<a class="yoast-badge yoast-badge__is-link yoast-premium-badge" id="%1$s-premium-badge" href="%2$s">%3$s</a>',
+				\esc_attr( $this->id ),
+				\esc_url( $this->link ),
+				'Premium' // We don't want this string to be translatable.
+			);
+		}
+
+		return \sprintf(
+			'<span class="yoast-badge yoast-premium-badge" id="%1$s-premium-badge">%2$s</span>',
+			\esc_attr( $this->id ),
+			'Premium' // We don't want this string to be translatable.
+		);
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to introduce a new "Social settings" headings before the social forms and display the "Premium" and "New" badges there instead of close to the social settings fields.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a "Social settings" heading in the Search appearance settings to better distinguish the social settings.

## Relevant technical choices:

* Introduces a new Presenter class for the "Premium" badge.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- activate Yaost SEO Free, switched to this branch, and build it as usual
- activate Yoast SEO Premium 
- activate Local SEO (to test the settings for CPTs)
- go to Search appearance > General > Homepage 
- check there's a new heading "Social settings" with only a "New" badge 
- check that Social image, Social title, and Social description don't have any badge
- go to Search appearance > Content Types 
- for each post type (posts, pages, locations) check there's a new heading "Social settings" with a "Premium" badge and a "New" badge 
- check that Social image, Social title, and Social description don't have any badges 
- check the same thing for:
  - Search appearance > Taxonomies
  - Search appearance > Archives
- edit `src/config/badge-group-names.php` line 19, so it becomes: `self::GROUP_GLOBAL_TEMPLATES => '16.4-beta0'`
- refresh the Search appearance page and check the "New" badge disappeared from all the Social settings headings
- revert the changes to the `src/config/badge-group-names.php` file 
- deactivate Premium 
- go to Search appearance > General > Homepage 
- check that nothing changed and the "New" badge is still displayed 
- go to Search appearance > Content Types 
- check the Social settings are now disabled and there's a semi-transparent overlay with an upsell button "Unlock with Premium"
- check the "Social settings" heading under the overlay doesn't display any badge
- check the same thing for:
  - Search appearance > Taxonomies
  - Search appearance > Archives

Note:
- this PR slightly changes the size of the expandable panels titles, as discussed with design 
- this PR also slightly changes the size of the H3 headings within the panels, as discussed with design, e.t.:
  - Single Post settings 
  - Locations archive settings
- the new "Social settings" heading has the same size of these H3 headings


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-677]
