### PR TITLE
Add Norwegian transition words assessment

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/languages/nb/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/nb/ResearcherSpec.js
@@ -2,6 +2,8 @@ import Researcher from "../../../../src/languageProcessing/languages/nb/Research
 import Paper from "../../../../src/values/Paper.js";
 import getMorphologyData from "../../../specHelpers/getMorphologyData";
 import functionWords from "../../../../src/languageProcessing/languages/nb/config/functionWords";
+import transitionWords from "../../../../src/languageProcessing/languages/nb/config/transitionWords";
+import twoPartTransitionWords from "../../../../src/languageProcessing/languages/nb/config/twoPartTransitionWords";
 
 const morphologyDataNB = getMorphologyData( "nb" );
 
@@ -22,6 +24,14 @@ describe( "a test for Norwegian Researcher", function() {
 
 	it( "returns the Norwegian function words", function() {
 		expect( researcher.getConfig( "functionWords" ) ).toEqual( functionWords );
+	} );
+
+	it( "returns the Norwegian transition words", function() {
+		expect( researcher.getConfig( "transitionWords" ) ).toEqual( transitionWords );
+	} );
+
+	it( "returns the Norwegian two part transition word", function() {
+		expect( researcher.getConfig( "twoPartTransitionWords" ) ).toEqual( twoPartTransitionWords );
 	} );
 
 	it( "returns the Norwegian locale", function() {

--- a/packages/yoastseo/src/languageProcessing/languages/nb/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nb/Researcher.js
@@ -3,6 +3,8 @@ const { AbstractResearcher } = languageProcessing;
 
 // All config
 import functionWords from "./config/functionWords";
+import transitionWords from "./config/transitionWords";
+import twoPartTransitionWords from "./config/twoPartTransitionWords";
 
 // All helpers
 import getStemmer from "./helpers/getStemmer";
@@ -23,11 +25,12 @@ export default class Researcher extends AbstractResearcher {
 		delete this.defaultResearches.getFleschReadingScore;
 		delete this.defaultResearches.getPassiveVoiceResult;
 		delete this.defaultResearches.getSentenceBeginnings;
-		delete this.defaultResearches.findTransitionWords;
 
 		Object.assign( this.config, {
 			language: "nb",
 			functionWords,
+			transitionWords,
+			twoPartTransitionWords,
 		} );
 
 		Object.assign( this.helpers, {

--- a/packages/yoastseo/src/languageProcessing/languages/nb/config/transitionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nb/config/transitionWords.js
@@ -1,0 +1,21 @@
+/** @module config/transitionWords */
+
+export const singleWords = [ "også", "fortsatt", "derimot", "derfor", "faktisk", "endelig", "likevel", "følgelig", "likeså", "dessuten", "selvsagt",
+	"deretter", "men", "for", "fordi", "mens", "bare", "da", "dog", "enn", "ettersom", "før", "hvorpå", "inntil", "når", "omennskjønt", "samt",
+	"som", "uaktet", "pga.", "uansett", "foruten", "siden", "m.a.o", "attpåtil", "derved", "følgelig", "forøvrig", "iallfall", "imidlertid",
+	"især", "likefullt", "likeledes", "likeså", "likevel", "omsider", "samstundes", "samtidig", "sikkert", "således", "såleis", "særs", "ellers",
+	"enda", "dersom", "skjønt", "samme", "eansett", "etterpå", "generelt", "herav", "imens" ];
+
+export const multipleWords = [ "på den andre siden", "for øyeblikket", "i stedet", "i mellomtiden", "til slutt", "i tillegg", "i tilfelle",
+	"med mindre", "om enn", "om to strakser", "selv om", "på grunn av", "med hensyn til", "for eksempel", "en gang", "fremfor alt", "i alle fall",
+	"i et nøtteskall", "i hvert fall", "i mellomtiden", "med andre ord", "til dømes", "for øvrig", "i ettertid", "så langt", "på tross av",
+	"til tross for", "til tross for at ", "for at", "slik at", "i løpet av", "så at", "slik som", "så lenge", "så ofte", "så snart",
+	"etter hvert som", "så fremt", "så sant", "i fall", "for så vidt som", "fordi om", "enda om", "trass i at", "hvor så", "hva enn", "hvor enn",
+	"sånn at", "som om", "så som", "rett og slett ", "på samme måte", "etter hvert", "av dette følger", "i mellomtiden", "i dette tilfellet",
+	"i motsetning til", "som et resultat", "like viktig", "på grunn av det", "på den positive siden", "på den negative siden", "tvert imot",
+	"kort oppsummert", "i begge tilfeller" ];
+
+export const allWords = singleWords.concat( multipleWords );
+
+export default allWords;
+

--- a/packages/yoastseo/src/languageProcessing/languages/nb/config/twoPartTransitionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nb/config/twoPartTransitionWords.js
@@ -1,0 +1,10 @@
+/** @module config/twoPartTransitionWords */
+
+/**
+ * Returns an array with two-part transition words to be used by the assessments.
+ * @type {Array} The array filled with two-part transition words.
+ */
+export default [ [ "både", "og" ], [ "enten", "eller" ], [ "verken", "eller" ], [ "jo", "dess" ], [ "dess", "dess" ], [ "jo", "desto" ],
+	[ "ikke bare", "men" ], [ "ikke bare", "også" ],
+];
+


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the transition words assessment for Norwegian
* [yoastseo] Adds Norwegian transition words and activates the transition words assessment

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set your site to Norwegian (Norsk bokmål)
* Open a new post and paste the following text: `Da jeg var liten, bodde jeg i India. Jeg elsker katter.`
* Make sure that the transition words assessment returns a green bullet.
* Check that the first sentence, but not the second sentence is highlighted.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-721
