### PR TITLE
P3-678 do not prefill form with social templates on Free

### DIFF
--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -201,7 +201,11 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string The social title template.
 	 */
 	private function get_social_title_template() {
-		return $this->get_template( 'social-title' );
+		if ( YoastSEO()->helpers->product->is_premium() && WPSEO_Options::get( 'opengraph', false ) === true ) {
+			return $this->get_template( 'social-title' );
+		}
+
+		return '';
 	}
 
 	/**
@@ -210,7 +214,11 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string The social description template.
 	 */
 	private function get_social_description_template() {
-		return $this->get_template( 'social-description' );
+		if ( YoastSEO()->helpers->product->is_premium() && WPSEO_Options::get( 'opengraph', false ) === true ) {
+			return $this->get_template( 'social-description' );
+		}
+
+		return '';
 	}
 
 	/**
@@ -219,7 +227,11 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string The social description template.
 	 */
 	private function get_social_image_template() {
-		return $this->get_template( 'social-image-url' );
+		if ( YoastSEO()->helpers->product->is_premium() && WPSEO_Options::get( 'opengraph', false ) === true ) {
+			return $this->get_template( 'social-image-url' );
+		}
+
+		return '';
 	}
 
 	/**

--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -161,7 +161,11 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string The social title template.
 	 */
 	private function get_social_title_template() {
-		return $this->get_template( 'social-title' );
+		if ( YoastSEO()->helpers->product->is_premium() && WPSEO_Options::get( 'opengraph', false ) === true ) {
+			return $this->get_template( 'social-title' );
+		}
+
+		return '';
 	}
 
 	/**
@@ -170,7 +174,11 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string The social description template.
 	 */
 	private function get_social_description_template() {
-		return $this->get_template( 'social-description' );
+		if ( YoastSEO()->helpers->product->is_premium() && WPSEO_Options::get( 'opengraph', false ) === true ) {
+			return $this->get_template( 'social-description' );
+		}
+
+		return '';
 	}
 
 	/**
@@ -179,7 +187,11 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string The social description template.
 	 */
 	private function get_social_image_template() {
-		return $this->get_template( 'social-image-url' );
+		if ( YoastSEO()->helpers->product->is_premium() && WPSEO_Options::get( 'opengraph', false ) === true ) {
+			return $this->get_template( 'social-image-url' );
+		}
+
+		return '';
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to prefill the social tab of the metabox with values from the social templates if Premium is disabled or if Opengraph is (and thus the social templates are) disabled.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents the values from Social Templates to be used to prefill the fields in the Social tab of the Yoast Metabox

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* install and activate Premium
* fill the social templates (image, title and desc) for a single post, and for a term archive, then save
   * choose easily distinguishable values
* disable Premium
* edit a new post, visit the metabox, go to the social tab and check that the "title" and "description" fields are empty, for both Twitter and Facebook
* edit a new term, visit the metabox, go to the social tab and check that the "title" and "description" fields are empty, for both Twitter and Facebook
* re-enable Premium
* disable opengraph in SEO > Social
* edit a new post, visit the metabox, go to the social tab and check that the "title" and "description" fields are empty, for both Twitter, and the preview is right (using the SEO values, and the image is empty or using featured image or the image from the content if they are set)
* edit a new term, visit the metabox, go to the social tab and check that the "title" and "description" fields are empty, for both Twitter, and the preview is right (using the SEO values, and the image is empty or using the image form the description if set)



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-678]
