### PR TITLE
Exclude tables from consecutive sentences assessment

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
@@ -392,8 +392,8 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 	} );
 
 	it( "does not count consecutive sentences in tables", function() {
-		mockPaper = new Paper( "<table><td><tr>Sentence 1.</tr><tr>Sentence 2 that is longer.</tr><tr>Sentence 3 is shorter." +
-			"</tr><tr>Sentence 4.</tr></td></table>" );
+		mockPaper = new Paper( "<figure class='wp-block-table'><table><tbody><tr><td>Cats and dogs.</td><td>Cats are cute.</td></tr><tr><td>Cats" +
+			" are awesome.</td><td>Cats are nice.</td></tr></tbody></table><figcaption>Cats are great.</figcaption></figure>" );
 		researcher = new EnglishResearcher( mockPaper );
 
 		expect( getSentenceBeginnings( mockPaper, researcher ) ).toEqual( [] );

--- a/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
@@ -391,13 +391,12 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 4 );
 	} );
 
-	it( "returns an object with English sentence beginnings in tables", function() {
+	it( "does not count consecutive sentences in tables", function() {
 		mockPaper = new Paper( "<table><td><tr>Sentence 1.</tr><tr>Sentence 2 that is longer.</tr><tr>Sentence 3 is shorter." +
 			"</tr><tr>Sentence 4.</tr></td></table>" );
 		researcher = new EnglishResearcher( mockPaper );
 
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "sentence", { locale: "en_US" } );
-		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].count ).toBe( 4 );
+		expect( getSentenceBeginnings( mockPaper, researcher ) ).toEqual( [] );
 	} );
 
 	it( "returns an object with English sentence beginnings with paragraph tags - it should match over paragraphs", function() {

--- a/packages/yoastseo/src/languageProcessing/researches/getSentenceBeginnings.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getSentenceBeginnings.js
@@ -82,9 +82,7 @@ export default function( paper, researcher ) {
 	let text = paper.getText();
 
 	// Exclude text inside tables.
-	if ( text.includes( "<figure class='wp-block-table'>" ) && text.includes( "</figure>" ) ) {
-		text = text.replace( /<figure class='wp-block-table'>.*<\/figure>/sg, "" );
-	}
+	text = text.replace( /<figure class='wp-block-table'>.*<\/figure>/sg, "" );
 
 	let sentences = getSentences( text );
 

--- a/packages/yoastseo/src/languageProcessing/researches/getSentenceBeginnings.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getSentenceBeginnings.js
@@ -1,4 +1,5 @@
 import getWords from "../helpers/word/getWords.js";
+import getSentences from "../helpers/sentence/getSentences";
 import stripSpaces from "../helpers/sanitize/stripSpaces.js";
 import { stripFullTags as stripTags } from "../helpers/sanitize/stripHTMLTags.js";
 
@@ -78,7 +79,11 @@ function getSentenceBeginning( sentence, firstWordExceptions ) {
  */
 export default function( paper, researcher ) {
 	const firstWordExceptions = researcher.getConfig( "firstWordExceptions" );
-	let sentences = researcher.getResearch( "sentences" );
+	let text = paper.getText();
+	if ( text.includes( "<table>" ) && text.includes( "</table>" ) ) {
+		text = text.replace( /<table>.*<\/table>/sg, "" );
+	}
+	let sentences = getSentences( text );
 
 	let sentenceBeginnings = sentences.map( function( sentence ) {
 		return getSentenceBeginning( sentence, firstWordExceptions );

--- a/packages/yoastseo/src/languageProcessing/researches/getSentenceBeginnings.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getSentenceBeginnings.js
@@ -80,6 +80,8 @@ function getSentenceBeginning( sentence, firstWordExceptions ) {
 export default function( paper, researcher ) {
 	const firstWordExceptions = researcher.getConfig( "firstWordExceptions" );
 	let text = paper.getText();
+
+	// Exclude text inside tables.
 	if ( text.includes( "<table>" ) && text.includes( "</table>" ) ) {
 		text = text.replace( /<table>.*<\/table>/sg, "" );
 	}

--- a/packages/yoastseo/src/languageProcessing/researches/getSentenceBeginnings.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getSentenceBeginnings.js
@@ -82,9 +82,10 @@ export default function( paper, researcher ) {
 	let text = paper.getText();
 
 	// Exclude text inside tables.
-	if ( text.includes( "<table>" ) && text.includes( "</table>" ) ) {
-		text = text.replace( /<table>.*<\/table>/sg, "" );
+	if ( text.includes( "<figure class='wp-block-table'>" ) && text.includes( "</figure>" ) ) {
+		text = text.replace( /<figure class='wp-block-table'>.*<\/figure>/sg, "" );
 	}
+
 	let sentences = getSentences( text );
 
 	let sentenceBeginnings = sentences.map( function( sentence ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to count sentences that are inside tables or table captions for the consecutive sentences assessment.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Excludes sentences inside tables and table captions from the consecutive sentences assessment.
* [yoastseo] Filter out table block content from the getSentenceBeginnings research.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Do the following steps in default editor, classic editor, and Elementor.
* Open a new post and add some text.
* Create a table with 4 cells. Paste the following sentence in each cell: `Cats are cute.`
* Make sure that the consecutive sentence assessment returns a green bullet. 
* Add the following table caption: `Unicorns are cute`. Add the same sentence two times in the main text right below the table caption.
* Make sure that the consecutive sentence assessment still returns a green bullet. 
* Add the sentence `Squirrels are cute` three times somewhere in the main text.
* Make sure that the consecutive sentences assessment returns a red bullet with the feedback `Consecutive sentences: The text contains 3 consecutive sentences starting with the same word. Try to mix things up!`
* Click the eye marker (does not apply to Elementor) and make sure the sentences in the table and table caption are _not_ highlighted, and the consecutive sentences outside the table _are_ highlighted.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-846
