### PR TITLE
P2 1017 remove composer side effects

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -226,7 +226,7 @@ class WPSEO_Metabox_Formatter {
 	private function is_markdown_enabled() {
 		$is_markdown = false;
 
-		if ( class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'get_active_modules' ) ) {
+		if ( \class_exists( 'Jetpack', false ) && method_exists( 'Jetpack', 'get_active_modules' ) ) {
 			$active_modules = Jetpack::get_active_modules();
 
 			// First at all, check if Jetpack's markdown module is active.

--- a/admin/ryte/class-ryte.php
+++ b/admin/ryte/class-ryte.php
@@ -208,7 +208,7 @@ class WPSEO_Ryte implements WPSEO_WordPress_Integration {
 	 * @return bool True if WordFence protects the site.
 	 */
 	private function wordfence_protection_enabled() {
-		if ( ! class_exists( 'wfConfig' ) ) {
+		if ( ! \class_exists( 'wfConfig', false ) ) {
 			return false;
 		}
 

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -30,7 +30,7 @@ elseif ( filter_input( INPUT_POST, 'import_external' ) ) {
 	check_admin_referer( 'wpseo-import-plugins' );
 
 	$yoast_seo_class = filter_input( INPUT_POST, 'import_external_plugin' );
-	if ( class_exists( $yoast_seo_class ) ) {
+	if ( \class_exists( $yoast_seo_class, false ) ) {
 		$yoast_seo_import = new WPSEO_Import_Plugin( new $yoast_seo_class(), 'import' );
 	}
 }
@@ -38,7 +38,7 @@ elseif ( filter_input( INPUT_POST, 'clean_external' ) ) {
 	check_admin_referer( 'wpseo-clean-plugins' );
 
 	$yoast_seo_class = filter_input( INPUT_POST, 'clean_external_plugin' );
-	if ( class_exists( $yoast_seo_class ) ) {
+	if ( \class_exists( $yoast_seo_class, false ) ) {
 		$yoast_seo_import = new WPSEO_Import_Plugin( new $yoast_seo_class(), 'cleanup' );
 	}
 }

--- a/admin/views/tool-import-export.php
+++ b/admin/views/tool-import-export.php
@@ -96,8 +96,8 @@ $yoast_seo_tabs = [
 	<br/><br/>
 
 	<h2 class="nav-tab-wrapper" id="wpseo-tabs">
-		<?php foreach ( $yoast_seo_tabs as $identifier => $tab ) : ?>
-			<a class="nav-tab" id="<?php echo esc_attr( $identifier . '-tab' ); ?>" href="<?php echo esc_url( '#top#' . $identifier ); ?>"><?php echo esc_html( $tab['label'] ); ?></a>
+		<?php foreach ( $yoast_seo_tabs as $identifier => $seo_tab ) : ?>
+			<a class="nav-tab" id="<?php echo esc_attr( $identifier . '-tab' ); ?>" href="<?php echo esc_url( '#top#' . $identifier ); ?>"><?php echo esc_html( $seo_tab['label'] ); ?></a>
 		<?php endforeach; ?>
 
 		<?php
@@ -110,7 +110,7 @@ $yoast_seo_tabs = [
 
 <?php
 
-foreach ( $yoast_seo_tabs as $identifier => $tab ) {
+foreach ( $yoast_seo_tabs as $identifier => $seo_tab ) {
 	printf( '<div id="%s" class="wpseotab">', esc_attr( $identifier ) );
 	require_once WPSEO_PATH . 'admin/views/tabs/tool/' . $identifier . '.php';
 	echo '</div>';

--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -112,7 +112,7 @@ class Actions {
 	public static function compile_dependency_injection_container( Event $event ) {
 		$io = $event->getIO();
 
-		if ( ! \class_exists( ContainerBuilder::class ) ) {
+		if ( ! \class_exists( ContainerBuilder::class, false ) ) {
 			$io->write( 'Not compiling dependency injection container, due to the container builder not being installed' );
 
 			return;
@@ -273,7 +273,7 @@ class Actions {
 		if ( ! \preg_match( $correct_class_name_regex, $name ) ) {
 			throw new Exception( "$name is not a valid migration name." );
 		}
-		if ( \class_exists( $name ) ) {
+		if ( \class_exists( $name, false ) ) {
 			throw new Exception( "A class with the name $name already exists." );
 		}
 

--- a/config/dependency-injection/interface-injection-pass.php
+++ b/config/dependency-injection/interface-injection-pass.php
@@ -82,7 +82,7 @@ class Interface_Injection_Pass implements CompilerPassInterface {
 	private function get_variadic_constructor( $definition ) {
 		// Limit the processing to classes from our project.
 		$definition_class = $definition->getClass();
-		if ( ! \class_exists( $definition_class ) ) {
+		if ( ! \class_exists( $definition_class, false ) ) {
 			return null;
 		}
 

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -322,7 +322,7 @@ class WPSEO_Addon_Manager {
 			return false;
 		}
 
-		return class_exists( $slug_to_class_map[ $slug ] );
+		return \class_exists( $slug_to_class_map[ $slug ], false );
 	}
 
 	/**

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -171,7 +171,7 @@ class WPSEO_Sitemap_Image_Parser {
 
 		$images = [];
 
-		if ( ! class_exists( 'DOMDocument' ) ) {
+		if ( ! \class_exists( 'DOMDocument', false ) ) {
 			return $images;
 		}
 

--- a/lib/model.php
+++ b/lib/model.php
@@ -161,7 +161,7 @@ class Model implements JsonSerializable {
 	 * @return string The value of the property.
 	 */
 	protected static function get_static_property( $class_name, $property, $default = null ) {
-		if ( ! \class_exists( $class_name ) || ! \property_exists( $class_name, $property ) ) {
+		if ( ! \class_exists( $class_name, false ) || ! \property_exists( $class_name, $property ) ) {
 			return $default;
 		}
 

--- a/src/actions/addon-installation/addon-install-action.php
+++ b/src/actions/addon-installation/addon-install-action.php
@@ -79,15 +79,15 @@ class Addon_Install_Action {
 	 * @return void
 	 */
 	protected function load_wordpress_classes() {
-		if ( ! class_exists( 'WP_Upgrader' ) ) {
+		if ( ! \class_exists( 'WP_Upgrader', false ) ) {
 			$this->require_file_helper->require_file_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader.php' );
 		}
 
-		if ( ! class_exists( 'Plugin_Upgrader' ) ) {
+		if ( ! \class_exists( 'Plugin_Upgrader', false ) ) {
 			$this->require_file_helper->require_file_once( ABSPATH . 'wp-admin/includes/class-plugin-upgrader.php' );
 		}
 
-		if ( ! class_exists( 'WP_Upgrader_Skin' ) ) {
+		if ( ! \class_exists( 'WP_Upgrader_Skin', false ) ) {
 			$this->require_file_helper->require_file_once( ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php' );
 		}
 

--- a/src/conditionals/jetpack-conditional.php
+++ b/src/conditionals/jetpack-conditional.php
@@ -14,6 +14,6 @@ class Jetpack_Conditional implements Conditional {
 	 * @return bool `true` when the Jetpack plugin exists on this WordPress installation.
 	 */
 	public function is_met() {
-		return \class_exists( 'Jetpack' );
+		return \class_exists( 'Jetpack', false );
 	}
 }

--- a/src/conditionals/woocommerce-conditional.php
+++ b/src/conditionals/woocommerce-conditional.php
@@ -13,6 +13,6 @@ class WooCommerce_Conditional implements Conditional {
 	 * @return bool `true` when the WooCommerce plugin is installed and activated.
 	 */
 	public function is_met() {
-		return \class_exists( 'WooCommerce' );
+		return \class_exists( 'WooCommerce', false );
 	}
 }

--- a/src/helpers/woocommerce-helper.php
+++ b/src/helpers/woocommerce-helper.php
@@ -13,7 +13,7 @@ class Woocommerce_Helper {
 	 * @return bool Is WooCommerce active.
 	 */
 	public function is_active() {
-		return \class_exists( 'WooCommerce' );
+		return \class_exists( 'WooCommerce', false );
 	}
 
 	/**

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -333,7 +333,7 @@ class Front_End_Integration implements Integration_Interface {
 		$needed_presenters = $this->get_needed_presenters( $page_type );
 
 		$callback   = static function( $presenter ) {
-			if ( ! \class_exists( $presenter ) ) {
+			if ( ! \class_exists( $presenter, true ) ) {
 				return null;
 			}
 			return new $presenter();

--- a/src/main.php
+++ b/src/main.php
@@ -42,7 +42,7 @@ class Main extends Abstract_Main {
 	 * {@inheritDoc}
 	 */
 	protected function get_container() {
-		if ( $this->is_development() && \class_exists( '\Yoast\WP\SEO\Dependency_Injection\Container_Compiler' ) ) {
+		if ( $this->is_development() && \class_exists( '\Yoast\WP\SEO\Dependency_Injection\Container_Compiler', false ) ) {
 			// Exception here is unhandled as it will only occur in development.
 			Container_Compiler::compile(
 				$this->is_development(),

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -180,7 +180,7 @@ class Meta {
 
 		$presenter_class = $presenter_namespace . \implode( '_', \array_map( 'ucfirst', $parts ) ) . '_Presenter';
 
-		if ( \class_exists( $presenter_class ) ) {
+		if ( \class_exists( $presenter_class, true ) ) {
 			/**
 			 * The indexable presenter.
 			 *

--- a/tests/integration/config-ui/test-class-configuration-endpoint.php
+++ b/tests/integration/config-ui/test-class-configuration-endpoint.php
@@ -102,7 +102,7 @@ class WPSEO_Configuration_Endpoint_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_register() {
 
-		if ( ! class_exists( 'WP_REST_Server' ) ) {
+		if ( ! \class_exists( 'WP_REST_Server', false ) ) {
 			$this->markTestSkipped( 'WordPress version too low to test with WP_REST_Server.' );
 
 			return;

--- a/tests/integration/config-ui/test-class-configuration-service.php
+++ b/tests/integration/config-ui/test-class-configuration-service.php
@@ -166,7 +166,7 @@ class WPSEO_Configuration_Service_Test extends TestCase {
 	 */
 	public function test_set_configuration() {
 
-		if ( ! class_exists( 'WP_REST_Request' ) ) {
+		if ( ! \class_exists( 'WP_REST_Request', true ) ) {
 			$this->markTestSkipped( 'WordPress version too low to test with WP_REST_Request.' );
 
 			return;

--- a/tests/integration/doubles/wpseo-wp-rest-server-mock.php
+++ b/tests/integration/doubles/wpseo-wp-rest-server-mock.php
@@ -5,7 +5,7 @@
  * @package WPSEO\Tests\Doubles
  */
 
-if ( class_exists( 'WP_REST_Server' ) ) {
+if ( \class_exists( 'WP_REST_Server', true ) ) {
 	/**
 	 * Class WPSEO_WP_REST_Server_Mock.
 	 */

--- a/tests/integration/inc/test-class-wpseo-admin-bar-menu.php
+++ b/tests/integration/inc/test-class-wpseo-admin-bar-menu.php
@@ -45,7 +45,7 @@ class WPSEO_Admin_Bar_Menu_Test extends WPSEO_UnitTestCase {
 	 * @return void
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
-		if ( ! class_exists( 'WP_Admin_Bar' ) ) {
+		if ( ! \class_exists( 'WP_Admin_Bar', false ) ) {
 			require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
 		}
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -62,10 +62,10 @@ function wpseo_auto_load( $class ) {
 		];
 	}
 
-	$className = strtolower( $class );
+	$class_name = strtolower( $class );
 
-	if ( ! \class_exists( $class, false ) && isset( $classes[ $className ] ) ) {
-		require_once $classes[ $className ];
+	if ( ! \class_exists( $class, true ) && isset( $classes[ $class_name ] ) ) {
+		require_once $classes[ $class_name ];
 	}
 }
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -62,10 +62,10 @@ function wpseo_auto_load( $class ) {
 		];
 	}
 
-	$cn = strtolower( $class );
+	$className = strtolower( $class );
 
-	if ( ! class_exists( $class ) && isset( $classes[ $cn ] ) ) {
-		require_once $classes[ $cn ];
+	if ( ! \class_exists( $class, false ) && isset( $classes[ $className ] ) ) {
+		require_once $classes[ $className ];
 	}
 }
 
@@ -74,7 +74,7 @@ $yoast_autoload_file = WPSEO_PATH . 'vendor/autoload.php';
 if ( is_readable( $yoast_autoload_file ) ) {
 	require $yoast_autoload_file;
 }
-elseif ( ! class_exists( 'WPSEO_Options' ) ) { // Still checking since might be site-level autoload R.
+elseif ( ! \class_exists( 'WPSEO_Options', false ) ) { // Still checking since might be site-level autoload R.
 	add_action( 'admin_init', 'yoast_wpseo_missing_autoload', 1 );
 
 	return;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* closes #16938
* using composer to install premium causes side effects through default behavior of `\class_exists`. This PR prevents those side effects.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Fixes a bug where activating Yoast SEO would result in a fatal error on all admin pages, when Yoast SEO Premium was installed through Composer but not activated. Props to [andyblackwell](https://github.com/andyblackwell).

## Relevant technical choices:

* checking for existince of a class by default loads the file the checked class is in; in some cases this causes side effects (such as a 403 redirect with `die`  in premium. I gave every instance of `class_exists` an explicit value instead of relying on the default (true)
* in most cases, relying on a sideeffect of a core function to load the document is dangerous, so I've set the `autoload` parameter explicitly to false; except in the cases where the file in question is actually used within that same function.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

see #16938 for more details on reproducing the error.
to reproduce the error:
* use composer to install premium; do not activate premium. 
* go to the admin pages and notice that WP breaks. this is because code checks if premium is present, which triggers the premium code to be autoloaded - but because premium was not requested from an expected route, it throws a 403 and exits.

to test the fix:
* replace the premium folder with code from this branch; 
* go to the admin pages and notice WP no longer breaks.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #16938
