### PR TITLE
P3-681 Reset existing Social titles options to the new defaults via upgrade routine

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -823,10 +823,10 @@ class WPSEO_Upgrade {
 	 * @return void
 	 */
 	private function upgrade_165() {
-		$this->copy_og_settings_from_social_to_titles();
+		add_action( 'init', [ $this, 'copy_og_settings_from_social_to_titles' ], 99 );
 
 		// Run after the WPSEO_Options::enrich_defaults method which has priority 99.
-		\add_action( 'init', [ $this, 'reset_og_settings_to_default_values' ], 100 );
+		add_action( 'init', [ $this, 'reset_og_settings_to_default_values' ], 100 );
 	}
 
 	/**
@@ -1150,8 +1150,8 @@ class WPSEO_Upgrade {
 	 * @return void
 	 */
 	public function copy_og_settings_from_social_to_titles() {
-		$wpseo_social = \get_option( 'wpseo_social' );
-		$wpseo_titles = \get_option( 'wpseo_titles' );
+		$wpseo_social = get_option( 'wpseo_social' );
+		$wpseo_titles = get_option( 'wpseo_titles' );
 
 		// Reset to the correct default value.
 		$wpseo_titles['open_graph_frontpage_title'] = '%%sitename%%';
@@ -1170,9 +1170,9 @@ class WPSEO_Upgrade {
 			}
 		}
 
-		$wpseo_titles = \array_merge( $wpseo_titles, $copied_options );
+		$wpseo_titles = array_merge( $wpseo_titles, $copied_options );
 
-		\update_option( 'wpseo_titles', $wpseo_titles );
+		update_option( 'wpseo_titles', $wpseo_titles );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1153,11 +1153,11 @@ class WPSEO_Upgrade {
 		$wpseo_social = get_option( 'wpseo_social' );
 		$wpseo_titles = get_option( 'wpseo_titles' );
 
-		// Reset to the correct default value.
-		$wpseo_titles['open_graph_frontpage_title'] = '%%sitename%%';
-
 		$copied_options = [];
-		$options        = [
+		// Reset to the correct default value.
+		$copied_options['open_graph_frontpage_title'] = '%%sitename%%';
+
+		$options = [
 			'og_frontpage_title'    => 'open_graph_frontpage_title',
 			'og_frontpage_desc'     => 'open_graph_frontpage_desc',
 			'og_frontpage_image'    => 'open_graph_frontpage_image',

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1153,6 +1153,9 @@ class WPSEO_Upgrade {
 		$wpseo_social = \get_option( 'wpseo_social' );
 		$wpseo_titles = \get_option( 'wpseo_titles' );
 
+		// Reset to the correct default value.
+		$wpseo_titles['open_graph_frontpage_title'] = '%%sitename%%';
+
 		$copied_options = [];
 		$options        = [
 			'og_frontpage_title'    => 'open_graph_frontpage_title',
@@ -1162,7 +1165,7 @@ class WPSEO_Upgrade {
 		];
 
 		foreach ( $options as $social_option => $titles_option ) {
-			if ( isset( $wpseo_social[ $social_option ] ) ) {
+			if ( ! empty( $wpseo_social[ $social_option ] ) ) {
 				$copied_options[ $titles_option ] = $wpseo_social[ $social_option ];
 			}
 		}
@@ -1173,7 +1176,7 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Overwrites the social options defaults with the values from the matching SEO options.
+	 * Reset the social options with the correct default values.
 	 *
 	 * @return void
 	 */

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1184,10 +1184,6 @@ class WPSEO_Upgrade {
 		$updated_options['social-title-author-wpseo']  = '%%name%%';
 		$updated_options['social-title-archive-wpseo'] = '%%date%%';
 
-		$post_type_template         = 'social-title-';
-		$post_type_archive_template = 'social-title-ptarchive-';
-		$term_archive_template      = 'social-title-tax-';
-
 		/* translators: %s expands to the name of a post type (plural). */
 		$post_type_archive_default = sprintf( __( '%s Archive', 'wordpress-seo' ), '%%pt_plural%%' );
 
@@ -1199,10 +1195,10 @@ class WPSEO_Upgrade {
 		if ( $post_type_objects ) {
 			foreach ( $post_type_objects as $pt ) {
 				// Post types.
-				$updated_options[ $post_type_template . $pt->name ] = '%%title%%';
+				$updated_options[ 'social-title-' . $pt->name ] = '%%title%%';
 
 				// Post type archives.
-				$updated_options[ $post_type_archive_template . $pt->name ] = $post_type_archive_default;
+				$updated_options[ 'social-title-ptarchive-' . $pt->name ] = $post_type_archive_default;
 			}
 		}
 
@@ -1210,7 +1206,7 @@ class WPSEO_Upgrade {
 
 		if ( $taxonomy_objects ) {
 			foreach ( $taxonomy_objects as $tax ) {
-				$updated_options[ $term_archive_template . $tax->name ] = $term_archive_default;
+				$updated_options[ 'social-title-tax-' . $tax->name ] = $term_archive_default;
 			}
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The social titles options have been introduced since 16.3 with outdated defaults so users upgrading to 16.5 won't see the new default values. We want to reset those options.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an upgrade routine to reset the social title options to the new default values.

## Relevant technical choices:

*  We had to hook the method to copy social options for the home page to `init` action to make sure that integrations are loaded by then and the `Indexable_Home_Page_Watcher` can trigger the rebuilding of the home page indexable.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* some of the values will be localized so it would be better to have WP in a different language from the default English (US)
  * change the language in `Settings` > `General`
  * visit `Dashboard` > `Updates` and update the languages
* in a clean environment, install Free 16.4 (Premium is not strictly needed)
 * you can also empty the `wpseo_titles` option in the DB, then visit Search Appearance and save to trigger the saving of the options with the outdated values
 * also visit the Test Helper to make sure the current version is 16.4, if not use it to set it
* visit `SEO` > `Social`, `Facebook` tab, and set an empty title for the frontpage
* make sure you have custom post types: e.g. using the Test Helper plugin to add `Books` and `Movies`, or using Yoast SEO Local to add `Locations`
* upgrade Free to this branch, plus Premium 16.5
* visit `Search Appearance`, and check that the forms show the following values:
  * for the home page: the Social title should be set to `%%sitename%%`
  * for a single post, in every post type: the Social title should be set to `%%title%%`
  * for every custom post type archive: the Social title should be set to `%%pt_plural%% Archive` (translated in your language, so the order of the words may differ)
  * for every term archive: the Social title should be set to `%%term_title%% Archives` (translated in your language, so the order of the words may differ)
  * for author archives: the Social title should be set to `%%name%%`
  * for date archives: the Social title should be set to `%%date%%`
* do a smoke test to see the tags in the output get the right values:
  * publish a new post where you set just the title, and check if `og:title` is set to the title
  * visit a post type archive, and check if `og:title` is set to e.g. "Books Archive" (translated)
  * visit a term archive where social settings are empty, and check if `og:title` is set to "{Term name} Archives" (translated)
  * visit an author archive, and check if `og:title` is set to "{Author name}"
  * visit a date archive, and check if `og:title` is set to "{Date}"
  * visit the home page, and check if `og:title` is set to "{Sitename}"


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* some of the values will be localized so it would be better to have WP in a different language from the default English (US)
  * change the language in `Settings` > `General`
  * visit `Dashboard` > `Updates` and update the languages
* in a clean environment, install Free 16.4 (Premium is not strictly needed)
* make sure you have custom post types: e.g. using the Test Helper plugin to add `Books` and `Movies`, or using Yoast SEO Local to add `Locations`
* visit `SEO` > `Social`, `Facebook` tab, and set an empty title for the frontpage
* upgrade Free to 16.5, plus Premium 16.5
* visit `Search Appearance`, and check that the forms show the following values:
  * for the home page: the Social title should be set to `%%sitename%%`
  * for a single post, in every post type: the Social title should be set to `%%title%%`
  * for every custom post type archive: the Social title should be set to `%%pt_plural%% Archive` (translated in your language, so the order of the words may differ)
  * for every term archive: the Social title should be set to `%%term_title%% Archives` (translated in your language, so the order of the words may differ)
  * for author archives: the Social title should be set to `%%name%%`
  * for date archives: the Social title should be set to `%%date%%`
* do a smoke test to see the tags in the output get the right values:
  * publish a new post where you set just the title, and check if `og:title` is set to the title
  * visit a post type archive, and check if `og:title` is set to e.g. "Books Archive" (translated)
  * visit a term archive where social settings are empty, and check if `og:title` is set to "{Term name} Archives" (translated)
  * visit an author archive, and check if `og:title` is set to "{Author name}"
  * visit a date archive, and check if `og:title` is set to "{Date}"
  * visit the home page, and check if `og:title` is set to "{Sitename}"

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-681]
