### PR TITLE
Expand list of Norwegian function words

### DIFF
--- a/packages/yoastseo/src/languageProcessing/languages/nb/config/functionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nb/config/functionWords.js
@@ -41,7 +41,7 @@ const indefinitePronouns = [ "ingenting", "annen", "annet", "andre" ];
 
 const prepositions = [ "sånn", "ved", "mot", "ned", "enn", "over", "inn", "i", "sa", "opp", "der", "fra", "din", "nei", "mellom", "di", "oppe",
 	"av", "med", "til", "å", "på", "du", "uten", "én", "under", "hos", "inne", "gjennom", "unna", "del", "nede", "til", "over", "under", "etter",
-	"kun", "blant", "for", "mellom", "mot", "blant" ];
+	"kun", "blant", "for", "mellom", "blant" ];
 
 const conjunctions = [ "eller", "hvis", "ja", "et", "som", "i", "og", "både", "men", "mens", "enten", "verken", "at", "om", "da", "når", "før",
 	"idet", "etter at", "siden", "innen", "med det samme", "til", "inntil", "hver gang", "etter hvert som", "så lenge", "så lenge som", "så ofte",
@@ -74,14 +74,15 @@ const generalAdjectivesAdverbs = [
 	"helst", "dårligere", "dårligst", "vondt", "vondere", "vondest", "meget", "øverst", "enda", "neppe", "nokså", "nesten", "helt", "bitende",
 	"aller", "ganske", "aldeles", "derfra", "herfra", "utenlands", "noensteds", "oppå", "hjemme", "hit", "dit", "vekk", "fram", "fort", "hyggelig",
 	"hvorledes", "sånn", "således", "slik", "pent", "morsomt", "akkurat", "alt", "ofte", "nettopp", "bestandig", "noen gang", "noen ganger",
-	"fremdeles", "ennå", "da", "sjeldent", ];
+	"fremdeles", "ennå", "da", "sjeldent" ];
 
 const interjections = [ "hei", "fy", "au", "hurra", "uff", "takk", "hm", "fanden", "pokker", "fillern", "åh", "isj", "hallo", "æsj" ];
 
 const recipeWords = [ "g" ];
 
-const timeWords = [ "år", "året", "går", "dag", "nå", "tid", "tiden", "morgen", "dager", "minutt", "minutter", "dagen", "uke", "uker", "måneder", "stund",
-	"timer", "time", "morges", "ettermiddag", "tidlig", "fjor", "kveld", "natt", "fogårs", "vinter", "sommer", "vår", "høst"  ];
+const timeWords = [ "år", "året", "går", "dag", "nå", "tid", "tiden", "morgen", "dager", "minutt", "minutter", "dagen", "uke",
+	"uker", "måneder", "stund", "timer", "time", "morges", "ettermiddag", "tidlig", "fjor", "kveld", "natt", "fogårs", "vinter",
+	"sommer", "vår", "høst"  ];
 
 const vagueNouns = [ "ting", "tingene" ];
 

--- a/packages/yoastseo/src/languageProcessing/languages/nb/config/functionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nb/config/functionWords.js
@@ -1,3 +1,4 @@
+import { singleWords as transitionWords } from "./transitionWords";
 /**
  * Returns an object with function words.
  *
@@ -94,6 +95,6 @@ const miscellaneous = [ "ok", "okay", "ja", "jo", "jaså", "nei", "ikke", "unnsk
 export const all = [].concat( articles, cardinalNumerals, ordinalNumerals, pronouns, interrogatives,
 	quantifiers, reflexivePronouns, indefinitePronouns, prepositions, conjunctions, interviewVerbs,
 	intensifiers, auxiliariesAndDelexicalizedVerbs, generalAdjectivesAdverbs, interjections, recipeWords,
-	timeWords, vagueNouns, miscellaneous );
+	timeWords, vagueNouns, miscellaneous, transitionWords );
 
 export default all;

--- a/packages/yoastseo/src/languageProcessing/languages/nb/config/functionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nb/config/functionWords.js
@@ -3,61 +3,92 @@
  *
  * @returns {Object} The object filled with various categories of function word arrays.
  */
-const articles = [ "det", "en" ];
+// "En" is already listed among the cardinal numbers, "de", "det" and "den" among the personal pronouns.
+const articles = [ "ei", "et" ];
 
-const cardinalNumerals = [ "en", "to", "tre", "fire", "fem", "seks", "syv", "åtte", "ni", "ti", "elleve", "tolv",
-	"tretten", "fjorten", "femten", "seksten", "sytten", "atten", "nitten", "tjue", "hundre", "tusen", "million", "milliarder" ];
+const cardinalNumerals = [ "null", "en", "ett", "ene", "to", "tre", "fire", "fem", "seks", "syv", "åtte", "ni", "ti", "elleve", "tolv",
+	"tretten", "fjorten", "femten", "seksten", "sytten", "atten", "nitten", "tjue", "tyve", "tjueen", "enogtyve", "tretti", "tredve",
+	"førti", "førr", "femti", "seksti", "sytti", "åtti", "nitti", "hundre", "hundreogen", "etthundreogen", "tohundre", "tusen",
+	"tusenogen", "million", "millioner", "milliard", "milliarder" ];
 
-const ordinalNumerals = [ "første", "først", "sekund", "tredje", "fjerde", "femte", "sjette", "syvende", "åttende", "niende", "tiende" ];
+const ordinalNumerals = [ "nullte", "første", "først", "sekund", "tredje", "fjerde", "femte", "sjette", "syvende", "åttende", "niende", "tiende",
+	"ellevte", "tolvte", "trettende", "fjortende", "femtende", "sekstende", "syttende", "åttende", "nittende", "tjuende", "tjueførst", "tjueførste",
+	"trettiende", "førtiende", "femtiende", "sekstiende", "syttiende", "åttiende", "nittiende", "hundrede", "hundreogfemtiende", "to hundrede",
+	"tusende", "millionte", "millardte" ];
 
 const pronouns = [
 	// Personal pronouns.
-	"jeg", "du", "den", "vi", "de", "han", "hun", "henne", "oss", "meg", "ham", "dem",
+	"jeg", "du", "den", "det", "vi", "de", "han", "hun", "dere", "henne", "oss", "meg", "deg", "ham", "dem",
 	// Possessive pronouns.
-	"vår", "deres", "ditt", "mitt", "våre", "vårt", "hans", "hennes", "dens", "egen", "egne",
-	// Demonstrative pronouns.
-	"denne", "dette", "disse",
+	"min", "din", "deres", "vår", "deres", "ditt", "mitt", "våre", "vårt", "hans", "hennes", "dens", "dets", "egen",
+	"egne", "mi", "di", "sin", "si", "sitt", "sine", "mine", "dine",
+	// Demonstrative pronouns. "De", "det" and "den" are among the personal pronouns.
+	"denne", "dette", "disse", "slik", "slikt", "slike", "sånn", "sånt", "sånne", "samme",
 	// Reciprocal pronouns.
-	"hverandre", "hvert" ];
+	"hverandre", "hvert",
+	// Relative pronouns.
+	"som" ];
 
-const interrogatives = [ "hvem", "hvordan", "hvorfor", "hvor", "hva", "hvilken", "hvilket" ];
+const interrogatives = [ "hvem", "hvordan", "hvorfor", "hvor", "hva", "hvilken", "hvilket", "hvilke" ];
 
-const quantifiers = [ "mange", "hele", "mer", "ingen", "alle", "noen", "flere", "hver", "begge", "sov", "mest", "fleste" ];
+const quantifiers = [ "mange", "mye", "mang en", "mangt et", "hele", "mer", "ingen", "ingenting", "ikke noen", "ikke noe",
+	"alle", "all", "alt", "allting", "noen", "noe", "flere", "hver", "hvert", "annenhver", "ammethvert", "begge", "sov", "mest", "fleste",
+	"få", "fæst", "færrest", "flere", "flest" ];
 
-const reflexivePronouns = [  ];
+const reflexivePronouns = [ "seg", "selv" ];
 
-const indefinitePronouns = [ "ingenting" ];
+const indefinitePronouns = [ "ingenting", "annen", "annet", "andre" ];
 
-const prepositions = [ "sånn", "ved", "mot", "ned", "enn", "over", "inn", "sa", "opp", "der", "fra", "din", "nei", "mellom", "di", "oppe",
-	"av", "om", "den", "de", "at", "med", "til", "å", "på", "du", "uten", "én", "under", "hos", "inne", "gjennom", "unna", "del", "nede",
-	"kun", "innen", "blant" ];
+const prepositions = [ "sånn", "ved", "mot", "ned", "enn", "over", "inn", "i", "sa", "opp", "der", "fra", "din", "nei", "mellom", "di", "oppe",
+	"av", "med", "til", "å", "på", "du", "uten", "én", "under", "hos", "inne", "gjennom", "unna", "del", "nede", "til", "over", "under", "etter",
+	"kun", "blant", "for", "mellom", "mot", "blant" ];
 
-const conjunctions = [ "eller", "hvis", "ja", "et", "som", "i", "og" ];
+const conjunctions = [ "eller", "hvis", "ja", "et", "som", "i", "og", "både", "men", "mens", "enten", "verken", "at", "om", "da", "når", "før",
+	"idet", "etter at", "siden", "innen", "med det samme", "til", "inntil", "hver gang", "etter hvert som", "så lenge", "så lenge som", "så ofte",
+	"så ofte som", "så snart", "så snart som", "etter", "etterpå", "foran", "tidligere", "fordi", "ettersom", "derfor", "dersom", "hvis", "så fremt",
+	"så sant", "i fall", "i tilfelle", "med mindre", "uten at", "bare", "for så vidt som", "uten at", "uten å", "enda", "fordi om", "enda om",
+	"skjønt", "om enn", "hva så", "trass i at", "hvor så", "samme", "selv om", "hva enn", "til tross for at", "hvor enn", "uansett", "for at", "så",
+	"så at", "slik at", "sånn at", "for at, så", "slik som", "så som", "som om", "enn", "dess", "jo", "desto" ];
 
 const interviewVerbs = [ "tror", "fortelle", "fortell", "fortalte", "tenkte", "tenk" ];
 
 const intensifiers = [ "virkelig", "akkurat", "visst" ];
 
-const auxiliariesAndDelexicalizedVerbs = [ ];
+const auxiliariesAndDelexicalizedVerbs = [ "gjøre", "gjorde" ];
 
 const generalAdjectivesAdverbs = [
 	// General adjective.
-	"helt", "andre", "litt", "lenge", "siste", "fint", "annet", "stor", "neste", "lenger", "annen", "nye", "alene", "flott",
-	"klart", "liten", "langt", "gamle", "dårlig", "hyggelig", "gode", "sånt", "nytt", "best", "lang", "små", "lot", "større",
-	"høyt", "største", "slikt",
+	"helt", "andre", "litt", "lenge", "siste", "fint", "annet", "stor", "stort", "store", "neste", "lenger", "annen", "nye",
+	"alene", "flott", "gammel", "gammelt", "gamle", "klart", "liten", "langt", "gamle", "dårlig", "hyggelig", "gode", "sånt",
+	"nytt", "best", "lang", "små", "lot", "større", "vakker", "vakkert", "vakre", "ny", "bra", "bedre", "grei", "greit", "greie",
+	"høyt", "største", "størst", "slikt", "liten", "lita", "lite", "små", "mindre", "minst", "kort", "glad", "dårlig", "ille", "ond",
+	"vond", "verre", "verst", "eldre", "eldst", "lang", "lengre", "lengst", "nær", "næmerere", "nærere", "nærmest",
+	"nærest", "tung", "tyngre", "tyngst", "ung", "yngre", "yngst", "pen",
 	// General adverbs.
 	"alltid", "godt", "sammen", "tilbake", "etter", "igjen", "bare", "så", "veldig", "bedre", "samme", "far", "eneste", "enig",
-	"borte", "snart", "rundt", "beste", "bort", "vekk", "nesten", "ganske", "senere", "videre", "mindre", "straks", "svært" ];
+	"borte", "snart", "rundt", "beste", "bort", "vekk", "nesten", "ganske", "senere", "videre", "straks", "svært", "neste",
+	"bak", "bakre", "bakerst", "borte", "bortre", "bortest", "fremme", "fremre", "fremst", "foran", "forrest", "inne", "indre", "innerst",
+	"midt", "midtre", "midterst", "nede", "nedre", "nederst", "nord", "nordre", "nordligst", "øvre", "øverst", "sør", "søndre", "sørligst",
+	"vest", "vestre", "vestligst", "øst", "østre", "østligst", "ute", "ytre", "ytterst", "underst", "langt", "fram", "her", "der", "nok", "aldri",
+	"ut", "ned", "nede", "bort", "innom", "ingensteds", "sjelden", "sjeldnere", "sjeldnest", "raskt", "raskere", "raskest", "gjerne", "heller",
+	"helst", "dårligere", "dårligst", "vondt", "vondere", "vondest", "meget", "øverst", "enda", "neppe", "nokså", "nesten", "helt", "bitende",
+	"aller", "ganske", "aldeles", "derfra", "herfra", "utenlands", "noensteds", "oppå", "hjemme", "hit", "dit", "vekk", "fram", "fort", "hyggelig",
+	"hvorledes", "sånn", "således", "slik", "pent", "morsomt", "akkurat", "alt", "ofte", "nettopp", "bestandig", "noen gang", "noen ganger",
+	"fremdeles", "ennå", "da", "sjeldent", ];
 
-const interjections = [ "hei" ];
+const interjections = [ "hei", "fy", "au", "hurra", "uff", "takk", "hm", "fanden", "pokker", "fillern", "åh", "isj", "hallo", "æsj" ];
 
-const recipeWords = [  ];
+const recipeWords = [ "g" ];
 
-const timeWords = [ "år", "dag", "nå", "tid", "tiden", "morgen", "dager", "minutter", "dagen", "uke", "uker", "måneder", "stund" ];
+const timeWords = [ "år", "året", "går", "dag", "nå", "tid", "tiden", "morgen", "dager", "minutt", "minutter", "dagen", "uke", "uker", "måneder", "stund",
+	"timer", "time", "morges", "ettermiddag", "tidlig", "fjor", "kveld", "natt", "fogårs", "vinter", "sommer", "vår", "høst"  ];
 
 const vagueNouns = [ "ting", "tingene" ];
 
-const miscellaneous = [ "ok", "okay", "ja", "jaså", "nei", "ikke", "unnskyld", "beklager", "herr", "altså" ];
+const miscellaneous = [ "ok", "okay", "ja", "jo", "jaså", "nei", "ikke", "unnskyld", "beklager", "herr", "altså", "grader", "grad", "kr",
+	// Fractions.
+	"en halvdel", "en halv", "to halve", "en tredel", "tredjedel", "to tredeler", "tredjedeler", "en firedel", "fjerdedel",
+	"kvart", "en trettendedel", "en fjortendedel", "en promille", "en tusendel", "halvannen", "en og en halv" ];
 
 export const all = [].concat( articles, cardinalNumerals, ordinalNumerals, pronouns, interrogatives,
 	quantifiers, reflexivePronouns, indefinitePronouns, prepositions, conjunctions, interviewVerbs,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves keyword detection for Norwegian by expanding the list of function words.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test the following in WP SEO Free:

- Set the site language to Norwegian
- Create a new post and add a text with at least 300 words. To create a text you can use e.g., a [text generator](https://www.lipsum.com/feed/html) or use the [Norwegian Wikipedia](https://no.wikipedia.org/wiki/Portal:Forside)
- Set your keyphrase to `fjerde katt`
- Add the word `katt` to the text
- Make sure that the keyphrase density assessment shows the keyphrase is found once.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-747