### PR TITLE
P3-685 require Premium 16.5 for social templates

### DIFF
--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -52,8 +52,8 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 */
 	public function use_social_templates() {
 		return YoastSEO()->helpers->product->is_premium()
-			&& defined( '\WPSEO_PREMIUM_VERSION' )
-			&& \version_compare( \WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' )
+			&& defined( 'WPSEO_PREMIUM_VERSION' )
+			&& version_compare( WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' )
 			&& WPSEO_Options::get( 'opengraph', false ) === true;
 	}
 

--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -42,10 +42,19 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 		$this->post      = $post;
 		$this->permalink = $structure;
 
-		$this->use_social_templates = YoastSEO()->helpers->product->is_premium()
-									&& defined( '\WPSEO_PREMIUM_VERSION' )
-									&& \version_compare( \WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' )
-									&& WPSEO_Options::get( 'opengraph', false ) === true;
+		$this->use_social_templates = $this->use_social_templates();
+	}
+
+	/**
+	 * Determines whether the social templates should be used.
+	 *
+	 * @return bool Whether the social templates should be used.
+	 */
+	public function use_social_templates() {
+		return YoastSEO()->helpers->product->is_premium()
+			&& defined( '\WPSEO_PREMIUM_VERSION' )
+			&& \version_compare( \WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' )
+			&& WPSEO_Options::get( 'opengraph', false ) === true;
 	}
 
 	/**

--- a/admin/formatter/class-post-metabox-formatter.php
+++ b/admin/formatter/class-post-metabox-formatter.php
@@ -25,6 +25,13 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	private $permalink;
 
 	/**
+	 * Whether we must return social templates values.
+	 *
+	 * @var bool
+	 */
+	private $use_social_templates = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param WP_Post|array $post      Post object.
@@ -34,6 +41,11 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	public function __construct( $post, array $options, $structure ) {
 		$this->post      = $post;
 		$this->permalink = $structure;
+
+		$this->use_social_templates = YoastSEO()->helpers->product->is_premium()
+									&& defined( '\WPSEO_PREMIUM_VERSION' )
+									&& \version_compare( \WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' )
+									&& WPSEO_Options::get( 'opengraph', false ) === true;
 	}
 
 	/**
@@ -201,7 +213,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string The social title template.
 	 */
 	private function get_social_title_template() {
-		if ( YoastSEO()->helpers->product->is_premium() && WPSEO_Options::get( 'opengraph', false ) === true ) {
+		if ( $this->use_social_templates ) {
 			return $this->get_template( 'social-title' );
 		}
 
@@ -214,7 +226,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string The social description template.
 	 */
 	private function get_social_description_template() {
-		if ( YoastSEO()->helpers->product->is_premium() && WPSEO_Options::get( 'opengraph', false ) === true ) {
+		if ( $this->use_social_templates ) {
 			return $this->get_template( 'social-description' );
 		}
 
@@ -227,7 +239,7 @@ class WPSEO_Post_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string The social description template.
 	 */
 	private function get_social_image_template() {
-		if ( YoastSEO()->helpers->product->is_premium() && WPSEO_Options::get( 'opengraph', false ) === true ) {
+		if ( $this->use_social_templates ) {
 			return $this->get_template( 'social-image-url' );
 		}
 

--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -58,8 +58,8 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 */
 	public function use_social_templates() {
 		return YoastSEO()->helpers->product->is_premium()
-			&& defined( '\WPSEO_PREMIUM_VERSION' )
-			&& \version_compare( \WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' )
+			&& defined( 'WPSEO_PREMIUM_VERSION' )
+			&& version_compare( WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' )
 			&& WPSEO_Options::get( 'opengraph', false ) === true;
 	}
 

--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -25,6 +25,13 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	private $taxonomy;
 
 	/**
+	 * Whether we must return social templates values.
+	 *
+	 * @var bool
+	 */
+	private $use_social_templates = false;
+
+	/**
 	 * Array with the WPSEO_Titles options.
 	 *
 	 * @var array
@@ -40,6 +47,11 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	public function __construct( $taxonomy, $term ) {
 		$this->taxonomy = $taxonomy;
 		$this->term     = $term;
+
+		$this->use_social_templates = YoastSEO()->helpers->product->is_premium()
+									&& defined( '\WPSEO_PREMIUM_VERSION' )
+									&& \version_compare( \WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' )
+									&& WPSEO_Options::get( 'opengraph', false ) === true;
 	}
 
 	/**
@@ -161,7 +173,7 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string The social title template.
 	 */
 	private function get_social_title_template() {
-		if ( YoastSEO()->helpers->product->is_premium() && WPSEO_Options::get( 'opengraph', false ) === true ) {
+		if ( $this->use_social_templates ) {
 			return $this->get_template( 'social-title' );
 		}
 
@@ -174,7 +186,7 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string The social description template.
 	 */
 	private function get_social_description_template() {
-		if ( YoastSEO()->helpers->product->is_premium() && WPSEO_Options::get( 'opengraph', false ) === true ) {
+		if ( $this->use_social_templates ) {
 			return $this->get_template( 'social-description' );
 		}
 
@@ -187,7 +199,7 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 	 * @return string The social description template.
 	 */
 	private function get_social_image_template() {
-		if ( YoastSEO()->helpers->product->is_premium() && WPSEO_Options::get( 'opengraph', false ) === true ) {
+		if ( $this->use_social_templates ) {
 			return $this->get_template( 'social-image-url' );
 		}
 

--- a/admin/formatter/class-term-metabox-formatter.php
+++ b/admin/formatter/class-term-metabox-formatter.php
@@ -48,10 +48,19 @@ class WPSEO_Term_Metabox_Formatter implements WPSEO_Metabox_Formatter_Interface 
 		$this->taxonomy = $taxonomy;
 		$this->term     = $term;
 
-		$this->use_social_templates = YoastSEO()->helpers->product->is_premium()
-									&& defined( '\WPSEO_PREMIUM_VERSION' )
-									&& \version_compare( \WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' )
-									&& WPSEO_Options::get( 'opengraph', false ) === true;
+		$this->use_social_templates = $this->use_social_templates();
+	}
+
+	/**
+	 * Determines whether the social templates should be used.
+	 *
+	 * @return bool Whether the social templates should be used.
+	 */
+	public function use_social_templates() {
+		return YoastSEO()->helpers->product->is_premium()
+			&& defined( '\WPSEO_PREMIUM_VERSION' )
+			&& \version_compare( \WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' )
+			&& WPSEO_Options::get( 'opengraph', false ) === true;
 	}
 
 	/**

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -152,11 +152,11 @@ class Social_Templates_Integration implements Integration_Interface {
 	 * @param string     $page_type_specific    Editor specific type of page for a list of replaceable variables.
 	 */
 	protected function build_social_fields( Yoast_Form $yform, $identifier, $page_type_recommended, $page_type_specific ) {
-		$image_url_field_id = 'social-image-url-' . $identifier;
-		$image_id_field_id  = 'social-image-id-' . $identifier;
-		$is_premium         = YoastSEO()->helpers->product->is_premium();
-		$is_premium_16_5    = defined( '\WPSEO_PREMIUM_VERSION' ) && \version_compare( \WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' );
-		$is_form_enabled    = $is_premium && $is_premium_16_5;
+		$image_url_field_id    = 'social-image-url-' . $identifier;
+		$image_id_field_id     = 'social-image-id-' . $identifier;
+		$is_premium            = YoastSEO()->helpers->product->is_premium();
+		$is_premium_16_5_or_up = defined( '\WPSEO_PREMIUM_VERSION' ) && \version_compare( \WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' );
+		$is_form_enabled       = $is_premium && $is_premium_16_5_or_up;
 
 		$section_class = 'yoast-settings-section';
 
@@ -210,12 +210,16 @@ class Social_Templates_Integration implements Integration_Interface {
 		);
 		$editor->render();
 
-		if ( $is_premium && ! $is_premium_16_5 ) {
+		if ( $is_premium && ! $is_premium_16_5_or_up ) {
 			echo '<div class="yoast-settings-section-upsell">';
 
-			echo '<p>'
-			. \esc_html__( 'Unlock by updating Yoast SEO Premium or letting your admin update it', 'wordpress-seo' )
-			. '</p>';
+			echo '<p>';
+			printf(
+				/* translators: %s expands to 'Yoast SEO Premium'. */
+				\esc_html__( 'Unlock by updating %s or letting your admin update it', 'wordpress-seo' ),
+				'Yoast SEO Premium'
+			);
+			echo '</p>';
 			echo '</div>';
 		}
 

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -214,7 +214,7 @@ class Social_Templates_Integration implements Integration_Interface {
 			echo '<div class="yoast-settings-section-upsell">';
 
 			echo '<p>';
-			printf(
+			\printf(
 				/* translators: %s expands to 'Yoast SEO Premium'. */
 				\esc_html__( 'Unlock by updating %s or letting your admin update it', 'wordpress-seo' ),
 				'Yoast SEO Premium'

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -11,7 +11,6 @@ use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Conditionals\Open_Graph_Conditional;
 use Yoast\WP\SEO\Presenters\Admin\Badge_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Premium_Badge_Presenter;
-use Yoast\WP\SEO\Config\Badge_Group_Names;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast_Form;
 
@@ -156,10 +155,12 @@ class Social_Templates_Integration implements Integration_Interface {
 		$image_url_field_id = 'social-image-url-' . $identifier;
 		$image_id_field_id  = 'social-image-id-' . $identifier;
 		$is_premium         = YoastSEO()->helpers->product->is_premium();
+		$is_premium_16_5    = defined( '\WPSEO_PREMIUM_VERSION' ) && \version_compare( \WPSEO_PREMIUM_VERSION, '16.5-RC0', '>=' );
+		$is_form_enabled    = $is_premium && $is_premium_16_5;
 
 		$section_class = 'yoast-settings-section';
 
-		if ( ! $is_premium ) {
+		if ( ! $is_form_enabled ) {
 			$section_class .= ' yoast-settings-section-disabled';
 		}
 
@@ -167,7 +168,7 @@ class Social_Templates_Integration implements Integration_Interface {
 
 		echo '<div class="social-settings-heading-container">';
 		echo '<h3 class="social-settings-heading">' . \esc_html__( 'Social settings', 'wordpress-seo' ) . '</h3>';
-		if ( $is_premium ) {
+		if ( $is_form_enabled ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Is correctly escaped in the Premium_Badge_Presenter.
 			echo new Premium_Badge_Presenter( 'global-templates-' . $identifier );
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Is correctly escaped in the Badge_Presenter.
@@ -189,7 +190,7 @@ class Social_Templates_Integration implements Integration_Interface {
 			\esc_attr( 'yoast-social-' . $identifier . '-image-select' ),
 			\esc_attr( $image_url_field_id ),
 			\esc_attr( $image_id_field_id ),
-			\esc_attr( ! $is_premium ),
+			\esc_attr( ! $is_form_enabled ),
 			true
 		);
 
@@ -204,10 +205,19 @@ class Social_Templates_Integration implements Integration_Interface {
 				'label_title'             => \__( 'Social title', 'wordpress-seo' ),
 				'label_description'       => \__( 'Social description', 'wordpress-seo' ),
 				'description_placeholder' => \__( 'Modify your social description by editing it right here.', 'wordpress-seo' ),
-				'is_disabled'             => ! $is_premium,
+				'is_disabled'             => ! $is_form_enabled,
 			]
 		);
 		$editor->render();
+
+		if ( $is_premium && ! $is_premium_16_5 ) {
+			echo '<div class="yoast-settings-section-upsell">';
+
+			echo '<p>'
+			. \esc_html__( 'Unlock by updating Yoast SEO Premium or letting your admin update it', 'wordpress-seo' )
+			. '</p>';
+			echo '</div>';
+		}
 
 		if ( ! $is_premium ) {
 			$wpseo_page = filter_input( INPUT_GET, 'page' );

--- a/tests/unit/doubles/admin/formatter/post-metabox-formatter-double.php
+++ b/tests/unit/doubles/admin/formatter/post-metabox-formatter-double.php
@@ -17,4 +17,13 @@ class Post_Metabox_Formatter_Double extends WPSEO_Post_Metabox_Formatter {
 	public function get_image_url() {
 		return parent::get_image_url();
 	}
+
+	/**
+	 * Overrides the parent method.
+	 *
+	 * @return bool Whether the social templates should be used.
+	 */
+	public function use_social_templates() {
+		return false;
+	}
 }

--- a/tests/unit/doubles/admin/formatter/term-metabox-formatter-double.php
+++ b/tests/unit/doubles/admin/formatter/term-metabox-formatter-double.php
@@ -17,4 +17,13 @@ class Term_Metabox_Formatter_Double extends WPSEO_Term_Metabox_Formatter {
 	public function get_image_url() {
 		return parent::get_image_url();
 	}
+
+	/**
+	 * Overrides the parent method.
+	 *
+	 * @return bool Whether the social templates should be used.
+	 */
+	public function use_social_templates() {
+		return false;
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Premium should have version >= 16.5 for the social templates to work

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the Social Templates feature in unsupported Premium versions.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* run without Premium active:
  * you should see the Social Templates forms disabled, with the upsell "Unlock with Premium"
  * if you edit a new post, the fields in the social tab should not load the social template values
* run with Premium 16.5 active:
  * you should see the Social Templates forms enabled
  * if you edit a new post, the fields in the social tab should load the social template values
* run with Premium 16.4 or lower active:
  * you should see the Social Templates forms disabled, with a message advising to update Premium
  * if you edit a new post, the fields in the social tab should not load the social template values


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-685]
