### PR TITLE
Adjust content-analysis app configs

### DIFF
--- a/apps/content-analysis/config/paths.js
+++ b/apps/content-analysis/config/paths.js
@@ -85,6 +85,7 @@ module.exports = {
 	yoastSrc: resolveApp( "../../packages/yoastseo/src" ),
 	yoastSpec: resolveApp( "../../packages/yoastseo/spec" ),
 	yoastPackages: resolveApp( "../../packages" ),
+	yoastNodeModules: resolveApp( "node_modules/@yoast" ),
 	wpI18n: resolveApp( "node_modules/@wordpress/i18n" ),
 };
 

--- a/apps/content-analysis/config/webpack.config.js
+++ b/apps/content-analysis/config/webpack.config.js
@@ -30,7 +30,7 @@ const postcssNormalize = require( "postcss-normalize" );
 const appPackageJson = require( paths.appPackageJson );
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
-const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== "false";
+const shouldUseSourceMap = false;
 // Some apps do not need the benefits of saving a web request, so not inlining the chunk
 // Makes for a smoother build process.
 const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== "false";
@@ -391,6 +391,7 @@ module.exports = function( webpackEnv ) {
 								paths.appSrc,
 								paths.yoastSrc,
 								paths.yoastPackages,
+								paths.yoastNodeModules,
 							],
 							loader: require.resolve( "babel-loader" ),
 							options: {

--- a/apps/content-analysis/config/webpackDevServer.config.js
+++ b/apps/content-analysis/config/webpackDevServer.config.js
@@ -104,7 +104,7 @@ module.exports = function( proxy, allowedHost ) {
 			// We do this in development to avoid hitting the production cache if
 			// It used the same host and port.
 			// https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
-			app.use( noopServiceWorkerMiddleware() );
+			app.use( noopServiceWorkerMiddleware( "/" ) );
 		},
 	};
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* After Content-anlaysis app was moved to `wordpress-seo` from `javascript` repo, it stopped working. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adjusts the content-analysis app config after the merging of `javascript` monorepo to `wordpress-seo`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In `content-analysis` app, run `yarn`
* Run `yarn start`
* Confirm that the app is running and that there are no errors


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-851
