### PR TITLE
Fix breadcrumb name attribute

### DIFF
--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -36,11 +36,6 @@ class Breadcrumb extends Abstract_Schema_Piece {
 		// In case of pagination, replace the last breadcrumb, because it only contains "Page [number]" and has no URL.
 		if ( $this->helpers->current_page->is_paged() || ( $this->context->indexable->number_of_pages > 1 ) ) {
 			\array_pop( $breadcrumbs );
-
-			$breadcrumbs[] = [
-				'url'  => $this->context->canonical,
-				'text' => $this->context->title,
-			];
 		}
 
 		// Only output breadcrumbs that are not hidden.

--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -101,6 +101,7 @@ class Breadcrumb extends Abstract_Schema_Piece {
 		$crumb = [
 			'@type'    => 'ListItem',
 			'position' => ( $index + 1 ),
+			'name'     => $this->helpers->schema->html->smart_strip_tags( $breadcrumb['text'] ),
 			'item'     => [],
 		];
 
@@ -112,23 +113,19 @@ class Breadcrumb extends Abstract_Schema_Piece {
 		$crumb['item']['@type'] = 'WebPage';
 		$crumb['item']['@id']   = $breadcrumb['url'];
 		$crumb['item']['url']   = $breadcrumb['url'];
-		$crumb['item']['name']  = $this->helpers->schema->html->smart_strip_tags( $breadcrumb['text'] );
 
 		return $crumb;
 	}
 
 	/**
-	 * Creates the last breadcrumb in the breadcrumb list.
-	 * Provides a fallback for the URL and text:
-	 *  - URL falls back to the canonical of current page.
-	 *  - text falls back to the title of current page.
+	 * Creates the last breadcrumb in the breadcrumb list, linking it by @id to the webpage item.
 	 *
 	 * @param array $breadcrumb The position in the list.
 	 *
 	 * @return array The last of the breadcrumbs.
 	 */
 	private function format_last_breadcrumb( $breadcrumb ) {
-		unset( $breadcrumb['url'], $breadcrumb['text'], $breadcrumb['@type'] );
+		unset( $breadcrumb['url'], $breadcrumb['@type'] );
 		$breadcrumb['@id'] = $this->context->canonical . Schema_IDs::WEBPAGE_HASH;
 
 		return $breadcrumb;

--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -112,7 +112,9 @@ class Breadcrumb extends Abstract_Schema_Piece {
 	}
 
 	/**
-	 * Creates the last breadcrumb in the breadcrumb list, linking it by @id to the webpage item.
+	 * Creates the last breadcrumb in the breadcrumb list, omitting the URL per Google's spec.
+	 *
+	 * @link https://developers.google.com/search/docs/data-types/breadcrumb
 	 *
 	 * @param array $breadcrumb The position in the list.
 	 *

--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -102,17 +102,11 @@ class Breadcrumb extends Abstract_Schema_Piece {
 			'@type'    => 'ListItem',
 			'position' => ( $index + 1 ),
 			'name'     => $this->helpers->schema->html->smart_strip_tags( $breadcrumb['text'] ),
-			'item'     => [],
 		];
 
-		if ( ! isset( $breadcrumb['url'] ) && isset( $breadcrumb['@id'] ) ) {
-			$crumb['item']['@id'] = $breadcrumb['@id'];
-			return $crumb;
+		if ( ! empty( $breadcrumb['url'] ) ) {
+			$crumb['item'] = $breadcrumb['url'];
 		}
-
-		$crumb['item']['@type'] = 'WebPage';
-		$crumb['item']['@id']   = $breadcrumb['url'];
-		$crumb['item']['url']   = $breadcrumb['url'];
 
 		return $crumb;
 	}
@@ -125,8 +119,7 @@ class Breadcrumb extends Abstract_Schema_Piece {
 	 * @return array The last of the breadcrumbs.
 	 */
 	private function format_last_breadcrumb( $breadcrumb ) {
-		unset( $breadcrumb['url'], $breadcrumb['@type'] );
-		$breadcrumb['@id'] = $this->context->canonical . Schema_IDs::WEBPAGE_HASH;
+		unset( $breadcrumb['url'] );
 
 		return $breadcrumb;
 	}

--- a/tests/unit/generators/schema/breadcrumb-test.php
+++ b/tests/unit/generators/schema/breadcrumb-test.php
@@ -117,6 +117,11 @@ class Breadcrumb_Test extends TestCase {
 			->with( 'Home' )
 			->once()
 			->andReturnArg( 0 );
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Test post' )
+			->once()
+			->andReturnArg( 0 );
 
 		$actual = $this->instance->generate();
 
@@ -127,19 +132,13 @@ class Breadcrumb_Test extends TestCase {
 				[
 					'@type'    => 'ListItem',
 					'position' => 1,
-					'item'     => [
-						'@type' => 'WebPage',
-						'@id'   => 'https://wordpress.example.com/',
-						'url'   => 'https://wordpress.example.com/',
-						'name'  => 'Home',
-					],
+					'name'     => 'Home',
+					'item'     => 'https://wordpress.example.com/',
 				],
 				[
 					'@type'    => 'ListItem',
 					'position' => 2,
-					'item'     => [
-						'@id'   => 'https://wordpress.example.com/canonical#webpage',
-					],
+					'name'     => 'Test post',
 				],
 			],
 		];
@@ -169,6 +168,12 @@ class Breadcrumb_Test extends TestCase {
 		$this->current_page->expects( 'is_paged' )->andReturnFalse();
 		$this->current_page->expects( 'is_home_static_page' )->once()->andReturnTrue();
 
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Home' )
+			->once()
+			->andReturnArg( 0 );
+
 		$actual = $this->instance->generate();
 
 		$expected = [
@@ -178,9 +183,7 @@ class Breadcrumb_Test extends TestCase {
 				[
 					'@type'    => 'ListItem',
 					'position' => 1,
-					'item'     => [
-						'@id'   => 'https://wordpress.example.com/canonical#webpage',
-					],
+					'name'     => 'Home',
 				],
 			],
 		];
@@ -215,6 +218,12 @@ class Breadcrumb_Test extends TestCase {
 		$this->current_page->expects( 'is_paged' )->andReturnFalse();
 		$this->current_page->expects( 'is_home_static_page' )->once()->andReturnTrue();
 
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Home' )
+			->once()
+			->andReturnArg( 0 );
+
 		$actual = $this->instance->generate();
 
 		$expected = [
@@ -224,9 +233,7 @@ class Breadcrumb_Test extends TestCase {
 				[
 					'@type'    => 'ListItem',
 					'position' => 1,
-					'item'     => [
-						'@id'   => 'https://wordpress.example.com/canonical#webpage',
-					],
+					'name'     => 'Home',
 				],
 			],
 		];
@@ -263,6 +270,12 @@ class Breadcrumb_Test extends TestCase {
 		$this->current_page->expects( 'is_paged' )->andReturnFalse();
 		$this->current_page->expects( 'is_home_static_page' )->once()->andReturnFalse();
 
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Home' )
+			->once()
+			->andReturnArg( 0 );
+
 		$actual = $this->instance->generate();
 
 		$expected = [
@@ -272,9 +285,7 @@ class Breadcrumb_Test extends TestCase {
 				[
 					'@type'    => 'ListItem',
 					'position' => 1,
-					'item'     => [
-						'@id'   => 'https://wordpress.example.com/canonical#webpage',
-					],
+					'name'     => 'Home',
 				],
 			],
 		];
@@ -349,7 +360,6 @@ class Breadcrumb_Test extends TestCase {
 			->with( 'Home' )
 			->once()
 			->andReturnArg( 0 );
-
 		$this->html
 			->expects( 'smart_strip_tags' )
 			->with( 'Test post' )
@@ -363,29 +373,13 @@ class Breadcrumb_Test extends TestCase {
 				[
 					'@type'    => 'ListItem',
 					'position' => 1,
-					'item'     => [
-						'@type' => 'WebPage',
-						'@id'   => 'https://wordpress.example.com/',
-						'url'   => 'https://wordpress.example.com/',
-						'name'  => 'Home',
-					],
+					'name'     => 'Home',
+					'item'     => 'https://wordpress.example.com/',
 				],
 				[
 					'@type'    => 'ListItem',
 					'position' => 2,
-					'item'     => [
-						'@type' => 'WebPage',
-						'@id'   => 'https://wordpress.example.com/post-title',
-						'url'   => 'https://wordpress.example.com/post-title',
-						'name'  => 'Test post',
-					],
-				],
-				[
-					'@type'    => 'ListItem',
-					'position' => 3,
-					'item'     => [
-						'@id' => 'https://wordpress.example.com/canonical#webpage',
-					],
+					'name'     => 'Test post',
 				],
 			],
 		];
@@ -446,29 +440,13 @@ class Breadcrumb_Test extends TestCase {
 				[
 					'@type'    => 'ListItem',
 					'position' => 1,
-					'item'     => [
-						'@type' => 'WebPage',
-						'@id'   => 'https://wordpress.example.com/',
-						'url'   => 'https://wordpress.example.com/',
-						'name'  => 'Home',
-					],
+					'name'     => 'Home',
+					'item'     => 'https://wordpress.example.com/',
 				],
 				[
 					'@type'    => 'ListItem',
 					'position' => 2,
-					'item'     => [
-						'@type' => 'WebPage',
-						'@id'   => 'https://wordpress.example.com/post-title',
-						'url'   => 'https://wordpress.example.com/post-title',
-						'name'  => 'Test post',
-					],
-				],
-				[
-					'@type'    => 'ListItem',
-					'position' => 3,
-					'item'     => [
-						'@id'   => 'https://wordpress.example.com/canonical#webpage',
-					],
+					'name'     => 'Test post',
 				],
 			],
 		];
@@ -513,6 +491,11 @@ class Breadcrumb_Test extends TestCase {
 			->with( 'Home' )
 			->once()
 			->andReturnArg( 0 );
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->with( 'Test post' )
+			->once()
+			->andReturnArg( 0 );
 
 		$expected = [
 			'@type'           => 'BreadcrumbList',
@@ -521,19 +504,13 @@ class Breadcrumb_Test extends TestCase {
 				[
 					'@type'    => 'ListItem',
 					'position' => 1,
-					'item'     => [
-						'@type' => 'WebPage',
-						'@id'   => 'https://wordpress.example.com/',
-						'url'   => 'https://wordpress.example.com/',
-						'name'  => 'Home',
-					],
+					'name'     => 'Home',
+					'item'     => 'https://wordpress.example.com/',
 				],
 				[
 					'@type'    => 'ListItem',
 					'position' => 2,
-					'item'     => [
-						'@id'   => 'https://wordpress.example.com/canonical#webpage',
-					],
+					'name'     => 'Test post',
 				],
 			],
 		];
@@ -578,6 +555,11 @@ class Breadcrumb_Test extends TestCase {
 			->once()
 			->with( 'Home' )
 			->andReturn( 'Home' );
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->once()
+			->with( '' )
+			->andReturn( '' );
 
 		$expected = [
 			'@type'           => 'BreadcrumbList',
@@ -586,19 +568,13 @@ class Breadcrumb_Test extends TestCase {
 				[
 					'@type'    => 'ListItem',
 					'position' => 1,
-					'item'     => [
-						'@type' => 'WebPage',
-						'@id'   => 'https://wordpress.example.com/',
-						'url'   => 'https://wordpress.example.com/',
-						'name'  => 'Home',
-					],
+					'name'     => 'Home',
+					'item'     => 'https://wordpress.example.com/',
 				],
 				[
 					'@type'    => 'ListItem',
 					'position' => 2,
-					'item'     => [
-						'@id' => 'https://wordpress.example.com/canonical#webpage',
-					],
+					'name'     => '',
 				],
 			],
 		];


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the breadcrumbs schema output so Google can understand it better.

## Relevant technical choices:

* Our previous implementation was technically correct but Google failed to parse it correctly.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See https://yoast.atlassian.net/browse/P3-508


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #P3-508
