### PR TITLE
GST: change unlock by updating message to an alert

### DIFF
--- a/css/src/search-appearance.css
+++ b/css/src/search-appearance.css
@@ -64,6 +64,10 @@
 	margin-left: 8px;
 }
 
+.yoast-settings-section-upsell .yoast-alert {
+	margin: 0 32px;
+}
+
 .draftJsMentionPlugin__mention__29BEd, .draftJsMentionPlugin__mention__29BEd:visited {
   color: #575f67;
   cursor: pointer;

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -216,7 +216,7 @@ class Social_Templates_Integration implements Integration_Interface {
 
 			$unlock_alert = \sprintf(
 				/* translators: %s expands to 'Yoast SEO Premium'. */
-				\esc_html__( 'Unlock by updating %s or letting your admin update it.', 'wordpress-seo' ),
+				\esc_html__( 'Unlock by having %s updated to the latest version.', 'wordpress-seo' ),
 				'Yoast SEO Premium'
 			);
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped above.

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -11,6 +11,7 @@ use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Conditionals\Open_Graph_Conditional;
 use Yoast\WP\SEO\Presenters\Admin\Badge_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Premium_Badge_Presenter;
+use Yoast\WP\SEO\Presenters\Admin\Alert_Presenter;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast_Form;
 
@@ -213,13 +214,14 @@ class Social_Templates_Integration implements Integration_Interface {
 		if ( $is_premium && ! $is_premium_16_5_or_up ) {
 			echo '<div class="yoast-settings-section-upsell">';
 
-			echo '<p>';
-			\printf(
+			$unlock_alert = \sprintf(
 				/* translators: %s expands to 'Yoast SEO Premium'. */
-				\esc_html__( 'Unlock by updating %s or letting your admin update it', 'wordpress-seo' ),
+				\esc_html__( 'Unlock by updating %s or letting your admin update it.', 'wordpress-seo' ),
 				'Yoast SEO Premium'
 			);
-			echo '</p>';
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped above.
+			echo new Alert_Presenter( $unlock_alert );
+
 			echo '</div>';
 		}
 

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -9,10 +9,10 @@ use WPSEO_Admin_Utils;
 use WPSEO_Replacevar_Editor;
 use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Conditionals\Open_Graph_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Presenters\Admin\Alert_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Badge_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Premium_Badge_Presenter;
-use Yoast\WP\SEO\Presenters\Admin\Alert_Presenter;
-use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast_Form;
 
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Follow-up to P3-685 / https://github.com/Yoast/wordpress-seo/pull/17135

* We want to improve the message shown to users who are on Premium 16.4 or less by changing it to an alert.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improve the message to invite users to unlock the Social Templates features by updating to latest Premium version.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- install and activate Yoast SEO Free, switched to this branch, and build it as usual
- install and activate Premium **16.4**
  - note: if you're testing with the cloned repos of the plugin you can switch Premium to the 16.4 tag: `git checkout tags/16.4`  and then build it
- go to Search appearance > Content types > Posts
- check the social forms are disabled and there's a semi-transparent overlay on top of them, with a Yoast alert, see screenshot:

<img width="684" alt="Screenshot 2021-06-10 at 10 29 38" src="https://user-images.githubusercontent.com/1682452/121493285-f88bdf80-c9d7-11eb-9083-eb75a7a2f8a9.png">

- check it matches the design: https://www.sketch.com/s/e0a3ef51-6a94-47ac-8b76-82720fbe98f9/v/O0K8Ew/a/DPVxjz4/r/1xwvQw
- no need to check the other post types, taxonomies, archives because this overlay + alert is the same everywhere
- deactivate Premium
- go to Search appearance again
- check the overlay now displays an upsell button instead of the alert



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended


