### PR TITLE
GST: Change update to Premium alert text

### DIFF
--- a/css/src/search-appearance.css
+++ b/css/src/search-appearance.css
@@ -65,7 +65,7 @@
 }
 
 .yoast-settings-section-upsell .yoast-alert {
-	margin: 0 32px;
+	margin: 0 16px;
 }
 
 .draftJsMentionPlugin__mention__29BEd, .draftJsMentionPlugin__mention__29BEd:visited {

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -216,7 +216,7 @@ class Social_Templates_Integration implements Integration_Interface {
 
 			$unlock_alert = \sprintf(
 				/* translators: %s expands to 'Yoast SEO Premium'. */
-				\esc_html__( 'Unlock by having %s updated to the latest version.', 'wordpress-seo' ),
+				\esc_html__( 'To unlock this feature please update %s to the latest version.', 'wordpress-seo' ),
 				'Yoast SEO Premium'
 			);
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped above.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Follow-up to https://github.com/Yoast/wordpress-seo/pull/17139

* We want to avoid passive voice for the copy used for the GST "unlock by updating" alert.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Further Improve the message to invite users to unlock the Social Templates features by updating to latest Premium version.


## Relevant technical choices:

* Changes the alert text to "To unlock this feature please update Yoast SEO Premium to the latest version."
* Males sure the English text stays in one line. Translated, longer, text may go in two lines.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This PR changes only the copy of the alert and slightly adjusts left/right margins via CSS. This alert has already been tested and accepted in https://github.com/Yoast/wordpress-seo/pull/17139 
* Please follow the test instructions from https://github.com/Yoast/wordpress-seo/pull/17139
* Check the alert text is now: "To unlock this feature please update Yoast SEO Premium to the latest version."
* Screenshot:

<img width="680" alt="Screenshot 2021-06-10 at 11 45 25" src="https://user-images.githubusercontent.com/1682452/121504542-63daaf00-c9e2-11eb-9e9d-93dcb4d6a84b.png">



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended


