### PR TITLE
P3-696 Optimize loading of Social Templates Integration

### DIFF
--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -43,14 +43,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	 *
 	 * @var string
 	 */
-	private $group;
-
-	/**
-	 * Social_Templates_Integration constructor.
-	 */
-	public function __construct() {
-		$this->group = 'global-templates';
-	}
+	private $group = 'global-templates';
 
 	/**
 	 * Returns the conditionals based in which this loadable should be active.
@@ -77,7 +70,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	 *
 	 * @return \WPSEO_Admin_Recommended_Replace_Vars
 	 */
-	public function get_admin_recommended_replace_vars() {
+	protected function get_admin_recommended_replace_vars() {
 		if ( is_null( $this->recommended_replace_vars ) ) {
 			$this->recommended_replace_vars = new WPSEO_Admin_Recommended_Replace_Vars();
 		}
@@ -90,7 +83,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	 *
 	 * @return \WPSEO_Admin_Editor_Specific_Replace_Vars
 	 */
-	public function get_admin_editor_specific_replace_vars() {
+	protected function get_admin_editor_specific_replace_vars() {
 		if ( is_null( $this->editor_specific_replace_vars ) ) {
 			$this->editor_specific_replace_vars = new WPSEO_Admin_Editor_Specific_Replace_Vars();
 		}

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -78,7 +78,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	 * @return \WPSEO_Admin_Recommended_Replace_Vars
 	 */
 	public function get_admin_recommended_replace_vars() {
-		if ( ! is_null( $this->recommended_replace_vars ) ) {
+		if ( is_null( $this->recommended_replace_vars ) ) {
 			$this->recommended_replace_vars = new WPSEO_Admin_Recommended_Replace_Vars();
 		}
 
@@ -91,7 +91,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	 * @return \WPSEO_Admin_Editor_Specific_Replace_Vars
 	 */
 	public function get_admin_editor_specific_replace_vars() {
-		if ( ! is_null( $this->editor_specific_replace_vars ) ) {
+		if ( is_null( $this->editor_specific_replace_vars ) ) {
 			$this->editor_specific_replace_vars = new WPSEO_Admin_Editor_Specific_Replace_Vars();
 		}
 

--- a/src/integrations/admin/social-templates-integration.php
+++ b/src/integrations/admin/social-templates-integration.php
@@ -8,6 +8,7 @@ use WPSEO_Admin_Recommended_Replace_Vars;
 use WPSEO_Admin_Utils;
 use WPSEO_Replacevar_Editor;
 use WPSEO_Shortlinker;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\Open_Graph_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Alert_Presenter;
@@ -48,9 +49,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	 * Social_Templates_Integration constructor.
 	 */
 	public function __construct() {
-		$this->recommended_replace_vars     = new WPSEO_Admin_Recommended_Replace_Vars();
-		$this->editor_specific_replace_vars = new WPSEO_Admin_Editor_Specific_Replace_Vars();
-		$this->group                        = 'global-templates';
+		$this->group = 'global-templates';
 	}
 
 	/**
@@ -59,7 +58,7 @@ class Social_Templates_Integration implements Integration_Interface {
 	 * @return array
 	 */
 	public static function get_conditionals() {
-		return [ Open_Graph_Conditional::class ];
+		return [ Admin_Conditional::class, Open_Graph_Conditional::class ];
 	}
 
 	/**
@@ -74,14 +73,40 @@ class Social_Templates_Integration implements Integration_Interface {
 	}
 
 	/**
+	 * Returns the recommended replacements variables object, creating it if needed.
+	 *
+	 * @return \WPSEO_Admin_Recommended_Replace_Vars
+	 */
+	public function get_admin_recommended_replace_vars() {
+		if ( ! is_null( $this->recommended_replace_vars ) ) {
+			$this->recommended_replace_vars = new WPSEO_Admin_Recommended_Replace_Vars();
+		}
+
+		return $this->recommended_replace_vars;
+	}
+
+	/**
+	 * Returns the editor specific replacements variables object, creating it if needed.
+	 *
+	 * @return \WPSEO_Admin_Editor_Specific_Replace_Vars
+	 */
+	public function get_admin_editor_specific_replace_vars() {
+		if ( ! is_null( $this->editor_specific_replace_vars ) ) {
+			$this->editor_specific_replace_vars = new WPSEO_Admin_Editor_Specific_Replace_Vars();
+		}
+
+		return $this->editor_specific_replace_vars;
+	}
+
+	/**
 	 * Build a set of social fields for the author archives in the Search Appearance section.
 	 *
 	 * @param Yoast_Form $yform The form builder.
 	 */
 	public function social_author_archives( $yform ) {
 		$identifier            = 'author-wpseo';
-		$page_type_recommended = $this->recommended_replace_vars->determine_for_archive( 'author' );
-		$page_type_specific    = $this->editor_specific_replace_vars->determine_for_archive( 'author' );
+		$page_type_recommended = $this->get_admin_recommended_replace_vars()->determine_for_archive( 'author' );
+		$page_type_specific    = $this->get_admin_editor_specific_replace_vars()->determine_for_archive( 'author' );
 
 		$this->build_social_fields( $yform, $identifier, $page_type_recommended, $page_type_specific );
 	}
@@ -93,8 +118,8 @@ class Social_Templates_Integration implements Integration_Interface {
 	 */
 	public function social_date_archives( $yform ) {
 		$identifier            = 'archive-wpseo';
-		$page_type_recommended = $this->recommended_replace_vars->determine_for_archive( 'date' );
-		$page_type_specific    = $this->editor_specific_replace_vars->determine_for_archive( 'date' );
+		$page_type_recommended = $this->get_admin_recommended_replace_vars()->determine_for_archive( 'date' );
+		$page_type_specific    = $this->get_admin_editor_specific_replace_vars()->determine_for_archive( 'date' );
 
 		$this->build_social_fields( $yform, $identifier, $page_type_recommended, $page_type_specific );
 	}
@@ -110,8 +135,8 @@ class Social_Templates_Integration implements Integration_Interface {
 			return;
 		}
 
-		$page_type_recommended = $this->recommended_replace_vars->determine_for_post_type( $post_type_name );
-		$page_type_specific    = $this->editor_specific_replace_vars->determine_for_post_type( $post_type_name );
+		$page_type_recommended = $this->get_admin_recommended_replace_vars()->determine_for_post_type( $post_type_name );
+		$page_type_specific    = $this->get_admin_editor_specific_replace_vars()->determine_for_post_type( $post_type_name );
 
 		$this->build_social_fields( $yform, $post_type_name, $page_type_recommended, $page_type_specific );
 	}
@@ -124,8 +149,8 @@ class Social_Templates_Integration implements Integration_Interface {
 	 */
 	public function social_post_types_archive( $yform, $post_type_name ) {
 		$identifier            = 'ptarchive-' . $post_type_name;
-		$page_type_recommended = $this->recommended_replace_vars->determine_for_archive( $post_type_name );
-		$page_type_specific    = $this->editor_specific_replace_vars->determine_for_archive( $post_type_name );
+		$page_type_recommended = $this->get_admin_recommended_replace_vars()->determine_for_archive( $post_type_name );
+		$page_type_specific    = $this->get_admin_editor_specific_replace_vars()->determine_for_archive( $post_type_name );
 
 		$this->build_social_fields( $yform, $identifier, $page_type_recommended, $page_type_specific );
 	}
@@ -138,8 +163,8 @@ class Social_Templates_Integration implements Integration_Interface {
 	 */
 	public function social_taxonomies( $yform, $taxonomy ) {
 		$identifier            = 'tax-' . $taxonomy->name;
-		$page_type_recommended = $this->recommended_replace_vars->determine_for_term( $taxonomy->name );
-		$page_type_specific    = $this->editor_specific_replace_vars->determine_for_term( $taxonomy->name );
+		$page_type_recommended = $this->get_admin_recommended_replace_vars()->determine_for_term( $taxonomy->name );
+		$page_type_specific    = $this->get_admin_editor_specific_replace_vars()->determine_for_term( $taxonomy->name );
 
 		$this->build_social_fields( $yform, $identifier, $page_type_recommended, $page_type_specific );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to load the Social Templates integration only on Admin, and instatiate objects triggering queries only on demand

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where unnecessary queries were triggered by the Social Templates integration

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### test against regression
* visit SEO > Search Appearance and check that the Social Templates forms are there
* activate Premium 16.5
* visit SEO > Search Appearance and check that the variables work in the Social templates form.

#### test that the unnecessary query is prevented
* install and activate Query Monitor
* install the 16.5 release branch
* visit the home page and take note of the number of the DB queries
  * filter by component `wordpress-seo` and see there is a query called by `WPSEO_Custom_Fields::get_custom_fields()`
* switch to the PR branch
* visit the home page and take note of the number of the DB queries, it should be lower
  * filter by component `wordpress-seo` and see there is NO query called by `WPSEO_Custom_Fields::get_custom_fields()`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-696]
