### PR TITLE
P2-816 remove redundantblocks validation

### DIFF
--- a/packages/schema-blocks/src/core/validation/BlockValidation.ts
+++ b/packages/schema-blocks/src/core/validation/BlockValidation.ts
@@ -29,6 +29,4 @@ export enum BlockValidation {
 	MissingRequiredBlock = 302,
 	/** This block contains a Variationpicker to choose between subblocks, but no choice has been made yet for this recommended block. */
 	MissingRequiredVariation = 303,
-	/** There may be only one of this type of block, but we found more than one. */
-	TooMany = 304,
 }

--- a/packages/schema-blocks/src/core/validation/RequiredBlock.ts
+++ b/packages/schema-blocks/src/core/validation/RequiredBlock.ts
@@ -1,5 +1,4 @@
 import { InstructionOptions } from "../Instruction";
-import { RequiredBlockOption } from ".";
 import { SuggestedBlockProperties } from "./SuggestedBlockProperties";
 
 /**
@@ -8,5 +7,4 @@ import { SuggestedBlockProperties } from "./SuggestedBlockProperties";
 export type RequiredBlock = InstructionOptions & SuggestedBlockProperties & {
 	name: string;
 	warning?: string;
-	option: RequiredBlockOption;
 }

--- a/packages/schema-blocks/src/core/validation/RequiredBlockOption.ts
+++ b/packages/schema-blocks/src/core/validation/RequiredBlockOption.ts
@@ -1,4 +1,0 @@
-export enum RequiredBlockOption {
-	One = "One",
-	Multiple = "Multiple"
-}

--- a/packages/schema-blocks/src/core/validation/index.ts
+++ b/packages/schema-blocks/src/core/validation/index.ts
@@ -1,6 +1,5 @@
 import { BlockValidation } from "./BlockValidation";
 import { BlockValidationResult, BlockPresence } from "./BlockValidationResult";
-import { RequiredBlockOption } from "./RequiredBlockOption";
 import { RequiredBlock } from "./RequiredBlock";
 import { RecommendedBlock } from "./RecommendedBlock";
 import { SuggestedBlockProperties } from "./SuggestedBlockProperties";
@@ -11,6 +10,5 @@ export {
 	BlockValidationResult,
 	RecommendedBlock,
 	RequiredBlock,
-	RequiredBlockOption,
 	SuggestedBlockProperties,
 };

--- a/packages/schema-blocks/src/functions/redux/selectors/schemaBlocks.ts
+++ b/packages/schema-blocks/src/functions/redux/selectors/schemaBlocks.ts
@@ -79,6 +79,6 @@ export function getRecommendedBlockNames(): string[] {
  * @returns The list of required and recommended blocks.
  */
 export function getBlockNames(): string[] {
-	return [ ...getRecommendedBlockNames(), ... getRequiredBlockNames() ];
+	return [ ...getRecommendedBlockNames(), ...getRequiredBlockNames() ];
 }
 

--- a/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
+++ b/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
@@ -1,12 +1,10 @@
 import { BlockInstance } from "@wordpress/blocks";
-import { countBy } from "lodash";
 import { getBlockDefinition } from "../../core/blocks/BlockDefinitionRepository";
 import {
 	BlockValidation,
 	BlockValidationResult,
 	RecommendedBlock,
 	RequiredBlock,
-	RequiredBlockOption,
 } from "../../core/validation";
 import recurseOverBlocks from "../blocks/recurseOverBlocks";
 import { getInnerblocksByName } from "../innerBlocksHelper";
@@ -36,42 +34,6 @@ function findMissingBlocks(
 	return missingBlocks.map( missingBlock =>
 		BlockValidationResult.MissingBlock( getHumanReadableBlockName( missingBlock.name ), blockPresence ),
 	);
-}
-
-/**
- * Finds all blocks that occur more than once in the inner blocks.
- *
- * @param existingBlocks The actual array of all inner blocks.
- * @param allBlocks      All of the blocks that should occur (required), or could occur (recommended) in the inner blocks.
- * @param blockPresence  The block presence.
- *
- * @returns {BlockValidationResult[]} The names of blocks that occur more than once in the inner blocks with reason 'TooMany'.
- */
-function findRedundantBlocks(
-	existingBlocks: BlockInstance[],
-	allBlocks: RequiredBlock[] | RecommendedBlock[],
-	blockPresence: BlockPresence ): BlockValidationResult[] {
-	const validationResults: BlockValidationResult[] = [];
-	const singletons = allBlocks.filter( block => block.option !== RequiredBlockOption.Multiple );
-
-	if ( singletons.length > 0 ) {
-		// Count the occurrences of each block so we can find all keys that have too many occurrences.
-		const existingSingletons = existingBlocks.filter( block => singletons.some( s => s.name === block.name ) );
-		const countPerBlockType = countBy( existingSingletons, ( block: BlockInstance ) => block.name );
-
-		for ( const blockName in countPerBlockType ) {
-			if ( countPerBlockType[ blockName ] < 2 ) {
-				continue;
-			}
-
-			existingSingletons.forEach( ( block: BlockInstance ) => {
-				if ( block.name === blockName ) {
-					validationResults.push( new BlockValidationResult( block.clientId, blockName, BlockValidation.TooMany, blockPresence ) );
-				}
-			} );
-		}
-	}
-	return validationResults;
 }
 
 /**
@@ -120,17 +82,11 @@ function validateInnerBlocks( blockInstance: BlockInstance, requiredBlocks: Requ
 	// Find all required block types that do not occur in existingRequiredBlocks.
 	validationResults.push( ...findMissingBlocks( existingRequiredBlocks, requiredBlocks, BlockPresence.Required ) );
 
-	// Find all required block types that allow only one occurrence.
-	validationResults.push( ...findRedundantBlocks( existingRequiredBlocks, requiredBlocks, BlockPresence.Required ) );
-
 	// Find all instances of recommended block types.
 	const existingRecommendedBlocks = getInnerblocksByName( blockInstance, recommendedBlockKeys );
 
 	// Find all recommended block types that do not occur in existingRecommendedBlocks.
 	validationResults.push( ...findMissingBlocks( existingRecommendedBlocks, recommendedBlocks, BlockPresence.Recommended ) );
-
-	// Find all recommended block types that allow only one occurrence.
-	validationResults.push( ...findRedundantBlocks( existingRecommendedBlocks, recommendedBlocks, BlockPresence.Recommended ) );
 
 	// Let all innerblocks validate themselves.
 	// We differentiate between blocks that are internally valid but are not valid in the context of the innerblock.
@@ -141,4 +97,4 @@ function validateInnerBlocks( blockInstance: BlockInstance, requiredBlocks: Requ
 }
 
 export default validateInnerBlocks;
-export { findMissingBlocks, findRedundantBlocks, validateInnerblockTree };
+export { findMissingBlocks, validateInnerblockTree };

--- a/packages/schema-blocks/tests/functions/gutenberg/watchers/warningWatcher.test.ts
+++ b/packages/schema-blocks/tests/functions/gutenberg/watchers/warningWatcher.test.ts
@@ -4,7 +4,7 @@ import { dispatch } from "@wordpress/data";
 import warningWatcher from "../../../../src/functions/gutenberg/watchers/warningWatcher";
 import InnerBlocks from "../../../../src/instructions/blocks/InnerBlocks";
 import { getBlockDefinition } from "../../../../src/core/blocks/BlockDefinitionRepository";
-import { RequiredBlock, RequiredBlockOption } from "../../../../src/core/validation";
+import { RequiredBlock } from "../../../../src/core/validation";
 
 jest.mock( "@wordpress/i18n", () => ( {
 	__: jest.fn( text => text ),
@@ -95,7 +95,7 @@ describe( "The warning watcher", () => {
 				32: new InnerBlocks( 32, {
 					name: "anyBlock",
 					requiredBlocks: [
-						{ name: "yoast/ingredients", option: RequiredBlockOption.One } as RequiredBlock,
+						{ name: "yoast/ingredients" } as RequiredBlock,
 					],
 					warnings: {
 						"yoast/ingredients": "a warning",

--- a/packages/schema-blocks/tests/functions/process.test.ts
+++ b/packages/schema-blocks/tests/functions/process.test.ts
@@ -5,7 +5,7 @@ import BlockDefinition from "../../src/core/blocks/BlockDefinition";
 import BlockInstruction from "../../src/core/blocks/BlockInstruction";
 import "../../src/instructions/blocks/InnerBlocks";
 import InnerBlocks from "../../src/instructions/blocks/InnerBlocks";
-import { RequiredBlock, RequiredBlockOption } from "../../src/core/validation";
+import { RequiredBlock } from "../../src/core/validation";
 
 jest.mock( "@yoast/components", () => {
 	return {
@@ -74,15 +74,13 @@ describe( "the process function", () => {
 		// Arrange.
 		const template =
 			'{{inner-blocks allowed-blocks=[ "core/paragraph" ] ' +
-			'required-blocks=[ { "name": "core/paragraph", "option": "Multiple" }, { "name": "core/image", "option": "One" } ] }}';
+			'required-blocks=[ { "name": "core/paragraph" }, { "name": "core/image" } ] }}';
 		const expected: RequiredBlock[] = [
 			{
 				name: "core/paragraph",
-				option: RequiredBlockOption.Multiple,
 			} as RequiredBlock,
 			{
 				name: "core/image",
-				option: RequiredBlockOption.One,
 			} as RequiredBlock,
 		];
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* checking against redundantblocks is unnecessary; wordpress prohibits adding more than one block if the blocks are configured correctly. We do not need to validate that. The validation logic is a bit complicated, and removing the code reduces the complexity of our code.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes unnecessary validation logic and constants.

## Relevant technical choices:

* removed the findRedundantBlocks function, its usage and its tests; this meant other tests needed less setup and validation, and some enums/enum values were no longer needed. [P2-816](https://yoast.atlassian.net/browse/P2-816)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* since the removed function validated against a situation that was impossible to achieve in real life, it only needs regression tests to prove nothing new breaks.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* should not cause regression bugs. 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [X] I have added unittests to verify the code works as intended

Fixes #
