### PR TITLE
Added key props to all schema block instruction components

### DIFF
--- a/packages/schema-blocks/src/core/blocks/BlockDefinition.tsx
+++ b/packages/schema-blocks/src/core/blocks/BlockDefinition.tsx
@@ -21,6 +21,7 @@ import { openGeneralSidebar } from "../../functions/gutenberg/sidebar";
 export interface RenderEditProps extends BlockEditProps<Record<string, unknown>> {
 	clientId: string;
 	name?: string;
+	key?: string|number;
 }
 
 export interface RenderSaveProps extends BlockSaveProps<Record<string, unknown>> {
@@ -58,7 +59,7 @@ export default class BlockDefinition extends Definition {
 		const sidebarElements = this.sidebarElements( props );
 
 		// Take the children directly to avoid creating too many Fragments.
-		const elements = this.tree.children.map( ( leaf, i ) => leaf.edit( props, i ) ).filter( e => e !== null );
+		const elements = this.tree.children.map( ( leaf, i ) => leaf.edit( { ...props, key: i }, i ) ).filter( e => e !== null );
 
 		if ( sidebarElements.length > 0 ) {
 			const sidebarContainer =
@@ -75,7 +76,7 @@ export default class BlockDefinition extends Definition {
 			return elements[ 0 ] as ReactElement;
 		}
 
-		return createElement( Fragment, { key: props.clientId }, elements );
+		return createElement( Fragment, { key: props.clientId }, elements.map( ( element, i ) => createElement( Fragment, { key: i }, element ) ) );
 	}
 
 	/**

--- a/packages/schema-blocks/src/core/blocks/BlockDefinition.tsx
+++ b/packages/schema-blocks/src/core/blocks/BlockDefinition.tsx
@@ -21,7 +21,6 @@ import { openGeneralSidebar } from "../../functions/gutenberg/sidebar";
 export interface RenderEditProps extends BlockEditProps<Record<string, unknown>> {
 	clientId: string;
 	name?: string;
-	key?: string|number;
 }
 
 export interface RenderSaveProps extends BlockSaveProps<Record<string, unknown>> {
@@ -59,7 +58,7 @@ export default class BlockDefinition extends Definition {
 		const sidebarElements = this.sidebarElements( props );
 
 		// Take the children directly to avoid creating too many Fragments.
-		const elements = this.tree.children.map( ( leaf, i ) => leaf.edit( { ...props, key: i }, i ) ).filter( e => e !== null );
+		const elements = this.tree.children.map( ( leaf, i ) => leaf.edit( props, i ) ).filter( e => e !== null );
 
 		if ( sidebarElements.length > 0 ) {
 			const sidebarContainer =

--- a/packages/schema-blocks/src/core/blocks/BlockLeaf.ts
+++ b/packages/schema-blocks/src/core/blocks/BlockLeaf.ts
@@ -1,5 +1,6 @@
 import { RenderEditProps, RenderSaveProps } from "./BlockDefinition";
 import Leaf from "../Leaf";
+import { createElement, Fragment } from "@wordpress/element";
 
 /**
  * BlockLeaf class
@@ -26,4 +27,19 @@ export default abstract class BlockLeaf extends Leaf {
 	 * @returns The rendered element.
 	 */
 	abstract edit( props: RenderEditProps, i: number ): JSX.Element | string
+
+	/**
+	 * Takes the child leaves and wraps them in a Fragment with a key to prevent key errors.
+	 *
+	 * @param children The child elements.
+	 * @param props    Props to be passed down to the children.
+	 * @param type     Whether save or edit should be called on the child leaf.
+	 *
+	 * @returns The rendered leaf children.
+	 */
+	protected renderChildren( children: BlockLeaf[], props: RenderSaveProps|RenderEditProps, type: "edit"|"save" ): JSX.Element[] {
+		return children.map( ( child, index )  => {
+			return createElement( Fragment, { key: index }, child[ type ]( props as any, index ) );
+		} );
+	}
 }

--- a/packages/schema-blocks/src/leaves/blocks/BlockElementLeaf.ts
+++ b/packages/schema-blocks/src/leaves/blocks/BlockElementLeaf.ts
@@ -53,7 +53,7 @@ export default class BlockElementLeaf extends BlockLeaf {
 
 		attributes.key = i;
 
-		return createElement( this.tag, attributes, this.children && this.children.map( ( child, index ) => child.save( props, index ) ) );
+		return createElement( this.tag, attributes, this.renderChildren( this.children, props, "save" ) );
 	}
 
 	/**
@@ -84,6 +84,6 @@ export default class BlockElementLeaf extends BlockLeaf {
 
 		attributes.key = i;
 
-		return createElement( this.tag, attributes, this.children && this.children.map( ( child, index ) => child.edit( props, index ) ) );
+		return createElement( this.tag, attributes, this.renderChildren( this.children, props, "edit" ) );
 	}
 }

--- a/packages/schema-blocks/src/leaves/blocks/BlockRootLeaf.ts
+++ b/packages/schema-blocks/src/leaves/blocks/BlockRootLeaf.ts
@@ -27,7 +27,7 @@ export default class BlockRootLeaf extends BlockLeaf {
 	 * @returns The rendered element.
 	 */
 	save( props: RenderSaveProps ): JSX.Element {
-		return createElement( Fragment, null, this.children && this.children.map( ( child, i ) => child.save( props, i ) ) );
+		return createElement( Fragment, null, this.renderChildren( this.children, props, "save" ) );
 	}
 
 	/**
@@ -39,6 +39,6 @@ export default class BlockRootLeaf extends BlockLeaf {
 	 * @returns The rendered element.
 	 */
 	edit( props: RenderEditProps ): JSX.Element {
-		return createElement( Fragment, null, this.children && this.children.map( ( child, i ) => child.edit( props, i ) ) );
+		return createElement( Fragment, null, this.renderChildren( this.children, props, "edit" ) );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes React's unique keys in the console (in development builds).

## Relevant technical choices:

* Instead of fixing this for each instruction individually, I have chosen to surround all child elements of instructions with a Fragment to which I can assign a key. Since instructions are static, it doesn't really matter that I used the index as keys (something you should normally never do), because the order of blocks within instructions never change during runtime.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure premium is active.
* Add all jobs-blocks.
* Add a recipe block and add all possible child-blocks.
* Make sure there are no `Each child in a list should have a unique "key" prop` errors.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* QA cannot test this, because the warnings are only shown in development and not in production.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
