### PR TITLE
P2-1042 A few small renames regarding JobPosting

### DIFF
--- a/packages/schema-blocks/src/functions/presenters/SchemaAnalysis.tsx
+++ b/packages/schema-blocks/src/functions/presenters/SchemaAnalysis.tsx
@@ -59,7 +59,7 @@ export function SchemaAnalysis( props: SchemaAnalysisProps ): ReactElement {
 
 	return <div key={ "schema-analysis" } className={ "yoast-schema-analysis" }>
 		<LabelWithHelpLink
-			text={ __( "Job Posting schema", "yoast-schema-blocks" ) }
+			text={ __( "JobPosting schema", "yoast-schema-blocks" ) }
 			URL={ "https://yoa.st/4dk" }
 		/>
 		<TextControl onChange={ onChange } value={ jobTitle } label={ "Job title" } />

--- a/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
+++ b/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
@@ -30,8 +30,8 @@ function getAnalysisConclusion( issues: BlockValidationResult[] ): SidebarWarnin
 	if ( issues.some( issue => issue.result >= BlockValidation.Invalid ) ) {
 		conclusionText = sprintf(
 			/* translators: %s expands to the schema block name. */
-			__( "Not all required information has been provided! No %s schema will be generated for your page.", "yoast-schema-blocks" ),
-			"Job posting",
+			__( "Not all required information has been provided! %s schema will not be generated for your page.", "yoast-schema-blocks" ),
+			"JobPosting",
 		);
 
 		return { text: conclusionText, color: "red" };

--- a/packages/schema-blocks/src/functions/redux/selectors/schemaBlocks.ts
+++ b/packages/schema-blocks/src/functions/redux/selectors/schemaBlocks.ts
@@ -64,7 +64,7 @@ export function getRequiredBlockNames(): string[] {
  */
 export function getRecommendedBlockNames(): string[] {
 	return [
-		"yoast/job-expiration",
+		"yoast/job-closing-date",
 		"yoast/job-employment-type",
 		"yoast/job-salary",
 		"yoast/job-requirements",

--- a/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
+++ b/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
@@ -44,7 +44,7 @@ describe( "The SidebarWarningPresenter ", () => {
 			expect( result.length ).toEqual( 1 );
 			expect( result[ 0 ] ).toEqual(
 				{
-					text: "Not all required information has been provided! No JobPosting schema will be generated for your page.",
+					text: "Not all required information has been provided! JobPosting schema will not be generated for your page.",
 					color: "red",
 				},
 			);
@@ -67,7 +67,7 @@ describe( "The SidebarWarningPresenter ", () => {
 			} );
 			expect( result[ 1 ] ).toEqual(
 				{
-					text: "Not all required information has been provided! No JobPosting schema will be generated for your page.",
+					text: "Not all required information has been provided! JobPosting schema will not be generated for your page.",
 					color: "red",
 				},
 			);
@@ -146,7 +146,7 @@ describe( "The SidebarWarningPresenter ", () => {
 				color: "red",
 			} );
 			expect( result[ 1 ] ).toEqual( {
-				text: "Not all required information has been provided! No JobPosting schema will be generated for your page.",
+				text: "Not all required information has been provided! JobPosting schema will not be generated for your page.",
 				color: "red",
 			} );
 		} );

--- a/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
+++ b/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
@@ -44,7 +44,7 @@ describe( "The SidebarWarningPresenter ", () => {
 			expect( result.length ).toEqual( 1 );
 			expect( result[ 0 ] ).toEqual(
 				{
-					text: "Not all required information has been provided! No Job posting schema will be generated for your page.",
+					text: "Not all required information has been provided! No JobPosting schema will be generated for your page.",
 					color: "red",
 				},
 			);
@@ -67,7 +67,7 @@ describe( "The SidebarWarningPresenter ", () => {
 			} );
 			expect( result[ 1 ] ).toEqual(
 				{
-					text: "Not all required information has been provided! No Job posting schema will be generated for your page.",
+					text: "Not all required information has been provided! No JobPosting schema will be generated for your page.",
 					color: "red",
 				},
 			);
@@ -146,7 +146,7 @@ describe( "The SidebarWarningPresenter ", () => {
 				color: "red",
 			} );
 			expect( result[ 1 ] ).toEqual( {
-				text: "Not all required information has been provided! No Job posting schema will be generated for your page.",
+				text: "Not all required information has been provided! No JobPosting schema will be generated for your page.",
 				color: "red",
 			} );
 		} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Renames `Job Posting` to `JobPosting` in the context of Schema.

## Relevant technical choices:

* Also renames the `yoast/job-expiration` template to `yoast/job-closing-date`. This accompanies the rename of this template in Premium. https://github.com/Yoast/wordpress-seo-premium/pull/3355
    * We want to get rid of these hard-coded template names in Free at some point (this is a to-do in P2-971).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test together with https://github.com/Yoast/wordpress-seo-premium/pull/3355.
* See that we use the name `'JobPosting'` when we refer to Schema analysis, and `'Job Posting'` when we refer to the blocks or block patterns in general.
* In the Schema tab, see that there is a 'Job closing date' block listed under recommended blocks, and that you can add it with the 'Add' button.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR should have a very small impact and only changes some block names.
* Note that because I changed the block templates, the block patterns will break again. This because every time the block templates are changed, their HTML needs to be copied to all the block patterns. 
    * This is on the radar, but won't be fixed in this PR. We're deliberating whether we want to fix this every time, or just once in the end.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
