### PR TITLE
Show different HelpScout beacon to users with tracking on

### DIFF
--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -23,6 +23,13 @@ class HelpScout_Beacon implements Integration_Interface {
 	protected $beacon_id = '2496aba6-0292-489c-8f5d-1c0fba417c2f';
 
 	/**
+	 * The id for the beacon for users that have tracking on.
+	 *
+	 * @var string
+	 */
+	protected $beacon_id_tracking_users = '6b8e74c5-aa81-4295-b97b-c2a62a13ea7f';
+
+	/**
 	 * The products the beacon is loaded for.
 	 *
 	 * @var array
@@ -91,7 +98,13 @@ class HelpScout_Beacon implements Integration_Interface {
 		$this->page          = \filter_input( \INPUT_GET, 'page', \FILTER_SANITIZE_STRING );
 
 		foreach ( $this->base_pages as $page ) {
-			$this->pages_ids[ $page ] = $this->beacon_id;
+			if ( $this->ask_consent ) {
+				// We want to be able to show surveys to people who have tracking on, so we give them a different beacon.
+				$this->pages_ids[ $page ] = $this->beacon_id_tracking_users;
+			}
+			else {
+				$this->pages_ids[ $page ] = $this->beacon_id;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Show a different beacon to people who have tracking enabled so we can send them surveys.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* None needed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
