### PR TITLE
Fix breadcrumb for static posts page

### DIFF
--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -39,7 +39,7 @@ class Breadcrumb extends Abstract_Schema_Piece {
 				$this->helpers->current_page->is_paged() ||
 				$this->context->indexable->number_of_pages > 1
 			) &&
-			// Do not replace the last breadcrumb on static post pages
+			// Do not replace the last breadcrumb on static post pages.
 			! $this->helpers->current_page->is_static_posts_page()
 		) {
 			\array_pop( $breadcrumbs );

--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -39,6 +39,7 @@ class Breadcrumb extends Abstract_Schema_Piece {
 				$this->helpers->current_page->is_paged() ||
 				$this->context->indexable->number_of_pages > 1
 			) &&
+			// Do not replace the last breadcrumb on static post pages
 			! $this->helpers->current_page->is_static_posts_page()
 		) {
 			\array_pop( $breadcrumbs );

--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -34,7 +34,13 @@ class Breadcrumb extends Abstract_Schema_Piece {
 		$list_elements = [];
 
 		// In case of pagination, replace the last breadcrumb, because it only contains "Page [number]" and has no URL.
-		if ( $this->helpers->current_page->is_paged() || ( $this->context->indexable->number_of_pages > 1 ) ) {
+		if (
+			(
+				$this->helpers->current_page->is_paged() ||
+				$this->context->indexable->number_of_pages > 1
+			) &&
+			! $this->helpers->current_page->is_static_posts_page()
+		) {
 			\array_pop( $breadcrumbs );
 		}
 

--- a/tests/unit/generators/schema/breadcrumb-test.php
+++ b/tests/unit/generators/schema/breadcrumb-test.php
@@ -353,6 +353,7 @@ class Breadcrumb_Test extends TestCase {
 		$this->meta_tags_context->title                     = 'Page title';
 
 		$this->current_page->expects( 'is_paged' )->andReturnTrue();
+		$this->current_page->expects( 'is_static_posts_page' )->once()->andReturnFalse();
 		$this->current_page->expects( 'is_home_static_page' )->once()->andReturnFalse();
 
 		$this->html
@@ -419,6 +420,7 @@ class Breadcrumb_Test extends TestCase {
 		$this->meta_tags_context->indexable->number_of_pages = 3;
 
 		$this->current_page->expects( 'is_paged' )->andReturnFalse();
+		$this->current_page->expects( 'is_static_posts_page' )->once()->andReturnFalse();
 		$this->current_page->expects( 'is_home_static_page' )->andReturnFalse();
 
 		$this->html

--- a/tests/unit/generators/schema/breadcrumb-test.php
+++ b/tests/unit/generators/schema/breadcrumb-test.php
@@ -605,4 +605,45 @@ class Breadcrumb_Test extends TestCase {
 	public function test_is_needed_default() {
 		$this->assertTrue( $this->instance->is_needed() );
 	}
+
+	/**
+	 * Tests the generate method when the page is paginated (as detected through 'is_paged').
+	 *
+	 * @covers ::generate
+	 * @covers ::not_hidden
+	 * @covers ::is_broken
+	 * @covers ::create_breadcrumb
+	 * @covers ::format_last_breadcrumb
+	 */
+	public function test_generate_when_page_is_paginated_and_static_page() {
+		$breadcrumb_data = [
+			[
+				'url'  => 'https://wordpress.example.com/',
+				'text' => 'Home',
+			],
+			[
+				'url'  => 'https://wordpress.example.com/post-title',
+				'text' => 'Test post',
+				'id'   => '123',
+			],
+			[
+				'text' => 'Page 2',
+			],
+		];
+
+		$this->meta_tags_context->presentation->breadcrumbs = $breadcrumb_data;
+		$this->meta_tags_context->title                     = 'Page title';
+
+		$this->current_page->expects( 'is_paged' )->andReturnTrue();
+		$this->current_page->expects( 'is_static_posts_page' )->once()->andReturnTrue();
+		$this->current_page->expects( 'is_home_static_page' )->never();
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->never();
+
+		$actual = $this->instance->generate();
+
+		self::assertEquals( false, $actual );
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Prevents stripping the final breadcrumb for the static posts page as this page does not have a page crumb.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the last breadcrumb item is stripped in breadcrumb schema on subsequent pages of a static posts page.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set a static posts page.
* Go to the second page of it.
* The breadcrumb schema should not have an empty text.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Breadcrumbs schema generation.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
