### PR TITLE
Fixes the metabox for classic editor when schema blocks are active

### DIFF
--- a/packages/js/src/components/SchemaTab.js
+++ b/packages/js/src/components/SchemaTab.js
@@ -1,8 +1,8 @@
 import { createPortal, Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { FieldGroup, Select } from "@yoast/components";
+import { Slot } from "@wordpress/components";
 import { join } from "@yoast/helpers";
-import { SchemaAnalysis } from "@yoast/schema-blocks";
 import interpolateComponents from "interpolate-components";
 import PropTypes from "prop-types";
 import styled from "styled-components";
@@ -125,11 +125,7 @@ const Content = ( props ) => {
 	return (
 		<Fragment>
 			{ schemaBlocksEnabled ? <SchemaBlocksHeader { ...props } /> : <Header { ...props } /> }
-			{ schemaBlocksEnabled && <SchemaAnalysis
-				requiredBlocks={ props.requiredBlockNames }
-				recommendedBlocks={ props.recommendedBlockNames }
-			/>
-			}
+			{ schemaBlocksEnabled && <Slot name="YoastSchemaBlocksAnalysis" /> }
 			<FieldGroup
 				label={ __( "What type of page or content is this?", "wordpress-seo" ) }
 				linkTo={ props.additionalHelpTextLink }
@@ -171,8 +167,6 @@ Content.propTypes = {
 	defaultPageType: PropTypes.string.isRequired,
 	defaultArticleType: PropTypes.string.isRequired,
 	location: PropTypes.string.isRequired,
-	requiredBlockNames: PropTypes.array.isRequired,
-	recommendedBlockNames: PropTypes.array.isRequired,
 };
 
 Content.defaultProps = {
@@ -219,8 +213,6 @@ SchemaTab.propTypes = {
 	loadSchemaArticleData: PropTypes.func.isRequired,
 	loadSchemaPageData: PropTypes.func.isRequired,
 	location: PropTypes.string.isRequired,
-	requiredBlockNames: PropTypes.array.isRequired,
-	recommendedBlockNames: PropTypes.array.isRequired,
 };
 
 SchemaTab.defaultProps = {

--- a/packages/js/src/containers/SchemaTab.js
+++ b/packages/js/src/containers/SchemaTab.js
@@ -6,7 +6,6 @@ import PropTypes from "prop-types";
 import SchemaTab from "../components/SchemaTab";
 import SchemaFields from "../helpers/fields/SchemaFields";
 import withLocation from "../helpers/withLocation";
-import { isFeatureEnabled } from "@yoast/feature-flag";
 
 /**
  * Function to get props based on the location.

--- a/packages/js/src/containers/SchemaTab.js
+++ b/packages/js/src/containers/SchemaTab.js
@@ -96,27 +96,12 @@ export default compose( [
 			getDefaultArticleType,
 		} = select( "yoast-seo/editor" );
 
-		let requiredBlockNames = [];
-		let recommendedBlockNames = [];
-
-		if ( isFeatureEnabled( "SCHEMA_BLOCKS" ) ) {
-			const {
-				getRequiredBlockNames,
-				getRecommendedBlockNames,
-			} = select( "yoast-seo/schema-blocks" );
-
-			requiredBlockNames = getRequiredBlockNames();
-			recommendedBlockNames = getRecommendedBlockNames();
-		}
-
 		return {
 			displayFooter: getPreferences().displaySchemaSettingsFooter,
 			schemaPageTypeSelected: getPageType(),
 			schemaArticleTypeSelected: getArticleType(),
 			defaultArticleType: getDefaultArticleType(),
 			defaultPageType: getDefaultPageType(),
-			requiredBlockNames: requiredBlockNames,
-			recommendedBlockNames: recommendedBlockNames,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/js/src/helpers/classicEditor.js
+++ b/packages/js/src/helpers/classicEditor.js
@@ -72,8 +72,6 @@ export function renderClassicEditorMetabox( store ) {
 		isRtl: localizedData.isRtl,
 	};
 
-	console.log( SlotFillProvider );
-
 	render(
 		(
 			<SlotFillProvider>

--- a/packages/js/src/helpers/classicEditor.js
+++ b/packages/js/src/helpers/classicEditor.js
@@ -72,6 +72,8 @@ export function renderClassicEditorMetabox( store ) {
 		isRtl: localizedData.isRtl,
 	};
 
+	console.log( SlotFillProvider );
+
 	render(
 		(
 			<SlotFillProvider>

--- a/packages/schema-blocks/package.json
+++ b/packages/schema-blocks/package.json
@@ -15,6 +15,7 @@
     "@wordpress/element": "^2.20.1",
     "@wordpress/hooks": "^2.12.1",
     "@wordpress/i18n": "^3.19.1",
+    "@wordpress/plugins": "^3.1.2",
     "@yoast/components": "^2.19.0",
     "lodash": "^4.17.15",
     "tokenizr": "^1.6.4"
@@ -30,6 +31,7 @@
     "@types/react-test-renderer": "^16.9.5",
     "@types/wordpress__block-editor": "^2.2.9",
     "@types/wordpress__blocks": "^6.4.12",
+    "@types/wordpress__plugins": "^2.3.7",
     "core-js": "^2.6.12",
     "jest": "^26.0.15",
     "moment": "^2.24.0",

--- a/packages/schema-blocks/src/functions/initialize.tsx
+++ b/packages/schema-blocks/src/functions/initialize.tsx
@@ -1,5 +1,9 @@
 import "../instructions";
 import { registerBlockType } from "@wordpress/blocks";
+import { Fill } from "@wordpress/components";
+import { createElement } from "@wordpress/element";
+import { registerPlugin } from "@wordpress/plugins";
+
 import { initializeSchemaBlocksStore } from "./redux";
 import { WarningBlock } from "../blocks/warning-block/configuration";
 import { processBlock, processSchema } from "./process";
@@ -7,10 +11,7 @@ import filter from "./gutenberg/filter";
 import watch from "./gutenberg/watch";
 import logger, { LogLevel } from "./logger";
 import injectSidebar from "./gutenberg/inject-sidebar";
-import { registerPlugin } from "@wordpress/plugins";
-import { Fill } from "@wordpress/components";
 import { SchemaAnalysis } from "./presenters/SchemaAnalysis";
-import { createElement } from "@wordpress/element";
 
 /**
  * Removes all whitespace including line breaks from a string.
@@ -69,11 +70,11 @@ export function initialize( logLevel: LogLevel = LogLevel.ERROR ): void {
 	} );
 
 	/**
-	 * Creates the Analysis component.
+	 * Creates the SchemaAnalysis component.
 	 *
 	 * @param props The props.
 	 *
-	 * @returns The analysis component.
+	 * @returns The SchemaAnalysis component.
 	 */
 	const SchemaAnalysisFill = (): React.ReactElement => {
 		return (
@@ -83,7 +84,7 @@ export function initialize( logLevel: LogLevel = LogLevel.ERROR ): void {
 		);
 	};
 
-	// Register the schema analysis as a plugin, because it needs to be in the same react tree as gutenberg.
+	// Register the SchemaAnalysis as a plugin, because it needs to be in the same React tree as Gutenberg.
 	registerPlugin( "yoast-seo-schema-blocks-analysis", {
 		render: SchemaAnalysisFill,
 		icon: null,

--- a/packages/schema-blocks/src/functions/initialize.tsx
+++ b/packages/schema-blocks/src/functions/initialize.tsx
@@ -7,6 +7,10 @@ import filter from "./gutenberg/filter";
 import watch from "./gutenberg/watch";
 import logger, { LogLevel } from "./logger";
 import injectSidebar from "./gutenberg/inject-sidebar";
+import { registerPlugin } from "@wordpress/plugins";
+import { Fill } from "@wordpress/components";
+import { SchemaAnalysis } from "./presenters/SchemaAnalysis";
+import { createElement } from "@wordpress/element";
 
 /**
  * Removes all whitespace including line breaks from a string.
@@ -62,6 +66,26 @@ export function initialize( logLevel: LogLevel = LogLevel.ERROR ): void {
 		} catch ( e ) {
 			logger.error( "Failed to parse gutenberg-template", e, this );
 		}
+	} );
+
+	/**
+	 * Creates the Analysis component.
+	 *
+	 * @param props The props.
+	 *
+	 * @returns The analysis component.
+	 */
+	const SchemaAnalysisFill = (): React.ReactElement => {
+		return (
+			<Fill name="YoastSchemaBlocksAnalysis">
+				{ ( fillProps: any ) => <SchemaAnalysis { ...fillProps } /> }
+			</Fill>
+		);
+	};
+
+	registerPlugin( "yoast-seo-schema-blocks-analysis", {
+		render: SchemaAnalysisFill,
+		icon: null,
 	} );
 
 	// Watch Gutenberg for block changes that require schema updates.

--- a/packages/schema-blocks/src/functions/initialize.tsx
+++ b/packages/schema-blocks/src/functions/initialize.tsx
@@ -78,11 +78,12 @@ export function initialize( logLevel: LogLevel = LogLevel.ERROR ): void {
 	const SchemaAnalysisFill = (): React.ReactElement => {
 		return (
 			<Fill name="YoastSchemaBlocksAnalysis">
-				{ ( fillProps: any ) => <SchemaAnalysis { ...fillProps } /> }
+				<SchemaAnalysis />
 			</Fill>
 		);
 	};
 
+	// Register the schema analysis as a plugin, because it needs to be in the same react tree as gutenberg.
 	registerPlugin( "yoast-seo-schema-blocks-analysis", {
 		render: SchemaAnalysisFill,
 		icon: null,

--- a/packages/schema-blocks/src/functions/presenters/SchemaAnalysis.tsx
+++ b/packages/schema-blocks/src/functions/presenters/SchemaAnalysis.tsx
@@ -37,10 +37,25 @@ function useValidationResults(): BlockValidationResult[] {
  *
  * @constructor
  */
-export function SchemaAnalysis( props: SchemaAnalysisProps ): ReactElement {
+export function SchemaAnalysis(): ReactElement {
 	const validationResults = useValidationResults();
 
 	let warnings: SidebarWarning[] = [];
+
+	const {
+		requiredBlocks,
+		recommendedBlocks,
+	} = useSelect( select => {
+		const {
+			getRequiredBlockNames,
+			getRecommendedBlockNames,
+		} = select( "yoast-seo/schema-blocks" );
+
+		return {
+			requiredBlocks: getRequiredBlockNames() || [],
+			recommendedBlocks: getRecommendedBlockNames() || [],
+		};
+	} );
 
 	if ( validationResults ) {
 		warnings = createAnalysisMessages( validationResults );
@@ -66,11 +81,11 @@ export function SchemaAnalysis( props: SchemaAnalysisProps ): ReactElement {
 		<WarningList warnings={ warnings } />
 		<BlockSuggestions
 			heading={ __( "Required information", "yoast-schema-blocks" ) }
-			blockNames={ props.requiredBlocks }
+			blockNames={ requiredBlocks }
 		/>
 		<BlockSuggestions
 			heading={ __( "Recommended information", "yoast-schema-blocks" ) }
-			blockNames={ props.recommendedBlocks }
+			blockNames={ recommendedBlocks }
 		/>
 	</div>;
 }

--- a/packages/schema-blocks/src/functions/presenters/SchemaAnalysis.tsx
+++ b/packages/schema-blocks/src/functions/presenters/SchemaAnalysis.tsx
@@ -11,11 +11,6 @@ import { YOAST_SCHEMA_BLOCKS_STORE_NAME } from "../redux";
 import { BlockValidationResult } from "../../core/validation";
 import LabelWithHelpLink from "./LabelWithHelpLinkPresenter";
 
-interface SchemaAnalysisProps {
-	recommendedBlocks: string[];
-	requiredBlocks: string[];
-}
-
 /**
  * Retrieves the validation results from the Redux store.
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,6 +3167,15 @@
     "@types/react" "*"
     "@types/wordpress__data" "*"
 
+"@types/wordpress__plugins@^2.3.7":
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/@types/wordpress__plugins/-/wordpress__plugins-2.3.7.tgz#d4dd5c2d57e6a4ecba4c770ec5d1cc29b5aa31ee"
+  integrity sha512-Pe+yF9vaVyC4bYAkev+Rg054yhg3XGC+ZL0g6XM8mbONfVyR3FOk2y/B5j2el34LNQDGcREHLRrzC2uAdDwrrA==
+  dependencies:
+    "@types/react" "*"
+    "@types/wordpress__components" "*"
+    "@wordpress/element" "^2.14.0"
+
 "@types/wordpress__rich-text@*":
   version "3.4.5"
   resolved "https://registry.yarnpkg.com/@types/wordpress__rich-text/-/wordpress__rich-text-3.4.5.tgz#a231dddbeeb436bfc807d48a4c2a1968b4aa11c0"
@@ -3713,6 +3722,25 @@
     "@wordpress/is-shallow-equal" "^1.6.1"
     lodash "^4.17.15"
 
+"@wordpress/compose@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-4.1.2.tgz#af8a0fee25ca8fff8405e3ac8e3e16aeed8feb89"
+  integrity sha512-9QdldUzcsmBPB9hj3tzPMdjHktM8FNvRqXIW2Ese0MFLV8gvrRP1JQ6tstxW59AtuRgVw0nWz2fSt0nmsjnN8Q==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/deprecated" "^3.1.1"
+    "@wordpress/dom" "^3.1.1"
+    "@wordpress/element" "^3.1.1"
+    "@wordpress/is-shallow-equal" "^4.1.1"
+    "@wordpress/keycodes" "^3.1.1"
+    "@wordpress/priority-queue" "^2.1.1"
+    clipboard "^2.0.1"
+    lodash "^4.17.21"
+    memize "^1.1.0"
+    mousetrap "^1.6.5"
+    react-resize-aware "^3.1.0"
+    use-memo-one "^1.1.1"
+
 "@wordpress/core-data@^2.26.1":
   version "2.26.1"
   resolved "https://registry.yarnpkg.com/@wordpress/core-data/-/core-data-2.26.1.tgz#1517ffaa27289b2e077f292828928bec09d5743b"
@@ -3830,6 +3858,14 @@
     "@babel/runtime" "^7.4.4"
     "@wordpress/hooks" "^2.6.0"
 
+"@wordpress/deprecated@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-3.1.1.tgz#af644af63c28f913a321465c6df1e57284800290"
+  integrity sha512-0hILlCNhf0DukFo3hMWybf9q507cxnIHhC1GQ1crZtTqzKS2QY2C1/77V4YGPdBShUj5j1dPriYCzfB5jFFgqQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/hooks" "^3.1.1"
+
 "@wordpress/dom-ready@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@wordpress/dom-ready/-/dom-ready-1.2.0.tgz#d95877eb6f929532ec971983b55e731babb78d9c"
@@ -3851,6 +3887,14 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     lodash "^4.17.19"
+
+"@wordpress/dom@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/dom/-/dom-3.1.1.tgz#e533666db79ddc829d127fa11960726e3e22d341"
+  integrity sha512-NkNkgczdQweWXXiP7uaXmuu58JsRU/WN9OTWT0pVTZumTQKsvm0Fcs55jt3NBG+X/F80DC+DPVW6+sTKv0Lqxg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    lodash "^4.17.21"
 
 "@wordpress/editor@^9.26.1":
   version "9.26.1"
@@ -3928,6 +3972,19 @@
     react "^16.9.0"
     react-dom "^16.9.0"
 
+"@wordpress/element@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-3.1.1.tgz#a1f33ddf54902c671d7a3426bae9731287a80f05"
+  integrity sha512-OaqKQVEV3CCTdrx/G7fMbmxhrxjApobHUAGAVYCCR1MIqScfluYJRLWFLx8tlkl/Qm/UbF9IfdXS1lphufvYog==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@types/react" "^16.9.0"
+    "@types/react-dom" "^16.9.0"
+    "@wordpress/escape-html" "^2.1.1"
+    lodash "^4.17.21"
+    react "^16.13.1"
+    react-dom "^16.13.1"
+
 "@wordpress/escape-html@^1.12.1":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-1.12.1.tgz#1ecb9a269786706bbc7a4c06ddf2b949dca272d3"
@@ -3948,6 +4005,13 @@
   integrity sha512-PD4fEg7qIB2l8+buuRmYJ5edQhvUzydu6XoCigV2G4rju3BI+MO57BcEZf1LSPfbrYqTJCca3ElNW9nNbSQthQ==
   dependencies:
     "@babel/runtime" "^7.4.4"
+
+"@wordpress/escape-html@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-2.1.1.tgz#4b9e887c2b1b06ec0d4fc691328224b4e9736c95"
+  integrity sha512-ZIkLxGLBhXkZu3t0yF82/brPV5aCOGCXGiH0EMV8GCohhXCNIfQwwFrZ5gd5NyNX5Q8alTLsiA84azJd+n0XiQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
 
 "@wordpress/eslint-plugin@^9.0.3":
   version "9.0.3"
@@ -3985,6 +4049,13 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@wordpress/hooks@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-3.1.1.tgz#be9be2abbe97ad8c0bee52c96381e5a46e559963"
+  integrity sha512-9f6H9WBwu6x/MM4ZCVLGGBuMiBcyaLapmAku5IwcWaeB2PtPduwjmk2NfGx35TuhBQD554DUg8WtTjIS019UAg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
 "@wordpress/html-entities@^2.11.1":
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-2.11.1.tgz#86ad30cb20a8212f8c119894ff197574c84360e4"
@@ -4016,6 +4087,19 @@
     sprintf-js "^1.1.1"
     tannin "^1.2.0"
 
+"@wordpress/i18n@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-4.1.1.tgz#3e7efe97dfa22aefa5e1989e5ee30cc6601b7b40"
+  integrity sha512-Ra/hxR8WCLqDp2P49Ibr9ANhZZZ8WHnsO+4WG3XDarJ3lmzux0TcRThDKRCcYHsW3pzieARmrEa/BOlYD7ZEjQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/hooks" "^3.1.1"
+    gettext-parser "^1.3.1"
+    lodash "^4.17.21"
+    memize "^1.1.0"
+    sprintf-js "^1.1.1"
+    tannin "^1.2.0"
+
 "@wordpress/icons@^2.10.1":
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-2.10.1.tgz#8713d58b6f3c1e1843f03126e559113c4f3b8805"
@@ -4024,6 +4108,15 @@
     "@babel/runtime" "^7.13.10"
     "@wordpress/element" "^2.20.1"
     "@wordpress/primitives" "^1.12.1"
+
+"@wordpress/icons@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-4.0.1.tgz#6759b8bd0e47af9a6557d3cc8aa69893191e3a83"
+  integrity sha512-dYv2GsQ1o2a775mS7gVWNfZOK8S9PCZ/kdc8nz9lApebFFfUu1M0+eTWPvhs109P9yKQ2s1ZZGWGomP/WUwWOQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/element" "^3.1.1"
+    "@wordpress/primitives" "^2.1.1"
 
 "@wordpress/is-shallow-equal@^1.6.1":
   version "1.8.0"
@@ -4036,6 +4129,13 @@
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-3.1.1.tgz#c169dd6439e7f7179f1935e38635590ee0faac95"
   integrity sha512-K/tCcd5XfoZ9RGJUs7rmVKpeN7F/+ZX8AsVBjMgly0okG1Ug0XlaxFz0odKpSV4mV6YbDcfey+nOw6Z5AUrphw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@wordpress/is-shallow-equal@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-4.1.1.tgz#1e1a18ae15711f90e54e956f1d06fbb646c93e26"
+  integrity sha512-Bc782s4Kte98RKLtuDXOaUBpyJWUgN4XZJevEoFasKQTpABZUDF+Y2C0/dhnlJeYF5TDEd8TQgFfpF5csxEUNw==
   dependencies:
     "@babel/runtime" "^7.13.10"
 
@@ -4081,6 +4181,15 @@
     "@wordpress/i18n" "^3.19.1"
     lodash "^4.17.19"
 
+"@wordpress/keycodes@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/keycodes/-/keycodes-3.1.1.tgz#d842167401967908713d2f43b3ff9f53cbef2bf8"
+  integrity sha512-lLJTl/PJv0F5c02YfFdzS/sspmMM3kWYcix8sXsAQgjzLkOMizSQySBa3bpT2t5auN0YQ34YVyeupVfoY+evOQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/i18n" "^4.1.1"
+    lodash "^4.17.21"
+
 "@wordpress/media-utils@^1.20.1":
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/@wordpress/media-utils/-/media-utils-1.20.1.tgz#688b19ce7e16b6ddaf662e6cdc477f807c0cf72d"
@@ -4107,6 +4216,19 @@
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.0.3.tgz#cdb8362389b08e46a14b6bf429438bd140d78fed"
   integrity sha512-xN11CqH8oUmLbDd8/+0UU3rYuNNnF2PWedTrIDqcuZ9Lm+w3yEZJgzBv4XsZ4fS1R4c9oNBPhih0jdOxUCHpFg==
+
+"@wordpress/plugins@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@wordpress/plugins/-/plugins-3.1.2.tgz#17df984d879153982d3125358f947cc0d44d6628"
+  integrity sha512-Ws+ZIpcNRRGubF11u0xvtznfNFzGBVv4Qc4+4iDNln7wIjCSVRdpyZQTpvcgjMYNqFj1LPb0f3jrKeHnRp0P9g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/compose" "^4.1.2"
+    "@wordpress/element" "^3.1.1"
+    "@wordpress/hooks" "^3.1.1"
+    "@wordpress/icons" "^4.0.1"
+    lodash "^4.17.21"
+    memize "^1.1.0"
 
 "@wordpress/postcss-plugins-preset@^2.1.2":
   version "2.1.2"
@@ -4139,6 +4261,15 @@
     "@wordpress/element" "^2.20.1"
     classnames "^2.2.5"
 
+"@wordpress/primitives@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/primitives/-/primitives-2.1.1.tgz#62a8a901f56f7efe4f2d6e17383da2e9abdd5d3f"
+  integrity sha512-iX31v/302zOrxEVwFUbbwr4BKZcxR+XQ53wuShc8CzcydAYj5JUFdEuwG6Z9jRGJAX2AgizSP6Fex4ercgFLXA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@wordpress/element" "^3.1.1"
+    classnames "^2.2.5"
+
 "@wordpress/priority-queue@^1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@wordpress/priority-queue/-/priority-queue-1.11.1.tgz#253141f989f7459982aeb60f155c9d5a71e1b837"
@@ -4152,6 +4283,13 @@
   integrity sha512-KQ242PoGFpttTqoz2UZwnOeecHtSQ4qaVf45WSgjYvi1tTIqTNu4OlYiO70XmRDmHj2UcUvL02Ie7czTfbK2sw==
   dependencies:
     "@babel/runtime" "^7.4.4"
+
+"@wordpress/priority-queue@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/priority-queue/-/priority-queue-2.1.1.tgz#c22fc152c426181fecb0ca1397daff27a6ff2918"
+  integrity sha512-e4x4B+1F2wXejqjNr6L3LTf5aO7gzy/9MWy5pUgg1rlo8z+B73OyOUmK39WOnzFtzmwTbFqgzzCwY5JqIaZe2g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
 
 "@wordpress/redux-routine@^3.14.1":
   version "3.14.1"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a non-released bug where the classic editor would crash if the schema blocks feature flag is active.

## Relevant technical choices:

* Makes sure the schema-blocks package javascript is not loaded when the classic editor plugin is active. To achieve this we had to make sure that the schema blocks package is no longer a dependency of the classic-editor script. Because the Gutenberg and classic-editor script share the same metabox fills, I resorted to using Slot/Fill, so the schema-blocks package can inject itself into the metabox when the schema-blocks script is loaded.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate the classic-editor plugin.
* Enable the feature flag (`define( 'YOAST_SEO_SCHEMA_BLOCKS', true );`).
* When creating a post the Yoast metabox should load properly. The schema tab should not contain the schema-blocks analysis.
* Deactivate the classic editor plugin.
* Now in the block editor under the schema-tab make sure the schema-blocks analysis shows up.
* Disable the feature flag (`define( 'YOAST_SEO_SCHEMA_BLOCKS', false );`).
* Now in the block editor under the schema-tab make sure the schema-blocks analysis does NOT show up.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
