### PR TITLE
Rename  to avoid conflict with the global var

### DIFF
--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -25,8 +25,8 @@ $yform->admin_header( true, 'wpseo' );
 
 do_action( 'wpseo_all_admin_notices' );
 
-$tabs = new WPSEO_Option_Tabs( 'dashboard' );
-$tabs->add_tab(
+$dashboard_tabs = new WPSEO_Option_Tabs( 'dashboard' );
+$dashboard_tabs->add_tab(
 	new WPSEO_Option_Tab(
 		'dashboard',
 		__( 'Dashboard', 'wordpress-seo' ),
@@ -35,28 +35,28 @@ $tabs->add_tab(
 		]
 	)
 );
-$tabs->add_tab(
+$dashboard_tabs->add_tab(
 	new WPSEO_Option_Tab(
 		'features',
 		__( 'Features', 'wordpress-seo' )
 	)
 );
-$tabs->add_tab(
+$dashboard_tabs->add_tab(
 	new WPSEO_Option_Tab(
 		'integrations',
 		__( 'Integrations', 'wordpress-seo' )
 	)
 );
-$tabs->add_tab(
+$dashboard_tabs->add_tab(
 	new WPSEO_Option_Tab(
 		'webmaster-tools',
 		__( 'Webmaster Tools', 'wordpress-seo' )
 	)
 );
 
-do_action( 'wpseo_settings_tabs_dashboard', $tabs );
+do_action( 'wpseo_settings_tabs_dashboard', $dashboard_tabs );
 
-$tabs->display( $yform );
+$dashboard_tabs->display( $yform );
 
 do_action( 'wpseo_dashboard' );
 

--- a/admin/pages/metas.php
+++ b/admin/pages/metas.php
@@ -14,14 +14,14 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 $yform = Yoast_Form::get_instance();
 $yform->admin_header( true, 'wpseo_titles' );
 
-$tabs = new WPSEO_Option_Tabs( 'metas' );
-$tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'post-types', __( 'Content Types', 'wordpress-seo' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'media', __( 'Media', 'wordpress-seo' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'taxonomies', __( 'Taxonomies', 'wordpress-seo' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'archives', __( 'Archives', 'wordpress-seo' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'breadcrumbs', __( 'Breadcrumbs', 'wordpress-seo' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'rss', __( 'RSS', 'wordpress-seo' ) ) );
-$tabs->display( $yform );
+$metas_tabs = new WPSEO_Option_Tabs( 'metas' );
+$metas_tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ) ) );
+$metas_tabs->add_tab( new WPSEO_Option_Tab( 'post-types', __( 'Content Types', 'wordpress-seo' ) ) );
+$metas_tabs->add_tab( new WPSEO_Option_Tab( 'media', __( 'Media', 'wordpress-seo' ) ) );
+$metas_tabs->add_tab( new WPSEO_Option_Tab( 'taxonomies', __( 'Taxonomies', 'wordpress-seo' ) ) );
+$metas_tabs->add_tab( new WPSEO_Option_Tab( 'archives', __( 'Archives', 'wordpress-seo' ) ) );
+$metas_tabs->add_tab( new WPSEO_Option_Tab( 'breadcrumbs', __( 'Breadcrumbs', 'wordpress-seo' ) ) );
+$metas_tabs->add_tab( new WPSEO_Option_Tab( 'rss', __( 'RSS', 'wordpress-seo' ) ) );
+$metas_tabs->display( $yform );
 
 $yform->admin_footer();

--- a/admin/pages/network.php
+++ b/admin/pages/network.php
@@ -14,11 +14,11 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 $yform = Yoast_Form::get_instance();
 $yform->admin_header( true, 'wpseo_ms' );
 
-$tabs = new WPSEO_Option_Tabs( 'network' );
-$tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'features', __( 'Features', 'wordpress-seo' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'integrations', __( 'Integrations', 'wordpress-seo' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'restore-site', __( 'Restore Site', 'wordpress-seo' ), [ 'save_button' => false ] ) );
-$tabs->display( $yform );
+$network_tabs = new WPSEO_Option_Tabs( 'network' );
+$network_tabs->add_tab( new WPSEO_Option_Tab( 'general', __( 'General', 'wordpress-seo' ) ) );
+$network_tabs->add_tab( new WPSEO_Option_Tab( 'features', __( 'Features', 'wordpress-seo' ) ) );
+$network_tabs->add_tab( new WPSEO_Option_Tab( 'integrations', __( 'Integrations', 'wordpress-seo' ) ) );
+$network_tabs->add_tab( new WPSEO_Option_Tab( 'restore-site', __( 'Restore Site', 'wordpress-seo' ), [ 'save_button' => false ] ) );
+$network_tabs->display( $yform );
 
 $yform->admin_footer();

--- a/admin/pages/social.php
+++ b/admin/pages/social.php
@@ -14,12 +14,12 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 $yform = Yoast_Form::get_instance();
 $yform->admin_header( true, 'wpseo_social' );
 
-$tabs = new WPSEO_Option_Tabs( 'social' );
-$tabs->add_tab( new WPSEO_Option_Tab( 'accounts', __( 'Accounts', 'wordpress-seo' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'facebook', __( 'Facebook', 'wordpress-seo' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'twitterbox', __( 'Twitter', 'wordpress-seo' ) ) );
-$tabs->add_tab( new WPSEO_Option_Tab( 'pinterest', __( 'Pinterest', 'wordpress-seo' ) ) );
+$social_tabs = new WPSEO_Option_Tabs( 'social' );
+$social_tabs->add_tab( new WPSEO_Option_Tab( 'accounts', __( 'Accounts', 'wordpress-seo' ) ) );
+$social_tabs->add_tab( new WPSEO_Option_Tab( 'facebook', __( 'Facebook', 'wordpress-seo' ) ) );
+$social_tabs->add_tab( new WPSEO_Option_Tab( 'twitterbox', __( 'Twitter', 'wordpress-seo' ) ) );
+$social_tabs->add_tab( new WPSEO_Option_Tab( 'pinterest', __( 'Pinterest', 'wordpress-seo' ) ) );
 
-$tabs->display( $yform );
+$social_tabs->display( $yform );
 
 $yform->admin_footer();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
	
* Fixing the same CS error that occurred in several admin pages:

```
FOUND 1 ERROR AFFECTING 1 LINE
--
--------------------------------------------------------------------------------
35 | ERROR | Overriding WordPress globals is prohibited. Found assignment to $tabs

```

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Cleans up some code that caused an override of the global variable $tabs.


<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* There should still be tabs on the Yoast SEO admin pages:
* dashboard (general)
* metas (search appearance)
* network
* social


Fixes N/A
