### PR TITLE
Implement feature flag for Slovak support

### DIFF
--- a/packages/yoastseo/src/helpers/getLanguagesWithWordFormSupport.js
+++ b/packages/yoastseo/src/helpers/getLanguagesWithWordFormSupport.js
@@ -12,7 +12,6 @@ export function getLanguagesWithWordFormSupport() {
 	if ( isFeatureEnabled( "SLOVAK_SUPPORT" ) ) {
 		supportedLanguages.push( "sk" );
 	}
-	console.log( supportedLanguages );
 
 	return supportedLanguages;
 }

--- a/packages/yoastseo/src/helpers/getLanguagesWithWordFormSupport.js
+++ b/packages/yoastseo/src/helpers/getLanguagesWithWordFormSupport.js
@@ -1,4 +1,4 @@
-const supportedLanguages = [ "en", "de", "es", "fr", "it", "nl", "ru", "id", "pt", "pl", "ar", "sv", "he", "hu", "nb", "tr", "cs" ];
+import { isFeatureEnabled } from "@yoast/feature-flag";
 
 /**
  * Checks which languages have morphology support inside YoastSEO.js.
@@ -6,5 +6,13 @@ const supportedLanguages = [ "en", "de", "es", "fr", "it", "nl", "ru", "id", "pt
  * @returns {string[]} A list of languages that have morphology support.
  */
 export function getLanguagesWithWordFormSupport() {
+	const supportedLanguages = [ "en", "de", "es", "fr", "it", "nl", "ru", "id", "pt", "pl", "ar", "sv", "he", "hu", "nb", "tr", "cs" ];
+
+	// Add Slovak to the supported languages list if the feature is enabled.
+	if ( isFeatureEnabled( "SLOVAK_SUPPORT" ) ) {
+		supportedLanguages.push( "sk" );
+	}
+	console.log( supportedLanguages );
+
 	return supportedLanguages;
 }

--- a/src/conditionals/slovak-support-conditional.php
+++ b/src/conditionals/slovak-support-conditional.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Checks if the YOAST_SEO_SCHEMA_BLOCKS constant is set.
+ */
+class Slovak_Support_Conditional extends Feature_Flag_Conditional {
+
+	/**
+	 * Returns the name of the feature flag.
+	 * 'YOAST_SEO_' is automatically prepended to it and it will be uppercased.
+	 *
+	 * @return string the name of the feature flag.
+	 */
+	public function get_feature_flag() {
+		return 'SLOVAK_SUPPORT';
+	}
+}

--- a/src/conditionals/slovak-support-conditional.php
+++ b/src/conditionals/slovak-support-conditional.php
@@ -3,7 +3,7 @@
 namespace Yoast\WP\SEO\Conditionals;
 
 /**
- * Checks if the YOAST_SEO_SCHEMA_BLOCKS constant is set.
+ * Checks if the YOAST_SEO_SLOVAK_SUPPORT constant is set.
  */
 class Slovak_Support_Conditional extends Feature_Flag_Conditional {
 

--- a/src/helpers/language-helper.php
+++ b/src/helpers/language-helper.php
@@ -3,12 +3,24 @@
 namespace Yoast\WP\SEO\Helpers;
 
 use WPSEO_Language_Utils;
+use Yoast\WP\SEO\Conditionals\Slovak_Support_Conditional;
 use Yoast\WP\SEO\Config\Researcher_Languages;
 
 /**
  * A helper object for language features.
  */
 class Language_Helper {
+	/**
+	 * Schema_Blocks constructor.
+	 *
+	 * @param Slovak_Support_Conditional $slovak_conditional The Slovak support conditional.
+	 */
+	public function __construct(
+		Slovak_Support_Conditional  $slovak_conditional
+	) {
+		$this->slovak_conditional = $slovak_conditional;
+	}
+
 
 	/**
 	 * Checks whether word form recognition is active for the used language.
@@ -45,7 +57,13 @@ class Language_Helper {
 	 */
 	public function get_researcher_language() {
 		$researcher_language = WPSEO_Language_Utils::get_language( get_locale() );
-		if ( ! \in_array( $researcher_language, Researcher_Languages::SUPPORTED_LANGUAGES, true ) ) {
+		$supported_languages = Researcher_Languages::SUPPORTED_LANGUAGES;
+
+		if ( $this->slovak_conditional->is_met() ) {
+			array_push( $supported_languages, 'sk' );
+		}
+
+		if ( ! \in_array( $researcher_language, $supported_languages, true ) ) {
 			$researcher_language = 'default';
 		}
 

--- a/src/helpers/language-helper.php
+++ b/src/helpers/language-helper.php
@@ -58,6 +58,7 @@ class Language_Helper {
 		$researcher_language = WPSEO_Language_Utils::get_language( get_locale() );
 		$supported_languages = Researcher_Languages::SUPPORTED_LANGUAGES;
 
+		// If SLOVAK_SUPPORT feature is enabled, push Slovak to the array of the supported languages
 		if ( $this->slovak_conditional->is_met() ) {
 			array_push( $supported_languages, 'sk' );
 		}

--- a/src/helpers/language-helper.php
+++ b/src/helpers/language-helper.php
@@ -31,6 +31,11 @@ class Language_Helper {
 	public function is_word_form_recognition_active( $language ) {
 		$supported_languages = [ 'de', 'en', 'es', 'fr', 'it', 'nl', 'ru', 'id', 'pt', 'pl', 'ar', 'sv', 'he', 'hu', 'nb', 'tr', 'cs' ];
 
+		// If SLOVAK_SUPPORT feature is enabled, push Slovak to the array of the supported languages
+		if ( $this->slovak_conditional->is_met() ) {
+			array_push( $supported_languages, 'sk' );
+		}
+
 		return \in_array( $language, $supported_languages, true );
 	}
 
@@ -44,6 +49,11 @@ class Language_Helper {
 	 */
 	public function has_function_word_support( $language ) {
 		$supported_languages = [ 'en', 'de', 'nl', 'fr', 'es', 'it', 'pt', 'ru', 'pl', 'sv', 'id', 'he', 'ar', 'hu', 'nb', 'tr', 'cs' ];
+
+		// If SLOVAK_SUPPORT feature is enabled, push Slovak to the array of the supported languages
+		if ( $this->slovak_conditional->is_met() ) {
+			array_push( $supported_languages, 'sk' );
+		}
 
 		return \in_array( $language, $supported_languages, true );
 	}

--- a/src/helpers/language-helper.php
+++ b/src/helpers/language-helper.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Config\Researcher_Languages;
  */
 class Language_Helper {
 	/**
-	 * Schema_Blocks constructor.
+	 * Language_Helper constructor.
 	 *
 	 * @param Slovak_Support_Conditional $slovak_conditional The Slovak support conditional.
 	 */
@@ -20,7 +20,6 @@ class Language_Helper {
 	) {
 		$this->slovak_conditional = $slovak_conditional;
 	}
-
 
 	/**
 	 * Checks whether word form recognition is active for the used language.

--- a/src/helpers/language-helper.php
+++ b/src/helpers/language-helper.php
@@ -10,13 +10,14 @@ use Yoast\WP\SEO\Config\Researcher_Languages;
  * A helper object for language features.
  */
 class Language_Helper {
+
 	/**
 	 * Language_Helper constructor.
 	 *
 	 * @param Slovak_Support_Conditional $slovak_conditional The Slovak support conditional.
 	 */
 	public function __construct(
-		Slovak_Support_Conditional  $slovak_conditional
+		Slovak_Support_Conditional $slovak_conditional
 	) {
 		$this->slovak_conditional = $slovak_conditional;
 	}
@@ -31,7 +32,7 @@ class Language_Helper {
 	public function is_word_form_recognition_active( $language ) {
 		$supported_languages = [ 'de', 'en', 'es', 'fr', 'it', 'nl', 'ru', 'id', 'pt', 'pl', 'ar', 'sv', 'he', 'hu', 'nb', 'tr', 'cs' ];
 
-		// If SLOVAK_SUPPORT feature is enabled, push Slovak to the array of the supported languages
+		// If SLOVAK_SUPPORT feature is enabled, push Slovak to the array of the supported languages.
 		if ( $this->slovak_conditional->is_met() ) {
 			array_push( $supported_languages, 'sk' );
 		}
@@ -50,7 +51,7 @@ class Language_Helper {
 	public function has_function_word_support( $language ) {
 		$supported_languages = [ 'en', 'de', 'nl', 'fr', 'es', 'it', 'pt', 'ru', 'pl', 'sv', 'id', 'he', 'ar', 'hu', 'nb', 'tr', 'cs' ];
 
-		// If SLOVAK_SUPPORT feature is enabled, push Slovak to the array of the supported languages
+		// If SLOVAK_SUPPORT feature is enabled, push Slovak to the array of the supported languages.
 		if ( $this->slovak_conditional->is_met() ) {
 			array_push( $supported_languages, 'sk' );
 		}
@@ -68,7 +69,7 @@ class Language_Helper {
 		$researcher_language = WPSEO_Language_Utils::get_language( get_locale() );
 		$supported_languages = Researcher_Languages::SUPPORTED_LANGUAGES;
 
-		// If SLOVAK_SUPPORT feature is enabled, push Slovak to the array of the supported languages
+		// If SLOVAK_SUPPORT feature is enabled, push Slovak to the array of the supported languages.
 		if ( $this->slovak_conditional->is_met() ) {
 			array_push( $supported_languages, 'sk' );
 		}

--- a/tests/unit/helpers/language-helper-test.php
+++ b/tests/unit/helpers/language-helper-test.php
@@ -8,7 +8,7 @@ use Yoast\WP\SEO\Helpers\Language_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Language_Helper_Test
+ * Class Language_Helper_Test.
  *
  * @coversDefaultClass \Yoast\WP\SEO\Helpers\Language_Helper
  *
@@ -35,11 +35,10 @@ class Language_Helper_Test extends TestCase {
 	 */
 	protected function set_up() {
 		parent::set_up();
+
 		$this->slovak_conditional = Mockery::mock( Slovak_Support_Conditional::class );
 
-		$this->instance = new Language_Helper(
-			$this->slovak_conditional
-		);
+		$this->instance = new Language_Helper( $this->slovak_conditional );
 	}
 
 	/**

--- a/tests/unit/helpers/language-helper-test.php
+++ b/tests/unit/helpers/language-helper-test.php
@@ -61,6 +61,10 @@ class Language_Helper_Test extends TestCase {
 	 * @param string $language The language to test.
 	 */
 	public function test_is_word_form_recognition_active( $language ) {
+		$this->blocks_conditional
+			->expects( 'is_met' )
+			->andReturnFalse();
+
 		$this->assertTrue( $this->instance->is_word_form_recognition_active( $language ) );
 	}
 
@@ -83,6 +87,10 @@ class Language_Helper_Test extends TestCase {
 	 * @param string $language The language to test.
 	 */
 	public function test_has_function_word_support( $language ) {
+		$this->blocks_conditional
+			->expects( 'is_met' )
+			->andReturnFalse();
+
 		$this->assertTrue( $this->instance->has_function_word_support( $language ) );
 	}
 

--- a/tests/unit/helpers/language-helper-test.php
+++ b/tests/unit/helpers/language-helper-test.php
@@ -28,7 +28,7 @@ class Language_Helper_Test extends TestCase {
 	 *
 	 * @var Mockery\MockInterface|Slovak_Support_Conditional
 	 */
-	protected $blocks_conditional;
+	protected $slovak_conditional;
 
 	/**
 	 * Sets up the tests.
@@ -61,7 +61,7 @@ class Language_Helper_Test extends TestCase {
 	 * @param string $language The language to test.
 	 */
 	public function test_is_word_form_recognition_active( $language ) {
-		$this->blocks_conditional
+		$this->slovak_conditional
 			->expects( 'is_met' )
 			->andReturnFalse();
 
@@ -87,7 +87,7 @@ class Language_Helper_Test extends TestCase {
 	 * @param string $language The language to test.
 	 */
 	public function test_has_function_word_support( $language ) {
-		$this->blocks_conditional
+		$this->slovak_conditional
 			->expects( 'is_met' )
 			->andReturnFalse();
 

--- a/tests/unit/helpers/language-helper-test.php
+++ b/tests/unit/helpers/language-helper-test.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Slovak_Support_Conditional;
 use Yoast\WP\SEO\Helpers\Language_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -22,11 +24,31 @@ class Language_Helper_Test extends TestCase {
 	private $instance;
 
 	/**
+	 * The Slovak support conditional.
+	 *
+	 * @var Mockery\MockInterface|Slovak_Support_Conditional
+	 */
+	protected $blocks_conditional;
+
+	/**
 	 * Sets up the tests.
 	 */
 	protected function set_up() {
 		parent::set_up();
-		$this->instance = new Language_Helper();
+		$this->slovak_conditional = Mockery::mock( Slovak_Support_Conditional::class );
+
+		$this->instance = new Language_Helper(
+			$this->slovak_conditional
+		);
+	}
+
+	/**
+	 * Tests the constructor by checking the set attributes.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		static::assertInstanceOf( Slovak_Support_Conditional::class, self::getPropertyValue( $this, 'slovak_conditional' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a feature-flag for Slovak support.

## Relevant technical choices:

* This PR is accompanied by [another PR in Premium](https://github.com/Yoast/wordpress-seo-premium/pull/3364/files).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In PHPStorm/your preferred IDE, navigate to `packages/yoastseo/languageProcessing/languages/_default` and copy the contents
* Inside the `languages` folder, create an `sk` folder and paste the contents from `_default` (don't commit any changes)
* Build the free plugin
* Enable the `SLOVAK_SUPPORT` feature by adding `define( 'YOAST_SEO_SLOVAK_SUPPORT', true );` in `basic-wordpress-config.php` file
* Set your site to Slovak
* Create/open a post
* In the console, enter `window.yoast.Researcher` and confirm that it returns as shown below (the Researcher file should start with `sk`):
<img width="715" alt="Screenshot 2021-06-17 at 17 04 31" src="https://user-images.githubusercontent.com/48715883/122423595-4e3f2980-cf8e-11eb-9801-ac4e5bea208a.png">

* Run this command `composer require yoast/wordpress-seo:dev-LINGO-893-implement-feature-flag-for-slovak@dev` in `wordpress-seo-premium`
* Build the premium plugin
* Reload your page
* In your console, confirm that the morphology request returns with `404`:
<img width="680" alt="Screenshot 2021-06-17 at 17 01 27" src="https://user-images.githubusercontent.com/48715883/122423972-a1b17780-cf8e-11eb-90cb-c49076c98dfb.png">

* Disable the `SLOVAK_SUPPORT` by removing this  `define( 'YOAST_SEO_SLOVAK_SUPPORT', true );` from `basic-wordpress-config.php` file
* Reload your page
* Confirm that you get the default Researcher by entering `window.yoast.Researcher` in the console:
<img width="711" alt="Screenshot 2021-06-17 at 17 11 03" src="https://user-images.githubusercontent.com/48715883/122424676-34eaad00-cf8f-11eb-80b0-a11d72d9b7de.png">

* Confirm that there is no morphology request
<img width="728" alt="Screenshot 2021-06-17 at 17 11 19" src="https://user-images.githubusercontent.com/48715883/122424791-49c74080-cf8f-11eb-8880-728b64259b8d.png">


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Enable the `SLOVAK_SUPPORT` feature by adding `define( 'YOAST_SEO_SLOVAK_SUPPORT', true );` in `basic-wordpress-config.php` file
* Set your site to Slovak
* Create/open a post
* In the console, enter `window.yoast.Researcher` and confirm that it returns as shown below (the Researcher file should start with `sk`):
<img width="715" alt="Screenshot 2021-06-17 at 17 04 31" src="https://user-images.githubusercontent.com/48715883/122423595-4e3f2980-cf8e-11eb-9801-ac4e5bea208a.png">

* Install and activate the Premium
* Create/open a post
* In your console, confirm that the morphology request returns with `404`:
<img width="680" alt="Screenshot 2021-06-17 at 17 01 27" src="https://user-images.githubusercontent.com/48715883/122423972-a1b17780-cf8e-11eb-90cb-c49076c98dfb.png">

* Disable the `SLOVAK_SUPPORT` by removing this  `define( 'YOAST_SEO_SLOVAK_SUPPORT', true );` from `basic-wordpress-config.php` file
* Reload your page
* Confirm that you get the default Researcher by entering `window.yoast.Researcher` in the console:
<img width="711" alt="Screenshot 2021-06-17 at 17 11 03" src="https://user-images.githubusercontent.com/48715883/122424676-34eaad00-cf8f-11eb-80b0-a11d72d9b7de.png">

* Confirm that there is no morphology request

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-893
