### PR TITLE
Update class-register-capabilities.php

### DIFF
--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -32,7 +32,7 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 		$manager = WPSEO_Capability_Manager_Factory::get();
 
 		$manager->register( 'wpseo_bulk_edit', [ 'editor', 'wpseo_editor', 'wpseo_manager' ] );
-		$manager->register( 'wpseo_edit_advanced_metadata', [ 'wpseo_editor', 'wpseo_manager' ] );
+		$manager->register( 'wpseo_edit_advanced_metadata', [ 'editor', 'wpseo_editor', 'wpseo_manager' ] );
 
 		$manager->register( 'wpseo_manage_options', [ 'administrator', 'wpseo_manager' ] );
 		$manager->register( 'view_site_health_checks', [ 'wpseo_manager' ] );


### PR DESCRIPTION

## Context
According to the docs, only editors and administrators can see and use the Advanced tab in Yoast SEO (https://yoast.com/help/security-no-advanced-settings-for-authors/).

However, on a clean install of Wordpress with only the Yoast SEO plugin activated, the Advanced tab is not visible for editors. There are a few tickets in the Wordpress support forums reporting this.

The call to WPSEO_Capability_Utils::current_user_can( 'wpseo_edit_advanced_metadata' ) will only return true for administrators, wpseo_managers and wpseo_editors. The capability should be granted to editors as well.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Advanced section and Schema tab wouldn't be visible in the metabox for Editors. Props to [jordif](https://github.com/jordif).

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Without this patch:
* Install Yoast SEO Free
* Make sure that SEO -> General -> Features -> `Security: no advanced or schema settings for authors` is set to `on` (this is default)
* Create a user with the Editor role
* Log in as the editor and edit a post.
* Observe that:
  * There is no Schema tab in the metabox
  * The SEO tab does not have an `Advanced` section

Apply this patch
* Make sure you deactivate and reactivate the plugin! Or find another way to trigger the `WPSEO_Register_Capabilities` class
* Perform the same steps as before, but now the Advanced section and Schema tabs are visible.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes QAK-2717
