### PR TITLE
Update rel-next-presenter.php

### DIFF
--- a/src/presenters/rel-next-presenter.php
+++ b/src/presenters/rel-next-presenter.php
@@ -30,6 +30,13 @@ class Rel_Next_Presenter extends Abstract_Indexable_Tag_Presenter {
 	 */
 	public function present() {
 		$output = parent::present();
+		
+	    if (  is_front_page() && empty($output) ) {
+            global $paged;
+            if($paged > 1 ){
+                $output = '<link rel="prev" href="'. get_pagenum_link( $paged - 1 ) .'" />' . PHP_EOL;
+            }
+        }
 
 		if ( ! empty( $output ) ) {
 			/**


### PR DESCRIPTION
## Context
On static pages, like a home page, previous and next do not work. this is a proposed fix for this problem.
