### PR TITLE
Update rel-next-presenter.php

### DIFF
--- a/src/presenters/rel-next-presenter.php
+++ b/src/presenters/rel-next-presenter.php
@@ -30,6 +30,18 @@ class Rel_Next_Presenter extends Abstract_Indexable_Tag_Presenter {
 	 */
 	public function present() {
 		$output = parent::present();
+		
+		if ( is_front_page() && empty($output) ) {
+            global $paged, $wp_query;
+
+            if($paged===0){
+                $output = '<link rel="next" href="'. get_pagenum_link( ) . 'page/2" />' . PHP_EOL;
+            }elseif($paged === strval((int) $wp_query->max_num_pages)) {
+                return '';
+            }else{
+                $output = '<link rel="next" href="'. get_pagenum_link( $paged + 1 ) .'" />' . PHP_EOL;
+            }
+        }
 
 		if ( ! empty( $output ) ) {
 			/**


### PR DESCRIPTION
## Context
On static pages, like a home page, previous and next do not work. this is a proposed fix for this problem.
This works for the rel-next-presenter.
https://wordpress.stackexchange.com/questions/365884/yoasts-rel-next-rel-prev-tag-dont-work-on-static-homepages-paginated-pa#_=_
https://blogs.perficient.com/2015/12/20/how-to-implement-rel-prev-next-tags/

