### PR TITLE
Make Pagination work on Archives placed on static pages like the front page

### DIFF
--- a/src/presenters/rel-next-presenter.php
+++ b/src/presenters/rel-next-presenter.php
@@ -31,6 +31,18 @@ class Rel_Next_Presenter extends Abstract_Indexable_Tag_Presenter {
 	public function present() {
 		$output = parent::present();
 
+		if ( is_front_page() && empty($output) ) {
+            global $paged, $wp_query;
+
+            if($paged===0){
+                $output = '<link rel="next" href="'. get_pagenum_link( ) . 'page/2" />' . PHP_EOL;
+            }elseif($paged === strval((int) $wp_query->max_num_pages)) {
+                return '';
+            }else{
+                $output = '<link rel="next" href="'. get_pagenum_link( $paged + 1 ) .'" />' . PHP_EOL;
+            }
+        }
+		
 		if ( ! empty( $output ) ) {
 			/**
 			 * Filter: 'wpseo_next_rel_link' - Allow changing link rel output by Yoast SEO.

--- a/src/presenters/rel-prev-presenter.php
+++ b/src/presenters/rel-prev-presenter.php
@@ -30,6 +30,13 @@ class Rel_Prev_Presenter extends Abstract_Indexable_Tag_Presenter {
 	 */
 	public function present( $output_tag = true ) {
 		$output = parent::present();
+		
+        if (  is_front_page() && empty($output) ) {
+            global $paged;
+            if($paged > 1 ){
+                $output = '<link rel="prev" href="'. get_pagenum_link( $paged - 1 ) .'" />' . PHP_EOL;
+            }
+        }
 
 		if ( ! empty( $output ) ) {
 			/**


### PR DESCRIPTION
On static pages, like a home page, previous and next links do not work. This is a proposed fix for this problem.

it generates a:
<link rel="next" ...
<link rel="prev" ...

for each page on your pagination on static sites like your home page