### PR TITLE
Remove abstract schema piece type hint from Schema_Generator::type_filter.

### DIFF
--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -268,6 +268,9 @@ class Schema_Generator implements Generator_Interface {
 	/**
 	 * Allows filtering the graph piece by its schema type.
 	 *
+	 * Note: We removed the Abstract_Schema_Piece type-hint from the $graph_piece_generator argument, because
+	 *       it caused conflicts with old code, Yoast SEO Video specifically.
+	 *
 	 * @param array             $graph_piece The graph piece we're filtering.
 	 * @param string            $identifier  The identifier of the graph piece that is being filtered.
 	 * @param Meta_Tags_Context $context     The meta tags context.
@@ -276,7 +279,7 @@ class Schema_Generator implements Generator_Interface {
 	 *
 	 * @return array The filtered graph piece.
 	 */
-	private function type_filter( $graph_piece, $identifier, Meta_Tags_Context $context, Abstract_Schema_Piece $graph_piece_generator, array $graph_piece_generators ) {
+	private function type_filter( $graph_piece, $identifier, Meta_Tags_Context $context, $graph_piece_generator, array $graph_piece_generators ) {
 		$types = $this->get_type_from_piece( $graph_piece );
 		foreach ( $types as $type ) {
 			$type = \strtolower( $type );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In https://github.com/Yoast/wordpress-seo/pull/16943 we introduced 2 new arguments  to the `wpseo_schema_{identifier}` filter. This filter could overlap with the `wpseo_schema_{type}` filter, and when requesting 4 arguments from the `wpseo_schema_{type}` filter, a fatal error would occur because the called filter-function would receive only 2 arguments.

Initially, this was fixed by adding the 2 additional arguments to the `wpseo_schema_{type}` filter as well in https://github.com/Yoast/wordpress-seo/pull/17158. Due to type-hinting with would also lead to fatals because some addons still used the deprecated `WPSEO_Graph_Piece` interface instead of the new `Abstract_Graph_Piece` abstract class. The `type_filter` function expected a `Abstract_Graph_Piece`, but got a `WPSEO_Graph_Piece` instead, although the two are almost identical.

This was then fixed by updating the addon in question (`wpseo-video`) to use the abstract class instead of the deprecated interface in https://github.com/Yoast/wpseo-video/pull/886. Although the minimum version of Yoast SEO was bumped, concerns were raised that if people would update Yoast SEO, and not Yoast SEO Video, they would get fatals and contact support before updating.

Now we come to hopefully the last part of this saga, which is to remove the type-hinting completely and negated all the negative effects that come with it.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes `Abstract_Schema_Piece` type-hint from the `Schema_Generator::type_filter` function to ensure that plugins and add-ons that still use the deprecated `WPSEO_Graph_Piece` interface don't cause fatal errors.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check-out `wpseo-video` version `13.9` or install the [zip](https://github.com/Yoast/wpseo-video/releases/tag/13.9).
* Create a new post with a video (e.g. an embedded youtube video).
* Inspect the front-end and make sure there is not fatal error and the video SEO schema is still present.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
