### PR TITLE
When creating unindexed indexables ensure that they have a permalink

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=291",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=287",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=223",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Builders;
 
 use Yoast\WP\SEO\Exceptions\Indexable\Source_Exception;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
-use Yoast\WP\SEO\Helpers\Permalink_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
@@ -93,13 +92,6 @@ class Indexable_Builder {
 	protected $indexable_helper;
 
 	/**
-	 * The permalink helper.
-	 *
-	 * @var Permalink_Helper
-	 */
-	protected $permalink_helper;
-
-	/**
 	 * Returns the instance of this class constructed through the ORM Wrapper.
 	 *
 	 * @param Indexable_Author_Builder            $author_builder            The author builder for creating missing indexables.
@@ -112,7 +104,6 @@ class Indexable_Builder {
 	 * @param Indexable_Hierarchy_Builder         $hierarchy_builder         The hierarchy builder for creating the indexable hierarchy.
 	 * @param Primary_Term_Builder                $primary_term_builder      The primary term builder for creating primary terms for posts.
 	 * @param Indexable_Helper                    $indexable_helper          The indexable helper.
-	 * @param Permalink_Helper                    $permalink_helper          The permalink helper.
 	 */
 	public function __construct(
 		Indexable_Author_Builder $author_builder,
@@ -124,8 +115,7 @@ class Indexable_Builder {
 		Indexable_System_Page_Builder $system_page_builder,
 		Indexable_Hierarchy_Builder $hierarchy_builder,
 		Primary_Term_Builder $primary_term_builder,
-		Indexable_Helper $indexable_helper,
-		Permalink_Helper $permalink_helper
+		Indexable_Helper $indexable_helper
 	) {
 		$this->author_builder            = $author_builder;
 		$this->post_builder              = $post_builder;
@@ -137,7 +127,6 @@ class Indexable_Builder {
 		$this->hierarchy_builder         = $hierarchy_builder;
 		$this->primary_term_builder      = $primary_term_builder;
 		$this->indexable_helper          = $indexable_helper;
-		$this->permalink_helper          = $permalink_helper;
 	}
 
 	/**
@@ -201,12 +190,6 @@ class Indexable_Builder {
 					'post_status' => 'unindexed',
 				]
 			);
-
-			$indexable->permalink = $this->permalink_helper->get_permalink_for_indexable( $indexable );
-
-			if ( empty( $indexable->permalink ) ) {
-				$indexable->permalink = 'unindexed';
-			}
 		}
 
 		$indexable = $this->save_indexable( $indexable, $indexable_before );

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -202,9 +202,9 @@ class Indexable_Builder {
 				]
 			);
 
-			$permalink = $this->permalink_helper->get_permalink_for_indexable( $indexable );
+			$indexable->permalink = $this->permalink_helper->get_permalink_for_indexable( $indexable );
 
-			if ( empty( $permalink ) ) {
+			if ( empty( $indexable->permalink ) ) {
 				$indexable->permalink = "unindexed";
 			}
 		}

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -205,7 +205,7 @@ class Indexable_Builder {
 			$indexable->permalink = $this->permalink_helper->get_permalink_for_indexable( $indexable );
 
 			if ( empty( $indexable->permalink ) ) {
-				$indexable->permalink = "unindexed";
+				$indexable->permalink = 'unindexed';
 			}
 		}
 

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Builders;
 
 use Yoast\WP\SEO\Exceptions\Indexable\Source_Exception;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
+use Yoast\WP\SEO\Helpers\Permalink_Helper;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
@@ -92,6 +93,13 @@ class Indexable_Builder {
 	protected $indexable_helper;
 
 	/**
+	 * The permalink helper.
+	 *
+	 * @var Permalink_Helper
+	 */
+	protected $permalink_helper;
+
+	/**
 	 * Returns the instance of this class constructed through the ORM Wrapper.
 	 *
 	 * @param Indexable_Author_Builder            $author_builder            The author builder for creating missing indexables.
@@ -104,6 +112,7 @@ class Indexable_Builder {
 	 * @param Indexable_Hierarchy_Builder         $hierarchy_builder         The hierarchy builder for creating the indexable hierarchy.
 	 * @param Primary_Term_Builder                $primary_term_builder      The primary term builder for creating primary terms for posts.
 	 * @param Indexable_Helper                    $indexable_helper          The indexable helper.
+	 * @param Permalink_Helper                    $permalink_helper          The permalink helper.
 	 */
 	public function __construct(
 		Indexable_Author_Builder $author_builder,
@@ -115,7 +124,8 @@ class Indexable_Builder {
 		Indexable_System_Page_Builder $system_page_builder,
 		Indexable_Hierarchy_Builder $hierarchy_builder,
 		Primary_Term_Builder $primary_term_builder,
-		Indexable_Helper $indexable_helper
+		Indexable_Helper $indexable_helper,
+		Permalink_Helper $permalink_helper
 	) {
 		$this->author_builder            = $author_builder;
 		$this->post_builder              = $post_builder;
@@ -127,6 +137,7 @@ class Indexable_Builder {
 		$this->hierarchy_builder         = $hierarchy_builder;
 		$this->primary_term_builder      = $primary_term_builder;
 		$this->indexable_helper          = $indexable_helper;
+		$this->permalink_helper          = $permalink_helper;
 	}
 
 	/**
@@ -190,6 +201,12 @@ class Indexable_Builder {
 					'post_status' => 'unindexed',
 				]
 			);
+
+			$permalink = $this->permalink_helper->get_permalink_for_indexable( $indexable );
+
+			if ( empty( $permalink ) ) {
+				$indexable->permalink = "unindexed";
+			}
 		}
 
 		$indexable = $this->save_indexable( $indexable, $indexable_before );

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -268,10 +268,10 @@ class Schema_Generator implements Generator_Interface {
 	 * Note: We removed the Abstract_Schema_Piece type-hint from the $graph_piece_generator argument, because
 	 *       it caused conflicts with old code, Yoast SEO Video specifically.
 	 *
-	 * @param array             $graph_piece The graph piece we're filtering.
-	 * @param string            $identifier  The identifier of the graph piece that is being filtered.
-	 * @param Meta_Tags_Context $context     The meta tags context.
-	 * @param Abstract_Schema_Piece $graph_piece_generator A value object with context variables.
+	 * @param array                   $graph_piece The graph piece we're filtering.
+	 * @param string                  $identifier  The identifier of the graph piece that is being filtered.
+	 * @param Meta_Tags_Context       $context     The meta tags context.
+	 * @param Abstract_Schema_Piece   $graph_piece_generator A value object with context variables.
 	 * @param Abstract_Schema_Piece[] $graph_piece_generators A value object with context variables.
 	 *
 	 * @return array The filtered graph piece.

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -174,7 +174,7 @@ class Indexable extends Model {
 	 * @return void
 	 */
 	protected function sanitize_permalink() {
-		if ( $this->permalink === "unindexed" ) {
+		if ( $this->permalink === 'unindexed' ) {
 			return;
 		}
 

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -174,6 +174,10 @@ class Indexable extends Model {
 	 * @return void
 	 */
 	protected function sanitize_permalink() {
+		if ( $this->permalink === "unindexed" ) {
+			return;
+		}
+
 		$permalink_structure = \get_option( 'permalink_structure' );
 		$permalink_parts     = \wp_parse_url( $this->permalink );
 

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -482,8 +482,8 @@ class Indexable_Repository {
 		if ( $indexable && $indexable->permalink === null ) {
 			$indexable->permalink = $this->permalink_helper->get_permalink_for_indexable( $indexable );
 
-			if ( $indexable->permalink === null && $indexable->post_status === "unindexed" ) {
-				$indexable->permalink = "unindexed";
+			if ( $indexable->permalink === null && $indexable->post_status === 'unindexed' ) {
+				$indexable->permalink = 'unindexed';
 			}
 
 			// Only save if changed.

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -482,6 +482,10 @@ class Indexable_Repository {
 		if ( $indexable && $indexable->permalink === null ) {
 			$indexable->permalink = $this->permalink_helper->get_permalink_for_indexable( $indexable );
 
+			if ( $indexable->permalink === null && $indexable->post_status === "unindexed" ) {
+				$indexable->permalink = "unindexed";
+			}
+
 			// Only save if changed.
 			if ( $indexable->permalink !== null ) {
 				$indexable->save();

--- a/tests/unit/models/indexable-test.php
+++ b/tests/unit/models/indexable-test.php
@@ -143,4 +143,29 @@ class Indexable_Test extends TestCase {
 		// Check again to test if it is now set correctly. Not calling `has_one` again.
 		$this->assertSame( 'found one', $this->instance->get_extension( 'has_one' ) );
 	}
+
+	/**
+	 * Tests that if the permalink is 'unindexed' it does not get trailingslashed ('unindexed/').
+	 *
+	 * @covers ::sanitize_permalink
+	 * @covers ::save
+	 */
+	public function test_do_trailing_slash_permalink_when_unindexed() {
+		$permalink = 'unindexed';
+
+		$this->instance->orm->expects( 'get' )->times( 5 )->with( 'permalink' )->andReturn( $permalink );
+		$this->instance->orm->expects( 'set' )
+			->once()
+			->with( 'permalink', $permalink );
+		$this->instance->orm->expects( 'set' )
+			->once()
+			->with( 'permalink_hash', \strlen( $permalink ) . ':' . \md5( $permalink ) );
+		$this->instance->orm->expects( 'get' )->once()->with( 'primary_focus_keyword' )->andReturn( 'keyword' );
+		$this->instance->orm->expects( 'save' )->once();
+
+		$this->instance->set( 'permalink', $permalink );
+		$this->instance->save();
+
+		$this->assertSame( 'unindexed', $this->instance->permalink );
+	}
 }

--- a/tests/unit/models/indexable-test.php
+++ b/tests/unit/models/indexable-test.php
@@ -60,7 +60,7 @@ class Indexable_Test extends TestCase {
 			->once()
 			->with( 'permalink_hash', \strlen( $permalink ) . ':' . \md5( $permalink ) );
 		// Once for going into the if-statement, then twice for the permalink_hash.
-		$this->instance->orm->expects( 'get' )->times( 4 )->with( 'permalink' )->andReturn( $permalink );
+		$this->instance->orm->expects( 'get' )->times( 5 )->with( 'permalink' )->andReturn( $permalink );
 		$this->instance->orm->expects( 'get' )->once()->with( 'primary_focus_keyword' )->andReturn( 'keyword' );
 		$this->instance->orm->expects( 'save' )->once();
 
@@ -96,7 +96,7 @@ class Indexable_Test extends TestCase {
 			->once()
 			->with( 'permalink_hash', \strlen( $permalink_no_slash ) . ':' . \md5( $permalink_no_slash ) );
 		// Once for going into the if-statement, then once more for trailingslashit, then twice for the permalink_hash.
-		$this->instance->orm->expects( 'get' )->times( 4 )->with( 'permalink' )->andReturn( $permalink_no_slash );
+		$this->instance->orm->expects( 'get' )->times( 5 )->with( 'permalink' )->andReturn( $permalink_no_slash );
 		$this->instance->orm->expects( 'get' )->once()->with( 'primary_focus_keyword' )->andReturn( 'keyword' );
 		$this->instance->orm->expects( 'save' )->once();
 

--- a/tests/unit/repositories/indexable-repository-test.php
+++ b/tests/unit/repositories/indexable-repository-test.php
@@ -9,6 +9,7 @@ use Yoast\WP\SEO\Builders\Indexable_Builder;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Permalink_Helper;
 use Yoast\WP\SEO\Loggers\Logger;
+use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
@@ -462,5 +463,33 @@ class Indexable_Repository_Test extends TestCase {
 			->andReturn( 10 );
 
 		$this->assertSame( 10, $this->instance->reset_permalink( null, 'category' ) );
+	}
+
+	/**
+	 * Tests if ensure_permalink sets the permalink to 'unindexed' when the post_status is 'unindexed'.
+	 *
+	 * @covers ::ensure_permalink
+	 */
+	public function test_permalink_set_to_unindexed_ensure_permalink() {
+		/**
+		 * Mock indexable.
+		 *
+		 * @var Mockery\MockInterface|Indexable
+		 */
+		$indexable              = Mockery::mock( Indexable_Mock::class );
+		$indexable->permalink   = null;
+		$indexable->post_status = 'unindexed';
+
+		$indexable->expects( 'save' )
+			->once();
+
+		$this->permalink_helper
+			->expects( 'get_permalink_for_indexable' )
+			->with( $indexable )
+			->andReturn( null );
+
+		$this->instance->ensure_permalink( $indexable );
+
+		$this->assertSame( 'unindexed', $indexable->permalink );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the SEO optimization could run indefinitely when the database contained at least 25 faulty indexables without a permalink.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

I've been able to reliably test this on a clean WordPress installation. *Warning:* While will empty your database:
* Pull the latest version of the `plugin-development-docker`.
* Run `./clean.sh && ./make && ./start`, and stop the development environment after.
* Run `docker exec -it --user www-data basic-wordpress wp db reset`.
* Run `./start` again.
* When you navigate to your `wp-admin` you will have to initialize your WordPress installation.

#### Without already affected indexables (without permalink) in the database.
* Install the Yoast Test Helper and the FakerWordPress plugin.
* Using FakerPress create 30 new categories:
`FakerPress` => `Terms`
<img width="944" alt="Screenshot 2021-06-22 at 14 07 01" src="https://user-images.githubusercontent.com/5389513/122921719-202d6100-d363-11eb-89bb-03ffdfc5b7b2.png">

* Reset the Indexables tables using the Yoast test helper.
* Using a database management tool (i.e. SequelPro or TablePlus) delete the last 30 rows in the `wp_terms` table.
* Run the indexation process under `SEO` > `Tools`.
* It should not get stuck.

#### With already affected indexables in the database.

(This assumes you've already done the steps above).
* Reset the Indexables tables using the Yoast test helper.
* Install `Yoast SEO 16.6`.
* Run the indexation process under `SEO` > `Tools`.
* It should now get stuck.
* If you inspect the indexables table you should see multiple rows with `post_status` `unindexed` and permalink and permalink_has as `NULL`.
* Install a version of Yoast SEO with changes (or check-out this branch).
* Run the indexation process under `SEO` > `Tools`.
* It should not get stuck.
* If you inspect the indexables table you should see multiple rows with `post_status` `unindexed` and permalink `unindexed` and permalink_hash as some value (which is not very important).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
