### PR TITLE
P2-1115 Improve some performance for AJAX calls and empty WP_Queries

### DIFF
--- a/src/integrations/admin/admin-columns-cache-integration.php
+++ b/src/integrations/admin/admin-columns-cache-integration.php
@@ -55,10 +55,6 @@ class Admin_Columns_Cache_Integration implements Integration_Interface {
 	 * page (e.g. keyword score, incoming link count, etc.)
 	 */
 	public function register_hooks() {
-		if ( \wp_doing_ajax() ) {
-			\add_action( 'admin_init', [ $this, 'fill_cache' ] );
-		}
-
 		// Hook into tablenav to calculate links and linked.
 		\add_action( 'manage_posts_extra_tablenav', [ $this, 'maybe_fill_cache' ] );
 	}
@@ -80,7 +76,12 @@ class Admin_Columns_Cache_Integration implements Integration_Interface {
 	public function fill_cache() {
 		global $wp_query;
 
-		$posts    = empty( $wp_query->posts ) ? $wp_query->get_posts() : $wp_query->posts;
+		// No need to continue building a cache if the main query did not return anything to cache.
+		if ( empty( $wp_query->posts ) ){
+			return;
+		}
+
+		$posts    = $wp_query->posts;
 		$post_ids = [];
 
 		// Post lists return a list of objects.

--- a/src/integrations/admin/admin-columns-cache-integration.php
+++ b/src/integrations/admin/admin-columns-cache-integration.php
@@ -77,7 +77,7 @@ class Admin_Columns_Cache_Integration implements Integration_Interface {
 		global $wp_query;
 
 		// No need to continue building a cache if the main query did not return anything to cache.
-		if ( empty( $wp_query->posts ) ){
+		if ( empty( $wp_query->posts ) ) {
 			return;
 		}
 

--- a/tests/unit/integrations/admin/admin-columns-cache-integration-test.php
+++ b/tests/unit/integrations/admin/admin-columns-cache-integration-test.php
@@ -57,8 +57,7 @@ class Admin_Columns_Cache_Integration_Test extends TestCase {
 
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wp_query        = Mockery::mock( WP_Query::class );
-		$wp_query->posts = [];
-		$wp_query->expects( 'get_posts' )->once()->andReturn( $posts );
+		$wp_query->posts = $posts;
 
 		Functions\expect( 'wp_list_pluck' )
 			->once()
@@ -107,46 +106,12 @@ class Admin_Columns_Cache_Integration_Test extends TestCase {
 	 */
 	public function test_fill_cache_with_non_post_query() {
 		global $wp_query;
-		global $per_page;
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$per_page = 10;
-
-		$posts = [
-			(object) [
-				'ID'          => 1,
-				'post_parent' => 0,
-			],
-		];
-
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$wp_query        = Mockery::mock( WP_Query::class );
-		$wp_query->posts = [];
-		$wp_query->expects( 'get_posts' )->once()->andReturn( $posts );
-
-		Functions\expect( '_prime_post_caches' )->once()->with( [ 1 ] );
-
-		$results = [ (object) [ 'object_id' => 1 ] ];
-
-		$this->indexable_repository->expects( 'find_by_multiple_ids_and_type' )->once()->with( [ 1 ], 'post', false )->andReturn( $results );
-
-		$this->instance->fill_cache();
-	}
-
-	/**
-	 * Tests the fill_cache function.
-	 *
-	 * @covers ::__construct
-	 * @covers ::fill_cache
-	 */
-	public function test_fill_cache_with_no_results() {
-		global $wp_query;
 
 		$posts = [];
 
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wp_query        = Mockery::mock( WP_Query::class );
-		$wp_query->posts = [];
-		$wp_query->expects( 'get_posts' )->once()->andReturn( $posts );
+		$wp_query->posts = $posts;
 
 		$this->instance->fill_cache();
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes https://github.com/Yoast/wordpress-seo/issues/16812
* Fixes https://yoast.atlassian.net/browse/QAK-2911
* Prevents indexable caching on every ajax call
* Prevents building of seemingly random indexable caches

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where unrelated post queries were being done on ajax calls.
* Improves performance if the main query does not return posts.

## Relevant technical choices:

In the current behavior, you can observe that an ajax heartbeat request will enter the `fill_cache()` method without any posts in the main query. And because of `$wp_query->get_posts` we will query for the 10 most recent posts and put them in the indexable cache. This seems useless on heartbeat requests as that cache is not used at all.

This behavior would be fixed by any of the following 2 changes I did. But for completeness sake I did both changes, as I did not see the use for any of them. However, this should be verified by someone who has built with this code.

#### Removal of hook
I removed the hook on `admin_init` if we're in admin ajax. If that is really needed, I think there should be better conditionals, as in its current state, it was triggering on all admin ajax requests (like heartbeat), while this class is in the admin-columns context. 

#### Check if no posts return from main query
I introduced a check in the `fill_cache()` method that checks if the main query returned any posts. The current behavior caused a new query to be fired if the main query did not contain any posts. I feel like this new query was redundant as the main query was clearly not returning posts, so there was no reason to get seemingly random posts to cache.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

The changes are not immediately noticeable on the frontend, as they apply to the building of a cache.
* Put a breakpoint at the start of the `fill_cache()` method and have a browser open on the dashboard of your website.
* Have the network tab of the inspector open and await a call to admin-ajax.php. This is a timed-interval heartbeat request from WordPress, and it should not trigger the breakpoint with this PR.
* Navigate to your posts overview page. The breakpoint should trigger. Step forward and confirm that we skip the return conditional. After `$posts    = $wp_query->posts;`, confirm that `$posts` contains the posts that are / should be visible on your posts overview page (you can verify the first and last post in the array correspond to the first and last post on the overview page).

Extra test instructions added by @johannadevos following a meeting with @herregroen:
* On the posts overview, test whether pagination and quick edit still work as expected.
* Do this with Query Monitor enabled and verify that no more than 1 query is executed.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

The changes are not immediately noticeable on the frontend, as they apply to the building of a cache. Instead, make sure that no ajax-related calls break:
- Verify that editing posts, pages and taxonomies via the `quick-edit` function still work.
- Verify that creating and publishing a new post still works as intended.
- Verify that all columns on the posts overview page, that are added by Yoast, are correctly returning their corresponding values.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #16812