### PR TITLE
QAK-2961 Workouts improvements

### DIFF
--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -27,7 +27,7 @@ $container->register( WPSEO_Replace_Vars::class, WPSEO_Replace_Vars::class )->se
 $container->register( WPSEO_Admin_Asset_Manager::class, WPSEO_Admin_Asset_Manager::class )->setFactory( [ Wrapper::class, 'get_admin_asset_manager' ] )->setPublic( true );
 $container->register( Yoast_Notification_Center::class, Yoast_Notification_Center::class )->setFactory( [ Yoast_Notification_Center::class, 'get' ] )->setPublic( true );
 $container->register( WPSEO_Addon_Manager::class, WPSEO_Addon_Manager::class )->setFactory( [ Wrapper::class, 'get_addon_manager' ] )->setPublic( true );
-$container->register( WPSEO_Shortlinker::class, WPSEO_Shortlinker::class )->setFactory( [ Wrapper::class, 'get_addon_manager' ] )->setPublic( true );
+$container->register( WPSEO_Shortlinker::class, WPSEO_Shortlinker::class )->setFactory( [ Wrapper::class, 'get_shortlinker' ] )->setPublic( true );
 
 // Backwards-compatibility classes in the global namespace.
 $container->register( WPSEO_Breadcrumbs::class, WPSEO_Breadcrumbs::class )->setAutowired( true )->setPublic( true );

--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -8,6 +8,7 @@ use WPSEO_Breadcrumbs;
 use WPSEO_Addon_Manager;
 use WPSEO_Frontend;
 use WPSEO_Replace_Vars;
+use WPSEO_Shortlinker;
 use Yoast\WP\Lib\Migrations\Adapter;
 use Yoast\WP\SEO\WordPress\Wrapper;
 use Yoast_Notification_Center;
@@ -26,6 +27,7 @@ $container->register( WPSEO_Replace_Vars::class, WPSEO_Replace_Vars::class )->se
 $container->register( WPSEO_Admin_Asset_Manager::class, WPSEO_Admin_Asset_Manager::class )->setFactory( [ Wrapper::class, 'get_admin_asset_manager' ] )->setPublic( true );
 $container->register( Yoast_Notification_Center::class, Yoast_Notification_Center::class )->setFactory( [ Yoast_Notification_Center::class, 'get' ] )->setPublic( true );
 $container->register( WPSEO_Addon_Manager::class, WPSEO_Addon_Manager::class )->setFactory( [ Wrapper::class, 'get_addon_manager' ] )->setPublic( true );
+$container->register( WPSEO_Shortlinker::class, WPSEO_Shortlinker::class )->setFactory( [ Wrapper::class, 'get_addon_manager' ] )->setPublic( true );
 
 // Backwards-compatibility classes in the global namespace.
 $container->register( WPSEO_Breadcrumbs::class, WPSEO_Breadcrumbs::class )->setAutowired( true )->setPublic( true );

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -585,17 +585,20 @@ body.folded .wpseo-admin-submit-fixed {
   margin-right: 8px;
 }
 
-.yoast-badge {
+#wpadminbar .yoast-badge, .yoast-badge {
 	display: inline-block;
-	min-height: 16px;
 	padding: 0 8px;
 	border-radius: 8px;
 	font-weight: 600;
-	font-size: 10px;
 	line-height: 1.6;
 }
 
-.wp-submenu .yoast-badge {
+.yoast-badge {
+	min-height: 16px;
+	font-size: 10px;
+}
+
+#wpadminbar .yoast-badge, .wp-submenu .yoast-badge {
 	min-height: 14px;
 	font-size: 9px;
 }

--- a/packages/js/src/components/CollapsibleCornerstone.js
+++ b/packages/js/src/components/CollapsibleCornerstone.js
@@ -1,4 +1,5 @@
 import { __ } from "@wordpress/i18n";
+import { Slot } from "@wordpress/components";
 import { HelpText } from "@yoast/components";
 import { join, makeOutboundLink } from "@yoast/helpers";
 import PropTypes from "prop-types";
@@ -32,6 +33,7 @@ export default function CollapsibleCornerstone( { isCornerstone, onChange, learn
 				isEnabled={ isCornerstone }
 				onToggle={ onChange }
 			/>
+			<Slot name="YoastAfterCornerstoneToggle" />
 		</Collapsible>
 	);
 }

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -401,43 +401,6 @@ class Indexable_Repository {
 	}
 
 	/**
-	 * Finds the indexables that are cornerstones.
-	 *
-	 * @param int $limit The maximum amount of indexables to return.
-	 *
-	 * @return Indexable[] The found indexables.
-	 */
-	public function find_cornerstones( $limit = 20 ) {
-		$indexables = $this
-			->query()
-			->where( 'is_cornerstone', true )
-			->limit( $limit )
-			->find_many();
-
-		return \array_map( [ $this, 'ensure_permalink' ], $indexables );
-	}
-
-	/**
-	 * Finds the indexables with the most incoming links.
-	 *
-	 * @param int $limit The maximum amount of indexables to return.
-	 *
-	 * @return Indexable[] The found indexables.
-	 */
-	public function find_with_most_incoming_links( $limit = 20 ) {
-		$indexables = $this
-			->query()
-			->where_raw( 'object_sub_type NOT IN ( \'attachment\' ) OR post_status IS NULL' )
-			->where_raw( 'post_status NOT IN ( \'draft\', \'auto-draft\' ) OR post_status IS NULL' )
-			->where_in( 'object_type', [ 'term', 'post' ] )
-			->order_by_desc( 'incoming_link_count' )
-			->limit( $limit )
-			->find_many();
-
-		return \array_map( [ $this, 'ensure_permalink' ], $indexables );
-	}
-
-	/**
 	 * Returns all ancestors of a given indexable.
 	 *
 	 * @param Indexable $indexable The indexable to find the ancestors of.
@@ -515,7 +478,7 @@ class Indexable_Repository {
 	 *
 	 * @return bool|Indexable The indexable.
 	 */
-	protected function ensure_permalink( $indexable ) {
+	public function ensure_permalink( $indexable ) {
 		if ( $indexable && $indexable->permalink === null ) {
 			$indexable->permalink = $this->permalink_helper->get_permalink_for_indexable( $indexable );
 

--- a/src/wordpress/wrapper.php
+++ b/src/wordpress/wrapper.php
@@ -6,6 +6,7 @@ use wpdb;
 use WPSEO_Admin_Asset_Manager;
 use WPSEO_Replace_Vars;
 use WPSEO_Addon_Manager;
+use WPSEO_Shortlinker;
 
 /**
  * Wrapper class for WordPress globals.
@@ -50,5 +51,14 @@ class Wrapper {
 	 */
 	public static function get_addon_manager() {
 		return new WPSEO_Addon_Manager();
+	}
+
+	/**
+	 * Factory function for the shortlinker.
+	 *
+	 * @return WPSEO_Shortlinker
+	 */
+	public static function get_shortlinker() {
+		return new WPSEO_Shortlinker();
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Includes a few improvements needed in Premium.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes sure the badge styling can also be used in the admin bar menu.
* Adds a Slot below the cornerstone toggle

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Fixes https://yoast.atlassian.net/browse/QAK-2961


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities