### PR TITLE
[QAK-2956] Allow the admin menu to display submenus with different capabilities

### DIFF
--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -24,45 +24,48 @@ class WPSEO_Admin_Menu extends WPSEO_Base_Menu {
 	 * Registers the menu item submenus.
 	 */
 	public function register_settings_page() {
-		$can_manage_options = $this->check_manage_capability();
-
-		if ( $can_manage_options ) {
-			/*
-			 * The current user has the capability to control anything.
-			 * This means that all submenus and dashboard can be shown.
-			 */
-			global $admin_page_hooks;
-
-			add_menu_page(
-				'Yoast SEO: ' . __( 'Dashboard', 'wordpress-seo' ),
-				__( 'SEO', 'wordpress-seo' ) . ' ' . $this->get_notification_counter(),
-				$this->get_manage_capability(),
-				$this->get_page_identifier(),
-				$this->get_admin_page_callback(),
-				$this->get_icon_svg(),
-				'99.31337'
-			);
-
-			// Wipe notification bits from hooks.
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride -- This is a deliberate action.
-			$admin_page_hooks[ $this->get_page_identifier() ] = 'seo';
-		}
+		$manage_capability = $this->get_manage_capability();
+		$page_identifier = $this->get_page_identifier();
+		$admin_page_callback = $this->get_admin_page_callback();
 
 		// Get all submenu pages.
 		$submenu_pages = $this->get_submenu_pages();
 
-		// Add submenu items to the main menu if possible.
-		if ( $can_manage_options ) {
-			$this->register_submenu_pages( $submenu_pages );
+		foreach ( $submenu_pages as $submenu_page ){
+			if ( WPSEO_Capability_Utils::current_user_can( $submenu_page[3] ) ) {
+				$manage_capability = $submenu_page[3];
+				$page_identifier = $submenu_page[4];
+				$admin_page_callback = $submenu_page[5];
+				break;
+			}
+		}
+
+		foreach ( $submenu_pages as $index => $submenu_page ) {
+			$submenu_pages[$index][0] = $page_identifier;
 		}
 
 		/*
-		 * If the user does not have the general manage options capability,
-		 * we need to make sure the desired sub-item can be reached.
+		 * The current user has the capability to control anything.
+		 * This means that all submenus and dashboard can be shown.
 		 */
-		if ( ! $can_manage_options ) {
-			$this->register_menu_pages( $submenu_pages );
-		}
+		global $admin_page_hooks;
+
+		add_menu_page(
+			'Yoast SEO: ' . __( 'Dashboard', 'wordpress-seo' ),
+			__( 'SEO', 'wordpress-seo' ) . ' ' . $this->get_notification_counter(),
+			$manage_capability,
+			$page_identifier,
+			$admin_page_callback,
+			$this->get_icon_svg(),
+			'99.31337'
+		);
+
+		// Wipe notification bits from hooks.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride -- This is a deliberate action.
+		$admin_page_hooks[ $page_identifier ] = 'seo';
+
+		// Add submenu items to the main menu if possible.
+		$this->register_submenu_pages( $submenu_pages );
 	}
 
 	/**

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -24,24 +24,24 @@ class WPSEO_Admin_Menu extends WPSEO_Base_Menu {
 	 * Registers the menu item submenus.
 	 */
 	public function register_settings_page() {
-		$manage_capability = $this->get_manage_capability();
-		$page_identifier = $this->get_page_identifier();
+		$manage_capability   = $this->get_manage_capability();
+		$page_identifier     = $this->get_page_identifier();
 		$admin_page_callback = $this->get_admin_page_callback();
 
 		// Get all submenu pages.
 		$submenu_pages = $this->get_submenu_pages();
 
-		foreach ( $submenu_pages as $submenu_page ){
+		foreach ( $submenu_pages as $submenu_page ) {
 			if ( WPSEO_Capability_Utils::current_user_can( $submenu_page[3] ) ) {
-				$manage_capability = $submenu_page[3];
-				$page_identifier = $submenu_page[4];
+				$manage_capability   = $submenu_page[3];
+				$page_identifier     = $submenu_page[4];
 				$admin_page_callback = $submenu_page[5];
 				break;
 			}
 		}
 
 		foreach ( $submenu_pages as $index => $submenu_page ) {
-			$submenu_pages[$index][0] = $page_identifier;
+			$submenu_pages[ $index ][0] = $page_identifier;
 		}
 
 		/*
@@ -65,7 +65,7 @@ class WPSEO_Admin_Menu extends WPSEO_Base_Menu {
 		$admin_page_hooks[ $page_identifier ] = 'seo';
 
 		// Add submenu items to the main menu if possible.
-		$this->register_submenu_pages( $submenu_pages );
+		$this->register_submenu_pages( $submenu_pages, $page_identifier );
 	}
 
 	/**

--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -65,7 +65,7 @@ class WPSEO_Admin_Menu extends WPSEO_Base_Menu {
 		$admin_page_hooks[ $page_identifier ] = 'seo';
 
 		// Add submenu items to the main menu if possible.
-		$this->register_submenu_pages( $submenu_pages, $page_identifier );
+		$this->register_submenu_pages( $submenu_pages );
 	}
 
 	/**

--- a/admin/menu/class-base-menu.php
+++ b/admin/menu/class-base-menu.php
@@ -85,7 +85,7 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 	 *
 	 * @return void
 	 */
-	protected function register_submenu_pages( $submenu_pages ) {
+	protected function register_submenu_pages( $submenu_pages, $page_identifier = null ) {
 		if ( ! is_array( $submenu_pages ) || empty( $submenu_pages ) ) {
 			return;
 		}
@@ -95,9 +95,12 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 
 		// Set the first submenu title to the title of the first submenu page.
 		global $submenu;
-		if ( isset( $submenu[ $this->get_page_identifier() ] ) && $this->check_manage_capability() ) {
+		if ( ! $page_identifier ) {
+			$page_identifier = $this->get_page_identifier();
+		}
+		if ( isset( $submenu[ $page_identifier ] ) ) {
 			// phpcs:ignore WordPress.WP.GlobalVariablesOverride -- This is a deliberate action.
-			$submenu[ $this->get_page_identifier() ][0][0] = $submenu_pages[0][2];
+			$submenu[ $page_identifier ][0][0] = $submenu_pages[0][2];
 		}
 	}
 

--- a/admin/menu/class-base-menu.php
+++ b/admin/menu/class-base-menu.php
@@ -85,23 +85,13 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 	 *
 	 * @return void
 	 */
-	protected function register_submenu_pages( $submenu_pages, $page_identifier = null ) {
+	protected function register_submenu_pages( $submenu_pages ) {
 		if ( ! is_array( $submenu_pages ) || empty( $submenu_pages ) ) {
 			return;
 		}
 
 		// Loop through submenu pages and add them.
 		array_walk( $submenu_pages, [ $this, 'register_submenu_page' ] );
-
-		// Set the first submenu title to the title of the first submenu page.
-		global $submenu;
-		if ( ! $page_identifier ) {
-			$page_identifier = $this->get_page_identifier();
-		}
-		if ( isset( $submenu[ $page_identifier ] ) ) {
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride -- This is a deliberate action.
-			$submenu[ $page_identifier ][0][0] = $submenu_pages[0][2];
-		}
 	}
 
 	/**

--- a/admin/menu/class-base-menu.php
+++ b/admin/menu/class-base-menu.php
@@ -188,9 +188,6 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 
 		$page_title .= ' - Yoast SEO';
 
-		// Force the general manage capability to be used.
-		$submenu_page[3] = $this->get_manage_capability();
-
 		// Register submenu page.
 		$hook_suffix = add_submenu_page(
 			$submenu_page[0],


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allows the admin menu to display submenus with different capabilities such as the workouts.
* 
## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have a user that only has permission to see the workouts.
* The workouts should be under the SEO menu.
* Have a user that only has permission to manage redirects and workouts.
* Both should be under the SEO menu.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The display of Yoast SEO submenu items if the user can not access the SEO dashboard.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/QAK-2956