### PR TITLE
Add custom css for premium badges in admin / adminbar menu

### DIFF
--- a/src/integrations/admin/menu-badge-integration.php
+++ b/src/integrations/admin/menu-badge-integration.php
@@ -31,8 +31,8 @@ class Menu_Badge_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function add_inline_styles() {
-		$custom_css = 'ul.wp-submenu span.yoast-premium-badge::after, #wpadminbar span.yoast-premium-badge::after { content:' .
-			__( '"Premium"', 'wordpress-seo' ) . '}';
+		$custom_css = 'ul.wp-submenu span.yoast-premium-badge::after, #wpadminbar span.yoast-premium-badge::after { content:"' .
+			__( 'Premium', 'wordpress-seo' ) . '"}';
 		\wp_add_inline_style( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-global', $custom_css );
 	}
 }

--- a/src/integrations/admin/menu-badge-integration.php
+++ b/src/integrations/admin/menu-badge-integration.php
@@ -22,7 +22,7 @@ class Menu_Badge_Integration implements Integration_Interface {
 	 * {@inheritDoc}
 	 */
 	public function register_hooks() {
-		\add_action( 'admin_enqueue_scripts', [ $this, 'add_inline_styles'] );
+		\add_action( 'admin_enqueue_scripts', [ $this, 'add_inline_styles' ] );
 	}
 
 	/**

--- a/src/integrations/admin/menu-badge-integration.php
+++ b/src/integrations/admin/menu-badge-integration.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Menu_Badge_Integration class.
+ */
+class Menu_Badge_Integration implements Integration_Interface {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_conditionals() {
+		return [ Admin_Conditional::class ];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register_hooks() {
+		\add_action( 'admin_enqueue_scripts', [ $this, 'add_inline_styles'] );
+	}
+
+	/**
+	 * Renders the migration error.
+	 *
+	 * @return void
+	 */
+	public function add_inline_styles() {
+		$custom_css = 'ul.wp-submenu span.yoast-premium-badge::after, #wpadminbar span.yoast-premium-badge::after { content:' .
+			__( '"Premium"', 'wordpress-seo' ) . '}';
+		\wp_add_inline_style( WPSEO_Admin_Asset_Manager::PREFIX . 'admin-global', $custom_css );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds custom CSS which adds the "Premium" content to the Premium badge in admin and adminbar menus

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds custom CSS which adds the "Premium" content to the Premium badge in admin and adminbar menus

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This fixes a bug where the word "Premium" ended up in the title of the redirects manager in Yoast SEO Premium. Test this with the newest RC of Premium.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities