### PR TITLE
Changed get_feature_flag method from public to protected again.

### DIFF
--- a/src/conditionals/addon-installation-conditional.php
+++ b/src/conditionals/addon-installation-conditional.php
@@ -13,7 +13,7 @@ class Addon_Installation_Conditional extends Feature_Flag_Conditional {
 	 *
 	 * @return string the name of the feature flag.
 	 */
-	public function get_feature_flag() {
+	protected function get_feature_flag() {
 		return 'ADDON_INSTALLATION';
 	}
 }

--- a/src/conditionals/feature-flag-conditional.php
+++ b/src/conditionals/feature-flag-conditional.php
@@ -24,5 +24,14 @@ abstract class Feature_Flag_Conditional implements Conditional {
 	 *
 	 * @return string the name of the feature flag.
 	 */
-	abstract public function get_feature_flag();
+	abstract protected function get_feature_flag();
+
+	/**
+	 * Returns the feature name.
+	 *
+	 * @return string the name of the feature flag.
+	 */
+	public function get_feature_name() {
+		return $this->get_feature_flag();
+	}
 }

--- a/src/conditionals/schema-blocks-conditional.php
+++ b/src/conditionals/schema-blocks-conditional.php
@@ -13,7 +13,7 @@ class Schema_Blocks_Conditional extends Feature_Flag_Conditional {
 	 *
 	 * @return string the name of the feature flag.
 	 */
-	public function get_feature_flag() {
+	protected function get_feature_flag() {
 		return 'SCHEMA_BLOCKS';
 	}
 }

--- a/src/integrations/feature-flag-integration.php
+++ b/src/integrations/feature-flag-integration.php
@@ -73,7 +73,7 @@ class Feature_Flag_Integration implements Integration_Interface {
 		$enabled_features = [];
 		foreach ( $this->feature_flags as $feature_flag ) {
 			if ( $feature_flag->is_met() ) {
-				$enabled_features[] = $feature_flag->get_feature_flag();
+				$enabled_features[] = $feature_flag->get_feature_name();
 			}
 		}
 

--- a/tests/unit/integrations/feature-flag-integration-test.php
+++ b/tests/unit/integrations/feature-flag-integration-test.php
@@ -116,7 +116,7 @@ class Feature_Flag_Integration_Test extends TestCase {
 		$schema_blocks_conditional = \Mockery::mock( Schema_Blocks_Conditional::class );
 
 		$schema_blocks_conditional
-			->expects( 'get_feature_flag' )
+			->expects( 'get_feature_name' )
 			->andReturn( 'SCHEMA_BLOCKS' );
 
 		$schema_blocks_conditional
@@ -151,7 +151,7 @@ class Feature_Flag_Integration_Test extends TestCase {
 		$feature_flag_1 = \Mockery::mock( Feature_Flag_Conditional::class );
 
 		$feature_flag_1
-			->expects( 'get_feature_flag' )
+			->expects( 'get_feature_name' )
 			->andReturn( 'FEATURE_1' );
 
 		$feature_flag_1
@@ -194,7 +194,7 @@ class Feature_Flag_Integration_Test extends TestCase {
 		$feature_flag_1 = \Mockery::mock( Feature_Flag_Conditional::class );
 
 		$feature_flag_1
-			->expects( 'get_feature_flag' )
+			->expects( 'get_feature_name' )
 			->andReturn( 'FEATURE_1' );
 
 		$feature_flag_1
@@ -238,7 +238,7 @@ class Feature_Flag_Integration_Test extends TestCase {
 		$feature_flag_1 = \Mockery::mock( Feature_Flag_Conditional::class );
 
 		$feature_flag_1
-			->expects( 'get_feature_flag' )
+			->expects( 'get_feature_name' )
 			->andReturn( 'FEATURE_1' );
 
 		$feature_flag_1
@@ -283,7 +283,7 @@ class Feature_Flag_Integration_Test extends TestCase {
 		$feature_flag_1 = \Mockery::mock( Feature_Flag_Conditional::class );
 
 		$feature_flag_1
-			->expects( 'get_feature_flag' )
+			->expects( 'get_feature_name' )
 			->andReturn( 'FEATURE_1' );
 
 		$feature_flag_1


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where WordPress would crash with a fatal error when Yoast SEO would be used in tandem with Yoast SEO Premium <= 16.4.

## Relevant technical choices:

* It broke because the `get_feature_flag` method's visibility was changed from `protected` to `public`: a change that broke backwards compatibility.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install WordPress SEO Premium 16.4.
* Install this version of the WordPress SEO plugin
	* Either by checking out this branch or using the appropriate RC-zip.
* WordPress should **not** crash because of this fatal error:
<img width="787" alt="Screenshot 2021-06-28 at 14 48 25" src="https://user-images.githubusercontent.com/10195175/123654691-9849ca00-d82e-11eb-8a02-4e8cb4bc5b45.png">

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
