### PR TITLE
Make sure the schema blocks analysis is rendered in both the metabox and the sidebar

### DIFF
--- a/packages/js/src/components/SchemaTab.js
+++ b/packages/js/src/components/SchemaTab.js
@@ -125,7 +125,7 @@ const Content = ( props ) => {
 	return (
 		<Fragment>
 			{ schemaBlocksEnabled ? <SchemaBlocksHeader { ...props } /> : <Header { ...props } /> }
-			{ schemaBlocksEnabled && <Slot name="YoastSchemaBlocksAnalysis" /> }
+			{ schemaBlocksEnabled && <Slot name={ join( [ "yoast-schema-blocks-analysis", props.location ] ) } /> }
 			<FieldGroup
 				label={ __( "What type of page or content is this?", "wordpress-seo" ) }
 				linkTo={ props.additionalHelpTextLink }

--- a/packages/schema-blocks/src/functions/initialize.tsx
+++ b/packages/schema-blocks/src/functions/initialize.tsx
@@ -1,7 +1,7 @@
 import "../instructions";
 import { registerBlockType } from "@wordpress/blocks";
 import { Fill } from "@wordpress/components";
-import { createElement } from "@wordpress/element";
+import { createElement, Fragment } from "@wordpress/element";
 import { registerPlugin } from "@wordpress/plugins";
 
 import { initializeSchemaBlocksStore } from "./redux";
@@ -78,9 +78,16 @@ export function initialize( logLevel: LogLevel = LogLevel.ERROR ): void {
 	 */
 	const SchemaAnalysisFill = (): React.ReactElement => {
 		return (
-			<Fill name="YoastSchemaBlocksAnalysis">
-				<SchemaAnalysis />
-			</Fill>
+			<Fragment>
+				{ [ "sidebar", "metabox" ].map( location => (
+					<Fill
+						key={ location }
+						name={ [ "yoast-schema-blocks-analysis", location ].join( "-" ) }
+					>
+						<SchemaAnalysis />
+					</Fill>
+				) ) }
+			</Fragment>
 		);
 	};
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the schema blocks analysis is shown in either the sidebar or the metabox, not both.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure the `YOAST_SEO_SCHEMA_BLOCKS` feature flag is active.
* Create a new post in the block editor.
* Open the schema analysis in both the metabox and the sidebar.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
