### PR TITLE
Dont throw exception when no key is provided in abstract indexable tag presenter

### DIFF
--- a/src/presenters/abstract-indexable-presenter.php
+++ b/src/presenters/abstract-indexable-presenter.php
@@ -59,6 +59,15 @@ abstract class Abstract_Indexable_Presenter extends Abstract_Presenter {
 	}
 
 	/**
+	 * Returns the metafield's property key.
+	 *
+	 * @return string The property key.
+	 */
+	public function get_key() {
+		return $this->key;
+	}
+
+	/**
 	 * Replace replacement variables in a string.
 	 *
 	 * @param string $string The string.

--- a/src/presenters/abstract-indexable-tag-presenter.php
+++ b/src/presenters/abstract-indexable-tag-presenter.php
@@ -38,18 +38,11 @@ abstract class Abstract_Indexable_Tag_Presenter extends Abstract_Indexable_Prese
 	public function present() {
 		$value = $this->get();
 
-		if ( $this->key === 'NO KEY PROVIDED' ) {
-			/**
-			 * Required for backwards compatability with add-ons in which we override this class and define the key in the tag_format.
-			 */
-			return \sprintf( $this->tag_format, $this->escape_value( $value ) );
+		if ( ! \is_string( $value ) || $value === '' ) {
+			return '';
 		}
 
-		if ( \is_string( $value ) && $value !== '' ) {
-			return \sprintf( $this->tag_format, $this->escape_value( $value ), $this->key );
-		}
-
-		return '';
+		return \sprintf( $this->tag_format, $this->escape_value( $value ), $this->key );
 	}
 
 	/**

--- a/src/presenters/abstract-indexable-tag-presenter.php
+++ b/src/presenters/abstract-indexable-tag-presenter.php
@@ -32,8 +32,6 @@ abstract class Abstract_Indexable_Tag_Presenter extends Abstract_Indexable_Prese
 	 * Returns a tag in the head.
 	 *
 	 * @return string The tag.
-	 *
-	 * @throws \InvalidArgumentException When a subclass does not define a key property. This should appear during development.
 	 */
 	public function present() {
 		$value = $this->get();
@@ -42,6 +40,10 @@ abstract class Abstract_Indexable_Tag_Presenter extends Abstract_Indexable_Prese
 			return '';
 		}
 
+		/**
+		 * There may be some classes that are derived from this class that do not use the $key property
+		 * in their $tag_format string. In that case the key property will simply not be used.
+		 */
 		return \sprintf( $this->tag_format, $this->escape_value( $value ), $this->key );
 	}
 

--- a/src/presenters/abstract-indexable-tag-presenter.php
+++ b/src/presenters/abstract-indexable-tag-presenter.php
@@ -36,11 +36,14 @@ abstract class Abstract_Indexable_Tag_Presenter extends Abstract_Indexable_Prese
 	 * @throws \InvalidArgumentException When a subclass does not define a key property. This should appear during development.
 	 */
 	public function present() {
-		if ( $this->key === 'NO KEY PROVIDED' ) {
-			throw new \InvalidArgumentException( \get_class( $this ) . ' is an Abstract_Indexable_Presenter but does not override the key property.' );
-		}
-
 		$value = $this->get();
+
+		if ( $this->key === 'NO KEY PROVIDED' ) {
+			/**
+			 * Required for backwards compatability with add-ons in which we override this class and define the key in the tag_format.
+			 */
+			return \sprintf( $this->tag_format, $this->escape_value( $value ) );
+		}
 
 		if ( \is_string( $value ) && $value !== '' ) {
 			return \sprintf( $this->tag_format, $this->escape_value( $value ), $this->key );

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -270,6 +270,10 @@ class Meta {
 	 * @return object
 	 */
 	protected function create_json_field( $presenter ) {
+		if ( $presenter->key === 'NO KEY PROVIDED' ) {
+			return null;
+		}
+
 		$value = $presenter->get();
 		if ( empty( $value ) ) {
 			return null;

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -270,7 +270,7 @@ class Meta {
 	 * @return object
 	 */
 	protected function create_json_field( $presenter ) {
-		if ( $presenter->key === 'NO KEY PROVIDED' ) {
+		if ( $presenter->get_key() === 'NO KEY PROVIDED' ) {
 			return null;
 		}
 


### PR DESCRIPTION

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In https://github.com/Yoast/wordpress-seo/pull/17162/files#diff-e0fbc64494e81172a60a7095550fda610afe7ac055178800a81c773c3c1930a1R39 we broke BC because add-ons that extended the class would not have a key property, but instead they output the meta-tag property directly in `$this->tag_format`. Instead of throwing an exception this PR makes sure that the tag is still output.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where fatal errors would occur in add-ons.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Video.
* Create a post containing a video.
* Open the post on the front page.
* Inspect that the Video SEO meta tags are output as expected.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
