### PR TITLE
[IM-456] Fix backwards compatibility of feature-flags

### DIFF
--- a/packages/feature-flag/src/index.js
+++ b/packages/feature-flag/src/index.js
@@ -6,8 +6,8 @@
  * @returns {boolean} `true` when the feature is enabled, `false` if not.
  */
 const isFeatureEnabled = function( featureName ) {
-	if ( self.wpseoFeaturesL10n ) {
-		return self.wpseoFeaturesL10n.includes( featureName );
+	if ( self.wpseoFeatureFlags ) {
+		return self.wpseoFeatureFlags.includes( featureName );
 	}
 	return false;
 };
@@ -21,14 +21,14 @@ const isFeatureEnabled = function( featureName ) {
  */
 const enableFeatures = function( featureNames ) {
 	// If no features have been enabled yet, initialize the global array.
-	if ( ! self.wpseoFeaturesL10n ) {
-		self.wpseoFeaturesL10n = [];
+	if ( ! self.wpseoFeatureFlags ) {
+		self.wpseoFeatureFlags = [];
 	}
 
 	// Check whether the features are already enabled, if not: add them.
 	featureNames.forEach( name => {
-		if ( ! self.wpseoFeaturesL10n.includes( name ) ) {
-			self.wpseoFeaturesL10n.push( name );
+		if ( ! self.wpseoFeatureFlags.includes( name ) ) {
+			self.wpseoFeatureFlags.push( name );
 		}
 	} );
 };
@@ -39,7 +39,7 @@ const enableFeatures = function( featureNames ) {
  * @returns {string[]} The list of enabled features.
  */
 const enabledFeatures = function() {
-	return self.wpseoFeaturesL10n || [];
+	return self.wpseoFeatureFlags || [];
 };
 
 

--- a/packages/feature-flag/src/index.js
+++ b/packages/feature-flag/src/index.js
@@ -6,8 +6,8 @@
  * @returns {boolean} `true` when the feature is enabled, `false` if not.
  */
 const isFeatureEnabled = function( featureName ) {
-	if ( self.wpseoFeatureFlags ) {
-		return self.wpseoFeatureFlags.includes( featureName );
+	if ( self.wpseoFeaturesL10n ) {
+		return self.wpseoFeaturesL10n.includes( featureName );
 	}
 	return false;
 };
@@ -21,14 +21,14 @@ const isFeatureEnabled = function( featureName ) {
  */
 const enableFeatures = function( featureNames ) {
 	// If no features have been enabled yet, initialize the global array.
-	if ( ! self.wpseoFeatureFlags ) {
-		self.wpseoFeatureFlags = [];
+	if ( ! self.wpseoFeaturesL10n ) {
+		self.wpseoFeaturesL10n = [];
 	}
 
 	// Check whether the features are already enabled, if not: add them.
 	featureNames.forEach( name => {
-		if ( ! self.wpseoFeatureFlags.includes( name ) ) {
-			self.wpseoFeatureFlags.push( name );
+		if ( ! self.wpseoFeaturesL10n.includes( name ) ) {
+			self.wpseoFeaturesL10n.push( name );
 		}
 	} );
 };
@@ -39,7 +39,7 @@ const enableFeatures = function( featureNames ) {
  * @returns {string[]} The list of enabled features.
  */
 const enabledFeatures = function() {
-	return self.wpseoFeatureFlags || [];
+	return self.wpseoFeaturesL10n || [];
 };
 
 

--- a/src/integrations/feature-flag-integration.php
+++ b/src/integrations/feature-flag-integration.php
@@ -61,6 +61,8 @@ class Feature_Flag_Integration implements Integration_Interface {
 	 */
 	public function add_feature_flags() {
 		$enabled_features = $this->get_enabled_features();
+		// Localize under both names for BC.
+		$this->asset_manager->localize_script( 'feature-flag-package', 'wpseoFeatureFlags', $enabled_features );
 		$this->asset_manager->localize_script( 'feature-flag-package', 'wpseoFeaturesL10n', $enabled_features );
 	}
 

--- a/src/integrations/feature-flag-integration.php
+++ b/src/integrations/feature-flag-integration.php
@@ -61,7 +61,7 @@ class Feature_Flag_Integration implements Integration_Interface {
 	 */
 	public function add_feature_flags() {
 		$enabled_features = $this->get_enabled_features();
-		$this->asset_manager->localize_script( 'feature-flag-package', 'wpseoFeatureFlags', $enabled_features );
+		$this->asset_manager->localize_script( 'feature-flag-package', 'wpseoFeaturesL10n', $enabled_features );
 	}
 
 	/**

--- a/tests/unit/integrations/feature-flag-integration-test.php
+++ b/tests/unit/integrations/feature-flag-integration-test.php
@@ -110,6 +110,9 @@ class Feature_Flag_Integration_Test extends TestCase {
 
 		$this->asset_manager
 			->expects( 'localize_script' )
+			->with( 'feature-flag-package', 'wpseoFeaturesL10n', $expected_enabled_feature_flags );
+		$this->asset_manager
+			->expects( 'localize_script' )
 			->with( 'feature-flag-package', 'wpseoFeatureFlags', $expected_enabled_feature_flags );
 
 		// Mock a feature flag, in this case the Schema_Blocks_Conditional, to be set.
@@ -143,6 +146,9 @@ class Feature_Flag_Integration_Test extends TestCase {
 	public function test_add_feature_flags_not_met() {
 		$expected_enabled_feature_flags = [ 'FEATURE_1' ];
 
+		$this->asset_manager
+			->expects( 'localize_script' )
+			->with( 'feature-flag-package', 'wpseoFeaturesL10n', $expected_enabled_feature_flags );
 		$this->asset_manager
 			->expects( 'localize_script' )
 			->with( 'feature-flag-package', 'wpseoFeatureFlags', $expected_enabled_feature_flags );
@@ -188,6 +194,9 @@ class Feature_Flag_Integration_Test extends TestCase {
 
 		$this->asset_manager
 			->expects( 'localize_script' )
+			->with( 'feature-flag-package', 'wpseoFeaturesL10n', $expected_enabled_feature_flags );
+		$this->asset_manager
+			->expects( 'localize_script' )
 			->with( 'feature-flag-package', 'wpseoFeatureFlags', $expected_enabled_feature_flags );
 
 		// Mock a feature flag to be set.
@@ -230,6 +239,9 @@ class Feature_Flag_Integration_Test extends TestCase {
 		$currently_enabled_feature_flags = [ 'FEATURE_1' ];
 		$expected_enabled_feature_flags  = [];
 
+		$this->asset_manager
+			->expects( 'localize_script' )
+			->with( 'feature-flag-package', 'wpseoFeaturesL10n', $expected_enabled_feature_flags );
 		$this->asset_manager
 			->expects( 'localize_script' )
 			->with( 'feature-flag-package', 'wpseoFeatureFlags', $expected_enabled_feature_flags );
@@ -277,6 +289,9 @@ class Feature_Flag_Integration_Test extends TestCase {
 
 		$this->asset_manager
 			->expects( 'localize_script' )
+			->with( 'feature-flag-package', 'wpseoFeaturesL10n', $expected_enabled_feature_flags );
+		$this->asset_manager
+			->expects( 'localize_script' )
 			->with( 'feature-flag-package', 'wpseoFeatureFlags', $expected_enabled_feature_flags );
 
 		// Mock a feature flag to be set.
@@ -317,6 +332,9 @@ class Feature_Flag_Integration_Test extends TestCase {
 	public function test_add_feature_flags_non_available() {
 		$expected_enabled_feature_flags = [];
 
+		$this->asset_manager
+			->expects( 'localize_script' )
+			->with( 'feature-flag-package', 'wpseoFeaturesL10n', $expected_enabled_feature_flags );
 		$this->asset_manager
 			->expects( 'localize_script' )
 			->with( 'feature-flag-package', 'wpseoFeatureFlags', $expected_enabled_feature_flags );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where many Premium editor features would not work if Yoast SEO was updated to version 16.6 while Yoast SEO Premium was still on version 16.5 or lower.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Yoast SEO Premium 16.5 and Yoast SEO 16.6.1
* The related keyphrases feature should be working.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Feature flags in JavaScript.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/IM-456
