### PR TITLE
Add sentence beginning assessment for Slovak

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/languages/sk/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/sk/ResearcherSpec.js
@@ -4,6 +4,7 @@ import stopWords from "../../../../src/languageProcessing/languages/sk/config/st
 import functionWords from "../../../../src/languageProcessing/languages/sk/config/functionWords";
 import { allWords as transitionWords } from "../../../../src/languageProcessing/languages/sk/config/transitionWords";
 import twoPartTransitionWords from "../../../../src/languageProcessing/languages/sk/config/twoPartTransitionWords";
+import firstWordExceptions from "../../../../src/languageProcessing/languages/sk/config/firstWordExceptions";
 import getMorphologyData from "../../../specHelpers/getMorphologyData";
 
 const morphologyDataSK = getMorphologyData( "sk" );
@@ -26,6 +27,10 @@ describe( "a test for the Slovak Researcher", function() {
 
 	it( "returns Slovak stopwords", function() {
 		expect( researcher.getConfig( "stopWords" ) ).toEqual( stopWords );
+	} );
+
+	it( "returns Slovak first word exceptions", function() {
+		expect( researcher.getConfig( "firstWordExceptions" ) ).toEqual( firstWordExceptions );
 	} );
 
 	it( "returns the Slovak passive construction type", function() {

--- a/packages/yoastseo/src/languageProcessing/languages/sk/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/sk/Researcher.js
@@ -6,6 +6,7 @@ import stopWords from "./config/stopWords";
 import functionWords from "./config/functionWords";
 import { allWords as transitionWords } from "./config/transitionWords";
 import twoPartTransitionWords from "./config/twoPartTransitionWords";
+import firstWordExceptions from "./config/firstWordExceptions";
 
 // All helpers
 import getClauses from "./helpers/getClauses";
@@ -26,7 +27,6 @@ export default class Researcher extends AbstractResearcher {
 		// Deletes researches that are currently not available in Slovak.
 		// When the research is available, this line should be removed.
 		delete this.defaultResearches.getFleschReadingScore;
-		delete this.defaultResearches.getSentenceBeginnings;
 
 		Object.assign( this.config, {
 			language: "sk",
@@ -35,6 +35,7 @@ export default class Researcher extends AbstractResearcher {
 			functionWords,
 			transitionWords,
 			twoPartTransitionWords,
+			firstWordExceptions,
 		} );
 
 		Object.assign( this.helpers, {

--- a/packages/yoastseo/src/languageProcessing/languages/sk/config/firstWordExceptions.js
+++ b/packages/yoastseo/src/languageProcessing/languages/sk/config/firstWordExceptions.js
@@ -9,6 +9,6 @@ export default [
 	"jeden", "jedna", "jediný", "dva", "dvaja", "dve", "tri", "trojka", "traja", "štyri ", "štvoro", "štyria", "päť", "pät",
 	"šesť", "sedem", "osem", "deväť", "desať", "sto", "tisíc",
 	// Demonstrative pronouns:
-	"ten", "tá", "to", "tento ", "táto", "toto", "tamten", "tamtá", "tamto", "tí", "tie", "tieto", "toho", "tej", "tomu",
+	"ten", "tá", "to", "tento", "táto", "toto", "tamten", "tamtá", "tamto", "tí", "tie", "tieto", "toho", "tej", "tomu",
 	"tú", "tom", "tým", "tou", "tých", "tými", "títo", "tamtí", "tamtie", "tamtoho", "tomuto", "tohto",
 ];

--- a/packages/yoastseo/src/languageProcessing/languages/sk/config/firstWordExceptions.js
+++ b/packages/yoastseo/src/languageProcessing/languages/sk/config/firstWordExceptions.js
@@ -1,0 +1,14 @@
+/**
+ * Returns an array with exceptions for the sentence beginning researcher.
+ * @type {Array} The array filled with exceptions.
+ */
+export default [
+	// Indefinite pronouns:
+	"nejaký", "nejaká", "nejaké",
+	// Numbers 0-10, 100, 1000:
+	"jeden", "jedna", "jediný", "dva", "dvaja", "dve", "tri", "trojka", "traja", "štyri ", "štvoro", "štyria", "päť", "pät",
+	"šesť", "sedem", "osem", "deväť", "desať", "sto", "tisíc",
+	// Demonstrative pronouns:
+	"ten", "tá", "to", "tento ", "táto", "toto", "tamten", "tamtá", "tamto", "tí", "tie", "tieto", "toho", "tej", "tomu",
+	"tú", "tom", "tým", "tou", "tých", "tými", "títo", "tamtí", "tamtie", "tamtoho", "tomuto", "tohto",
+];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds the sentence beginnings assessment for Slovak.
* Implements the consecutive sentence beginnings assessment for Slovak to ensure variety in a text.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Test in Free**

* Enable the `SLOVAK_SUPPORT` feature by adding `define( 'YOAST_SEO_SLOVAK_SUPPORT', true );` in `basic-wordpress-config.php` file
* Set your website to Slovak.
* Create a new post and add three or more Slovak sentences:

> that all begin with the same written-out number, like `jeden` ("one" in masc. form)
E.g. `Jeden pisateľ o meditácii povedal: "Aby sme mohli vidieť veci jasne, naša myseľ musí byť prázdna.". Jeden prevádzkovateľ smie podať pri každej časti na každý základný výrobok len jednu žiadosť. Jeden kolega mi povedal: "Eugene, vďaka tebe sme nestratili dobré meno!".`

> that all begin with the same demonstrative pronoun, like tento ('this').
E.g. `Tento muž je Pedro. Tento článok nesmie ovplyvniť špecifickejšie pravidlá platné pre monitorovanie výživy zvierat. Tento nástroj sprevádza veľa nejasností.`
* In each of the above cases, the sentence beginning assessment should read: `Consecutive sentences: There is enough variety in your sentences. That's great!.`

* Write three or more Slovak sentences that begin with the same word.
E.g. `Mačky sú roztomilé. Mačky sú zlaté. Mačky sú anjeli.`

* The sentence beginning assessment should read: `Consecutive sentences: The text contains 3 consecutive sentences starting with the same word. Try to mix things up!.`

* Disable the `SLOVAK_SUPPORT` feature by adding `define( 'YOAST_SEO_SLOVAK_SUPPORT', false );` in `basic-wordpress-config.php` file
* Save the changes in the post
* Reload the page
* Confirm that the sentence beginning assessment doesn't appear in the metabox

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-885
