### PR TITLE
replace / with - in branch names during zip creation

### DIFF
--- a/config/jenkins/Jenkinsfile_artifact
+++ b/config/jenkins/Jenkinsfile_artifact
@@ -1,7 +1,6 @@
 node( 'docker-agent' ) {
 	checkout scm
 	env.GIT_COMMIT = sh(returnStdout: true, script: "git log -n 1 --pretty=format:'%h'")
-	echo "${env.GIT_COMMIT}"
 	docker.withServer( 'tcp://172.17.0.1:2375' ) {
 		def ubuntu = docker.image( 'yoastseo/docker-php-composer-node' )
 		ubuntu.pull()
@@ -17,8 +16,9 @@ node( 'docker-agent' ) {
 				sh 'grunt artifact'
 			}
 			stage( 'Expose Artifact' ) {
-				sh "BRANCH_NAME=\$(echo ${env.BRANCH_NAME} | sed -e s#/#-#) && mv artifact.zip wordpress-seo-\$BRANCH_NAME.zip"
-				archiveArtifacts artifacts: "wordpress-seo-${env.BRANCH_NAME}.zip", fingerprint: true
+				def BRANCH_NAME = sh(returnStdout: true, script: "echo ${env.BRANCH_NAME} | sed -e s#/#-# | tr --delete '\n'")
+				sh "mv artifact.zip wordpress-seo-${BRANCH_NAME}.zip"
+				archiveArtifacts artifacts: "wordpress-seo-${BRANCH_NAME}.zip", fingerprint: true
 			}
 		}
 	}

--- a/config/jenkins/Jenkinsfile_artifact
+++ b/config/jenkins/Jenkinsfile_artifact
@@ -17,8 +17,7 @@ node( 'docker-agent' ) {
 				sh 'grunt artifact'
 			}
 			stage( 'Expose Artifact' ) {
-				
-				sh "BRANCH_NAME=$(echo ${env.BRANCH_NAME} | sed -e s#/#-#) && mv artifact.zip wordpress-seo-\$BRANCH_NAME}.zip"
+				sh "BRANCH_NAME=\$(echo ${env.BRANCH_NAME} | sed -e s#/#-#) && mv artifact.zip wordpress-seo-\$BRANCH_NAME.zip"
 				archiveArtifacts artifacts: "wordpress-seo-${env.BRANCH_NAME}.zip", fingerprint: true
 			}
 		}

--- a/config/jenkins/Jenkinsfile_artifact
+++ b/config/jenkins/Jenkinsfile_artifact
@@ -17,7 +17,8 @@ node( 'docker-agent' ) {
 				sh 'grunt artifact'
 			}
 			stage( 'Expose Artifact' ) {
-				sh "mv artifact.zip wordpress-seo-${env.BRANCH_NAME}.zip"
+				
+				sh "BRANCH_NAME=$(echo ${env.BRANCH_NAME} | sed -e s#/#-#) && mv artifact.zip wordpress-seo-\$BRANCH_NAME}.zip"
 				archiveArtifacts artifacts: "wordpress-seo-${env.BRANCH_NAME}.zip", fingerprint: true
 			}
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The Branch names contains slashes which does not play nicely with path names, changed the zip creation to replace "/" with "-" to fix broken zip building in release branches

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changed the zip creation to replace "/" with "-" in branch name

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
