### PR TITLE
Added Meta_Tags_Context to wpseo_frontend_presenters filter

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -298,7 +298,7 @@ class Front_End_Integration implements Integration_Interface {
 	 */
 	public function present_head() {
 		$context    = $this->context_memoizer->for_current_page();
-		$presenters = $this->get_presenters( $context->page_type );
+		$presenters = $this->get_presenters( $context->page_type, $context );
 
 		/**
 		 * Filter 'wpseo_frontend_presentation' - Allow filtering the presentation used to output our meta values.
@@ -326,10 +326,11 @@ class Front_End_Integration implements Integration_Interface {
 	 * Returns all presenters for this page.
 	 *
 	 * @param string $page_type The page type.
+	 * @param Meta_Tags_Context $context The meta tags context.
 	 *
 	 * @return Abstract_Indexable_Presenter[] The presenters.
 	 */
-	public function get_presenters( $page_type ) {
+	public function get_presenters( $page_type, $context = null ) {
 		$needed_presenters = $this->get_needed_presenters( $page_type );
 
 		$callback   = static function( $presenter ) {
@@ -345,7 +346,7 @@ class Front_End_Integration implements Integration_Interface {
 		 *
 		 * @api Abstract_Indexable_Presenter[] List of presenter instances.
 		 */
-		$presenter_instances = \apply_filters( 'wpseo_frontend_presenters', $presenters );
+		$presenter_instances = \apply_filters( 'wpseo_frontend_presenters', $presenters, $context );
 
 		if ( ! \is_array( $presenter_instances ) ) {
 			$presenter_instances = $presenters;

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -298,7 +298,7 @@ class Front_End_Integration implements Integration_Interface {
 	 */
 	public function present_head() {
 		$context    = $this->context_memoizer->for_current_page();
-		$presenters = $this->get_presenters( $context->page_type, $context );
+		$presenters = $this->get_presenters( $context->page_type );
 
 		/**
 		 * Filter 'wpseo_frontend_presentation' - Allow filtering the presentation used to output our meta values.
@@ -330,7 +330,7 @@ class Front_End_Integration implements Integration_Interface {
 	 *
 	 * @return Abstract_Indexable_Presenter[] The presenters.
 	 */
-	public function get_presenters( $page_type, $context = null ) {
+	public function get_presenters( $page_type ) {
 		$needed_presenters = $this->get_needed_presenters( $page_type );
 
 		$callback   = static function( $presenter ) {
@@ -346,7 +346,7 @@ class Front_End_Integration implements Integration_Interface {
 		 *
 		 * @api Abstract_Indexable_Presenter[] List of presenter instances.
 		 */
-		$presenter_instances = \apply_filters( 'wpseo_frontend_presenters', $presenters, $context );
+		$presenter_instances = \apply_filters( 'wpseo_frontend_presenters', $presenters, $this->context_memoizer->for_current_page() );
 
 		if ( ! \is_array( $presenter_instances ) ) {
 			$presenter_instances = $presenters;

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Integrations;
 
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Request_Helper;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
@@ -326,7 +327,6 @@ class Front_End_Integration implements Integration_Interface {
 	 * Returns all presenters for this page.
 	 *
 	 * @param string            $page_type The page type.
-	 * @param Meta_Tags_Context $context   The meta tags context.
 	 *
 	 * @return Abstract_Indexable_Presenter[] The presenters.
 	 */
@@ -343,6 +343,9 @@ class Front_End_Integration implements Integration_Interface {
 
 		/**
 		 * Filter 'wpseo_frontend_presenters' - Allow filtering the presenter instances in or out of the request.
+		 *
+		 * @param $presenters array The presenters.
+		 * @param Meta_Tags_Context The meta tags context for the current page.
 		 *
 		 * @api Abstract_Indexable_Presenter[] List of presenter instances.
 		 */

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -326,7 +326,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * Returns all presenters for this page.
 	 *
-	 * @param string            $page_type The page type.
+	 * @param string $page_type The page type.
 	 *
 	 * @return Abstract_Indexable_Presenter[] The presenters.
 	 */

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -325,8 +325,8 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * Returns all presenters for this page.
 	 *
-	 * @param string $page_type The page type.
-	 * @param Meta_Tags_Context $context The meta tags context.
+	 * @param string            $page_type The page type.
+	 * @param Meta_Tags_Context $context   The meta tags context.
 	 *
 	 * @return Abstract_Indexable_Presenter[] The presenters.
 	 */

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -19,14 +19,14 @@ use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 class Yoast_Head_REST_Field implements Route_Interface {
 
 	/**
-	 * The name of the yoast head field.
+	 * The name of the Yoast head field.
 	 *
 	 * @var string
 	 */
 	const YOAST_HEAD_ATTRIBUTE_NAME = 'yoast_head';
 
 	/**
-	 * The name of the yoast head field.
+	 * The name of the Yoast head JSON field.
 	 *
 	 * @var string
 	 */

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -12,6 +12,7 @@ use Yoast\WP\SEO\Helpers\Request_Helper;
 use Yoast\WP\SEO\Integrations\Front_End_Integration;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
@@ -61,6 +62,25 @@ class Front_End_Integration_Test extends TestCase {
 	private $context_memoizer;
 
 	/**
+	 * @var Mockery\LegacyMockInterface|Mockery\MockInterface|Indexable_Presentation
+	 */
+	private $presentation;
+
+	/**
+	 * Represents the meta tags context.
+	 *
+	 * @var Mockery\LegacyMockInterface|Mockery\MockInterface|Meta_Tags_Context
+	 */
+	private $context;
+
+	/**
+	 * Represents the options helper.
+	 *
+	 * @var Mockery\LegacyMockInterface|Mockery\MockInterface|Abstract_Indexable_Presenter
+	 */
+	private $presenter;
+
+	/**
 	 * Method that runs before each test case.
 	 */
 	protected function set_up() {
@@ -82,6 +102,13 @@ class Front_End_Integration_Test extends TestCase {
 				Mockery::mock( WPSEO_Replace_Vars::class ),
 			]
 		)->makePartial();
+
+		// Set up mocks for classes which which are used in multiple tests.
+		$this->context      = Mockery::mock( Meta_Tags_Context::class );
+		$this->presenter    = Mockery::mock( Abstract_Indexable_Presenter::class );
+
+		$this->context->page_type    = 'page_type';
+		$this->context->presentation = $this->presentation;
 	}
 
 	/**
@@ -134,25 +161,18 @@ class Front_End_Integration_Test extends TestCase {
 	 * @covers ::present_head
 	 */
 	public function test_present_head() {
-		$presentation = Mockery::mock( Indexable_Presentation::class );
-		$context      = Mockery::mock( Meta_Tags_Context::class );
-		$presenter    = Mockery::mock( Abstract_Indexable_Presenter::class );
-
-		$context->page_type    = 'page_type';
-		$context->presentation = $presentation;
-
 		$this->context_memoizer
 			->expects( 'for_current_page' )
 			->once()
-			->andReturn( $context );
+			->andReturn( $this->context );
 
 		$this->instance
 			->expects( 'get_presenters' )
 			->once()
 			->with( 'page_type' )
-			->andReturn( [ $presenter ] );
+			->andReturn( [ $this->presenter ] );
 
-		$presenter
+		$this->presenter
 			->expects( 'present' )
 			->once()
 			->with()
@@ -177,6 +197,11 @@ class Front_End_Integration_Test extends TestCase {
 		$this->options->expects( 'get' )->with( 'opengraph' )->andReturnTrue();
 		$this->options->expects( 'get' )->with( 'twitter' )->andReturnTrue();
 		$this->options->expects( 'get' )->with( 'enable_enhanced_slack_sharing' )->andReturnTrue();
+
+		$this->context_memoizer
+			->expects( 'for_current_page' )
+			->once()
+			->andReturn( $this->context );
 
 		$expected = [
 			'Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter',
@@ -234,6 +259,11 @@ class Front_End_Integration_Test extends TestCase {
 			->with( 'opengraph' )
 			->andReturnTrue();
 
+		$this->context_memoizer
+			->expects( 'for_current_page' )
+			->once()
+			->andReturn( $this->context );
+
 		$callback = static function ( $presenter ) {
 			return \get_class( $presenter );
 		};
@@ -280,6 +310,11 @@ class Front_End_Integration_Test extends TestCase {
 			->expects( 'get' )
 			->with( 'enable_enhanced_slack_sharing' )
 			->andReturnTrue();
+
+		$this->context_memoizer
+			->expects( 'for_current_page' )
+			->once()
+			->andReturn( $this->context );
 
 		$callback = static function ( $presenter ) {
 			return \get_class( $presenter );
@@ -336,6 +371,11 @@ class Front_End_Integration_Test extends TestCase {
 			->with( 'opengraph' )
 			->andReturnTrue();
 
+		$this->context_memoizer
+			->expects( 'for_current_page' )
+			->once()
+			->andReturn( $this->context );
+
 		$callback = static function ( $presenter ) {
 			return \get_class( $presenter );
 		};
@@ -377,6 +417,11 @@ class Front_End_Integration_Test extends TestCase {
 			->expects( 'get' )
 			->with( 'opengraph' )
 			->andReturnTrue();
+
+		$this->context_memoizer
+			->expects( 'for_current_page' )
+			->once()
+			->andReturn( $this->context );
 
 		$callback = static function ( $presenter ) {
 			return \get_class( $presenter );

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -149,7 +149,7 @@ class Front_End_Integration_Test extends TestCase {
 		$this->instance
 			->expects( 'get_presenters' )
 			->once()
-			->with( 'page_type', $context )
+			->with( 'page_type' )
 			->andReturn( [ $presenter ] );
 
 		$presenter

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -104,8 +104,8 @@ class Front_End_Integration_Test extends TestCase {
 		)->makePartial();
 
 		// Set up mocks for classes which which are used in multiple tests.
-		$this->context      = Mockery::mock( Meta_Tags_Context::class );
-		$this->presenter    = Mockery::mock( Abstract_Indexable_Presenter::class );
+		$this->context   = Mockery::mock( Meta_Tags_Context::class );
+		$this->presenter = Mockery::mock( Abstract_Indexable_Presenter::class );
 
 		$this->context->page_type    = 'page_type';
 		$this->context->presentation = $this->presentation;
@@ -233,7 +233,7 @@ class Front_End_Integration_Test extends TestCase {
 			'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
 		];
 
-		$callback = static function ( $presenter ) {
+		$callback = static function( $presenter ) {
 			return \get_class( $presenter );
 		};
 
@@ -264,7 +264,7 @@ class Front_End_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $this->context );
 
-		$callback = static function ( $presenter ) {
+		$callback = static function( $presenter ) {
 			return \get_class( $presenter );
 		};
 		$expected = \array_map( $callback, $this->instance->get_presenters( 'Error_Page' ) );
@@ -316,7 +316,7 @@ class Front_End_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $this->context );
 
-		$callback = static function ( $presenter ) {
+		$callback = static function( $presenter ) {
 			return \get_class( $presenter );
 		};
 		$expected = \array_map( $callback, \array_values( $this->instance->get_presenters( 'Term_Archive' ) ) );
@@ -376,7 +376,7 @@ class Front_End_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $this->context );
 
-		$callback = static function ( $presenter ) {
+		$callback = static function( $presenter ) {
 			return \get_class( $presenter );
 		};
 		$actual   = \array_map( $callback, \array_values( $this->instance->get_presenters( 'Error_Page' ) ) );
@@ -423,7 +423,7 @@ class Front_End_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $this->context );
 
-		$callback = static function ( $presenter ) {
+		$callback = static function( $presenter ) {
 			return \get_class( $presenter );
 		};
 		$expected = \array_map( $callback, \array_values( $this->instance->get_presenters( 'Error_Page' ) ) );

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -149,7 +149,7 @@ class Front_End_Integration_Test extends TestCase {
 		$this->instance
 			->expects( 'get_presenters' )
 			->once()
-			->with( 'page_type' )
+			->with( 'page_type', $context )
 			->andReturn( [ $presenter ] );
 
 		$presenter


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds Meta_Tags_Context to `wpseo_frontend_presenters` filter.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* The changes in this PR can be tested in the following add-on PR's, which rely on the changes in this PR:
    * https://github.com/Yoast/wpseo-video/pull/889
    * https://github.com/Yoast/wpseo-woocommerce/pull/698
    * https://github.com/Yoast/wpseo-news/pull/703
    * [Local SEO PR to be added]
* To test this PR on its own: visit the front-end and see no notices about undefined variables.
    * FYI, this tests if `$this->context_memoizer->for_current_page()` can be found, which is the only code change that was made to this PR (apart from documentation changes). 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
