### PR TITLE
Add screen reader text to image select button

### DIFF
--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -110,7 +110,6 @@ ImageSelect.propTypes = {
 ImageSelect.defaultProps = {
 	defaultImageUrl: "",
 	imageUrl: "",
-	imageAltText: "",
 	onClick: () => {},
 	onMouseEnter: () => {},
 	onMouseLeave: () => {},

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { __ } from "@wordpress/i18n";
 import ImageSelectButtons from "./ImageSelectButtons";
 import PropTypes from "prop-types";
 import FieldGroup from "../field-group/FieldGroup";
@@ -31,6 +32,21 @@ function ImageSelect( props ) {
 		isDisabled: props.isDisabled,
 	};
 
+	/**
+	 * @returns {JSXElement} returns a text for screen readers.
+	 */
+	const ScreenReaderText = () => {
+		return (
+			<span className="screen-reader-text">
+				{
+					imageSelected
+						? __( "Replace image", "yoast-components" )
+						: __( "Select image", "yoast-components" )
+				}
+			</span>
+		);
+	}
+
 	return (
 		<div
 			className="yoast-image-select"
@@ -52,6 +68,7 @@ function ImageSelect( props ) {
 						{ previewImageUrl !== "" &&
 							<img src={ previewImageUrl } alt={ props.imageAltText } className="yoast-image-select__preview--image" />
 						}
+						<ScreenReaderText />
 					</button>
 				}
 				{
@@ -74,7 +91,7 @@ export default ImageSelect;
 ImageSelect.propTypes = {
 	defaultImageUrl: PropTypes.string,
 	imageUrl: PropTypes.string,
-	imageAltText: PropTypes.string,
+	imageAltText: PropTypes.string.isRequired,
 	hasPreview: PropTypes.bool.isRequired,
 	label: PropTypes.string.isRequired,
 	onClick: PropTypes.func,

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -45,7 +45,7 @@ function ImageSelect( props ) {
 				}
 			</span>
 		);
-	}
+	};
 
 	return (
 		<div

--- a/packages/components/tests/ImageSelectTest.js
+++ b/packages/components/tests/ImageSelectTest.js
@@ -32,6 +32,7 @@ describe( "ImageSelect", () => {
 			const component = renderer.create(
 				<ImageSelect
 					label={ imageSelect.label }
+					imageAltText={ "" }
 					hasPreview={ imageSelect.hasPreview }
 					imageUrl={ imageSelect.imageUrl }
 				/>

--- a/packages/components/tests/__snapshots__/ImageSelectTest.js.snap
+++ b/packages/components/tests/__snapshots__/ImageSelectTest.js.snap
@@ -21,7 +21,13 @@ exports[`ImageSelect ImageSelects match the snapshot 1`] = `
       disabled={false}
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="screen-reader-text"
+      >
+        Select image
+      </span>
+    </button>
     <div
       className="yoast-image-select-buttons"
     >
@@ -66,6 +72,11 @@ exports[`ImageSelect ImageSelects match the snapshot 2`] = `
         className="yoast-image-select__preview--image"
         src="http://placekitten.com/300/300"
       />
+      <span
+        className="screen-reader-text"
+      >
+        Replace image
+      </span>
     </button>
     <div
       className="yoast-image-select-buttons"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The ImageSelect missed a button text for screenreaders. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/components] Fixes a bug where the ImageSelect did not a have a screen reader text.

## Relevant technical choices:

* The ImageSelect component is ready to receive an alt text for the image, but this has to be provided at the places of implementation.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Checkout this branch and go to one of the places where the ImageSelect component is used, e.g. the Facebook preview.
* Inspect the image preview in the dev tools or use Voice Over on Mac and make sure the image preview has focus. 
* When there's no image selected, the screen reader should say: "select image". 
* When an image is selected, the screen reader should say: "replace image".


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/IM-184 partly. 
