### PR TITLE
P2-1099 improve json output

### DIFF
--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Surfaces\Values;
 
 use Exception;
 use WPSEO_Replace_Vars;
+use WPSEO_Utils;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Integrations\Front_End_Integration;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
@@ -143,7 +144,7 @@ class Meta {
 
 		return (object) [
 			'html' => $html_output,
-			'json' => \json_encode( $json_head_fields, JSON_FORCE_OBJECT | JSON_NUMERIC_CHECK | JSON_UNESCAPED_SLASHES ),
+			'json' => WPSEO_Utils::format_json_encode( $json_head_fields ),
 		];
 	}
 

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -143,7 +143,7 @@ class Meta {
 
 		return (object) [
 			'html' => $html_output,
-			'json' => $json_head_fields,
+			'json' => \json_encode( $json_head_fields,JSON_FORCE_OBJECT | JSON_NUMERIC_CHECK | JSON_UNESCAPED_SLASHES ),
 		];
 	}
 

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -143,7 +143,7 @@ class Meta {
 
 		return (object) [
 			'html' => $html_output,
-			'json' => \json_encode( $json_head_fields,JSON_FORCE_OBJECT | JSON_NUMERIC_CHECK | JSON_UNESCAPED_SLASHES ),
+			'json' => \json_encode( $json_head_fields, JSON_FORCE_OBJECT | JSON_NUMERIC_CHECK | JSON_UNESCAPED_SLASHES ),
 		];
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* P2-925 adds json output to the rest api output. the output format of that json was formatting numbers and booleans as strings and that was not optimal, we'd like to format non-strings as non-strings and this is what json_encode does for us.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* formats headless rest API json head fields

## Relevant technical choices:

* added json encode call to optimally format data object as json

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* follow test steps of https://github.com/Yoast/wordpress-seo/pull/17162

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
