### PR TITLE
Fix urls being decoded by WP API

### DIFF
--- a/src/routes/indexables-head-route.php
+++ b/src/routes/indexables-head-route.php
@@ -80,7 +80,7 @@ class Indexables_Head_Route implements Route_Interface {
 	 * @return WP_REST_Response The response.
 	 */
 	public function get_head( WP_REST_Request $request ) {
-		$url  = \esc_url_raw( $request['url'] );
+		$url  = \esc_url_raw( \utf8_uri_encode( $request['url'] ) );
 		$data = $this->head_action->for_url( $url );
 
 		return new WP_REST_Response( $data, $data->status );
@@ -94,7 +94,7 @@ class Indexables_Head_Route implements Route_Interface {
 	 * @return bool Whether or not the url is valid.
 	 */
 	public function is_valid_url( $url ) {
-		if ( \filter_var( $url, \FILTER_VALIDATE_URL ) === false ) {
+		if ( \filter_var( \utf8_uri_encode( $url ), \FILTER_VALIDATE_URL ) === false ) {
 			return false;
 		}
 		return true;

--- a/tests/unit/routes/indexables-head-route-test.php
+++ b/tests/unit/routes/indexables-head-route-test.php
@@ -116,6 +116,10 @@ class Indexables_Head_Route_Test extends TestCase {
 
 		Mockery::mock( 'overload:WP_REST_Response' );
 
+		Monkey\Functions\expect( 'utf8_uri_encode' )
+			->with( 'https://example.org' )
+			->andReturnFirstArg();
+
 		$this->assertInstanceOf( 'WP_REST_Response', $this->instance->get_head( $request ) );
 	}
 
@@ -125,6 +129,10 @@ class Indexables_Head_Route_Test extends TestCase {
 	 * @covers ::is_valid_url
 	 */
 	public function test_is_valid_url_with_invalid_url_given() {
+		Monkey\Functions\expect( 'utf8_uri_encode' )
+			->with( 'foo bar baz' )
+			->andReturnFirstArg();
+
 		$this->assertFalse( $this->instance->is_valid_url( 'foo bar baz' ) );
 	}
 
@@ -134,6 +142,10 @@ class Indexables_Head_Route_Test extends TestCase {
 	 * @covers ::is_valid_url
 	 */
 	public function test_is_valid_url_with_valid_url_given() {
+		Monkey\Functions\expect( 'utf8_uri_encode' )
+			->with( 'https://example.org' )
+			->andReturnFirstArg();
+
 		$this->assertTrue( $this->instance->is_valid_url( 'https://example.org' ) );
 	}
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the Yoast head API route when used with URLs including unicode characters.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Call a route such as: http://basic.wordpress.test/wp-json/yoast/v1/get_head?url=http://basic.wordpress.test/%d0%b4
* If you do not have a page by that URL you should get a 404 response.
* If you create a page with that slug you should get a 200 response with the SEO data of your page.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The `/wp-json/yoast/v1/get_head?url=` route.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
