### PR TITLE
replace is_singular check with post type check

### DIFF
--- a/src/presenters/slack/enhanced-data-presenter.php
+++ b/src/presenters/slack/enhanced-data-presenter.php
@@ -44,7 +44,7 @@ class Enhanced_Data_Presenter extends Abstract_Indexable_Presenter {
 		$author_id              = $this->presentation->source->post_author;
 		$estimated_reading_time = $this->presentation->estimated_reading_time_minutes;
 
-		if ( \is_singular( 'post' ) && $author_id ) {
+		if ( $this->presentation->model->object_sub_type === 'post' && $author_id ) {
 			$data[ \__( 'Written by', 'wordpress-seo' ) ] = \get_the_author_meta( 'display_name', $author_id );
 		}
 

--- a/tests/unit/presenters/slack/enhanced-data-presenter-test.php
+++ b/tests/unit/presenters/slack/enhanced-data-presenter-test.php
@@ -5,8 +5,6 @@ namespace Yoast\WP\SEO\Tests\Unit\Presenters\Slack;
 use Brain\Monkey\Functions;
 use Mockery;
 use WP_Post;
-use Yoast\WP\Lib\ORM;
-use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Presenters\Slack\Enhanced_Data_Presenter;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
@@ -47,9 +45,7 @@ class Enhanced_Data_Presenter_Test extends TestCase {
 		$this->instance                       = new Enhanced_Data_Presenter();
 		$this->instance->presentation         = Mockery::mock( Indexable_Presentation::class );
 		$this->instance->presentation->source = Mockery::mock( WP_Post::class );
-		$indexable                            = new Indexable_Mock();
-		$this->instance->presentation->model  = $indexable;
-
+		$this->instance->presentation->model  = new Indexable_Mock();
 		$this->presentation                   = $this->instance->presentation;
 	}
 
@@ -61,7 +57,7 @@ class Enhanced_Data_Presenter_Test extends TestCase {
 	 */
 	public function test_present() {
 		$post_content = '';
-		for ( $i = 0; $i < 10000; $i++ ) {
+		for ( $i = 0; $i < 10; $i++ ) {
 			$post_content .= 'yoast ';
 		}
 
@@ -94,7 +90,7 @@ class Enhanced_Data_Presenter_Test extends TestCase {
 	 */
 	public function test_present_no_post() {
 		$post_content = '';
-		for ( $i = 0; $i < 10000; $i++ ) {
+		for ( $i = 0; $i < 10; $i++ ) {
 			$post_content .= 'yoast ';
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The presenter checked for post type in the wrong way, which broke json head output

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the post type was verified incorrectly

## Relevant technical choices:

* replaced an `\is_singular` check with `model->obj_sub_type === 'post'`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* check the json head output according to test instructions in [P2-925 / PR 17162](https://github.com/Yoast/wordpress-seo/pull/17162)
* for posts, the written by AND est reading time fields should be together in a JSON object in the json head output, under the twitter_misc key. e.g.
` twitter_misc: { "Est. reading time": "4 minutes", "Written by": "Henk" }`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
