### PR TITLE
Fix protection of password protected posts in schema generation

### DIFF
--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -228,7 +228,7 @@ class Schema_Generator implements Generator_Interface {
 	 * @return Abstract_Schema_Piece[] A filtered array of graph pieces.
 	 */
 	protected function get_graph_pieces( $context ) {
-		if ( \is_single() && \post_password_required() ) {
+		if ( $context->indexable->object_type === 'post' && \post_password_required( $context->post ) ) {
 			$schema_pieces = [
 				new Schema\Organization(),
 				new Schema\Website(),

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -9,8 +9,10 @@ use Yoast\WP\SEO\Generators\Schema\FAQ;
 use Yoast\WP\SEO\Generators\Schema\Organization;
 use Yoast\WP\SEO\Generators\Schema_Generator;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Helpers\Date_Helper;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Language_Helper;
@@ -64,6 +66,20 @@ class Schema_Generator_Test extends TestCase {
 	protected $current_page;
 
 	/**
+	 * The article helper.
+	 *
+	 * @var Article_Helper|Mockery\MockInterface
+	 */
+	protected $article;
+
+	/**
+	 * The date helper.
+	 *
+	 * @var Date_Helper|Mockery\MockInterface
+	 */
+	protected $date;
+
+	/**
 	 * The organisation scheme generator.
 	 *
 	 * @var Organization|Mockery\MockInterface
@@ -100,7 +116,9 @@ class Schema_Generator_Test extends TestCase {
 		$this->id           = Mockery::mock( ID_Helper::class );
 		$this->current_page = Mockery::mock( Current_Page_Helper::class );
 
-		$this->html = Mockery::mock( HTML_Helper::class )->makePartial();
+		$this->html    = Mockery::mock( HTML_Helper::class )->makePartial();
+		$this->article = Mockery::mock( Article_Helper::class );
+		$this->date    = Mockery::mock( Date_Helper::class );
 
 		$helpers = Mockery::mock( Helpers_Surface::class );
 
@@ -110,7 +128,9 @@ class Schema_Generator_Test extends TestCase {
 			'id'       => $this->id,
 			'html'     => $this->html,
 			'language' => Mockery::mock( Language_Helper::class )->makePartial(),
+			'article'  => $this->article,
 		];
+		$helpers->date         = $this->date;
 
 		$this->replace_vars_helper = Mockery::mock( Replace_Vars_Helper::class );
 
@@ -204,11 +224,6 @@ class Schema_Generator_Test extends TestCase {
 		$this->context->indexable->object_sub_type = 'super-custom-post-type';
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
 
-		Monkey\Functions\expect( 'is_single' )
-			->once()
-			->withNoArgs()
-			->andReturnFalse();
-
 		$this->current_page
 			->expects( 'is_front_page' )
 			->andReturnTrue();
@@ -277,15 +292,30 @@ class Schema_Generator_Test extends TestCase {
 		$this->stubEscapeFunctions();
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
 
+		$this->context->indexable->object_type     = 'post';
+		$this->context->indexable->object_sub_type = 'post';
+		$this->context->post                       = (object) [
+			'post_date_gmt'     => 'date',
+			'post_modified_gmt' => 'date',
+		];
+		$this->context->has_image                  = false;
+
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
-			->withNoArgs()
+			->with( $this->context->post )
 			->andReturnFalse();
 
-		Monkey\Functions\expect( 'is_single' )
-			->once()
-			->withNoArgs()
-			->andReturnTrue();
+		$this->article
+			->expects( 'is_author_supported' )
+			->twice()
+			->with( 'post' )
+			->andReturnFalse();
+
+		$this->date
+			->expects( 'format' )
+			->twice()
+			->with( 'date' )
+			->andReturn( 'date' );
 
 		$this->current_page
 			->expects( 'is_front_page' )
@@ -442,15 +472,30 @@ class Schema_Generator_Test extends TestCase {
 		$this->stubEscapeFunctions();
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
 
-		Monkey\Functions\expect( 'is_single' )
-			->once()
-			->withNoArgs()
-			->andReturnTrue();
+		$this->context->indexable->object_type     = 'post';
+		$this->context->indexable->object_sub_type = 'post';
+		$this->context->post                       = (object) [
+			'post_date_gmt'     => 'date',
+			'post_modified_gmt' => 'date',
+		];
+		$this->context->has_image                  = false;
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
-			->withNoArgs()
+			->with( $this->context->post )
 			->andReturnFalse();
+
+		$this->article
+			->expects( 'is_author_supported' )
+			->twice()
+			->with( 'post' )
+			->andReturnFalse();
+
+		$this->date
+			->expects( 'format' )
+			->twice()
+			->with( 'date' )
+			->andReturn( 'date' );
 
 		$this->current_page
 			->expects( 'is_front_page' )
@@ -483,15 +528,30 @@ class Schema_Generator_Test extends TestCase {
 		$this->context->blocks = [];
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
 
-		Monkey\Functions\expect( 'is_single' )
-			->once()
-			->withNoArgs()
-			->andReturnTrue();
+		$this->context->indexable->object_type     = 'post';
+		$this->context->indexable->object_sub_type = 'post';
+		$this->context->post                       = (object) [
+			'post_date_gmt'     => 'date',
+			'post_modified_gmt' => 'date',
+		];
+		$this->context->has_image                  = false;
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
-			->withNoArgs()
+			->with( $this->context->post )
 			->andReturnFalse();
+
+		$this->article
+			->expects( 'is_author_supported' )
+			->twice()
+			->with( 'post' )
+			->andReturnFalse();
+
+		$this->date
+			->expects( 'format' )
+			->twice()
+			->with( 'date' )
+			->andReturn( 'date' );
 
 		$this->current_page
 			->expects( 'is_front_page' )
@@ -559,15 +619,30 @@ class Schema_Generator_Test extends TestCase {
 		$this->context->blocks = [];
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
 
-		Monkey\Functions\expect( 'is_single' )
-			->once()
-			->withNoArgs()
-			->andReturnTrue();
+		$this->context->indexable->object_type     = 'post';
+		$this->context->indexable->object_sub_type = 'post';
+		$this->context->post                       = (object) [
+			'post_date_gmt'     => 'date',
+			'post_modified_gmt' => 'date',
+		];
+		$this->context->has_image                  = false;
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
-			->withNoArgs()
+			->with( $this->context->post )
 			->andReturnFalse();
+
+		$this->article
+			->expects( 'is_author_supported' )
+			->twice()
+			->with( 'post' )
+			->andReturnFalse();
+
+		$this->date
+			->expects( 'format' )
+			->twice()
+			->with( 'date' )
+			->andReturn( 'date' );
 
 		$this->current_page
 			->expects( 'is_front_page' )
@@ -630,15 +705,24 @@ class Schema_Generator_Test extends TestCase {
 	 * @covers ::get_graph_pieces
 	 */
 	public function test_get_graph_pieces_on_single_post_with_password_required() {
-		Monkey\Functions\expect( 'is_single' )
-			->once()
-			->withNoArgs()
-			->andReturnTrue();
+		$this->context->indexable->object_type     = 'post';
+		$this->context->indexable->object_sub_type = 'post';
+		$this->context->post                       = (object) [
+			'post_date_gmt'     => 'date',
+			'post_modified_gmt' => 'date',
+		];
+		$this->context->has_image                  = false;
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
-			->withNoArgs()
+			->with( $this->context->post )
 			->andReturnTrue();
+
+		$this->date
+			->expects( 'format' )
+			->twice()
+			->with( 'date' )
+			->andReturn( 'date' );
 
 		$this->current_page
 			->expects( 'is_front_page' )
@@ -770,6 +854,8 @@ class Schema_Generator_Test extends TestCase {
 							'@id' => '#id-1',
 						],
 					],
+					'datePublished'   => 'date',
+					'dateModified'    => 'date',
 				],
 				[
 					'@type'          => 'Question',


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a check that attempted to use the global post for checking if a post is password protected.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a password protected post.
* View that post using the REST API.
* It should only have Website, WebPage and, if filled out, Organization schema. Nothing else.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Schema generation.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
