### PR TITLE
Add conditional for the Norwegian readability feature flag

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/runFullTextTests.js
+++ b/packages/yoastseo/spec/fullTextTests/runFullTextTests.js
@@ -40,7 +40,7 @@ import sentenceBeginningsAssessment from "../../src/scoring/assessments/readabil
 import testPapers from "./testTexts";
 
 // Enable Norwegian Readability feature
-enableFeatures( [ "norwegian-readability" ] );
+enableFeatures( [ "NORWEGIAN_READABILITY" ] );
 
 testPapers.forEach( function( testPaper ) {
 	// eslint-disable-next-line max-statements

--- a/packages/yoastseo/src/scoring/assessments/readability/passiveVoiceAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/passiveVoiceAssessment.js
@@ -112,7 +112,7 @@ const passiveVoiceMarker = function( paper, researcher ) {
  */
 const passiveVoiceAssessment = function( paper, researcher, i18n ) {
 	// Check if the Norwegian readability feature is enabled and return the default result if it isn't.
-	if ( researcher.getConfig( "language" ) === "nb" && ! isFeatureEnabled( "norwegian-readability" ) ) {
+	if ( researcher.getConfig( "language" ) === "nb" && ! isFeatureEnabled( "NORWEGIAN_READABILITY" ) ) {
 		return new AssessmentResult();
 	}
 

--- a/packages/yoastseo/src/scoring/assessments/readability/sentenceBeginningsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/sentenceBeginningsAssessment.js
@@ -119,7 +119,7 @@ const sentenceBeginningMarker = function( paper, researcher ) {
  */
 const sentenceBeginningsAssessment = function( paper, researcher, i18n ) {
 	// Check if the Norwegian readability feature is enabled and return the default result if it isn't.
-	if ( researcher.getConfig( "language" ) === "nb" && ! isFeatureEnabled( "norwegian-readability" ) ) {
+	if ( researcher.getConfig( "language" ) === "nb" && ! isFeatureEnabled( "NORWEGIAN_READABILITY" ) ) {
 		return new AssessmentResult();
 	}
 

--- a/packages/yoastseo/src/scoring/assessments/readability/transitionWordsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/transitionWordsAssessment.js
@@ -119,7 +119,7 @@ const calculateTransitionWordResult = function( transitionWordSentences, i18n ) 
  */
 const transitionWordsAssessment = function( paper, researcher, i18n ) {
 	// Check if the Norwegian readability feature is enabled and return the default result if it isn't.
-	if ( researcher.getConfig( "language" ) === "nb" && ! isFeatureEnabled( "norwegian-readability" ) ) {
+	if ( researcher.getConfig( "language" ) === "nb" && ! isFeatureEnabled( "NORWEGIAN_READABILITY" ) ) {
 		return new AssessmentResult();
 	}
 

--- a/src/conditionals/norwegian-readability-conditional.php
+++ b/src/conditionals/norwegian-readability-conditional.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Checks if the YOAST_SEO_NORWEGIAN_READABILITY constant is set.
+ */
+class Norwegian_Readability_Conditional extends Feature_Flag_Conditional {
+
+	/**
+	 * Returns the name of the feature flag.
+	 * 'YOAST_SEO_' is automatically prepended to it and it will be uppercased.
+	 *
+	 * @return string the name of the feature flag.
+	 */
+	public function get_feature_flag() {
+		return 'NORWEGIAN_READABILITY';
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the Norwegian readability feature flag.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add the statement `define( 'YOAST_SEO_NORWEGIAN_READABILITY', true );` in your `basic-wordpress.config.php` file. 
* Build the Free plugin and set your site to Norwegian.
* Open a post, add some text, and make sure that the sentence beginnings, transition words, and passive voice assessments show up.
* Try to get different results for the assessments, e.g. by adding a transition word or a passive sentence, and confirm that the assessment feedback changes accordingly.
* Remove the statement `define( 'YOAST_SEO_NORWEGIAN_READABILITY', true );` from your `basic-wordpress.config.php` file and rebuild the plugin.
* Make sure the sentence beginnings, transition words, and passive voice assessments do not show up for Norwegian.
* Change site language to English and make sure all readability assessments show up.
* Confirm that the assessments disappear if you disabled the feature flag and refresh the page.



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
