### PR TITLE
P2 1105 correctly deprecate elementor exclusions

### DIFF
--- a/config/dependency-injection/renamed-classes.php
+++ b/config/dependency-injection/renamed-classes.php
@@ -1,9 +1,17 @@
-<?php
+<?php // phpcs:ignore
 /**
  * Yoast SEO Plugin File.
  *
  * Configuration file for dependency injection. Registers renamed classes.
  *
+ * @phpcs:disable Yoast.Files.FileName.InvalidFunctionsFileName
+ * @phpcs:disable Yoast.Commenting.FileComment.MissingPackageTag
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+ * @phpcs:disable WordPress.Arrays.CommaAfterArrayItem.NoComma
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+ * @phpcs:disable Squiz.Commenting.FunctionComment.Missing
+ * @phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
  */
 
 /**
@@ -19,7 +27,7 @@ $renamed_classes = [
 	Elementor_Exclude_Post_Types::class => [ Renamed_To_Exclude_Elementor_Post_Types::class, '16.7' ]
 ];
 
-foreach( $renamed_classes as $original_class => $replacement ) {
+foreach ( $renamed_classes as $original_class => $replacement ) {
 	list( $renamed_class, $version ) = $replacement;
 	$container->register( $original_class, $original_class )
 		->setAutowired( true )

--- a/config/dependency-injection/renamed-classes.php
+++ b/config/dependency-injection/renamed-classes.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * Configuration file for dependency injection. Registers renamed classes.
+ *
+ */
+
+/**
+ * Holds the dependency injection container.
+ *
+ * @var $container \Symfony\Component\DependencyInjection\ContainerBuilder
+ */
+
+use Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types as Renamed_To_Exclude_Elementor_Post_Types;
+
+$renamed_classes = [
+	Elementor_Exclude_Post_Types::class => [ Renamed_To_Exclude_Elementor_Post_Types::class, '16.7' ]
+];
+
+foreach( $renamed_classes as $original_class => $replacement ) {
+	list( $renamed_class, $version ) = $replacement;
+	$container->register( $original_class, $original_class )
+		->setAutowired( true )
+		->setAutoconfigured( true )
+		->setPublic( true )
+		->setDeprecated( true, "%service_id% is deprecated since version $version! Use $renamed_class instead." );
+}
+
+// If the DI container is built by composer this WordPress function will not exist.
+if ( ! function_exists( '_deprecated_file' ) ) {
+	function _deprecated_file( $file, $version, $replacement = '', $message = '' ) {}
+}

--- a/config/dependency-injection/renamed-classes.php
+++ b/config/dependency-injection/renamed-classes.php
@@ -12,6 +12,7 @@
  * @var $container \Symfony\Component\DependencyInjection\ContainerBuilder
  */
 
+use Yoast\WP\SEO\Integrations\Third_Party\Elementor_Exclude_Post_Types;
 use Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types as Renamed_To_Exclude_Elementor_Post_Types;
 
 $renamed_classes = [

--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -39,6 +39,9 @@ $container->setAlias( ContainerInterface::class, 'service_container' );
 // Required for the migrations framework.
 $container->register( Adapter::class, Adapter::class )->setAutowired( true )->setPublic( true );
 
+// Elegantly deprecate renamed classes.
+include __DIR__ . '/renamed-classes.php';
+
 $yoast_seo_excluded_files = [
 	'main.php',
 ];

--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -18,6 +18,8 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
  * Holds the dependency injection container.
  *
  * @var $container \Symfony\Component\DependencyInjection\ContainerBuilder
+ *
+ * @phpcs:disable PEAR.Files.IncludingFile.UseRequire
  */
 // WordPress factory functions.
 $container->register( 'wpdb', 'wpdb' )->setFactory( [ Wrapper::class, 'get_wpdb' ] );

--- a/src/deprecated/src/integrations/third-party/elementor.php
+++ b/src/deprecated/src/integrations/third-party/elementor.php
@@ -31,7 +31,7 @@ class Elementor_Exclude_Post_Types extends Exclude_Elementor_Post_Types {
 	* @deprecated 16.7 Use {@see \Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types} instead.
 	*/
 	public function __construct() {
-		\_deprecated_function( __METHOD__, 'Yoast SEO Premium 16.7', '\Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 16.7', '\Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types' );
 
 		// Only call a constructor if the parent has one; we already are a subclass of the parent.
 		if (is_callable('parent::__construct')) {

--- a/src/deprecated/src/integrations/third-party/elementor.php
+++ b/src/deprecated/src/integrations/third-party/elementor.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable Yoast.Commenting.FileComment.Unnecessary
 /**
  * Graceful deprecation of various classes which were renamed.
  *
@@ -20,21 +21,22 @@
 namespace Yoast\WP\SEO\Integrations\Third_Party;
 
 /**
-* Class Elementor_Exclude_Post_Types.
-*
-* @deprecated 16.7 Use {@see \Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types} instead.
-*/
+ * Class Elementor_Exclude_Post_Types.
+ *
+ * @deprecated 16.7 Use {@see \Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types} instead.
+ */
 class Elementor_Exclude_Post_Types extends Exclude_Elementor_Post_Types {
+
 	/**
-	* Elementor Exclude Post Types constructor.
-	*
-	* @deprecated 16.7 Use {@see \Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types} instead.
-	*/
+	 * Elementor Exclude Post Types constructor.
+	 *
+	 * @deprecated 16.7 Use {@see \Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types} instead.
+	 */
 	public function __construct() {
 		\_deprecated_function( __METHOD__, 'Yoast SEO 16.7', '\Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types' );
 
 		// Only call a constructor if the parent has one; we already are a subclass of the parent.
-		if (is_callable('parent::__construct')) {
+		if ( is_callable( 'parent::__construct' ) ) {
 			parent::__construct();
 		}
 	}

--- a/src/deprecated/src/integrations/third-party/elementor.php
+++ b/src/deprecated/src/integrations/third-party/elementor.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Graceful deprecation of various classes which were renamed.
+ *
+ * {@internal As this file is just (temporarily) put in place to warn extending
+ * plugins about the class name changes, it is exempt from select CS standards.}
+ *
+ * @package Yoast\WP\SEO
+ *
+ * @since      16.7
+ * @deprecated 16.7
+ *
+ * @phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound
+ * @phpcs:disable Yoast.Commenting.CodeCoverageIgnoreDeprecated
+ * @phpcs:disable Yoast.Commenting.FileComment.Unnecessary
+ * @phpcs:disable Yoast.Files.FileName.InvalidClassFileName
+ */
+
+use Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types;
+
+/**
+* Class Elementor_Exclude_Post_Types.
+*
+* @deprecated 16.7 Use {@see \Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types} instead.
+*/
+class Elementor_Exclude_Post_Types extends Exclude_Elementor_Post_Types {
+	/**
+	* Elementor Exclude Post Types constructor.
+	*
+	* @deprecated 16.7 Use {@see \Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types} instead.
+	*/
+	public function __construct() {
+		\_deprecated_function( __METHOD__, 'Yoast SEO Premium 16.7', '\Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types' );
+
+		// Only call a constructor if the parent has one; we already are a subclass of the parent.
+		if (is_callable('parent::__construct')) {
+			parent::__construct();
+		}
+	}
+}

--- a/src/deprecated/src/integrations/third-party/elementor.php
+++ b/src/deprecated/src/integrations/third-party/elementor.php
@@ -17,7 +17,7 @@
  * @phpcs:disable Yoast.Files.FileName.InvalidClassFileName
  */
 
-use Yoast\WP\SEO\Integrations\Third_Party\Exclude_Elementor_Post_Types;
+namespace Yoast\WP\SEO\Integrations\Third_Party;
 
 /**
 * Class Elementor_Exclude_Post_Types.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The class Elementor_Exclude_Post_Types has been renamed to Exclude_Elementor_Post_Types. This PR allows us to safely rename classes and deprecate the old ones in favor of the new classes.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enhances code deprecation by safely redirecting to the new version of a class.

## Relevant technical choices:

* applied the same mechanism as [Premium already has in place](https://github.com/Yoast/wordpress-seo-premium/blob/0997ce62fce8b77a8b97647b6596f7d713893816/config/dependency-injection/renamed-classes.php)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

create an instance of the old class anywhere in php code that's being used. for instance, add this line:
`$deprecated = new \Yoast\WP\SEO\Integrations\Third_Party\Elementor_Exclude_Post_Types();`
to the file 
`\src\integrations\front-end\wp-robots-integration.php`
as the first line in the `public function register_hooks` function.

this will trigger any time wordpress outputs the robots tag, which happens on any post.

expected outcome is that it runs without error, and if debug logging is on, you could get a line in debug log mentioning the deprecation "Elementor_Exclude_Post_Types has been deprecated since 16.7, use Exclude_Elementor_Post_Type instead"

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
