### PR TITLE
Fix replacevars for rest api

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -421,9 +421,10 @@ class WPSEO_Replace_Vars {
 	private function retrieve_parent_title() {
 		$replacement = null;
 
-		if ( ( is_singular() || is_admin() ) && isset( $GLOBALS['post'] ) ) {
-			if ( isset( $GLOBALS['post']->post_parent ) && $GLOBALS['post']->post_parent !== 0 ) {
-				$replacement = get_the_title( $GLOBALS['post']->post_parent );
+		if ( isset( $this->args->ID ) ) {
+			$parent_id = wp_get_post_parent_id( $this->args->ID );
+			if ( $parent_id ) {
+				$replacement = get_the_title( $parent_id );
 			}
 		}
 
@@ -729,21 +730,19 @@ class WPSEO_Replace_Vars {
 	 * @return string|null
 	 */
 	private function retrieve_cf_custom_field_name( $var ) {
-		global $post;
 		$replacement = null;
 
 		if ( is_string( $var ) && $var !== '' ) {
 			$field = substr( $var, 3 );
-			if ( ( is_singular() || is_admin() ) && ( is_object( $post ) && isset( $post->ID ) ) ) {
+			if ( isset( $this->args->ID ) ) {
 				// Post meta can be arrays and in this case we need to exclude them.
-				$name = get_post_meta( $post->ID, $field, true );
+				$name = get_post_meta( $this->args->ID, $field, true );
 				if ( $name !== '' && ! is_array( $name ) ) {
 					$replacement = $name;
 				}
 			}
-			elseif ( is_category() || is_tag() || is_tax() ) {
-				$term = $GLOBALS['wp_query']->get_queried_object();
-				$name = get_term_meta( $term->term_id, $field, true );
+			elseif ( isset( $this->args->term_id ) ) {
+				$name = get_term_meta( $this->args->term_id, $field, true );
 				if ( $name !== '' ) {
 					$replacement = $name;
 				}
@@ -785,13 +784,12 @@ class WPSEO_Replace_Vars {
 	 * @return string|null
 	 */
 	private function retrieve_ct_desc_custom_tax_name( $var ) {
-		global $post;
 		$replacement = null;
 
 		if ( is_string( $var ) && $var !== '' ) {
 			$tax = substr( $var, 8 );
-			if ( is_object( $post ) && isset( $post->ID ) ) {
-				$terms = get_the_terms( $post->ID, $tax );
+			if ( isset( $this->args->ID ) ) {
+				$terms = get_the_terms( $this->args->ID, $tax );
 				if ( is_array( $terms ) && $terms !== [] ) {
 					$term      = current( $terms );
 					$term_desc = get_term_field( 'description', $term->term_id, $tax );
@@ -1355,9 +1353,8 @@ class WPSEO_Replace_Vars {
 		$output = '';
 
 		// If we're on a specific tag, category or taxonomy page, use that.
-		if ( is_category() || is_tag() || is_tax() ) {
-			$term   = $GLOBALS['wp_query']->get_queried_object();
-			$output = $term->name;
+		if ( isset( $this->args->term_id ) ) {
+			$output = $this->args->name;
 		}
 		elseif ( ! empty( $id ) && ! empty( $taxonomy ) ) {
 			$terms = get_the_terms( $id, $taxonomy );

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -421,7 +421,7 @@ class WPSEO_Replace_Vars {
 	private function retrieve_parent_title() {
 		$replacement = null;
 
-		if ( isset( $this->args->ID ) ) {
+		if ( ! empty( $this->args->ID ) ) {
 			$parent_id = wp_get_post_parent_id( $this->args->ID );
 			if ( $parent_id ) {
 				$replacement = get_the_title( $parent_id );
@@ -506,7 +506,7 @@ class WPSEO_Replace_Vars {
 	private function retrieve_tag() {
 		$replacement = null;
 
-		if ( isset( $this->args->ID ) ) {
+		if ( ! empty( $this->args->ID ) ) {
 			$tags = $this->get_terms( $this->args->ID, 'post_tag' );
 			if ( $tags !== '' ) {
 				$replacement = $tags;
@@ -533,7 +533,7 @@ class WPSEO_Replace_Vars {
 	private function retrieve_term_description() {
 		$replacement = null;
 
-		if ( isset( $this->args->term_id ) && ! empty( $this->args->taxonomy ) ) {
+		if ( ! empty( $this->args->term_id ) && ! empty( $this->args->taxonomy ) ) {
 			$term_desc = get_term_field( 'description', $this->args->term_id, $this->args->taxonomy );
 			if ( $term_desc !== '' ) {
 				$replacement = wp_strip_all_tags( $term_desc );
@@ -734,14 +734,14 @@ class WPSEO_Replace_Vars {
 
 		if ( is_string( $var ) && $var !== '' ) {
 			$field = substr( $var, 3 );
-			if ( isset( $this->args->ID ) ) {
+			if ( ! empty( $this->args->ID ) ) {
 				// Post meta can be arrays and in this case we need to exclude them.
 				$name = get_post_meta( $this->args->ID, $field, true );
 				if ( $name !== '' && ! is_array( $name ) ) {
 					$replacement = $name;
 				}
 			}
-			elseif ( isset( $this->args->term_id ) ) {
+			elseif ( ! empty( $this->args->term_id ) ) {
 				$name = get_term_meta( $this->args->term_id, $field, true );
 				if ( $name !== '' ) {
 					$replacement = $name;
@@ -788,7 +788,7 @@ class WPSEO_Replace_Vars {
 
 		if ( is_string( $var ) && $var !== '' ) {
 			$tax = substr( $var, 8 );
-			if ( isset( $this->args->ID ) ) {
+			if ( ! empty( $this->args->ID ) ) {
 				$terms = get_the_terms( $this->args->ID, $tax );
 				if ( is_array( $terms ) && $terms !== [] ) {
 					$term      = current( $terms );
@@ -1349,11 +1349,10 @@ class WPSEO_Replace_Vars {
 	 * @return string Either a single term or a comma delimited string of terms.
 	 */
 	public function get_terms( $id, $taxonomy, $return_single = false ) {
-
 		$output = '';
 
 		// If we're on a specific tag, category or taxonomy page, use that.
-		if ( isset( $this->args->term_id ) ) {
+		if ( ! empty( $this->args->term_id ) ) {
 			$output = $this->args->name;
 		}
 		elseif ( ! empty( $id ) && ! empty( $taxonomy ) ) {
@@ -1416,7 +1415,7 @@ class WPSEO_Replace_Vars {
 	private function retrieve_term_hierarchy() {
 		$replacement = null;
 
-		if ( isset( $this->args->term_id ) && ! empty( $this->args->taxonomy ) ) {
+		if ( ! empty( $this->args->term_id ) && ! empty( $this->args->taxonomy ) ) {
 			$hierarchy = $this->get_term_hierarchy();
 
 			if ( $hierarchy !== '' ) {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the `cf_`, `ct_`, `ct_desc`, `tag`, `category` and `parent_title` replacement variables in the REST API.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a custom taxonomy for posts.
* Create a term in that taxonomy that has a description.
* Create a tag
* Create a category
* Create a post and add all your created taxonomies to it.
* Set it's meta description to `%%tag%% %%category%% %%ct_{YOUR_CUSTOM_TAXONOMY_NAME}%%` %%ct_desc_{YOUR_CUSTOM_TAXONOMY_NAME}%%`
* View your post in the REST API. It's meta description should include all names of your taxonomies and the description of your custom taxonomy.
* Create a page
* Give that page a parent
* Set it's meta description to `%%parent_title%%`
* View it int he REST API, It's meta description should be the title of it's parent.
* Create a new entry in your postmeta table for a post.
* Give that post the meta description `%%cf_{KEY_OF_YOUR_POSTMETA}%%`
* View that post in the REST API. The meta description should be the value of your postmeta.
* Create a new entry in your termmeta table for a term.
* Give that term the meta description `%%cf_{KEY_OF_YOUR_TERMMETA}%%`
* View that term in the REST API. The meta description should be the value of your termmeta.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* All of the above listed replacement variables.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
