### PR TITLE
[P2-1109] Fix passing context to get presenters

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -299,7 +299,7 @@ class Front_End_Integration implements Integration_Interface {
 	 */
 	public function present_head() {
 		$context    = $this->context_memoizer->for_current_page();
-		$presenters = $this->get_presenters( $context->page_type );
+		$presenters = $this->get_presenters( $context->page_type, $context );
 
 		/**
 		 * Filter 'wpseo_frontend_presentation' - Allow filtering the presentation used to output our meta values.
@@ -330,7 +330,11 @@ class Front_End_Integration implements Integration_Interface {
 	 *
 	 * @return Abstract_Indexable_Presenter[] The presenters.
 	 */
-	public function get_presenters( $page_type ) {
+	public function get_presenters( $page_type, $context = null ) {
+		if ( \is_null( $context ) ) {
+			$context = $this->context_memoizer->for_current_page();
+		}
+
 		$needed_presenters = $this->get_needed_presenters( $page_type );
 
 		$callback   = static function( $presenter ) {
@@ -349,7 +353,7 @@ class Front_End_Integration implements Integration_Interface {
 		 *
 		 * @api Abstract_Indexable_Presenter[] List of presenter instances.
 		 */
-		$presenter_instances = \apply_filters( 'wpseo_frontend_presenters', $presenters, $this->context_memoizer->for_current_page() );
+		$presenter_instances = \apply_filters( 'wpseo_frontend_presenters', $presenters, $context );
 
 		if ( ! \is_array( $presenter_instances ) ) {
 			$presenter_instances = $presenters;

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -227,7 +227,7 @@ class Meta {
 	 * @return Abstract_Indexable_Presenter[]
 	 */
 	protected function get_presenters() {
-		$presenters = $this->front_end->get_presenters( $this->context->page_type );
+		$presenters = $this->front_end->get_presenters( $this->context->page_type, $this->context );
 
 		if ( $this->context->page_type === 'Date_Archive' ) {
 			/**

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -169,7 +169,7 @@ class Front_End_Integration_Test extends TestCase {
 		$this->instance
 			->expects( 'get_presenters' )
 			->once()
-			->with( 'page_type' )
+			->with( 'page_type', $this->context )
 			->andReturn( [ $this->presenter ] );
 
 		$this->presenter


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes passing the context correctly to the presenters filter.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is tested with https://github.com/Yoast/wordpress-seo-local/pull/2294/files


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* SEO data from addons when viewed in the REST API.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
