### PR TITLE
Rename WordPress_Helper to Wordpress_Helper.

### DIFF
--- a/src/helpers/wordpress-helper.php
+++ b/src/helpers/wordpress-helper.php
@@ -4,8 +4,11 @@ namespace Yoast\WP\SEO\Helpers;
 
 /**
  * A helper object for WordPress matters.
+ *
+ * Note: it is spelled like `Wordpress_Helper` because of Yoast's naming conventions for classes,
+ * which would otherwise break dependency injection in some cases.
  */
-class WordPress_Helper {
+class Wordpress_Helper {
 
 	/**
 	 * Returns the WordPress version.

--- a/src/helpers/wordpress-helper.php
+++ b/src/helpers/wordpress-helper.php
@@ -2,11 +2,10 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
+// phpcs:disable WordPress.WP.CapitalPDangit.MisspelledClassName -- It is spelled like `Wordpress_Helper` because of Yoast's naming conventions for classes, which would otherwise break dependency injection in some cases.
+
 /**
  * A helper object for WordPress matters.
- *
- * Note: it is spelled like `Wordpress_Helper` because of Yoast's naming conventions for classes,
- * which would otherwise break dependency injection in some cases.
  */
 class Wordpress_Helper {
 

--- a/src/integrations/blocks/block-categories.php
+++ b/src/integrations/blocks/block-categories.php
@@ -2,7 +2,7 @@
 
 namespace Yoast\WP\SEO\Integrations\Blocks;
 
-use Yoast\WP\SEO\Helpers\WordPress_Helper;
+use Yoast\WP\SEO\Helpers\Wordpress_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
@@ -13,16 +13,16 @@ class Internal_Linking_Category implements Integration_Interface {
 	/**
 	 * Represents the WordPress helper.
 	 *
-	 * @var WordPress_Helper
+	 * @var Wordpress_Helper
 	 */
 	protected $wordpress_helper;
 
 	/**
 	 * Internal_Linking_Category constructor.
 	 *
-	 * @param WordPress_Helper $wordpress_helper The WordPress helper.
+	 * @param Wordpress_Helper $wordpress_helper The WordPress helper.
 	 */
-	public function __construct( WordPress_Helper $wordpress_helper ) {
+	public function __construct( Wordpress_Helper $wordpress_helper ) {
 		$this->wordpress_helper = $wordpress_helper;
 	}
 

--- a/src/surfaces/helpers-surface.php
+++ b/src/surfaces/helpers-surface.php
@@ -33,17 +33,17 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
  * @property Helpers\Primary_Term_Helper   $primary_term
  * @property Helpers\Product_Helper        $product
  * @property Helpers\Redirect_Helper       $redirect
- * @property Helpers\Request_Helper        $request
- * @property Helpers\Require_File_Helper   $require_file
- * @property Helpers\Robots_Helper         $robots
- * @property Helpers\Short_Link_Helper     $short_link
- * @property Helpers\Site_Helper           $site
- * @property Helpers\String_Helper         $string
- * @property Helpers\Taxonomy_Helper       $taxonomy
- * @property Helpers\Url_Helper            $url
- * @property Helpers\User_Helper           $user
- * @property Helpers\Woocommerce_Helper    $woocommerce
- * @property Helpers\WordPress_Helper      $wordpress
+ * @property Helpers\Request_Helper      $request
+ * @property Helpers\Require_File_Helper $require_file
+ * @property Helpers\Robots_Helper       $robots
+ * @property Helpers\Short_Link_Helper   $short_link
+ * @property Helpers\Site_Helper         $site
+ * @property Helpers\String_Helper       $string
+ * @property Helpers\Taxonomy_Helper     $taxonomy
+ * @property Helpers\Url_Helper          $url
+ * @property Helpers\User_Helper         $user
+ * @property Helpers\Woocommerce_Helper  $woocommerce
+ * @property Helpers\Wordpress_Helper    $wordpress
  */
 class Helpers_Surface {
 

--- a/tests/unit/helpers/wordpress-helper-test.php
+++ b/tests/unit/helpers/wordpress-helper-test.php
@@ -3,21 +3,21 @@
 namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 
 use Yoast\WP\SEO\Tests\Unit\TestCase;
-use Yoast\WP\SEO\Helpers\WordPress_Helper;
+use Yoast\WP\SEO\Helpers\Wordpress_Helper;
 
 /**
  * Class WordPress_Helper_Test.
  *
  * @group helpers
  *
- * @coversDefaultClass \Yoast\WP\SEO\Helpers\WordPress_Helper
+ * @coversDefaultClass \Yoast\WP\SEO\Helpers\Wordpress_Helper
  */
-class WordPress_Helper_Test extends TestCase {
+class Wordpress_Helper_Test extends TestCase {
 
 	/**
 	 * The instance under test.
 	 *
-	 * @var WordPress_Helper
+	 * @var Wordpress_Helper
 	 */
 	protected $instance;
 
@@ -27,7 +27,7 @@ class WordPress_Helper_Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->instance = new WordPress_Helper();
+		$this->instance = new Wordpress_Helper();
 	}
 
 	/**

--- a/tests/unit/helpers/wordpress-helper-test.php
+++ b/tests/unit/helpers/wordpress-helper-test.php
@@ -8,7 +8,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Helpers\Wordpress_Helper;
 
 /**
- * Class WordPress_Helper_Test.
+ * Class Wordpress_Helper_Test.
  *
  * @group helpers
  *

--- a/tests/unit/helpers/wordpress-helper-test.php
+++ b/tests/unit/helpers/wordpress-helper-test.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 
+// phpcs:disable WordPress.WP.CapitalPDangit.MisspelledClassName -- It is spelled like `Wordpress_Helper` because of Yoast's naming conventions for classes, which would otherwise break dependency injection in some cases.
+
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Helpers\Wordpress_Helper;
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where a deprecation warning was shown when calling the WordPress helper using the `YoastSEO()->helpers->wordpress` helpers surface.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure that you have Local SEO 14.0-RC1 or later installed.
	* Although it is a fix in WordPress SEO, this bugfix can best be tested using Local SEO, since we use the `wordpress` helper surface in its code. 
* Make sure that you have the Query monitor plugin installed.

#### Reproducing the bug
* Go to any page on your website (on the frontend of your website).
* You should get this PHP deprecation warning in Query monitor.
  ```
  Service identifiers will be made case sensitive in Symfony 4.0. 
  Using "Yoast\WP\SEO\Helpers\Wordpress_Helper" instead of "Yoast\WP\SEO\Helpers\WordPress_Helper" 
  is deprecated since Symfony 3.3.
  ``` 

#### Checking that the bug is fixed
* Use this branch / RC in which this bug is fixed.
* Go to any page on your website (on the frontend of your website).
* You should **not** get the PHP deprecation warning, as described above, in Query monitor.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* The structured data block categories should still work.
	* edit a post
	* open the block inserter by clicking on the plus-button in the top-left corner of the editor.
	* the inserter should still show the 'YOAST INTERNAL LINKING BLOCKS' (added by Yoast SEO) and 'YOAST LOCAL SEO BLOCKS' (added by Local SEO) block categories. 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
