### PR TITLE
IM-465 Prevent an empty breadcrumbs array on a paginated static frontpage

### DIFF
--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -40,7 +40,9 @@ class Breadcrumb extends Abstract_Schema_Piece {
 				$this->context->indexable->number_of_pages > 1
 			) &&
 			// Do not replace the last breadcrumb on static post pages.
-			! $this->helpers->current_page->is_static_posts_page()
+			! $this->helpers->current_page->is_static_posts_page() &&
+			// Do not remove the last breadcrumb if only one exists (bugfix for custom paginated frontpages).
+			count( $breadcrumbs ) > 1
 		) {
 			\array_pop( $breadcrumbs );
 		}

--- a/src/generators/schema/breadcrumb.php
+++ b/src/generators/schema/breadcrumb.php
@@ -39,10 +39,12 @@ class Breadcrumb extends Abstract_Schema_Piece {
 				$this->helpers->current_page->is_paged() ||
 				$this->context->indexable->number_of_pages > 1
 			) &&
-			// Do not replace the last breadcrumb on static post pages.
-			! $this->helpers->current_page->is_static_posts_page() &&
-			// Do not remove the last breadcrumb if only one exists (bugfix for custom paginated frontpages).
-			count( $breadcrumbs ) > 1
+			(
+				// Do not replace the last breadcrumb on static post pages.
+				! $this->helpers->current_page->is_static_posts_page() &&
+				// Do not remove the last breadcrumb if only one exists (bugfix for custom paginated frontpages).
+				\count( $breadcrumbs ) > 1
+			)
 		) {
 			\array_pop( $breadcrumbs );
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Prevent removing the last breadcrumb if there is only one.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where paginated static frontpages would fail to output a valid breadcrumb.

## Relevant technical choices:

* Some plugins / themes will allow a static frontpage to be paginated. Our code did not account for that and we would strip the breadcrumbs on such paginated frontpages.
* This fix is a bandaid and extended an already fairly complex logic check. I feel this should be rewritten at some point.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Follow these steps with and without this fix and check the breadcrumbs in the schema on the frontpage.
* Set your frontpage to be a static page in Settings -> Reading
* Navigate to `http://basic.wordpress.test/page/2` and make sure it does not 404 (if it does 404, try `page/3` and / or re-save permalinks)
* Check the schema of this page. Without this fix it will have an empty name. 
* With PHP warning enabled, a warning will also be shown that `Trying to access array offset on value of type null in /var/www/html/wp-content/plugins/wordpress-seo-git/src/generators/schema/breadcrumb.php on line 108`


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* It affects breadcrumbs, but only a very narrow usecase that is conditionally "locked off". So I recon no additional testing is needed.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/17175
Fixes https://yoast.atlassian.net/browse/IM-465
