### PR TITLE
Remove Norwegian readability feature flag

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/runFullTextTests.js
+++ b/packages/yoastseo/spec/fullTextTests/runFullTextTests.js
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import { enableFeatures } from "@yoast/feature-flag";
 import getLanguage from "../../src/languageProcessing/helpers/language/getLanguage";
 import factory from "../specHelpers/factory.js";
 const i18n = factory.buildJed();

--- a/packages/yoastseo/spec/fullTextTests/runFullTextTests.js
+++ b/packages/yoastseo/spec/fullTextTests/runFullTextTests.js
@@ -39,9 +39,6 @@ import sentenceBeginningsAssessment from "../../src/scoring/assessments/readabil
 // Import test papers
 import testPapers from "./testTexts";
 
-// Enable Norwegian Readability feature
-enableFeatures( [ "NORWEGIAN_READABILITY" ] );
-
 testPapers.forEach( function( testPaper ) {
 	// eslint-disable-next-line max-statements
 	describe( "Full-text test for paper " + testPaper.name, function() {

--- a/packages/yoastseo/src/scoring/assessments/readability/passiveVoiceAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/passiveVoiceAssessment.js
@@ -7,7 +7,6 @@ import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import { stripIncompleteTags as stripTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
 import AssessmentResult from "../../../values/AssessmentResult";
 import Mark from "../../../values/Mark";
-import { isFeatureEnabled } from "@yoast/feature-flag";
 
 /**
  * Calculates the result based on the number of sentences and passives.
@@ -111,11 +110,6 @@ const passiveVoiceMarker = function( paper, researcher ) {
  * @returns {object} the Assessmentresult
  */
 const passiveVoiceAssessment = function( paper, researcher, i18n ) {
-	// Check if the Norwegian readability feature is enabled and return the default result if it isn't.
-	if ( researcher.getConfig( "language" ) === "nb" && ! isFeatureEnabled( "NORWEGIAN_READABILITY" ) ) {
-		return new AssessmentResult();
-	}
-
 	const passiveVoice = researcher.getResearch( "getPassiveVoiceResult" );
 
 	const passiveVoiceResult = calculatePassiveVoiceResult( passiveVoice, i18n );

--- a/packages/yoastseo/src/scoring/assessments/readability/sentenceBeginningsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/sentenceBeginningsAssessment.js
@@ -1,4 +1,3 @@
-import { isFeatureEnabled } from "@yoast/feature-flag";
 import { filter, flatten, map, partition, sortBy } from "lodash-es";
 
 import marker from "../../../markers/addMark";
@@ -118,11 +117,6 @@ const sentenceBeginningMarker = function( paper, researcher ) {
  * @returns {object} The Assessment result
  */
 const sentenceBeginningsAssessment = function( paper, researcher, i18n ) {
-	// Check if the Norwegian readability feature is enabled and return the default result if it isn't.
-	if ( researcher.getConfig( "language" ) === "nb" && ! isFeatureEnabled( "NORWEGIAN_READABILITY" ) ) {
-		return new AssessmentResult();
-	}
-
 	const sentenceBeginnings = researcher.getResearch( "getSentenceBeginnings" );
 	const groupedSentenceBeginnings = groupSentenceBeginnings( sentenceBeginnings );
 	const sentenceBeginningsResult = calculateSentenceBeginningsResult( groupedSentenceBeginnings, i18n );

--- a/packages/yoastseo/src/scoring/assessments/readability/transitionWordsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/transitionWordsAssessment.js
@@ -1,4 +1,3 @@
-import { isFeatureEnabled } from "@yoast/feature-flag";
 import { map } from "lodash-es";
 
 import formatNumber from "../../../helpers/formatNumber";
@@ -118,11 +117,6 @@ const calculateTransitionWordResult = function( transitionWordSentences, i18n ) 
  * @returns {object} The Assessment result.
  */
 const transitionWordsAssessment = function( paper, researcher, i18n ) {
-	// Check if the Norwegian readability feature is enabled and return the default result if it isn't.
-	if ( researcher.getConfig( "language" ) === "nb" && ! isFeatureEnabled( "NORWEGIAN_READABILITY" ) ) {
-		return new AssessmentResult();
-	}
-
 	const transitionWordSentences = researcher.getResearch( "findTransitionWords" );
 	const transitionWordResult = calculateTransitionWordResult( transitionWordSentences, i18n );
 	const assessmentResult = new AssessmentResult();

--- a/src/deprecated/src/conditionals/norwegian-readability-conditional.php
+++ b/src/deprecated/src/conditionals/norwegian-readability-conditional.php
@@ -4,6 +4,9 @@ namespace Yoast\WP\SEO\Conditionals;
 
 /**
  * Checks if the YOAST_SEO_NORWEGIAN_READABILITY constant is set.
+ *
+ * @deprecated 16.8
+ * @codeCoverageIgnore
  */
 class Norwegian_Readability_Conditional extends Feature_Flag_Conditional {
 
@@ -11,9 +14,13 @@ class Norwegian_Readability_Conditional extends Feature_Flag_Conditional {
 	 * Returns the name of the feature flag.
 	 * 'YOAST_SEO_' is automatically prepended to it and it will be uppercased.
 	 *
+	 * @deprecated 16.8
+	 * @codeCoverageIgnore
+	 *
 	 * @return string the name of the feature flag.
 	 */
 	public function get_feature_flag() {
+		_deprecated_function( __METHOD__, 'WPSEO 16.8' );
 		return 'NORWEGIAN_READABILITY';
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the Norwegian readability feature flag.
* [yoastseo] Removes the Norwegian readability feature flag and deprecates the Norwegian readability feature flag conditional.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### To test that the Norwegian readability functionality works:

* Set your site to Norwegian (Norsk Bokmål).
* Open/create a post and add a text of at least 300 words.
* Make sure that the transition words, passive voice, and consecutive sentences assessments show up.
* Add the word `eansett` to the text. Make sure that it's detected by the transition word assessment.
* Add the sentence 'Oppgaven vil bli gjort.`. Make sure that it's detected by the passive voice assessment.
* Remove all of your text and add the sentences `En katt. En hund. En hest.`. Make sure that the consecutive sentences assessment returns a green bullet.

### To test that the deprecation works:

* Open the `functions.php` file for your WordPress theme (the location of the file would be something like `plugin-development-docker/wordpress/wp-content/themes/twentytwentyone/functions.php` if testing in Docker, or `Local Sites/test1/app/public/wp-content/themes/twentytwentyone/functions.php` in Local by Flywheel.)
* Enter the following code on top of the file, after the `Functions and definitions` line:
<img width="778" alt="Screenshot 2021-07-09 at 15 40 04" src="https://user-images.githubusercontent.com/32479012/125087401-be902500-e0cc-11eb-88f1-a65333fac981.png">

```
$flag = new \Yoast\WP\SEO\Conditionals\Norwegian_Readability_Conditional();
$flag->is_met();
```
* Activate the Free plugin and click on the WordPress icon in top left corner.
* The admin bar should show one PHP error:
<img width="310" alt="Screenshot 2021-07-09 at 15 35 38" src="https://user-images.githubusercontent.com/32479012/125087553-dd8eb700-e0cc-11eb-9d83-233980cbcc64.png">

* After clicking on it, the following warning should show:
<img width="1093" alt="Screenshot 2021-07-09 at 15 37 28" src="https://user-images.githubusercontent.com/32479012/125086103-981dba00-e0cb-11eb-8a14-715b1826040b.png">

* Remove the line of code after testing


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
