### PR TITLE
Fix incorrect robots tag generation

### DIFF
--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -139,24 +139,24 @@ class WP_Robots_Integration implements Integration_Interface {
 	 * @return array The filtered robots.
 	 */
 	protected function enforce_robots_congruence( $robots ) {
-		if ( isset( $robots['nofollow'] ) ) {
+		if ( ! empty( $robots['nofollow'] ) ) {
 			$robots['follow'] = null;
 		}
-		if ( isset( $robots['noarchive'] ) ) {
+		if ( ! empty( $robots['noarchive'] ) ) {
 			$robots['archive'] = null;
 		}
-		if ( isset( $robots['noimageindex'] ) ) {
+		if ( ! empty( $robots['noimageindex'] ) ) {
 			$robots['imageindex'] = null;
 
 			// max-image-preview should be to none when noimageindex is present.
-			if ( isset( $robots['max-image-preview'] ) ) {
+			if ( ! empty( $robots['max-image-preview'] ) ) {
 				$robots['max-image-preview'] = 'none';
 			}
 		}
-		if ( isset( $robots['nosnippet'] ) ) {
+		if ( ! empty( $robots['nosnippet'] ) ) {
 			$robots['snippet'] = null;
 		}
-		if ( isset( $robots['noindex'] ) ) {
+		if ( ! empty( $robots['noindex'] ) ) {
 			$robots['index']             = null;
 			$robots['imageindex']        = null;
 			$robots['noimageindex']      = null;

--- a/src/integrations/front-end/wp-robots-integration.php
+++ b/src/integrations/front-end/wp-robots-integration.php
@@ -148,8 +148,10 @@ class WP_Robots_Integration implements Integration_Interface {
 		if ( ! empty( $robots['noimageindex'] ) ) {
 			$robots['imageindex'] = null;
 
-			// max-image-preview should be to none when noimageindex is present.
-			if ( ! empty( $robots['max-image-preview'] ) ) {
+			// `max-image-preview` should set be to `none` when `noimageindex` is present.
+			// Using `isset` rather than `! empty` here so that in the rare case of `max-image-preview`
+			// being equal to an empty string due to filtering, its value would still be set to `none`.
+			if ( isset( $robots['max-image-preview'] ) ) {
 				$robots['max-image-preview'] = 'none';
 			}
 		}

--- a/tests/unit/integrations/front-end/wp-robots-integration-test.php
+++ b/tests/unit/integrations/front-end/wp-robots-integration-test.php
@@ -239,6 +239,47 @@ class WP_Robots_Integration_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the add robots with with passing both true and false for associated keys ('index'/'noindex').
+	 *
+	 * This test fails when using `isset( $robots['noindex'] )`,
+	 * and passes when using `! empty( $robots['noindex'] )`.
+	 *
+	 * @covers ::add_robots
+	 * @covers ::get_robots_value
+	 * @covers ::format_robots
+	 * @covers ::enforce_robots_congruence
+	 * @covers ::sort_robots
+	 */
+	public function test_add_robots_with_index_true_and_noindex_false() {
+		$context = (object) [
+			'presentation' => (object) [
+				'robots' => [
+					'index'  => 'index',
+					'follow' => 'follow',
+				],
+			],
+		];
+
+		$this->context_memoizer
+			->expects( 'for_current_page' )
+			->once()
+			->andReturn( $context );
+
+		static::assertEquals(
+			[
+				'index'  => true,
+				'follow' => true,
+			],
+			$this->instance->add_robots(
+				[
+					'index'   => true,
+					'noindex' => false,
+				]
+			)
+		);
+	}
+
+	/**
 	 * Tests the add robots with having the robots input being overwritten by our data.
 	 *
 	 * @covers ::add_robots

--- a/tests/unit/integrations/front-end/wp-robots-integration-test.php
+++ b/tests/unit/integrations/front-end/wp-robots-integration-test.php
@@ -83,7 +83,7 @@ class WP_Robots_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the add robots with having the robots input value being a string.
+	 * Tests the add_robots with having the robots input value being a string.
 	 *
 	 * @covers ::add_robots
 	 * @covers ::get_robots_value
@@ -113,7 +113,7 @@ class WP_Robots_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the add robots with the robots input being overwritten by our data,
+	 * Tests the add_robots with the robots input being overwritten by our data,
 	 * by setting 'index' and 'follow' to 'true'.
 	 *
 	 * @covers ::add_robots
@@ -156,7 +156,7 @@ class WP_Robots_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the add robots with setting 'imageindex' to 'noimageindex' in the context object.
+	 * Tests the add_robots with setting 'imageindex' to 'noimageindex' in the context object.
 	 *
 	 * @covers ::add_robots
 	 * @covers ::get_robots_value
@@ -198,7 +198,7 @@ class WP_Robots_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the add robots with the robots input being overwritten by our data,
+	 * Tests the add_robots with the robots input being overwritten by our data,
 	 * by setting 'noindex' and 'follow' to 'true'.
 	 *
 	 * @covers ::add_robots
@@ -239,7 +239,7 @@ class WP_Robots_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the add robots with with passing both true and false for associated keys ('index'/'noindex').
+	 * Tests the add_robots with passing both true and false for associated keys ('index'/'noindex').
 	 *
 	 * This test fails when using `isset( $robots['noindex'] )`,
 	 * and passes when using `! empty( $robots['noindex'] )`.

--- a/tests/unit/integrations/front-end/wp-robots-integration-test.php
+++ b/tests/unit/integrations/front-end/wp-robots-integration-test.php
@@ -280,7 +280,50 @@ class WP_Robots_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the add robots with having the robots input being overwritten by our data.
+	 * Tests the add_robots with passing `noimageindex` in combination with an empty string for `max-image-preview`.
+	 *
+	 * This test fails when using `! empty( $robots['max-image-preview'] )`,
+	 * and passes when using `isset( $robots['max-image-preview'] )`.
+	 *
+	 * @covers ::add_robots
+	 * @covers ::get_robots_value
+	 * @covers ::format_robots
+	 * @covers ::enforce_robots_congruence
+	 * @covers ::sort_robots
+	 */
+	public function test_add_robots_with_noimageindex_and_maximagepreview_empty() {
+		$context = (object) [
+			'presentation' => (object) [
+				'robots' => [
+					'index'  => 'index',
+					'follow' => 'follow',
+				],
+			],
+		];
+
+		$this->context_memoizer
+			->expects( 'for_current_page' )
+			->once()
+			->andReturn( $context );
+
+		static::assertEquals(
+			[
+				'index'             => true,
+				'follow'            => true,
+				'noimageindex'      => true,
+				'max-image-preview' => 'none',
+			],
+			$this->instance->add_robots(
+				[
+					'noimageindex'      => true,
+					'max-image-preview' => '',
+				]
+			)
+		);
+	}
+
+	/**
+	 * Tests the add_robots with having the robots input being overwritten by our data.
 	 *
 	 * @covers ::add_robots
 	 * @covers ::get_robots_value

--- a/tests/unit/integrations/front-end/wp-robots-integration-test.php
+++ b/tests/unit/integrations/front-end/wp-robots-integration-test.php
@@ -113,14 +113,16 @@ class WP_Robots_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the add robots with having the robots input being overwritten by our data.
+	 * Tests the add robots with the robots input being overwritten by our data,
+	 * by setting 'index' and 'follow' to 'true'.
 	 *
 	 * @covers ::add_robots
 	 * @covers ::get_robots_value
 	 * @covers ::format_robots
 	 * @covers ::enforce_robots_congruence
+	 * @covers ::sort_robots
 	 */
-	public function test_add_robots() {
+	public function test_add_robots_overwrite_robots_value_set_to_true() {
 		$context = (object) [
 			'presentation' => (object) [
 				'robots' => [
@@ -154,12 +156,13 @@ class WP_Robots_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the add robots with having the robots input being overwritten by our data.
+	 * Tests the add robots with setting 'imageindex' to 'noimageindex' in the context object.
 	 *
 	 * @covers ::add_robots
 	 * @covers ::get_robots_value
 	 * @covers ::format_robots
 	 * @covers ::enforce_robots_congruence
+	 * @covers ::sort_robots
 	 */
 	public function test_add_robots_with_noimageindex() {
 		$context = (object) [
@@ -195,12 +198,14 @@ class WP_Robots_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the add robots with having the robots input being overwritten by our data.
+	 * Tests the add robots with the robots input being overwritten by our data,
+	 * by setting 'noindex' and 'follow' to 'true'.
 	 *
 	 * @covers ::add_robots
 	 * @covers ::get_robots_value
 	 * @covers ::format_robots
 	 * @covers ::enforce_robots_congruence
+	 * @covers ::sort_robots
 	 */
 	public function test_add_robots_with_noindex_set() {
 		$context = (object) [
@@ -240,6 +245,7 @@ class WP_Robots_Integration_Test extends TestCase {
 	 * @covers ::get_robots_value
 	 * @covers ::format_robots
 	 * @covers ::enforce_robots_congruence
+	 * @covers ::sort_robots
 	 */
 	public function test_enforce_robots_congruence() {
 		$context = (object) [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `robots` meta tag could have incorrect values if users called the `wp_robots` filter to set certain values to `false`. Props to [Roy-Orbison](https://github.com/Roy-Orbison).

## Relevant technical choices:

**Copied from the issue**: 
* The `wp_robots` filter is applied in WP core's `wp-includes/robots-template.php` and it ignores falsey values in the array that aren't strings. 
* This means that a filter added to this hook that sets the `index` key to `true` and `noindex` to `false` gets broken by `Yoast\WP\SEO\Integrations\Front_End\WP_Robots_Integration::enforce_robots_congruence` because [it (incorrectly) assumes](https://github.com/Yoast/wordpress-seo/blob/595e98bd530d24fc327b44d993df5b0cd11ed87e/src/integrations/front-end/wp-robots-integration.php#L142) `isset( $robots['nofollow'] )` is equivalent to `isset( $robots['nofollow'] ) && $robots['nofollow']`. 
* This is rectified in this PR by changing the `isset()` tests to `! empty()` tests.

**In addition:**
* I added a unit test that proves that the bug was present in the old state of the code, and is fixed in the new state of the code.
* All of the keys in `enforce_robots_congruence()` take a boolean value, except for `max-image-preview`, which takes a string. `max-image-preview` is supposed to take any of the values `none`, `standard` or `large` (see [here](https://yoast.com/robots-meta-tags/)). As explained [here](https://yoast.atlassian.net/browse/P3-546), "we should set `max-image-preview` to `none` when `noimageindex` is present". Using `isset()` rather than `! empty` will ensure this is also the case if `max-image-preview` had an empty string as its value (for example, because of filtering).
    * I also added a unit test to show that this works as expected. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**To reproduce**
* Use `trunk` or a previous RC that doesn't include this fix.
* Add this line to `register_hooks()` in `wp-robots-integration.php`:
    * `\add_filter( 'wp_robots', [ $this, 'custom_robots_filter' ], 1, 10 );`.
* Below the `register_hooks()` function, add the following code:
```
	function custom_robots_filter( $robots ){
		$robots['index'] = true;
		$robots['noindex'] = false;
		return $robots;
	}
```
* Go to a post on the front-end and open the page source.
* See that the `robots` meta tag does **not** include an `index` value, even though it was set to `true` in the function above. For example:
    * `<meta name='robots' content='follow' />`;

**To test the fix**
* Check out this branch or an RC that includes this fix.
* Add this line to `register_hooks()` in `wp-robots-integration.php`:
    * `\add_filter( 'wp_robots', [ $this, 'custom_robots_filter' ], 1, 10 );`.
* Below the `register_hooks()` function, add the following code:
```
	function custom_robots_filter( $robots ){
		$robots['index'] = true;
		$robots['noindex'] = false;
		return $robots;
	}
```
* Go to a post on the front-end and open the page source.
* See that the `robots` meta tag looks now includes an `index` value, and potentially some other additional values too:
    * `<meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #17204 
