### PR TITLE
P2-1133 update core/editor getBlocks deprecation

### DIFF
--- a/packages/js/src/containers/DocumentSidebar.js
+++ b/packages/js/src/containers/DocumentSidebar.js
@@ -18,13 +18,13 @@ import {
 export function mapSelectToProps( select ) {
 	const yoastStore = select( "yoast-seo/editor" );
 	const yoastSchemaStore = select( "yoast-seo/schema-blocks" );
-	const wpEditorStore = select( "core/editor" );
+	const wpBlockEditorStore = select( "core/block-editor" );
 
 	const checklist = [];
 
 	maybeAddReadabilityCheck( checklist, yoastStore );
 	maybeAddSEOCheck( checklist, yoastStore );
-	maybeAddSchemaBlocksValidationCheck( checklist, yoastSchemaStore, wpEditorStore );
+	maybeAddSchemaBlocksValidationCheck( checklist, yoastSchemaStore, wpBlockEditorStore );
 
 	return { checklist };
 }

--- a/packages/js/src/containers/PrePublish.js
+++ b/packages/js/src/containers/PrePublish.js
@@ -19,14 +19,14 @@ import {
 export function mapSelectToProps( select ) {
 	const yoastStore = select( "yoast-seo/editor" );
 	const schemaBlocksStore = select( "yoast-seo/schema-blocks" );
-	const wpEditorStore = select( "core/editor" );
+	const wpBlockEditorStore = select( "core/block-editor" );
 
 	const checklist = [];
 
 	maybeAddFocusKeyphraseCheck( checklist, yoastStore );
 	maybeAddReadabilityCheck( checklist, yoastStore );
 	maybeAddSEOCheck( checklist, yoastStore );
-	maybeAddSchemaBlocksValidationCheck( checklist, schemaBlocksStore, wpEditorStore );
+	maybeAddSchemaBlocksValidationCheck( checklist, schemaBlocksStore, wpBlockEditorStore );
 
 	return { checklist };
 }

--- a/packages/js/src/decorator/gutenberg.js
+++ b/packages/js/src/decorator/gutenberg.js
@@ -7,7 +7,6 @@ import {
 import "@wordpress/annotations";
 import { create } from "@wordpress/rich-text";
 import { select, dispatch } from "@wordpress/data";
-import {BlockInstance} from "@wordpress/blocks";
 
 const ANNOTATION_SOURCE = "yoast";
 

--- a/packages/js/src/decorator/gutenberg.js
+++ b/packages/js/src/decorator/gutenberg.js
@@ -7,6 +7,7 @@ import {
 import "@wordpress/annotations";
 import { create } from "@wordpress/rich-text";
 import { select, dispatch } from "@wordpress/data";
+import {BlockInstance} from "@wordpress/blocks";
 
 const ANNOTATION_SOURCE = "yoast";
 
@@ -103,7 +104,7 @@ function scheduleAnnotationQueueApplication() {
  * @returns {boolean} Whether or not annotations are available in Gutenberg.
  */
 export function isAnnotationAvailable() {
-	return select( "core/editor" ) && isFunction( select( "core/editor" ).getBlocks ) &&
+	return select( "core/block-editor" ) && isFunction( select( "core/block-editor" ).getBlocks ) &&
 		select( "core/annotations" ) && isFunction( dispatch( "core/annotations" ).__experimentalAddAnnotation );
 }
 
@@ -373,8 +374,7 @@ export function applyAsAnnotations( paper, marks ) {
 	if ( marks.length === 0 ) {
 		return;
 	}
-
-	const blocks = select( "core/editor" ).getBlocks();
+	const blocks = select( "core/block-editor" ).getBlocks();
 
 	// For every block...
 	const annotations = flatMap( blocks, ( ( block ) => {

--- a/packages/js/src/helpers/addCheckToChecklist.js
+++ b/packages/js/src/helpers/addCheckToChecklist.js
@@ -83,14 +83,14 @@ function includesSchemaBlocks( blocks ) {
  * This check is hidden when no schema validation results are known
  * (e.g. when no schema blocks exist on the page).
  *
- * @param {Object[]} checklist        The score items to add the score to.
- * @param {Object}   yoastSchemaStore The `yoast-seo/schema-blocks` Yoast SEO redux store.
- * @param {Object}   wpEditorStore    The `core/editor` WordPress store.
+ * @param {Object[]} checklist          The score items to add the score to.
+ * @param {Object}   yoastSchemaStore   The `yoast-seo/schema-blocks` Yoast SEO redux store.
+ * @param {Object}   wpBlockEditorStore The `core/block-editor` WordPress store.
  *
  * @returns {void}
  */
-export function maybeAddSchemaBlocksValidationCheck( checklist, yoastSchemaStore, wpEditorStore ) {
-	const blocks = wpEditorStore.getBlocks();
+export function maybeAddSchemaBlocksValidationCheck( checklist, yoastSchemaStore, wpBlockEditorStore ) {
+	const blocks = wpBlockEditorStore.getBlocks();
 
 	if ( ! includesSchemaBlocks( blocks ) ) {
 		return;

--- a/packages/js/tests/containers/mockSelectors.js
+++ b/packages/js/tests/containers/mockSelectors.js
@@ -57,7 +57,7 @@ export function mockSelectors( name, schemaBlocksValidations = null ) {
 		},
 	] );
 
-	const coreEditorSelectors = {
+	const coreBlockEditorSelectors = {
 		getBlocks,
 	};
 
@@ -65,8 +65,8 @@ export function mockSelectors( name, schemaBlocksValidations = null ) {
 		switch ( storeName ) {
 			case "yoast-seo/editor" :
 				return yoastSEOSelectors;
-			case "core/editor" :
-				return coreEditorSelectors;
+			case "core/block-editor" :
+				return coreBlockEditorSelectors;
 			case "yoast-seo/schema-blocks" :
 				return schemaBlocksSelectors;
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* This PR removes the following console warning:

> wp.data.select( 'core/editor' ).getBlocks` is deprecated. Please use `wp.data.select( 'core/block-editor' ).getBlocks` instead.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Use the new block editor store to get Blocks, instead of the deprecated core editor store.

## Relevant technical choices:

* replaced core/editor with core/block-editor where getBlocks was used.
* renamed variables to follow suit
* updated unit tests

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

No errors or console warnings should be visible when using these features:
* Regression test for Document Sidebar
* Regression test for PrePublish checks
* Regression test for annotations
* Regression test for schema blocks (behind feature toggle)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Sidebar
* Prepublish checks
* annotations
* schema blocks package validation checklist

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
