### PR TITLE
Refactored logic for background indexation to reduce count queries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,8 +80,8 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=276",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=223",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=274",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=222",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs-summary": [

--- a/src/actions/indexing/abstract-indexing-action.php
+++ b/src/actions/indexing/abstract-indexing-action.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Yoast\WP\SEO\Actions\Indexing;
 
 /**
  * Trait used to calculate unindexed object.
  */
-trait Limited_Count_Trait {
+abstract class Abstract_Indexing_Action implements Indexation_Action_Interface {
 
 	/**
 	 * Returns the transient key for the limited count.

--- a/src/actions/indexing/abstract-indexing-action.php
+++ b/src/actions/indexing/abstract-indexing-action.php
@@ -52,6 +52,8 @@ abstract class Abstract_Indexing_Action implements Indexation_Action_Interface {
 			return (int) $transient;
 		}
 
+		\set_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT, 0, ( \MINUTE_IN_SECONDS * 15 ) );
+
 		$query = $this->get_select_query( $limit );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.

--- a/src/actions/indexing/abstract-indexing-action.php
+++ b/src/actions/indexing/abstract-indexing-action.php
@@ -14,7 +14,7 @@ abstract class Abstract_Indexing_Action implements Indexation_Action_Interface {
 	 *
 	 * @var string
 	 */
-	const UNINDEXED_COUNT_TRANSIENT = self::UNINDEXED_COUNT_TRANSIENT;
+	const UNINDEXED_COUNT_TRANSIENT = null;
 
 	/**
 	 * The transient cache key for limited counts.

--- a/src/actions/indexing/abstract-indexing-action.php
+++ b/src/actions/indexing/abstract-indexing-action.php
@@ -44,7 +44,7 @@ abstract class Abstract_Indexing_Action implements Indexation_Action_Interface {
 	 *
 	 * @param int $limit Limit the maximum number of unindexed posts that are counted.
 	 *
-	 * @return int|false The limited number of unindexed posts. False if the query fails.
+	 * @return int The limited number of unindexed posts. 0 if the query fails.
 	 */
 	public function get_limited_unindexed_count( $limit ) {
 		$transient = \get_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT );

--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -60,17 +60,19 @@ abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interf
 	/**
 	 * Returns the total number of unindexed links.
 	 *
+	 * @param int $limit Limit the number of unindexed posts that are counted.
+	 *
 	 * @return int|false The total number of unindexed links or `false` when there
 	 *                   are no unindexes links.
 	 */
-	public function get_total_unindexed() {
+	public function get_total_unindexed( $limit = false ) {
 		$transient = \get_transient( static::UNINDEXED_COUNT_TRANSIENT );
 
 		if ( $transient !== false ) {
 			return (int) $transient;
 		}
 
-		$query = $this->get_query( true );
+		$query = $this->get_count_query( $limit );
 
 		$result = $this->wpdb->get_var( $query );
 
@@ -135,4 +137,22 @@ abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interf
 	 * @return string The query.
 	 */
 	abstract protected function get_query( $count, $limit = 1 );
+
+	/**
+	 * Builds a query for counting the number of unindexed links.
+	 *
+	 * @param bool $limit The maximum amount of unindexed links that should be counted.
+	 *
+	 * @return string The prepared query string.
+	 */
+	abstract protected function get_count_query( $limit = false );
+
+	/**
+	 * Builds a query for selecting the ID's of unindexed links.
+	 *
+	 * @param bool $limit The maximum number of link IDs to return.
+	 *
+	 * @return string The prepared query string.
+	 */
+	abstract protected function get_select_query( $limit = false );
 }

--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -111,13 +111,8 @@ abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interf
 		$query = $this->get_select_query( $limit );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_select_query returns a prepared query.
-		$post_ids = $this->wpdb->get_col( $query );
-
-		if ( \is_null( $post_ids ) ) {
-			return false;
-		}
-
-		$count = (int) count( $post_ids );
+		$unindexed_object_ids = $this->wpdb->get_col( $query );
+		$count                = (int) count( $unindexed_object_ids );
 
 		\set_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT, $count, ( \MINUTE_IN_SECONDS * 15 ) );
 
@@ -142,6 +137,7 @@ abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interf
 		}
 
 		\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
+		\delete_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT );
 
 		return $indexables;
 	}

--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -96,11 +96,11 @@ abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interf
 	}
 
 	/**
-	 * Returns a limited number of unindexed posts.
+	 * Returns a limited number of unindexed links.
 	 *
-	 * @param int $limit Limit the maximum number of unindexed posts that are counted.
+	 * @param int $limit Limit the maximum number of unindexed links that are counted.
 	 *
-	 * @return int|false The limited number of unindexed posts. False if the query fails.
+	 * @return int|false The limited number of unindexed links. False if the query fails.
 	 */
 	protected function get_limited_unindexed_count( $limit ) {
 		$transient = \get_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT );

--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -10,8 +10,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 /**
  * Reindexing action for link indexables.
  */
-abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interface {
-	use Limited_Count_Trait;
+abstract class Abstract_Link_Indexing_Action extends Abstract_Indexing_Action {
 
 	/**
 	 * The transient name.

--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -13,20 +13,6 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 abstract class Abstract_Link_Indexing_Action extends Abstract_Indexing_Action {
 
 	/**
-	 * The transient name.
-	 *
-	 * @var string
-	 */
-	const UNINDEXED_COUNT_TRANSIENT = null;
-
-	/**
-	 * The transient cache key for limited counts.
-	 *
-	 * @var string
-	 */
-	const UNINDEXED_LIMITED_COUNT_TRANSIENT = self::UNINDEXED_COUNT_TRANSIENT . '_LIMITED';
-
-	/**
 	 * The link builder.
 	 *
 	 * @var Indexable_Link_Builder

--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -83,9 +83,7 @@ abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interf
 		}
 
 		$query = $this->get_count_query();
-
 		$result = $this->wpdb->get_var( $query );
-
 		if ( \is_null( $result ) ) {
 			return false;
 		}

--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -65,31 +65,6 @@ abstract class Abstract_Link_Indexing_Action extends Abstract_Indexing_Action {
 	}
 
 	/**
-	 * Returns the total number of unindexed links.
-	 *
-	 * @return int|false The total number of unindexed links or `false` when there are no unindexed links.
-	 */
-	public function get_total_unindexed() {
-		$transient = \get_transient( static::UNINDEXED_COUNT_TRANSIENT );
-
-		if ( $transient !== false ) {
-			return (int) $transient;
-		}
-
-		$query = $this->get_count_query();
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.
-		$result = $this->wpdb->get_var( $query );
-		if ( \is_null( $result ) ) {
-			return false;
-		}
-
-		\set_transient( static::UNINDEXED_COUNT_TRANSIENT, $result, \DAY_IN_SECONDS );
-
-		return (int) $result;
-	}
-
-	/**
 	 * Builds links for indexables which haven't had their links indexed yet.
 	 *
 	 * @return SEO_Links[] The created SEO links.
@@ -132,20 +107,4 @@ abstract class Abstract_Link_Indexing_Action extends Abstract_Indexing_Action {
 	 * @return array Objects to be indexed, should be an array of objects with object_id, object_type and content.
 	 */
 	abstract protected function get_objects();
-
-	/**
-	 * Builds a query for counting the number of unindexed links.
-	 *
-	 * @return string The prepared query string.
-	 */
-	abstract protected function get_count_query();
-
-	/**
-	 * Returns the transient key for the limited count.
-	 *
-	 * @return string The transient key.
-	 */
-	protected function get_limited_count_transient() {
-		return static::UNINDEXED_LIMITED_COUNT_TRANSIENT;
-	}
 }

--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -115,7 +115,7 @@ abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interf
 
 		$count = (int) count( $post_ids );
 
-		\set_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT . '_' . $limit, $count, \MINUTE_IN_SECONDS * 15 );
+		\set_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT, $count, \MINUTE_IN_SECONDS * 15 );
 
 		return $count;
 	}

--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -83,6 +83,8 @@ abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interf
 		}
 
 		$query = $this->get_count_query();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.
 		$result = $this->wpdb->get_var( $query );
 		if ( \is_null( $result ) ) {
 			return false;
@@ -107,6 +109,8 @@ abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interf
 		}
 
 		$query = $this->get_select_query( $limit );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_select_query returns a prepared query.
 		$post_ids = $this->wpdb->get_col( $query );
 
 		if ( \is_null( $post_ids ) ) {
@@ -115,7 +119,7 @@ abstract class Abstract_Link_Indexing_Action implements Indexation_Action_Interf
 
 		$count = (int) count( $post_ids );
 
-		\set_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT, $count, \MINUTE_IN_SECONDS * 15 );
+		\set_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT, $count, ( \MINUTE_IN_SECONDS * 15 ) );
 
 		return $count;
 	}

--- a/src/actions/indexing/indexable-general-indexation-action.php
+++ b/src/actions/indexing/indexable-general-indexation-action.php
@@ -52,6 +52,17 @@ class Indexable_General_Indexation_Action implements Indexation_Action_Interface
 	}
 
 	/**
+	 * Returns a limited number of unindexed posts.
+	 *
+	 * @param int $limit Limit the maximum number of unindexed posts that are counted.
+	 *
+	 * @return int|false The limited number of unindexed posts. False if the query fails.
+	 */
+	public function get_limited_unindexed_count( $limit ) {
+		return $this->get_total_unindexed();
+	}
+
+	/**
 	 * Creates indexables for unindexed system pages, the date archive, and the homepage.
 	 *
 	 * @return Indexable[] The created indexables.

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -110,7 +110,7 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 
 		$count = (int) count( $post_ids );
 
-		\set_transient( static::TRANSIENT_CACHE_KEY_LIMITED . '_' . $limit, $count, \MINUTE_IN_SECONDS * 15 );
+		\set_transient( static::TRANSIENT_CACHE_KEY_LIMITED, $count, \MINUTE_IN_SECONDS * 15 );
 
 		return $count;
 	}
@@ -152,21 +152,6 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 		}
 
 		return $limit;
-	}
-
-	/**
-	 * Queries the database for unindexed post IDs.
-	 *
-	 * @param bool $count Whether or not it should be a count query.
-	 * @param int  $limit The maximum number of post IDs to return.
-	 *
-	 * @return string The query.
-	 */
-	protected function get_query( $count, $limit = 1 ) {
-		if ( $count ) {
-			return $this->get_count_query( $limit );
-		}
-		return $this->get_select_query( $limit );
 	}
 
 	/**

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -18,14 +18,7 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 	 *
 	 * @var string
 	 */
-	const TRANSIENT_CACHE_KEY = 'wpseo_total_unindexed_posts';
-
-	/**
-	 * The transient cache key for limited counts.
-	 *
-	 * @var string
-	 */
-	const TRANSIENT_CACHE_KEY_LIMITED = 'wpseo_limited_unindexed_posts_count';
+	const UNINDEXED_COUNT_TRANSIENT = 'wpseo_total_unindexed_posts';
 
 	/**
 	 * The post type helper.
@@ -62,31 +55,6 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 	}
 
 	/**
-	 * Returns the total number of unindexed posts.
-	 *
-	 * @return int|false The total number of unindexed posts. False if the query fails.
-	 */
-	public function get_total_unindexed() {
-		$transient = \get_transient( static::TRANSIENT_CACHE_KEY );
-		if ( $transient !== false ) {
-			return (int) $transient;
-		}
-
-		$query = $this->get_count_query();
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.
-		$count = $this->wpdb->get_var( $query );
-
-		if ( \is_null( $count ) ) {
-			return false;
-		}
-
-		\set_transient( static::TRANSIENT_CACHE_KEY, $count, \DAY_IN_SECONDS );
-
-		return (int) $count;
-	}
-
-	/**
 	 * Creates indexables for unindexed posts.
 	 *
 	 * @return Indexable[] The created indexables.
@@ -102,8 +70,8 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			$indexables[] = $this->repository->find_by_id_and_type( (int) $post_id, 'post' );
 		}
 
-		\delete_transient( static::TRANSIENT_CACHE_KEY );
-		\delete_transient( static::TRANSIENT_CACHE_KEY_LIMITED );
+		\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
+		\delete_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT );
 
 		return $indexables;
 	}
@@ -197,14 +165,5 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 
 		// `array_values`, to make sure that the keys are reset.
 		return \array_values( \array_diff( $public_post_types, $excluded_post_types ) );
-	}
-
-	/**
-	 * Returns the transient key for the limited count.
-	 *
-	 * @return string The transient key.
-	 */
-	protected function get_limited_count_transient() {
-		return static::TRANSIENT_CACHE_KEY_LIMITED;
 	}
 }

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -21,6 +21,13 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 	const UNINDEXED_COUNT_TRANSIENT = 'wpseo_total_unindexed_posts';
 
 	/**
+	 * The transient cache key for limited counts.
+	 *
+	 * @var string
+	 */
+	const UNINDEXED_LIMITED_COUNT_TRANSIENT = self::UNINDEXED_COUNT_TRANSIENT . '_limited';
+
+	/**
 	 * The post type helper.
 	 *
 	 * @var Post_Type_Helper

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -65,11 +65,9 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 	/**
 	 * Returns the total number of unindexed posts.
 	 *
-	 * @param int|false $limit Limit the number of unindexed posts that are counted.
-	 *
 	 * @return int|false The total number of unindexed posts. False if the query fails.
 	 */
-	public function get_total_unindexed( $limit = false ) {
+	public function get_total_unindexed() {
 		$transient = \get_transient( static::TRANSIENT_CACHE_KEY );
 		if ( $transient !== false ) {
 			return (int) $transient;
@@ -84,10 +82,7 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 			return false;
 		}
 
-		// Limited queries have their own transient caching.
-		if ( $limit === false ) {
-			\set_transient( static::TRANSIENT_CACHE_KEY, $count, \DAY_IN_SECONDS );
-		}
+		\set_transient( static::TRANSIENT_CACHE_KEY, $count, \DAY_IN_SECONDS );
 
 		return (int) $count;
 	}

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -102,7 +102,7 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 	 * @return Indexable[] The created indexables.
 	 */
 	public function index() {
-		$query    = $this->get_select_query( $this->get_limit() );
+		$query = $this->get_select_query( $this->get_limit() );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_select_query returns a prepared query.
 		$post_ids = $this->wpdb->get_col( $query );

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -11,8 +11,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 /**
  * Reindexing action for post indexables.
  */
-class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
-	use Limited_Count_Trait;
+class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 
 	/**
 	 * The transient cache key.
@@ -47,7 +46,7 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 	 *
 	 * @var wpdb
 	 */
-	private $wpdb;
+	protected $wpdb;
 
 	/**
 	 * Indexable_Post_Indexing_Action constructor

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -113,6 +113,7 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 		}
 
 		\delete_transient( static::TRANSIENT_CACHE_KEY );
+		\delete_transient( static::TRANSIENT_CACHE_KEY_LIMITED );
 
 		return $indexables;
 	}
@@ -177,13 +178,8 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 		$query = $this->get_select_query( $limit );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.
-		$post_ids = $this->wpdb->get_col( $query );
-
-		if ( \is_null( $post_ids ) ) {
-			return false;
-		}
-
-		$count = (int) count( $post_ids );
+		$unindexed_object_ids = $this->wpdb->get_col( $query );
+		$count                = (int) count( $unindexed_object_ids );
 
 		\set_transient( static::TRANSIENT_CACHE_KEY_LIMITED, $count, ( \MINUTE_IN_SECONDS * 15 ) );
 

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -15,11 +15,15 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 
 	/**
 	 * The transient cache key.
+	 *
+	 * @var string
 	 */
 	const TRANSIENT_CACHE_KEY = 'wpseo_total_unindexed_posts';
 
 	/**
 	 * The transient cache key for limited counts.
+	 *
+	 * @var string
 	 */
 	const TRANSIENT_CACHE_KEY_LIMITED = 'wpseo_limited_unindexed_posts_count';
 
@@ -65,17 +69,12 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 	 * @return int|false The total number of unindexed posts. False if the query fails.
 	 */
 	public function get_total_unindexed( $limit = false ) {
-		// Limited queries are use to determine whether background indexing should occur, the exact number is irrelevant.
-		if ( $limit !== false ) {
-			return $this->get_limited_unindexed_count( $limit );
-		}
-
 		$transient = \get_transient( static::TRANSIENT_CACHE_KEY );
 		if ( $transient !== false ) {
 			return (int) $transient;
 		}
 
-		$query = $this->get_count_query();
+		$query = $this->get_count_query( $limit );
 
 		$result = $this->wpdb->get_var( $query );
 
@@ -157,11 +156,16 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 	/**
 	 * Builds a query for counting the number of unindexed posts.
 	 *
-	 * @param bool $limit The maximum amount of unindexed posts that should be counted.
+	 * @param bool|int $limit The maximum amount of unindexed posts that should be counted.
 	 *
 	 * @return string The prepared query string.
 	 */
-	protected function get_count_query() {
+	protected function get_count_query( $limit = false ) {
+		// Limited queries are use to determine whether background indexing should occur, the exact number is irrelevant.
+		if ( $limit !== false ) {
+			return $this->get_limited_unindexed_count( $limit );
+		}
+
 		$indexable_table = Model::get_table_name( 'Indexable' );
 		$post_types      = $this->get_post_types();
 

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -144,7 +144,7 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 		$post_types      = $this->get_post_types();
 		$replacements    = $post_types;
 
-		$limit = '';
+		$limit_query = '';
 		if ( $limit ) {
 			$limit_query    = 'LIMIT %d';
 			$replacements[] = $limit;
@@ -178,7 +178,7 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 		$post_types      = $this->get_post_types();
 		$replacements    = $post_types;
 
-		$limit = '';
+		$limit_query = '';
 		if ( $limit ) {
 			$limit_query    = 'LIMIT %d';
 			$replacements[] = $limit;

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -80,6 +80,8 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 		}
 
 		$query = $this->get_count_query();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.
 		$count = $this->wpdb->get_var( $query );
 
 		if ( \is_null( $count ) ) {
@@ -101,6 +103,8 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 	 */
 	public function index() {
 		$query    = $this->get_select_query( $this->get_limit() );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_select_query returns a prepared query.
 		$post_ids = $this->wpdb->get_col( $query );
 
 		$indexables = [];
@@ -136,8 +140,6 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 	/**
 	 * Builds a query for counting the number of unindexed posts.
 	 *
-	 * @param bool|int $limit The maximum amount of unindexed posts that should be counted.
-	 *
 	 * @return string The prepared query string.
 	 */
 	protected function get_count_query() {
@@ -145,7 +147,8 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 		$post_types      = $this->get_post_types();
 
 		// Warning: If this query is changed, makes sure to update the query in get_select_query as well.
-		return $this->wpdb->prepare( "
+		return $this->wpdb->prepare(
+			"
 			SELECT COUNT(P.ID)
 			FROM {$this->wpdb->posts} AS P
 			LEFT JOIN $indexable_table AS I
@@ -153,7 +156,7 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 				AND I.object_type = 'post'
 				AND I.permalink_hash IS NOT NULL
 			WHERE I.object_id IS NULL
-				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ")",
+				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')',
 			$post_types
 		);
 	}
@@ -172,6 +175,8 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 		}
 
 		$query = $this->get_select_query( $limit );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.
 		$post_ids = $this->wpdb->get_col( $query );
 
 		if ( \is_null( $post_ids ) ) {
@@ -180,7 +185,7 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 
 		$count = (int) count( $post_ids );
 
-		\set_transient( static::TRANSIENT_CACHE_KEY_LIMITED, $count, \MINUTE_IN_SECONDS * 15 );
+		\set_transient( static::TRANSIENT_CACHE_KEY_LIMITED, $count, ( \MINUTE_IN_SECONDS * 15 ) );
 
 		return $count;
 	}
@@ -204,7 +209,8 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 		}
 
 		// Warning: If this query is changed, makes sure to update the query in get_count_query as well.
-		return $this->wpdb->prepare( "
+		return $this->wpdb->prepare(
+			"
 			SELECT P.ID
 			FROM {$this->wpdb->posts} AS P
 			LEFT JOIN $indexable_table AS I

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -80,7 +80,10 @@ class Indexable_Post_Indexation_Action implements Indexation_Action_Interface {
 			return false;
 		}
 
-		\set_transient( static::TRANSIENT_CACHE_KEY, $count, \DAY_IN_SECONDS );
+		// Limited queries have their own transient caching.
+		if ( $limit === false ) {
+			\set_transient( static::TRANSIENT_CACHE_KEY, $count, \DAY_IN_SECONDS );
+		}
 
 		return (int) $count;
 	}

--- a/src/actions/indexing/indexable-post-type-archive-indexation-action.php
+++ b/src/actions/indexing/indexable-post-type-archive-indexation-action.php
@@ -60,13 +60,13 @@ class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action
 	 *
 	 * @return int The total number of unindexed post type archives.
 	 */
-	public function get_total_unindexed() {
+	public function get_total_unindexed( $limit = false ) {
 		$transient = \get_transient( static::TRANSIENT_CACHE_KEY );
 		if ( $transient !== false ) {
 			return (int) $transient;
 		}
 
-		$result = \count( $this->get_unindexed_post_type_archives( false ) );
+		$result = \count( $this->get_unindexed_post_type_archives( $limit ) );
 
 		\set_transient( static::TRANSIENT_CACHE_KEY, $result, \DAY_IN_SECONDS );
 

--- a/src/actions/indexing/indexable-post-type-archive-indexation-action.php
+++ b/src/actions/indexing/indexable-post-type-archive-indexation-action.php
@@ -58,6 +58,8 @@ class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action
 	/**
 	 * Returns the total number of unindexed post type archives.
 	 *
+	 * @param int $limit Limit the number of counted objects.
+	 *
 	 * @return int The total number of unindexed post type archives.
 	 */
 	public function get_total_unindexed( $limit = false ) {

--- a/src/actions/indexing/indexable-post-type-archive-indexation-action.php
+++ b/src/actions/indexing/indexable-post-type-archive-indexation-action.php
@@ -68,6 +68,8 @@ class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action
 			return (int) $transient;
 		}
 
+		\set_transient( static::UNINDEXED_COUNT_TRANSIENT, 0, \DAY_IN_SECONDS );
+
 		$result = \count( $this->get_unindexed_post_type_archives( $limit ) );
 
 		\set_transient( static::UNINDEXED_COUNT_TRANSIENT, $result, \DAY_IN_SECONDS );

--- a/src/actions/indexing/indexable-post-type-archive-indexation-action.php
+++ b/src/actions/indexing/indexable-post-type-archive-indexation-action.php
@@ -172,4 +172,15 @@ class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action
 		};
 		return \array_map( $callback, $results );
 	}
+
+	/**
+	 * Returns a limited number of unindexed posts.
+	 *
+	 * @param int $limit Limit the maximum number of unindexed posts that are counted.
+	 *
+	 * @return int|false The limited number of unindexed posts. False if the query fails.
+	 */
+	public function get_limited_unindexed_count( $limit ) {
+		return $this->get_total_unindexed( $limit );
+	}
 }

--- a/src/actions/indexing/indexable-post-type-archive-indexation-action.php
+++ b/src/actions/indexing/indexable-post-type-archive-indexation-action.php
@@ -15,7 +15,7 @@ class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action
 	/**
 	 * The transient cache key.
 	 */
-	const TRANSIENT_CACHE_KEY = 'wpseo_total_unindexed_post_type_archives';
+	const UNINDEXED_COUNT_TRANSIENT = 'wpseo_total_unindexed_post_type_archives';
 
 	/**
 	 * The post type helper.
@@ -63,14 +63,14 @@ class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action
 	 * @return int The total number of unindexed post type archives.
 	 */
 	public function get_total_unindexed( $limit = false ) {
-		$transient = \get_transient( static::TRANSIENT_CACHE_KEY );
+		$transient = \get_transient( static::UNINDEXED_COUNT_TRANSIENT );
 		if ( $transient !== false ) {
 			return (int) $transient;
 		}
 
 		$result = \count( $this->get_unindexed_post_type_archives( $limit ) );
 
-		\set_transient( static::TRANSIENT_CACHE_KEY, $result, \DAY_IN_SECONDS );
+		\set_transient( static::UNINDEXED_COUNT_TRANSIENT, $result, \DAY_IN_SECONDS );
 
 		return $result;
 	}
@@ -88,7 +88,7 @@ class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action
 			$indexables[] = $this->builder->build_for_post_type_archive( $post_type_archive );
 		}
 
-		\delete_transient( static::TRANSIENT_CACHE_KEY );
+		\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
 
 		return $indexables;
 	}

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -16,12 +16,7 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 	/**
 	 * The transient cache key.
 	 */
-	const TRANSIENT_CACHE_KEY = 'wpseo_total_unindexed_terms';
-
-	/**
-	 * The transient cache key for limited counts.
-	 */
-	const TRANSIENT_CACHE_KEY_LIMITED = 'wpseo_limited_unindexed_terms_count';
+	const UNINDEXED_COUNT_TRANSIENT = 'wpseo_total_unindexed_terms';
 
 	/**
 	 * The post type helper.
@@ -98,8 +93,8 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 			$indexables[] = $this->repository->find_by_id_and_type( (int) $term_id, 'term' );
 		}
 
-		\delete_transient( static::TRANSIENT_CACHE_KEY );
-		\delete_transient( static::TRANSIENT_CACHE_KEY_LIMITED );
+		\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
+		\delete_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT );
 
 		return $indexables;
 	}
@@ -180,14 +175,5 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 			$limit_query",
 			$replacements
 		);
-	}
-
-	/**
-	 * Returns the transient key for the limited count.
-	 *
-	 * @return string The transient key.
-	 */
-	protected function get_limited_count_transient() {
-		return static::TRANSIENT_CACHE_KEY_LIMITED;
 	}
 }

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -61,8 +61,6 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 	/**
 	 * Returns the total number of unindexed terms.
 	 *
-	 * @param int|false $limit Limit the number of unindexed posts that are counted.
-	 *
 	 * @return int|false The number of unindexed terms. False if the query fails.
 	 */
 	public function get_total_unindexed( $limit = false ) {
@@ -80,10 +78,7 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 			return false;
 		}
 
-		// Limited queries have their own transient caching.
-		if ( $limit === false ) {
-			\set_transient( static::TRANSIENT_CACHE_KEY, $count, \DAY_IN_SECONDS );
-		}
+		\set_transient( static::TRANSIENT_CACHE_KEY, $count, \DAY_IN_SECONDS );
 
 		return (int) $count;
 	}

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -11,8 +11,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 /**
  * Reindexing action for term indexables.
  */
-class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
-	use Limited_Count_Trait;
+class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 
 	/**
 	 * The transient cache key.
@@ -43,7 +42,7 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 	 *
 	 * @var wpdb
 	 */
-	private $wpdb;
+	protected $wpdb;
 
 	/**
 	 * Indexable_Term_Indexation_Action constructor

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -138,7 +138,8 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 		$public_taxonomies = $this->taxonomy->get_public_taxonomies();
 
 		// Warning: If this query is changed, makes sure to update the query in get_count_query as well.
-		return $this->wpdb->prepare( "
+		return $this->wpdb->prepare(
+			"
 			SELECT COUNT(term_id)
 			FROM {$this->wpdb->term_taxonomy} AS T
 			LEFT JOIN $indexable_table AS I
@@ -146,7 +147,7 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 				AND I.object_type = 'term'
 				AND I.permalink_hash IS NOT NULL
 			WHERE I.object_id IS NULL
-				AND taxonomy IN (" . \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) ) . ")",
+				AND taxonomy IN (" . \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) ) . ')',
 			$public_taxonomies
 		);
 	}
@@ -173,7 +174,7 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 
 		$count = (int) count( $unindexed_object_ids );
 
-		\set_transient( static::TRANSIENT_CACHE_KEY_LIMITED, $count, \MINUTE_IN_SECONDS * 15 );
+		\set_transient( static::TRANSIENT_CACHE_KEY_LIMITED, $count, ( \MINUTE_IN_SECONDS * 15 ) );
 
 		return $count;
 	}
@@ -197,7 +198,8 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 		}
 
 		// Warning: If this query is changed, makes sure to update the query in get_count_query as well.
-		return $this->wpdb->prepare( "
+		return $this->wpdb->prepare(
+			"
 			SELECT term_id
 			FROM {$this->wpdb->term_taxonomy} AS T
 			LEFT JOIN $indexable_table AS I

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -88,7 +88,7 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 	 * @return Indexable[] The created indexables.
 	 */
 	public function index() {
-		$query    = $this->$this->get_select_query( $this->get_limit() );
+		$query    = $this->get_select_query( $this->get_limit() );
 		$term_ids = $this->wpdb->get_col( $query );
 
 		$indexables = [];

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -60,31 +60,6 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 	}
 
 	/**
-	 * Returns the total number of unindexed terms.
-	 *
-	 * @return int|false The number of unindexed terms. False if the query fails.
-	 */
-	public function get_total_unindexed( $limit = false ) {
-		$transient = \get_transient( static::UNINDEXED_COUNT_TRANSIENT );
-		if ( $transient !== false ) {
-			return (int) $transient;
-		}
-
-		$query = $this->get_count_query();
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.
-		$count = $this->wpdb->get_var( $query );
-
-		if ( \is_null( $count ) ) {
-			return false;
-		}
-
-		\set_transient( static::UNINDEXED_COUNT_TRANSIENT, $count, \DAY_IN_SECONDS );
-
-		return (int) $count;
-	}
-
-	/**
 	 * Creates indexables for unindexed terms.
 	 *
 	 * @return Indexable[] The created indexables.

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -88,7 +88,7 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 	 * @return Indexable[] The created indexables.
 	 */
 	public function index() {
-		$query    = $this->get_query( false, $this->get_limit() );
+		$query    = $this->$this->get_select_query( $this->get_limit() );
 		$term_ids = $this->wpdb->get_col( $query );
 
 		$indexables = [];
@@ -150,7 +150,11 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 			$public_taxonomies
 		);
 
-		return $this->wpdb->get_var( $query );
+		$result = $this->wpdb->get_var( $query );
+		if ( $result ) {
+			return (int) $result;
+		}
+		return false;
 	}
 
 	/**

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -60,6 +60,8 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 	/**
 	 * Returns the total number of unindexed terms.
 	 *
+	 * @param int|false $limit Limit the number of unindexed posts that are counted.
+	 *
 	 * @return int|false The number of unindexed terms. False if the query fails.
 	 */
 	public function get_total_unindexed( $limit = false ) {
@@ -73,6 +75,8 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 		}
 
 		$query = $this->get_count_query();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.
 		$count = $this->wpdb->get_var( $query );
 
 		if ( \is_null( $count ) ) {
@@ -165,7 +169,9 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 			return (int) $transient;
 		}
 
-		$query                = $this->get_select_query( $limit );
+		$query = $this->get_select_query( $limit );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_select_query returns a prepared query.
 		$unindexed_object_ids = $this->wpdb->get_col( $query );
 
 		if ( \is_null( $unindexed_object_ids ) ) {

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -19,6 +19,13 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 	const UNINDEXED_COUNT_TRANSIENT = 'wpseo_total_unindexed_terms';
 
 	/**
+	 * The transient cache key for limited counts.
+	 *
+	 * @var string
+	 */
+	const UNINDEXED_LIMITED_COUNT_TRANSIENT = self::UNINDEXED_COUNT_TRANSIENT . '_limited';
+
+	/**
 	 * The post type helper.
 	 *
 	 * @var Taxonomy_Helper
@@ -58,7 +65,7 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 	 * @return int|false The number of unindexed terms. False if the query fails.
 	 */
 	public function get_total_unindexed( $limit = false ) {
-		$transient = \get_transient( static::TRANSIENT_CACHE_KEY );
+		$transient = \get_transient( static::UNINDEXED_COUNT_TRANSIENT );
 		if ( $transient !== false ) {
 			return (int) $transient;
 		}
@@ -72,7 +79,7 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 			return false;
 		}
 
-		\set_transient( static::TRANSIENT_CACHE_KEY, $count, \DAY_IN_SECONDS );
+		\set_transient( static::UNINDEXED_COUNT_TRANSIENT, $count, \DAY_IN_SECONDS );
 
 		return (int) $count;
 	}

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -106,6 +106,7 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 		}
 
 		\delete_transient( static::TRANSIENT_CACHE_KEY );
+		\delete_transient( static::TRANSIENT_CACHE_KEY_LIMITED );
 
 		return $indexables;
 	}
@@ -173,12 +174,7 @@ class Indexable_Term_Indexation_Action implements Indexation_Action_Interface {
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_select_query returns a prepared query.
 		$unindexed_object_ids = $this->wpdb->get_col( $query );
-
-		if ( \is_null( $unindexed_object_ids ) ) {
-			return false;
-		}
-
-		$count = (int) count( $unindexed_object_ids );
+		$count                = (int) count( $unindexed_object_ids );
 
 		\set_transient( static::TRANSIENT_CACHE_KEY_LIMITED, $count, ( \MINUTE_IN_SECONDS * 15 ) );
 

--- a/src/actions/indexing/indexation-action-interface.php
+++ b/src/actions/indexing/indexation-action-interface.php
@@ -15,6 +15,15 @@ interface Indexation_Action_Interface {
 	public function get_total_unindexed();
 
 	/**
+	 * Returns a limited number of unindexed posts.
+	 *
+	 * @param int $limit Limit the maximum number of unindexed posts that are counted.
+	 *
+	 * @return int|false The limited number of unindexed posts. False if the query fails.
+	 */
+	public function get_limited_unindexed_count( $limit );
+
+	/**
 	 * Indexes a number of objects.
 	 *
 	 * NOTE: ALWAYS use limits, this method is intended to be called multiple times over several requests.

--- a/src/actions/indexing/limited-count-trait.php
+++ b/src/actions/indexing/limited-count-trait.php
@@ -1,0 +1,48 @@
+<?php
+namespace Yoast\WP\SEO\Actions\Indexing;
+
+/**
+ * Trait used to calculate unindexed object.
+ */
+trait Limited_Count_Trait {
+
+	/**
+	 * Returns the transient key for the limited count.
+	 *
+	 * @return string The transient key.
+	 */
+	abstract protected function get_limited_count_transient();
+
+	/**
+	 * Builds a query for selecting the ID's of unindexed posts.
+	 *
+	 * @param bool $limit The maximum number of post IDs to return.
+	 *
+	 * @return string The prepared query string.
+	 */
+	abstract protected function get_select_query();
+
+	/**
+	 * Returns a limited number of unindexed posts.
+	 *
+	 * @param int $limit Limit the maximum number of unindexed posts that are counted.
+	 *
+	 * @return int|false The limited number of unindexed posts. False if the query fails.
+	 */
+	public function get_limited_unindexed_count( $limit ) {
+		$transient = \get_transient( $this->get_limited_count_transient() );
+		if ( $transient !== false ) {
+			return (int) $transient;
+		}
+
+		$query = $this->get_select_query( $limit );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.
+		$unindexed_object_ids = $this->wpdb->get_col( $query );
+		$count                = (int) count( $unindexed_object_ids );
+
+		\set_transient( $this->get_limited_count_transient(), $count, ( \MINUTE_IN_SECONDS * 15 ) );
+
+		return $count;
+	}
+}

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -88,9 +88,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 				AND L.target_post_id != 0
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
 				AND P.post_status = 'publish'
-				AND P.post_type IN ($post_types)
-			ORDER BY P.ID
-			",
+				AND P.post_type IN ($post_types)",
 			$public_post_types
 		);
 	}
@@ -116,8 +114,8 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		}
 
 		// Warning: If this query is changed, makes sure to update the query in get_count_query as well.
-		return $this->wpdb->prepare(
-			"SELECT P.ID, P.post_content
+		return $this->wpdb->prepare( "
+			SELECT P.ID, P.post_content
 			FROM {$this->wpdb->posts} AS P
 			LEFT JOIN $indexable_table AS I
 				ON P.ID = I.object_id
@@ -132,8 +130,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
 				AND P.post_status = 'publish'
 				AND P.post_type IN ($post_types)
-			$limit_query
-			",
+			$limit_query",
 			$replacements
 		);
 	}

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -132,13 +132,4 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 			$replacements
 		);
 	}
-
-	/**
-	 * Returns the transient key for the limited count.
-	 *
-	 * @return string The transient key.
-	 */
-	protected function get_limited_count_transient() {
-		return static::UNINDEXED_LIMITED_COUNT_TRANSIENT;
-	}
 }

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -9,6 +9,7 @@ use Yoast\WP\SEO\Helpers\Post_Type_Helper;
  * Reindexing action for post link indexables.
  */
 class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
+	use Limited_Count_Trait;
 
 	/**
 	 * The transient name.
@@ -127,9 +128,18 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 				AND L.target_post_id != 0
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
 				AND P.post_status = 'publish'
-				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) )  . ")
+				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) ) . ")
 			$limit_query",
 			$replacements
 		);
+	}
+
+	/**
+	 * Returns the transient key for the limited count.
+	 *
+	 * @return string The transient key.
+	 */
+	protected function get_limited_count_transient() {
+		return static::UNINDEXED_LIMITED_COUNT_TRANSIENT;
 	}
 }

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -9,7 +9,6 @@ use Yoast\WP\SEO\Helpers\Post_Type_Helper;
  * Reindexing action for post link indexables.
  */
 class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
-	use Limited_Count_Trait;
 
 	/**
 	 * The transient name.

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -60,21 +60,6 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	}
 
 	/**
-	 * Queries the database for unindexed post link IDs.
-	 *
-	 * @param bool $count Whether or not it should be a count query.
-	 * @param int  $limit The maximum number of post link IDs to return.
-	 *
-	 * @return string The query.
-	 */
-	protected function get_query( $count, $limit = 1 ) {
-		if ( $count ) {
-			return $this->get_count_query( $limit );
-		}
-		return $this->get_select_query( $limit );
-	}
-
-	/**
 	 * Builds a query for counting the number of unindexed post links.
 	 *
 	 * @param bool $limit The maximum amount of unindexed post links that should be counted.

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -66,29 +66,15 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	 *
 	 * @return string The prepared query string.
 	 */
-	protected function get_count_query( $limit = false ) {
-		// Limited queries are use to determine whether background indexing should occur, the exact number is irrelevant.
-		if ( $limit !== false ) {
-			return $this->get_limited_unindexed_count( $limit );
-		}
-
+	protected function get_count_query() {
 		$public_post_types = $this->post_type_helper->get_accessible_post_types();
 		$post_types        = \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) );
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$links_table       = Model::get_table_name( 'SEO_Links' );
-		$replacements      = $public_post_types;
-
-		$query_columns = 'COUNT(P.ID)';
-		$limit_query = '';
-		if ( $limit ) {
-			$limit_query    = 'LIMIT %d';
-			$replacements[] = $limit;
-			$query_columns    = 'P.ID';
-		}
 
 		// Warning: If this query is changed, makes sure to update the query in get_select_query as well.
 		return $this->wpdb->prepare(
-			"SELECT $query_columns
+			"SELECT COUNT(P.ID)
 			FROM {$this->wpdb->posts} AS P
 			LEFT JOIN $indexable_table AS I
 				ON P.ID = I.object_id
@@ -104,9 +90,8 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 				AND P.post_status = 'publish'
 				AND P.post_type IN ($post_types)
 			ORDER BY P.ID
-			$limit_query
 			",
-			$replacements
+			$public_post_types
 		);
 	}
 

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -67,7 +67,6 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	 */
 	protected function get_count_query() {
 		$public_post_types = $this->post_type_helper->get_accessible_post_types();
-		$post_types        = \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) );
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$links_table       = Model::get_table_name( 'SEO_Links' );
 
@@ -87,7 +86,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 				AND L.target_post_id != 0
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
 				AND P.post_status = 'publish'
-				AND P.post_type IN ($post_types)",
+				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) ) . ')',
 			$public_post_types
 		);
 	}
@@ -101,7 +100,6 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	 */
 	protected function get_select_query( $limit = false ) {
 		$public_post_types = $this->post_type_helper->get_accessible_post_types();
-		$post_types        = \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) );
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$links_table       = Model::get_table_name( 'SEO_Links' );
 		$replacements      = $public_post_types;
@@ -129,7 +127,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 				AND L.target_post_id != 0
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
 				AND P.post_status = 'publish'
-				AND P.post_type IN ($post_types)
+				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) )  . ")
 			$limit_query",
 			$replacements
 		);

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -45,6 +45,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	protected function get_objects() {
 		$query = $this->get_select_query( $this->get_limit() );
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_select_query returns a prepared query.
 		$posts = $this->wpdb->get_results( $query );
 
 		return \array_map(
@@ -61,8 +62,6 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 
 	/**
 	 * Builds a query for counting the number of unindexed post links.
-	 *
-	 * @param bool $limit The maximum amount of unindexed post links that should be counted.
 	 *
 	 * @return string The prepared query string.
 	 */
@@ -96,7 +95,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	/**
 	 * Builds a query for selecting the ID's of unindexed post links.
 	 *
-	 * @param bool $limit The maximum number of post link IDs to return.
+	 * @param int|false $limit The maximum number of post link IDs to return.
 	 *
 	 * @return string The prepared query string.
 	 */
@@ -114,7 +113,8 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		}
 
 		// Warning: If this query is changed, makes sure to update the query in get_count_query as well.
-		return $this->wpdb->prepare( "
+		return $this->wpdb->prepare(
+			"
 			SELECT P.ID, P.post_content
 			FROM {$this->wpdb->posts} AS P
 			LEFT JOIN $indexable_table AS I

--- a/src/actions/indexing/term-link-indexing-action.php
+++ b/src/actions/indexing/term-link-indexing-action.php
@@ -60,21 +60,6 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	}
 
 	/**
-	 * Queries the database for unindexed term link IDs.
-	 *
-	 * @param bool $count Whether or not it should be a count query.
-	 * @param int  $limit The maximum number of term link IDs to return.
-	 *
-	 * @return string The query.
-	 */
-	protected function get_query( $count, $limit = 1 ) {
-		if ( $count ) {
-			return $this->get_count_query( $limit );
-		}
-		return $this->get_select_query( $limit );
-	}
-
-	/**
 	 * Builds a query for counting the number of unindexed term links.
 	 *
 	 * @param bool $limit The maximum amount of unindexed term links that should be counted.
@@ -82,6 +67,11 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	 * @return string The prepared query string.
 	 */
 	protected function get_count_query( $limit = false ) {
+		// Limited queries are use to determine whether background indexing should occur, the exact number is irrelevant.
+		if ( $limit !== false ) {
+			return $this->get_limited_unindexed_count( $limit );
+		}
+
 		$public_taxonomies = $this->taxonomy_helper->get_public_taxonomies();
 		$placeholders      = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
 		$indexable_table   = Model::get_table_name( 'Indexable' );

--- a/src/actions/indexing/term-link-indexing-action.php
+++ b/src/actions/indexing/term-link-indexing-action.php
@@ -72,7 +72,8 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 
 		// Warning: If this query is changed, makes sure to update the query in get_select_query as well.
-		return $this->wpdb->prepare( "
+		return $this->wpdb->prepare(
+			"
 			SELECT COUNT(T.term_id)
 			FROM {$this->wpdb->term_taxonomy} AS T
 			LEFT JOIN $indexable_table AS I
@@ -105,7 +106,8 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		}
 
 		// Warning: If this query is changed, makes sure to update the query in get_count_query as well.
-		return $this->wpdb->prepare( "
+		return $this->wpdb->prepare(
+			"
 			SELECT T.term_id, T.description
 			FROM {$this->wpdb->term_taxonomy} AS T
 			LEFT JOIN $indexable_table AS I

--- a/src/actions/indexing/term-link-indexing-action.php
+++ b/src/actions/indexing/term-link-indexing-action.php
@@ -9,6 +9,7 @@ use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
  * Reindexing action for term link indexables.
  */
 class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
+	use Limited_Count_Trait;
 
 	/**
 	 * The transient name.
@@ -117,5 +118,14 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 			$limit_query",
 			$replacements
 		);
+	}
+
+	/**
+	 * Returns the transient key for the limited count.
+	 *
+	 * @return string The transient key.
+	 */
+	protected function get_limited_count_transient() {
+		return static::UNINDEXED_LIMITED_COUNT_TRANSIENT;
 	}
 }

--- a/src/actions/indexing/term-link-indexing-action.php
+++ b/src/actions/indexing/term-link-indexing-action.php
@@ -45,6 +45,7 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	protected function get_objects() {
 		$query = $this->get_select_query( $this->get_limit() );
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_select_query returns a prepared query.
 		$terms = $this->wpdb->get_results( $query );
 
 		return \array_map(
@@ -61,8 +62,6 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 
 	/**
 	 * Builds a query for counting the number of unindexed term links.
-	 *
-	 * @param bool $limit The maximum amount of unindexed term links that should be counted.
 	 *
 	 * @return string The prepared query string.
 	 */
@@ -89,13 +88,12 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	/**
 	 * Builds a query for selecting the ID's of unindexed term links.
 	 *
-	 * @param bool $limit The maximum number of term link IDs to return.
+	 * @param int|false $limit The maximum number of term link IDs to return.
 	 *
 	 * @return string The prepared query string.
 	 */
 	protected function get_select_query( $limit = false ) {
 		$public_taxonomies = $this->taxonomy_helper->get_public_taxonomies();
-		$placeholders      = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$replacements      = $public_taxonomies;
 
@@ -115,7 +113,7 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 				AND I.object_type = 'term'
 				AND I.link_count IS NOT NULL
 			WHERE I.object_id IS NULL
-				AND T.taxonomy IN ($placeholders)
+				AND T.taxonomy IN (" . \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) ) . ")
 			$limit_query",
 			$replacements
 		);

--- a/src/actions/indexing/term-link-indexing-action.php
+++ b/src/actions/indexing/term-link-indexing-action.php
@@ -72,17 +72,15 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 
 		// Warning: If this query is changed, makes sure to update the query in get_select_query as well.
-		return $this->wpdb->prepare(
-			"SELECT COUNT(T.term_id)
+		return $this->wpdb->prepare( "
+			SELECT COUNT(T.term_id)
 			FROM {$this->wpdb->term_taxonomy} AS T
 			LEFT JOIN $indexable_table AS I
 				ON T.term_id = I.object_id
 				AND I.object_type = 'term'
 				AND I.link_count IS NOT NULL
 			WHERE I.object_id IS NULL
-				AND T.taxonomy IN ($placeholders)
-			ORDER BY T.term_id
-			",
+				AND T.taxonomy IN ($placeholders)",
 			$public_taxonomies
 		);
 	}
@@ -107,8 +105,8 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		}
 
 		// Warning: If this query is changed, makes sure to update the query in get_count_query as well.
-		return $this->wpdb->prepare(
-			"SELECT T.term_id, T.description
+		return $this->wpdb->prepare( "
+			SELECT T.term_id, T.description
 			FROM {$this->wpdb->term_taxonomy} AS T
 			LEFT JOIN $indexable_table AS I
 				ON T.term_id = I.object_id
@@ -116,8 +114,7 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 				AND I.link_count IS NOT NULL
 			WHERE I.object_id IS NULL
 				AND T.taxonomy IN ($placeholders)
-			$limit_query
-			",
+			$limit_query",
 			$replacements
 		);
 	}

--- a/src/actions/indexing/term-link-indexing-action.php
+++ b/src/actions/indexing/term-link-indexing-action.php
@@ -9,7 +9,6 @@ use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
  * Reindexing action for term link indexables.
  */
 class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
-	use Limited_Count_Trait;
 
 	/**
 	 * The transient name.

--- a/src/actions/indexing/term-link-indexing-action.php
+++ b/src/actions/indexing/term-link-indexing-action.php
@@ -66,22 +66,10 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	 *
 	 * @return string The prepared query string.
 	 */
-	protected function get_count_query( $limit = false ) {
-		// Limited queries are use to determine whether background indexing should occur, the exact number is irrelevant.
-		if ( $limit !== false ) {
-			return $this->get_limited_unindexed_count( $limit );
-		}
-
+	protected function get_count_query() {
 		$public_taxonomies = $this->taxonomy_helper->get_public_taxonomies();
 		$placeholders      = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
 		$indexable_table   = Model::get_table_name( 'Indexable' );
-		$replacements      = $public_taxonomies;
-
-		$limit_query = '';
-		if ( $limit ) {
-			$limit_query    = 'LIMIT %d';
-			$replacements[] = $limit;
-		}
 
 		// Warning: If this query is changed, makes sure to update the query in get_select_query as well.
 		return $this->wpdb->prepare(
@@ -94,9 +82,8 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 			WHERE I.object_id IS NULL
 				AND T.taxonomy IN ($placeholders)
 			ORDER BY T.term_id
-			$limit_query
 			",
-			$replacements
+			$public_taxonomies
 		);
 	}
 

--- a/src/actions/indexing/term-link-indexing-action.php
+++ b/src/actions/indexing/term-link-indexing-action.php
@@ -118,13 +118,4 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 			$replacements
 		);
 	}
-
-	/**
-	 * Returns the transient key for the limited count.
-	 *
-	 * @return string The transient key.
-	 */
-	protected function get_limited_count_transient() {
-		return static::UNINDEXED_LIMITED_COUNT_TRANSIENT;
-	}
 }

--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -170,9 +170,9 @@ class Index_Command implements Command_Interface {
 			$this->clear();
 
 			// Delete the transients to make sure re-indexing runs every time.
-			\delete_transient( Indexable_Post_Indexation_Action::TRANSIENT_CACHE_KEY );
-			\delete_transient( Indexable_Post_Type_Archive_Indexation_Action::TRANSIENT_CACHE_KEY );
-			\delete_transient( Indexable_Term_Indexation_Action::TRANSIENT_CACHE_KEY );
+			\delete_transient( Indexable_Post_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
+			\delete_transient( Indexable_Post_Type_Archive_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
+			\delete_transient( Indexable_Term_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
 		}
 
 		$indexation_actions = [

--- a/src/helpers/indexable-helper.php
+++ b/src/helpers/indexable-helper.php
@@ -121,9 +121,9 @@ class Indexable_Helper {
 		$this->indexing_helper->set_reason( $reason );
 
 		if ( $result !== false && $result > 0 ) {
-			\delete_transient( Indexable_Post_Indexation_Action::TRANSIENT_CACHE_KEY );
-			\delete_transient( Indexable_Post_Type_Archive_Indexation_Action::TRANSIENT_CACHE_KEY );
-			\delete_transient( Indexable_Term_Indexation_Action::TRANSIENT_CACHE_KEY );
+			\delete_transient( Indexable_Post_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
+			\delete_transient( Indexable_Post_Type_Archive_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
+			\delete_transient( Indexable_Term_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
 		}
 	}
 

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -261,13 +261,10 @@ class Indexing_Helper {
 			$this->term_link_indexing_action,
 		];
 
-		if ( $limit === null ) {
-			$limit = $this->get_shutdown_limit();
-		}
-
 		$unindexed_count = 0;
+
 		foreach ( $indexing_actions as $indexing_action ) {
-			$unindexed_count += $indexing_action->get_unindexed_count( $limit );
+			$unindexed_count += $indexing_action->get_unindexed_count( $limit - $unindexed_count );
 			if( $unindexed_count > $limit ) {
 				return $unindexed_count;
 			}
@@ -295,23 +292,9 @@ class Indexing_Helper {
 	 *
 	 * @return bool Should background indexation be performed.
 	 */
-	public function should_index_on_shutdown() {
-		$total =$this->get_unindexed_count();
+	public function should_index_on_shutdown( $shutdown_limit ) {
+		$total = $this->get_unindexed_count( $shutdown_limit );
 
-		return  $total > 0 && $total < $this->get_shutdown_limit();
-	}
-
-	/**
-	 * Retrieves the shutdown limit. This limit is the amount of indexables that is generated in the background.
-	 *
-	 * @return int The shutdown limit.
-	 */
-	protected function get_shutdown_limit() {
-		/**
-		 * Filter 'wpseo_shutdown_indexation_limit' - Allow filtering the number of objects that can be indexed during shutdown.
-		 *
-		 * @api int The maximum number of objects indexed.
-		 */
-		return \apply_filters( 'wpseo_shutdown_indexation_limit', 25 );
+		return  $total > 0 && $total < $shutdown_limit;
 	}
 }

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -213,15 +213,8 @@ class Indexing_Helper {
 	 * @return int The total number of unindexed objects.
 	 */
 	public function get_unindexed_count( $limit = null ) {
-		$query_started = \get_transient( self::COUNT_QUERY_STARTED_TRANSIENT );
-
-		if ( $query_started ) {
-			return 0;
-		}
-
-		\set_transient( self::COUNT_QUERY_STARTED_TRANSIENT, true, ( \MINUTE_IN_SECONDS * 15 ) );
-
 		$unindexed_count = 0;
+
 		if ( $limit === null ) {
 			$unindexed_count = $this->get_total_unindexed_count();
 		}
@@ -229,7 +222,6 @@ class Indexing_Helper {
 			$unindexed_count = $this->get_limited_unindexed_count( $limit );
 		}
 
-		\delete_transient( self::COUNT_QUERY_STARTED_TRANSIENT );
 		return $unindexed_count;
 	}
 
@@ -271,12 +263,18 @@ class Indexing_Helper {
 	 *
 	 * @return int The total number of unindexed objects.
 	 */
-	public function get_filtered_unindexed_count() {
+	public function get_filtered_unindexed_count( $limit = false ) {
+		$unindexed_count = $this->get_unindexed_count( $limit );
+
+		if ( $limit !== false && $unindexed_count > $limit ) {
+			return $unindexed_count;
+		}
+
 		/**
 		 * Filter: 'wpseo_indexing_get_unindexed_count' - Allow changing the amount of unindexed objects.
 		 *
 		 * @param int $unindexed_count The amount of unindexed objects.
 		 */
-		return \apply_filters( 'wpseo_indexing_get_unindexed_count', $this->get_unindexed_count() );
+		return \apply_filters( 'wpseo_indexing_get_unindexed_count', $unindexed_count, $limit );
 	}
 }

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -249,7 +249,7 @@ class Indexing_Helper {
 			return 0;
 		}
 
-		\set_transient( self::COUNT_QUERY_STARTED_TRANSIENT, true, MINUTE_IN_SECONDS * 15 );
+		\set_transient( self::COUNT_QUERY_STARTED_TRANSIENT, true, \MINUTE_IN_SECONDS * 15 );
 
 		$indexing_actions = [
 			$this->post_indexation,

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -265,12 +265,12 @@ class Indexing_Helper {
 		foreach ( $indexing_actions as $indexing_action ) {
 			$unindexed_count += $indexing_action->get_total_unindexed( $limit - $unindexed_count + 1 );
 			if( $unindexed_count > $limit ) {
+				\delete_transient( self::COUNT_QUERY_STARTED_TRANSIENT );
 				return $unindexed_count;
 			}
 		}
 
 		\delete_transient( self::COUNT_QUERY_STARTED_TRANSIENT );
-
 		return $unindexed_count;
 	}
 

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -251,7 +251,6 @@ class Indexing_Helper {
 
 		\set_transient( self::COUNT_QUERY_STARTED_TRANSIENT, true, MINUTE_IN_SECONDS * 15 );
 
-		/** @var $indexing_actions Indexation_Action_Interface[] */
 		$indexing_actions = [
 			$this->post_indexation,
 			$this->term_indexation,
@@ -264,11 +263,13 @@ class Indexing_Helper {
 		$unindexed_count = 0;
 
 		foreach ( $indexing_actions as $indexing_action ) {
-			$unindexed_count += $indexing_action->get_unindexed_count( $limit - $unindexed_count );
+			$unindexed_count += $indexing_action->get_total_unindexed( $limit - $unindexed_count + 1 );
 			if( $unindexed_count > $limit ) {
 				return $unindexed_count;
 			}
 		}
+
+		\delete_transient( self::COUNT_QUERY_STARTED_TRANSIENT );
 
 		return $unindexed_count;
 	}
@@ -285,16 +286,5 @@ class Indexing_Helper {
 		 * @param int $unindexed_count The amount of unindexed objects.
 		 */
 		return \apply_filters( 'wpseo_indexing_get_unindexed_count', $this->get_unindexed_count() );
-	}
-
-	/**
-	 * Determine whether background indexation should be performed.
-	 *
-	 * @return bool Should background indexation be performed.
-	 */
-	public function should_index_on_shutdown( $shutdown_limit ) {
-		$total = $this->get_unindexed_count( $shutdown_limit );
-
-		return  $total > 0 && $total < $shutdown_limit;
 	}
 }

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -204,36 +204,34 @@ class Indexing_Helper {
 	}
 
 	/**
-	 * Returns the total or a limited number of unindexed objects.
-	 *
-	 * @param int $limit Limit the number of unindexed objects that are counted.
+	 * Returns the total number of unindexed objects.
 	 *
 	 * @return int The total number of unindexed objects.
 	 */
-	public function get_unindexed_count( $limit = false ) {
+	public function get_unindexed_count() {
 		$unindexed_count = 0;
 
-		if ( $limit === false ) {
-			$unindexed_count = $this->get_total_unindexed_count();
-		}
-		else {
-			$unindexed_count = $this->get_limited_unindexed_count( $limit );
+		foreach ( $this->indexing_actions as $indexing_action ) {
+			$unindexed_count += $indexing_action->get_total_unindexed();
 		}
 
 		return $unindexed_count;
 	}
 
 	/**
-	 * Returns the total number of unindexed objects.
+	 * Returns the total number of unindexed objects and applies a filter for third party integrations.
 	 *
 	 * @return int The total number of unindexed objects.
 	 */
-	private function get_total_unindexed_count() {
-		$unindexed_count = 0;
-		foreach ( $this->indexing_actions as $indexing_action ) {
-			$unindexed_count += $indexing_action->get_total_unindexed();
-		}
-		return $unindexed_count;
+	public function get_filtered_unindexed_count() {
+		$unindexed_count = $this->get_unindexed_count();
+
+		/**
+		 * Filter: 'wpseo_indexing_get_unindexed_count' - Allow changing the amount of unindexed objects.
+		 *
+		 * @param int $unindexed_count The amount of unindexed objects.
+		 */
+		return \apply_filters( 'wpseo_indexing_get_unindexed_count', $unindexed_count );
 	}
 
 	/**
@@ -243,7 +241,7 @@ class Indexing_Helper {
 	 *
 	 * @return int The total number of unindexed objects.
 	 */
-	private function get_limited_unindexed_count( $limit ) {
+	public function get_limited_unindexed_count( $limit ) {
 		$unindexed_count = 0;
 
 		foreach ( $this->indexing_actions as $indexing_action ) {
@@ -259,20 +257,25 @@ class Indexing_Helper {
 	/**
 	 * Returns the total number of unindexed objects and applies a filter for third party integrations.
 	 *
+	 * @param int $limit Limit the number of unindexed objects that are counted.
+	 *
 	 * @return int The total number of unindexed objects.
 	 */
-	public function get_filtered_unindexed_count( $limit = false ) {
-		$unindexed_count = $this->get_unindexed_count( $limit );
+	public function get_limited_filtered_unindexed_count( $limit ) {
+		$unindexed_count = $this->get_limited_unindexed_count( $limit );
 
-		if ( $limit !== false && $unindexed_count > $limit ) {
+		if ( $unindexed_count > $limit ) {
 			return $unindexed_count;
 		}
 
 		/**
-		 * Filter: 'wpseo_indexing_get_unindexed_count' - Allow changing the amount of unindexed objects.
+		 * Filter: 'wpseo_indexing_get_limited_unindexed_count' - Allow changing the amount of unindexed objects,
+		 * and allow for a maximum number of items counted to improve performance.
 		 *
-		 * @param int $unindexed_count The amount of unindexed objects.
+		 * @param int       $unindexed_count The amount of unindexed objects.
+		 * @param int|false $limit           Limit the number of unindexed objects that need to be counted.
+		 *                                   False if it doesn't need to be limited.
 		 */
-		return \apply_filters( 'wpseo_indexing_get_unindexed_count', $unindexed_count, $limit );
+		return \apply_filters( 'wpseo_indexing_get_limited_unindexed_count', $unindexed_count, $limit );
 	}
 }

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -210,10 +210,10 @@ class Indexing_Helper {
 	 *
 	 * @return int The total number of unindexed objects.
 	 */
-	public function get_unindexed_count( $limit = null ) {
+	public function get_unindexed_count( $limit = false ) {
 		$unindexed_count = 0;
 
-		if ( $limit === null ) {
+		if ( $limit === false ) {
 			$unindexed_count = $this->get_total_unindexed_count();
 		}
 		else {

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -47,8 +47,6 @@ class Indexing_Helper {
 	 */
 	protected $indexing_actions;
 
-	const COUNT_QUERY_STARTED_TRANSIENT = 'wpseo_count_query_started';
-
 	/**
 	 * Indexing_Helper constructor.
 	 *

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -81,7 +81,7 @@ class Indexing_Helper {
 	 */
 	protected $general_indexation;
 
-	const COUNT_QUERY_STARTED_TRANSIENT = "wpseo-count-query-started";
+	const COUNT_QUERY_STARTED_TRANSIENT = "wpseo_count_query_started";
 
 	/**
 	 * Indexing_Helper constructor.

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -81,7 +81,7 @@ class Indexing_Helper {
 	 */
 	protected $general_indexation;
 
-	const COUNT_QUERY_STARTED_TRANSIENT = "wpseo_count_query_started";
+	const COUNT_QUERY_STARTED_TRANSIENT = 'wpseo_count_query_started';
 
 	/**
 	 * Indexing_Helper constructor.
@@ -240,6 +240,8 @@ class Indexing_Helper {
 	/**
 	 * Returns the total number of unindexed objects.
 	 *
+	 * @param int $limit Limit the number of unindexed objects that are counted.
+	 *
 	 * @return int The total number of unindexed objects.
 	 */
 	public function get_unindexed_count( $limit = null ) {
@@ -249,7 +251,7 @@ class Indexing_Helper {
 			return 0;
 		}
 
-		\set_transient( self::COUNT_QUERY_STARTED_TRANSIENT, true, \MINUTE_IN_SECONDS * 15 );
+		\set_transient( self::COUNT_QUERY_STARTED_TRANSIENT, true, ( \MINUTE_IN_SECONDS * 15 ) );
 
 		$indexing_actions = [
 			$this->post_indexation,
@@ -264,7 +266,7 @@ class Indexing_Helper {
 
 		foreach ( $indexing_actions as $indexing_action ) {
 			$unindexed_count += $indexing_action->get_total_unindexed( $limit - $unindexed_count + 1 );
-			if( $unindexed_count > $limit ) {
+			if ( $unindexed_count > $limit ) {
 				\delete_transient( self::COUNT_QUERY_STARTED_TRANSIENT );
 				return $unindexed_count;
 			}

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -173,11 +173,13 @@ class Background_Indexing_Integration implements Integration_Interface {
 	/**
 	 * Determine whether background indexation should be performed.
 	 *
+	 * @param int $shutdown_limit The shutdown limit used to determine whether indexation should be run.
+	 *
 	 * @return bool Should background indexation be performed.
 	 */
 	public function should_index_on_shutdown( $shutdown_limit ) {
 		$total = $this->indexing_helper->get_unindexed_count( $shutdown_limit );
 
-		return $total > $shutdown_limit;
+		return ( $total > 0 && $total < $shutdown_limit );
 	}
 }

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -136,10 +136,9 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_shutdown_indexing() {
-		$total = $this->indexing_helper->get_unindexed_count();
-		if ( $total > 0 && $total < $this->get_shutdown_limit() ) {
+		if ( $this->indexing_helper->should_index_on_shutdown() ) {
 			\register_shutdown_function( [ $this, 'index' ] );
-		}
+		 }
 	}
 
 	/**
@@ -155,19 +154,5 @@ class Background_Indexing_Integration implements Integration_Interface {
 		$this->post_link_indexing_action->index();
 		$this->term_link_indexing_action->index();
 		$this->complete_indexation_action->complete();
-	}
-
-	/**
-	 * Retrieves the shutdown limit. This limit is the amount of indexables that is generated in the background.
-	 *
-	 * @return int The shutdown limit.
-	 */
-	protected function get_shutdown_limit() {
-		/**
-		 * Filter 'wpseo_shutdown_indexation_limit' - Allow filtering the number of objects that can be indexed during shutdown.
-		 *
-		 * @api int The maximum number of objects indexed.
-		 */
-		return \apply_filters( 'wpseo_shutdown_indexation_limit', 25 );
 	}
 }

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -136,7 +136,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_shutdown_indexing() {
-		if ( $this->indexing_helper->should_index_on_shutdown( $this->get_shutdown_limit() ) ) {
+		if ( $this->should_index_on_shutdown( $this->get_shutdown_limit() ) ) {
 			\register_shutdown_function( [ $this, 'index' ] );
 		 }
 	}
@@ -168,5 +168,16 @@ class Background_Indexing_Integration implements Integration_Interface {
 		 * @api int The maximum number of objects indexed.
 		 */
 		return \apply_filters( 'wpseo_shutdown_indexation_limit', 25 );
+	}
+
+	/**
+	 * Determine whether background indexation should be performed.
+	 *
+	 * @return bool Should background indexation be performed.
+	 */
+	public function should_index_on_shutdown( $shutdown_limit ) {
+		$total = $this->indexing_helper->get_unindexed_count( $shutdown_limit );
+
+		return  $total > 0 && $total < $shutdown_limit;
 	}
 }

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -136,7 +136,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_shutdown_indexing() {
-		if ( $this->indexing_helper->should_index_on_shutdown() ) {
+		if ( $this->indexing_helper->should_index_on_shutdown( $this->get_shutdown_limit() ) ) {
 			\register_shutdown_function( [ $this, 'index' ] );
 		 }
 	}
@@ -154,5 +154,19 @@ class Background_Indexing_Integration implements Integration_Interface {
 		$this->post_link_indexing_action->index();
 		$this->term_link_indexing_action->index();
 		$this->complete_indexation_action->complete();
+	}
+
+	/**
+	 * Retrieves the shutdown limit. This limit is the amount of indexables that is generated in the background.
+	 *
+	 * @return int The shutdown limit.
+	 */
+	protected function get_shutdown_limit() {
+		/**
+		 * Filter 'wpseo_shutdown_indexation_limit' - Allow filtering the number of objects that can be indexed during shutdown.
+		 *
+		 * @api int The maximum number of objects indexed.
+		 */
+		return \apply_filters( 'wpseo_shutdown_indexation_limit', 25 );
 	}
 }

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -178,7 +178,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 * @return bool Should background indexation be performed.
 	 */
 	public function should_index_on_shutdown( $shutdown_limit ) {
-		$total = $this->indexing_helper->get_unindexed_count( $shutdown_limit );
+		$total = $this->indexing_helper->get_filtered_unindexed_count( $shutdown_limit );
 
 		return ( $total > 0 && $total < $shutdown_limit );
 	}

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -178,7 +178,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 * @return bool Should background indexation be performed.
 	 */
 	public function should_index_on_shutdown( $shutdown_limit ) {
-		$total = $this->indexing_helper->get_filtered_unindexed_count( $shutdown_limit );
+		$total = $this->indexing_helper->get_limited_filtered_unindexed_count( $shutdown_limit );
 
 		return ( $total > 0 && $total < $shutdown_limit );
 	}

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -178,6 +178,6 @@ class Background_Indexing_Integration implements Integration_Interface {
 	public function should_index_on_shutdown( $shutdown_limit ) {
 		$total = $this->indexing_helper->get_unindexed_count( $shutdown_limit );
 
-		return  $total > 0 && $total < $shutdown_limit;
+		return  $total > $shutdown_limit;
 	}
 }

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -138,7 +138,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	public function register_shutdown_indexing() {
 		if ( $this->should_index_on_shutdown( $this->get_shutdown_limit() ) ) {
 			\register_shutdown_function( [ $this, 'index' ] );
-		 }
+		}
 	}
 
 	/**
@@ -178,6 +178,6 @@ class Background_Indexing_Integration implements Integration_Interface {
 	public function should_index_on_shutdown( $shutdown_limit ) {
 		$total = $this->indexing_helper->get_unindexed_count( $shutdown_limit );
 
-		return  $total > $shutdown_limit;
+		return $total > $shutdown_limit;
 	}
 }

--- a/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
@@ -89,6 +89,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 				AND I.permalink_hash IS NOT NULL
 			WHERE I.object_id IS NULL
 				AND P.post_type IN (%s)
+			ORDER BY P.ID
 			$limit_placeholder";
 
 		Functions\expect( 'get_transient' )->once()->with( 'wpseo_total_unindexed_posts' )->andReturnFalse();
@@ -162,6 +163,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 				AND I.permalink_hash IS NOT NULL
 			WHERE I.object_id IS NULL
 				AND P.post_type IN (%s)
+			ORDER BY P.ID
 			$limit_placeholder";
 
 		Functions\expect( 'get_transient' )->once()->with( 'wpseo_total_unindexed_posts' )->andReturnFalse();

--- a/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
@@ -79,7 +79,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	 * @covers ::get_post_types
 	 */
 	public function test_get_total_unindexed() {
-		$expected_query    = "
+		$expected_query = "
 			SELECT COUNT(P.ID)
 			FROM wp_posts AS P
 			LEFT JOIN wp_yoast_indexable AS I
@@ -133,7 +133,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		];
 
 		Functions\expect( 'get_transient' )->once()->with( 'wpseo_limited_unindexed_posts_count' )->andReturnFalse();
-		Functions\expect( 'set_transient' )->once()->with( 'wpseo_limited_unindexed_posts_count', count( $query_result ), \MINUTE_IN_SECONDS * 15 )->andReturnTrue();
+		Functions\expect( 'set_transient' )->once()->with( 'wpseo_limited_unindexed_posts_count', count( $query_result ), ( \MINUTE_IN_SECONDS * 15 ) )->andReturnTrue();
 
 		$this->wpdb->expects( 'prepare' )
 			->once()
@@ -193,7 +193,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$excluded_post_types = [ 'excluded_post_type' ];
 		$queried_post_types  = [ 'public_post_type' ];
 
-		$expected_query    = "
+		$expected_query = "
 			SELECT COUNT(P.ID)
 			FROM wp_posts AS P
 			LEFT JOIN wp_yoast_indexable AS I

--- a/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
@@ -105,11 +105,11 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the get total unindexed method with a limit.
+	 * Tests the get_limited_unindexed_count method with a limit.
 	 *
 	 * @covers ::__construct
-	 * @covers ::get_total_unindexed
 	 * @covers ::get_post_types
+	 * @covers ::get_limited_count_transient
 	 * @covers ::get_limited_unindexed_count
 	 * @covers ::get_select_query
 	 */
@@ -144,7 +144,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$this->post_type_helper->expects( 'get_public_post_types' )->once()->andReturn( [ 'public_post_type' ] );
 		$this->post_type_helper->expects( 'get_excluded_post_types_for_indexables' )->once()->andReturn( [] );
 
-		$this->assertEquals( count( $query_result ), $this->instance->get_total_unindexed( $limit ) );
+		$this->assertEquals( count( $query_result ), $this->instance->get_limited_unindexed_count( $limit ) );
 	}
 
 	/**
@@ -269,6 +269,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'post' );
 
 		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_posts' );
+		Functions\expect( 'delete_transient' )->with( 'wpseo_limited_unindexed_posts_count' );
 
 		$this->instance->index();
 	}
@@ -293,6 +294,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'post' );
 
 		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_posts' );
+		Functions\expect( 'delete_transient' )->with( 'wpseo_limited_unindexed_posts_count' );
 
 		$this->instance->index();
 	}
@@ -350,6 +352,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'post' );
 
 		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_posts' );
+		Functions\expect( 'delete_transient' )->with( 'wpseo_limited_unindexed_posts_count' );
 
 		$this->instance->index();
 	}

--- a/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
@@ -109,11 +109,10 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	 *
 	 * @covers ::__construct
 	 * @covers ::get_post_types
-	 * @covers ::get_limited_count_transient
 	 * @covers ::get_limited_unindexed_count
 	 * @covers ::get_select_query
 	 */
-	public function test_get_total_unindexed_with_limit() {
+	public function test_get_limited_unindexed_count() {
 		$limit          = 25;
 		$expected_query = "
 			SELECT P.ID
@@ -132,8 +131,8 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 			'post_id_3',
 		];
 
-		Functions\expect( 'get_transient' )->once()->with( 'wpseo_limited_unindexed_posts_count' )->andReturnFalse();
-		Functions\expect( 'set_transient' )->once()->with( 'wpseo_limited_unindexed_posts_count', count( $query_result ), ( \MINUTE_IN_SECONDS * 15 ) )->andReturnTrue();
+		Functions\expect( 'get_transient' )->once()->with( 'wpseo_total_unindexed_posts_limited' )->andReturnFalse();
+		Functions\expect( 'set_transient' )->once()->with( 'wpseo_total_unindexed_posts_limited', count( $query_result ), ( \MINUTE_IN_SECONDS * 15 ) )->andReturnTrue();
 
 		$this->wpdb->expects( 'prepare' )
 			->once()
@@ -269,7 +268,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'post' );
 
 		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_posts' );
-		Functions\expect( 'delete_transient' )->with( 'wpseo_limited_unindexed_posts_count' );
+		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_posts_limited' );
 
 		$this->instance->index();
 	}
@@ -294,7 +293,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'post' );
 
 		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_posts' );
-		Functions\expect( 'delete_transient' )->with( 'wpseo_limited_unindexed_posts_count' );
+		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_posts_limited' );
 
 		$this->instance->index();
 	}
@@ -352,7 +351,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'post' );
 
 		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_posts' );
-		Functions\expect( 'delete_transient' )->with( 'wpseo_limited_unindexed_posts_count' );
+		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_posts_limited' );
 
 		$this->instance->index();
 	}

--- a/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
@@ -127,8 +127,8 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 			'term_id_3',
 		];
 
-		Functions\expect( 'get_transient' )->once()->with( 'wpseo_limited_unindexed_terms_count' )->andReturnFalse();
-		Functions\expect( 'set_transient' )->once()->with( 'wpseo_limited_unindexed_terms_count', count( $query_result ), ( \MINUTE_IN_SECONDS * 15 ) )->andReturnTrue();
+		Functions\expect( 'get_transient' )->once()->with( 'wpseo_total_unindexed_terms_limited' )->andReturnFalse();
+		Functions\expect( 'set_transient' )->once()->with( 'wpseo_total_unindexed_terms_limited', count( $query_result ), ( \MINUTE_IN_SECONDS * 15 ) )->andReturnTrue();
 		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturn( [ 'public_taxonomy' ] );
 		$this->wpdb->expects( 'prepare' )
 			->once()
@@ -202,7 +202,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'term' );
 
 		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_terms' );
-		Functions\expect( 'delete_transient' )->with( 'wpseo_limited_unindexed_terms_count' );
+		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_terms_limited' );
 
 		$this->instance->index();
 	}
@@ -225,7 +225,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'term' );
 
 		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_terms' );
-		Functions\expect( 'delete_transient' )->with( 'wpseo_limited_unindexed_terms_count' );
+		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_terms_limited' );
 
 		$this->instance->index();
 	}

--- a/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
@@ -78,7 +78,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 	 * @covers ::get_count_query
 	 */
 	public function test_get_total_unindexed() {
-		$expected_query    = "
+		$expected_query = "
 			SELECT COUNT(term_id)
 			FROM wp_term_taxonomy AS T
 			LEFT JOIN wp_yoast_indexable AS I
@@ -128,7 +128,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 		];
 
 		Functions\expect( 'get_transient' )->once()->with( 'wpseo_limited_unindexed_terms_count' )->andReturnFalse();
-		Functions\expect( 'set_transient' )->once()->with( 'wpseo_limited_unindexed_terms_count', count( $query_result ), \MINUTE_IN_SECONDS * 15 )->andReturnTrue();
+		Functions\expect( 'set_transient' )->once()->with( 'wpseo_limited_unindexed_terms_count', count( $query_result ), ( \MINUTE_IN_SECONDS * 15 ) )->andReturnTrue();
 		$this->taxonomy->expects( 'get_public_taxonomies' )->once()->andReturn( [ 'public_taxonomy' ] );
 		$this->wpdb->expects( 'prepare' )
 			->once()

--- a/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
@@ -101,14 +101,14 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the get total unindexed method with a limit.
+	 * Tests the get get_limited_unindexed_count with a limit.
 	 *
 	 * @covers ::__construct
-	 * @covers ::get_total_unindexed
+	 * @covers ::get_limited_count_transient
 	 * @covers ::get_limited_unindexed_count
 	 * @covers ::get_select_query
 	 */
-	public function test_get_total_unindexed_with_limit() {
+	public function test_get_limited_unindexed_count() {
 		$limit          = 10;
 		$expected_query = "
 			SELECT term_id
@@ -136,7 +136,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 			->andReturn( 'query' );
 		$this->wpdb->expects( 'get_col' )->once()->with( 'query' )->andReturn( $query_result );
 
-		$this->assertEquals( count( $query_result ), $this->instance->get_total_unindexed( $limit ) );
+		$this->assertEquals( count( $query_result ), $this->instance->get_limited_unindexed_count( $limit ) );
 	}
 
 	/**
@@ -202,6 +202,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'term' );
 
 		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_terms' );
+		Functions\expect( 'delete_transient' )->with( 'wpseo_limited_unindexed_terms_count' );
 
 		$this->instance->index();
 	}
@@ -224,6 +225,7 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 		$this->repository->expects( 'find_by_id_and_type' )->once()->with( 8, 'term' );
 
 		Functions\expect( 'delete_transient' )->with( 'wpseo_total_unindexed_terms' );
+		Functions\expect( 'delete_transient' )->with( 'wpseo_limited_unindexed_terms_count' );
 
 		$this->instance->index();
 	}

--- a/tests/unit/actions/indexing/post-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/post-link-indexing-action-test.php
@@ -145,13 +145,14 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 	}
 
 	/**
-	 * Tests getting the unindexed count with a limit.
+	 * Tests getting get_limited_unindexed_count method with a limit.
 	 *
 	 * @covers ::get_select_query
-	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::get_total_unindexed
+	 * @covers ::get_limited_count_transient
+	 * @covers ::get_limited_unindexed_count
 	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::get_limited_unindexed_count
 	 */
-	public function test_get_total_unindexed_with_limit() {
+	public function test_get_limited_unindexed_count() {
 		$limit          = 10;
 		$expected_query = "
 			SELECT P.ID, P.post_content
@@ -203,7 +204,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->with( 'query' )
 			->andReturn( $query_result );
 
-		$this->assertSame( count( $query_result ), $this->instance->get_total_unindexed( $limit ) );
+		$this->assertSame( count( $query_result ), $this->instance->get_limited_unindexed_count( $limit ) );
 	}
 
 	/**
@@ -276,6 +277,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 		}
 
 		Functions\expect( 'delete_transient' )->once()->with( Post_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT );
+		Functions\expect( 'delete_transient' )->once()->with( Post_Link_Indexing_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT );
 
 		$this->instance->index();
 	}

--- a/tests/unit/actions/indexing/post-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/post-link-indexing-action-test.php
@@ -184,7 +184,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 
 		Functions\expect( 'set_transient' )
 			->once()
-			->with( Post_Link_Indexing_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT, count( $query_result ), \MINUTE_IN_SECONDS * 15 );
+			->with( Post_Link_Indexing_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT, count( $query_result ), ( \MINUTE_IN_SECONDS * 15 ) );
 
 		$this->post_type_helper
 			->expects( 'get_accessible_post_types' )

--- a/tests/unit/actions/indexing/post-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/post-link-indexing-action-test.php
@@ -99,7 +99,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 	/**
 	 * Tests getting the total unindexed.
 	 *
-	 * @covers ::get_query
+	 * @covers ::get_count_query
 	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::get_total_unindexed
 	 */
 	public function test_get_total_unindexed() {
@@ -113,7 +113,6 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->once()
 			->andReturn( [ 'post', 'page' ] );
 
-		$empty_string   = '';
 		$expected_query = "SELECT COUNT(P.ID)
 			FROM wp_posts AS P
 			LEFT JOIN wp_yoast_indexable AS I
@@ -128,9 +127,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 				AND L.target_post_id != 0
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
 				AND P.post_status = 'publish'
-				AND P.post_type IN (%s, %s)
-			$empty_string
-			";
+				AND P.post_type IN (%s, %s)";
 
 		$this->wpdb
 			->expects( 'prepare' )
@@ -145,6 +142,68 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->andReturn( null );
 
 		$this->assertFalse( $this->instance->get_total_unindexed() );
+	}
+
+	/**
+	 * Tests getting the unindexed count with a limit.
+	 *
+	 * @covers ::get_select_query
+	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::get_total_unindexed
+	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::get_limited_unindexed_count
+	 */
+	public function test_get_total_unindexed_with_limit() {
+		$limit          = 10;
+		$expected_query = "
+			SELECT P.ID, P.post_content
+			FROM wp_posts AS P
+			LEFT JOIN wp_yoast_indexable AS I
+				ON P.ID = I.object_id
+				AND I.link_count IS NOT NULL
+				AND I.object_type = 'post'
+			LEFT JOIN wp_yoast_seo_links AS L
+				ON L.post_id = P.ID
+				AND L.target_indexable_id IS NULL
+				AND L.type = 'internal'
+				AND L.target_post_id IS NOT NULL
+				AND L.target_post_id != 0
+			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
+				AND P.post_status = 'publish'
+				AND P.post_type IN (%s, %s)
+			LIMIT %d";
+
+		$query_result = [
+			'post_id_1',
+			'post_id_2',
+			'post_id_3',
+		];
+
+		Functions\expect( 'get_transient' )
+			->once()
+			->with( Post_Link_Indexing_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT )
+			->andReturn( false );
+
+		Functions\expect( 'set_transient' )
+			->once()
+			->with( Post_Link_Indexing_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT, count( $query_result ), \MINUTE_IN_SECONDS * 15 );
+
+		$this->post_type_helper
+			->expects( 'get_accessible_post_types' )
+			->once()
+			->andReturn( [ 'post', 'page' ] );
+
+		$this->wpdb
+			->expects( 'prepare' )
+			->once()
+			->with( $expected_query, [ 'post', 'page', $limit ] )
+			->andReturn( 'query' );
+
+		$this->wpdb
+			->expects( 'get_col' )
+			->once()
+			->with( 'query' )
+			->andReturn( $query_result );
+
+		$this->assertSame( count( $query_result ), $this->instance->get_total_unindexed( $limit ) );
 	}
 
 	/**
@@ -176,7 +235,8 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->once()
 			->andReturn( [ 'post', 'page' ] );
 
-		$expected_query = "SELECT P.ID, P.post_content
+		$expected_query = "
+			SELECT P.ID, P.post_content
 			FROM wp_posts AS P
 			LEFT JOIN wp_yoast_indexable AS I
 				ON P.ID = I.object_id
@@ -191,8 +251,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
 				AND P.post_status = 'publish'
 				AND P.post_type IN (%s, %s)
-			LIMIT %d
-			";
+			LIMIT %d";
 
 		$this->wpdb
 			->expects( 'prepare' )
@@ -236,7 +295,8 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->once()
 			->andReturn( [ 'post', 'page' ] );
 
-		$expected_query = "SELECT P.ID, P.post_content
+		$expected_query = "
+			SELECT P.ID, P.post_content
 			FROM wp_posts AS P
 			LEFT JOIN wp_yoast_indexable AS I
 				ON P.ID = I.object_id
@@ -251,8 +311,7 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
 				AND P.post_status = 'publish'
 				AND P.post_type IN (%s, %s)
-			LIMIT %d
-			";
+			LIMIT %d";
 
 		$this->wpdb
 			->expects( 'prepare' )

--- a/tests/unit/actions/indexing/term-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/term-link-indexing-action-test.php
@@ -97,7 +97,7 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 	}
 
 	/**
-	 * Tests getting the total unindexed.
+	 * Tests getting the unindexed count with a limit.
 	 *
 	 * @covers ::get_count_query
 	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::get_total_unindexed

--- a/tests/unit/actions/indexing/term-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/term-link-indexing-action-test.php
@@ -144,13 +144,13 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 	}
 
 	/**
-	 * Tests getting the total unindexed.
+	 * Tests get_limited_unindexed_count with a limit.
 	 *
 	 * @covers ::get_select_query
-	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::get_total_unindexed
+	 * @covers ::get_limited_count_transient
 	 * @covers \Yoast\WP\SEO\Actions\Indexation\Abstract_Link_Indexing_Action::get_limited_unindexed_count
 	 */
-	public function test_get_total_unindexed_with_limit() {
+	public function test_get_limited_unindexed_count() {
 		$limit          = 10;
 		$expected_query = "
 			SELECT T.term_id, T.description
@@ -196,7 +196,7 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 			->with( Term_Link_Indexing_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT, \count( $query_result ), ( \MINUTE_IN_SECONDS * 15 ) )
 			->andReturn( true );
 
-		$this->assertEquals( count( $query_result ), $this->instance->get_total_unindexed( $limit ) );
+		$this->assertEquals( count( $query_result ), $this->instance->get_limited_unindexed_count( $limit ) );
 	}
 
 	/**
@@ -320,6 +320,7 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 		}
 
 		Functions\expect( 'delete_transient' )->once()->with( Term_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT );
+		Functions\expect( 'delete_transient' )->once()->with( Term_Link_Indexing_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT );
 
 		$this->instance->index();
 	}

--- a/tests/unit/actions/indexing/term-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/term-link-indexing-action-test.php
@@ -193,7 +193,7 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 
 		Functions\expect( 'set_transient' )
 			->once()
-			->with( Term_Link_Indexing_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT, count( $query_result ), \MINUTE_IN_SECONDS * 15 )
+			->with( Term_Link_Indexing_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT, \count( $query_result ), ( \MINUTE_IN_SECONDS * 15 ) )
 			->andReturn( true );
 
 		$this->assertEquals( count( $query_result ), $this->instance->get_total_unindexed( $limit ) );
@@ -231,7 +231,6 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 			->once()
 			->andReturn( [ 'category', 'tag' ] );
 
-		$empty_string   = '';
 		$expected_query = "
 			SELECT COUNT(T.term_id)
 			FROM wp_term_taxonomy AS T

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -155,27 +155,27 @@ class Indexing_Helper_Test extends TestCase {
 	public function test_set_indexing_actions() {
 		static::assertInstanceOf(
 			Indexable_Post_Indexation_Action::class,
-			$this->getPropertyValue( $this->instance, 'post_indexation' )
+			$this->getPropertyValue( $this->instance, 'indexing_actions' )[ 0 ]
 		);
 		static::assertInstanceOf(
 			Indexable_Term_Indexation_Action::class,
-			$this->getPropertyValue( $this->instance, 'term_indexation' )
+			$this->getPropertyValue( $this->instance, 'indexing_actions' )[ 1 ]
 		);
 		static::assertInstanceOf(
 			Indexable_Post_Type_Archive_Indexation_Action::class,
-			$this->getPropertyValue( $this->instance, 'post_type_archive_indexation' )
+			$this->getPropertyValue( $this->instance, 'indexing_actions' )[ 2 ]
 		);
 		static::assertInstanceOf(
 			Indexable_General_Indexation_Action::class,
-			$this->getPropertyValue( $this->instance, 'general_indexation' )
+			$this->getPropertyValue( $this->instance, 'indexing_actions' )[ 3 ]
 		);
 		static::assertInstanceOf(
 			Post_Link_Indexing_Action::class,
-			$this->getPropertyValue( $this->instance, 'post_link_indexing_action' )
+			$this->getPropertyValue( $this->instance, 'indexing_actions' )[ 4 ]
 		);
 		static::assertInstanceOf(
 			Term_Link_Indexing_Action::class,
-			$this->getPropertyValue( $this->instance, 'term_link_indexing_action' )
+			$this->getPropertyValue( $this->instance, 'indexing_actions' )[ 5 ]
 		);
 	}
 

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -155,27 +155,27 @@ class Indexing_Helper_Test extends TestCase {
 	public function test_set_indexing_actions() {
 		static::assertInstanceOf(
 			Indexable_Post_Indexation_Action::class,
-			$this->getPropertyValue( $this->instance, 'indexing_actions' )[ 0 ]
+			$this->getPropertyValue( $this->instance, 'indexing_actions' )[0]
 		);
 		static::assertInstanceOf(
 			Indexable_Term_Indexation_Action::class,
-			$this->getPropertyValue( $this->instance, 'indexing_actions' )[ 1 ]
+			$this->getPropertyValue( $this->instance, 'indexing_actions' )[1]
 		);
 		static::assertInstanceOf(
 			Indexable_Post_Type_Archive_Indexation_Action::class,
-			$this->getPropertyValue( $this->instance, 'indexing_actions' )[ 2 ]
+			$this->getPropertyValue( $this->instance, 'indexing_actions' )[2]
 		);
 		static::assertInstanceOf(
 			Indexable_General_Indexation_Action::class,
-			$this->getPropertyValue( $this->instance, 'indexing_actions' )[ 3 ]
+			$this->getPropertyValue( $this->instance, 'indexing_actions' )[3]
 		);
 		static::assertInstanceOf(
 			Post_Link_Indexing_Action::class,
-			$this->getPropertyValue( $this->instance, 'indexing_actions' )[ 4 ]
+			$this->getPropertyValue( $this->instance, 'indexing_actions' )[4]
 		);
 		static::assertInstanceOf(
 			Term_Link_Indexing_Action::class,
-			$this->getPropertyValue( $this->instance, 'indexing_actions' )[ 5 ]
+			$this->getPropertyValue( $this->instance, 'indexing_actions' )[5]
 		);
 	}
 

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -319,6 +319,7 @@ class Indexing_Helper_Test extends TestCase {
 	 * Tests the retrieval of the unindexed count.
 	 *
 	 * @covers ::get_unindexed_count
+	 * @covers ::get_total_unindexed_count
 	 */
 	public function test_get_unindexed_count() {
 		$this->post_indexation
@@ -351,20 +352,6 @@ class Indexing_Helper_Test extends TestCase {
 			->once()
 			->andReturn( 0 );
 
-		Monkey\Functions\expect( 'get_transient' )
-			->once()
-			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT )
-			->andReturn( false );
-
-		Monkey\Functions\expect( 'set_transient' )
-			->once()
-			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT, true, ( \MINUTE_IN_SECONDS * 15 ) )
-			->andReturn( false );
-
-		Monkey\Functions\expect( 'delete_transient' )
-			->once()
-			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT );
-
 		static::assertEquals( 0, $this->instance->get_unindexed_count() );
 	}
 
@@ -372,55 +359,74 @@ class Indexing_Helper_Test extends TestCase {
 	 * Tests the retrieval of the filtered unindexed count.
 	 *
 	 * @covers ::get_filtered_unindexed_count
+	 * @covers ::get_unindexed_count
+	 * @covers ::get_limited_unindexed_count
 	 */
 	public function test_get_filtered_unindexed_count() {
 		$this->post_indexation
-			->expects( 'get_total_unindexed' )
+			->expects( 'get_limited_unindexed_count' )
 			->once()
 			->andReturn( 0 );
 
 		$this->term_indexation
-			->expects( 'get_total_unindexed' )
+			->expects( 'get_limited_unindexed_count' )
 			->once()
 			->andReturn( 0 );
 
 		$this->general_indexation
-			->expects( 'get_total_unindexed' )
+			->expects( 'get_limited_unindexed_count' )
 			->once()
 			->andReturn( 0 );
 
 		$this->post_type_archive_indexation
-			->expects( 'get_total_unindexed' )
+			->expects( 'get_limited_unindexed_count' )
 			->once()
 			->andReturn( 0 );
 
 		$this->post_link_indexing_action
-			->expects( 'get_total_unindexed' )
+			->expects( 'get_limited_unindexed_count' )
 			->once()
 			->andReturn( 0 );
 
 		$this->term_link_indexing_action
-			->expects( 'get_total_unindexed' )
+			->expects( 'get_limited_unindexed_count' )
 			->once()
 			->andReturn( 0 );
 
 		Monkey\Filters\expectApplied( 'wpseo_indexing_get_unindexed_count' )
 			->andReturn( 20 );
 
-		Monkey\Functions\expect( 'get_transient' )
-			->once()
-			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT )
-			->andReturn( false );
-
-		Monkey\Functions\expect( 'set_transient' )
-			->once()
-			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT, true, ( \MINUTE_IN_SECONDS * 15 ) )
-			->andReturn( false );
-
-		Monkey\Functions\expect( 'delete_transient' )
-			->once()
-			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT );
-
 		static::assertEquals( 20, $this->instance->get_filtered_unindexed_count() );
+	}
+
+	/**
+	 * Tests the retrieval of the filtered unindexed count with a limit.
+	 *
+	 * @covers ::get_filtered_unindexed_count
+	 * @covers ::get_unindexed_count
+	 * @covers ::get_limited_unindexed_count
+	 */
+	public function test_get_filtered_unindexed_count_with_limit() {
+		$limit = 25;
+
+		$this->post_indexation
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit + 1 )
+			->once()
+			->andReturn( 10 );
+
+		$this->term_indexation
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit - 10 + 1 )
+			->once()
+			->andReturn( 10 );
+
+		$this->post_type_archive_indexation
+			->expects( 'get_limited_unindexed_count' )
+			->with( $limit - 20 + 1 )
+			->once()
+			->andReturn( 10 );
+
+		static::assertEquals( 30, $this->instance->get_filtered_unindexed_count( 25 ) );
 	}
 }

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -358,7 +358,7 @@ class Indexing_Helper_Test extends TestCase {
 
 		Monkey\Functions\expect( 'set_transient' )
 			->once()
-			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT, true, \MINUTE_IN_SECONDS * 15 )
+			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT, true, ( \MINUTE_IN_SECONDS * 15 ) )
 			->andReturn( false );
 
 		Monkey\Functions\expect( 'delete_transient' )
@@ -414,7 +414,7 @@ class Indexing_Helper_Test extends TestCase {
 
 		Monkey\Functions\expect( 'set_transient' )
 			->once()
-			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT, true, \MINUTE_IN_SECONDS * 15 )
+			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT, true, ( \MINUTE_IN_SECONDS * 15 ) )
 			->andReturn( false );
 
 		Monkey\Functions\expect( 'delete_transient' )

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -319,7 +319,6 @@ class Indexing_Helper_Test extends TestCase {
 	 * Tests the retrieval of the unindexed count.
 	 *
 	 * @covers ::get_unindexed_count
-	 * @covers ::get_total_unindexed_count
 	 */
 	public function test_get_unindexed_count() {
 		$this->post_indexation
@@ -359,7 +358,6 @@ class Indexing_Helper_Test extends TestCase {
 	 * Tests the retrieval of the filtered unindexed count.
 	 *
 	 * @covers ::get_filtered_unindexed_count
-	 * @covers ::get_unindexed_count
 	 * @covers ::get_limited_unindexed_count
 	 */
 	public function test_get_filtered_unindexed_count() {
@@ -402,11 +400,10 @@ class Indexing_Helper_Test extends TestCase {
 	/**
 	 * Tests the retrieval of the filtered unindexed count with a limit.
 	 *
-	 * @covers ::get_filtered_unindexed_count
-	 * @covers ::get_unindexed_count
+	 * @covers ::get_limited_filtered_unindexed_count
 	 * @covers ::get_limited_unindexed_count
 	 */
-	public function test_get_filtered_unindexed_count_with_limit() {
+	public function test_get__limitedfiltered_unindexed_count() {
 		$limit = 25;
 
 		$this->post_indexation
@@ -427,6 +424,6 @@ class Indexing_Helper_Test extends TestCase {
 			->once()
 			->andReturn( 10 );
 
-		static::assertEquals( 30, $this->instance->get_filtered_unindexed_count( 25 ) );
+		static::assertEquals( 30, $this->instance->get_limited_filtered_unindexed_count( 25 ) );
 	}
 }

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -364,32 +364,32 @@ class Indexing_Helper_Test extends TestCase {
 	 */
 	public function test_get_filtered_unindexed_count() {
 		$this->post_indexation
-			->expects( 'get_limited_unindexed_count' )
+			->expects( 'get_total_unindexed' )
 			->once()
 			->andReturn( 0 );
 
 		$this->term_indexation
-			->expects( 'get_limited_unindexed_count' )
+			->expects( 'get_total_unindexed' )
 			->once()
 			->andReturn( 0 );
 
 		$this->general_indexation
-			->expects( 'get_limited_unindexed_count' )
+			->expects( 'get_total_unindexed' )
 			->once()
 			->andReturn( 0 );
 
 		$this->post_type_archive_indexation
-			->expects( 'get_limited_unindexed_count' )
+			->expects( 'get_total_unindexed' )
 			->once()
 			->andReturn( 0 );
 
 		$this->post_link_indexing_action
-			->expects( 'get_limited_unindexed_count' )
+			->expects( 'get_total_unindexed' )
 			->once()
 			->andReturn( 0 );
 
 		$this->term_link_indexing_action
-			->expects( 'get_limited_unindexed_count' )
+			->expects( 'get_total_unindexed' )
 			->once()
 			->andReturn( 0 );
 

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -12,6 +12,7 @@ use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Helpers\Date_Helper;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
@@ -350,6 +351,20 @@ class Indexing_Helper_Test extends TestCase {
 			->once()
 			->andReturn( 0 );
 
+		Monkey\Functions\expect( 'get_transient' )
+			->once()
+			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT )
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'set_transient' )
+			->once()
+			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT, true, \MINUTE_IN_SECONDS * 15 )
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'delete_transient' )
+			->once()
+			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT );
+
 		static::assertEquals( 0, $this->instance->get_unindexed_count() );
 	}
 
@@ -391,6 +406,20 @@ class Indexing_Helper_Test extends TestCase {
 
 		Monkey\Filters\expectApplied( 'wpseo_indexing_get_unindexed_count' )
 			->andReturn( 20 );
+
+		Monkey\Functions\expect( 'get_transient' )
+			->once()
+			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT )
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'set_transient' )
+			->once()
+			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT, true, \MINUTE_IN_SECONDS * 15 )
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'delete_transient' )
+			->once()
+			->with( Indexing_Helper::COUNT_QUERY_STARTED_TRANSIENT );
 
 		static::assertEquals( 20, $this->instance->get_filtered_unindexed_count() );
 	}

--- a/tests/unit/integrations/admin/background-indexing-integration-test.php
+++ b/tests/unit/integrations/admin/background-indexing-integration-test.php
@@ -186,7 +186,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 	 */
 	public function test_register_shutdown_indexing() {
 		$this->indexing_helper
-			->expects( 'get_unindexed_count' )
+			->expects( 'get_filtered_unindexed_count' )
 			->once()
 			->andReturn( 10 );
 

--- a/tests/unit/integrations/admin/background-indexing-integration-test.php
+++ b/tests/unit/integrations/admin/background-indexing-integration-test.php
@@ -186,7 +186,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 	 */
 	public function test_register_shutdown_indexing() {
 		$this->indexing_helper
-			->expects( 'get_filtered_unindexed_count' )
+			->expects( 'get_limited_filtered_unindexed_count' )
 			->once()
 			->andReturn( 10 );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Partially fixes a bug where queries due to the background indexation would put a lot of strain on the database.

## Relevant technical choices:

* In step 3 on the issue we say: "Move `if ( $total > 0 && $total < $this->get_shutdown_limit() )` to the indexing helper and call it something like: `should_index_on_shutdown()`." We decided to not this function, but create it in the background indexing integration instead, because it has all logic regarding the indexing on shutdown.
* Added an `Abstract_Indexing_Action` class to reduce duplicate code in relation to counting unindexed objects.
* Split up `get_query` in indexing actions in `get_select_query` and `get_count_query` for better eadability.
* Count queries will now set the transient to 0 before counting to prevent multiple requests performing the same counts.
* Added limited count queries to all indexing actions, using select, to speed up the queries.
* Added early returns when passing a $limit to get_unindexed_count in the indexing helper.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Here is a database dump with 15000 posts and 6000 existing indexibles. You can import it using your preferred database tool, in tableplus you can run "restore" from the start-screen.
[wordpress.dump.zip](https://github.com/Yoast/wordpress-seo/files/6855514/wordpress.dump.zip)

Test together with https://github.com/Yoast/wordpress-seo-premium/pull/3396.

- Make sure you have Query Monitor installed.
- Make sure you have checked out and built the premium branch. https://github.com/Yoast/wordpress-seo-premium/pull/3396
- Make sure you have a site with a lot of posts (you can use the database dump above).
- Using the Yoast test-helper, reset the indexables-tables.
- Open a database tool and delete all transients:
```
DELETE FROM wp_options
WHERE option_name LIKE '%_transient_%'
```
- Open any admin page.
- Open the query-monitor query overview and set `component` to `wordpress-seo` to see all queries performed by our plugin.
- You should see the following query:
```
SELECT P.ID
FROM wp_posts AS P
LEFT JOIN wp_yoast_indexable AS I
ON P.ID = I.object_id
AND I.object_type = 'post'
AND I.permalink_hash IS NOT NULL
WHERE I.object_id IS NULL
AND P.post_type IN ('post', 'page', 'attachment')
LIMIT 26
```
- You should NOT see the following query:
```
SELECT T.ID
FROM wp_terms AS T
LEFT JOIN wp_yoast_indexable AS I
ON T.ID = I.object_id
AND I.object_type = 'term'
AND I.permalink_hash IS NOT NULL
WHERE I.object_id IS NULL
AND taxonomy IN (...),
LIMIT 26
```
- Reload the page again, the post count query should not be fired now, as well as the term query.
- Go to `SEO` > `Tools`.
- In the javascript console inspect the value of `yoastIndexingData.amount`, and make sure it is an accurate representation of the number of unindexed entities on your site. In my case it was 17687.
- Test if the indexation completes successfully. To speed up this process you can also partially run it with wp-cli. (In the plugin development docker `docker exec -it -u www-data basic-wordpress wp yoast index`.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
