### PR TITLE
P2-1129 Improve editor performance by reducing estimated reading time calculations

### DIFF
--- a/packages/js/src/initializers/estimated-reading-time.js
+++ b/packages/js/src/initializers/estimated-reading-time.js
@@ -61,7 +61,7 @@ function initializeEstimatedReadingTimeBlockEditor() {
  *
  * @returns {void}
  */
-function blockEditorDebounce() {
+function getEstimatedReadingTimeBlockEditor() {
 	const content = select( "core/editor" ).getEditedPostAttribute( "content" );
 	if ( previousContent !== content ) {
 		previousContent = content;
@@ -70,7 +70,7 @@ function blockEditorDebounce() {
 }
 
 // Delays execution by 1,5 seconds for any change, forces execution after 3 seconds.
-const doBlockEditorDebounce = debounce( blockEditorDebounce, 1500, { maxWait: 3000 } );
+const debounceBlockEditor = debounce( getEstimatedReadingTimeBlockEditor, 1500, { maxWait: 3000 } );
 
 /**
  * Gets the estimated reading time in the Elementor editor if the content has changed.
@@ -88,7 +88,7 @@ function initializeEstimatedReadingTimeElementor() {
  *
  * @returns {void}
  */
- function elementorEditorDebounce() {
+function getEstimatedReadingTimeBlockElementor() {
 	const content = select( "yoast-seo/editor" ).getEditorDataContent();
 	if ( previousContent !== content ) {
 		previousContent = content;
@@ -97,7 +97,7 @@ function initializeEstimatedReadingTimeElementor() {
 }
 
 // Delays execution by 1,5 seconds for any change, forces execution after 3 seconds.
-const doElementorEditorDebounce = debounce( elementorEditorDebounce, 1500, { maxWait: 3000 } );
+const debounceElementorEditor = debounce( getEstimatedReadingTimeBlockElementor, 1500, { maxWait: 3000 } );
 
 /**
  * Initializes the estimated reading time.

--- a/packages/js/src/initializers/estimated-reading-time.js
+++ b/packages/js/src/initializers/estimated-reading-time.js
@@ -43,10 +43,10 @@ function initializeEstimatedReadingTimeClassic() {
 }
 
 // Used to trigger the initial reading time calculation for the block and Elementor editors.
-let previousContent = '';
+let previousContent = "";
 
 /**
- * Initializes the estimated reading time for the block editor.
+ * Gets the estimated reading time in the block editor if the content has changed.
  *
  * @returns {void}
  */
@@ -63,7 +63,7 @@ function initializeEstimatedReadingTimeBlockEditor() {
  */
 function blockEditorDebounce() {
 	const content = select( "core/editor" ).getEditedPostAttribute( "content" );
-	if ( previousContent != content ){
+	if ( previousContent !== content ) {
 		previousContent = content;
 		getEstimatedReadingTime( content );
 	}
@@ -73,7 +73,7 @@ function blockEditorDebounce() {
 const doBlockEditorDebounce = debounce( blockEditorDebounce, 1500, { maxWait: 3000 } );
 
 /**
- * Initializes the estimated reading time for the Elementor editor.
+ * Gets the estimated reading time in the Elementor editor if the content has changed.
  *
  * @returns {void}
  */
@@ -90,7 +90,7 @@ function initializeEstimatedReadingTimeElementor() {
  */
  function elementorEditorDebounce() {
 	const content = select( "yoast-seo/editor" ).getEditorDataContent();
-	if ( previousContent != content ){
+	if ( previousContent !== content ) {
 		previousContent = content;
 		getEstimatedReadingTime( content );
 	}
@@ -111,6 +111,8 @@ export default function initializeEstimatedReadingTime() {
 
 	dispatch( "yoast-seo/editor" ).loadEstimatedReadingTime();
 
+	// For the Elementor and Block editor, debounce the subscribe function, since this fires almost continuously.
+	// If not debounced, the editor would become very slow.
 	if ( window.wpseoScriptData.isElementorEditor === "1" ) {
 		initializeEstimatedReadingTimeElementor();
 	} else if ( window.wpseoScriptData.isBlockEditor === "1" ) {

--- a/packages/js/src/initializers/estimated-reading-time.js
+++ b/packages/js/src/initializers/estimated-reading-time.js
@@ -16,7 +16,7 @@ function getEstimatedReadingTime( content ) {
 		} );
 }
 
-// Delays execution by 1,5 seconds for any change, forces execution after 3 seconds.
+// Delays execution by 1.5 seconds for any change, forces execution after 3 seconds.
 const debouncedGetEstimatedReadingTime = debounce( getEstimatedReadingTime, 1500, { maxWait: 3000 } );
 
 /**
@@ -58,9 +58,6 @@ function getEstimatedReadingTimeBlockEditor() {
 	}
 }
 
-// Delays execution by 1,5 seconds for any change, forces execution after 3 seconds.
-const debounceBlockEditor = debounce( getEstimatedReadingTimeBlockEditor, 1500, { maxWait: 3000 } );
-
 /**
  * Gets the estimated reading time in the Elementor editor if the content has changed.
  *
@@ -73,9 +70,6 @@ function getEstimatedReadingTimeElementor() {
 		getEstimatedReadingTime( content );
 	}
 }
-
-// Delays execution by 1,5 seconds for any change, forces execution after 3 seconds.
-const debounceElementorEditor = debounce( getEstimatedReadingTimeElementor, 1500, { maxWait: 3000 } );
 
 /**
  * Initializes the estimated reading time.
@@ -92,13 +86,10 @@ export default function initializeEstimatedReadingTime() {
 	// For the Elementor and Block editor, debounce the subscribe function, since this fires almost continuously.
 	// If not debounced, the editor would become very slow.
 	if ( window.wpseoScriptData.isElementorEditor === "1" ) {
-		subscribe( () => {
-			debounceElementorEditor();
-		} );
+		// Delays execution by 1.5 seconds for any change, forces execution after 3 seconds.
+		subscribe( debounce( getEstimatedReadingTimeElementor, 1500, { maxWait: 3000 } ) );
 	} else if ( window.wpseoScriptData.isBlockEditor === "1" ) {
-		subscribe( () => {
-			debounceBlockEditor();
-		} );
+		subscribe( debounce( getEstimatedReadingTimeBlockEditor, 1500, { maxWait: 3000 } ) );
 	} else {
 		initializeEstimatedReadingTimeClassic();
 	}

--- a/packages/js/src/initializers/estimated-reading-time.js
+++ b/packages/js/src/initializers/estimated-reading-time.js
@@ -66,7 +66,7 @@ const debounceBlockEditor = debounce( getEstimatedReadingTimeBlockEditor, 1500, 
  *
  * @returns {void}
  */
-function getEstimatedReadingTimeBlockElementor() {
+function getEstimatedReadingTimeElementor() {
 	const content = select( "yoast-seo/editor" ).getEditorDataContent();
 	if ( previousContent !== content ) {
 		previousContent = content;
@@ -75,7 +75,7 @@ function getEstimatedReadingTimeBlockElementor() {
 }
 
 // Delays execution by 1,5 seconds for any change, forces execution after 3 seconds.
-const debounceElementorEditor = debounce( getEstimatedReadingTimeBlockElementor, 1500, { maxWait: 3000 } );
+const debounceElementorEditor = debounce( getEstimatedReadingTimeElementor, 1500, { maxWait: 3000 } );
 
 /**
  * Initializes the estimated reading time.

--- a/packages/js/src/initializers/estimated-reading-time.js
+++ b/packages/js/src/initializers/estimated-reading-time.js
@@ -16,7 +16,8 @@ function getEstimatedReadingTime( content ) {
 		} );
 }
 
-const debouncedGetEstimatedReadingTime = debounce( getEstimatedReadingTime, 500 );
+// Delays execution by 1,5 seconds for any change, forces execution after 3 seconds.
+const debouncedGetEstimatedReadingTime = debounce( getEstimatedReadingTime, 1500, { maxWait: 3000 } );
 
 /**
  * Initializes the estimated reading time for the classic editor.
@@ -41,23 +42,35 @@ function initializeEstimatedReadingTimeClassic() {
 	} );
 }
 
+// Used to trigger the initial reading time calculation for the block and Elementor editors.
+let previousContent = '';
+
 /**
  * Initializes the estimated reading time for the block editor.
  *
  * @returns {void}
  */
 function initializeEstimatedReadingTimeBlockEditor() {
-	let previousContent = select( "core/editor" ).getEditedPostAttribute( "content" );
-
 	subscribe( () => {
-		const content = select( "core/editor" ).getEditedPostAttribute( "content" );
-
-		if ( content !== previousContent ) {
-			previousContent = content;
-			debouncedGetEstimatedReadingTime( content );
-		}
+		doBlockEditorDebounce();
 	} );
 }
+
+/**
+ * Reads and compares the data from the block editor.
+ *
+ * @returns {void}
+ */
+function blockEditorDebounce() {
+	const content = select( "core/editor" ).getEditedPostAttribute( "content" );
+	if ( previousContent != content ){
+		previousContent = content;
+		getEstimatedReadingTime( content );
+	}
+}
+
+// Delays execution by 1,5 seconds for any change, forces execution after 3 seconds.
+const doBlockEditorDebounce = debounce( blockEditorDebounce, 1500, { maxWait: 3000 } );
 
 /**
  * Initializes the estimated reading time for the Elementor editor.
@@ -65,17 +78,26 @@ function initializeEstimatedReadingTimeBlockEditor() {
  * @returns {void}
  */
 function initializeEstimatedReadingTimeElementor() {
-	let previousContent = select( "yoast-seo/editor" ).getEditorDataContent();
-
 	subscribe( () => {
-		const content = select( "yoast-seo/editor" ).getEditorDataContent();
-
-		if ( content !== previousContent ) {
-			previousContent = content;
-			debouncedGetEstimatedReadingTime( content );
-		}
+		doElementorEditorDebounce();
 	} );
 }
+
+/**
+ * Reads and compares the data from the Elementor editor.
+ *
+ * @returns {void}
+ */
+ function elementorEditorDebounce() {
+	const content = select( "yoast-seo/editor" ).getEditorDataContent();
+	if ( previousContent != content ){
+		previousContent = content;
+		getEstimatedReadingTime( content );
+	}
+}
+
+// Delays execution by 1,5 seconds for any change, forces execution after 3 seconds.
+const doElementorEditorDebounce = debounce( elementorEditorDebounce, 1500, { maxWait: 3000 } );
 
 /**
  * Initializes the estimated reading time.

--- a/packages/js/src/initializers/estimated-reading-time.js
+++ b/packages/js/src/initializers/estimated-reading-time.js
@@ -50,17 +50,6 @@ let previousContent = "";
  *
  * @returns {void}
  */
-function initializeEstimatedReadingTimeBlockEditor() {
-	subscribe( () => {
-		doBlockEditorDebounce();
-	} );
-}
-
-/**
- * Reads and compares the data from the block editor.
- *
- * @returns {void}
- */
 function getEstimatedReadingTimeBlockEditor() {
 	const content = select( "core/editor" ).getEditedPostAttribute( "content" );
 	if ( previousContent !== content ) {
@@ -74,17 +63,6 @@ const debounceBlockEditor = debounce( getEstimatedReadingTimeBlockEditor, 1500, 
 
 /**
  * Gets the estimated reading time in the Elementor editor if the content has changed.
- *
- * @returns {void}
- */
-function initializeEstimatedReadingTimeElementor() {
-	subscribe( () => {
-		doElementorEditorDebounce();
-	} );
-}
-
-/**
- * Reads and compares the data from the Elementor editor.
  *
  * @returns {void}
  */
@@ -114,9 +92,13 @@ export default function initializeEstimatedReadingTime() {
 	// For the Elementor and Block editor, debounce the subscribe function, since this fires almost continuously.
 	// If not debounced, the editor would become very slow.
 	if ( window.wpseoScriptData.isElementorEditor === "1" ) {
-		initializeEstimatedReadingTimeElementor();
+		subscribe( () => {
+			debounceElementorEditor();
+		} );
 	} else if ( window.wpseoScriptData.isBlockEditor === "1" ) {
-		initializeEstimatedReadingTimeBlockEditor();
+		subscribe( () => {
+			debounceBlockEditor();
+		} );
 	} else {
 		initializeEstimatedReadingTimeClassic();
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improve (typing) performance in all supported editors, especially the block editor.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces a `debounce` on getting content from the store, this may or may not improve typing performance in all supported editors, especially the block editor

## Relevant technical choices:

* The `subscribe()` function triggers as soon as a user even looks at their monitor. This would cause multiple `select( "" ).getEditedPostAttribute( "" )` per second and these were more expensive than the eventual reading time calculations. So for the Elementor and Block editors (that use the `subscribe()` function) I moved all logic into a debounce.
* I used a debounce of 1.5 seconds with a forced execution after 3 seconds. This means that as long as `subscribe()` is firing, the debounce will hold off execution until either:
  * No `subscribe()` is fired for 1.5 seconds.
  * 3 seconds since the first `subscribe()` have passed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Copy a long text into the editor (use chapter I through X from [Moby Dick](https://gist.githubusercontent.com/StevenClontz/4445774/raw/1722a289b665d940495645a5eaaad4da8e3ad4c7/mobydick.txt)).
  * Without this PR, the editor will become sluggish and rapid typing will cause ghosttyping (where the editor needs a few seconds to add your keystrokes without you actually typing)
  * With this PR, the performance will still degrade, but it should be much less prominent. Typing will still cause a bit of ghosttyping, but not as much.
  * **Note** that both @leonidasmi  and myself weren't able to see this performance improvement. So for QA, if you can confirm that this PR doesn't introduce any regressions, we're good, even if you're not seeing a performance improvement either.
* Make sure that the estimated reading time updates in the classic, block and Elementor editors.
* You can check this by using the Premium Estimated Reading Time block (block editor only), the Premium insights in the metabox, or the Redux store.
    * Open the inspector and choose the `Redux` tab. 
    * Under `Autoselect instances`, choose the `yoast-seo/editor` store.
    * In the left scroll bar with capitalized strings, choose the lowest one. 
    * Inspect the `State`.
    * Open the `root` and see the value for `estimatedReadingTime`.
    * Make sure this value is updated when removing a significant chunk of text.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Estimated reading time
* Editor performance

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/16899
Fixes https://yoast.atlassian.net/browse/P2-1129

## Additional info
Because this PR is very subjective in terms of performance, I have taken some screenshots of actual times taken in the block editor. It is important to know the frequency of the `subscribe()` call. This function is really called for anything, so it can fire tens of times per second.

Without this PR, every subscribe event takes approximately 0.020 seconds to complete:
![Pasted image 20210716160100](https://user-images.githubusercontent.com/34372510/126121601-35d85c15-52d1-4b2d-8ea0-1fcffc2594e4.png)

With this PR you will see that the subscription times are almost always near 0.000 seconds, and only when the debounce is hit, an additional 0.020 seconds is used:
![Pasted image 20210716155725](https://user-images.githubusercontent.com/34372510/126121779-1abcea9a-7d2a-4212-b087-e7047d4f73ae.png)
