### PR TITLE
Store the result count of the general indexing action in a transient.

### DIFF
--- a/src/actions/indexing/indexable-general-indexation-action.php
+++ b/src/actions/indexing/indexable-general-indexation-action.php
@@ -11,6 +11,11 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 class Indexable_General_Indexation_Action implements Indexation_Action_Interface {
 
 	/**
+	 * The transient cache key.
+	 */
+	const TRANSIENT_CACHE_KEY = 'wpseo_total_unindexed_general_items';
+
+	/**
 	 * Represents the indexables repository.
 	 *
 	 * @var Indexable_Repository
@@ -32,9 +37,18 @@ class Indexable_General_Indexation_Action implements Indexation_Action_Interface
 	 * @return int The total number of unindexed objects.
 	 */
 	public function get_total_unindexed() {
+		$transient = \get_transient( static::TRANSIENT_CACHE_KEY );
+		if ( $transient !== false ) {
+			return (int) $transient;
+		}
+
 		$indexables_to_create = $this->query();
 
-		return \count( $indexables_to_create );
+		$result = \count( $indexables_to_create );
+
+		\set_transient( static::TRANSIENT_CACHE_KEY, $result, \DAY_IN_SECONDS );
+
+		return $result;
 	}
 
 	/**

--- a/tests/unit/actions/indexing/indexable-general-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-general-indexation-action-test.php
@@ -52,7 +52,28 @@ class Indexable_General_Indexation_Action_Test extends TestCase {
 	public function test_get_total_unindexed() {
 		$this->set_query();
 
+		Monkey\Functions\expect( 'get_transient' )
+			->with( 'wpseo_total_unindexed_general_items' )
+			->andReturn( false );
+		Monkey\Functions\expect( 'set_transient' )
+			->with( 'wpseo_total_unindexed_general_items', 4, \DAY_IN_SECONDS );
+
 		$this->assertEquals( 4, $this->instance->get_total_unindexed() );
+	}
+
+	/**
+	 * Tests the calculation of the unindexed general pages.
+	 *
+	 * @covers ::__construct
+	 * @covers ::get_total_unindexed
+	 * @covers ::query
+	 */
+	public function test_get_total_unindexed_transient_set() {
+		Monkey\Functions\expect( 'get_transient' )
+			->with( 'wpseo_total_unindexed_general_items' )
+			->andReturn( 9 );
+
+		$this->assertEquals( 9, $this->instance->get_total_unindexed() );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid duplicate database queries wherever possible. To do this we can store the result in a transient. We already do this for the unindexed counts for the other indexing actions. This PR adds it for the general indexing action as well.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents some superfluous database queries for our indexables, preventing some unnecessary load on the database.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Reproducing the issue
* Checkout `trunk` or use a previous version of the plugin.
* Make sure that you have the Query Monitor plugin installed and activated.
* Go to the SEO tools page (_SEO_ > _Tools_ in your WP admin).
* Query Monitor should report duplicate queries.

#### Checking that the issue
* Checkout this branch or use the RC in which you should test this PR.
* Make sure that you have the Query Monitor plugin installed and activated.
* Go to the SEO tools page (_SEO_ > _Tools_ in your WP admin).
* Query Monitor **should not** report duplicate queries.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
