### PR TITLE
P2-1153 Added post- and term-link indexing to the index cli command

### DIFF
--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -12,6 +12,8 @@ use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Type_Archive_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexation_Action_Interface;
 use Yoast\WP\SEO\Actions\Indexing\Indexing_Prepare_Action;
+use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
+use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Main;
 
 /**
@@ -48,6 +50,20 @@ class Index_Command implements Command_Interface {
 	private $general_indexation_action;
 
 	/**
+	 * The term link indexing action.
+	 *
+	 * @var Term_Link_Indexing_Action
+	 */
+	private $term_link_indexing_action;
+
+	/**
+	 * The post link indexing action.
+	 *
+	 * @var Post_Link_Indexing_Action
+	 */
+	private $post_link_indexing_action;
+
+	/**
 	 * The complete indexation action.
 	 *
 	 * @var Indexable_Indexing_Complete_Action
@@ -76,6 +92,10 @@ class Index_Command implements Command_Interface {
 	 *                                                                                           action.
 	 * @param Indexing_Prepare_Action                       $prepare_indexing_action             The prepare indexing
 	 *                                                                                           action.
+	 * @param Post_Link_Indexing_Action                     $post_link_indexing_action           The post link indexation
+	 *                                                                                           action.
+	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action           The term link indexation
+	 *                                                                                           action.
 	 */
 	public function __construct(
 		Indexable_Post_Indexation_Action $post_indexation_action,
@@ -83,7 +103,9 @@ class Index_Command implements Command_Interface {
 		Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation_action,
 		Indexable_General_Indexation_Action $general_indexation_action,
 		Indexable_Indexing_Complete_Action $complete_indexation_action,
-		Indexing_Prepare_Action $prepare_indexing_action
+		Indexing_Prepare_Action $prepare_indexing_action,
+		Post_Link_Indexing_Action $post_link_indexing_action,
+		Term_Link_Indexing_Action $term_link_indexing_action
 	) {
 		$this->post_indexation_action              = $post_indexation_action;
 		$this->term_indexation_action              = $term_indexation_action;
@@ -91,6 +113,8 @@ class Index_Command implements Command_Interface {
 		$this->general_indexation_action           = $general_indexation_action;
 		$this->complete_indexation_action          = $complete_indexation_action;
 		$this->prepare_indexing_action             = $prepare_indexing_action;
+		$this->post_link_indexing_action           = $post_link_indexing_action;
+		$this->term_link_indexing_action           = $term_link_indexing_action;
 	}
 
 	/**
@@ -180,6 +204,8 @@ class Index_Command implements Command_Interface {
 			'terms'              => $this->term_indexation_action,
 			'post type archives' => $this->post_type_archive_indexation_action,
 			'general objects'    => $this->general_indexation_action,
+			'post links'         => $this->post_link_indexing_action,
+			'term links'         => $this->term_link_indexing_action,
 		];
 
 		$this->prepare_indexing_action->prepare();

--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -10,6 +10,8 @@ use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Type_Archive_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexing_Prepare_Action;
+use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
+use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Commands\Index_Command;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -53,6 +55,20 @@ class Index_Command_Test extends TestCase {
 	private $general_indexation_action;
 
 	/**
+	 * The post link indexation action.
+	 *
+	 * @var Post_Link_Indexing_Action
+	 */
+	private $post_link_indexation_action;
+
+	/**
+	 * The term link indexation action.
+	 *
+	 * @var Term_Link_Indexing_Action
+	 */
+	private $term_link_indexation_action;
+
+	/**
 	 * The complete indexation action.
 	 *
 	 * @var Indexable_Indexing_Complete_Action
@@ -83,6 +99,8 @@ class Index_Command_Test extends TestCase {
 		$this->term_indexation_action              = Mockery::mock( Indexable_Term_Indexation_Action::class );
 		$this->post_type_archive_indexation_action = Mockery::mock( Indexable_Post_Type_Archive_Indexation_Action::class );
 		$this->general_indexation_action           = Mockery::mock( Indexable_General_Indexation_Action::class );
+		$this->post_link_indexation_action         = Mockery::mock( Post_Link_Indexing_Action::class );
+		$this->term_link_indexation_action         = Mockery::mock( Term_Link_Indexing_Action::class );
 		$this->complete_indexation_action          = Mockery::mock( Indexable_Indexing_Complete_Action::class );
 		$this->prepare_indexing_action             = Mockery::mock( Indexing_Prepare_Action::class );
 
@@ -92,7 +110,9 @@ class Index_Command_Test extends TestCase {
 			$this->post_type_archive_indexation_action,
 			$this->general_indexation_action,
 			$this->complete_indexation_action,
-			$this->prepare_indexing_action
+			$this->prepare_indexing_action,
+			$this->post_link_indexation_action,
+			$this->term_link_indexation_action
 		);
 	}
 
@@ -136,6 +156,8 @@ class Index_Command_Test extends TestCase {
 			$this->term_indexation_action,
 			$this->post_type_archive_indexation_action,
 			$this->general_indexation_action,
+			$this->post_link_indexation_action,
+			$this->term_link_indexation_action,
 		];
 
 		foreach ( $indexation_actions as $indexation_action ) {
@@ -152,12 +174,12 @@ class Index_Command_Test extends TestCase {
 
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
-			->times( 4 )
+			->times( 6 )
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
-		$progress_bar_mock->expects( 'tick' )->times( 4 )->with( 25 );
-		$progress_bar_mock->expects( 'tick' )->times( 4 )->with( 5 );
-		$progress_bar_mock->expects( 'finish' )->times( 4 );
+		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 25 );
+		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 5 );
+		$progress_bar_mock->expects( 'finish' )->times( 6 );
 
 		$this->instance->index();
 	}
@@ -175,6 +197,8 @@ class Index_Command_Test extends TestCase {
 			$this->term_indexation_action,
 			$this->post_type_archive_indexation_action,
 			$this->general_indexation_action,
+			$this->post_link_indexation_action,
+			$this->term_link_indexation_action,
 		];
 
 		foreach ( $indexation_actions as $indexation_action ) {
@@ -191,12 +215,12 @@ class Index_Command_Test extends TestCase {
 
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
-			->times( 4 )
+			->times( 6 )
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
-		$progress_bar_mock->expects( 'tick' )->times( 4 )->with( 25 );
-		$progress_bar_mock->expects( 'tick' )->times( 4 )->with( 5 );
-		$progress_bar_mock->expects( 'finish' )->times( 4 );
+		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 25 );
+		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 5 );
+		$progress_bar_mock->expects( 'finish' )->times( 6 );
 
 		$cli = Mockery::mock( 'overload:WP_CLI' );
 		$cli
@@ -273,6 +297,8 @@ class Index_Command_Test extends TestCase {
 			$this->term_indexation_action,
 			$this->post_type_archive_indexation_action,
 			$this->general_indexation_action,
+			$this->post_link_indexation_action,
+			$this->term_link_indexation_action,
 		];
 
 		foreach ( $indexation_actions as $indexation_action ) {
@@ -294,12 +320,12 @@ class Index_Command_Test extends TestCase {
 
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
-			->times( 8 )
+			->times( 12 )
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
-		$progress_bar_mock->expects( 'tick' )->times( 8 )->with( 25 );
-		$progress_bar_mock->expects( 'tick' )->times( 8 )->with( 5 );
-		$progress_bar_mock->expects( 'finish' )->times( 8 );
+		$progress_bar_mock->expects( 'tick' )->times( 12 )->with( 25 );
+		$progress_bar_mock->expects( 'tick' )->times( 12 )->with( 5 );
+		$progress_bar_mock->expects( 'finish' )->times( 12 );
 
 		$this->instance->index( null, [ 'network' => true ] );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds post link indexing and term link indexing to the `wp yoast index` WP-CLI command.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run the `wp yoast index` cli command.
* For docker that is `docker exec -it -u www-data basic-wordpress wp yoast index`
*  Make sure the post- and term-links are indexed.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
