### PR TITLE
Improve performance for the query to find unindexed posts

### DIFF
--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -117,12 +117,11 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			"
 			SELECT COUNT(P.ID)
 			FROM {$this->wpdb->posts} AS P
-			LEFT JOIN $indexable_table AS I
-				ON P.ID = I.object_id
-				AND I.object_type = 'post'
-				AND I.permalink_hash IS NOT NULL
-			WHERE I.object_id IS NULL
-				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')',
+			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ")
+			AND P.ID not in (
+				SELECT I.object_id from $indexable_table as I
+				WHERE I.object_type = 'post'
+				AND I.permalink_hash IS NOT NULL)",
 			$post_types
 		);
 	}
@@ -150,12 +149,11 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			"
 			SELECT P.ID
 			FROM {$this->wpdb->posts} AS P
-			LEFT JOIN $indexable_table AS I
-				ON P.ID = I.object_id
-				AND I.object_type = 'post'
-				AND I.permalink_hash IS NOT NULL
-			WHERE I.object_id IS NULL
-				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ")
+			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ")
+			AND P.ID not in (
+				SELECT I.object_id from $indexable_table as I
+				WHERE I.object_type = 'post'
+				AND I.permalink_hash IS NOT NULL)
 			$limit_query",
 			$replacements
 		);

--- a/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
@@ -82,12 +82,11 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$expected_query = "
 			SELECT COUNT(P.ID)
 			FROM wp_posts AS P
-			LEFT JOIN wp_yoast_indexable AS I
-				ON P.ID = I.object_id
-				AND I.object_type = 'post'
-				AND I.permalink_hash IS NOT NULL
-			WHERE I.object_id IS NULL
-				AND P.post_type IN (%s)";
+			WHERE P.post_type IN (%s)
+			AND P.ID not in (
+				SELECT I.object_id from wp_yoast_indexable as I
+				WHERE I.object_type = 'post'
+				AND I.permalink_hash IS NOT NULL)";
 
 		Functions\expect( 'get_transient' )->once()->with( 'wpseo_total_unindexed_posts' )->andReturnFalse();
 		Functions\expect( 'set_transient' )->once()->with( 'wpseo_total_unindexed_posts', '10', \DAY_IN_SECONDS )->andReturnTrue();
@@ -117,12 +116,11 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$expected_query = "
 			SELECT P.ID
 			FROM wp_posts AS P
-			LEFT JOIN wp_yoast_indexable AS I
-				ON P.ID = I.object_id
-				AND I.object_type = 'post'
-				AND I.permalink_hash IS NOT NULL
-			WHERE I.object_id IS NULL
-				AND P.post_type IN (%s)
+			WHERE P.post_type IN (%s)
+			AND P.ID not in (
+				SELECT I.object_id from wp_yoast_indexable as I
+				WHERE I.object_type = 'post'
+				AND I.permalink_hash IS NOT NULL)
 			LIMIT %d";
 
 		$query_result = [
@@ -195,12 +193,11 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$expected_query = "
 			SELECT COUNT(P.ID)
 			FROM wp_posts AS P
-			LEFT JOIN wp_yoast_indexable AS I
-				ON P.ID = I.object_id
-				AND I.object_type = 'post'
-				AND I.permalink_hash IS NOT NULL
-			WHERE I.object_id IS NULL
-				AND P.post_type IN (%s)";
+			WHERE P.post_type IN (%s)
+			AND P.ID not in (
+				SELECT I.object_id from wp_yoast_indexable as I
+				WHERE I.object_type = 'post'
+				AND I.permalink_hash IS NOT NULL)";
 
 		Functions\expect( 'get_transient' )->once()->with( 'wpseo_total_unindexed_posts' )->andReturnFalse();
 		Functions\expect( 'set_transient' )->once()->with( 'wpseo_total_unindexed_posts', '10', \DAY_IN_SECONDS )->andReturnTrue();
@@ -230,12 +227,11 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$expected_query = "
 			SELECT P.ID
 			FROM wp_posts AS P
-			LEFT JOIN wp_yoast_indexable AS I
-				ON P.ID = I.object_id
-				AND I.object_type = 'post'
-				AND I.permalink_hash IS NOT NULL
-			WHERE I.object_id IS NULL
-				AND P.post_type IN (%s)
+			WHERE P.post_type IN (%s)
+			AND P.ID not in (
+				SELECT I.object_id from wp_yoast_indexable as I
+				WHERE I.object_type = 'post'
+				AND I.permalink_hash IS NOT NULL)
 			LIMIT %d";
 
 		Filters\expectApplied( 'wpseo_post_indexation_limit' )->andReturn( 25 );
@@ -314,12 +310,11 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$expected_query = "
 			SELECT P.ID
 			FROM wp_posts AS P
-			LEFT JOIN wp_yoast_indexable AS I
-				ON P.ID = I.object_id
-				AND I.object_type = 'post'
-				AND I.permalink_hash IS NOT NULL
-			WHERE I.object_id IS NULL
-				AND P.post_type IN (%s)
+			WHERE P.post_type IN (%s)
+			AND P.ID not in (
+				SELECT I.object_id from wp_yoast_indexable as I
+				WHERE I.object_type = 'post'
+				AND I.permalink_hash IS NOT NULL)
 			LIMIT %d";
 
 		Filters\expectApplied( 'wpseo_post_indexation_limit' )->andReturn( 25 );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves performance of an SQL query used to find the number of unindexed posts in the indexable table.

## Relevant technical choices:

* This improvement really concerns the `COUNT` query. It hardly has an impact on the `SELECT` query when you pass a (default) limit of 25, but for code consistency I decided to keep the two queries the same.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Preparations**
* Test on a big site with +- 10.000 posts.
    * To generate posts in Docker, you can run the following commands:
    * `docker exec  -ti basic-wordpress /bin/bash -c 'php -d memory_limit=512M "$(which wp)" package install git@github.com:Yoast/wp-cli-faker.git --allow-root'`
    * `docker exec -it basic-wordpress wp faker core content --posts=10000 --allow-root`.
* Make sure these 10.000 posts are unindexed (reset the indexables in the Test Helper if need be).
    * If you just created them in Docker you're good.
* Activate Query Monitor.
* Comment out [getting and using the transient](https://github.com/Yoast/wordpress-seo/blob/f170b2373403c352498dcc5fbc35eb2ad1038861/src/actions/indexing/abstract-indexing-action.php#L50-L53) for the `get_limited_unindexed_count()` function.
    * Otherwise the query won't get executed.
* Comment out [getting and using the transient](https://github.com/Yoast/wordpress-seo/blob/f170b2373403c352498dcc5fbc35eb2ad1038861/src/actions/indexing/abstract-indexing-action.php#L74-L77) for the `get_total_unindexed()` function.
    * Otherwise the query won't get executed.

**Investigating the `COUNT` query**

_On `trunk` / the 16.8 RC_
*  Go to the Tools page.
* In Query Monitor, inspect the following query with the caller `Abstract_Indexing_Action->get_total_unindexed()`:

<img width="296" alt="Screenshot 2021-07-22 at 13 49 11" src="https://user-images.githubusercontent.com/20280513/126634575-cb8ed241-8431-425a-88cf-755ebade0ed8.png">

* Note the time the query took to execute.
* If you're proficient with Xdebug, place a breakpoint [in the code](https://github.com/Yoast/wordpress-seo/blob/f170b2373403c352498dcc5fbc35eb2ad1038861/src/actions/indexing/abstract-indexing-action.php#L82) to see how many non-indexed posts are returned from the query.
    * If you're not proficient with Xdebug, you can write `var_dump( $count ); die;` after the above line in the code.

_On this branch / the 16.9 RC_
*  Follow the same steps.
* The number of non-indexed posts that are returned should be equal to the number in `trunk` / the 16.8 RC.
* Compare the time the query took to execute to the time on `trunk` / the 16.8 RC. It should be significantly faster.
    * In my case, the query took 0.0424 on this branch and 0.9946 on `trunk`, but I've seen the numbers vary in different sessions.

**Investigating the `SELECT` query**

_On `trunk` / the 16.8 RC_
*  Go to the Tools page.
* In Query Monitor, inspect the following query with the caller `Abstract_Indexing_Action->get_limited_unindexed_count()`:

<img width="298" alt="Screenshot 2021-07-22 at 13 50 32" src="https://user-images.githubusercontent.com/20280513/126634701-792eec7d-f16d-46e4-a807-50b01f9693f0.png">

* See that the `LIMIT` in the query is set to 26 (if you didn't modify the shutdown limit - which you shouldn't).
* Note the time the query took to execute.

_On this branch / the 16.9 RC_
*  Follow the same steps.
* The `LIMIT` in the query should again be 26.
* Compare the time the query took to execute to the time on `trunk` / the 16.8 RC. It should not be (significantly) slower as compared to `trunk` / the 16.8 RC.
    * In my case, the query was slightly slower on this branch: 0.0005 on this branch versus 0.0004 on `trunk`. Since this difference is one ten-thousand-th of a second, I chose to implement the query for reasons of code consistency.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
