### PR TITLE
P2-1155 Fixes a bug where the incorrect amount of unindexed general pages was returned

### DIFF
--- a/src/actions/indexing/indexable-general-indexation-action.php
+++ b/src/actions/indexing/indexable-general-indexation-action.php
@@ -86,7 +86,7 @@ class Indexable_General_Indexation_Action implements Indexation_Action_Interface
 			$indexables[] = $this->indexable_repository->find_for_home_page();
 		}
 
-		\set_transient( static::TRANSIENT_CACHE_KEY, 0, \DAY_IN_SECONDS );
+		\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
 
 		return $indexables;
 	}

--- a/src/actions/indexing/indexable-general-indexation-action.php
+++ b/src/actions/indexing/indexable-general-indexation-action.php
@@ -86,6 +86,8 @@ class Indexable_General_Indexation_Action implements Indexation_Action_Interface
 			$indexables[] = $this->indexable_repository->find_for_home_page();
 		}
 
+		\set_transient( static::TRANSIENT_CACHE_KEY, 0, \DAY_IN_SECONDS );
+
 		return $indexables;
 	}
 

--- a/src/actions/indexing/indexable-general-indexation-action.php
+++ b/src/actions/indexing/indexable-general-indexation-action.php
@@ -13,7 +13,7 @@ class Indexable_General_Indexation_Action implements Indexation_Action_Interface
 	/**
 	 * The transient cache key.
 	 */
-	const TRANSIENT_CACHE_KEY = 'wpseo_total_unindexed_general_items';
+	const UNINDEXED_COUNT_TRANSIENT = 'wpseo_total_unindexed_general_items';
 
 	/**
 	 * Represents the indexables repository.
@@ -37,7 +37,7 @@ class Indexable_General_Indexation_Action implements Indexation_Action_Interface
 	 * @return int The total number of unindexed objects.
 	 */
 	public function get_total_unindexed() {
-		$transient = \get_transient( static::TRANSIENT_CACHE_KEY );
+		$transient = \get_transient( static::UNINDEXED_COUNT_TRANSIENT );
 		if ( $transient !== false ) {
 			return (int) $transient;
 		}
@@ -46,7 +46,7 @@ class Indexable_General_Indexation_Action implements Indexation_Action_Interface
 
 		$result = \count( $indexables_to_create );
 
-		\set_transient( static::TRANSIENT_CACHE_KEY, $result, \DAY_IN_SECONDS );
+		\set_transient( static::UNINDEXED_COUNT_TRANSIENT, $result, \DAY_IN_SECONDS );
 
 		return $result;
 	}

--- a/src/actions/indexing/indexable-general-indexation-action.php
+++ b/src/actions/indexing/indexable-general-indexation-action.php
@@ -86,7 +86,7 @@ class Indexable_General_Indexation_Action implements Indexation_Action_Interface
 			$indexables[] = $this->indexable_repository->find_for_home_page();
 		}
 
-		\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
+		\set_transient( static::TRANSIENT_CACHE_KEY, 0, \DAY_IN_SECONDS );
 
 		return $indexables;
 	}

--- a/src/actions/indexing/indexable-general-indexation-action.php
+++ b/src/actions/indexing/indexable-general-indexation-action.php
@@ -86,7 +86,7 @@ class Indexable_General_Indexation_Action implements Indexation_Action_Interface
 			$indexables[] = $this->indexable_repository->find_for_home_page();
 		}
 
-		\set_transient( static::TRANSIENT_CACHE_KEY, 0, \DAY_IN_SECONDS );
+		\set_transient( static::UNINDEXED_COUNT_TRANSIENT, 0, \DAY_IN_SECONDS );
 
 		return $indexables;
 	}

--- a/tests/unit/actions/indexing/indexable-general-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-general-indexation-action-test.php
@@ -114,8 +114,8 @@ class Indexable_General_Indexation_Action_Test extends TestCase {
 			->expects( 'find_for_home_page' )
 			->andReturn( 'home page' );
 
-		Monkey\Functions\expect( 'set_transient' )
-			->with( 'wpseo_total_unindexed_general_items', 0, \DAY_IN_SECONDS );
+		Monkey\Functions\expect( 'delete_transient' )
+			->with( 'wpseo_total_unindexed_general_items' );
 
 		$this->assertEquals( [ '404', 'search', 'date archive', 'home page' ], $this->instance->index() );
 	}

--- a/tests/unit/actions/indexing/indexable-general-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-general-indexation-action-test.php
@@ -114,6 +114,9 @@ class Indexable_General_Indexation_Action_Test extends TestCase {
 			->expects( 'find_for_home_page' )
 			->andReturn( 'home page' );
 
+		Monkey\Functions\expect( 'set_transient' )
+			->with( 'wpseo_total_unindexed_general_items', 0, \DAY_IN_SECONDS );
+
 		$this->assertEquals( [ '404', 'search', 'date archive', 'home page' ], $this->instance->index() );
 	}
 

--- a/tests/unit/actions/indexing/indexable-general-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-general-indexation-action-test.php
@@ -114,8 +114,8 @@ class Indexable_General_Indexation_Action_Test extends TestCase {
 			->expects( 'find_for_home_page' )
 			->andReturn( 'home page' );
 
-		Monkey\Functions\expect( 'delete_transient' )
-			->with( 'wpseo_total_unindexed_general_items' );
+		Monkey\Functions\expect( 'set_transient' )
+			->with( 'wpseo_total_unindexed_general_items', 0, \DAY_IN_SECONDS );
 
 		$this->assertEquals( [ '404', 'search', 'date archive', 'home page' ], $this->instance->index() );
 	}


### PR DESCRIPTION

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Because the general indexing count transient is not deleted on indexation, the total unindexed count would return a small number, meaning that on each admin request the background indexation would be run, and this would clear out all count transients for the individual indexation actions, causing expensive count queries to be run on each request.
* This bug was introduced in https://github.com/Yoast/wordpress-seo/pull/17264 because we forgot the delete the transient upon indexing the general indexation.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the background indexing would keep running on each request because a wrong number of general pages was returned in the count. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

    * Make sure Query monitor is enabled.
    * Clear all indexables using the test helper.
    * Go to the SEO > Tools page.
    * Run a full indexation of your site.
    * Now go to the admin-dashboard, notice that no count-queries are run.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
