### PR TITLE
Add product assessors

### DIFF
--- a/packages/yoastseo/spec/scoring/productPages/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/contentAssessorSpec.js
@@ -1,0 +1,48 @@
+import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
+import DefaultResearcher from "../../../src/languageProcessing/languages/_default/Researcher";
+import ContentAssessor from "../../../src/scoring/productPages/contentAssessor.js";
+import Factory from "../../specHelpers/factory.js";
+import Paper from "../../../src/values/Paper.js";
+
+const i18n = Factory.buildJed();
+
+describe( "A product page content assessor", function() {
+	describe( "Checks the applicable assessments", function() {
+		it( "Should have 6 available assessments for a fully supported language", function() {
+			const paper = new Paper( "test", { locale: "en_US" } );
+			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ) );
+
+			contentAssessor.getPaper = function() {
+				return paper;
+			};
+			const actual = contentAssessor.getApplicableAssessments().map( result => result.identifier );
+			const expected = [
+				"subheadingsTooLong",
+				"textParagraphTooLong",
+				"textSentenceLength",
+				"textTransitionWords",
+				"passiveVoice",
+				"textPresence"
+			];
+			expect( actual ).toEqual( expected );
+		} );
+
+		it( "Should have 4 available assessments for a basic supported language", function() {
+			const paper = new Paper( "test", { locale: "xx_XX" } );
+			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ) );
+
+			contentAssessor.getPaper = function() {
+				return paper;
+			};
+
+			const actual = contentAssessor.getApplicableAssessments().map( result => result.identifier );
+			const expected = [
+				"subheadingsTooLong",
+				"textParagraphTooLong",
+				"textSentenceLength",
+				"textPresence"
+			];
+			expect( actual ).toEqual( expected );
+		} );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/productPages/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/contentAssessorSpec.js
@@ -22,7 +22,7 @@ describe( "A product page content assessor", function() {
 				"textSentenceLength",
 				"textTransitionWords",
 				"passiveVoice",
-				"textPresence"
+				"textPresence",
 			];
 			expect( actual ).toEqual( expected );
 		} );
@@ -40,7 +40,7 @@ describe( "A product page content assessor", function() {
 				"subheadingsTooLong",
 				"textParagraphTooLong",
 				"textSentenceLength",
-				"textPresence"
+				"textPresence",
 			];
 			expect( actual ).toEqual( expected );
 		} );

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
@@ -7,7 +7,7 @@ import Factory from "../../../specHelpers/factory";
 const i18n = Factory.buildJed();
 
 describe( "A cornerstone product page content assessor", function() {
-		describe( "Checks the applicable assessments", function() {
+	describe( "Checks the applicable assessments", function() {
 		const paper = new Paper( "test" );
 		it( "Should have 8 available assessments for a fully supported language", function() {
 			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ) );

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
@@ -16,7 +16,7 @@ describe( "A cornerstone product page content assessor", function() {
 			};
 
 			const actual = contentAssessor.getApplicableAssessments().length;
-			const expected = 8;
+			const expected = 6;
 			expect( actual ).toBe( expected );
 		} );
 

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
@@ -1,0 +1,55 @@
+import DefaultResearcher from "../../../../src/languageProcessing/languages/_default/Researcher";
+import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
+import ContentAssessor from "../../../../src/scoring/productPages/cornerstone/contentAssessor";
+import Paper from "../../../../src/values/Paper";
+import Factory from "../../../specHelpers/factory";
+
+const i18n = Factory.buildJed();
+
+describe( "A cornerstone product page content assessor", function() {
+		describe( "Checks the applicable assessments", function() {
+		const paper = new Paper( "test" );
+		it( "Should have 8 available assessments for a fully supported language", function() {
+			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ) );
+			contentAssessor.getPaper = function() {
+				return paper;
+			};
+
+			const actual = contentAssessor.getApplicableAssessments().length;
+			const expected = 8;
+			expect( actual ).toBe( expected );
+		} );
+
+		it( "Should have 4 available assessments for a basic supported language", function() {
+			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ) );
+			contentAssessor.getPaper = function() {
+				return paper;
+			};
+
+			const actual = contentAssessor.getApplicableAssessments().length;
+			const expected = 4;
+			expect( actual ).toBe( expected );
+		} );
+	} );
+
+	describe( "has configuration overrides", () => {
+		const assessor = new ContentAssessor( i18n );
+
+		test( "SubheadingsDistributionTooLong", () => {
+			const assessment = assessor.getAssessment( "subheadingsTooLong" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.parameters ).toBeDefined();
+			expect( assessment._config.parameters.recommendedMaximumWordCount ).toBe( 250 );
+			expect( assessment._config.parameters.slightlyTooMany ).toBe( 250 );
+			expect( assessment._config.parameters.farTooMany ).toBe( 300 );
+		} );
+
+		it( "should pass a 'true' value for the isCornerstone parameter in the SentenceLengthInTextAssessment", function() {
+			const assessment = assessor.getAssessment( "textSentenceLength" );
+
+			expect( assessment._isCornerstone ).toBeTruthy();
+		} );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/relatedKeywordAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/relatedKeywordAssessorSpec.js
@@ -1,0 +1,79 @@
+import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
+import Assessor from "../../../../src/scoring/productPages/cornerstone/relatedKeywordAssessor.js";
+import Paper from "../../../../src/values/Paper.js";
+import factory from "../../../specHelpers/factory.js";
+import getResults from "../../../specHelpers/getListOfAssessmentResults";
+const i18n = factory.buildJed();
+const assessor = new Assessor( i18n, new EnglishResearcher() );
+
+describe( "running assessments in the cornerstone related keyword product assessor", function() {
+	it( "runs assessments without any specific requirements", function() {
+		assessor.assess( new Paper( "" ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+		] );
+	} );
+
+	it( "runs assessments that only require a keyword", function() {
+		assessor.assess( new Paper( "", { keyword: "keyword" } ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+		] );
+	} );
+
+	it( "runs assessments that only require a keyword that consists of function words only", function() {
+		assessor.assess( new Paper( "", { keyword: "a" } ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"functionWordsInKeyphrase",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"textImages",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text, a keyword, and a meta description", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", description: "description" } ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionKeyword",
+			"textImages",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text of at least 100 words and a keyword", function() {
+		assessor.assess( new Paper( "This is a text about the keyword. Lorem ipsum dolor sit amet, fugit" +
+			"munere consulatu an est, ex eruditi gloriatur reformidans vim. At ius falli laboramus, ei" +
+			"euripidis dissentiet vix. Pro novum eligendi repudiare no, in vix stet hinc. Mollis qualisque" +
+			"iudicabit id mei, legimus aliquando democritum duo cu. Id eripuit omnesque appellantur pro," +
+			"vim ne menandri appellantur. Usu omnes timeam tritani et, an falli consectetuer vix. Vel" +
+			"ne enim constituam. Et summo mentitum mea. Cu his nusquam civibus officiis, vix tota appellantur" +
+			"no, fuisset invenire molestiae pro ne. Ne case essent mei, ut quo ferri malorum albucius. Id nonumes" +
+			"inimicus vix. Ei duo prompta electram, iudico.", { keyword: "keyword" } ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"textImages",
+		] );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/relatedKeywordAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/relatedKeywordAssessorSpec.js
@@ -42,7 +42,7 @@ describe( "running assessments in the cornerstone related keyword product assess
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"textImages",
+			"images",
 		] );
 	} );
 
@@ -54,7 +54,7 @@ describe( "running assessments in the cornerstone related keyword product assess
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionKeyword",
-			"textImages",
+			"images",
 		] );
 	} );
 
@@ -73,7 +73,7 @@ describe( "running assessments in the cornerstone related keyword product assess
 			"introductionKeyword",
 			"keyphraseLength",
 			"keywordDensity",
-			"textImages",
+			"images",
 		] );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
@@ -1,0 +1,245 @@
+import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
+import Assessor from "../../../../src/scoring/productPages/cornerstone/seoAssessor.js";
+import Paper from "../../../../src/values/Paper.js";
+import factory from "../../../specHelpers/factory.js";
+import getResults from "../../../specHelpers/getAssessorResults";
+
+const i18n = factory.buildJed();
+
+describe( "running assessments in the product page SEO assessor", function() {
+	let assessor;
+
+	beforeEach( () => {
+		assessor = new Assessor( i18n, new EnglishResearcher() );
+	} );
+
+	it( "runs assessments without any specific requirements", function() {
+		assessor.assess( new Paper( "" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that only require a text", function() {
+		assessor.assess( new Paper( "text" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally returns a singleH1Assessment if the text contains two h1s", function() {
+		assessor.assess( new Paper( "<h1>Title1</h1><h1>Title2</h1>" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+			"singleH1",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a keyword with function words only", function() {
+		assessor.assess( new Paper( "", { keyword: "a" } ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textLength",
+			"titleWidth",
+			"functionWordsInKeyphrase",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a long enough text and a keyword and a synonym", function() {
+		const text = "a ".repeat( 200 );
+		assessor.assess( new Paper( text, { keyword: "keyword", synonyms: "synonym" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text and a long url with stop words", function() {
+		assessor.assess( new Paper( "text", { url: "a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text, a url and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", url: "sample url" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+			"urlKeyword",
+		] );
+	} );
+
+	// These specifications will additionally trigger the largest keyword distance assessment.
+	it( "additionally runs assessments that require a long enough text and two keyword occurrences", function() {
+		assessor.assess( new Paper( "This is a keyword and a keyword. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a long enough text and one keyword occurrence and one synonym occurrence", function() {
+		assessor.assess( new Paper( "This is a keyword. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas synonym." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword", synonyms: "synonym" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	describe( "has configuration overrides", () => {
+		test( "MetaDescriptionLengthAssessment", () => {
+			const assessment = assessor.getAssessment( "metaDescriptionLength" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.tooLong ).toBe( 3 );
+			expect( assessment._config.scores.tooShort ).toBe( 3 );
+		} );
+
+		test( "TextImagesAssessment", () => {
+			const assessment = assessor.getAssessment( "textImages" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.noImages ).toBe( 3 );
+			expect( assessment._config.scores.withAltNonKeyword ).toBe( 3 );
+			expect( assessment._config.scores.withAlt ).toBe( 3 );
+			expect( assessment._config.scores.noAlt ).toBe( 3 );
+		} );
+
+		test( "TextLengthAssessment", () => {
+			const assessment = assessor.getAssessment( "textLength" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.recommendedMinimum ).toBe( 900 );
+			expect( assessment._config.slightlyBelowMinimum ).toBe( 400 );
+			expect( assessment._config.belowMinimum ).toBe( 300 );
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.belowMinimum ).toBe( -20 );
+			expect( assessment._config.scores.farBelowMinimum ).toBe( -20 );
+		} );
+
+		test( "PageTitleWidthAssesment", () => {
+			const assessment = assessor.getAssessment( "titleWidth" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.widthTooShort ).toBe( 3 );
+			expect( assessment._config.scores.widthTooLong ).toBe( 3 );
+		} );
+
+		test( "UrlKeywordAssessment", () => {
+			const assessment = assessor.getAssessment( "urlKeyword" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.okay ).toBe( 3 );
+		} );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
@@ -34,9 +34,9 @@ describe( "running assessments in the product page SEO assessor", function() {
 		expect( assessments ).toEqual( [
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
+			"images",
 		] );
 	} );
 
@@ -48,10 +48,10 @@ describe( "running assessments in the product page SEO assessor", function() {
 		expect( assessments ).toEqual( [
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
 			"singleH1",
+			"images",
 		] );
 	} );
 
@@ -64,9 +64,9 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
+			"images",
 		] );
 	} );
 
@@ -94,9 +94,9 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"keyphraseLength",
 			"keywordDensity",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
+			"images",
 		] );
 	} );
 
@@ -108,9 +108,9 @@ describe( "running assessments in the product page SEO assessor", function() {
 		expect( assessments ).toEqual( [
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
+			"images",
 		] );
 	} );
 
@@ -123,10 +123,10 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
 			"urlKeyword",
+			"images",
 		] );
 	} );
 
@@ -153,9 +153,9 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"keyphraseLength",
 			"keywordDensity",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
+			"images",
 		] );
 	} );
 
@@ -181,9 +181,9 @@ describe( "running assessments in the product page SEO assessor", function() {
 			"keyphraseLength",
 			"keywordDensity",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
+			"images",
 		] );
 	} );
 
@@ -198,14 +198,12 @@ describe( "running assessments in the product page SEO assessor", function() {
 			expect( assessment._config.scores.tooShort ).toBe( 3 );
 		} );
 
-		test( "TextImagesAssessment", () => {
-			const assessment = assessor.getAssessment( "textImages" );
+		test( "ImageKeyphrase", () => {
+			const assessment = assessor.getAssessment( "imageKeyphrase" );
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.scores ).toBeDefined();
-			expect( assessment._config.scores.noImages ).toBe( 3 );
-			expect( assessment._config.scores.withAltNonKeyword ).toBe( 3 );
 			expect( assessment._config.scores.withAlt ).toBe( 3 );
 			expect( assessment._config.scores.noAlt ).toBe( 3 );
 		} );

--- a/packages/yoastseo/spec/scoring/productPages/relatedKeywordAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/relatedKeywordAssessorSpec.js
@@ -1,0 +1,79 @@
+import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
+import Assessor from "../../../src/scoring/productPages/relatedKeywordAssessor";
+import Paper from "../../../src/values/Paper";
+import factory from "../../specHelpers/factory";
+import getResults from "../../specHelpers/getListOfAssessmentResults";
+const i18n = factory.buildJed();
+const assessor = new Assessor( i18n, new EnglishResearcher() );
+
+describe( "running assessments in the related keyword product assessor", function() {
+	it( "runs assessments without any specific requirements", function() {
+		assessor.assess( new Paper( "" ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+		] );
+	} );
+
+	it( "runs assessments that only require a keyword", function() {
+		assessor.assess( new Paper( "", { keyword: "keyword" } ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+		] );
+	} );
+
+	it( "runs assessments that only require a keyword that contains function words only", function() {
+		assessor.assess( new Paper( "", { keyword: "a" } ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"functionWordsInKeyphrase",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"textImages",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text, a keyword, and a meta description", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", description: "description" } ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionKeyword",
+			"textImages",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text of at least 100 words and a keyword", function() {
+		assessor.assess( new Paper( "This is a text about the keyword. Lorem ipsum dolor sit amet, fugit" +
+			"munere consulatu an est, ex eruditi gloriatur reformidans vim. At ius falli laboramus, ei" +
+			"euripidis dissentiet vix. Pro novum eligendi repudiare no, in vix stet hinc. Mollis qualisque" +
+			"iudicabit id mei, legimus aliquando democritum duo cu. Id eripuit omnesque appellantur pro," +
+			"vim ne menandri appellantur. Usu omnes timeam tritani et, an falli consectetuer vix. Vel" +
+			"ne enim constituam. Et summo mentitum mea. Cu his nusquam civibus officiis, vix tota appellantur" +
+			"no, fuisset invenire molestiae pro ne. Ne case essent mei, ut quo ferri malorum albucius. Id nonumes" +
+			"inimicus vix. Ei duo prompta electram, iudico.", { keyword: "keyword" } ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"textImages",
+		] );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/productPages/relatedKeywordAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/relatedKeywordAssessorSpec.js
@@ -42,7 +42,7 @@ describe( "running assessments in the related keyword product assessor", functio
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"textImages",
+			"images",
 		] );
 	} );
 
@@ -54,7 +54,7 @@ describe( "running assessments in the related keyword product assessor", functio
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionKeyword",
-			"textImages",
+			"images",
 		] );
 	} );
 
@@ -73,7 +73,7 @@ describe( "running assessments in the related keyword product assessor", functio
 			"introductionKeyword",
 			"keyphraseLength",
 			"keywordDensity",
-			"textImages",
+			"images",
 		] );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
@@ -33,9 +33,9 @@ describe( "running assessments in the product page cornerstone SEO assessor", fu
 		expect( assessments ).toEqual( [
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
+			"images",
 		] );
 	} );
 
@@ -47,10 +47,10 @@ describe( "running assessments in the product page cornerstone SEO assessor", fu
 		expect( assessments ).toEqual( [
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
 			"singleH1",
+			"images",
 		] );
 	} );
 
@@ -63,9 +63,9 @@ describe( "running assessments in the product page cornerstone SEO assessor", fu
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
+			"images",
 		] );
 	} );
 
@@ -91,9 +91,9 @@ describe( "running assessments in the product page cornerstone SEO assessor", fu
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
+			"images",
 		] );
 	} );
 
@@ -108,9 +108,9 @@ describe( "running assessments in the product page cornerstone SEO assessor", fu
 			"keyphraseLength",
 			"keywordDensity",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
+			"images",
 		] );
 	} );
 
@@ -122,9 +122,9 @@ describe( "running assessments in the product page cornerstone SEO assessor", fu
 		expect( assessments ).toEqual( [
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
+			"images",
 		] );
 	} );
 
@@ -137,10 +137,10 @@ describe( "running assessments in the product page cornerstone SEO assessor", fu
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
 			"urlKeyword",
+			"images",
 		] );
 	} );
 
@@ -167,9 +167,9 @@ describe( "running assessments in the product page cornerstone SEO assessor", fu
 			"keyphraseLength",
 			"keywordDensity",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
+			"images",
 		] );
 	} );
 
@@ -195,9 +195,9 @@ describe( "running assessments in the product page cornerstone SEO assessor", fu
 			"keyphraseLength",
 			"keywordDensity",
 			"metaDescriptionLength",
-			"textImages",
 			"textLength",
 			"titleWidth",
+			"images",
 		] );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
@@ -1,0 +1,203 @@
+import DefaultResearcher from "../../../src/languageProcessing/languages/_default/Researcher";
+import Assessor from "../../../src/scoring/productPages/seoAssessor.js";
+import Paper from "../../../src/values/Paper.js";
+import factory from "../../specHelpers/factory.js";
+import getResults from "../../specHelpers/getAssessorResults";
+const i18n = factory.buildJed();
+
+describe( "running assessments in the product page cornerstone SEO assessor", function() {
+	let assessor;
+
+	beforeEach( () => {
+		assessor = new Assessor( i18n, new DefaultResearcher() );
+	} );
+
+	it( "runs assessments without any specific requirements", function() {
+		assessor.assess( new Paper( "" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that only require a text", function() {
+		assessor.assess( new Paper( "text" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs singleH1assessment if the text contains two H1s", function() {
+		assessor.assess( new Paper( "<h1>First title</h1><h1>Second title</h1>" ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+			"singleH1",
+		] );
+	} );
+
+	it( "additionally runs assessments that only require a text and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that only require a keyword that contains function words only", function() {
+		assessor.assess( new Paper( "", { keyword: "a" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require text and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a long enough text and a keyword and a synonym", function() {
+		const text = "a ".repeat( 200 );
+		assessor.assess( new Paper( text, { keyword: "keyword", synonyms: "synonym" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text and a super-long url with stop words", function() {
+		assessor.assess( new Paper( "text", { url: "a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url-a-sample-url" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a text, a url and a keyword", function() {
+		assessor.assess( new Paper( "text", { keyword: "keyword", url: "sample url" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+			"urlKeyword",
+		] );
+	} );
+
+	// These specifications will additionally trigger the largest keyword distance assessment.
+	it( "additionally runs assessments that require a long enough text and two keyword occurrences", function() {
+		assessor.assess( new Paper( "This is a keyword and a keyword. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+
+	it( "additionally runs assessments that require a long enough text and one keyword occurrence and one synonym occurrence", function() {
+		assessor.assess( new Paper( "This is a keyword. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse. Lorem ipsum dolor sit amet, vim illum aeque" +
+			" constituam at. Id latine tritani alterum pro. Ei quod stet affert sed. Usu putent fabellas suavitate id." +
+			" Quo ut stet recusabo torquatos. Eum ridens possim expetenda te. Ex per putant comprehensam. At vel utinam" +
+			" cotidieque, at erat brute eum, velit percipit ius et. Has vidit accusata deterruisset ea, quod facete te" +
+			" vis. Vix ei duis dolor, id eum sonet fabulas. Id vix imperdiet efficiantur. Percipit probatus pertinax te" +
+			" sit. Putant intellegebat eu sit. Vix reque tation prompta id, ea quo labore viderer definiebas synonym." +
+			" Oratio vocibus offendit an mei, est esse pericula liberavisse.", { keyword: "keyword", synonyms: "synonym" } ) );
+		const AssessmentResults = assessor.getValidResults();
+		const assessments = getResults( AssessmentResults );
+
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"keywordDensity",
+			"metaDescriptionLength",
+			"textImages",
+			"textLength",
+			"titleWidth",
+		] );
+	} );
+} );

--- a/packages/yoastseo/src/scoring/productPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/contentAssessor.js
@@ -1,0 +1,49 @@
+import Assessor from "../assessor.js";
+import ContentAssessor from "../contentAssessor";
+import fleschReadingEase from "../assessments/readability/fleschReadingEaseAssessment.js";
+import paragraphTooLong from "../assessments/readability/paragraphTooLongAssessment.js";
+import SentenceLengthInText from "../assessments/readability/sentenceLengthInTextAssessment.js";
+import SubheadingDistributionTooLong from "../assessments/readability/subheadingDistributionTooLongAssessment.js";
+import transitionWords from "../assessments/readability/transitionWordsAssessment.js";
+import passiveVoice from "../assessments/readability/passiveVoiceAssessment.js";
+import sentenceBeginnings from "../assessments/readability/sentenceBeginningsAssessment.js";
+import textPresence from "../assessments/readability/textPresenceAssessment.js";
+
+/*
+ Temporarily disabled:
+
+ var wordComplexity = require( "./assessments/readability/wordComplexityAssessment.js" );
+ var sentenceLengthInDescription = require( "./assessments/readability/sentenceLengthInDescriptionAssessment.js" );
+ */
+
+/**
+ * Creates the Assessor
+ *
+ * @param {object} i18n The i18n object used for translations.
+ * @param {Object} options The options for this assessor.
+ * @param {Object} options.marker The marker to pass the list of marks to.
+ *
+ * @constructor
+ */
+const productContentAssessor = function( i18n, options = {} ) {
+	Assessor.call( this, i18n, options );
+	this.type = "ProductCornerstoneContentAssessor";
+
+	this._assessments = [
+		fleschReadingEase,
+		new SubheadingDistributionTooLong(),
+		paragraphTooLong,
+		new SentenceLengthInText(),
+		transitionWords,
+		passiveVoice,
+		textPresence,
+		sentenceBeginnings,
+		// Temporarily disabled: wordComplexity,
+	];
+};
+
+require( "util" ).inherits( productContentAssessor, ContentAssessor );
+
+
+export default productContentAssessor;
+

--- a/packages/yoastseo/src/scoring/productPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/contentAssessor.js
@@ -22,7 +22,6 @@ const ProductContentAssessor = function( i18n, options = {} ) {
 	this.type = "productContentAssessor";
 
 	this._assessments = [
-		fleschReadingEase,
 		new SubheadingDistributionTooLong(),
 		paragraphTooLong,
 		new SentenceLengthInText(),

--- a/packages/yoastseo/src/scoring/productPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/contentAssessor.js
@@ -1,6 +1,5 @@
 import Assessor from "../assessor.js";
 import ContentAssessor from "../contentAssessor";
-import fleschReadingEase from "../assessments/readability/fleschReadingEaseAssessment.js";
 import paragraphTooLong from "../assessments/readability/paragraphTooLongAssessment.js";
 import SentenceLengthInText from "../assessments/readability/sentenceLengthInTextAssessment.js";
 import SubheadingDistributionTooLong from "../assessments/readability/subheadingDistributionTooLongAssessment.js";

--- a/packages/yoastseo/src/scoring/productPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/contentAssessor.js
@@ -6,15 +6,7 @@ import SentenceLengthInText from "../assessments/readability/sentenceLengthInTex
 import SubheadingDistributionTooLong from "../assessments/readability/subheadingDistributionTooLongAssessment.js";
 import transitionWords from "../assessments/readability/transitionWordsAssessment.js";
 import passiveVoice from "../assessments/readability/passiveVoiceAssessment.js";
-import sentenceBeginnings from "../assessments/readability/sentenceBeginningsAssessment.js";
 import textPresence from "../assessments/readability/textPresenceAssessment.js";
-
-/*
- Temporarily disabled:
-
- var wordComplexity = require( "./assessments/readability/wordComplexityAssessment.js" );
- var sentenceLengthInDescription = require( "./assessments/readability/sentenceLengthInDescriptionAssessment.js" );
- */
 
 /**
  * Creates the Assessor
@@ -25,9 +17,9 @@ import textPresence from "../assessments/readability/textPresenceAssessment.js";
  *
  * @constructor
  */
-const productContentAssessor = function( i18n, options = {} ) {
+const ProductContentAssessor = function( i18n, options = {} ) {
 	Assessor.call( this, i18n, options );
-	this.type = "ProductCornerstoneContentAssessor";
+	this.type = "productContentAssessor";
 
 	this._assessments = [
 		fleschReadingEase,
@@ -37,13 +29,11 @@ const productContentAssessor = function( i18n, options = {} ) {
 		transitionWords,
 		passiveVoice,
 		textPresence,
-		sentenceBeginnings,
-		// Temporarily disabled: wordComplexity,
 	];
 };
 
-require( "util" ).inherits( productContentAssessor, ContentAssessor );
+require( "util" ).inherits( ProductContentAssessor, ContentAssessor );
 
 
-export default productContentAssessor;
+export default ProductContentAssessor;
 

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
@@ -1,0 +1,56 @@
+import Assessor from "../../assessor.js";
+import ContentAssessor from "../../contentAssessor";
+import fleschReadingEase from "../../assessments/readability/fleschReadingEaseAssessment.js";
+import paragraphTooLong from "../../assessments/readability/paragraphTooLongAssessment.js";
+import SentenceLengthInText from "../../assessments/readability/sentenceLengthInTextAssessment.js";
+import SubheadingDistributionTooLong from "../../assessments/readability/subheadingDistributionTooLongAssessment.js";
+import transitionWords from "../../assessments/readability/transitionWordsAssessment.js";
+import passiveVoice from "../../assessments/readability/passiveVoiceAssessment.js";
+import sentenceBeginnings from "../../assessments/readability/sentenceBeginningsAssessment.js";
+import textPresence from "../../assessments/readability/textPresenceAssessment.js";
+
+/*
+ Temporarily disabled:
+
+ var wordComplexity = require( "./assessments/readability/wordComplexityAssessment.js" );
+ var sentenceLengthInDescription = require( "./assessments/readability/sentenceLengthInDescriptionAssessment.js" );
+ */
+
+/**
+ * Creates the Assessor
+ *
+ * @param {object} i18n The i18n object used for translations.
+ * @param {Object} options The options for this assessor.
+ * @param {Object} options.marker The marker to pass the list of marks to.
+ *
+ * @constructor
+ */
+const productCornerstoneContentAssessor = function( i18n, options = {} ) {
+	Assessor.call( this, i18n, options );
+	this.type = "ProductCornerstoneContentAssessor";
+
+	this._assessments = [
+
+		fleschReadingEase,
+		new SubheadingDistributionTooLong( {
+			parameters:	{
+				slightlyTooMany: 250,
+				farTooMany: 300,
+				recommendedMaximumWordCount: 250,
+			},
+		} ),
+		paragraphTooLong,
+		new SentenceLengthInText( true ),
+		transitionWords,
+		passiveVoice,
+		textPresence,
+		sentenceBeginnings,
+		// Temporarily disabled: wordComplexity,
+	];
+};
+
+require( "util" ).inherits( productCornerstoneContentAssessor, ContentAssessor );
+
+
+export default productCornerstoneContentAssessor;
+

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
@@ -1,20 +1,11 @@
 import Assessor from "../../assessor.js";
 import ContentAssessor from "../../contentAssessor";
-import fleschReadingEase from "../../assessments/readability/fleschReadingEaseAssessment.js";
 import paragraphTooLong from "../../assessments/readability/paragraphTooLongAssessment.js";
 import SentenceLengthInText from "../../assessments/readability/sentenceLengthInTextAssessment.js";
 import SubheadingDistributionTooLong from "../../assessments/readability/subheadingDistributionTooLongAssessment.js";
 import transitionWords from "../../assessments/readability/transitionWordsAssessment.js";
 import passiveVoice from "../../assessments/readability/passiveVoiceAssessment.js";
-import sentenceBeginnings from "../../assessments/readability/sentenceBeginningsAssessment.js";
 import textPresence from "../../assessments/readability/textPresenceAssessment.js";
-
-/*
- Temporarily disabled:
-
- var wordComplexity = require( "./assessments/readability/wordComplexityAssessment.js" );
- var sentenceLengthInDescription = require( "./assessments/readability/sentenceLengthInDescriptionAssessment.js" );
- */
 
 /**
  * Creates the Assessor
@@ -25,13 +16,11 @@ import textPresence from "../../assessments/readability/textPresenceAssessment.j
  *
  * @constructor
  */
-const productCornerstoneContentAssessor = function( i18n, options = {} ) {
+const ProductCornerstoneContentAssessor = function( i18n, options = {} ) {
 	Assessor.call( this, i18n, options );
-	this.type = "ProductCornerstoneContentAssessor";
+	this.type = "productCornerstoneContentAssessor";
 
 	this._assessments = [
-
-		fleschReadingEase,
 		new SubheadingDistributionTooLong( {
 			parameters:	{
 				slightlyTooMany: 250,
@@ -44,13 +33,11 @@ const productCornerstoneContentAssessor = function( i18n, options = {} ) {
 		transitionWords,
 		passiveVoice,
 		textPresence,
-		sentenceBeginnings,
-		// Temporarily disabled: wordComplexity,
 	];
 };
 
-require( "util" ).inherits( productCornerstoneContentAssessor, ContentAssessor );
+require( "util" ).inherits( ProductCornerstoneContentAssessor, ContentAssessor );
 
 
-export default productCornerstoneContentAssessor;
+export default ProductCornerstoneContentAssessor;
 

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
@@ -1,0 +1,44 @@
+import { inherits } from "util";
+import Assessor from "../../assessor.js";
+
+import IntroductionKeyword from "../../assessments/seo/IntroductionKeywordAssessment.js";
+import KeyphraseLength from "../../assessments/seo/KeyphraseLengthAssessment.js";
+import KeywordDensity from "../../assessments/seo/KeywordDensityAssessment.js";
+import MetaDescriptionKeyword from "../../assessments/seo/MetaDescriptionKeywordAssessment.js";
+import TextImages from "../../assessments/seo/TextImagesAssessment.js";
+import TextCompetingLinks from "../../assessments/seo/TextCompetingLinksAssessment.js";
+import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyphraseAssessment";
+
+/**
+ * Creates the Assessor
+ *
+ * @param {object} i18n The i18n object used for translations.
+ * @param {Object} options The options for this assessor.
+ * @param {Object} options.marker The marker to pass the list of marks to.
+ *
+ * @constructor
+ */
+const productRelatedKeywordAssessor = function( i18n, options ) {
+	Assessor.call( this, i18n, options );
+
+	this._assessments = [
+		new IntroductionKeyword(),
+		new KeyphraseLength(),
+		new KeywordDensity(),
+		new MetaDescriptionKeyword(),
+		new TextCompetingLinks(),
+		new TextImages( {
+			scores: {
+				noImages: 3,
+				withAltNonKeyword: 3,
+				withAlt: 3,
+				noAlt: 3,
+			},
+		} ),
+		new FunctionWordsInKeyphrase(),
+	];
+};
+
+inherits( productRelatedKeywordAssessor, Assessor );
+
+export default productRelatedKeywordAssessor;

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
@@ -5,7 +5,8 @@ import IntroductionKeyword from "../../assessments/seo/IntroductionKeywordAssess
 import KeyphraseLength from "../../assessments/seo/KeyphraseLengthAssessment.js";
 import KeywordDensity from "../../assessments/seo/KeywordDensityAssessment.js";
 import MetaDescriptionKeyword from "../../assessments/seo/MetaDescriptionKeywordAssessment.js";
-import TextImages from "../../assessments/seo/TextImagesAssessment.js";
+import ImageKeyphrase from "../../assessments/seo/KeyphraseInImageTextAssessment";
+import ImageCount from "../../assessments/seo/ImageCountAssessment";
 import TextCompetingLinks from "../../assessments/seo/TextCompetingLinksAssessment.js";
 import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyphraseAssessment";
 
@@ -27,15 +28,15 @@ const ProductCornerStoneRelatedKeywordAssessor = function( i18n, options ) {
 		new KeywordDensity(),
 		new MetaDescriptionKeyword(),
 		new TextCompetingLinks(),
-		new TextImages( {
+		new FunctionWordsInKeyphrase(),
+		new ImageCount(),
+		new ImageKeyphrase( {
 			scores: {
-				noImages: 3,
 				withAltNonKeyword: 3,
 				withAlt: 3,
 				noAlt: 3,
 			},
 		} ),
-		new FunctionWordsInKeyphrase(),
 	];
 };
 

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
@@ -18,7 +18,7 @@ import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyph
  *
  * @constructor
  */
-const productRelatedKeywordAssessor = function( i18n, options ) {
+const ProductCornerStoneRelatedKeywordAssessor = function( i18n, options ) {
 	Assessor.call( this, i18n, options );
 
 	this._assessments = [
@@ -39,6 +39,6 @@ const productRelatedKeywordAssessor = function( i18n, options ) {
 	];
 };
 
-inherits( productRelatedKeywordAssessor, Assessor );
+inherits( ProductCornerStoneRelatedKeywordAssessor, Assessor );
 
-export default productRelatedKeywordAssessor;
+export default ProductCornerStoneRelatedKeywordAssessor;

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -1,0 +1,97 @@
+import { inherits } from "util";
+
+import IntroductionKeywordAssessment from "../../assessments/seo/IntroductionKeywordAssessment";
+import KeyphraseLengthAssessment from "../../assessments/seo/KeyphraseLengthAssessment";
+import KeywordDensityAssessment from "../../assessments/seo/KeywordDensityAssessment";
+import MetaDescriptionKeywordAssessment from "../../assessments/seo/MetaDescriptionKeywordAssessment";
+import TextCompetingLinksAssessment from "../../assessments/seo/TextCompetingLinksAssessment";
+import InternalLinksAssessment from "../../assessments/seo/InternalLinksAssessment";
+import TitleKeywordAssessment from "../../assessments/seo/TitleKeywordAssessment";
+import UrlKeywordAssessment from "../../assessments/seo/UrlKeywordAssessment";
+import Assessor from "../../assessor";
+import SEOAssessor from "../seoAssessor";
+import MetaDescriptionLength from "../../assessments/seo/MetaDescriptionLengthAssessment";
+import SubheadingsKeyword from "../../assessments/seo/SubHeadingsKeywordAssessment";
+import TextImages from "../../assessments/seo/TextImagesAssessment";
+import TextLength from "../../assessments/seo/TextLengthAssessment";
+import OutboundLinks from "../../assessments/seo/OutboundLinksAssessment";
+import TitleWidth from "../../assessments/seo/PageTitleWidthAssessment";
+import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyphraseAssessment";
+import SingleH1Assessment from "../../assessments/seo/SingleH1Assessment";
+
+/**
+ * Creates the Assessor
+ *
+ * @param {Object} i18n The i18n object used for translations.
+ * @param {Object} options The options for this assessor.
+ * @param {Object} options.marker The marker to pass the list of marks to.
+ *
+ * @constructor
+ */
+const ProductCornerstoneSEOAssessor = function( i18n, options ) {
+	Assessor.call( this, i18n, options );
+	this.type = "CornerstoneSEOAssessor";
+
+	this._assessments = [
+		new IntroductionKeywordAssessment(),
+		new KeyphraseLengthAssessment(),
+		new KeywordDensityAssessment(),
+		new MetaDescriptionKeywordAssessment(),
+		new MetaDescriptionLength( {
+			scores:	{
+				tooLong: 3,
+				tooShort: 3,
+			},
+		} ),
+		new SubheadingsKeyword(),
+		new TextCompetingLinksAssessment(),
+		new TextImages( {
+			scores: {
+				noImages: 3,
+				withAltNonKeyword: 3,
+				withAlt: 3,
+				noAlt: 3,
+			},
+		} ),
+		new TextLength( {
+			recommendedMinimum: 900,
+			slightlyBelowMinimum: 400,
+			belowMinimum: 300,
+
+			scores: {
+				belowMinimum: -20,
+				farBelowMinimum: -20,
+			},
+
+			cornerstoneContent: true,
+		} ),
+		new OutboundLinks( {
+			scores: {
+				noLinks: 3,
+			},
+		} ),
+		new TitleKeywordAssessment(),
+		new InternalLinksAssessment(),
+		new TitleWidth(
+			{
+				scores: {
+					widthTooShort: 3,
+					widthTooLong: 3,
+				},
+			}
+		),
+		new UrlKeywordAssessment(
+			{
+				scores: {
+					okay: 3,
+				},
+			}
+		),
+		new FunctionWordsInKeyphrase(),
+		new SingleH1Assessment(),
+	];
+};
+
+inherits( ProductCornerstoneSEOAssessor, SEOAssessor );
+
+export default ProductCornerstoneSEOAssessor;

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -11,7 +11,8 @@ import Assessor from "../../assessor";
 import SEOAssessor from "../seoAssessor";
 import MetaDescriptionLength from "../../assessments/seo/MetaDescriptionLengthAssessment";
 import SubheadingsKeyword from "../../assessments/seo/SubHeadingsKeywordAssessment";
-import TextImages from "../../assessments/seo/TextImagesAssessment";
+import ImageKeyphrase from "../../assessments/seo/KeyphraseInImageTextAssessment";
+import ImageCount from "../../assessments/seo/ImageCountAssessment";
 import TextLength from "../../assessments/seo/TextLengthAssessment";
 import TitleWidth from "../../assessments/seo/PageTitleWidthAssessment";
 import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyphraseAssessment";
@@ -43,14 +44,6 @@ const ProductCornerstoneSEOAssessor = function( i18n, options ) {
 		} ),
 		new SubheadingsKeyword(),
 		new TextCompetingLinksAssessment(),
-		new TextImages( {
-			scores: {
-				noImages: 3,
-				withAltNonKeyword: 3,
-				withAlt: 3,
-				noAlt: 3,
-			},
-		} ),
 		new TextLength( {
 			recommendedMinimum: 900,
 			slightlyBelowMinimum: 400,
@@ -81,6 +74,14 @@ const ProductCornerstoneSEOAssessor = function( i18n, options ) {
 		),
 		new FunctionWordsInKeyphrase(),
 		new SingleH1Assessment(),
+		new ImageCount(),
+		new ImageKeyphrase( {
+			scores: {
+				withAltNonKeyword: 3,
+				withAlt: 3,
+				noAlt: 3,
+			},
+		} ),
 	];
 };
 

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -5,7 +5,6 @@ import KeyphraseLengthAssessment from "../../assessments/seo/KeyphraseLengthAsse
 import KeywordDensityAssessment from "../../assessments/seo/KeywordDensityAssessment";
 import MetaDescriptionKeywordAssessment from "../../assessments/seo/MetaDescriptionKeywordAssessment";
 import TextCompetingLinksAssessment from "../../assessments/seo/TextCompetingLinksAssessment";
-import InternalLinksAssessment from "../../assessments/seo/InternalLinksAssessment";
 import TitleKeywordAssessment from "../../assessments/seo/TitleKeywordAssessment";
 import UrlKeywordAssessment from "../../assessments/seo/UrlKeywordAssessment";
 import Assessor from "../../assessor";
@@ -14,7 +13,6 @@ import MetaDescriptionLength from "../../assessments/seo/MetaDescriptionLengthAs
 import SubheadingsKeyword from "../../assessments/seo/SubHeadingsKeywordAssessment";
 import TextImages from "../../assessments/seo/TextImagesAssessment";
 import TextLength from "../../assessments/seo/TextLengthAssessment";
-import OutboundLinks from "../../assessments/seo/OutboundLinksAssessment";
 import TitleWidth from "../../assessments/seo/PageTitleWidthAssessment";
 import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyphraseAssessment";
 import SingleH1Assessment from "../../assessments/seo/SingleH1Assessment";
@@ -30,7 +28,7 @@ import SingleH1Assessment from "../../assessments/seo/SingleH1Assessment";
  */
 const ProductCornerstoneSEOAssessor = function( i18n, options ) {
 	Assessor.call( this, i18n, options );
-	this.type = "CornerstoneSEOAssessor";
+	this.type = "ProductCornerstoneSEOAssessor";
 
 	this._assessments = [
 		new IntroductionKeywordAssessment(),
@@ -65,13 +63,7 @@ const ProductCornerstoneSEOAssessor = function( i18n, options ) {
 
 			cornerstoneContent: true,
 		} ),
-		new OutboundLinks( {
-			scores: {
-				noLinks: 3,
-			},
-		} ),
 		new TitleKeywordAssessment(),
-		new InternalLinksAssessment(),
 		new TitleWidth(
 			{
 				scores: {

--- a/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
@@ -1,0 +1,38 @@
+import { inherits } from "util";
+
+import Assessor from "../assessor.js";
+import IntroductionKeyword from "../assessments/seo/IntroductionKeywordAssessment.js";
+import KeyphraseLength from "../assessments/seo/KeyphraseLengthAssessment.js";
+import KeywordDensity from "../assessments/seo/KeywordDensityAssessment.js";
+import MetaDescriptionKeyword from "../assessments/seo/MetaDescriptionKeywordAssessment.js";
+import TextImages from "../assessments/seo/TextImagesAssessment.js";
+import TextCompetingLinks from "../assessments/seo/TextCompetingLinksAssessment.js";
+import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
+
+/**
+ * Creates the Assessor
+ *
+ * @param {object}  i18n            The i18n object used for translations.
+ * @param {object}  researcher      The researcher to use for the analysis.
+ * @param {Object}  options         The options for this assessor.
+ * @param {Object}  options.marker  The marker to pass the list of marks to.
+ *
+ * @constructor
+ */
+const productRelatedKeywordAssessor = function( i18n, researcher, options ) {
+	Assessor.call( this, i18n, researcher, options );
+
+	this._assessments = [
+		new IntroductionKeyword(),
+		new KeyphraseLength( { isRelatedKeyphrase: true } ),
+		new KeywordDensity(),
+		new MetaDescriptionKeyword(),
+		new TextCompetingLinks(),
+		new TextImages(),
+		new FunctionWordsInKeyphrase(),
+	];
+};
+
+inherits( productRelatedKeywordAssessor, Assessor );
+
+export default productRelatedKeywordAssessor;

--- a/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
@@ -5,7 +5,8 @@ import IntroductionKeyword from "../assessments/seo/IntroductionKeywordAssessmen
 import KeyphraseLength from "../assessments/seo/KeyphraseLengthAssessment.js";
 import KeywordDensity from "../assessments/seo/KeywordDensityAssessment.js";
 import MetaDescriptionKeyword from "../assessments/seo/MetaDescriptionKeywordAssessment.js";
-import TextImages from "../assessments/seo/TextImagesAssessment.js";
+import ImageKeyphrase from "../assessments/seo/KeyphraseInImageTextAssessment";
+import ImageCount from "../assessments/seo/ImageCountAssessment";
 import TextCompetingLinks from "../assessments/seo/TextCompetingLinksAssessment.js";
 import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
 
@@ -28,8 +29,9 @@ const ProductRelatedKeywordAssessor = function( i18n, researcher, options ) {
 		new KeywordDensity(),
 		new MetaDescriptionKeyword(),
 		new TextCompetingLinks(),
-		new TextImages(),
 		new FunctionWordsInKeyphrase(),
+		new ImageCount(),
+		new ImageKeyphrase(),
 	];
 };
 

--- a/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
@@ -19,7 +19,7 @@ import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphras
  *
  * @constructor
  */
-const productRelatedKeywordAssessor = function( i18n, researcher, options ) {
+const ProductRelatedKeywordAssessor = function( i18n, researcher, options ) {
 	Assessor.call( this, i18n, researcher, options );
 
 	this._assessments = [
@@ -33,6 +33,6 @@ const productRelatedKeywordAssessor = function( i18n, researcher, options ) {
 	];
 };
 
-inherits( productRelatedKeywordAssessor, Assessor );
+inherits( ProductRelatedKeywordAssessor, Assessor );
 
-export default productRelatedKeywordAssessor;
+export default ProductRelatedKeywordAssessor;

--- a/packages/yoastseo/src/scoring/productPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/seoAssessor.js
@@ -1,0 +1,56 @@
+import { inherits } from "util";
+
+import IntroductionKeywordAssessment from "../assessments/seo/IntroductionKeywordAssessment";
+import KeyphraseLengthAssessment from "../assessments/seo/KeyphraseLengthAssessment";
+import KeywordDensityAssessment from "../assessments/seo/KeywordDensityAssessment";
+import MetaDescriptionKeywordAssessment from "../assessments/seo/MetaDescriptionKeywordAssessment";
+import TextCompetingLinksAssessment from "../assessments/seo/TextCompetingLinksAssessment";
+import InternalLinksAssessment from "../assessments/seo/InternalLinksAssessment";
+import TitleKeywordAssessment from "../assessments/seo/TitleKeywordAssessment";
+import UrlKeywordAssessment from "../assessments/seo/UrlKeywordAssessment";
+import Assessor from "../assessor";
+import MetaDescriptionLength from "../assessments/seo/MetaDescriptionLengthAssessment";
+import SubheadingsKeyword from "../assessments/seo/SubHeadingsKeywordAssessment";
+import TextImages from "../assessments/seo/TextImagesAssessment";
+import TextLength from "../assessments/seo/TextLengthAssessment";
+import OutboundLinks from "../assessments/seo/OutboundLinksAssessment";
+import TitleWidth from "../assessments/seo/PageTitleWidthAssessment";
+import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
+import SingleH1Assessment from "../assessments/seo/SingleH1Assessment";
+/**
+ * Creates the Assessor
+ *
+ * @param {object}  i18n            The i18n object used for translations.
+ * @param {object}  researcher      The researcher to use for the analysis.
+ * @param {Object}  options         The options for this assessor.
+ * @param {Object}  options.marker  The marker to pass the list of marks to.
+ *
+ * @constructor
+ */
+const productSEOAssessor = function( i18n, researcher, options ) {
+	Assessor.call( this, i18n, researcher, options );
+	this.type = "SeoAssessor";
+
+	this._assessments = [
+		new IntroductionKeywordAssessment(),
+		// new KeyphraseLengthAssessment(),
+		// new KeywordDensityAssessment(),
+		// new MetaDescriptionKeywordAssessment(),
+		// new MetaDescriptionLength(),
+		// new SubheadingsKeyword(),
+		// new TextCompetingLinksAssessment(),
+		// new TextImages(),
+		// new TextLength(),
+		// new OutboundLinks(),
+		// new TitleKeywordAssessment(),
+		// new InternalLinksAssessment(),
+		// new TitleWidth(),
+		// new UrlKeywordAssessment(),
+		// new FunctionWordsInKeyphrase(),
+		// new SingleH1Assessment(),
+	];
+};
+
+inherits( productSEOAssessor, Assessor );
+
+export default productSEOAssessor;

--- a/packages/yoastseo/src/scoring/productPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/seoAssessor.js
@@ -10,7 +10,8 @@ import UrlKeywordAssessment from "../assessments/seo/UrlKeywordAssessment";
 import Assessor from "../assessor";
 import MetaDescriptionLength from "../assessments/seo/MetaDescriptionLengthAssessment";
 import SubheadingsKeyword from "../assessments/seo/SubHeadingsKeywordAssessment";
-import TextImages from "../assessments/seo/TextImagesAssessment";
+import ImageKeyphrase from "../assessments/seo/KeyphraseInImageTextAssessment";
+import ImageCount from "../assessments/seo/ImageCountAssessment";
 import TextLength from "../assessments/seo/TextLengthAssessment";
 import TitleWidth from "../assessments/seo/PageTitleWidthAssessment";
 import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
@@ -37,13 +38,14 @@ const ProductSEOAssessor = function( i18n, researcher, options ) {
 		new MetaDescriptionLength(),
 		new SubheadingsKeyword(),
 		new TextCompetingLinksAssessment(),
-		new TextImages(),
 		new TextLength(),
 		new TitleKeywordAssessment(),
 		new TitleWidth(),
 		new UrlKeywordAssessment(),
 		new FunctionWordsInKeyphrase(),
 		new SingleH1Assessment(),
+		new ImageCount(),
+		new ImageKeyphrase(),
 	];
 };
 

--- a/packages/yoastseo/src/scoring/productPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/seoAssessor.js
@@ -5,7 +5,6 @@ import KeyphraseLengthAssessment from "../assessments/seo/KeyphraseLengthAssessm
 import KeywordDensityAssessment from "../assessments/seo/KeywordDensityAssessment";
 import MetaDescriptionKeywordAssessment from "../assessments/seo/MetaDescriptionKeywordAssessment";
 import TextCompetingLinksAssessment from "../assessments/seo/TextCompetingLinksAssessment";
-import InternalLinksAssessment from "../assessments/seo/InternalLinksAssessment";
 import TitleKeywordAssessment from "../assessments/seo/TitleKeywordAssessment";
 import UrlKeywordAssessment from "../assessments/seo/UrlKeywordAssessment";
 import Assessor from "../assessor";
@@ -13,7 +12,6 @@ import MetaDescriptionLength from "../assessments/seo/MetaDescriptionLengthAsses
 import SubheadingsKeyword from "../assessments/seo/SubHeadingsKeywordAssessment";
 import TextImages from "../assessments/seo/TextImagesAssessment";
 import TextLength from "../assessments/seo/TextLengthAssessment";
-import OutboundLinks from "../assessments/seo/OutboundLinksAssessment";
 import TitleWidth from "../assessments/seo/PageTitleWidthAssessment";
 import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
 import SingleH1Assessment from "../assessments/seo/SingleH1Assessment";
@@ -27,30 +25,28 @@ import SingleH1Assessment from "../assessments/seo/SingleH1Assessment";
  *
  * @constructor
  */
-const productSEOAssessor = function( i18n, researcher, options ) {
+const ProductSEOAssessor = function( i18n, researcher, options ) {
 	Assessor.call( this, i18n, researcher, options );
-	this.type = "SeoAssessor";
+	this.type = "productSEOAssessor";
 
 	this._assessments = [
 		new IntroductionKeywordAssessment(),
-		// new KeyphraseLengthAssessment(),
-		// new KeywordDensityAssessment(),
-		// new MetaDescriptionKeywordAssessment(),
-		// new MetaDescriptionLength(),
-		// new SubheadingsKeyword(),
-		// new TextCompetingLinksAssessment(),
-		// new TextImages(),
-		// new TextLength(),
-		// new OutboundLinks(),
-		// new TitleKeywordAssessment(),
-		// new InternalLinksAssessment(),
-		// new TitleWidth(),
-		// new UrlKeywordAssessment(),
-		// new FunctionWordsInKeyphrase(),
-		// new SingleH1Assessment(),
+		new KeyphraseLengthAssessment(),
+		new KeywordDensityAssessment(),
+		new MetaDescriptionKeywordAssessment(),
+		new MetaDescriptionLength(),
+		new SubheadingsKeyword(),
+		new TextCompetingLinksAssessment(),
+		new TextImages(),
+		new TextLength(),
+		new TitleKeywordAssessment(),
+		new TitleWidth(),
+		new UrlKeywordAssessment(),
+		new FunctionWordsInKeyphrase(),
+		new SingleH1Assessment(),
 	];
 };
 
-inherits( productSEOAssessor, Assessor );
+inherits( ProductSEOAssessor, Assessor );
 
-export default productSEOAssessor;
+export default ProductSEOAssessor;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds assessors for product pages.
* [yoastseo] Removes the outbound links and internal links assessments from the SEO analysis on product pages. Removes the Flesch Reading Ease assessment and the consecutive sentences assessment from the readability analysis on product pages.

## Relevant technical choices:

The assessors are not exported via the index so that they don't get bundled for use in the Yoast SEO plugin. This is important because we will not use these assessors in the plugin itself, but only in extensions and other integrations.
I've combined LINGO-961 with LINGO-911 (removing assessments) because having some visible differences in the product page assessors makes testing easier.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure that all specs pass.
* Since the assessor files aren't loaded yet, it's not possible/necessary to test them at this stage.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.
* [ ] 

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
