### PR TITLE
Add product pages config for SEO title width assessment

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/seo/PageTitleWidthAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/PageTitleWidthAssessmentSpec.js
@@ -47,3 +47,30 @@ describe( "the SEO title length assessment", function() {
 		expect( pageTitleLengthAssessment.getMaximumLength() ).toBe( 600 );
 	} );
 } );
+
+describe( "test for SEO title width assessment when is used in product page analysis", function() {
+	it( "assesses a paper from product page with short title width", function() {
+		const paper = new Paper( "", { title: "Controversial: A tortie cat turns out to be the most beatiful cat a study claims" } );
+		const config = {
+			scores: {
+				widthTooShort: 9,
+			},
+		};
+		const result = new PageTitleLengthAssessment( config, true ).getResult( paper, factory.buildMockResearcher( 300 ), i18n );
+		expect( result.getScore() ).toEqual( 9 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: Good job!" );
+	} );
+
+	it( "assesses a paper from product page with too long title width", function() {
+		const paper = new Paper( "", { title: "Controversial: A tortie cat turns out to be the most beatiful cat a study claims" } );
+		const config = {
+			scores: {
+				widthTooShort: 9,
+			},
+		};
+		const result = new PageTitleLengthAssessment( config, true ).getResult( paper, factory.buildMockResearcher( 620 ), i18n );
+		expect( result.getScore() ).toEqual( 3 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34h' target='_blank'>SEO title width</a>: " +
+			"The SEO title is wider than the viewable limit. <a href='https://yoa.st/34i' target='_blank'>Try to make it shorter</a>." );
+	} );
+} );

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
@@ -227,7 +227,7 @@ describe( "running assessments in the product page SEO assessor", function() {
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.scores ).toBeDefined();
-			expect( assessment._config.scores.widthTooShort ).toBe( 3 );
+			expect( assessment._config.scores.widthTooShort ).toBe( 9 );
 			expect( assessment._config.scores.widthTooLong ).toBe( 3 );
 		} );
 

--- a/packages/yoastseo/src/scoring/assessments/seo/PageTitleWidthAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/PageTitleWidthAssessment.js
@@ -13,11 +13,12 @@ export default class PageTitleWidthAssessment extends Assessment {
 	/**
 	 * Sets the identifier and the config.
 	 *
-	 * @param {Object} [config] The configuration to use.
+	 * @param {Object}  [config]        The configuration to use.
+	 * @param {boolean} isProductPage   Whether this assessment is run product page or not.
 	 *
 	 * @returns {void}
 	 */
-	constructor( config = {} ) {
+	constructor( config = {}, isProductPage = false ) {
 		super();
 
 		const defaultConfig = {
@@ -33,6 +34,7 @@ export default class PageTitleWidthAssessment extends Assessment {
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/34i" ),
 		};
 
+		this._isProductPage = isProductPage;
 		this.identifier = "titleWidth";
 		this._config = merge( defaultConfig, config );
 	}
@@ -101,6 +103,17 @@ export default class PageTitleWidthAssessment extends Assessment {
 	 */
 	translateScore( pageTitleWidth, i18n ) {
 		if ( inRange( pageTitleWidth, 1, 400 ) ) {
+			if ( this._isProductPage ) {
+				return i18n.sprintf(
+					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+					i18n.dgettext(
+						"js-text-analysis",
+						"%1$sSEO title width%2$s: Good job!"
+					),
+					this._config.urlTitle,
+					"</a>"
+				);
+			}
 			return i18n.sprintf(
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 				i18n.dgettext(

--- a/packages/yoastseo/src/scoring/assessments/seo/PageTitleWidthAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/PageTitleWidthAssessment.js
@@ -14,11 +14,11 @@ export default class PageTitleWidthAssessment extends Assessment {
 	 * Sets the identifier and the config.
 	 *
 	 * @param {Object}  [config]        The configuration to use.
-	 * @param {boolean} isProductPage   Whether this assessment is run for product page or not.
+	 * @param {boolean} allowShortTitle Whether the short title width is penalized with a bad score or not.
 	 *
 	 * @returns {void}
 	 */
-	constructor( config = {}, isProductPage = false ) {
+	constructor( config = {}, allowShortTitle = false ) {
 		super();
 
 		const defaultConfig = {
@@ -34,7 +34,7 @@ export default class PageTitleWidthAssessment extends Assessment {
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/34i" ),
 		};
 
-		this._isProductPage = isProductPage;
+		this._allowShortTitle = allowShortTitle;
 		this.identifier = "titleWidth";
 		this._config = merge( defaultConfig, config );
 	}
@@ -103,7 +103,7 @@ export default class PageTitleWidthAssessment extends Assessment {
 	 */
 	translateScore( pageTitleWidth, i18n ) {
 		if ( inRange( pageTitleWidth, 1, 400 ) ) {
-			if ( this._isProductPage ) {
+			if ( this._allowShortTitle ) {
 				return i18n.sprintf(
 					/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
 					i18n.dgettext(

--- a/packages/yoastseo/src/scoring/assessments/seo/PageTitleWidthAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/PageTitleWidthAssessment.js
@@ -14,7 +14,7 @@ export default class PageTitleWidthAssessment extends Assessment {
 	 * Sets the identifier and the config.
 	 *
 	 * @param {Object}  [config]        The configuration to use.
-	 * @param {boolean} isProductPage   Whether this assessment is run product page or not.
+	 * @param {boolean} isProductPage   Whether this assessment is run for product page or not.
 	 *
 	 * @returns {void}
 	 */

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -57,13 +57,11 @@ const ProductCornerstoneSEOAssessor = function( i18n, options ) {
 			cornerstoneContent: true,
 		} ),
 		new TitleKeywordAssessment(),
-		new TitleWidth(
-			{
-				scores: {
-					widthTooShort: 9,
-				},
-			}
-		),
+		new TitleWidth( {
+			scores: {
+				widthTooShort: 9,
+			},
+		}, true ),
 		new UrlKeywordAssessment(
 			{
 				scores: {

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -60,8 +60,7 @@ const ProductCornerstoneSEOAssessor = function( i18n, options ) {
 		new TitleWidth(
 			{
 				scores: {
-					widthTooShort: 3,
-					widthTooLong: 3,
+					widthTooShort: 9,
 				},
 			}
 		),

--- a/packages/yoastseo/src/scoring/productPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/seoAssessor.js
@@ -40,7 +40,11 @@ const ProductSEOAssessor = function( i18n, researcher, options ) {
 		new TextCompetingLinksAssessment(),
 		new TextLength(),
 		new TitleKeywordAssessment(),
-		new TitleWidth(),
+		new TitleWidth( {
+			scores: {
+				widthTooShort: 9,
+			},
+		} ),
 		new UrlKeywordAssessment(),
 		new FunctionWordsInKeyphrase(),
 		new SingleH1Assessment(),

--- a/packages/yoastseo/src/scoring/productPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/seoAssessor.js
@@ -44,7 +44,7 @@ const ProductSEOAssessor = function( i18n, researcher, options ) {
 			scores: {
 				widthTooShort: 9,
 			},
-		} ),
+		}, true ),
 		new UrlKeywordAssessment(),
 		new FunctionWordsInKeyphrase(),
 		new SingleH1Assessment(),


### PR DESCRIPTION
# Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds custom config for `TitleWidth` assessment for product pages and adds extra feedback string in the assessment file for when short title width is not penalized with a bad score.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Note: Currently this PR cannot be tested in Product pages since the assessors for the product pages haven't been used anywhere yet. Hence, for now we can test this PR in normal pages by adding product pages configuration in `seoAssessor.js` for normal analysis**

* Set the `allowShortTitle` to true in `scoring/seoAssessor.js` file for `TitleWidth` assessment and add this config `{ scores { widthTooShort: 9 } }` (don't commit anything): 
<img width="406" alt="Screenshot 2021-07-26 at 10 55 32" src="https://user-images.githubusercontent.com/48715883/126953586-9e74ffbc-06e8-497d-bffb-d90a5db5b8f2.png">


* Build the plugin
* Create a post and add some text
* Set the SEO title with the variables of `Title`, `Page`, `Separator`, `Site title`:
<img width="581" alt="Screenshot 2021-07-23 at 17 24 20" src="https://user-images.githubusercontent.com/48715883/126796605-55ff12d9-e4a6-475b-b1fd-85c1a53c4005.png">

* Confirm that the feedback is `SEO title width: Good job!`
* Add more words to the SEO title field until the indicator shows red
* Confirm that the feedback is `SEO title width: The SEO title is wider than the viewable limit. Try to make it shorter.`



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-941
