### PR TITLE
Adapt config for product pages text length assessment

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/seo/TextLengthAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/TextLengthAssessmentSpec.js
@@ -230,7 +230,7 @@ describe( "A word count assessment", function() {
 	} );
 
 	it( "different boundaries are applied if the content is cornerstone: far below minimum", function() {
-		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 75 ) );
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 190 ) );
 		const productAssessmentCornerstone = new TextLengthAssessment( cornerstoneProductPageConfig );
 
 		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 75 ), i18n );

--- a/packages/yoastseo/spec/scoring/assessments/seo/TextLengthAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/TextLengthAssessmentSpec.js
@@ -136,4 +136,71 @@ describe( "A word count assessment", function() {
 		expect( results.getScore() ).toEqual( 9 );
 		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 925 words. Good job!" );
 	} );
+
+	const productPageConfig = {
+		recommendedMinimum: 200,
+		slightlyBelowMinimum: 150,
+		belowMinimum: 100,
+		veryFarBelowMinimum: 50,
+	};
+
+	it( "different boundaries are applied for a product page: very far below minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 25 ) );
+		const productAssessment = new TextLengthAssessment( productPageConfig );
+
+		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( 25 ), i18n );
+
+		expect( result.getScore() ).toEqual( -20 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
+			"The text contains 25 words. This is far below the recommended minimum of 200 words. <a href='https://yoa.st/34o' " +
+			"target='_blank'>Add more content</a>." );
+	} );
+
+	it( "different boundaries are applied for a product page: far below minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 55 ) );
+		const productAssessment = new TextLengthAssessment( productPageConfig );
+
+		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( 55 ), i18n );
+
+		expect( result.getScore() ).toEqual( -10 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
+			"The text contains 55 words. This is far below the recommended minimum of 200 words. <a href='https://yoa.st/34o' " +
+			"target='_blank'>Add more content</a>." );
+	} );
+
+	it( "different boundaries are applied for a product page: below minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 101 ) );
+		const productAssessment = new TextLengthAssessment( productPageConfig );
+
+		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( 101 ), i18n );
+
+		expect( result.getScore() ).toEqual( 3 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
+			"The text contains 101 words. This is below the recommended minimum of 200 words. <a href='https://yoa.st/34o' " +
+			"target='_blank'>Add more content</a>." );
+	} );
+
+	it( "different boundaries are applied for a product page: slightly below minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 155 ) );
+		const productAssessment = new TextLengthAssessment( productPageConfig );
+
+		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( 155 ), i18n );
+
+		expect( result.getScore() ).toEqual( 6 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
+			"The text contains 155 words. This is slightly below the recommended minimum of 200 words." +
+			" <a href='https://yoa.st/34o' target='_blank'>Add a bit more copy</a>." );
+	} );
+
+
+	it( "different boundaries are applied for a product page: above minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 201 ) );
+		const productAssessment = new TextLengthAssessment( productPageConfig );
+
+		const result = productAssessment.getResult( mockPaper, Factory.buildMockResearcher( 201 ), i18n );
+
+		expect( result.getScore() ).toEqual( 9 );
+		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
+			"The text contains 201 words. Good job!" );
+	} );
 } );

--- a/packages/yoastseo/spec/scoring/assessments/seo/TextLengthAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/TextLengthAssessmentSpec.js
@@ -203,4 +203,75 @@ describe( "A word count assessment", function() {
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
 			"The text contains 201 words. Good job!" );
 	} );
+
+	const cornerstoneProductPageConfig = {
+		recommendedMinimum: 400,
+		slightlyBelowMinimum: 300,
+		belowMinimum: 200,
+
+		scores: {
+			belowMinimum: -20,
+			farBelowMinimum: -20,
+		},
+
+		cornerstoneContent: true,
+	};
+
+	it( "different boundaries are applied for a product pagge if the content is cornerstone: very far below minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 25 ) );
+		const productAssessmentCornerstone = new TextLengthAssessment( cornerstoneProductPageConfig );
+
+		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 25 ), i18n );
+
+		expect( results.getScore() ).toEqual( -20 );
+		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
+			"The text contains 25 words. This is far below the recommended minimum of 400 words. <a href='https://yoa.st/34o' " +
+			"target='_blank'>Add more content</a>." );
+	} );
+
+	it( "different boundaries are applied if the content is cornerstone: far below minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 75 ) );
+		const productAssessmentCornerstone = new TextLengthAssessment( cornerstoneProductPageConfig );
+
+		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 75 ), i18n );
+
+		expect( results.getScore() ).toEqual( -20 );
+		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
+			"The text contains 75 words. This is far below the recommended minimum of 400 words. <a href='https://yoa.st/34o' " +
+			"target='_blank'>Add more content</a>." );
+	} );
+
+	it( "different boundaries are applied if the content is cornerstone: below minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 225 ) );
+		const productAssessmentCornerstone = new TextLengthAssessment( cornerstoneProductPageConfig );
+
+		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 225 ), i18n );
+
+		expect( results.getScore() ).toEqual( -20 );
+		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
+			"The text contains 225 words. This is below the recommended minimum of 400 words. <a href='https://yoa.st/34o' " +
+			"target='_blank'>Add more content</a>." );
+	} );
+
+	it( "different boundaries are applied if the content is cornerstone: slightly below minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 380 ) );
+		const productAssessmentCornerstone = new TextLengthAssessment( cornerstoneProductPageConfig );
+
+		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 380 ), i18n );
+
+		expect( results.getScore() ).toEqual( 6 );
+		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: " +
+			"The text contains 380 words. This is below the recommended minimum of 400 words. <a href='https://yoa.st/34o' " +
+			"target='_blank'>Add more content</a>." );
+	} );
+
+	it( "different boundaries are applied if the content is cornerstone: above minimum", function() {
+		const mockPaper = new Paper( Factory.buildMockString( "Sample ", 425 ) );
+		const productAssessmentCornerstone = new TextLengthAssessment( cornerstoneProductPageConfig );
+
+		const results = productAssessmentCornerstone.getResult( mockPaper, Factory.buildMockResearcher( 425 ), i18n );
+
+		expect( results.getScore() ).toEqual( 9 );
+		expect( results.getText() ).toEqual( "<a href='https://yoa.st/34n' target='_blank'>Text length</a>: The text contains 425 words. Good job!" );
+	} );
 } );

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
@@ -230,6 +230,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 			expect( assessment._config.scores ).toBeDefined();
 			expect( assessment._config.scores.belowMinimum ).toBe( -20 );
 			expect( assessment._config.scores.farBelowMinimum ).toBe( -20 );
+			expect( assessment._config.cornerstoneContent ).toBeDefined();
+			expect( assessment._config.cornerstoneContent ).toBeTruthy();
 		} );
 
 		test( "PageTitleWidthAssesment", () => {

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
@@ -208,14 +208,25 @@ describe( "running assessments in the product page SEO assessor", function() {
 			expect( assessment._config.scores.noAlt ).toBe( 3 );
 		} );
 
+		test( "ImageCountAssessment", () => {
+			const assessment = assessor.getAssessment( "images" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores.okay ).toBe( 6 );
+			expect( assessment._config.recommendedCount ).toBe( 4 );
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.recommendedCount ).toBeDefined();
+		} );
+
 		test( "TextLengthAssessment", () => {
 			const assessment = assessor.getAssessment( "textLength" );
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.recommendedMinimum ).toBe( 900 );
-			expect( assessment._config.slightlyBelowMinimum ).toBe( 400 );
-			expect( assessment._config.belowMinimum ).toBe( 300 );
+			expect( assessment._config.recommendedMinimum ).toBe( 400 );
+			expect( assessment._config.slightlyBelowMinimum ).toBe( 300 );
+			expect( assessment._config.belowMinimum ).toBe( 200 );
 			expect( assessment._config.scores ).toBeDefined();
 			expect( assessment._config.scores.belowMinimum ).toBe( -20 );
 			expect( assessment._config.scores.farBelowMinimum ).toBe( -20 );

--- a/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
@@ -200,4 +200,26 @@ describe( "running assessments in the product page cornerstone SEO assessor", fu
 			"images",
 		] );
 	} );
+
+	test( "TextLengthAssessment", () => {
+		const assessment = assessor.getAssessment( "textLength" );
+
+		expect( assessment ).toBeDefined();
+		expect( assessment._config ).toBeDefined();
+		expect( assessment._config.recommendedMinimum ).toBe( 200 );
+		expect( assessment._config.slightlyBelowMinimum ).toBe( 150 );
+		expect( assessment._config.belowMinimum ).toBe( 100 );
+		expect( assessment._config.veryFarBelowMinimum ).toBe( 50 );
+	} );
+
+	test( "ImageCountAssessment", () => {
+		const assessment = assessor.getAssessment( "images" );
+
+		expect( assessment ).toBeDefined();
+		expect( assessment._config ).toBeDefined();
+		expect( assessment._config.scores.okay ).toBe( 6 );
+		expect( assessment._config.recommendedCount ).toBe( 4 );
+		expect( assessment._config.scores ).toBeDefined();
+		expect( assessment._config.recommendedCount ).toBeDefined();
+	} );
 } );

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -45,9 +45,9 @@ const ProductCornerstoneSEOAssessor = function( i18n, options ) {
 		new SubheadingsKeyword(),
 		new TextCompetingLinksAssessment(),
 		new TextLength( {
-			recommendedMinimum: 900,
-			slightlyBelowMinimum: 400,
-			belowMinimum: 300,
+			recommendedMinimum: 400,
+			slightlyBelowMinimum: 300,
+			belowMinimum: 200,
 
 			scores: {
 				belowMinimum: -20,

--- a/packages/yoastseo/src/scoring/productPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/seoAssessor.js
@@ -38,7 +38,12 @@ const ProductSEOAssessor = function( i18n, researcher, options ) {
 		new MetaDescriptionLength(),
 		new SubheadingsKeyword(),
 		new TextCompetingLinksAssessment(),
-		new TextLength(),
+		new TextLength( {
+			recommendedMinimum: 200,
+			slightlyBelowMinimum: 150,
+			belowMinimum: 100,
+			veryFarBelowMinimum: 50,
+		} ),
 		new TitleKeywordAssessment(),
 		new TitleWidth(),
 		new UrlKeywordAssessment(),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Lowers the minimum recommended text length for product pages.
* [yoastseo] Adds text length score boundaries config for product pages to the product page SEO assessors.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* For now, the changes can only be tested by temporarily adding the config of the product config to the non-product assessors. 
* Add the following as a parameter to `TextLength` in `yoastseo/src/scoring/seoAssessor.js`: `{
			recommendedMinimum: 200,
			slightlyBelowMinimum: 150,
			belowMinimum: 100,
			veryFarBelowMinimum: 50,
		}` 
* Build the plugin and add a text of less than 100 words. The assessment should return a red bullet and the following feedback: `Text length: the text contains X words. This is far below the recommended minimum of 200 words. Add more content.`
* Add more text so that the text is between 100 and 150 words. The assessment should return a red bullet and the following feedback: `Text length: the text contains X words. This is below the recommended minimum of 200 words. Add more content.`
* Add more text so that the text is between 150 and 200 words. The assessment should return an orange bullet and the following feedback: `Text length: the text contains X words. This is slightly below the recommended minimum of 200 words. Add more content.`
* Add more text so that the text is above 200 words. The assessment should return a green bullet and the following feedback: `Text length: the text contains X words. Good job!`
* Add the following as a parameter to TextLength in `yoastseo/src/scoring/cornerstone/seoAssessor.js`:
`{
			recommendedMinimum: 400,
			slightlyBelowMinimum: 300,
			belowMinimum: 200,
			scores: {
				belowMinimum: -20,
				farBelowMinimum: -20,
			},
			cornerstoneContent: true,
		}`
		
* Build the plugin and add a text of less than 200 words to a cornerstone page. The assessment should return a red bullet and the following feedback: `Text length: the text contains X words. This is far below the recommended minimum of 400 words. Add more content.`
* Add more text so that the text is between 200 and 300 words. The assessment should return a red bullet and the following feedback: `Text length: the text contains X words. This is below the recommended minimum of 400 words. Add more content.`
* Add more text so that the text is between 300 and 400 words. The assessment should return an orange bullet and the following feedback: `Text length: the text contains X words. This is slightly below the recommended minimum of 400 words. Add more content.`
* Add more text so that the text is above 400 words. The assessment should return a green bullet and the following feedback: `Text length: the text contains X words. Good job!`
* Revert the changes made to the code.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
