### PR TITLE
Gutenberg performance improvements

### DIFF
--- a/packages/js/src/analysis/blockEditorData.js
+++ b/packages/js/src/analysis/blockEditorData.js
@@ -176,15 +176,19 @@ export default class BlockEditorData {
 	 * @returns {{content: string, title: string, slug: string, excerpt: string}} The content, title, slug and excerpt.
 	 */
 	collectGutenbergData() {
+		const content = this.getPostAttribute( "content" );
+		const contentImage = this.calculateContentImage( content );
+		const excerpt = this.getPostAttribute( "excerpt" ) || "";
+
 		return {
-			content: this.getPostAttribute( "content" ),
+			content,
 			title: this.getPostAttribute( "title" ) || "",
 			slug: this.getSlug(),
-			excerpt: this.getExcerpt(),
+			excerpt: excerpt || excerptFromContent( content ),
 			// eslint-disable-next-line camelcase
-			excerpt_only: this.getExcerpt( false ),
-			snippetPreviewImageURL: this.getFeaturedImage() || this.getContentImage(),
-			contentImage: this.getContentImage(),
+			excerpt_only: excerpt,
+			snippetPreviewImageURL: this.getFeaturedImage() || contentImage,
+			contentImage,
 		};
 	}
 
@@ -209,11 +213,11 @@ export default class BlockEditorData {
 	/**
 	 * Returns the image from the content.
 	 *
+	 * @param {string} content The content.
+	 *
 	 * @returns {string} The first image found in the content.
 	 */
-	getContentImage() {
-		const content = this._coreEditorSelect.getEditedPostContent();
-
+	calculateContentImage( content ) {
 		const images = languageProcessing.imageInText( content );
 		let image = "";
 
@@ -265,22 +269,6 @@ export default class BlockEditorData {
 		if ( this._data.contentImage !== newData.contentImage ) {
 			this._store.dispatch( setContentImage( newData.contentImage ) );
 		}
-	}
-
-	/**
-	 * Gets the excerpt from the post.
-	 *
-	 * @param {boolean} useFallBack Whether the fallback for content should be used.
-	 *
-	 * @returns {string} The excerpt.
-	 */
-	getExcerpt( useFallBack = true ) {
-		const excerpt = this.getPostAttribute( "excerpt" ) || "";
-		if ( excerpt !== "" || useFallBack === false ) {
-			return excerpt;
-		}
-
-		return excerptFromContent( this.getPostAttribute( "content" ) );
 	}
 
 	/**

--- a/packages/js/src/components/SettingsReplacementVariableField.js
+++ b/packages/js/src/components/SettingsReplacementVariableField.js
@@ -1,4 +1,4 @@
-/* External dpendencies */
+/* External dependencies */
 import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 import {
@@ -36,7 +36,8 @@ class SettingsReplacementVariableField extends Component {
 			isHovered: false,
 		};
 
-		this.focus = this.focus.bind( this );
+		this.focus  = this.focus.bind( this );
+		this.setRef = this.setRef.bind( this );
 	}
 
 	/**
@@ -46,6 +47,17 @@ class SettingsReplacementVariableField extends Component {
 	 */
 	focus() {
 		this.inputRef.focus();
+	}
+
+	/**
+	 * Sets the input ref.
+	 *
+	 * @param {Object} ref The input ref.
+	 *
+	 * @returns {void}
+	 */
+	setRef( ref ) {
+		this.inputRef = ref;
 	}
 
 	/**
@@ -75,9 +87,7 @@ class SettingsReplacementVariableField extends Component {
 					onFocus={ this.focus }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
-					editorRef={ ref => {
-						this.inputRef = ref;
-					} }
+					editorRef={ this.setRef }
 				/>
 			</SnippetEditorWidthContainer>
 		);

--- a/packages/js/src/initializers/estimated-reading-time.js
+++ b/packages/js/src/initializers/estimated-reading-time.js
@@ -44,6 +44,7 @@ function initializeEstimatedReadingTimeClassic() {
 
 // Used to trigger the initial reading time calculation for the block and Elementor editors.
 let previousContent = "";
+let previousRecord = null;
 
 /**
  * Gets the estimated reading time in the block editor if the content has changed.
@@ -51,6 +52,16 @@ let previousContent = "";
  * @returns {void}
  */
 function getEstimatedReadingTimeBlockEditor() {
+	const postId   = select( "core/editor" ).getCurrentPostId();
+	const postType = select( "core/editor" ).getCurrentPostType();
+	const record   = select( "core" ).getEditedEntityRecord( "postType", postType, postId );
+
+	// If the post object itself hasn't changed don't convert blocks to HTML.
+	if ( previousRecord === record ) {
+		return;
+	}
+	previousRecord = record;
+
 	const content = select( "core/editor" ).getEditedPostAttribute( "content" );
 	if ( previousContent !== content ) {
 		previousContent = content;

--- a/packages/js/src/post-edit.js
+++ b/packages/js/src/post-edit.js
@@ -47,6 +47,6 @@ domReady( () => {
 	// Initialize global admin scripts.
 	initAdmin( jQuery );
 
-	// Initialize the Estimated Reading Time
-	initializeEstimatedReadingTime();
+	// Initialize the Estimated Reading Time after 500ms to avoid blocking initial loading.
+	setTimeout( initializeEstimatedReadingTime, 500 );
 } );

--- a/packages/js/src/redux/selectors/results.js
+++ b/packages/js/src/redux/selectors/results.js
@@ -1,5 +1,8 @@
 import { get, isEmpty } from "lodash";
 
+const emptyObject = {};
+const emptyArray  = [];
+
 /**
  * Gets the SEO results.
  *
@@ -8,9 +11,9 @@ import { get, isEmpty } from "lodash";
  * @returns {Object} The SEO results for all keywords.
  */
 export function getSeoResults( state ) {
-	const results = get( state, "analysis.seo", {} );
+	const results = get( state, "analysis.seo", emptyObject );
 
-	return isEmpty( results ) ? { results: [], overallScore: null } : results;
+	return isEmpty( results ) ? { results: emptyArray, overallScore: null } : results;
 }
 
 /**
@@ -24,7 +27,7 @@ export function getSeoResults( state ) {
 export function getResultsForKeyword( state, keyword ) {
 	const seoResults = getSeoResults( state );
 
-	return get( seoResults, keyword, {} );
+	return get( seoResults, keyword, emptyObject );
 }
 
 /**
@@ -37,7 +40,7 @@ export function getResultsForKeyword( state, keyword ) {
 export function getReadabilityResults( state ) {
 	const results = get( state, "analysis.readability", {} );
 
-	return isEmpty( results ) ? { results: [], overallScore: null } : results;
+	return isEmpty( results ) ? { results: emptyArray, overallScore: null } : results;
 }
 
 /**
@@ -60,8 +63,8 @@ export function getResultsForFocusKeyword( state ) {
  * @returns {Object|null} The assessment result.
  */
 export function getResultById( state, id ) {
-	const focusKeywordResults = getResultsForFocusKeyword( state ).results || [];
-	const readabilityResults = getReadabilityResults( state ).results || [];
+	const focusKeywordResults = getResultsForFocusKeyword( state ).results || emptyArray;
+	const readabilityResults = getReadabilityResults( state ).results || emptyArray;
 
 	const allResults = [
 		...focusKeywordResults,

--- a/packages/replacement-variable-editor/src/SettingsSnippetEditorFields.js
+++ b/packages/replacement-variable-editor/src/SettingsSnippetEditorFields.js
@@ -44,7 +44,13 @@ class SettingsSnippetEditorFields extends React.Component {
 		};
 
 		this.setRef = this.setRef.bind( this );
+		this.setTitleRef = this.setTitleRef.bind( this );
+		this.setDescriptionRef = this.setDescriptionRef.bind( this );
 		this.triggerReplacementVariableSuggestions = this.triggerReplacementVariableSuggestions.bind( this );
+		this.onFocusTitle = this.onFocusTitle.bind( this );
+		this.onChangeTitle = this.onChangeTitle.bind( this );
+		this.onFocusDescription = this.onFocusDescription.bind( this );
+		this.onChangeDescription = this.onChangeDescription.bind( this );
 	}
 
 	/**
@@ -57,6 +63,28 @@ class SettingsSnippetEditorFields extends React.Component {
 	 */
 	setRef( field, ref ) {
 		this.elements[ field ] = ref;
+	}
+
+	/**
+	 * Sets the title ref.
+	 *
+	 * @param {Object} ref The ref.
+	 *
+	 * @returns {void}
+	 */
+	setTitleRef( ref ) {
+		this.setRef( "title", ref );
+	}
+
+	/**
+	 * Sets the description ref.
+	 *
+	 * @param {Object} ref The ref.
+	 *
+	 * @returns {void}
+	 */
+	 setDescriptionRef( ref ) {
+		this.setRef( "description", ref );
 	}
 
 	/**
@@ -100,6 +128,46 @@ class SettingsSnippetEditorFields extends React.Component {
 	}
 
 	/**
+	 * Call the onFocus event for the title.
+	 *
+	 * @returns {void}
+	 */
+	onFocusTitle() {
+		this.props.onFocus( "title" );
+	}
+
+	/**
+	 * Call the onChange event for the title.
+	 *
+	 * @param {string} content The content.
+	 *
+	 * @returns {void}
+	 */
+	onChangeTitle( content ) {
+		this.props.onChange( "title", content );
+	}
+
+	/**
+	 * Call the onFocus event for the description.
+	 *
+	 * @returns {void}
+	 */
+	 onFocusDescription() {
+		this.props.onFocus( "description" );
+	}
+
+	/**
+	 * Call the onChange event for the description.
+	 *
+	 * @param {string} content The content.
+	 *
+	 * @returns {void}
+	 */
+	onChangeDescription( content ) {
+		this.props.onChange( "description", content );
+	}
+
+	/**
 	 * Renders the snippet editor.
 	 *
 	 * @returns {ReactElement} The snippet editor element.
@@ -111,9 +179,7 @@ class SettingsSnippetEditorFields extends React.Component {
 			hoveredField,
 			replacementVariables,
 			recommendedReplacementVariables,
-			onFocus,
 			onBlur,
-			onChange,
 			data: {
 				title,
 				description,
@@ -133,15 +199,15 @@ class SettingsSnippetEditorFields extends React.Component {
 				<ReplacementVariableEditor
 					type="title"
 					label={ labels.title || __( "SEO title", "yoast-components" ) }
-					onFocus={ () => onFocus( "title" ) }
+					onFocus={ this.onFocusTitle }
 					onBlur={ onBlur }
 					isActive={ activeField === "title" }
 					isHovered={ hoveredField === "title" }
-					editorRef={ ref => this.setRef( "title", ref ) }
+					editorRef={ this.setTitleRef }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					content={ title }
-					onChange={ content => onChange( "title", content ) }
+					onChange={ this.onChangeTitle }
 					fieldId={ fieldIds.title }
 					hasNewBadge={ hasNewBadge }
 					isDisabled={ isDisabled }
@@ -151,15 +217,15 @@ class SettingsSnippetEditorFields extends React.Component {
 					type="description"
 					placeholder={ descriptionEditorFieldPlaceholder }
 					label={ labels.description ||  __( "Meta description", "yoast-components" ) }
-					onFocus={ () => onFocus( "description" ) }
+					onFocus={ this.onFocusDescription }
 					onBlur={ onBlur }
 					isActive={ activeField === "description" }
 					isHovered={ hoveredField === "description" }
-					editorRef={ ref => this.setRef( "description", ref ) }
+					editorRef={ this.setDescriptionRef }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					content={ description }
-					onChange={ content => onChange( "description", content ) }
+					onChange={ this.onChangeDescription }
 					fieldId={ fieldIds.description }
 					hasNewBadge={ hasNewBadge }
 					isDisabled={ isDisabled }

--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditorFields.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditorFields.js
@@ -83,7 +83,17 @@ class SnippetEditorFields extends React.Component {
 		this.uniqueId = uniqueId( "snippet-editor-field-" );
 
 		this.setRef = this.setRef.bind( this );
+		this.setTitleRef = this.setTitleRef.bind( this );
+		this.setSlugRef = this.setSlugRef.bind( this );
+		this.setDescriptionRef = this.setDescriptionRef.bind( this );
 		this.triggerReplacementVariableSuggestions = this.triggerReplacementVariableSuggestions.bind( this );
+		this.onFocusTitle = this.onFocusTitle.bind( this );
+		this.onChangeTitle = this.onChangeTitle.bind( this );
+		this.onFocusSlug = this.onFocusSlug.bind( this );
+		this.focusSlug = this.focusSlug.bind( this );
+		this.onChangeSlug = this.onChangeSlug.bind( this );
+		this.onFocusDescription = this.onFocusDescription.bind( this );
+		this.onChangeDescription = this.onChangeDescription.bind( this );
 	}
 
 	/**
@@ -96,6 +106,39 @@ class SnippetEditorFields extends React.Component {
 	 */
 	setRef( fieldName, ref ) {
 		this.elements[ fieldName ] = ref;
+	}
+
+	/**
+	 * Sets the title ref.
+	 *
+	 * @param {Object} ref The ref.
+	 *
+	 * @returns {void}
+	 */
+	setTitleRef( ref ) {
+		this.setRef( "title", ref );
+	}
+
+	/**
+	 * Sets the slug ref.
+	 *
+	 * @param {Object} ref The ref.
+	 *
+	 * @returns {void}
+	 */
+	setSlugRef( ref ) {
+		this.setRef( "slug", ref );
+	}
+
+	/**
+	 * Sets the description ref.
+	 *
+	 * @param {Object} ref The ref.
+	 *
+	 * @returns {void}
+	 */
+	setDescriptionRef( ref ) {
+		this.setRef( "description", ref );
 	}
 
 	/**
@@ -144,6 +187,75 @@ class SnippetEditorFields extends React.Component {
 	}
 
 	/**
+	 * Call the onFocus event for the title.
+	 *
+	 * @returns {void}
+	 */
+	 onFocusTitle() {
+		this.props.onFocus( "title" );
+	}
+
+	/**
+	 * Call the onChange event for the title.
+	 *
+	 * @param {string} content The content.
+	 *
+	 * @returns {void}
+	 */
+	onChangeTitle( content ) {
+		this.props.onChange( "title", content );
+	}
+
+	/**
+	 * Call the onFocus event for the slug.
+	 *
+	 * @returns {void}
+	 */
+	onFocusSlug() {
+		this.props.onFocus( "slug" );
+	}
+
+	/**
+	 * Focusses the slug element.
+	 *
+	 * @returns {void}
+	 */
+	focusSlug() {
+		this.elements.slug.focus();
+	}
+
+	/**
+	 * Call the onChange event for the slug.
+	 *
+	 * @param {string} content The content.
+	 *
+	 * @returns {void}
+	 */
+	 onChangeSlug( content ) {
+		this.props.onChange( "slug", content );
+	}
+
+	/**
+	 * Call the onFocus event for the description.
+	 *
+	 * @returns {void}
+	 */
+	 onFocusDescription() {
+		this.props.onFocus( "description" );
+	}
+
+	/**
+	 * Call the onChange event for the description.
+	 *
+	 * @param {string} content The content.
+	 *
+	 * @returns {void}
+	 */
+	onChangeDescription( content ) {
+		this.props.onChange( "description", content );
+	}
+
+	/**
 	 * Renders the snippet editor.
 	 *
 	 * @returns {ReactElement} The snippet editor element.
@@ -180,15 +292,15 @@ class SnippetEditorFields extends React.Component {
 				<ReplacementVariableEditor
 					withCaret={ true }
 					label={ __( "SEO title", "yoast-components" ) }
-					onFocus={ () => onFocus( "title" ) }
-					onBlur={ () => onBlur() }
+					onFocus={ this.onFocusTitle }
+					onBlur={ onBlur }
 					isActive={ activeField === "title" }
 					isHovered={ hoveredField === "title" }
-					editorRef={ ref => this.setRef( "title", ref ) }
+					editorRef={ this.setTitleRef }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					content={ title }
-					onChange={ content => onChange( "title", content ) }
+					onChange={ this.onChangeTitle }
 					fieldId={ titleInputId }
 					type="title"
 				/>
@@ -199,21 +311,21 @@ class SnippetEditorFields extends React.Component {
 				/>
 				<SimulatedLabel
 					id={ slugLabelId }
-					onClick={ () => onFocus( "slug" ) }
+					onClick={ this.onFocusSlug }
 				>
 					{ __( "Slug", "yoast-components" ) }
 				</SimulatedLabel>
 				<InputContainerWithCaretStyles
-					onClick={ () => this.elements.slug.focus() }
+					onClick={ this.focusSlug }
 					isActive={ activeField === "slug" }
 					isHovered={ hoveredField === "slug" }
 				>
 					<SlugInput
 						value={ slug }
-						onChange={ event => onChange( "slug", event.target.value ) }
-						onFocus={ () => onFocus( "slug" ) }
-						onBlur={ () => onBlur() }
-						ref={ ref => this.setRef( "slug", ref ) }
+						onChange={ this.onChangeSlug }
+						onFocus={ this.onFocusSlug }
+						onBlur={ onBlur }
+						ref={ this.setSlugRef }
 						aria-labelledby={ this.uniqueId + "-slug" }
 						id={ slugInputId }
 					/>
@@ -223,15 +335,15 @@ class SnippetEditorFields extends React.Component {
 					type="description"
 					placeholder={ descriptionEditorFieldPlaceholder }
 					label={ __( "Meta description", "yoast-components" ) }
-					onFocus={ () => onFocus( "description" ) }
-					onBlur={ () => onBlur() }
+					onFocus={ this.onFocusDescription }
+					onBlur={ onBlur }
 					isActive={ activeField === "description" }
 					isHovered={ hoveredField === "description" }
-					editorRef={ ref => this.setRef( "description", ref ) }
+					editorRef={ this.setDescriptionRef }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					content={ description }
-					onChange={ content => onChange( "description", content ) }
+					onChange={ this.onChangeDescription }
 					fieldId={ descriptionInputId }
 				/>
 				<ProgressBar

--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditorFields.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditorFields.js
@@ -268,9 +268,7 @@ class SnippetEditorFields extends React.Component {
 			recommendedReplacementVariables,
 			titleLengthProgress,
 			descriptionLengthProgress,
-			onFocus,
 			onBlur,
-			onChange,
 			descriptionEditorFieldPlaceholder,
 			data: {
 				title,


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves overall performance and responsiveness in Gutenberg.

## Relevant technical choices:
This PR makes 3 main changes to improve overall performance in Gutenberg
1. The anonymous callback functions in the replacement variable editor were changed to methods to avoid unnecessary rerenders and garbage collection of previously created functions.
2. The gutenberg data collector class was changed to only call `getEditedPostContent` once as this is the most expensive call, once gotten this data is then reused in every other function.
3. The estimated reading time analysis is changed to first check if the record is changed before getting the edited post content ( see above ) and loading is delayed by 500ms to avoid blocking the initial render of Gutenberg itself.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Behavior of the SEO and readability analysis, replacement variables and the estimated reading time in Gutenberg should be identical.
* Behavior of replacement variables and estimated reading time in the classic editor should be identical.
* Behavior of replacement variables in elementor should be identical.
* Behavior of the replacement variables editors in the settings page should be identical.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The SEO & readability analysis in Gutenberg.
* The replacement variable editors both in the post edit ( for all editors, including classic and elementor ) as well as the settings page.
* The estimated reading time in both classic and Gutenberg.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
