### PR TITLE
Add extra check for subheading distribution assessment's applicability

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/readability/subheadingDistributionTooLongAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/subheadingDistributionTooLongAssessmentSpec.js
@@ -129,6 +129,21 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 		const assessment = subheadingDistributionTooLong.hasSubheadings( new Paper( shortText + subheading + longText ) );
 		expect( assessment ).toBe( true );
 	} );
+
+	it( "Returns false when the assessment shouldn't appear in short text analysis and the text contains less than 300 words", function() {
+		const assessment = new SubheadingDistributionTooLong( { shouldNotAppearInShortText: true } ).isApplicable( new Paper( shortText ) );
+		expect( assessment ).toBe( false );
+	} );
+
+	it( "Returns false when the assessment shouldn't appear in short text analysis and the paper is empty", function() {
+		const assessment = new SubheadingDistributionTooLong( { shouldNotAppearInShortText: true } ).isApplicable( new Paper( "" ) );
+		expect( assessment ).toBe( false );
+	} );
+
+	it( "Returns true when the assessment shouldn't appear in short text analysis but the text contains more than 300 words", function() {
+		const assessment = new SubheadingDistributionTooLong( { shouldNotAppearInShortText: true } ).isApplicable( new Paper( longText ) );
+		expect( assessment ).toBe( true );
+	} );
 } );
 
 describe.skip( "A test for marking too long text segments not separated by a subheading", function() {

--- a/packages/yoastseo/spec/scoring/productPages/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/contentAssessorSpec.js
@@ -7,8 +7,8 @@ import Paper from "../../../src/values/Paper.js";
 const i18n = Factory.buildJed();
 
 describe( "A product page content assessor", function() {
-	describe( "Checks the applicable assessments", function() {
-		it( "Should have 7 available assessments for a fully supported language", function() {
+	describe( "Checks the applicable assessments for text containing less than 300 words", function() {
+		it( "Should have 6 available assessments for a fully supported language", function() {
 			const paper = new Paper( "Lorem ipsum dolor sit amet, voluptua probatus ullamcorper id vis, ceteros consetetur qui ea, " +
 				"nam movet populo aliquam te. His eu debitis fastidii. Pri ea amet dicant. Ut his suas corpora, eu reformidans " +
 				"signiferumque duo. At erant expetenda patrioque quo, rebum atqui nam ad, tempor elaboraret interpretaris pri ad. " +
@@ -29,6 +29,45 @@ describe( "A product page content assessor", function() {
 			};
 			const actual = contentAssessor.getApplicableAssessments().map( result => result.identifier );
 			const expected = [
+				"textParagraphTooLong",
+				"textSentenceLength",
+				"textTransitionWords",
+				"passiveVoice",
+				"textPresence",
+				"listsPresence",
+			];
+			expect( actual ).toEqual( expected );
+		} );
+
+		it( "Should have 4 available assessments for a basic supported language", function() {
+			const paper = new Paper( "test", { locale: "xx_XX" } );
+			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ) );
+
+			contentAssessor.getPaper = function() {
+				return paper;
+			};
+
+			const actual = contentAssessor.getApplicableAssessments().map( result => result.identifier );
+			const expected = [
+				"textParagraphTooLong",
+				"textSentenceLength",
+				"textPresence",
+				"listsPresence",
+			];
+			expect( actual ).toEqual( expected );
+		} );
+	} );
+
+	describe( "Checks the applicable assessments for text containing more than 300 words", function() {
+		it( "Should have 7 available assessments for a fully supported language", function() {
+			const paper = new Paper( "beautiful cats ".repeat( 200 ), { locale: "en_US" } );
+			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ) );
+
+			contentAssessor.getPaper = function() {
+				return paper;
+			};
+			const actual = contentAssessor.getApplicableAssessments().map( result => result.identifier );
+			const expected = [
 				"subheadingsTooLong",
 				"textParagraphTooLong",
 				"textSentenceLength",
@@ -41,7 +80,7 @@ describe( "A product page content assessor", function() {
 		} );
 
 		it( "Should have 5 available assessments for a basic supported language", function() {
-			const paper = new Paper( "test", { locale: "xx_XX" } );
+			const paper = new Paper( "test ".repeat( 310 ), { locale: "xx_XX" } );
 			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ) );
 
 			contentAssessor.getPaper = function() {

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
@@ -7,7 +7,7 @@ import Factory from "../../../specHelpers/factory";
 const i18n = Factory.buildJed();
 
 describe( "A cornerstone product page content assessor", function() {
-	describe( "Checks the applicable assessments", function() {
+	describe( "Checks the applicable assessments for text that contains less than 300 words", function() {
 		const paper = new Paper( "Lorem ipsum dolor sit amet, voluptua probatus ullamcorper id vis, ceteros consetetur qui ea, " +
 			"nam movet populo aliquam te. His eu debitis fastidii. Pri ea amet dicant. Ut his suas corpora, eu reformidans " +
 			"signiferumque duo. At erant expetenda patrioque quo, rebum atqui nam ad, tempor elaboraret interpretaris pri ad. " +
@@ -21,6 +21,31 @@ describe( "A cornerstone product page content assessor", function() {
 			"accommodare. Mutat gloriatur ex cum, rebum salutandi ei his, vis delenit quaestio ne. Iisque qualisque duo ei. " +
 			"Splendide tincidunt te sit, commune oporteat quo id. Sumo recusabo suscipiantur duo an, no eum malis vulputate " +
 			"consectetuer. Mel te noster invenire, nec ad vidisse constituto. Eos ut quod." );
+		it( "Should have 6 available assessments for a fully supported language", function() {
+			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ) );
+			contentAssessor.getPaper = function() {
+				return paper;
+			};
+
+			const actual = contentAssessor.getApplicableAssessments().length;
+			const expected = 6;
+			expect( actual ).toBe( expected );
+		} );
+
+		it( "Should have 4 available assessments for a basic supported language", function() {
+			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ) );
+			contentAssessor.getPaper = function() {
+				return paper;
+			};
+
+			const actual = contentAssessor.getApplicableAssessments().length;
+			const expected = 4;
+			expect( actual ).toBe( expected );
+		} );
+	} );
+
+	describe( "Checks the applicable assessments for text that contains more than 300 words", function() {
+		const paper = new Paper( "a tortie cat ".repeat( 150 ) );
 		it( "Should have 7 available assessments for a fully supported language", function() {
 			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ) );
 			contentAssessor.getPaper = function() {
@@ -52,10 +77,8 @@ describe( "A cornerstone product page content assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.parameters ).toBeDefined();
-			expect( assessment._config.parameters.recommendedMaximumWordCount ).toBe( 250 );
-			expect( assessment._config.parameters.slightlyTooMany ).toBe( 250 );
-			expect( assessment._config.parameters.farTooMany ).toBe( 300 );
+			expect( assessment._config.shouldNotAppearInShortText ).toBeDefined();
+			expect( assessment._config.shouldNotAppearInShortText ).toBe( true );
 		} );
 
 		it( "should pass a 'true' value for the isCornerstone parameter in the SentenceLengthInTextAssessment", function() {

--- a/packages/yoastseo/src/scoring/assessments/readability/subheadingDistributionTooLongAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/subheadingDistributionTooLongAssessment.js
@@ -37,6 +37,7 @@ class SubheadingsDistributionTooLong extends Assessment {
 				badSubheadings: 3,
 				badLongTextNoSubheadings: 2,
 			},
+			shouldNotAppearInShortText: false,
 		};
 
 		this.identifier = "subheadingsTooLong";
@@ -84,7 +85,8 @@ class SubheadingsDistributionTooLong extends Assessment {
 	 * @returns {boolean} True when there is text.
 	 */
 	isApplicable( paper ) {
-		return paper.hasText();
+		const textLength = getWords( paper.getText() ).length;
+		return this._config.shouldNotAppearInShortText ? paper.hasText() && textLength > 300 : paper.hasText();
 	}
 
 	/**

--- a/packages/yoastseo/src/scoring/assessments/readability/subheadingDistributionTooLongAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/subheadingDistributionTooLongAssessment.js
@@ -82,7 +82,7 @@ class SubheadingsDistributionTooLong extends Assessment {
 	 *
 	 * @param {Paper}       paper       The paper to use for the assessment.
 	 *
-	 * @returns {boolean} True when there is text.
+	 * @returns {boolean} True when there is text or when the text contains more than 300 words if "shouldNotAppearInShortText" is set to true.
 	 */
 	isApplicable( paper ) {
 		const textLength = getWords( paper.getText() ).length;

--- a/packages/yoastseo/src/scoring/productPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/contentAssessor.js
@@ -22,7 +22,7 @@ const ProductContentAssessor = function( i18n, options = {} ) {
 	this.type = "productContentAssessor";
 
 	this._assessments = [
-		new SubheadingDistributionTooLong(),
+		new SubheadingDistributionTooLong( { shouldNotAppearInShortText: true } ),
 		paragraphTooLong,
 		new SentenceLengthInText(),
 		transitionWords,

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
@@ -22,13 +22,7 @@ const ProductCornerstoneContentAssessor = function( i18n, options = {} ) {
 	this.type = "productCornerstoneContentAssessor";
 
 	this._assessments = [
-		new SubheadingDistributionTooLong( {
-			parameters:	{
-				slightlyTooMany: 250,
-				farTooMany: 300,
-				recommendedMaximumWordCount: 250,
-			},
-		} ),
+		new SubheadingDistributionTooLong( { shouldNotAppearInShortText: true } ),
 		paragraphTooLong,
 		new SentenceLengthInText( true ),
 		transitionWords,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds an extra check in the `SubheadingsDistributionTooLong` assessment's applicability where we can adjust whether the assessment should appear in a short text analysis or not.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Note: Currently this PR cannot be tested in Product pages since the assessors for the product pages haven't been used anywhere yet. Hence, for now we can test this PR in normal pages by adding product pages configuration in `seoAssessor.js` for normal analysis**

* Set the `shouldNotAppearInShortText` to true in `scoring/contentAssessor.js` and `scoring/cornerstone/contentAssessor.js` file for `SubheadingDistributionTooLong` assessment by adding this config `{ shouldNotAppearInShortText: true }` (don't commit anything): 
<img width="728" alt="Screenshot 2021-07-27 at 12 21 04" src="https://user-images.githubusercontent.com/48715883/127129900-a9f43712-e2ac-4072-a6a4-518627214e27.png">


Run the steps below for both normal page and cornerstone content:
* Create a post and add a text with less than 300 words
* Confirm that the subheading distribution assessment doesn't appear in the metabox
* Add more words to the text so it's more than 300 words
* Confirm that the subheading distribution assessment appear in the metabox


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-952
