### PR TITLE
Flush rewrite rules on shutdown without using options

### DIFF
--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -22,27 +22,28 @@ class WPSEO_Rewrite {
 		add_action( 'created_category', [ $this, 'schedule_flush' ] );
 		add_action( 'edited_category', [ $this, 'schedule_flush' ] );
 		add_action( 'delete_category', [ $this, 'schedule_flush' ] );
-
-		add_action( 'init', [ $this, 'flush' ], 999 );
 	}
 
 	/**
-	 * Save an option that triggers a flush on the next init.
+	 * Trigger a rewrite_rule flush on shutdown.
 	 *
 	 * @since 1.2.8
 	 */
 	public function schedule_flush() {
-		update_option( 'wpseo_flush_rewrite', 1 );
+		add_action( 'shutdown', 'flush_rewrite_rules' );
 	}
 
 	/**
 	 * If the flush option is set, flush the rewrite rules.
 	 *
 	 * @since 1.2.8
+	 * @deprecated 17.0
+	 * @codeCoverageIgnore
 	 *
 	 * @return bool
 	 */
 	public function flush() {
+		_deprecated_function( __METHOD__, 'WPSEO 17.0', __CLASS__ . '::schedule_flush' );
 		if ( get_option( 'wpseo_flush_rewrite' ) ) {
 
 			add_action( 'shutdown', 'flush_rewrite_rules' );

--- a/inc/class-rewrite.php
+++ b/inc/class-rewrite.php
@@ -37,13 +37,13 @@ class WPSEO_Rewrite {
 	 * If the flush option is set, flush the rewrite rules.
 	 *
 	 * @since 1.2.8
-	 * @deprecated 17.0
+	 * @deprecated 17.4
 	 * @codeCoverageIgnore
 	 *
 	 * @return bool
 	 */
 	public function flush() {
-		_deprecated_function( __METHOD__, 'WPSEO 17.0', __CLASS__ . '::schedule_flush' );
+		_deprecated_function( __METHOD__, 'WPSEO 17.4', __CLASS__ . '::schedule_flush' );
 		if ( get_option( 'wpseo_flush_rewrite' ) ) {
 
 			add_action( 'shutdown', 'flush_rewrite_rules' );

--- a/tests/integration/test-class-rewrite.php
+++ b/tests/integration/test-class-rewrite.php
@@ -39,21 +39,7 @@ class WPSEO_Rewrite_Test extends WPSEO_UnitTestCase {
 	 */
 	public function test_schedule_flush() {
 		self::$class_instance->schedule_flush();
-		$this->assertTrue( get_option( $this->flush_option_name ) === 1 );
-	}
-
-	/**
-	 * Tests whether the flush listens to the option.
-	 *
-	 * @covers WPSEO_Rewrite::flush
-	 */
-	public function test_flush() {
-		delete_option( $this->flush_option_name );
-
-		$this->assertFalse( self::$class_instance->flush() );
-
-		self::$class_instance->schedule_flush();
-		$this->assertTrue( self::$class_instance->flush() );
+		$this->assertIsInt( has_action( 'shutdown', 'flush_rewrite_rules' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context
* There's a known race condition with `delete_option` and `all_options` in combination with persistent caches that would cause Yoast SEO to keep flushing rewrite rules on every single page load. (see https://github.com/woocommerce/woocommerce/pull/27696 and https://github.com/Automattic/jetpack/pull/19229) 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a race condition may occur that causes the rewrite rules to be flushed on every page request when using a persistent cache like Redis.

## Relevant technical choices:

* I chose to schedule the rewrite flush on shutdown on the same request instead of on init on the next request. This way, it doesn't impact the next request, doesn't rely on db/cache storage and is a bit more predictable. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The impact of this PR is limited to flushing the rewrite rules when a category is added, edited or removed.
	* The option that we set and checked for before (`wpseo_flush_rewrite`) was only used in the class where it has been removed. Removing that option should therefor not lead to any impact elsewhere. (We also checked WordPress SEO Premium and the other plugins).
	* The now deprecated `flush` method was also only used in the class where it's method call has been removed. (We also checked WordPress SEO Premium and the other plugins).

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
