### PR TITLE
Moves limited indexation count to new interface to avoid complication with backwards compatibility.

### DIFF
--- a/src/actions/indexing/abstract-indexing-action.php
+++ b/src/actions/indexing/abstract-indexing-action.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Actions\Indexing;
 /**
  * Trait used to calculate unindexed object.
  */
-abstract class Abstract_Indexing_Action implements Indexation_Action_Interface {
+abstract class Abstract_Indexing_Action implements Indexation_Action_Interface, Limited_Indexing_Action_Interface {
 
 	/**
 	 * The transient name.

--- a/src/actions/indexing/indexable-general-indexation-action.php
+++ b/src/actions/indexing/indexable-general-indexation-action.php
@@ -8,7 +8,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 /**
  * General reindexing action for indexables.
  */
-class Indexable_General_Indexation_Action implements Indexation_Action_Interface {
+class Indexable_General_Indexation_Action implements Indexation_Action_Interface, Limited_Indexing_Action_Interface {
 
 	/**
 	 * The transient cache key.

--- a/src/actions/indexing/indexable-post-type-archive-indexation-action.php
+++ b/src/actions/indexing/indexable-post-type-archive-indexation-action.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 /**
  * Reindexing action for post type archive indexables.
  */
-class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action_Interface {
+class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action_Interface, Limited_Indexing_Action_Interface {
 
 	/**
 	 * The transient cache key.

--- a/src/actions/indexing/indexation-action-interface.php
+++ b/src/actions/indexing/indexation-action-interface.php
@@ -15,15 +15,6 @@ interface Indexation_Action_Interface {
 	public function get_total_unindexed();
 
 	/**
-	 * Returns a limited number of unindexed posts.
-	 *
-	 * @param int $limit Limit the maximum number of unindexed posts that are counted.
-	 *
-	 * @return int|false The limited number of unindexed posts. False if the query fails.
-	 */
-	public function get_limited_unindexed_count( $limit );
-
-	/**
 	 * Indexes a number of objects.
 	 *
 	 * NOTE: ALWAYS use limits, this method is intended to be called multiple times over several requests.

--- a/src/actions/indexing/limited-indexing-action-interface.php
+++ b/src/actions/indexing/limited-indexing-action-interface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Yoast\WP\SEO\Actions\Indexing;
+
+/**
+ * Interface definition of a reindexing action for indexables that have a limited unindexed count.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+interface Limited_Indexing_Action_Interface {
+
+	/**
+	 * Returns a limited number of unindexed posts.
+	 *
+	 * @param int $limit Limit the maximum number of unindexed posts that are counted.
+	 *
+	 * @return int|false The limited number of unindexed posts. False if the query fails.
+	 */
+	public function get_limited_unindexed_count( $limit );
+}

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -44,7 +44,7 @@ class Indexing_Helper {
 	/**
 	 * The indexation actions.
 	 *
-	 * @var Indexation_Action_Interface[]
+	 * @var Indexation_Action_Interface[]|Limited_Indexing_Action_Interface[]
 	 */
 	protected $indexing_actions;
 

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -7,6 +7,7 @@ use Yoast\WP\SEO\Actions\Indexing\Indexation_Action_Interface;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Type_Archive_Indexation_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
+use Yoast\WP\SEO\Actions\Indexing\Limited_Indexing_Action_Interface;
 use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_General_Indexation_Action;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We can't add methods or arguments to interfaces that are used in other plugins, since that can lead to backwards compatibility problems. E.g. older versions of plugins that do not implement this new interface leading to fatal errors. In this case a method was added to the `Indexation_Action_Interface`, which is also used in WordPress SEO Premium.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Fixes an unreleased bug where updating WordPress SEO before WordPress SEO Premium lead to a fatal error.

## Relevant technical choices:

* We can't change the `Indexation_Action_Interface` without backwards compatibility issues. However, we can add a new interface.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure that you have WordPress SEO Premium, version 16.8 or lower, installed.
	* E.g. for acceptance testers: checkout the `master` branch of Premium. 
* Check out this branch or make sure that you have the latest RC of WordPress SEO installed.
* You should **not** get a fatal error on your website.
* Update/install the latest WordPress SEO Premium 16.9 RC, or checkout the `release/16.9` branch on Premium.
* You should **not** get a fatal error.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This changes the code added in https://github.com/Yoast/wordpress-seo/pull/17247. It would be worthwhile to check whether that code still works as expected. 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
