### PR TITLE
Don't delete transients when no indexables have been created

### DIFF
--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -67,8 +67,10 @@ abstract class Abstract_Link_Indexing_Action extends Abstract_Indexing_Action {
 			$indexables[] = $indexable;
 		}
 
-		\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
-		\delete_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT );
+		if ( \count( $indexables ) > 0 ) {
+			\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
+			\delete_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT );
+		}
 
 		return $indexables;
 	}

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -77,8 +77,10 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			$indexables[] = $this->repository->find_by_id_and_type( (int) $post_id, 'post' );
 		}
 
-		\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
-		\delete_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT );
+		if ( \count( $indexables ) > 0 ) {
+			\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
+			\delete_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT );
+		}
 
 		return $indexables;
 	}

--- a/src/actions/indexing/indexable-post-type-archive-indexation-action.php
+++ b/src/actions/indexing/indexable-post-type-archive-indexation-action.php
@@ -90,7 +90,9 @@ class Indexable_Post_Type_Archive_Indexation_Action implements Indexation_Action
 			$indexables[] = $this->builder->build_for_post_type_archive( $post_type_archive );
 		}
 
-		\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
+		if ( \count( $indexables ) > 0 ) {
+			\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
+		}
 
 		return $indexables;
 	}

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -75,8 +75,10 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 			$indexables[] = $this->repository->find_by_id_and_type( (int) $term_id, 'term' );
 		}
 
-		\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
-		\delete_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT );
+		if ( \count( $indexables ) > 0 ) {
+			\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
+			\delete_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT );
+		}
 
 		return $indexables;
 	}

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -18,6 +18,13 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	const UNINDEXED_COUNT_TRANSIENT = 'wpseo_unindexed_post_link_count';
 
 	/**
+	 * The transient cache key for limited counts.
+	 *
+	 * @var string
+	 */
+	const UNINDEXED_LIMITED_COUNT_TRANSIENT = self::UNINDEXED_COUNT_TRANSIENT . '_limited';
+
+	/**
 	 * The post type helper.
 	 *
 	 * @var Post_Type_Helper

--- a/src/actions/indexing/term-link-indexing-action.php
+++ b/src/actions/indexing/term-link-indexing-action.php
@@ -18,6 +18,13 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	const UNINDEXED_COUNT_TRANSIENT = 'wpseo_unindexed_term_link_count';
 
 	/**
+	 * The transient cache key for limited counts.
+	 *
+	 * @var string
+	 */
+	const UNINDEXED_LIMITED_COUNT_TRANSIENT = self::UNINDEXED_COUNT_TRANSIENT . '_limited';
+
+	/**
 	 * The post type helper.
 	 *
 	 * @var Taxonomy_Helper

--- a/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
@@ -350,4 +350,52 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 
 		$this->instance->index();
 	}
+
+	/**
+	 * Tests that the transients are not deleted when no indexables have been created.
+	 *
+	 * @covers ::__construct
+	 * @covers ::index
+	 * @covers ::get_query
+	 * @covers ::get_limit
+	 * @covers ::get_post_types
+	 */
+	public function test_index_no_indexables_created() {
+		$expected_query = "
+			SELECT P.ID
+			FROM wp_posts AS P
+			WHERE P.post_type IN (%s)
+			AND P.ID not in (
+				SELECT I.object_id from wp_yoast_indexable as I
+				WHERE I.object_type = 'post'
+				AND I.permalink_hash IS NOT NULL)
+			LIMIT %d";
+
+		Filters\expectApplied( 'wpseo_post_indexation_limit' )->andReturn( 25 );
+
+		$this->post_type_helper
+			->expects( 'get_public_post_types' )
+			->once()
+			->andReturn( [ 'public_post_type' ] );
+		$this->post_type_helper
+			->expects( 'get_excluded_post_types_for_indexables' )
+			->once()
+			->andReturn( [] );
+
+		$this->wpdb
+			->expects( 'prepare' )
+			->once()
+			->with(
+				$expected_query,
+				[ 'public_post_type', 25 ]
+			)
+			->andReturn( 'query' );
+		$this->wpdb
+			->expects( 'get_col' )
+			->once()
+			->with( 'query' )
+			->andReturn( [] );
+
+		$this->instance->index();
+	}
 }

--- a/tests/unit/actions/indexing/indexable-post-type-archive-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-type-archive-indexation-action-test.php
@@ -258,6 +258,43 @@ class Indexable_Post_Type_Archive_Indexation_Action_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that the transients are not deleted when no indexables have been created.
+	 *
+	 * @covers ::index
+	 * @covers ::get_limit
+	 * @covers ::get_unindexed_post_type_archives
+	 * @covers ::get_post_types_with_archive_pages
+	 * @covers ::get_indexed_post_type_archives
+	 */
+	public function test_index_no_indexables_created() {
+		$public_post_types = [
+			[
+				'name'        => 'movies',
+				'has_archive' => true,
+			],
+			[
+				'name'        => 'books',
+				'has_archive' => true,
+			],
+			[
+				'name'        => 'posts',
+				'has_archive' => true,
+			],
+		];
+
+		$indexed_post_types = [ 'movies', 'books', 'posts' ];
+
+		$this->set_expectations_for_post_type_helper( $public_post_types );
+		$this->set_expectations_for_repository( $indexed_post_types );
+
+		Monkey\Filters\expectApplied( 'wpseo_post_type_archive_indexation_limit' )
+			->with( 25 )
+			->andReturn( 25 );
+
+		$this->assertEquals( [], $this->instance->index() );
+	}
+
+	/**
 	 * Sets the expectations for the post type helper.
 	 *
 	 * @param array $public_post_types The public post types.

--- a/tests/unit/actions/indexing/term-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/term-link-indexing-action-test.php
@@ -391,4 +391,44 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 
 		$this->instance->index();
 	}
+
+	/**
+	 * Tests that the transients are not deleted when no indexables have been created.
+	 *
+	 * @covers ::get_objects
+	 * @covers ::get_query
+	 */
+	public function test_index_no_indexables_created() {
+		Filters\expectApplied( 'wpseo_link_indexing_limit' );
+
+		$this->taxonomy_helper
+			->expects( 'get_public_taxonomies' )
+			->once()
+			->andReturn( [ 'category', 'tag' ] );
+
+		$expected_query = "
+			SELECT T.term_id, T.description
+			FROM wp_term_taxonomy AS T
+			LEFT JOIN wp_yoast_indexable AS I
+				ON T.term_id = I.object_id
+				AND I.object_type = 'term'
+				AND I.link_count IS NOT NULL
+			WHERE I.object_id IS NULL
+				AND T.taxonomy IN (%s, %s)
+			LIMIT %d";
+
+		$this->wpdb
+			->expects( 'prepare' )
+			->once()
+			->with( $expected_query, [ 'category', 'tag', 5 ] )
+			->andReturn( 'query' );
+
+		$this->wpdb
+			->expects( 'get_results' )
+			->once()
+			->with( 'query' )
+			->andReturn( [] );
+
+		$this->instance->index();
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Speeds up load times of admin pages by preventing unnecessary counts of unindexed objects.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure query monitor is enabled.
* Make sure your entire site is indexed.
* Clear all transients in the database.
  ```sql
  DELETE FROM wp_options
  WHERE option_name LIKE '%_transient_%'
  ```
* Visit the Wordpress Dashboard.
* Now you have 15 minutes to do the following steps to test it reliably, because of the duration of the limited unindexed objects transients.
* De-activate Yoast SEO and Yoast SEO Premium.
* Create a new category.
* Enable Yoast SEO and Yoast SEO Premium.
* Make sure the background-indexing is run by deleting the `_transient_wpseo_total_unindexed_terms_limited` transient.
  ```sql
  DELETE FROM wp_options
  WHERE option_name = '_transient_wpseo_total_unindexed_terms_limited'
  ```
* Refresh the WordPress dashboard, the background indexing should have triggered now. Normally this would have cleared all transients used to determine whether the background indexing should be run.
* Now when refreshing the WordPress dashboard again, only the query used to count terms should be run. Verify this using Query Monitor.
  ```sql
  SELECT term_id
  FROM wp_term_taxonomy AS T
  LEFT JOIN wp_yoast_indexable AS I
  ON T.term_id = I.object_id
  AND I.object_type = 'term'
  AND I.permalink_hash IS NOT NULL
  WHERE I.object_id IS NULL
  AND taxonomy IN ('category', 'post_tag', 'post_format')
  LIMIT 26
  ```

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
