### PR TITLE
Use total counts for unindexed links

### DIFF
--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -68,9 +68,20 @@ abstract class Abstract_Link_Indexing_Action extends Abstract_Indexing_Action {
 		}
 
 		\delete_transient( static::UNINDEXED_COUNT_TRANSIENT );
-		\delete_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT );
 
 		return $indexables;
+	}
+
+	/**
+	 * In the case of term-links and post-links we want to use the total unindexed count, because using
+	 * the limited unindexed count actually leads to worse performance.
+	 *
+	 * @param int|bool $limit Unused.
+	 *
+	 * @return int The total number of unindexed links.
+	 */
+	public function get_limited_unindexed_count( $limit = false ) {
+		return $this->get_total_unindexed();
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reverts to using the total count for post-links and term-links in background-indexing, instead of a limited select, because it was actually was harmful to the performance.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure Query monitor is installed.
* Delete all transients.
```
DELETE FROM wp_options
WHERE option_name LIKE '%_transient_%'
```
* Visit the WordPress dashboard.
* The following queries should have run on that request:
```
SELECT COUNT(T.term_id)
FROM wp_term_taxonomy AS T
LEFT JOIN wp_yoast_indexable AS I
ON T.term_id = I.object_id
AND I.object_type = 'term'
AND I.permalink_hash IS NOT NULL
WHERE I.object_id IS NULL
AND taxonomy IN ('category', 'post_tag', 'post_format')
```
```
SELECT COUNT(P.ID)
FROM wp_posts AS P
LEFT JOIN wp_yoast_indexable AS I
ON P.ID = I.object_id
AND I.link_count IS NOT NULL
AND I.object_type = 'post'
LEFT JOIN wp_yoast_seo_links AS L
ON L.post_id = P.ID
AND L.target_indexable_id IS NULL
AND L.type = 'internal'
AND L.target_post_id IS NOT NULL
AND L.target_post_id != 0
WHERE ( I.object_id IS NULL
OR L.post_id IS NOT NULL )
AND P.post_status = 'publish'
AND P.post_type IN ('post', 'page')
```
**Note:**
The following lines may differ based on what custom post-types and custom taxonomies are used on your site.
```
AND taxonomy IN ('category', 'post_tag', 'post_format')
```
```
AND P.post_type IN ('post', 'page')
```
* The following queries should **not** have run:
```
SELECT T.term_id, T.description
FROM wp_term_taxonomy AS T
LEFT JOIN wp_yoast_indexable AS I
ON T.term_id = I.object_id
AND I.object_type = 'term'
AND I.permalink_hash IS NOT NULL
WHERE I.object_id IS NULL
AND taxonomy IN ('category', 'post_tag', 'post_format')
LIMIT 26
```
```
SELECT P.ID, P.post_content
FROM wp_posts AS P
LEFT JOIN wp_yoast_indexable AS I
ON P.ID = I.object_id
AND I.link_count IS NOT NULL
AND I.object_type = 'post'
LEFT JOIN wp_yoast_seo_links AS L
ON L.post_id = P.ID
AND L.target_indexable_id IS NULL
AND L.type = 'internal'
AND L.target_post_id IS NOT NULL
AND L.target_post_id != 0
WHERE ( I.object_id IS NULL
OR L.post_id IS NOT NULL )
AND P.post_status = 'publish'
AND P.post_type IN ('post', 'page')
LIMIT 26
```

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
