### PR TITLE
Use non-product-page values on store blog assessors

### DIFF
--- a/packages/yoastseo/spec/scoring/storeBlog/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/storeBlog/cornerstone/seoAssessorSpec.js
@@ -177,7 +177,7 @@ describe( "running assessments in the store blog SEO assessor", function() {
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.scores ).toBeDefined();
-			expect( assessment._config.scores.widthTooShort ).toBe( 9 );
+			expect( assessment._config.scores.widthTooShort ).toBe( 3 );
 			expect( assessment._config.scores.widthTooLong ).toBe( 3 );
 		} );
 

--- a/packages/yoastseo/spec/scoring/storeBlog/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/storeBlog/seoAssessorSpec.js
@@ -178,7 +178,7 @@ describe( "running assessments in the store blog cornerstone SEO assessor", func
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.scores ).toBeDefined();
-			expect( assessment._config.scores.widthTooShort ).toBe( 9 );
+			expect( assessment._config.scores.widthTooShort ).toBe( 6 );
 			expect( assessment._config.scores.widthTooLong ).toBe( 3 );
 		} );
 	} );

--- a/packages/yoastseo/src/scoring/storeBlog/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storeBlog/cornerstone/seoAssessor.js
@@ -34,13 +34,11 @@ const StoreBlogCornerstoneSEOAssessor = function( i18n, options ) {
 		} ),
 		new TitleKeywordAssessment(),
 		new TitleWidth( {
-			scores: {
 				scores: {
 					widthTooShort: 3,
 					widthTooLong: 3,
 				},
-			},
-		}, true ),
+		} ),
 		new UrlKeywordAssessment(
 			{
 				scores: {

--- a/packages/yoastseo/src/scoring/storeBlog/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storeBlog/cornerstone/seoAssessor.js
@@ -34,10 +34,10 @@ const StoreBlogCornerstoneSEOAssessor = function( i18n, options ) {
 		} ),
 		new TitleKeywordAssessment(),
 		new TitleWidth( {
-				scores: {
-					widthTooShort: 3,
-					widthTooLong: 3,
-				},
+			scores: {
+				widthTooShort: 3,
+				widthTooLong: 3,
+			},
 		} ),
 		new UrlKeywordAssessment(
 			{

--- a/packages/yoastseo/src/scoring/storeBlog/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storeBlog/cornerstone/seoAssessor.js
@@ -35,7 +35,10 @@ const StoreBlogCornerstoneSEOAssessor = function( i18n, options ) {
 		new TitleKeywordAssessment(),
 		new TitleWidth( {
 			scores: {
-				widthTooShort: 9,
+				scores: {
+					widthTooShort: 3,
+					widthTooLong: 3,
+				},
 			},
 		}, true ),
 		new UrlKeywordAssessment(

--- a/packages/yoastseo/src/scoring/storeBlog/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storeBlog/seoAssessor.js
@@ -27,11 +27,7 @@ const StoreBlogSEOAssessor = function( i18n, researcher, options ) {
 		new MetaDescriptionKeywordAssessment(),
 		new MetaDescriptionLength(),
 		new TitleKeywordAssessment(),
-		new TitleWidth( {
-			scores: {
-				widthTooShort: 9,
-			},
-		}, true ),
+		new TitleWidth(),
 		new UrlKeywordAssessment(),
 		new FunctionWordsInKeyphrase(),
 	];


### PR DESCRIPTION
The store blog assessors were using product page values for the title width assessment. They should use regular values.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Fixes incorrect assessors values. The store blog assessor was using values for product pages for the title width assessments. It should use regular values.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In `apps/content-analysis/src/App.js` on the line before `worker.initialize( config )`, please add this:

```
		config.customAnalysisType = "storeBlog";
```
* Confirm that the title width assessment behaves as specified here (both regular & cornerstone): https://github.com/Yoast/javascript/wiki/Scoring-SEO-analysis#16-title-width


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
