### PR TITLE
Added keys to sidebar items

### DIFF
--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -30,10 +30,13 @@ import SEMrushRelatedKeyphrases from "../../containers/SEMrushRelatedKeyphrases"
 export default function MetaboxFill( { settings } ) {
 	return (
 		<Fill name="YoastMetabox">
-			<SidebarItem renderPriority={ 1 }>
+			<SidebarItem
+				key="warning"
+				renderPriority={ 1 }
+			>
 				<Warning />
 			</SidebarItem>
-			{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
+			{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>
 				<KeywordInput
 					isSEMrushIntegrationActive={ settings.isSEMrushIntegrationActive }
 				/>
@@ -41,7 +44,7 @@ export default function MetaboxFill( { settings } ) {
 					<SEMrushRelatedKeyphrases />
 				</Fill> }
 			</SidebarItem> }
-			<SidebarItem renderPriority={ 9 }>
+			<SidebarItem key="google-preview" renderPriority={ 9 }>
 				<MetaboxCollapsible
 					id={ "yoast-snippet-editor-metabox" }
 					title={ __( "Google preview", "wordpress-seo" ) } initialIsOpen={ true }
@@ -49,27 +52,28 @@ export default function MetaboxFill( { settings } ) {
 					<SnippetEditor hasPaperStyle={ false } />
 				</MetaboxCollapsible>
 			</SidebarItem>
-			{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
+			{ settings.isContentAnalysisActive && <SidebarItem key="readability-analysis" renderPriority={ 10 }>
 				<ReadabilityAnalysis />
 			</SidebarItem> }
-			{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
+			{ settings.isKeywordAnalysisActive && <SidebarItem key="seo-analysis" renderPriority={ 20 }>
 				<SeoAnalysis
 					shouldUpsell={ settings.shouldUpsell }
 					shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
 				/>
 			</SidebarItem> }
-			{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
+			{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
 				<CollapsibleCornerstone />
 			</SidebarItem> }
-			{ settings.displayAdvancedTab && <SidebarItem renderPriority={ 40 }>
+			{ settings.displayAdvancedTab && <SidebarItem key="advanced" renderPriority={ 40 }>
 				<MetaboxCollapsible id={ "collapsible-advanced-settings" } title={ __( "Advanced", "wordpress-seo" ) }>
 					<AdvancedSettings />
 				</MetaboxCollapsible>
 			</SidebarItem> }
-			{ settings.displaySchemaSettings && <SidebarItem renderPriority={ 50 }>
+			{ settings.displaySchemaSettings && <SidebarItem key="schema" renderPriority={ 50 }>
 				<SchemaTabContainer />
 			</SidebarItem> }
 			<SidebarItem
+				key="social"
 				renderPriority={ -1 }
 			>
 				<SocialMetadataPortal target="wpseo-section-social" />

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -34,47 +34,47 @@ export default function SidebarFill( { settings } ) {
 	return (
 		<Fragment>
 			<Fill name="YoastSidebar">
-				<SidebarItem renderPriority={ 1 }>
+				<SidebarItem key="warning" renderPriority={ 1 }>
 					<Warning />
 				</SidebarItem>
-				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
+				{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>
 					<KeywordInput
 						isSEMrushIntegrationActive={ settings.isSEMrushIntegrationActive }
 					/>
 				</SidebarItem> }
-				<SidebarItem renderPriority={ 23 }>
+				<SidebarItem key="google-preview" renderPriority={ 23 }>
 					<GooglePreviewModal />
 				</SidebarItem>
-				{ settings.displayFacebook && <SidebarItem renderPriority={ 24 }>
+				{ settings.displayFacebook && <SidebarItem key="facebook-preview" renderPriority={ 24 }>
 					<FacebookPreviewModal />
 				</SidebarItem> }
-				{ settings.displayTwitter && <SidebarItem renderPriority={ 25 }>
+				{ settings.displayTwitter && <SidebarItem key="twitter-preview" renderPriority={ 25 }>
 					<TwitterPreviewModal />
 				</SidebarItem> }
-				{ settings.displaySchemaSettings && <SidebarItem renderPriority={ 26 }>
+				{ settings.displaySchemaSettings && <SidebarItem key="schema" renderPriority={ 26 }>
 					<SidebarCollapsible
 						title={ __( "Schema", "wordpress-seo" ) }
 					>
 						<SchemaTabContainer />
 					</SidebarCollapsible>
 				</SidebarItem> }
-				{ settings.displayAdvancedTab && <SidebarItem renderPriority={ 27 }>
+				{ settings.displayAdvancedTab && <SidebarItem key="advanced" renderPriority={ 27 }>
 					<SidebarCollapsible
 						title={ __( "Advanced", "wordpress-seo" ) }
 					>
 						<AdvancedSettings />
 					</SidebarCollapsible>
 				</SidebarItem> }
-				{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 10 }>
+				{ settings.isContentAnalysisActive && <SidebarItem key="readability" renderPriority={ 10 }>
 					<ReadabilityAnalysis />
 				</SidebarItem> }
-				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 20 }>
+				{ settings.isKeywordAnalysisActive && <SidebarItem key="seo" renderPriority={ 20 }>
 					<SeoAnalysis
 						shouldUpsell={ settings.shouldUpsell }
 						shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
 					/>
 				</SidebarItem> }
-				{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
+				{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
 					<CollapsibleCornerstone />
 				</SidebarItem> }
 			</Fill>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes duplicate key errors in the console.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate:
  * Yoast SEO Premium (Branch: P2-1178-add-keys-to-sidebar-items)
  * Yoast SEO News (Branch: P2-1178-add-key-to-sidebar-item)
  * Yoast SEO Woocommerce (Latest trunk)
  * Yoast SEO Local (Latest trunk)
  * Yoast SEO Video (Branch: P2-1178-add-key-to-sidebar-item)
  * Woocommerce
* Open the editor, make sure there are no duplicate key errors and each sidebar-item is only displayed once.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Install and activate:
  * Yoast SEO Premium (Latest RC)
  * Yoast SEO News (Latest RC)
  * Yoast SEO Woocommerce (Latest version)
  * Yoast SEO Local (Latest version)
  * Yoast SEO Video (Latest RC)
  * Woocommerce
* Open the editor, make sure there are no duplicate key errors and each sidebar-item is only displayed once.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
