### PR TITLE
Delete images assessment from related keyphrase assessors

### DIFF
--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/relatedKeywordAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/relatedKeywordAssessorSpec.js
@@ -42,7 +42,6 @@ describe( "running assessments in the cornerstone related keyword product assess
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"images",
 		] );
 	} );
 
@@ -54,7 +53,6 @@ describe( "running assessments in the cornerstone related keyword product assess
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionKeyword",
-			"images",
 		] );
 	} );
 
@@ -73,7 +71,6 @@ describe( "running assessments in the cornerstone related keyword product assess
 			"introductionKeyword",
 			"keyphraseLength",
 			"keywordDensity",
-			"images",
 		] );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/productPages/relatedKeywordAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/relatedKeywordAssessorSpec.js
@@ -42,7 +42,6 @@ describe( "running assessments in the related keyword product assessor", functio
 		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
-			"images",
 		] );
 	} );
 
@@ -54,7 +53,6 @@ describe( "running assessments in the related keyword product assessor", functio
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionKeyword",
-			"images",
 		] );
 	} );
 
@@ -73,7 +71,6 @@ describe( "running assessments in the related keyword product assessor", functio
 			"introductionKeyword",
 			"keyphraseLength",
 			"keywordDensity",
-			"images",
 		] );
 	} );
 } );

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
@@ -37,12 +37,6 @@ const ProductCornerStoneRelatedKeywordAssessor = function( i18n, options ) {
 		new MetaDescriptionKeyword(),
 		new TextCompetingLinks(),
 		new FunctionWordsInKeyphrase(),
-		new ImageCount( {
-			scores: {
-				okay: 6,
-			},
-			recommendedCount: 4,
-		}, true ),
 		new ImageKeyphrase( {
 			scores: {
 				withAltNonKeyword: 3,

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
@@ -6,7 +6,6 @@ import KeyphraseLength from "../../assessments/seo/KeyphraseLengthAssessment.js"
 import KeywordDensity from "../../assessments/seo/KeywordDensityAssessment.js";
 import MetaDescriptionKeyword from "../../assessments/seo/MetaDescriptionKeywordAssessment.js";
 import ImageKeyphrase from "../../assessments/seo/KeyphraseInImageTextAssessment";
-import ImageCount from "../../assessments/seo/ImageCountAssessment";
 import TextCompetingLinks from "../../assessments/seo/TextCompetingLinksAssessment.js";
 import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyphraseAssessment";
 

--- a/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
@@ -6,7 +6,6 @@ import KeyphraseLength from "../assessments/seo/KeyphraseLengthAssessment.js";
 import KeywordDensity from "../assessments/seo/KeywordDensityAssessment.js";
 import MetaDescriptionKeyword from "../assessments/seo/MetaDescriptionKeywordAssessment.js";
 import ImageKeyphrase from "../assessments/seo/KeyphraseInImageTextAssessment";
-import ImageCount from "../assessments/seo/ImageCountAssessment";
 import TextCompetingLinks from "../assessments/seo/TextCompetingLinksAssessment.js";
 import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
 

--- a/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
@@ -38,12 +38,6 @@ const ProductRelatedKeywordAssessor = function( i18n, researcher, options ) {
 		new MetaDescriptionKeyword(),
 		new TextCompetingLinks(),
 		new FunctionWordsInKeyphrase(),
-		new ImageCount( {
-			scores: {
-				okay: 6,
-			},
-			recommendedCount: 4,
-		}, true ),
 		new ImageKeyphrase(),
 	];
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes `Images` assessment from related keyphrase analysis.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Test in Shopify**
This PR can be tested together with this PR https://github.com/Yoast/shopify-seo/pull/145
* Make sure that `Images` assessment doesn't show in the side bar for related keyphrase analysis both in normal and cornerstone content


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-980
