### PR TITLE
Add shortlinks to the Lists assessment

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/readability/ListAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/ListAssessmentSpec.js
@@ -12,8 +12,8 @@ describe( "A list assessment", function() {
 		const assessment = listAssessment.getResult( mockPaper, Factory.buildMockResearcher( false ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoast.com' target='_blank'>Lists</a>: " +
-			"No lists appear on this page. <a href='https://yoast.com' target='_blank'>Add at least one ordered or unordered list</a>!" );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/shopify38' target='_blank'>Lists</a>: " +
+			"No lists appear on this page. <a href='https://yoa.st/shopify39' target='_blank'>Add at least one ordered or unordered list</a>!" );
 	} );
 	it( "assesses when there is a list", function() {
 		const mockPaper = new Paper( "text with a list <ol type=\"i\">\n" +
@@ -25,7 +25,7 @@ describe( "A list assessment", function() {
 		const assessment = listAssessment.getResult( mockPaper, Factory.buildMockResearcher( true ), i18n );
 
 		expect( assessment.getScore() ).toEqual( 9 );
-		expect( assessment.getText() ).toEqual( "<a href='https://yoast.com' target='_blank'>Lists</a>: " +
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/shopify38' target='_blank'>Lists</a>: " +
 			"There is at least one list on this page. Great!" );
 	} );
 } );

--- a/packages/yoastseo/src/scoring/assessments/readability/ListAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/ListAssessment.js
@@ -17,8 +17,8 @@ export default class ListAssessment extends Assessment {
 		super();
 
 		this._config = {
-			urlTitle: createAnchorOpeningTag( "https://yoast.com" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoast.com" ),
+			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify38" ),
+			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify39" ),
 			scores: {
 				bad: 3,
 				good: 9,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds shortlinks to the feedback text of the Lists assessment.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In apps/content-analysis/src/App.js on the line before `worker.initialize( config )`, please add this (don't commit):
```
config.customAnalysisType = "productPage";
```
* Run the content analysis app and add some text
* The Lists assessment should show up with a red bullet
* However over the links in the feedback text and make sure that the first link is `https://yoa.st/shopify38` and the second one is `https://yoa.st/shopify39`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-965
