### PR TITLE
Updated message for recommended addons with dependencies

### DIFF
--- a/admin/class-admin-init.php
+++ b/admin/class-admin-init.php
@@ -35,7 +35,6 @@ class WPSEO_Admin_Init {
 		$this->asset_manager = new WPSEO_Admin_Asset_Manager();
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_dismissible' ] );
-		add_action( 'admin_init', [ $this, 'yoast_plugin_suggestions_notification' ], 15 );
 		add_action( 'admin_init', [ $this, 'unsupported_php_notice' ], 15 );
 		add_action( 'admin_init', [ $this->asset_manager, 'register_assets' ] );
 		add_action( 'admin_init', [ $this, 'show_hook_deprecation_warnings' ] );
@@ -76,59 +75,6 @@ class WPSEO_Admin_Init {
 	 */
 	public function enqueue_dismissible() {
 		$this->asset_manager->enqueue_style( 'dismissible' );
-	}
-
-	/**
-	 * Determines whether a suggested plugins notification needs to be displayed.
-	 *
-	 * @return void
-	 */
-	public function yoast_plugin_suggestions_notification() {
-		$checker             = new WPSEO_Plugin_Availability();
-		$notification_center = Yoast_Notification_Center::get();
-
-		// Get all Yoast plugins that have dependencies.
-		$plugins = $checker->get_plugins_with_dependencies();
-
-		foreach ( $plugins as $plugin_name => $plugin ) {
-			$dependency_names = $checker->get_dependency_names( $plugin );
-			$notification     = $this->get_yoast_seo_suggested_plugins_notification( $plugin_name, $plugin, $dependency_names[0] );
-
-			if ( $checker->dependencies_are_satisfied( $plugin ) && ! $checker->is_installed( $plugin ) ) {
-				$notification_center->add_notification( $notification );
-
-				continue;
-			}
-
-			$notification_center->remove_notification( $notification );
-		}
-	}
-
-	/**
-	 * Build Yoast SEO suggested plugins notification.
-	 *
-	 * @param string $name            The plugin name to use for the unique ID.
-	 * @param array  $plugin          The plugin to retrieve the data from.
-	 * @param string $dependency_name The name of the dependency.
-	 *
-	 * @return Yoast_Notification The notification containing the suggested plugin.
-	 */
-	private function get_yoast_seo_suggested_plugins_notification( $name, $plugin, $dependency_name ) {
-		$info_message = sprintf(
-			/* translators: %1$s expands to Yoast SEO, %2$s expands to the plugin version, %3$s expands to the plugin name */
-			__( '%1$s and %2$s can work together a lot better by adding a helper plugin. Please install %3$s to make your life better.', 'wordpress-seo' ),
-			'Yoast SEO',
-			$dependency_name,
-			sprintf( '<a href="%s">%s</a>', $plugin['url'], $plugin['title'] )
-		);
-
-		return new Yoast_Notification(
-			$info_message,
-			[
-				'id'   => 'wpseo-suggested-plugin-' . $name,
-				'type' => Yoast_Notification::WARNING,
-			]
-		);
 	}
 
 	/**

--- a/admin/class-suggested-plugins.php
+++ b/admin/class-suggested-plugins.php
@@ -61,8 +61,7 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 				continue;
 			}
 
-			$dependency_names = $checker->get_dependency_names( $plugin );
-			$notification     = $this->get_yoast_seo_suggested_plugins_notification( $plugin_name, $plugin, $dependency_names[0] );
+			$notification = $this->get_yoast_seo_suggested_plugins_notification( $plugin_name, $plugin );
 
 			if ( ! $checker->is_installed( $plugin ) || ! $checker->is_active( $plugin['slug'] ) ) {
 				$this->notification_center->add_notification( $notification );
@@ -79,15 +78,14 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	 *
 	 * @param string $name            The plugin name to use for the unique ID.
 	 * @param array  $plugin          The plugin to retrieve the data from.
-	 * @param string $dependency_name The name of the dependency.
 	 *
 	 * @return Yoast_Notification The notification containing the suggested plugin.
 	 */
-	protected function get_yoast_seo_suggested_plugins_notification( $name, $plugin, $dependency_name ) {
-		$message = $this->create_install_suggested_plugin_message( $plugin, $dependency_name );
+	protected function get_yoast_seo_suggested_plugins_notification( $name, $plugin ) {
+		$message = $this->create_install_suggested_plugin_message( $plugin );
 
 		if ( $this->availability_checker->is_installed( $plugin ) && ! $this->availability_checker->is_active( $plugin['slug'] ) ) {
-			$message = $this->create_activate_suggested_plugin_message( $plugin, $dependency_name );
+			$message = $this->create_activate_suggested_plugin_message( $plugin );
 		}
 
 		return new Yoast_Notification(
@@ -104,11 +102,10 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	 * Creates a message to suggest the installation of a particular plugin.
 	 *
 	 * @param array $suggested_plugin   The suggested plugin.
-	 * @param array $third_party_plugin The third party plugin that we have a suggested plugin for.
 	 *
 	 * @return string The install suggested plugin message.
 	 */
-	protected function create_install_suggested_plugin_message( $suggested_plugin, $third_party_plugin ) {
+	protected function create_install_suggested_plugin_message( $suggested_plugin ) {
 		/* translators: %1$s expands to an opening strong tag, %2$s expands to the dependency name, %3$s expands to a closing strong tag, %4$s expands to and opening anchor tag, %5$s expands to a closing anchor tag. */
 		$message      = __( 'It looks like you aren\'t using our %1$s%2$s addon%3$s. %4$sUpgrade today%5$s to unlock more tools and SEO features to make your products stand out in search results.', 'wordpress-seo' );
 		$install_link = WPSEO_Admin_Utils::get_install_link( $suggested_plugin );
@@ -144,11 +141,10 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	 * Creates a message to suggest the activation of a particular plugin.
 	 *
 	 * @param array $suggested_plugin   The suggested plugin.
-	 * @param array $third_party_plugin The third party plugin that we have a suggested plugin for.
 	 *
 	 * @return string The activate suggested plugin message.
 	 */
-	protected function create_activate_suggested_plugin_message( $suggested_plugin, $third_party_plugin ) {
+	protected function create_activate_suggested_plugin_message( $suggested_plugin ) {
 		/* translators: %1$s expands to an opening strong tag, %2$s expands to the dependency name, %3$s expands to a closing strong tag, %4$s expands to and opening anchor tag, %5$s expands to a closing anchor tag. */
 		$message        = __( 'It looks like you\'ve installed our %1$s%2$s addon%3$s. %4$sActivate it now%5$s to unlock more tools and SEO features to make your products stand out in search results.', 'wordpress-seo' );
 		$activation_url = WPSEO_Admin_Utils::get_activation_url( $suggested_plugin['slug'] );

--- a/admin/class-suggested-plugins.php
+++ b/admin/class-suggested-plugins.php
@@ -106,7 +106,7 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	 * @return string The install suggested plugin message.
 	 */
 	protected function create_install_suggested_plugin_message( $suggested_plugin ) {
-		/* translators: %1$s expands to an opening strong tag, %2$s expands to the dependency name, %3$s expands to a closing strong tag, %4$s expands to and opening anchor tag, %5$s expands to a closing anchor tag. */
+		/* translators: %1$s expands to an opening strong tag, %2$s expands to the dependency name, %3$s expands to a closing strong tag, %4$s expands to an opening anchor tag, %5$s expands to a closing anchor tag. */
 		$message      = __( 'It looks like you aren\'t using our %1$s%2$s addon%3$s. %4$sUpgrade today%5$s to unlock more tools and SEO features to make your products stand out in search results.', 'wordpress-seo' );
 		$install_link = WPSEO_Admin_Utils::get_install_link( $suggested_plugin );
 

--- a/admin/class-suggested-plugins.php
+++ b/admin/class-suggested-plugins.php
@@ -109,16 +109,17 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	 * @return string The install suggested plugin message.
 	 */
 	protected function create_install_suggested_plugin_message( $suggested_plugin, $third_party_plugin ) {
-		/* translators: %1$s expands to Yoast SEO, %2$s expands to the dependency name, %3$s expands to the install link, %4$s expands to the more info link. */
-		$message      = __( '%1$s and %2$s can work together a lot better by adding a helper plugin. Please install %3$s to make your life better. %4$s.', 'wordpress-seo' );
+		/* translators: %1$s expands to an opening strong tag, %2$s expands to the dependency name, %3$s expands to a closing strong tag, %4$s expands to and opening anchor tag, %5$s expands to a closing anchor tag. */
+		$message      = __( 'It looks like you aren\'t using our %1$s%2$s addon%3$s. %4$sUpgrade today%5$s to unlock more tools and SEO features to make your products stand out in search results.', 'wordpress-seo' );
 		$install_link = WPSEO_Admin_Utils::get_install_link( $suggested_plugin );
 
 		return sprintf(
 			$message,
-			'Yoast SEO',
-			$third_party_plugin,
+			'<strong>',
 			$install_link,
-			$this->create_more_information_link( $suggested_plugin['url'], $suggested_plugin['title'] )
+			'</strong>',
+			$this->create_more_information_link( $suggested_plugin['url'], $suggested_plugin['title'] ),
+			'</a>'
 		);
 	}
 
@@ -132,11 +133,10 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	 */
 	protected function create_more_information_link( $url, $name ) {
 		return sprintf(
-			'<a href="%s" aria-label="%s" target="_blank" rel="noopener noreferrer">%s</a>',
+			'<a href="%s" aria-label="%s" target="_blank" rel="noopener noreferrer">',
 			$url,
 			/* translators: %1$s expands to the dependency name. */
-			sprintf( __( 'More information about %1$s', 'wordpress-seo' ), $name ),
-			__( 'More information', 'wordpress-seo' )
+			sprintf( __( 'More information about %1$s', 'wordpress-seo' ), $name )
 		);
 	}
 
@@ -149,15 +149,17 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	 * @return string The activate suggested plugin message.
 	 */
 	protected function create_activate_suggested_plugin_message( $suggested_plugin, $third_party_plugin ) {
-		/* translators: %1$s expands to Yoast SEO, %2$s expands to the dependency name, %3$s expands to activation link. */
-		$message        = __( '%1$s and %2$s can work together a lot better by adding a helper plugin. Please activate %3$s to make your life better.', 'wordpress-seo' );
+		/* translators: %1$s expands to an opening strong tag, %2$s expands to the dependency name, %3$s expands to a closing strong tag, %4$s expands to and opening anchor tag, %5$s expands to a closing anchor tag. */
+		$message        = __( 'It looks like you\'ve installed our %1$s%2$s addon%3$s. %4$sActivate it now%5$s to unlock more tools and SEO features to make your products stand out in search results.', 'wordpress-seo' );
 		$activation_url = WPSEO_Admin_Utils::get_activation_url( $suggested_plugin['slug'] );
 
 		return sprintf(
 			$message,
-			'Yoast SEO',
-			$third_party_plugin,
-			sprintf( '<a href="%s">%s</a>', $activation_url, $suggested_plugin['title'] )
+			'<strong>',
+			$suggested_plugin['title'],
+			'</strong>',
+			'<a href="' . $activation_url . '">',
+			'</a>'
 		);
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updated the message that recommends you to install WooCommerce SEO when WooCommerce is installed.

## Relevant technical choices:

* Removed `yoast_plugin_suggestions_notification` and  `get_yoast_seo_suggested_plugins_notification` from `WPSEO_Admin_Init`, because the coee is never executed. [This function](https://github.com/Yoast/wordpress-seo/pull/17313/files#diff-12ee615e5fe8e5cae1aa9d83ab002c96743a69001694a8c86639744193a4d042L91) will always return an empty array, therefore the following loop does nothing. The reason `get_plugins_with_dependencies` will always return an empty array is because `register()` is never called on `$checker`, which is necessary to instatiate the class' functionality. These functions are meant to register notifications regarding recommended plugins, but this functionality already exists (and actually works) in `WPSEO_Suggested_Plugins`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Uninstall (so actually remove) `wpseo-woocommerce`.
* Go to `SEO` > `Dashboard`. 
* Make sure the following notification is present and the link points to the `Benefits of Yoast WooCommerce SEO` page on yoast.com.
  <img width="734" alt="Screenshot 2021-08-04 at 14 43 14" src="https://user-images.githubusercontent.com/5389513/128182635-2cf3a9d0-6ddf-408a-9769-0bd29ca1f28b.png">
* Install (but do not activate) `wpseo-woocommerce`.
* Go to `SEO` > `Dashboard`. 
* Make sure the following notification is present.
  <img width="727" alt="Screenshot 2021-08-04 at 14 46 48" src="https://user-images.githubusercontent.com/5389513/128183065-644a2126-9f15-4c95-bfd0-dee285414c19.png">
* Click `Activate it now` and make sure woocommerce is activated.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
