### PR TITLE
Delete orphaned entries from Yoast tables with a scheduled action

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -74,6 +74,7 @@ class WPSEO_Upgrade {
 			'16.2-RC0'   => 'upgrade_162',
 			'16.5-RC0'   => 'upgrade_165',
 			'16.9-RC0'   => 'upgrade_169',
+			'17.0-RC0'   => 'upgrade_170',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -850,6 +851,22 @@ class WPSEO_Upgrade {
 					$indexables_to_clean
 				);
 			}
+		}
+	}
+
+	/**
+	 * Performs the 17.0 upgrade. shop_order indexables were cleaned from the indexable table in 16.9, so we have to clean out the orphaned entries from the rest of the tables.
+	 *
+	 * @return void
+	 */
+	private function upgrade_170() {
+		// Sets a scheduled job to do the cleanup eventually and not in the upgrade process itself. When that cleanup is completed, the job will de-register itself.
+		if ( ! wp_next_scheduled( 'wpseo_cleanup_orphaned_indexables' ) ) {
+			wp_schedule_event(
+				time(),
+				'hourly',
+				'wpseo_cleanup_orphaned_indexables'
+			);
 		}
 	}
 

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -83,12 +83,12 @@ class Cleanup_Integration implements Integration_Interface {
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: There is no unescaped user input.
 		$query = $wpdb->prepare(
 			"
-			SELECT h.{$column}
-			FROM {$table} h
-			LEFT JOIN {$indexable_table} AS i
-			ON h.{$column} = i.id
-			WHERE i.id IS NULL
-			AND h.{$column} IS NOT NULL
+			SELECT table_to_clean.{$column}
+			FROM {$table} table_to_clean
+			LEFT JOIN {$indexable_table} AS indexable_table
+			ON table_to_clean.{$column} = indexable_table.id
+			WHERE indexable_table.id IS NULL
+			AND table_to_clean.{$column} IS NOT NULL
 			LIMIT %d",
 			$limit
 		);

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -79,6 +79,10 @@ class Cleanup_Integration implements Integration_Interface {
 		$indexable_table = Model::get_table_name( 'Indexable' );
 		$limit           = \apply_filters( 'wpseo_cron_query_limit_size', $limit );
 
+		// Sanitize the $limit.
+		$limit = ! is_int( $limit ) ? 1000 : $limit;
+		$limit = $limit > 5000 ? 5000 : ( $limit <= 0 ? 1000 : $limit );
+
 		// Warning: If this query is changed, make sure to update the query in cleanup_orphaned_from_table in Premium as well.
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: There is no unescaped user input.
 		$query = $wpdb->prepare(

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -26,6 +26,7 @@ class Cleanup_Integration implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'wpseo_cleanup_indexables', [ $this, 'cleanup_obsolete_indexables' ], 10, 2 );
+		\add_action( 'wpseo_cleanup_orphaned_indexables', [ $this, 'cleanup_orphaned_indexables' ] );
 		\add_action( 'wpseo_deactivate', [ $this, 'unschedule_cron' ] );
 	}
 
@@ -41,8 +42,64 @@ class Cleanup_Integration implements Integration_Interface {
 		$number_of_deletions = $this->clean_indexables_with_object_type( $object_type, $object_sub_type, 1000 );
 
 		if ( empty( $number_of_deletions ) ) {
-			$this->unschedule_cron();
+			$this->unschedule_cron( 'wpseo_cleanup_indexables' );
 		}
+	}
+
+	/**
+	 * Cleans orphaned rows from the yoast tables and unregisters the cron if no deletions.
+	 *
+	 * @return void
+	 */
+	public function cleanup_orphaned_indexables() {
+		$deleted_orphans  = $this->cleanup_orphaned_from_table( 'Indexable_Hierarchy', 'indexable_id', 1000 );
+		$deleted_orphans += $this->cleanup_orphaned_from_table( 'SEO_Links', 'indexable_id', 1000 );
+		$deleted_orphans += $this->cleanup_orphaned_from_table( 'SEO_Links', 'target_indexable_id', 1000 );
+
+		if ( empty( $deleted_orphans ) ) {
+			$this->unschedule_cron( 'wpseo_cleanup_orphaned_indexables' );
+		}
+	}
+
+	/**
+	 * Cleans orphaned rows from a yoast table.
+	 *
+	 * @param string $table  The table to cleanup.
+	 * @param string $column The table column the cleanup will rely on.
+	 * @param int    $limit  The limit we'll apply to the queries.
+	 *
+	 * @return int The number of deleted rows.
+	 */
+	public function cleanup_orphaned_from_table( $table, $column, $limit = 1000 ) {
+		global $wpdb;
+
+		$table           = Model::get_table_name( $table );
+		$indexable_table = Model::get_table_name( 'Indexable' );
+		$limit           = \apply_filters( 'wpseo_cron_query_limit_size', $limit );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: There is no unescaped user input.
+		$query = $wpdb->prepare(
+			"
+			SELECT h.{$column}
+			FROM {$table} h
+			LEFT JOIN {$indexable_table} AS i
+			ON h.{$column} = i.id
+			WHERE i.id IS NULL
+			AND h.{$column} IS NOT NULL
+			LIMIT %d",
+			$limit
+		);
+		// phpcs:enable
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		$orphans = $wpdb->get_col( $query );
+
+		if ( empty( $orphans ) ) {
+			return 0;
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
+		return intval( $wpdb->query( "DELETE FROM $table WHERE {$column} IN( " . implode( ',', $orphans ) . ' ) ' ) );
 	}
 
 	/**
@@ -67,11 +124,17 @@ class Cleanup_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Unschedules the WP-Cron job to cleanup indexables.
+	 * Unschedules the WP-Cron jobs to cleanup indexables and orphaned rows.
 	 *
+	 * @param string|null $hook The hook to unregister.
 	 * @return void
 	 */
-	public function unschedule_cron() {
-		\wp_unschedule_hook( 'wpseo_cleanup_indexables' );
+	public function unschedule_cron( $hook = null ) {
+		if ( is_string( $hook ) && ! empty( $hook ) ) {
+			\wp_unschedule_hook( $hook );
+		} else {
+			\wp_unschedule_hook( 'wpseo_cleanup_indexables' );
+			\wp_unschedule_hook( 'wpseo_cleanup_orphaned_indexables' );
+		}
 	}
 }

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -56,6 +56,8 @@ class Cleanup_Integration implements Integration_Interface {
 		$deleted_orphans += $this->cleanup_orphaned_from_table( 'SEO_Links', 'indexable_id', 1000 );
 		$deleted_orphans += $this->cleanup_orphaned_from_table( 'SEO_Links', 'target_indexable_id', 1000 );
 
+		$deleted_orphans = \apply_filters( 'wpseo_cleanup_orphaned', $deleted_orphans );
+
 		if ( empty( $deleted_orphans ) ) {
 			$this->unschedule_cron( 'wpseo_cleanup_orphaned_indexables' );
 		}
@@ -77,6 +79,7 @@ class Cleanup_Integration implements Integration_Interface {
 		$indexable_table = Model::get_table_name( 'Indexable' );
 		$limit           = \apply_filters( 'wpseo_cron_query_limit_size', $limit );
 
+		// Warning: If this query is changed, make sure to update the query in cleanup_orphaned_from_table in Premium as well.
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: There is no unescaped user input.
 		$query = $wpdb->prepare(
 			"
@@ -132,7 +135,8 @@ class Cleanup_Integration implements Integration_Interface {
 	public function unschedule_cron( $hook = null ) {
 		if ( is_string( $hook ) && ! empty( $hook ) ) {
 			\wp_unschedule_hook( $hook );
-		} else {
+		}
+		else {
 			\wp_unschedule_hook( 'wpseo_cleanup_indexables' );
 			\wp_unschedule_hook( 'wpseo_cleanup_orphaned_indexables' );
 		}

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -81,7 +81,7 @@ class Cleanup_Integration implements Integration_Interface {
 
 		// Sanitize the $limit.
 		$limit = ! is_int( $limit ) ? 1000 : $limit;
-		$limit = $limit > 5000 ? 5000 : ( $limit <= 0 ? 1000 : $limit );
+		$limit = ( $limit > 5000 ) ? 5000 : ( ( $limit <= 0 ) ? 1000 : $limit );
 
 		// Warning: If this query is changed, make sure to update the query in cleanup_orphaned_from_table in Premium as well.
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: There is no unescaped user input.

--- a/tests/unit/integrations/cleanup-integration-test.php
+++ b/tests/unit/integrations/cleanup-integration-test.php
@@ -62,28 +62,28 @@ class Cleanup_Integration_Test extends TestCase {
 			->withAnyArgs()
 			->andReturn(
 				'
-				SELECT h.indexable_id
-				FROM wp_yoast_indexable_hierarchy h
-				LEFT JOIN wp_yoast_indexable AS i
-				ON h.indexable_id = i.id
-				WHERE i.id IS NULL
-				AND h.indexable_id IS NOT NULL
+				SELECT htable_to_clean.indexable_id
+				FROM wp_yoast_indexable_hierarchy table_to_clean
+				LEFT JOIN wp_yoast_indexable AS indexable_table
+				ON table_to_clean.indexable_id = indexable_table.id
+				WHERE indexable_table.id IS NULL
+				AND table_to_clean.indexable_id IS NOT NULL
 				LIMIT 1000',
 				'
-				SELECT h.indexable_id
-				FROM wp_yoast_seo_links h
-				LEFT JOIN wp_yoast_indexable AS i
-				ON h.indexable_id = i.id
-				WHERE i.id IS NULL
-				AND h.indexable_id IS NOT NULL
+				SELECT table_to_clean.indexable_id
+				FROM wp_yoast_seo_links table_to_clean
+				LEFT JOIN wp_yoast_indexable AS indexable_table
+				ON table_to_clean.indexable_id = indexable_table.id
+				WHERE indexable_table.id IS NULL
+				AND table_to_clean.indexable_id IS NOT NULL
 				LIMIT 1000',
 				'
-				SELECT h.target_indexable_id
-				FROM wp_yoast_seo_links h
-				LEFT JOIN wp_yoast_indexable AS i
-				ON h.target_indexable_id = i.id
-				WHERE i.id IS NULL
-				AND h.target_indexable_id IS NOT NULL
+				SELECT table_to_clean.target_indexable_id
+				FROM wp_yoast_seo_links table_to_clean
+				LEFT JOIN wp_yoast_indexable AS indexable_table
+				ON table_to_clean.target_indexable_id = indexable_table.id
+				WHERE indexable_table.id IS NULL
+				AND table_to_clean.target_indexable_id IS NOT NULL
 				LIMIT 1000'
 			);
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* With this PR we want to add a cron job that will gradually clean in chunks every orphaned entry from the seo_links and indexable_hierarchy and prominent_words tables. Those orphaned entries can be orphaned because the respective entries from the indexable table have been previously cleaned with https://github.com/Yoast/wordpress-seo/pull/17234
* That cron job will unregister itself when there's no deletion in those tables, which means that when the cleanup is complete, we no longer query for orphaned entries
* Although the original task at hand talked about orphaned entries due to cleanup of the shop_order indexables, this PR cleans up EVERY orphaned entry in those table, not specifically shop_order indexables.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Cleans up orphaned db entries from Yoast tables, in order to improve performance

## Relevant technical choices:

* Each cron job iteration will check for orphaned indexable ids in chunks of 1000. 
* When no cleanup is performed in one cron job iteration, the cron job will unregister itself
* In order to perform cleanup in the prominent_words table, we allow Premium to hook into the cleanup_orphaned_indexables() method.
* Because there's no way we can safely retrieve only shop_order indexables, since the indexable cleanup may have been already performed, we base the cleanup on whether the entries from the seo_links and indexable_hierarchy and prominent_words tables have respective entries in the indexable table. 
* Upon plugin deactivation, the cron job will be de-registered.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* To be tested in tandem with https://github.com/Yoast/wordpress-seo-premium/pull/3414, so checkout that branch in Premium as well.
* Add the `add_filter( "wpseo_cron_query_limit_size", function() { return 1; } );` code [via mu-plugin](https://wordpress.org/support/article/must-use-plugins/). That way we will work with a chunk of 1, instead of 1000.
	* E.g. add a `wpseo-test.php` file in `wp-content/mu-plugins` with the following code:
	  ```php
	  <php
	  add_filter( "wpseo_cron_query_limit_size", function() { return 1; } );
	  ```
* Comment out/remove line 140 from `src/integrations/admin/background-indexing-integration.php`.
	* E.g. this line: `\register_shutdown_function( [ $this, 'index' ] );`.
	* This prevents the indexables that you will remove in the near future to be recreated.

#### Create a couple of indexables
* Create a post.
* Add content to the post (at least 200 words for prominent words to be generated).
* Add links in the content of the post.
* Add an image in the content of the post.
* Add a category to the post.
* Note down the post id of the post. (can be found in the URL of the editor: `...?post={post_id}`)
* Publish the post. 
	* This will create a new indexable for the post in the database.
* Create another post.
* Add content to the post (at least 200 words for prominent words to be generated).
* Add a link to the post you created earlier.
* Add a category to the post.
* Note down the post id of the post.
* Publish the post. 
	* This will create a new indexable for the post in the database.

#### Remove the created indexables.
We want to have links, prominent words and entries in the hierarchy table (used for generating bread crumbs) that mention a indexable (e.g. post, term) that does not exist anymore. This way, we can test if this PR (and the accompanying Premium PR) correctly cleans them up.
* Open your database tool of choice.
* In the `wp_yoast_indexable` database table, remove the two indexables that were created for the two posts you published before. 
	* E.g. the two indexables that have `object_type` post and `object_id` the post id you noted down earlier.
	* Please note down their indexable ids.

#### Testing whether the orphaned entries in the hierarchy, links and prominent words tables are removed.
* Now, lets test the PR.
* In Tools->Yoast test, set as DB version for Yoast SEO, a version lower than what the current RC/PR is on. So, if we're on 16.9, set 17.0 there
* Once you hit Save, the upgrade routine will be performed. The routine should add a cron job that whenever run, it will delete rows from the seo_links and indexable_hierarchy and prominent_words tables based on 1 deleted id from the indexable table.
	* Check whether all the entries in the `wp_yoast_seo_links` that mention the removed post got removed.
		* You can use the following SQL query (no entries should be returned): 
		  ```sql
		  SELECT * FROM wp_yoast_seo_links WHERE post_id = {post_id} OR target_post_id = {post_id}
		  ```
		* Check both post ids, since we do not know which one got removed first.
	* Check whether all the entries in the `wp_yoast_indexable_hierarchy` that mention the removed post got removed.
		* You can use the following SQL query: 
		```sql
		SELECT * FROM wp_yoast_indexable_hierarchy WHERE indexable_id = {indexable_id} OR ancestor_id = {indexable_id}
		```
	* Check whether all the entries in the `wp_yoast_prominent_words` that mention the removed post got removed.
		* You can use the following SQL query: 
		```sql
		SELECT * FROM wp_yoast_prominent_words WHERE indexable_id = {indexable_id}
		```	
* With WP Crontrol enabled, go to the Tools->Cron Events page and confirm that the `wpseo_cleanup_orphaned_indexables ` action exists.
* Run the `wpseo_cleanup_orphaned_indexables ` action from that page, so we dont have to wait 1 hour to be triggered.
* That next trigger should again delete rows from the seo_links and indexable_hierarchy and prominent_words tables based on 1 deleted id from the indexable table.
	* Check whether all its entries in the seo_links and indexable_hierarchy and prominent_words tables got removed as well (see the steps above).
* Run the `wpseo_cleanup_orphaned_indexables ` action from that page again, so we dont have to wait 1 hour to be triggered.
* No deletion should have happened now, since we have run out of orphaned entries. The `wpseo_cleanup_orphaned_indexables ` action should have been removed from the Tools->Cron Events page.
* The test is done, you can restore your db to its original state.



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Upon plugin deactivation, both the `wpseo_cleanup_indexables` and the `wpseo_cleanup_orphaned_indexables` cron job should be deleted.
* In http://basic.wordpress.test/wp-admin/tools.php?page=crontrol_admin_manage_page&action=new-cron add those two cron jobs.
* Deactivate the Yoast Free plugin
* Confirm in the Tools->Cron Events page, that the two cron job have been deleted.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
