### PR TITLE
Remove flesch reading ease assessment from the blog posts and pages a…

### DIFF
--- a/packages/yoastseo/src/scoring/storePostsAndPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/contentAssessor.js
@@ -1,5 +1,4 @@
 import Assessor from "../assessor.js";
-import fleschReadingEase from "../assessments/readability/fleschReadingEaseAssessment.js";
 import ParagraphTooLong from "../assessments/readability/ParagraphTooLongAssessment.js";
 import SentenceLengthInText from "../assessments/readability/SentenceLengthInTextAssessment.js";
 import SubheadingDistributionTooLong from "../assessments/readability/SubheadingDistributionTooLongAssessment.js";
@@ -35,7 +34,6 @@ const StorePostsAndPagesContentAssessor = function( i18n, researcher, options = 
 	this.type = "storePostsAndPagesContentAssessor";
 	this._assessments = [
 
-		fleschReadingEase,
 		new SubheadingDistributionTooLong(),
 		new ParagraphTooLong(),
 		new SentenceLengthInText(),

--- a/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/contentAssessor.js
@@ -1,6 +1,5 @@
 import Assessor from "../../assessor.js";
 import ContentAssessor from "../../contentAssessor";
-import fleschReadingEase from "../../assessments/readability/fleschReadingEaseAssessment.js";
 import ParagraphTooLong from "../../assessments/readability/ParagraphTooLongAssessment.js";
 import SentenceLengthInText from "../../assessments/readability/SentenceLengthInTextAssessment.js";
 import SubheadingDistributionTooLong from "../../assessments/readability/SubheadingDistributionTooLongAssessment.js";
@@ -31,7 +30,6 @@ const StorePostsAndPagesCornerstoneContentAssessor = function( i18n, options = {
 
 	this._assessments = [
 
-		fleschReadingEase,
 		new SubheadingDistributionTooLong( {
 			parameters:	{
 				slightlyTooMany: 250,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Removes Flesch Reading Ease assessment from the blog posts and pages assessors.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In apps/content-analysis/src/App.js on the line before `worker.initialize( config )`, please add this (don't commit):
```
config.customAnalysisType = "storePostsAndPages";
```
* Run the content analysis app and add some text
* Confirm that the Flesch Reading Ease assessment doesn't show up in `Readability Analysis`.
* Turn the `Is a cornerstone article` toggle on
* Confirm that the Flesch Reading Ease assessment still doesn't show up in `Readability Analysis`.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #https://yoast.atlassian.net/browse/LINGO-976
