### PR TITLE
Adjust recommended text length values for non-cornerstone collections pages

### DIFF
--- a/packages/yoastseo/spec/scoring/collectionPages/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/seoAssessorSpec.js
@@ -199,9 +199,9 @@ describe( "running assessments in the collection page SEO assessor", function() 
 
 		expect( assessment ).toBeDefined();
 		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.recommendedMinimum ).toBe( 250 );
-		expect( assessment._config.slightlyBelowMinimum ).toBe( 200 );
-		expect( assessment._config.belowMinimum ).toBe( 100 );
-		expect( assessment._config.veryFarBelowMinimum ).toBe( 50 );
+		expect( assessment._config.recommendedMinimum ).toBe( 80 );
+		expect( assessment._config.slightlyBelowMinimum ).toBe( 50 );
+		expect( assessment._config.belowMinimum ).toBe( 20 );
+		expect( assessment._config.veryFarBelowMinimum ).toBe( 10 );
 	} );
 } );

--- a/packages/yoastseo/src/scoring/collectionPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/collectionPages/seoAssessor.js
@@ -23,10 +23,10 @@ import KeyphraseDistribution from "./../assessments/seo/KeyphraseDistributionAss
 export const getTextLengthAssessment = function() {
 	// Export so it can be used in tests.
 	return new TextLengthAssessment( {
-		recommendedMinimum: 250,
-		slightlyBelowMinimum: 200,
-		belowMinimum: 100,
-		veryFarBelowMinimum: 50,
+		recommendedMinimum: 80,
+		slightlyBelowMinimum: 50,
+		belowMinimum: 20,
+		veryFarBelowMinimum: 10,
 		urlTitle: createAnchorOpeningTag( "https://yoa.st/34j" ),
 		urlCallToAction: createAnchorOpeningTag( "https://yoa.st/34k" ),
 	} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adjust recommended text length values for non-cornerstone collections pages so that they are lower than the cornerstone ones.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In apps/content-analysis/src/App.js on the line before worker.initialize( config ), please add this (don't commit):
```
config.customAnalysisType = "collectionPage";
```
* Make sure the cornerstone toggle is off
* Add a text of 80 words, e.g. `Figure out what you want to write. The large field of creative writing splits into subcategories (fiction, poetry, creative nonfiction) and there are even specialized genres (sci-fi, mysteries, experimental… the list goes on). Figure out what you want to write. Write what you would want to read. Your best writing will spring forth from something that you, and maybe only you, are passionate about. No one can write the way you write. When your passion is injected into your writing.`
* Confirm that the text length assessment returns a green bullet and the following feedback: `Text length: The text contains 80 words. Good job!`
* Remove one word from the text. Confirm that the text length assessment returns an orange bullet and the following feedback: `Text length: The text contains 79 words. This is slightly below the recommended minimum of 80 words. Add a bit more copy.`
* Remove some text so that it's 50 words long: `Figure out what exactly you would want to write. The large field of creative writing splits into subcategories (fiction, poetry, creative nonfiction) and there are even specialized genres (sci-fi, mysteries, experimental… the list goes on). Figure out what you want to write and write what you would want to read. ` Confirm that the feedback is the same as in the previous step.
* Remove one word from the text. Confirm that the text length assessment returns a red bullet and the following feedback: `Text length: The text contains 49 words. This is below the recommended minimum of 80 words. Add more content.`
* Remove some text so that it's 20 words long: `Figure out what you would want to write. The field of writing splits into subcategories, there are even specialized genres.`
 Confirm that the feedback is the same as in the previous step.
* Remove one word from the text. Confirm that the text length assessment returns a red bullet and the following feedback: `Text length: The text contains 19 words. This is far below the recommended minimum of 80 words. Add more content.`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #https://yoast.atlassian.net/secure/RapidBoard.jspa?rapidView=99&modal=detail&selectedIssue=LINGO-984
