### PR TITLE
Set isRelatedKeyphrase to true in related keyword assessor for keyphrase length assesment

### DIFF
--- a/packages/yoastseo/spec/scoring/cornerstone/relatedKeywordAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/cornerstone/relatedKeywordAssessorSpec.js
@@ -74,3 +74,23 @@ describe( "running assessments in the assessor", function() {
 		] );
 	} );
 } );
+
+describe( "has configuration overrides", () => {
+	test( "KeyphraseLength", () => {
+		const assessment = assessor.getAssessment( "keyphraseLength" );
+
+		expect( assessment ).toBeDefined();
+		expect( assessment._config ).toBeDefined();
+		expect( assessment._config.isRelatedKeyphrase ).toBeTruthy();
+	} );
+
+	test( "ImageKeyphrase", () => {
+		const assessment = assessor.getAssessment( "imageKeyphrase" );
+
+		expect( assessment ).toBeDefined();
+		expect( assessment._config ).toBeDefined();
+		expect( assessment._config.scores.withAltNonKeyword ).toBe( 3 );
+		expect( assessment._config.scores.withAlt ).toBe( 3 );
+		expect( assessment._config.scores.noAlt ).toBe( 3 );
+	} );
+} );

--- a/packages/yoastseo/src/scoring/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/cornerstone/relatedKeywordAssessor.js
@@ -24,7 +24,7 @@ const relatedKeywordAssessor = function( i18n, options ) {
 
 	this._assessments = [
 		new IntroductionKeyword(),
-		new KeyphraseLength(),
+		new KeyphraseLength( { isRelatedKeyphrase: true } ),
 		new KeywordDensity(),
 		new MetaDescriptionKeyword(),
 		new TextCompetingLinks(),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets `isRelatedKeyphrase` to `true` for keyphrase length assesment in related keyword assessor in cornerstone.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Build the free plugin from this branch
* In `wordpress-seo-premium`, run this command `composer require yoast/wordpress-seo:dev-LINGO-983-adjust-keyphrase-length-config-in-related-keyword-assessor@dev` and build the premium plugin
* Make sure that the Free and Premium plugins are activated.
* Set the `Cornerstone content` toggle on.
* Set a related keyphrase with one word.
* Make sure the feedback is `Keyphrase length: Good job!`
* Delete the related keyphrase.
* Confirm that the feedback is `Keyphrase length: Set a keyphrase in order to calculate your SEO score.`


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-983
