### PR TITLE
Also set custom options when setting the custom assessors

### DIFF
--- a/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
+++ b/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
@@ -1807,39 +1807,46 @@ describe( "AnalysisWebWorker", () => {
 	} );
 
 	describe( "set assessors", () => {
+		const customAssessorOptions = { url: "url" };
 		beforeEach( () => {
 			scope = createScope();
 			worker = new AnalysisWebWorker( scope, researcher );
 		} );
 
 		it( "can set a custom SEO assessor.", () => {
-			worker.setCustomSEOAssessorClass( SEOAssessor, "test" );
+			worker.setCustomSEOAssessorClass( SEOAssessor, "test", customAssessorOptions  );
 			expect( worker._CustomSEOAssessorClasses.test ).toBe( SEOAssessor );
+			expect( worker._CustomSEOAssessorOptions.test ).toBe( customAssessorOptions );
 		} );
 
 		it( "can set a custom cornerstone SEO assessor.", () => {
-			worker.setCustomCornerstoneSEOAssessorClass( SEOAssessor, "test" );
+			worker.setCustomCornerstoneSEOAssessorClass( SEOAssessor, "test", customAssessorOptions );
 			expect( worker._CustomCornerstoneSEOAssessorClasses.test ).toBe( SEOAssessor );
+			expect( worker._CustomCornerstoneSEOAssessorOptions.test ).toBe( customAssessorOptions );
 		} );
 
 		it( "can set a custom content assessor.", () => {
-			worker.setCustomContentAssessorClass( SEOAssessor, "test" );
+			worker.setCustomContentAssessorClass( SEOAssessor, "test", customAssessorOptions );
 			expect( worker._CustomContentAssessorClasses.test ).toBe( SEOAssessor );
+			expect( worker._CustomContentAssessorOptions.test ).toBe( customAssessorOptions );
 		} );
 
 		it( "can set a custom cornerstone content assessor.", () => {
-			worker.setCustomCornerstoneContentAssessorClass( SEOAssessor, "test" );
+			worker.setCustomCornerstoneContentAssessorClass( SEOAssessor, "test", customAssessorOptions );
 			expect( worker._CustomCornerstoneContentAssessorClasses.test ).toBe( SEOAssessor );
+			expect( worker._CustomCornerstoneContentAssessorOptions.test ).toBe( customAssessorOptions );
 		} );
 
 		it( "can set a custom related keyword assessor.", () => {
-			worker.setCustomRelatedKeywordAssessorClass( SEOAssessor, "test" );
+			worker.setCustomRelatedKeywordAssessorClass( SEOAssessor, "test", customAssessorOptions );
 			expect( worker._CustomRelatedKeywordAssessorClasses.test ).toBe( SEOAssessor );
+			expect( worker._CustomRelatedKeywordAssessorOptions.test ).toBe( customAssessorOptions );
 		} );
 
 		it( "can set a custom cornerstone related keyword assessor.", () => {
-			worker.setCustomCornerstoneRelatedKeywordAssessorClass( SEOAssessor, "test" );
+			worker.setCustomCornerstoneRelatedKeywordAssessorClass( SEOAssessor, "test", customAssessorOptions );
 			expect( worker._CustomCornerstoneRelatedKeywordAssessorClasses.test ).toBe( SEOAssessor );
+			expect( worker._CustomCornerstoneRelatedKeywordAssessorOptions.test ).toBe( customAssessorOptions );
 		} );
 	} );
 } );

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -155,13 +155,15 @@ export default class AnalysisWebWorker {
 	/**
 	 * Sets a custom content assessor class.
 	 *
-	 * @param {Class}   ContentAssessorClass    A content assessor class.
-	 * @param {string } customAnalysisType      The type of analysis.
+	 * @param {Class}  ContentAssessorClass     A content assessor class.
+	 * @param {string} customAnalysisType       The type of analysis.
+	 * @param {Object} customAssessorOptions    The options to use.
 	 *
 	 * @returns {void}
 	 */
-	setCustomContentAssessorClass( ContentAssessorClass, customAnalysisType ) {
+	setCustomContentAssessorClass( ContentAssessorClass, customAnalysisType, customAssessorOptions ) {
 		this._CustomContentAssessorClasses[ customAnalysisType ] = ContentAssessorClass;
+		this._CustomContentAssessorOptions[ customAnalysisType ] = customAssessorOptions;
 	}
 
 	/**
@@ -169,35 +171,41 @@ export default class AnalysisWebWorker {
 	 *
 	 * @param {Class}  CornerstoneContentAssessorClass  A cornerstone content assessor class.
 	 * @param {string} customAnalysisType               The type of analysis.
+	 * @param {Object} customAssessorOptions            The options to use.
 	 *
 	 * @returns {void}
 	 */
-	setCustomCornerstoneContentAssessorClass( CornerstoneContentAssessorClass, customAnalysisType ) {
+	setCustomCornerstoneContentAssessorClass( CornerstoneContentAssessorClass, customAnalysisType, customAssessorOptions ) {
 		this._CustomCornerstoneContentAssessorClasses[ customAnalysisType ] = CornerstoneContentAssessorClass;
+		this._CustomCornerstoneContentAssessorOptions[ customAnalysisType ] = customAssessorOptions;
 	}
 
 	/**
 	 * Sets a custom SEO assessor class.
 	 *
-	 * @param {Class} SEOAssessorClass      An SEO assessor class.
-	 * @param {string} customAnalysisType  The type of analysis.
+	 * @param {Class}   SEOAssessorClass         An SEO assessor class.
+	 * @param {string}  customAnalysisType       The type of analysis.
+	 * @param {Object}  customAssessorOptions    The options to use.
 	 *
 	 * @returns {void}
 	 */
-	setCustomSEOAssessorClass( SEOAssessorClass, customAnalysisType ) {
+	setCustomSEOAssessorClass( SEOAssessorClass, customAnalysisType, customAssessorOptions ) {
 		this._CustomSEOAssessorClasses[ customAnalysisType ] = SEOAssessorClass;
+		this._CustomSEOAssessorOptions[ customAnalysisType ] = customAssessorOptions;
 	}
 
 	/**
 	 * Sets a custom cornerstone SEO assessor class.
 	 *
-	 * @param {Class} CornerstoneSEOAssessorClass   A cornerstone SEO assessor class.
-	 * @param {string} customAnalysisType          The type of analysis.
+	 * @param {Class}   CornerstoneSEOAssessorClass  A cornerstone SEO assessor class.
+	 * @param {string}  customAnalysisType           The type of analysis.
+	 * @param {Object}  customAssessorOptions        The options to use.
 	 *
 	 * @returns {void}
 	 */
-	setCustomCornerstoneSEOAssessorClass( CornerstoneSEOAssessorClass, customAnalysisType ) {
+	setCustomCornerstoneSEOAssessorClass( CornerstoneSEOAssessorClass, customAnalysisType, customAssessorOptions ) {
 		this._CustomCornerstoneSEOAssessorClasses[ customAnalysisType ] = CornerstoneSEOAssessorClass;
+		this._CustomCornerstoneSEOAssessorOptions[ customAnalysisType ] = customAssessorOptions;
 	}
 
 	/**
@@ -205,23 +213,27 @@ export default class AnalysisWebWorker {
 	 *
 	 * @param {Class}   RelatedKeywordAssessorClass A related keyword assessor class.
 	 * @param {string}  customAnalysisType          The type of analysis.
+	 * @param {Object}  customAssessorOptions       The options to use.
 	 *
 	 * @returns {void}
 	 */
-	setCustomRelatedKeywordAssessorClass( RelatedKeywordAssessorClass, customAnalysisType ) {
+	setCustomRelatedKeywordAssessorClass( RelatedKeywordAssessorClass, customAnalysisType, customAssessorOptions ) {
 		this._CustomRelatedKeywordAssessorClasses[ customAnalysisType ] = RelatedKeywordAssessorClass;
+		this._CustomRelatedKeywordAssessorOptions[ customAnalysisType ] = customAssessorOptions;
 	}
 
 	/**
 	 * Sets a custom cornerstone related keyword assessor class.
 	 *
-	 * @param {Class}   CornerstoneRelatedKeywordAssessorClass A cornerstone related keyword assessor class.
-	 * @param {string}  customAnalysisType                     The type of analysis.
-
+	 * @param {Class}   CornerstoneRelatedKeywordAssessorClass  A cornerstone related keyword assessor class.
+	 * @param {string}  customAnalysisType                      The type of analysis.
+	 * @param {Object}  customAssessorOptions                   The options to use.
+	 *
 	 * @returns {void}
 	 */
-	setCustomCornerstoneRelatedKeywordAssessorClass( CornerstoneRelatedKeywordAssessorClass, customAnalysisType ) {
+	setCustomCornerstoneRelatedKeywordAssessorClass( CornerstoneRelatedKeywordAssessorClass, customAnalysisType, customAssessorOptions  ) {
 		this._CustomCornerstoneRelatedKeywordAssessorClasses[ customAnalysisType ] = CornerstoneRelatedKeywordAssessorClass;
+		this._CustomCornerstoneRelatedKeywordAssessorOptions[ customAnalysisType ] = customAssessorOptions;
 	}
 
 	/**
@@ -249,6 +261,14 @@ export default class AnalysisWebWorker {
 		this._CustomCornerstoneContentAssessorClasses = {};
 		this._CustomRelatedKeywordAssessorClasses = {};
 		this._CustomCornerstoneRelatedKeywordAssessorClasses = {};
+
+		// Custom assessor options.
+		this._CustomSEOAssessorOptions = {};
+		this._CustomCornerstoneSEOAssessorOptions = {};
+		this._CustomContentAssessorOptions = {};
+		this._CustomCornerstoneContentAssessorOptions = {};
+		this._CustomRelatedKeywordAssessorOptions = {};
+		this._CustomCornerstoneRelatedKeywordAssessorOptions = {};
 
 		// Registered assessments
 		this._registeredTreeAssessments = [];
@@ -404,7 +424,10 @@ export default class AnalysisWebWorker {
 			 * otherwise set the default cornerstone content assessor.
 			 */
 			assessor = this._CustomCornerstoneContentAssessorClasses[ customAnalysisType ]
-				? new this._CustomCornerstoneContentAssessorClasses[ customAnalysisType ]( this._i18n, this._researcher )
+				? new this._CustomCornerstoneContentAssessorClasses[ customAnalysisType ](
+					this._i18n,
+					this._researcher,
+					this._CustomCornerstoneContentAssessorOptions[ customAnalysisType ] )
 				: new CornerstoneContentAssessor( this._i18n, this._researcher );
 		} else {
 			/*
@@ -412,7 +435,10 @@ export default class AnalysisWebWorker {
 	         * otherwise use the default SEO assessor.
 			 */
 			assessor = this._CustomContentAssessorClasses[ customAnalysisType ]
-				? new this._CustomContentAssessorClasses[ customAnalysisType ]( this._i18n, this._researcher )
+				? new this._CustomContentAssessorClasses[ customAnalysisType ](
+					this._i18n,
+					this._researcher,
+					this._CustomContentAssessorOptions[ customAnalysisType ] )
 				: new ContentAssessor( this._i18n, this._researcher );
 		}
 
@@ -446,7 +472,10 @@ export default class AnalysisWebWorker {
 			if ( useCornerstone === true ) {
 				// Use a custom cornerstone SEO assessor if available, otherwise set the default cornerstone SEO assessor.
 				assessor = this._CustomCornerstoneSEOAssessorClasses[ customAnalysisType ]
-					? new this._CustomCornerstoneSEOAssessorClasses[ customAnalysisType ]( this._i18n, this._researcher )
+					? new this._CustomCornerstoneSEOAssessorClasses[ customAnalysisType ](
+						this._i18n,
+						this._researcher,
+						this._CustomCornerstoneSEOAssessorOptions[ customAnalysisType ] )
 					: new CornerstoneSEOAssessor( this._i18n, this._researcher );
 			} else {
 			/*
@@ -454,7 +483,10 @@ export default class AnalysisWebWorker {
 			 * otherwise use the default SEO assessor.
 			 */
 				assessor = this._CustomSEOAssessorClasses[ customAnalysisType ]
-					? new this._CustomSEOAssessorClasses[ customAnalysisType ]( this._i18n, this._researcher )
+					? new this._CustomSEOAssessorClasses[ customAnalysisType ](
+						this._i18n,
+						this._researcher,
+						this._CustomSEOAssessorOptions[ customAnalysisType ] )
 					: new SEOAssessor( this._i18n, this._researcher );
 			}
 		}
@@ -498,7 +530,10 @@ export default class AnalysisWebWorker {
 			if ( useCornerstone === true ) {
 				// Use a custom related keyword assessor if available, otherwise use the default related keyword assessor.
 				assessor = this._CustomCornerstoneRelatedKeywordAssessorClasses[ customAnalysisType ]
-					? new this._CustomCornerstoneRelatedKeywordAssessorClasses[ customAnalysisType ]( this._i18n, this._researcher )
+					? new this._CustomCornerstoneRelatedKeywordAssessorClasses[ customAnalysisType ](
+						this._i18n,
+						this._researcher,
+						this._CustomCornerstoneRelatedKeywordAssessorOptions[ customAnalysisType ] )
 					: new CornerstoneRelatedKeywordAssessor( this._i18n, this._researcher );
 			} else {
 			/*
@@ -506,7 +541,10 @@ export default class AnalysisWebWorker {
 			 * otherwise use the default related keyword assessor.
 			 */
 				assessor = this._CustomRelatedKeywordAssessorClasses[ customAnalysisType ]
-					? new this._CustomRelatedKeywordAssessorClasses[ customAnalysisType ]( this._i18n, this._researcher )
+					? new this._CustomRelatedKeywordAssessorClasses[ customAnalysisType ](
+						this._i18n,
+						this._researcher,
+						this._CustomRelatedKeywordAssessorOptions[ customAnalysisType ] )
 					: new RelatedKeywordAssessor( this._i18n, this._researcher );
 			}
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds functionality for the webworker to also set custom options when loading the custom assessors for the SEO analysis (regular/cornerstone), the SEO analysis for related keyphrases (regular/cornerstone), and the readability analysis (regular/cornerstone).


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run `yarn test` and make sure everything is passing.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-990
