### PR TITLE
Replace assessment shortlinks in product assessors with variables

### DIFF
--- a/packages/yoastseo/spec/scoring/productPages/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/contentAssessorSpec.js
@@ -99,7 +99,22 @@ describe( "A product page content assessor", function() {
 		} );
 	} );
 	describe( "has configuration overrides", () => {
-		const assessor = new ContentAssessor( i18n );
+		const assessor = new ContentAssessor( i18n, {
+			subheadingUrlTitle: "https://yoast.com/1",
+			subheadingCTAUrl: "https://yoast.com/2",
+			paragraphUrlTitle: "https://yoast.com/3",
+			paragraphCTAUrl: "https://yoast.com/4",
+			sentenceLengthUrlTitle: "https://yoast.com/5",
+			sentenceLengthCTAUrl: "https://yoast.com/6",
+			transitionWordsUrlTitle: "https://yoast.com/7",
+			transitionWordsCTAUrl: "https://yoast.com/8",
+			passiveVoiceUrlTitle: "https://yoast.com/9",
+			passiveVoiceCTAUrl: "https://yoast.com/10",
+			textPresenceUrlTitle: "https://yoast.com/11",
+			textPresenceCTAUrl: "https://yoast.com/12",
+			listsUrlTitle: "https://yoast.com/13",
+			listsCTAUrl: "https://yoast.com/14",
+		} );
 
 		test( "SubheadingsDistributionTooLong", () => {
 			const assessment = assessor.getAssessment( "subheadingsTooLong" );
@@ -108,8 +123,19 @@ describe( "A product page content assessor", function() {
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.shouldNotAppearInShortText ).toBeDefined();
 			expect( assessment._config.shouldNotAppearInShortText ).toBe( true );
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify68' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify69' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/1' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/2' target='_blank'>" );
+		} );
+
+		test( "ParagraphTooLong", () => {
+			const assessment = assessor.getAssessment( "textParagraphTooLong" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.parameters.recommendedLength ).toBe( 70 );
+			expect( assessment._config.parameters.maximumRecommendedLength ).toBe( 100 );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/3' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/4' target='_blank'>" );
 		} );
 
 		test( "SentenceLengthAssessment", () => {
@@ -120,19 +146,8 @@ describe( "A product page content assessor", function() {
 			expect( assessment._config.slightlyTooMany ).toBe( 20 );
 			expect( assessment._config.farTooMany ).toBe( 25 );
 			expect( assessment._isProduct ).toBe( true );
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify48' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify49' target='_blank'>" );
-		} );
-
-		test( "ParagraphTooLong", () => {
-			const assessment = assessor.getAssessment( "textParagraphTooLong" );
-
-			expect( assessment ).toBeDefined();
-			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.parameters.recommendedLength ).toBe( 70 );
-			expect( assessment._config.parameters.maximumRecommendedLength ).toBe( 100 );
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify66' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify67' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/5' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/6' target='_blank'>" );
 		} );
 
 		test( "TransitionWords", () => {
@@ -140,8 +155,8 @@ describe( "A product page content assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify44' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify45' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/7' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/8' target='_blank'>" );
 		} );
 
 		test( "PassiveVoice", () => {
@@ -149,8 +164,8 @@ describe( "A product page content assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify42' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify43' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/9' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/10' target='_blank'>" );
 		} );
 
 		test( "TextPresence", () => {
@@ -158,8 +173,8 @@ describe( "A product page content assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify56' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify57' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/11' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/12' target='_blank'>" );
 		} );
 
 		test( "ListsPresence", () => {
@@ -167,8 +182,8 @@ describe( "A product page content assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify38' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify39' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/13' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/14' target='_blank'>" );
 		} );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/productPages/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/contentAssessorSpec.js
@@ -5,6 +5,22 @@ import Factory from "../../specHelpers/factory.js";
 import Paper from "../../../src/values/Paper.js";
 
 const i18n = Factory.buildJed();
+const options = {
+	subheadingUrlTitle: "https://yoast.com/1",
+	subheadingCTAUrl: "https://yoast.com/2",
+	paragraphUrlTitle: "https://yoast.com/3",
+	paragraphCTAUrl: "https://yoast.com/4",
+	sentenceLengthUrlTitle: "https://yoast.com/5",
+	sentenceLengthCTAUrl: "https://yoast.com/6",
+	transitionWordsUrlTitle: "https://yoast.com/7",
+	transitionWordsCTAUrl: "https://yoast.com/8",
+	passiveVoiceUrlTitle: "https://yoast.com/9",
+	passiveVoiceCTAUrl: "https://yoast.com/10",
+	textPresenceUrlTitle: "https://yoast.com/11",
+	textPresenceCTAUrl: "https://yoast.com/12",
+	listsUrlTitle: "https://yoast.com/13",
+	listsCTAUrl: "https://yoast.com/14",
+};
 
 describe( "A product page content assessor", function() {
 	describe( "Checks the applicable assessments for text containing less than 300 words", function() {
@@ -22,7 +38,7 @@ describe( "A product page content assessor", function() {
 				"accommodare. Mutat gloriatur ex cum, rebum salutandi ei his, vis delenit quaestio ne. Iisque qualisque duo ei. " +
 				"Splendide tincidunt te sit, commune oporteat quo id. Sumo recusabo suscipiantur duo an, no eum malis vulputate " +
 				"consectetuer. Mel te noster invenire, nec ad vidisse constituto. Eos ut quod.", { locale: "en_US" } );
-			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ) );
+			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ), options );
 
 			contentAssessor.getPaper = function() {
 				return paper;
@@ -41,7 +57,7 @@ describe( "A product page content assessor", function() {
 
 		it( "Should have 4 available assessments for a basic supported language", function() {
 			const paper = new Paper( "test", { locale: "xx_XX" } );
-			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ) );
+			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ), options );
 
 			contentAssessor.getPaper = function() {
 				return paper;
@@ -61,7 +77,7 @@ describe( "A product page content assessor", function() {
 	describe( "Checks the applicable assessments for text containing more than 300 words", function() {
 		it( "Should have 7 available assessments for a fully supported language", function() {
 			const paper = new Paper( "beautiful cats ".repeat( 200 ), { locale: "en_US" } );
-			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ) );
+			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ), options );
 
 			contentAssessor.getPaper = function() {
 				return paper;
@@ -81,7 +97,7 @@ describe( "A product page content assessor", function() {
 
 		it( "Should have 5 available assessments for a basic supported language", function() {
 			const paper = new Paper( "test ".repeat( 310 ), { locale: "xx_XX" } );
-			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ) );
+			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ), options );
 
 			contentAssessor.getPaper = function() {
 				return paper;
@@ -99,7 +115,9 @@ describe( "A product page content assessor", function() {
 		} );
 	} );
 	describe( "has configuration overrides", () => {
-		const assessor = new ContentAssessor( i18n, {
+		const paper = new Paper( "a tortie cat ".repeat( 150 ) );
+
+		const assessor = new ContentAssessor( i18n, new DefaultResearcher( paper ), {
 			subheadingUrlTitle: "https://yoast.com/1",
 			subheadingCTAUrl: "https://yoast.com/2",
 			paragraphUrlTitle: "https://yoast.com/3",

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
@@ -5,7 +5,21 @@ import Paper from "../../../../src/values/Paper";
 import Factory from "../../../specHelpers/factory";
 
 const i18n = Factory.buildJed();
-
+const options = {
+	subheadingUrlTitle: "https://yoast.com/1",
+	subheadingCTAUrl: "https://yoast.com/2",
+	paragraphUrlTitle: "https://yoast.com/3",
+	paragraphCTAUrl: "https://yoast.com/4",
+	sentenceLengthUrlTitle: "https://yoast.com/5",
+	sentenceLengthCTAUrl: "https://yoast.com/6",
+	transitionWordsUrlTitle: "https://yoast.com/7",
+	transitionWordsCTAUrl: "https://yoast.com/8",
+	passiveVoiceUrlTitle: "https://yoast.com/9",
+	passiveVoiceCTAUrl: "https://yoast.com/10",
+	textPresenceUrlTitle: "https://yoast.com/11",
+	textPresenceCTAUrl: "https://yoast.com/12",
+	listsUrlTitle: "https://yoast.com/13",
+	listsCTAUrl: "https://yoast.com/14" };
 describe( "A cornerstone product page content assessor", function() {
 	describe( "Checks the applicable assessments for text that contains less than 300 words", function() {
 		const paper = new Paper( "Lorem ipsum dolor sit amet, voluptua probatus ullamcorper id vis, ceteros consetetur qui ea, " +
@@ -22,7 +36,7 @@ describe( "A cornerstone product page content assessor", function() {
 			"Splendide tincidunt te sit, commune oporteat quo id. Sumo recusabo suscipiantur duo an, no eum malis vulputate " +
 			"consectetuer. Mel te noster invenire, nec ad vidisse constituto. Eos ut quod." );
 		it( "Should have 6 available assessments for a fully supported language", function() {
-			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ) );
+			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ), options );
 			contentAssessor.getPaper = function() {
 				return paper;
 			};
@@ -33,7 +47,7 @@ describe( "A cornerstone product page content assessor", function() {
 		} );
 
 		it( "Should have 4 available assessments for a basic supported language", function() {
-			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ) );
+			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ), options );
 			contentAssessor.getPaper = function() {
 				return paper;
 			};
@@ -47,7 +61,7 @@ describe( "A cornerstone product page content assessor", function() {
 	describe( "Checks the applicable assessments for text that contains more than 300 words", function() {
 		const paper = new Paper( "a tortie cat ".repeat( 150 ) );
 		it( "Should have 7 available assessments for a fully supported language", function() {
-			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ) );
+			const contentAssessor = new ContentAssessor( i18n, new EnglishResearcher( paper ), options );
 			contentAssessor.getPaper = function() {
 				return paper;
 			};
@@ -58,7 +72,7 @@ describe( "A cornerstone product page content assessor", function() {
 		} );
 
 		it( "Should have 5 available assessments for a basic supported language", function() {
-			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ) );
+			const contentAssessor = new ContentAssessor( i18n, new DefaultResearcher( paper ), options );
 			contentAssessor.getPaper = function() {
 				return paper;
 			};

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
@@ -19,7 +19,9 @@ const options = {
 	textPresenceUrlTitle: "https://yoast.com/11",
 	textPresenceCTAUrl: "https://yoast.com/12",
 	listsUrlTitle: "https://yoast.com/13",
-	listsCTAUrl: "https://yoast.com/14" };
+	listsCTAUrl: "https://yoast.com/14",
+};
+
 describe( "A cornerstone product page content assessor", function() {
 	describe( "Checks the applicable assessments for text that contains less than 300 words", function() {
 		const paper = new Paper( "Lorem ipsum dolor sit amet, voluptua probatus ullamcorper id vis, ceteros consetetur qui ea, " +
@@ -84,7 +86,8 @@ describe( "A cornerstone product page content assessor", function() {
 	} );
 
 	describe( "has configuration overrides", () => {
-		const assessor = new ContentAssessor( i18n, {
+		const paper = new Paper( "a tortie cat ".repeat( 150 ) );
+		const assessor = new ContentAssessor( i18n, new DefaultResearcher( paper ), {
 			subheadingUrlTitle: "https://yoast.com/1",
 			subheadingCTAUrl: "https://yoast.com/2",
 			paragraphUrlTitle: "https://yoast.com/3",

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
@@ -85,7 +85,7 @@ describe( "A cornerstone product page content assessor", function() {
 			textPresenceCTAUrl: "https://yoast.com/12",
 			listsUrlTitle: "https://yoast.com/13",
 			listsCTAUrl: "https://yoast.com/14",
-			} );
+		} );
 
 		test( "SubheadingsDistributionTooLong", () => {
 			const assessment = assessor.getAssessment( "subheadingsTooLong" );

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/contentAssessorSpec.js
@@ -70,7 +70,22 @@ describe( "A cornerstone product page content assessor", function() {
 	} );
 
 	describe( "has configuration overrides", () => {
-		const assessor = new ContentAssessor( i18n );
+		const assessor = new ContentAssessor( i18n, {
+			subheadingUrlTitle: "https://yoast.com/1",
+			subheadingCTAUrl: "https://yoast.com/2",
+			paragraphUrlTitle: "https://yoast.com/3",
+			paragraphCTAUrl: "https://yoast.com/4",
+			sentenceLengthUrlTitle: "https://yoast.com/5",
+			sentenceLengthCTAUrl: "https://yoast.com/6",
+			transitionWordsUrlTitle: "https://yoast.com/7",
+			transitionWordsCTAUrl: "https://yoast.com/8",
+			passiveVoiceUrlTitle: "https://yoast.com/9",
+			passiveVoiceCTAUrl: "https://yoast.com/10",
+			textPresenceUrlTitle: "https://yoast.com/11",
+			textPresenceCTAUrl: "https://yoast.com/12",
+			listsUrlTitle: "https://yoast.com/13",
+			listsCTAUrl: "https://yoast.com/14",
+			} );
 
 		test( "SubheadingsDistributionTooLong", () => {
 			const assessment = assessor.getAssessment( "subheadingsTooLong" );
@@ -79,8 +94,8 @@ describe( "A cornerstone product page content assessor", function() {
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.shouldNotAppearInShortText ).toBeDefined();
 			expect( assessment._config.shouldNotAppearInShortText ).toBe( true );
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify68' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify69' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/1' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/2' target='_blank'>" );
 		} );
 
 		test( "SentenceLengthAssessment", () => {
@@ -92,8 +107,8 @@ describe( "A cornerstone product page content assessor", function() {
 			expect( assessment._config.farTooMany ).toBe( 20 );
 			expect( assessment._isCornerstone ).toBe( true );
 			expect( assessment._isProduct ).toBe( true );
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify48' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify49' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/5' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/6' target='_blank'>" );
 		} );
 
 		test( "ParagraphTooLong", () => {
@@ -103,8 +118,8 @@ describe( "A cornerstone product page content assessor", function() {
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.parameters.recommendedLength ).toBe( 70 );
 			expect( assessment._config.parameters.maximumRecommendedLength ).toBe( 100 );
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify66' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify67' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/3' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/4' target='_blank'>" );
 		} );
 
 		test( "TransitionWords", () => {
@@ -112,8 +127,8 @@ describe( "A cornerstone product page content assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify44' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify45' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/7' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/8' target='_blank'>" );
 		} );
 
 		test( "PassiveVoice", () => {
@@ -121,8 +136,8 @@ describe( "A cornerstone product page content assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify42' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify43' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/9' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/10' target='_blank'>" );
 		} );
 
 		test( "TextPresence", () => {
@@ -130,8 +145,8 @@ describe( "A cornerstone product page content assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify56' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify57' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/11' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/12' target='_blank'>" );
 		} );
 
 		test( "ListsPresence", () => {
@@ -139,8 +154,8 @@ describe( "A cornerstone product page content assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify38' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify39' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/13' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/14' target='_blank'>" );
 		} );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/relatedKeywordAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/relatedKeywordAssessorSpec.js
@@ -4,7 +4,22 @@ import Paper from "../../../../src/values/Paper.js";
 import factory from "../../../specHelpers/factory.js";
 import getResults from "../../../specHelpers/getListOfAssessmentResults";
 const i18n = factory.buildJed();
-const assessor = new Assessor( i18n, new EnglishResearcher() );
+const assessor = new Assessor( i18n, new EnglishResearcher(), {
+	introductionKeyphraseUrlTitle: "https://yoast.com/1",
+	introductionKeyphraseCTAUrl: "https://yoast.com/2",
+	keyphraseLengthUrlTitle: "https://yoast.com/3",
+	keyphraseLengthCTAUrl: "https://yoast.com/4",
+	keyphraseDensityUrlTitle: "https://yoast.com/5",
+	keyphraseDensityCTAUrl: "https://yoast.com/6",
+	metaDescriptionKeyphraseUrlTitle: "https://yoast.com/7",
+	metaDescriptionKeyphraseCTAUrl: "https://yoast.com/8",
+	textCompetingLinksUrlTitle: "https://yoast.com/9",
+	textCompetingLinksCTAUrl: "https://yoast.com/10",
+	functionWordsInKeyphraseUrlTitle: "https://yoast.com/11",
+	functionWordsInKeyphraseCTAUrl: "https://yoast.com/12",
+	imageKeyphraseUrlTitle: "https://yoast.com/13",
+	imageKeyphraseCTAUrl: "https://yoast.com/14",
+} );
 
 describe( "running assessments in the cornerstone related keyword product assessor", function() {
 	it( "runs assessments without any specific requirements", function() {
@@ -81,8 +96,8 @@ describe( "has configuration overrides", () => {
 
 		expect( assessment ).toBeDefined();
 		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify8' target='_blank'>" );
-		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify9' target='_blank'>" );
+		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/1' target='_blank'>" );
+		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/2' target='_blank'>" );
 	} );
 
 	test( "KeyphraseLengthAssessment", () => {
@@ -90,17 +105,8 @@ describe( "has configuration overrides", () => {
 
 		expect( assessment ).toBeDefined();
 		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify10' target='_blank'>" );
-		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify11' target='_blank'>" );
-	} );
-
-	test( "MetaDescriptionKeywordAssessment", () => {
-		const assessment = assessor.getAssessment( "metaDescriptionKeyword" );
-
-		expect( assessment ).toBeDefined();
-		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify14' target='_blank'>" );
-		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify15' target='_blank'>" );
+		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/3' target='_blank'>" );
+		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/4' target='_blank'>" );
 	} );
 
 	test( "KeywordDensityAssessment", () => {
@@ -108,17 +114,17 @@ describe( "has configuration overrides", () => {
 
 		expect( assessment ).toBeDefined();
 		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify12' target='_blank'>" );
-		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify13' target='_blank'>" );
+		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/5' target='_blank'>" );
+		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/6' target='_blank'>" );
 	} );
 
-	test( "FunctionWordsInKeyphrase", () => {
-		const assessment = assessor.getAssessment( "functionWordsInKeyphrase" );
+	test( "MetaDescriptionKeywordAssessment", () => {
+		const assessment = assessor.getAssessment( "metaDescriptionKeyword" );
 
 		expect( assessment ).toBeDefined();
 		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify50' target='_blank'>" );
-		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify51' target='_blank'>" );
+		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/7' target='_blank'>" );
+		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/8' target='_blank'>" );
 	} );
 
 	test( "TextCompetingLinks", () => {
@@ -126,8 +132,17 @@ describe( "has configuration overrides", () => {
 
 		expect( assessment ).toBeDefined();
 		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify18' target='_blank'>" );
-		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify19' target='_blank'>" );
+		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/9' target='_blank'>" );
+		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/10' target='_blank'>" );
+	} );
+
+	test( "FunctionWordsInKeyphrase", () => {
+		const assessment = assessor.getAssessment( "functionWordsInKeyphrase" );
+
+		expect( assessment ).toBeDefined();
+		expect( assessment._config ).toBeDefined();
+		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/11' target='_blank'>" );
+		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/12' target='_blank'>" );
 	} );
 
 	test( "ImageKeyphrase", () => {
@@ -135,7 +150,7 @@ describe( "has configuration overrides", () => {
 
 		expect( assessment ).toBeDefined();
 		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify22' target='_blank'>" );
-		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify23' target='_blank'>" );
+		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/13' target='_blank'>" );
+		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/14' target='_blank'>" );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/cornerstone/seoAssessorSpec.js
@@ -10,7 +10,41 @@ describe( "running assessments in the product page SEO assessor", function() {
 	let assessor;
 
 	beforeEach( () => {
-		assessor = new Assessor( i18n, new EnglishResearcher() );
+		assessor = new Assessor( i18n, new EnglishResearcher(), { introductionKeyphraseUrlTitle: "https://yoast.com/1",
+			introductionKeyphraseCTAUrl: "https://yoast.com/2",
+			keyphraseLengthUrlTitle: "https://yoast.com/3",
+			keyphraseLengthCTAUrl: "https://yoast.com/4",
+			keyphraseDensityUrlTitle: "https://yoast.com/5",
+			keyphraseDensityCTAUrl: "https://yoast.com/6",
+			metaDescriptionKeyphraseUrlTitle: "https://yoast.com/7",
+			metaDescriptionKeyphraseCTAUrl: "https://yoast.com/8",
+			metaDescriptionLengthUrlTitle: "https://yoast.com/9",
+			metaDescriptionLengthCTAUrl: "https://yoast.com/10",
+			subheadingsKeyphraseUrlTitle: "https://yoast.com/11",
+			subheadingsKeyphraseCTAUrl: "https://yoast.com/12",
+			textCompetingLinksUrlTitle: "https://yoast.com/13",
+			textCompetingLinksCTAUrl: "https://yoast.com/14",
+			textLengthUrlTitle: "https://yoast.com/15",
+			textLengthCTAUrl: "https://yoast.com/16",
+			titleKeyphraseUrlTitle: "https://yoast.com/17",
+			titleKeyphraseCTAUrl: "https://yoast.com/18",
+			titleWidthUrlTitle: "https://yoast.com/19",
+			titleWidthCTAUrl: "https://yoast.com/20",
+			urlKeyphraseUrlTitle: "https://yoast.com/21",
+			urlKeyphraseCTAUrl: "https://yoast.com/22",
+			functionWordsInKeyphraseUrlTitle: "https://yoast.com/23",
+			functionWordsInKeyphraseCTAUrl: "https://yoast.com/24",
+			singleH1UrlTitle: "https://yoast.com/25",
+			singleH1CTAUrl: "https://yoast.com/26",
+			imageCountUrlTitle: "https://yoast.com/27",
+			imageCountCTAUrl: "https://yoast.com/28",
+			imageKeyphraseUrlTitle: "https://yoast.com/29",
+			imageKeyphraseCTAUrl: "https://yoast.com/30",
+			imageAltTagsUrlTitle: "https://yoast.com/31",
+			imageAltTagsCTAUrl: "https://yoast.com/32",
+			keyphraseDistributionUrlTitle: "https://yoast.com/33",
+			keyphraseDistributionCTAUrl: "https://yoast.com/34",
+		} );
 	} );
 
 	it( "runs assessments without any specific requirements", function() {
@@ -195,8 +229,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify8' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify9' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/1' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/2' target='_blank'>" );
 		} );
 
 		test( "KeyphraseLengthAssessment", () => {
@@ -204,8 +238,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify10' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify11' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/3' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/4' target='_blank'>" );
 		} );
 
 		test( "KeywordDensityAssessment", () => {
@@ -213,8 +247,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify12' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify13' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/5' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/6' target='_blank'>" );
 		} );
 
 		test( "MetaDescriptionKeywordAssessment", () => {
@@ -222,8 +256,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify14' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify15' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/7' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/8' target='_blank'>" );
 		} );
 
 		test( "MetaDescriptionLengthAssessment", () => {
@@ -234,8 +268,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 			expect( assessment._config.scores ).toBeDefined();
 			expect( assessment._config.scores.tooLong ).toBe( 3 );
 			expect( assessment._config.scores.tooShort ).toBe( 3 );
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify46' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify47' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/9' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/10' target='_blank'>" );
 		} );
 
 		test( "SubheadingsKeyword", () => {
@@ -243,8 +277,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify16' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify17' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/11' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/12' target='_blank'>" );
 		} );
 
 		test( "TextCompetingLinksAssessment", () => {
@@ -252,8 +286,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify18' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify19' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/13' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/14' target='_blank'>" );
 		} );
 
 		test( "TextLengthAssessment", () => {
@@ -269,8 +303,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 			expect( assessment._config.scores.farBelowMinimum ).toBe( -20 );
 			expect( assessment._config.cornerstoneContent ).toBeDefined();
 			expect( assessment._config.cornerstoneContent ).toBeTruthy();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify58' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify59' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/15' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/16' target='_blank'>" );
 		} );
 
 		test( "TitleKeywordAssessment", () => {
@@ -278,8 +312,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify24' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify25' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/17' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/18' target='_blank'>" );
 		} );
 
 		test( "PageTitleWidthAssesment", () => {
@@ -290,8 +324,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 			expect( assessment._config.scores ).toBeDefined();
 			expect( assessment._config.scores.widthTooShort ).toBe( 9 );
 			expect( assessment._allowShortTitle ).toBe( true );
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify52' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify53' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/19' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/20' target='_blank'>" );
 		} );
 
 		test( "UrlKeywordAssessment", () => {
@@ -301,8 +335,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.scores ).toBeDefined();
 			expect( assessment._config.scores.okay ).toBe( 3 );
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify26' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify27' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/21' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/22' target='_blank'>" );
 		} );
 
 		test( "FunctionWordsInKeyphrase", () => {
@@ -310,8 +344,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify50' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify51' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/23' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/24' target='_blank'>" );
 		} );
 
 		test( "SingleH1Assessment", () => {
@@ -319,8 +353,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify54' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify55' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/25' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/26' target='_blank'>" );
 		} );
 
 		test( "ImageCount", () => {
@@ -328,8 +362,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify20' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify21' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/27' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/28' target='_blank'>" );
 		} );
 
 		test( "ImageKeyphrase", () => {
@@ -337,8 +371,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify22' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify23' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/29' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/30' target='_blank'>" );
 		} );
 
 		test( "ImageAltTags", () => {
@@ -346,8 +380,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify40' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify41' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/31' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/32' target='_blank'>" );
 		} );
 
 		test( "KeyphraseDistribution", () => {
@@ -355,8 +389,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify30' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify31' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/33' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/34' target='_blank'>" );
 		} );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/productPages/relatedKeywordAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/relatedKeywordAssessorSpec.js
@@ -4,7 +4,22 @@ import Paper from "../../../src/values/Paper";
 import factory from "../../specHelpers/factory";
 import getResults from "../../specHelpers/getListOfAssessmentResults";
 const i18n = factory.buildJed();
-const assessor = new Assessor( i18n, new EnglishResearcher() );
+const assessor = new Assessor( i18n, new EnglishResearcher(), {
+	introductionKeyphraseUrlTitle: "https://yoast.com/1",
+	introductionKeyphraseCTAUrl: "https://yoast.com/2",
+	keyphraseLengthUrlTitle: "https://yoast.com/3",
+	keyphraseLengthCTAUrl: "https://yoast.com/4",
+	keyphraseDensityUrlTitle: "https://yoast.com/5",
+	keyphraseDensityCTAUrl: "https://yoast.com/6",
+	metaDescriptionKeyphraseUrlTitle: "https://yoast.com/7",
+	metaDescriptionKeyphraseCTAUrl: "https://yoast.com/8",
+	textCompetingLinksUrlTitle: "https://yoast.com/9",
+	textCompetingLinksCTAUrl: "https://yoast.com/10",
+	functionWordsInKeyphraseUrlTitle: "https://yoast.com/11",
+	functionWordsInKeyphraseCTAUrl: "https://yoast.com/12",
+	imageKeyphraseUrlTitle: "https://yoast.com/13",
+	imageKeyphraseCTAUrl: "https://yoast.com/14",
+} );
 
 describe( "running assessments in the related keyword product assessor", function() {
 	it( "runs assessments without any specific requirements", function() {
@@ -81,8 +96,8 @@ describe( "has configuration overrides", () => {
 
 		expect( assessment ).toBeDefined();
 		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify8' target='_blank'>" );
-		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify9' target='_blank'>" );
+		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/1' target='_blank'>" );
+		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/2' target='_blank'>" );
 	} );
 
 	test( "KeyphraseLengthAssessment", () => {
@@ -90,8 +105,8 @@ describe( "has configuration overrides", () => {
 
 		expect( assessment ).toBeDefined();
 		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify10' target='_blank'>" );
-		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify11' target='_blank'>" );
+		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/3' target='_blank'>" );
+		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/4' target='_blank'>" );
 	} );
 
 	test( "MetaDescriptionKeywordAssessment", () => {
@@ -99,8 +114,8 @@ describe( "has configuration overrides", () => {
 
 		expect( assessment ).toBeDefined();
 		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify14' target='_blank'>" );
-		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify15' target='_blank'>" );
+		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/7' target='_blank'>" );
+		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/8' target='_blank'>" );
 	} );
 
 	test( "KeywordDensityAssessment", () => {
@@ -108,8 +123,8 @@ describe( "has configuration overrides", () => {
 
 		expect( assessment ).toBeDefined();
 		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify12' target='_blank'>" );
-		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify13' target='_blank'>" );
+		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/5' target='_blank'>" );
+		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/6' target='_blank'>" );
 	} );
 
 	test( "FunctionWordsInKeyphrase", () => {
@@ -117,8 +132,8 @@ describe( "has configuration overrides", () => {
 
 		expect( assessment ).toBeDefined();
 		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify50' target='_blank'>" );
-		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify51' target='_blank'>" );
+		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/11' target='_blank'>" );
+		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/12' target='_blank'>" );
 	} );
 
 	test( "TextCompetingLinks", () => {
@@ -126,8 +141,8 @@ describe( "has configuration overrides", () => {
 
 		expect( assessment ).toBeDefined();
 		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify18' target='_blank'>" );
-		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify19' target='_blank'>" );
+		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/9' target='_blank'>" );
+		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/10' target='_blank'>" );
 	} );
 
 	test( "ImageKeyphrase", () => {
@@ -135,7 +150,7 @@ describe( "has configuration overrides", () => {
 
 		expect( assessment ).toBeDefined();
 		expect( assessment._config ).toBeDefined();
-		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify22' target='_blank'>" );
-		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify23' target='_blank'>" );
+		expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/13' target='_blank'>" );
+		expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/14' target='_blank'>" );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
@@ -9,7 +9,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 	let assessor;
 
 	beforeEach( () => {
-		assessor = new Assessor( i18n, new DefaultResearcher(), { introductionKeyphraseUrlTitle: "https://yoast.com/1",
+		assessor = new Assessor( i18n, new DefaultResearcher(), {
+			introductionKeyphraseUrlTitle: "https://yoast.com/1",
 			introductionKeyphraseCTAUrl: "https://yoast.com/2",
 			keyphraseLengthUrlTitle: "https://yoast.com/3",
 			keyphraseLengthCTAUrl: "https://yoast.com/4",

--- a/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
@@ -9,7 +9,40 @@ describe( "running assessments in the product page SEO assessor", function() {
 	let assessor;
 
 	beforeEach( () => {
-		assessor = new Assessor( i18n, new DefaultResearcher() );
+		assessor = new Assessor( i18n, new DefaultResearcher(), { introductionKeyphraseUrlTitle: "https://yoast.com/1",
+			introductionKeyphraseCTAUrl: "https://yoast.com/2",
+			keyphraseLengthUrlTitle: "https://yoast.com/3",
+			keyphraseLengthCTAUrl: "https://yoast.com/4",
+			keyphraseDensityUrlTitle: "https://yoast.com/5",
+			keyphraseDensityCTAUrl: "https://yoast.com/6",
+			metaDescriptionKeyphraseUrlTitle: "https://yoast.com/7",
+			metaDescriptionKeyphraseCTAUrl: "https://yoast.com/8",
+			metaDescriptionLengthUrlTitle: "https://yoast.com/9",
+			metaDescriptionLengthCTAUrl: "https://yoast.com/10",
+			subheadingsKeyphraseUrlTitle: "https://yoast.com/11",
+			subheadingsKeyphraseCTAUrl: "https://yoast.com/12",
+			textCompetingLinksUrlTitle: "https://yoast.com/13",
+			textCompetingLinksCTAUrl: "https://yoast.com/14",
+			textLengthUrlTitle: "https://yoast.com/15",
+			textLengthCTAUrl: "https://yoast.com/16",
+			titleKeyphraseUrlTitle: "https://yoast.com/17",
+			titleKeyphraseCTAUrl: "https://yoast.com/18",
+			titleWidthUrlTitle: "https://yoast.com/19",
+			titleWidthCTAUrl: "https://yoast.com/20",
+			urlKeyphraseUrlTitle: "https://yoast.com/21",
+			urlKeyphraseCTAUrl: "https://yoast.com/22",
+			functionWordsInKeyphraseUrlTitle: "https://yoast.com/23",
+			functionWordsInKeyphraseCTAUrl: "https://yoast.com/24",
+			singleH1UrlTitle: "https://yoast.com/25",
+			singleH1CTAUrl: "https://yoast.com/26",
+			imageCountUrlTitle: "https://yoast.com/27",
+			imageCountCTAUrl: "https://yoast.com/28",
+			imageKeyphraseUrlTitle: "https://yoast.com/29",
+			imageKeyphraseCTAUrl: "https://yoast.com/30",
+			imageAltTagsUrlTitle: "https://yoast.com/31",
+			imageAltTagsCTAUrl: "https://yoast.com/32",
+			keyphraseDistributionUrlTitle: "https://yoast.com/33",
+			keyphraseDistributionCTAUrl: "https://yoast.com/34",} );
 	} );
 
 	it( "runs assessments without any specific requirements", function() {
@@ -209,8 +242,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify8' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify9' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/1' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/2' target='_blank'>" );
 		} );
 
 		test( "KeyphraseLengthAssessment", () => {
@@ -222,8 +255,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 			expect( assessment._config.parameters.recommendedMaximum ).toBe( 6 );
 			expect( assessment._config.parameters.acceptableMaximum ).toBe( 8 );
 			expect( assessment._config.parameters.acceptableMinimum ).toBe( 2 );
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify10' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify11' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/3' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/4' target='_blank'>" );
 		} );
 
 		test( "KeywordDensityAssessment", () => {
@@ -231,8 +264,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify12' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify13' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/5' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/6' target='_blank'>" );
 		} );
 
 		test( "MetaDescriptionKeywordAssessment", () => {
@@ -240,8 +273,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify14' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify15' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/7' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/8' target='_blank'>" );
 		} );
 
 		test( "MetaDescriptionLengthAssessment", () => {
@@ -249,8 +282,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify46' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify47' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/9' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/10' target='_blank'>" );
 		} );
 
 		test( "SubheadingsKeyword", () => {
@@ -258,8 +291,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify16' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify17' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/11' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/12' target='_blank'>" );
 		} );
 
 		test( "TextCompetingLinksAssessment", () => {
@@ -267,8 +300,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify18' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify19' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/13' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/14' target='_blank'>" );
 		} );
 
 		test( "TextLengthAssessment", () => {
@@ -280,8 +313,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 			expect( assessment._config.slightlyBelowMinimum ).toBe( 150 );
 			expect( assessment._config.belowMinimum ).toBe( 100 );
 			expect( assessment._config.veryFarBelowMinimum ).toBe( 50 );
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify58' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify59' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/15' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/16' target='_blank'>" );
 		} );
 
 		test( "TitleKeywordAssessment", () => {
@@ -289,8 +322,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify24' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify25' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/17' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/18' target='_blank'>" );
 		} );
 
 		test( "PageTitleWidthAssesment", () => {
@@ -301,8 +334,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 			expect( assessment._config.scores ).toBeDefined();
 			expect( assessment._config.scores.widthTooShort ).toBe( 9 );
 			expect( assessment._allowShortTitle ).toBe( true );
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify52' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify53' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/19' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/20' target='_blank'>" );
 		} );
 
 		test( "UrlKeywordAssessment", () => {
@@ -310,8 +343,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify26' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify27' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/21' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/22' target='_blank'>" );
 		} );
 
 		test( "FunctionWordsInKeyphrase", () => {
@@ -319,8 +352,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify50' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify51' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/23' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/24' target='_blank'>" );
 		} );
 
 		test( "SingleH1Assessment", () => {
@@ -328,8 +361,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify54' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify55' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/25' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/26' target='_blank'>" );
 		} );
 
 		test( "ImageCount", () => {
@@ -339,8 +372,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.scores.okay ).toBe( 6 );
 			expect( assessment._config.recommendedCount ).toBe( 4 );
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify20' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify21' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/27' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/28' target='_blank'>" );
 		} );
 
 		test( "ImageKeyphrase", () => {
@@ -348,8 +381,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify22' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify23' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/29' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/30' target='_blank'>" );
 		} );
 
 		test( "ImageAltTags", () => {
@@ -357,8 +390,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify40' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify41' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/31' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/32' target='_blank'>" );
 		} );
 
 		test( "KeyphraseDistribution", () => {
@@ -366,8 +399,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
-			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify30' target='_blank'>" );
-			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify31' target='_blank'>" );
+			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoast.com/33' target='_blank'>" );
+			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoast.com/34' target='_blank'>" );
 		} );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/productPages/seoAssessorSpec.js
@@ -42,7 +42,8 @@ describe( "running assessments in the product page SEO assessor", function() {
 			imageAltTagsUrlTitle: "https://yoast.com/31",
 			imageAltTagsCTAUrl: "https://yoast.com/32",
 			keyphraseDistributionUrlTitle: "https://yoast.com/33",
-			keyphraseDistributionCTAUrl: "https://yoast.com/34",} );
+			keyphraseDistributionCTAUrl: "https://yoast.com/34",
+		} );
 	} );
 
 	it( "runs assessments without any specific requirements", function() {

--- a/packages/yoastseo/src/scoring/assessments/readability/ListAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/ListAssessment.js
@@ -1,6 +1,7 @@
 import Assessment from "../assessment";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import AssessmentResult from "../../../values/AssessmentResult";
+import { merge } from "lodash-es";
 
 /**
  * Represents the assessment that will look if the text has a list (only applicable for product pages).
@@ -13,10 +14,10 @@ export default class ListAssessment extends Assessment {
 	 *
 	 * @returns {void}
 	 */
-	constructor() {
+	constructor( config = {} ) {
 		super();
 
-		this._config = {
+		const defaultConfig = {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify38" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify39" ),
 			scores: {
@@ -24,6 +25,8 @@ export default class ListAssessment extends Assessment {
 				good: 9,
 			},
 		};
+
+		this._config = merge( defaultConfig, config );
 
 		this.identifier = "listsPresence";
 	}

--- a/packages/yoastseo/src/scoring/productPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/contentAssessor.js
@@ -19,7 +19,7 @@ import ListsPresence from "../assessments/readability/ListAssessment.js";
  *
  * @constructor
  */
-const ProductContentAssessor = function( i18n, options = {} ) {
+const ProductContentAssessor = function( i18n, options ) {
 	Assessor.call( this, i18n, options );
 	this.type = "productContentAssessor";
 

--- a/packages/yoastseo/src/scoring/productPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/contentAssessor.js
@@ -13,14 +13,14 @@ import ListsPresence from "../assessments/readability/ListAssessment.js";
 /**
  * Creates the Assessor
  *
- * @param {object} i18n The i18n object used for translations.
- * @param {Object} options The options for this assessor.
- * @param {Object} options.marker The marker to pass the list of marks to.
+ * @param {object} i18n         The i18n object used for translations.
+ * @param {object} researcher   The researcher to use for the analysis.
+ * @param {Object} options      The options for this assessor.
  *
  * @constructor
  */
-const ProductContentAssessor = function( i18n, options ) {
-	Assessor.call( this, i18n, options );
+const ProductContentAssessor = function( i18n, researcher, options ) {
+	Assessor.call( this, i18n, researcher, options );
 	this.type = "productContentAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/scoring/productPages/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/contentAssessor.js
@@ -26,38 +26,38 @@ const ProductContentAssessor = function( i18n, options = {} ) {
 	this._assessments = [
 		new SubheadingDistributionTooLong( {
 			shouldNotAppearInShortText: true,
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify68" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify69" ),
+			urlTitle: createAnchorOpeningTag( options.subheadingUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.subheadingCTAUrl ),
 		} ),
 		new ParagraphTooLong( {
 			parameters: {
 				recommendedLength: 70,
 				maximumRecommendedLength: 100,
 			},
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify66" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify67" ),
+			urlTitle: createAnchorOpeningTag( options.paragraphUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.paragraphCTAUrl ),
 		} ),
 		new SentenceLengthInText( {
 			slightlyTooMany: 20,
 			farTooMany: 25,
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify48" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify49" ),
+			urlTitle: createAnchorOpeningTag( options.sentenceLengthUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.sentenceLengthCTAUrl ),
 		}, false, true ),
 		new TransitionWords( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify44" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify45" ),
+			urlTitle: createAnchorOpeningTag( options.transitionWordsUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.transitionWordsCTAUrl ),
 		} ),
 		new PassiveVoice( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify42" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify43" ),
+			urlTitle: createAnchorOpeningTag( options.passiveVoiceUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.passiveVoiceCTAUrl ),
 		} ),
 		new TextPresence( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify56" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify57" ),
+			urlTitle: createAnchorOpeningTag( options.textPresenceUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.textPresenceCTAUrl ),
 		} ),
 		new ListsPresence( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify38" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify39" ),
+			urlTitle: createAnchorOpeningTag( options.listsUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.listsCTAUrl ),
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
@@ -30,38 +30,38 @@ const ProductCornerstoneContentAssessor = function( i18n, options = {} ) {
 				recommendedMaximumWordCount: 250,
 			},
 			shouldNotAppearInShortText: true,
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify68" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify69" ),
+			urlTitle: createAnchorOpeningTag( options.subheadingUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.subheadingCTAUrl ),
 		} ),
 		new ParagraphTooLong( {
 			parameters: {
 				recommendedLength: 70,
 				maximumRecommendedLength: 100,
 			},
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify66" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify67" ),
+			urlTitle: createAnchorOpeningTag( options.paragraphUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.paragraphCTAUrl ),
 		} ),
 		new SentenceLengthInText( {
 			slightlyTooMany: 15,
 			farTooMany: 20,
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify48" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify49" ),
+			urlTitle: createAnchorOpeningTag( options.sentenceLengthUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.sentenceLengthCTAUrl ),
 		}, true, true ),
 		new TransitionWords( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify44" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify45" ),
+			urlTitle: createAnchorOpeningTag( options.transitionWordsUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.transitionWordsCTAUrl ),
 		} ),
 		new PassiveVoice( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify42" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify43" ),
+			urlTitle: createAnchorOpeningTag( options.passiveVoiceUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.passiveVoiceCTAUrl ),
 		} ),
 		new TextPresence( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify56" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify57" ),
+			urlTitle: createAnchorOpeningTag( options.textPresenceUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.textPresenceCTAUrl ),
 		} ),
 		new ListsPresence( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify38" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify39" ),
+			urlTitle: createAnchorOpeningTag( options.listsUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.listsCTAUrl ),
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
@@ -18,7 +18,7 @@ import ListsPresence from "../../assessments/readability/ListAssessment.js";
  *
  * @constructor
  */
-const ProductCornerstoneContentAssessor = function( i18n, options = {} ) {
+const ProductCornerstoneContentAssessor = function( i18n, options ) {
 	Assessor.call( this, i18n, options );
 	this.type = "productCornerstoneContentAssessor";
 

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
@@ -12,14 +12,14 @@ import ListsPresence from "../../assessments/readability/ListAssessment.js";
 /**
  * Creates the Assessor
  *
- * @param {object} i18n The i18n object used for translations.
- * @param {Object} options The options for this assessor.
- * @param {Object} options.marker The marker to pass the list of marks to.
+ * @param {object} i18n         The i18n object used for translations.
+ * @param {object} researcher   The researcher to use for the analysis.
+ * @param {Object} options      The options for this assessor.
  *
  * @constructor
  */
-const ProductCornerstoneContentAssessor = function( i18n, options ) {
-	Assessor.call( this, i18n, options );
+const ProductCornerstoneContentAssessor = function( i18n, researcher, options ) {
+	Assessor.call( this, i18n, researcher, options );
 	this.type = "productCornerstoneContentAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
@@ -19,8 +19,8 @@ import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyph
  *
  * @constructor
  */
-const ProductCornerStoneRelatedKeywordAssessor = function( i18n, options ) {
-	Assessor.call( this, i18n, options );
+const ProductCornerStoneRelatedKeywordAssessor = function( i18n, researcher, options ) {
+	Assessor.call( this, i18n, researcher, options );
 	this.type = "productPageCornerstoneRelatedKeywordAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
@@ -14,6 +14,7 @@ import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyph
  * Creates the Assessor
  *
  * @param {object} i18n The i18n object used for translations.
+ * @param {object}  researcher      The researcher to use for the analysis.
  * @param {Object} options The options for this assessor.
  * @param {Object} options.marker The marker to pass the list of marks to.
  *

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
@@ -13,10 +13,9 @@ import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyph
 /**
  * Creates the Assessor
  *
- * @param {object} i18n The i18n object used for translations.
- * @param {object}  researcher      The researcher to use for the analysis.
- * @param {Object} options The options for this assessor.
- * @param {Object} options.marker The marker to pass the list of marks to.
+ * @param {object} i18n         The i18n object used for translations.
+ * @param {object} researcher   The researcher to use for the analysis.
+ * @param {Object} options      The options for this assessor.
  *
  * @constructor
  */

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/relatedKeywordAssessor.js
@@ -25,8 +25,8 @@ const ProductCornerStoneRelatedKeywordAssessor = function( i18n, options ) {
 
 	this._assessments = [
 		new IntroductionKeyword( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify8" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify9" ),
+			urlTitle: createAnchorOpeningTag( options.introductionKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.introductionKeyphraseCTAUrl ),
 		} ),
 		new KeyphraseLength( {
 			parameters: {
@@ -36,24 +36,24 @@ const ProductCornerStoneRelatedKeywordAssessor = function( i18n, options ) {
 				acceptableMinimum: 2,
 			},
 			isRelatedKeyphrase: true,
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify10" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify11" ),
+			urlTitle: createAnchorOpeningTag( options.keyphraseLengthUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.keyphraseLengthCTAUrl ),
 		}, true ),
 		new KeywordDensity( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify12" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify13" ),
+			urlTitle: createAnchorOpeningTag( options.keyphraseDensityUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.keyphraseDensityCTAUrl ),
 		} ),
 		new MetaDescriptionKeyword( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify14" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify15" ),
+			urlTitle: createAnchorOpeningTag( options.metaDescriptionKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.metaDescriptionKeyphraseCTAUrl ),
 		} ),
 		new TextCompetingLinks( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify18" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify19" ),
+			urlTitle: createAnchorOpeningTag( options.textCompetingLinksUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.textCompetingLinksCTAUrl ),
 		} ),
 		new FunctionWordsInKeyphrase( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify50" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify51" ),
+			urlTitle: createAnchorOpeningTag( options.functionWordsInKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.functionWordsInKeyphraseCTAUrl ),
 		} ),
 		new ImageKeyphrase( {
 			scores: {
@@ -61,8 +61,8 @@ const ProductCornerStoneRelatedKeywordAssessor = function( i18n, options ) {
 				withAlt: 3,
 				noAlt: 3,
 			},
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify22" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify23" ),
+			urlTitle: createAnchorOpeningTag( options.imageKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.imageKeyphraseCTAUrl ),
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -30,8 +30,8 @@ import KeyphraseDistribution from "../../assessments/seo/KeyphraseDistributionAs
  *
  * @constructor
  */
-const ProductCornerstoneSEOAssessor = function( i18n, options ) {
-	Assessor.call( this, i18n, options );
+const ProductCornerstoneSEOAssessor = function( i18n, researcher, options ) {
+	Assessor.call( this, i18n, researcher, options );
 	this.type = "ProductCornerstoneSEOAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -36,8 +36,8 @@ const ProductCornerstoneSEOAssessor = function( i18n, options ) {
 
 	this._assessments = [
 		new IntroductionKeywordAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify8" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify9" ),
+			urlTitle: createAnchorOpeningTag( options.introductionKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.introductionKeyphraseCTAUrl ),
 		} ),
 		new KeyphraseLengthAssessment( {
 			parameters: {
@@ -46,32 +46,32 @@ const ProductCornerstoneSEOAssessor = function( i18n, options ) {
 				acceptableMaximum: 8,
 				acceptableMinimum: 2,
 			},
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify10" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify11" ),
+			urlTitle: createAnchorOpeningTag( options.keyphraseLengthUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.keyphraseLengthCTAUrl ),
 		}, true ),
 		new KeywordDensityAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify12" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify13" ),
+			urlTitle: createAnchorOpeningTag( options.keyphraseDensityUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.keyphraseDensityCTAUrl ),
 		} ),
 		new MetaDescriptionKeywordAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify14" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify15" ),
+			urlTitle: createAnchorOpeningTag( options.metaDescriptionKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.metaDescriptionKeyphraseCTAUrl ),
 		} ),
 		new MetaDescriptionLength( {
 			scores:	{
 				tooLong: 3,
 				tooShort: 3,
 			},
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify46" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify47" ),
+			urlTitle: createAnchorOpeningTag( options.metaDescriptionLengthUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.metaDescriptionLengthCTAUrl ),
 		} ),
 		new SubheadingsKeyword( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify16" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify17" ),
+			urlTitle: createAnchorOpeningTag( options.subheadingsKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.subheadingsKeyphraseCTAUrl ),
 		} ),
 		new TextCompetingLinksAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify18" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify19" ),
+			urlTitle: createAnchorOpeningTag( options.textCompetingLinksUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.textCompetingLinksCTAUrl ),
 		} ),
 		new TextLength( {
 			recommendedMinimum: 400,
@@ -82,45 +82,45 @@ const ProductCornerstoneSEOAssessor = function( i18n, options ) {
 				belowMinimum: -20,
 				farBelowMinimum: -20,
 			},
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify58" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify59" ),
+			urlTitle: createAnchorOpeningTag( options.textLengthUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.textLengthCTAUrl ),
 			cornerstoneContent: true,
 		} ),
 		new TitleKeywordAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify24" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify25" ),
+			urlTitle: createAnchorOpeningTag( options.titleKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.titleKeyphraseCTAUrl ),
 		} ),
 		new TitleWidth( {
 			scores: {
 				widthTooShort: 9,
 			},
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify52" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify53" ),
+			urlTitle: createAnchorOpeningTag( options.titleWidthUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.titleWidthCTAUrl ),
 		}, true ),
 		new UrlKeywordAssessment(
 			{
 				scores: {
 					okay: 3,
 				},
-				urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify26" ),
-				urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify27" ),
+				urlTitle: createAnchorOpeningTag( options.urlKeyphraseUrlTitle ),
+				urlCallToAction: createAnchorOpeningTag( options.urlKeyphraseCTAUrl ),
 			}
 		),
 		new FunctionWordsInKeyphrase( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify50" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify51" ),
+			urlTitle: createAnchorOpeningTag( options.functionWordsInKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.functionWordsInKeyphraseCTAUrl ),
 		} ),
 		new SingleH1Assessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify54" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify55" ),
+			urlTitle: createAnchorOpeningTag( options.singleH1UrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.singleH1CTAUrl ),
 		} ),
 		new ImageCount( {
 			scores: {
 				okay: 6,
 			},
 			recommendedCount: 4,
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify20" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify21" ),
+			urlTitle: createAnchorOpeningTag( options.imageCountUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.imageCountCTAUrl ),
 		}, true ),
 		new ImageKeyphrase( {
 			scores: {
@@ -128,17 +128,17 @@ const ProductCornerstoneSEOAssessor = function( i18n, options ) {
 				withAlt: 3,
 				noAlt: 3,
 			},
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify22" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify23" ),
+			urlTitle: createAnchorOpeningTag( options.imageKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.imageKeyphraseCTAUrl ),
 		} ),
 		new ImageAltTags( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify40" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify41" ),
+			urlTitle: createAnchorOpeningTag( options.imageAltTagsUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.imageAltTagsCTAUrl ),
 		}
 		),
 		new KeyphraseDistribution( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify30" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify31" ),
+			urlTitle: createAnchorOpeningTag( options.keyphraseDistributionUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.keyphraseDistributionCTAUrl ),
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -24,10 +24,9 @@ import KeyphraseDistribution from "../../assessments/seo/KeyphraseDistributionAs
 /**
  * Creates the Assessor
  *
- * @param {Object} i18n 			The i18n object used for translations.
- * @param {object} researcher       The researcher to use for the analysis.
- * @param {Object} options 			The options for this assessor.
- * @param {Object} options.marker 	The marker to pass the list of marks to.
+ * @param {object} i18n         The i18n object used for translations.
+ * @param {object} researcher   The researcher to use for the analysis.
+ * @param {Object} options      The options for this assessor.
  *
  * @constructor
  */

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/seoAssessor.js
@@ -24,9 +24,10 @@ import KeyphraseDistribution from "../../assessments/seo/KeyphraseDistributionAs
 /**
  * Creates the Assessor
  *
- * @param {Object} i18n The i18n object used for translations.
- * @param {Object} options The options for this assessor.
- * @param {Object} options.marker The marker to pass the list of marks to.
+ * @param {Object} i18n 			The i18n object used for translations.
+ * @param {object} researcher       The researcher to use for the analysis.
+ * @param {Object} options 			The options for this assessor.
+ * @param {Object} options.marker 	The marker to pass the list of marks to.
  *
  * @constructor
  */

--- a/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
@@ -26,8 +26,8 @@ const ProductRelatedKeywordAssessor = function( i18n, researcher, options ) {
 
 	this._assessments = [
 		new IntroductionKeyword( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify8" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify9" ),
+			urlTitle: createAnchorOpeningTag( options.introductionKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.introductionKeyphraseCTAUrl ),
 		} ),
 		new KeyphraseLength( {
 			parameters: {
@@ -37,28 +37,28 @@ const ProductRelatedKeywordAssessor = function( i18n, researcher, options ) {
 				acceptableMinimum: 2,
 			},
 			isRelatedKeyphrase: true,
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify10" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify11" ),
+			urlTitle: createAnchorOpeningTag( options.keyphraseLengthUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.keyphraseLengthCTAUrl ),
 		}, true ),
 		new KeywordDensity( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify12" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify13" ),
+			urlTitle: createAnchorOpeningTag( options.keyphraseDensityUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.keyphraseDensityCTAUrl ),
 		} ),
 		new MetaDescriptionKeyword( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify14" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify15" ),
+			urlTitle: createAnchorOpeningTag( options.metaDescriptionKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.metaDescriptionKeyphraseCTAUrl ),
 		} ),
 		new TextCompetingLinks( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify18" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify19" ),
+			urlTitle: createAnchorOpeningTag( options.textCompetingLinksUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.textCompetingLinksCTAUrl ),
 		} ),
 		new FunctionWordsInKeyphrase( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify50" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify51" ),
+			urlTitle: createAnchorOpeningTag( options.functionWordsInKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.functionWordsInKeyphraseCTAUrl ),
 		} ),
 		new ImageKeyphrase( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify22" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify23" ),
+			urlTitle: createAnchorOpeningTag( options.imageKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.imageKeyphraseCTAUrl ),
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/relatedKeywordAssessor.js
@@ -13,10 +13,9 @@ import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphras
 /**
  * Creates the Assessor
  *
- * @param {object}  i18n            The i18n object used for translations.
- * @param {object}  researcher      The researcher to use for the analysis.
- * @param {Object}  options         The options for this assessor.
- * @param {Object}  options.marker  The marker to pass the list of marks to.
+ * @param {object} i18n         The i18n object used for translations.
+ * @param {object} researcher   The researcher to use for the analysis.
+ * @param {Object} options      The options for this assessor.
  *
  * @constructor
  */

--- a/packages/yoastseo/src/scoring/productPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/seoAssessor.js
@@ -35,8 +35,8 @@ const ProductSEOAssessor = function( i18n, researcher, options ) {
 
 	this._assessments = [
 		new IntroductionKeywordAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify8" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify9" ),
+			urlTitle: createAnchorOpeningTag( options.introductionKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.introductionKeyphraseCTAUrl ),
 		} ),
 		new KeyphraseLengthAssessment( {
 			parameters: {
@@ -45,80 +45,80 @@ const ProductSEOAssessor = function( i18n, researcher, options ) {
 				acceptableMaximum: 8,
 				acceptableMinimum: 2,
 			},
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify10" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify11" ),
+			urlTitle: createAnchorOpeningTag( options.keyphraseLengthUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.keyphraseLengthCTAUrl ),
 		}, true ),
 		new KeywordDensityAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify12" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify13" ),
+			urlTitle: createAnchorOpeningTag( options.keyphraseDensityUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.keyphraseDensityCTAUrl ),
 		} ),
 		new MetaDescriptionKeywordAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify14" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify15" ),
+			urlTitle: createAnchorOpeningTag( options.metaDescriptionKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.metaDescriptionKeyphraseCTAUrl ),
 		} ),
 		new MetaDescriptionLength( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify46" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify47" ),
+			urlTitle: createAnchorOpeningTag( options.metaDescriptionLengthUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.metaDescriptionLengthCTAUrl ),
 		} ),
 		new SubheadingsKeyword( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify16" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify17" ),
+			urlTitle: createAnchorOpeningTag( options.subheadingsKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.subheadingsKeyphraseCTAUrl ),
 		} ),
 		new TextCompetingLinksAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify18" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify19" ),
+			urlTitle: createAnchorOpeningTag( options.textCompetingLinksUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.textCompetingLinksCTAUrl ),
 		} ),
 		new TextLength( {
 			recommendedMinimum: 200,
 			slightlyBelowMinimum: 150,
 			belowMinimum: 100,
 			veryFarBelowMinimum: 50,
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify58" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify59" ),
+			urlTitle: createAnchorOpeningTag( options.textLengthUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.textLengthCTAUrl ),
 		} ),
 		new TitleKeywordAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify24" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify25" ),
+			urlTitle: createAnchorOpeningTag( options.titleKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.titleKeyphraseCTAUrl ),
 		} ),
 		new TitleWidth( {
 			scores: {
 				widthTooShort: 9,
 			},
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify52" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify53" ),
+			urlTitle: createAnchorOpeningTag( options.titleWidthUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.titleWidthCTAUrl ),
 		}, true ),
 		new UrlKeywordAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify26" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify27" ),
+			urlTitle: createAnchorOpeningTag( options.urlKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.urlKeyphraseCTAUrl ),
 		} ),
 		new FunctionWordsInKeyphrase( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify50" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify51" ),
+			urlTitle: createAnchorOpeningTag( options.functionWordsInKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.functionWordsInKeyphraseCTAUrl ),
 		} ),
 		new SingleH1Assessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify54" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify55" ),
+			urlTitle: createAnchorOpeningTag( options.singleH1UrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.singleH1CTAUrl ),
 		} ),
 		new ImageCount( {
 			scores: {
 				okay: 6,
 			},
 			recommendedCount: 4,
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify20" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify21" ),
+			urlTitle: createAnchorOpeningTag( options.imageCountUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.imageCountCTAUrl ),
 		}, true ),
 		new ImageKeyphrase( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify22" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify23" ),
+			urlTitle: createAnchorOpeningTag( options.imageKeyphraseUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.imageKeyphraseCTAUrl ),
 		} ),
 		new ImageAltTags( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify40" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify41" ),
+			urlTitle: createAnchorOpeningTag( options.imageAltTagsUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.imageAltTagsCTAUrl ),
 		}
 		),
 		new KeyphraseDistribution( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify30" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify31" ),
+			urlTitle: createAnchorOpeningTag( options.keyphraseDistributionUrlTitle ),
+			urlCallToAction: createAnchorOpeningTag( options.keyphraseDistributionCTAUrl ),
 		} ),
 	];
 };

--- a/packages/yoastseo/src/scoring/productPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/seoAssessor.js
@@ -25,7 +25,6 @@ import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphras
  * @param {object}  i18n            The i18n object used for translations.
  * @param {object}  researcher      The researcher to use for the analysis.
  * @param {Object}  options         The options for this assessor.
- * @param {Object}  options.marker  The marker to pass the list of marks to.
  *
  * @constructor
  */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the possibility to pass different shortlinks to the options of the assessor.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Replaces assessment shortlinks that are passed to the assessment constructors in the product assessors with variables.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
