### PR TITLE
Use the event's target value instead of the event itself when the slug has changed.

### DIFF
--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditorFields.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditorFields.js
@@ -227,12 +227,12 @@ class SnippetEditorFields extends React.Component {
 	/**
 	 * Call the onChange event for the slug.
 	 *
-	 * @param {string} content The content.
+	 * @param {SyntheticEvent} event The event.
 	 *
 	 * @returns {void}
 	 */
-	 onChangeSlug( content ) {
-		this.props.onChange( "slug", content );
+	 onChangeSlug( event ) {
+		this.props.onChange( "slug", event.target.value );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where a post's slug could not be updated in the Google preview.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Reproducing the bug in the block editor
* Create a post.
* Try to update the slug.
* The slug should have changed too `[object Object]`.
* Check the developer console, it should have the following error:
  ```
  analysis-170-RC1.js:344 Uncaught DOMException: Failed to execute 'postMessage' on 'Worker': function () {
      return null;
    } could not be cloned.
  ```

#### Reproducing the bug in the Elementor editor
* Edit the post in Elementor.
* Try to update the slug.
* The slug should not update.
* Check the developer console, it should have the following error:
  ```
  Uncaught TypeError: r.trim is not a function
  ```

#### Testing if the bug has been fixed in the block editor
* Edit the post in the block editor.
* Try to update the slug.
* The slug should have changed as usual.
* Publish the post.
* The URL of the post should include the slug you entered/changed.

#### Testing if the bug has been fixed in Elementor
* Edit the post in the Elementor editor.
* Try to update the slug.
* The slug should have changed as usual.
* Publish the post.
* The URL of the post should include the slug you entered/changed.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
