### PR TITLE
Fix autoloading priority in development builds

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -5,6 +5,8 @@
  * @package WPSEO\Main
  */
 
+use Composer\Autoload\ClassLoader;
+
 if ( ! function_exists( 'add_filter' ) ) {
 	header( 'Status: 403 Forbidden' );
 	header( 'HTTP/1.1 403 Forbidden' );
@@ -92,6 +94,10 @@ require_once WPSEO_PATH . 'src/functions.php';
  */
 if ( ! defined( 'YOAST_ENVIRONMENT' ) ) {
 	define( 'YOAST_ENVIRONMENT', 'production' );
+}
+
+if ( YOAST_ENVIRONMENT === 'development' ) {
+	add_action( 'plugins_loaded', 'yoast_wpseo_reregister_autoload', 1 );
 }
 
 /**
@@ -544,6 +550,21 @@ function yoast_wpseo_missing_autoload_notice() {
 	$message = esc_html__( 'The %1$s plugin installation is incomplete. Please refer to %2$sinstallation instructions%3$s.', 'wordpress-seo' );
 	$message = sprintf( $message, 'Yoast SEO', '<a href="https://github.com/Yoast/wordpress-seo#installation">', '</a>' );
 	yoast_wpseo_activation_failed_notice( $message );
+}
+
+/**
+ * Reregisters the autoloader so that Yoast SEO is at the front.
+ * This prevents conflicts with the development versions of our addons.
+ *
+ * @return void
+ */
+function yoast_wpseo_reregister_autoload() {
+	$all_autoloaders = ClassLoader::getRegisteredLoaders();
+	if ( isset( $all_autoloaders[ __DIR__ . '/vendor' ] ) ) {
+		$autoloader = $all_autoloaders[ __DIR__ . '/vendor' ];
+		$autoloader->unregister();
+		$autoloader->register();
+	}
 }
 
 /**

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -563,7 +563,7 @@ function yoast_wpseo_reregister_autoload() {
 	if ( isset( $all_autoloaders[ __DIR__ . '/vendor' ] ) ) {
 		$autoloader = $all_autoloaders[ __DIR__ . '/vendor' ];
 		$autoloader->unregister();
-		$autoloader->register();
+		$autoloader->register( true );
 	}
 }
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -74,7 +74,7 @@ function wpseo_auto_load( $class ) {
 $yoast_autoload_file = WPSEO_PATH . 'vendor/autoload.php';
 
 if ( is_readable( $yoast_autoload_file ) ) {
-	$autoloader = require $yoast_autoload_file;
+	$yoast_autoloader = require $yoast_autoload_file;
 }
 elseif ( ! class_exists( 'WPSEO_Options' ) ) { // Still checking since might be site-level autoload R.
 	add_action( 'admin_init', 'yoast_wpseo_missing_autoload', 1 );
@@ -96,7 +96,7 @@ if ( ! defined( 'YOAST_ENVIRONMENT' ) ) {
 	define( 'YOAST_ENVIRONMENT', 'production' );
 }
 
-if ( YOAST_ENVIRONMENT === 'development' && isset( $autoloader ) ) {
+if ( YOAST_ENVIRONMENT === 'development' && isset( $yoast_autoloader ) ) {
 	add_action(
 		'plugins_loaded',
 		/**
@@ -107,9 +107,9 @@ if ( YOAST_ENVIRONMENT === 'development' && isset( $autoloader ) ) {
 		 *
 		 * @return void
 		 */
-		function() use ( $autoloader ) {
-			$autoloader->unregister();
-			$autoloader->register( true );
+		function() use ( $yoast_autoloader ) {
+			$yoast_autoloader->unregister();
+			$yoast_autoloader->register( true );
 		},
 		1
 	);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Both Yoast SEO and our addons register their autoloaders immediately when loaded. Since many of our addons now include Yoast SEO as a dev-dependency this can cause free classes to be loaded from the vendor directory of one of our addons as opposed to it's own files if the autoloader from that addon was loaded last.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an autoloading problem when using a development version of any Yoast addon.

## Relevant technical choices:

* After all plugins are loaded the Yoast SEO autoloader unregisters and reregisters itself with the `true` argument to ensure it takes priority.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Load this branch and, for example, Yoast SEO WooCommerce from GitHub. It should not cause any fatal errors.

### Test instructions for QA when the code is in the RC
<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* This issue only impacts development builds.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This issue only impacts development builds.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
