### PR TITLE
Create insert_many() function for bulked INSERT INTO queries

### DIFF
--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2211,7 +2211,7 @@ class ORM implements \ArrayAccess {
 		$values     = [];
 		$success    = true;
 
-		foreach ( $models as $model) {
+		foreach ( $models as $model ) {
 
 			if ( ! $model->orm->is_new ) {
 				$model->save();
@@ -2221,7 +2221,7 @@ class ORM implements \ArrayAccess {
 			$new_models[] = $model;
 		}
 
-		foreach ( $new_models as $new_model) {
+		foreach ( $new_models as $new_model ) {
 			// Remove any expression fields as they are already baked into the query.
 			$model_values = \array_values( \array_diff_key( $new_model->orm->dirty_fields, $new_model->orm->expr_fields ) );
 			$values       = \array_merge( $values, $model_values );
@@ -2231,10 +2231,11 @@ class ORM implements \ArrayAccess {
 		$chunk = \apply_filters( 'wpseo_bulk_insert_chunk', 1000 );
 		$chunk = ! is_int( $chunk ) ? 1000 : $chunk;
 		$chunk = ( $chunk > 1000 ) ? 1000 : ( ( $chunk <= 0 ) ? 1000 : $chunk );
-		
-		$values_chunk = $chunk * count( $model_values );
 
-		while ( count( $new_models ) > 0 ) {
+		$values_chunk = ( $chunk * count( $model_values ) );
+
+		$model_count = ( count( $new_models ) );
+		while ( $model_count > 0 ) {
 			$models_to_use = array_slice( $new_models, 0, $chunk );
 			$values_to_use = array_slice( $values, 0, $values_chunk );
 
@@ -2243,8 +2244,10 @@ class ORM implements \ArrayAccess {
 
 			$new_models = array_slice( $new_models, $chunk );
 			$values     = array_slice( $values, $values_chunk );
+
+			$model_count = ( count( $new_models ) );
 		}
-		
+
 		return $success;
 	}
 
@@ -2357,7 +2360,7 @@ class ORM implements \ArrayAccess {
 			$query[] = "({$placeholders}),";
 		}
 
-		return \rtrim( \implode( ' ', $query ), ',');
+		return \rtrim( \implode( ' ', $query ), ',' );
 	}
 
 	/**

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2203,6 +2203,8 @@ class ORM implements \ArrayAccess {
 	 *
 	 * @return int|false The number of inserted rows on success, false for failure.
 	 *
+	 * @example From the Indexable_Link_Builder class: $this->seo_links_repository->query()->save_many( $links );
+	 *
 	 * @throws \Exception Primary key ID contains null value(s).
 	 * @throws \Exception Primary key ID missing from row or is null.
 	 */
@@ -2227,25 +2229,29 @@ class ORM implements \ArrayAccess {
 			$values       = \array_merge( $values, $model_values );
 		}
 
-		// We have to have maximum 1000 rows to be bulk inserted as this is the native MySQL limit for bulk INSERTs.
-		$chunk = \apply_filters( 'wpseo_bulk_insert_chunk', 1000 );
-		$chunk = ! is_int( $chunk ) ? 1000 : $chunk;
+		/**
+		* Filter: 'wpseo_chunk_bulked_insert_queries' - Allow filtering the chunk size of each bulked INSERT query to comply with MySQL limits.
+		*
+		* @api int The chunk size of the bulked INSERT queries.
+		*/
+		$chunk = \apply_filters( 'wpseo_chunk_bulked_insert_queries', 1000 );
+		$chunk = ! \is_int( $chunk ) ? 1000 : $chunk;
 		$chunk = ( $chunk > 1000 ) ? 1000 : ( ( $chunk <= 0 ) ? 1000 : $chunk );
 
-		$values_chunk = ( $chunk * count( $model_values ) );
+		$values_chunk = ( $chunk * \count( $model_values ) );
 
-		$model_count = ( count( $new_models ) );
+		$model_count = ( \count( $new_models ) );
 		while ( $model_count > 0 ) {
-			$models_to_use = array_slice( $new_models, 0, $chunk );
-			$values_to_use = array_slice( $values, 0, $values_chunk );
+			$models_to_use = \array_slice( $new_models, 0, $chunk );
+			$values_to_use = \array_slice( $values, 0, $values_chunk );
 
 			$query   = $this->build_insert_many( $models_to_use );
 			$success = $success && (bool) self::execute( $query, $values_to_use );
 
-			$new_models = array_slice( $new_models, $chunk );
-			$values     = array_slice( $values, $values_chunk );
+			$new_models = \array_slice( $new_models, $chunk );
+			$values     = \array_slice( $values, $values_chunk );
 
-			$model_count = ( count( $new_models ) );
+			$model_count = ( \count( $new_models ) );
 		}
 
 		return $success;

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2222,13 +2222,13 @@ class ORM implements \ArrayAccess {
 		}
 
 		/**
-		* Filter: 'wpseo_chunk_bulked_insert_queries' - Allow filtering the chunk size of each bulked INSERT query to comply with MySQL limits. The value passed shouldn't be over 1000, if it is, we lower it back to 1000 after the filter.
-		*
-		* @api int The chunk size of the bulked INSERT queries.
-		*/
+		 * Filter: 'wpseo_chunk_bulked_insert_queries' - Allow filtering the chunk size of each bulked INSERT query.
+		 *
+		 * @api int The chunk size of the bulked INSERT queries.
+		 */
 		$chunk = \apply_filters( 'wpseo_chunk_bulked_insert_queries', 1000 );
 		$chunk = ! \is_int( $chunk ) ? 1000 : $chunk;
-		$chunk = ( $chunk > 1000 ) ? 1000 : ( ( $chunk <= 0 ) ? 1000 : $chunk );
+		$chunk = ( $chunk <= 0 ) ? 1000 : $chunk;
 
 		$values_chunk = ( $chunk * \count( $model_values ) );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Because inserting multiple rows with a single query instead of using multiple INSERT queries is much more performant in most cases, we needed an ORM function that will enable our classes to perform those batch INSERT queries. This PR creates that function, called `insert_many()`.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a function in our ORM model that enables using a batch INSERT query

## Relevant technical choices:

* The new `insert_many()` function takes an array of model instances as params
* If one of those model instances is not new (so, it's to be **updated** instead of **inserted**), throw an exception as this function should be used only for INSERT queries.
* The reason we made it into a pure INSERT function is that if things went wrong somewhere we wouldnt be able to identify if it was the fault of any UPDATE queries or INSERT ones.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* After Code Review is passed, this can be merged (as per our team meeting), as it "just" adds two new functions in the ORM without using them elsewhere


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* This can be passed when one of the PRs for P2-1131 or P2-1165 is passed, as those two tasks are actually gonna be using the new functions

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
