### PR TITLE
Test filters correctly and get rid of a few partial mocks along the way

### DIFF
--- a/tests/unit/helpers/open-graph/image-helper-test.php
+++ b/tests/unit/helpers/open-graph/image-helper-test.php
@@ -48,13 +48,7 @@ class Image_Helper_Test extends TestCase {
 		$this->url   = Mockery::mock( Url_Helper::class )->makePartial();
 		$this->image = Mockery::mock( Base_Image_Helper::class )->makePartial();
 
-		$this->instance = Mockery::mock(
-			Image_Helper::class,
-			[
-				$this->url,
-				$this->image,
-			]
-		)->makePartial();
+		$this->instance = new Image_Helper( $this->url, $this->image );
 	}
 
 	/**
@@ -99,8 +93,8 @@ class Image_Helper_Test extends TestCase {
 	 * @covers ::get_override_image_size
 	 */
 	public function test_get_override_image_size() {
-		Monkey\Functions\expect( 'apply_filters' )
-			->with( 'wpseo_opengraph_image_size', null )
+		Monkey\Filters\expectApplied( 'wpseo_opengraph_image_size' )
+			->with( null )
 			->once()
 			->andReturn( 'full' );
 
@@ -140,8 +134,8 @@ class Image_Helper_Test extends TestCase {
 			->once()
 			->andReturn( 'image.jpg' );
 
-		$this->instance
-			->expects( 'get_override_image_size' )
+		Monkey\Filters\expectApplied( 'wpseo_opengraph_image_size' )
+			->with( null )
 			->once()
 			->andReturn( 'full' );
 
@@ -165,11 +159,6 @@ class Image_Helper_Test extends TestCase {
 			->with( 1337 )
 			->once()
 			->andReturn( 'image.jpg' );
-
-		$this->instance
-			->expects( 'get_override_image_size' )
-			->once()
-			->andReturn( null );
 
 		$this->assertEquals( 'image.jpg', $this->instance->get_image_by_id( 1337 ) );
 	}

--- a/tests/unit/helpers/twitter/image-helper-test.php
+++ b/tests/unit/helpers/twitter/image-helper-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Helpers\Twitter;
 
 use Brain\Monkey;
 use Mockery;
+use Yoast\WP\SEO\Helpers\Image_Helper as Base_Image_Helper;
 use Yoast\WP\SEO\Helpers\Twitter\Image_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -29,7 +30,7 @@ class Image_Helper_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->instance = Mockery::mock( Image_Helper::class )->makePartial();
+		$this->instance = new Image_Helper( Mockery::mock( Base_Image_Helper::class ) );
 	}
 
 	/**
@@ -38,8 +39,8 @@ class Image_Helper_Test extends TestCase {
 	 * @covers ::get_image_size
 	 */
 	public function test_get_image_size() {
-		Monkey\Functions\expect( 'apply_filters' )
-			->with( 'wpseo_twitter_image_size', 'full' )
+		Monkey\Filters\expectApplied( 'wpseo_twitter_image_size' )
+			->with( 'full' )
 			->once()
 			->andReturn( 'full' );
 

--- a/tests/unit/inc/sitemaps/sitemaps-admin-test.php
+++ b/tests/unit/inc/sitemaps/sitemaps-admin-test.php
@@ -45,7 +45,7 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->instance             = Mockery::mock( WPSEO_Sitemaps_Admin::class )->makePartial();
+		$this->instance             = new WPSEO_Sitemaps_Admin();
 		$this->options_mock         = Mockery::mock( WPSEO_Options::class )->shouldAllowMockingProtectedMethods();
 		$this->mock_post            = Mockery::mock( '\WP_Post' )->makePartial();
 		$this->mock_post->post_type = 'post';
@@ -74,7 +74,7 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 			->shouldReceive( 'is_multisite' )
 			->andReturn( false );
 
-		Monkey\Functions\expect( 'apply_filters' )
+		Monkey\Filters\expectApplied( 'wpseo_allow_xml_sitemap_ping' )
 			->never();
 
 		$this->instance->status_transition( 'publish', 'draft', $this->mock_post );
@@ -103,7 +103,7 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 			->shouldReceive( 'is_multisite' )
 			->andReturn( false );
 
-		Monkey\Functions\expect( 'apply_filters' )
+		Monkey\Filters\expectApplied( 'wpseo_allow_xml_sitemap_ping' )
 			->once()
 			->andReturn( true );
 

--- a/tests/unit/presentations/indexable-presentation/open-graph-locale-test.php
+++ b/tests/unit/presentations/indexable-presentation/open-graph-locale-test.php
@@ -48,7 +48,7 @@ class Open_Graph_Locale_Test extends TestCase {
 			->once()
 			->andReturn( 'en_US' );
 
-		Monkey\Functions\expect( 'apply_filters' )
+		Monkey\Filters\expectApplied( 'wpseo_locale' )
 			->once()
 			->andReturn( 'en_GB' );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Correctly uses the appropriate methods for testing filters rather than mocking `apply_filters` directly.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes several unit tests to use the correct methods.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* The unit tests should pass.
* There should be no unit tests that mock `apply_filters`.


### Test instructions for QA when the code is in the RC

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* None, this only impacts unit tests.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Unit tests.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
