### PR TITLE
P2-1131 Only update necessary links

### DIFF
--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -360,6 +360,12 @@ class Indexable_Link_Builder {
 	 * @return void
 	 */
 	protected function update_related_indexables( $indexable, $links ) {
+		// Old links were only stored by post id, so remove all old seo links for this post that have no indexable id.
+		// This can be removed if we ever fully clear all seo links.
+		if ( $indexable->object_type === 'post' ) {
+			$this->seo_links_repository->delete_all_by_post_id_where_indexable_id_null( $indexable->object_id );
+		}
+
 		$updated_indexable_ids = [];
 		$old_links             = $this->seo_links_repository->find_all_by_indexable_id( $indexable->id );
 
@@ -368,11 +374,6 @@ class Indexable_Link_Builder {
 
 		if ( ! empty( $links_to_remove ) ) {
 			$this->seo_links_repository->delete_many_by_id( \wp_list_pluck( $links_to_remove, 'id' ) );
-		}
-
-		// Old links were only stored by post id, so remove this as well. This can be removed if we ever fully clear all seo links.
-		if ( $indexable->object_type === 'post' ) {
-			$this->seo_links_repository->delete_all_by_post_id_where_indexable_id_null( $indexable->object_id );
 		}
 
 		if ( ! empty( $links_to_add ) ) {

--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -376,7 +376,7 @@ class Indexable_Link_Builder {
 		}
 
 		if ( ! empty( $links_to_add ) ) {
-			$this->seo_links_repository->query()->insert_many( $links_to_add );
+			$this->seo_links_repository->insert_many( $links_to_add );
 		}
 
 		foreach ( $links as $link ) {
@@ -400,9 +400,13 @@ class Indexable_Link_Builder {
 	 * @return SEO_Links[] Links that are in $links_a, but not in $links_b.
 	 */
 	protected function links_diff( $links_a, $links_b ) {
-		return \array_udiff( $links_a, $links_b, function( SEO_Links $link_a, SEO_Links $link_b ) {
-			return strcmp( $link_a->url, $link_b->url );
-		} );
+		return \array_udiff(
+			$links_a,
+			$links_b,
+			function( SEO_Links $link_a, SEO_Links $link_b ) {
+				return strcmp( $link_a->url, $link_b->url );
+			}
+		);
 	}
 
 	/**

--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -379,12 +379,12 @@ class Indexable_Link_Builder {
 			$this->seo_links_repository->insert_many( $links_to_add );
 		}
 
-		foreach ( $links as $link ) {
+		foreach ( $links_to_add as $link ) {
 			if ( $link->target_indexable_id ) {
 				$updated_indexable_ids[] = $link->target_indexable_id;
 			}
 		}
-		foreach ( $old_links as $link ) {
+		foreach ( $links_to_remove as $link ) {
 			$updated_indexable_ids[] = $link->target_indexable_id;
 		}
 

--- a/src/repositories/seo-links-repository.php
+++ b/src/repositories/seo-links-repository.php
@@ -59,6 +59,20 @@ class SEO_Links_Repository {
 	}
 
 	/**
+	 * Clears all SEO Links by post ID where the indexable id is null.
+	 *
+	 * @param int $post_id The post ID.
+	 *
+	 * @return bool Whether or not the delete was succesfull.
+	 */
+	public function delete_all_by_post_id_where_indexable_id_null( $post_id ) {
+		return $this->query()
+			->where( 'post_id', $post_id )
+			->where_null( 'indexable_id' )
+			->delete_many();
+	}
+
+	/**
 	 * Clears all SEO Links by indexable ID.
 	 *
 	 * @param int $indexable_id The indexable ID.
@@ -101,5 +115,18 @@ class SEO_Links_Repository {
 			->where_in( 'target_indexable_id', $indexable_ids )
 			->group_by( 'target_indexable_id' )
 			->find_array();
+	}
+
+	/**
+	 * Deletes all seo links for the given ids.
+	 *
+	 * @param int[] $ids The seo link ids.
+	 *
+	 * @return bool Whether or not the delete was succesfull.
+	 */
+	public function delete_many_by_id( $ids ) {
+		return $this->query()
+			->where_in( 'id', $ids )
+			->delete_many();
 	}
 }

--- a/src/repositories/seo-links-repository.php
+++ b/src/repositories/seo-links-repository.php
@@ -129,4 +129,16 @@ class SEO_Links_Repository {
 			->where_in( 'id', $ids )
 			->delete_many();
 	}
+
+	/**
+	 * Insert multiple seo links.
+	 *
+	 * @param SEO_Links[] $links The seo links to be inserted.
+	 *
+	 * @return bool Whether or not the insert was succesfull.
+	 */
+	public function insert_many( $links ) {
+		return $this->query()
+			->insert_many( $links );
+	}
 }

--- a/tests/unit/builders/indexable-link-builder-test.php
+++ b/tests/unit/builders/indexable-link-builder-test.php
@@ -125,16 +125,21 @@ class Indexable_Link_Builder_Test extends TestCase {
 		Filters\expectApplied( 'the_content' )->with( $content )->andReturnFirstArg();
 		Functions\expect( 'wp_reset_postdata' )->once();
 
-		$parsed_home_url = [
+		$parsed_home_url          = [
 			'scheme' => 'https',
 			'host'   => 'site.com',
 		];
-		$parsed_page_url = [
+		$parsed_page_url          = [
 			'scheme' => 'https',
 			'host'   => 'site.com',
 			'path'   => 'page',
 		];
-		$parsed_link_url = [
+		$parsed_new_link_url      = [
+			'scheme' => 'https',
+			'host'   => 'link.com',
+			'path'   => 'newly-added-in-post',
+		];
+		$parsed_existing_link_url = [
 			'scheme' => 'https',
 			'host'   => 'link.com',
 			'path'   => 'newly-added-in-post',
@@ -143,18 +148,26 @@ class Indexable_Link_Builder_Test extends TestCase {
 		Functions\expect( 'home_url' )->once()->andReturn( 'https://site.com' );
 		Functions\expect( 'wp_parse_url' )->once()->with( 'https://site.com' )->andReturn( $parsed_home_url );
 		Functions\expect( 'wp_parse_url' )->once()->with( 'https://site.com/page' )->andReturn( $parsed_page_url );
-		Functions\expect( 'wp_parse_url' )->once()->with( 'https://link.com/newly-added-in-post' )->andReturn( $parsed_link_url );
+		Functions\expect( 'wp_parse_url' )->once()->with( 'https://link.com/newly-added-in-post' )->andReturn( $parsed_new_link_url );
+		Functions\expect( 'wp_parse_url' )->once()->with( 'https://link.com/already-existed-in-post' )->andReturn( $parsed_existing_link_url );
 
-		$this->url_helper->expects( 'get_link_type' )->with( $parsed_link_url, $parsed_home_url, $is_image )->andReturn( $link_type );
+		$this->url_helper->expects( 'get_link_type' )->with( $parsed_new_link_url, $parsed_home_url, $is_image )->andReturn( $link_type );
+		$this->url_helper->expects( 'get_link_type' )->with( $parsed_existing_link_url, $parsed_home_url, $is_image )->andReturn( $link_type );
 
-		$query_mock             = Mockery::mock();
-		$seo_link               = Mockery::mock( SEO_Links_Mock::class );
-		$seo_link->type         = $link_type;
-		$seo_link->url          = 'https://link.com/newly-added-in-post';
-		$seo_link->indexable_id = $indexable->id;
-		$seo_link->post_id      = $indexable->object_id;
+		$query_mock                 = Mockery::mock();
+		$new_seo_link               = Mockery::mock( SEO_Links_Mock::class );
+		$new_seo_link->type         = $link_type;
+		$new_seo_link->url          = 'https://link.com/newly-added-in-post';
+		$new_seo_link->indexable_id = $indexable->id;
+		$new_seo_link->post_id      = $indexable->object_id;
 
-		$this->seo_links_repository->expects( 'query' )->once()->andReturn( $query_mock );
+		$existing_seo_link               = Mockery::mock( SEO_Links_Mock::class );
+		$existing_seo_link->type         = $link_type;
+		$existing_seo_link->url          = 'https://link.com/already-existed-in-post';
+		$existing_seo_link->indexable_id = $indexable->id;
+		$existing_seo_link->post_id      = $indexable->object_id;
+
+		$this->seo_links_repository->expects( 'query' )->twice()->andReturn( $query_mock );
 		$query_mock->expects( 'create' )->once()->with(
 			[
 				'url'          => 'https://link.com/newly-added-in-post',
@@ -162,16 +175,24 @@ class Indexable_Link_Builder_Test extends TestCase {
 				'indexable_id' => $indexable->id,
 				'post_id'      => $indexable->object_id,
 			]
-		)->andReturn( $seo_link );
+		)->andReturn( $new_seo_link );
+		$query_mock->expects( 'create' )->once()->with(
+			[
+				'url'          => 'https://link.com/already-existed-in-post',
+				'type'         => $link_type,
+				'indexable_id' => $indexable->id,
+				'post_id'      => $indexable->object_id,
+			]
+		)->andReturn( $existing_seo_link );
 
 		$old_seo_link                      = new SEO_Links_Mock();
 		$old_seo_link->target_indexable_id = 3;
 		$old_seo_link->url                 = 'https://link.com/no-longer-in-post/';
 		$old_seo_link->id                  = 567;
-		$this->seo_links_repository->expects( 'find_all_by_indexable_id' )->once()->with( $indexable->id )->andReturn( [ $old_seo_link ] );
+		$this->seo_links_repository->expects( 'find_all_by_indexable_id' )->once()->with( $indexable->id )->andReturn( [ $old_seo_link, $existing_seo_link ] );
 		$this->seo_links_repository->expects( 'delete_many_by_id' )->once()->with( [ 567 ] );
 		$this->seo_links_repository->expects( 'delete_all_by_post_id_where_indexable_id_null' )->once()->with( $indexable->object_id );
-		$this->seo_links_repository->expects( 'insert_many' )->once()->with( [ $seo_link ] );
+		$this->seo_links_repository->expects( 'insert_many' )->once()->with( [ $new_seo_link ] );
 		$this->seo_links_repository
 			->expects( 'get_incoming_link_counts_for_indexable_ids' )
 			->once()
@@ -188,8 +209,9 @@ class Indexable_Link_Builder_Test extends TestCase {
 
 		$links = $this->instance->build( $indexable, $content );
 
-		$this->assertEquals( 1, \count( $links ) );
-		$this->assertEquals( $seo_link, $links[0] );
+		$this->assertEquals( 2, \count( $links ) );
+		$this->assertContains( $new_seo_link, $links );
+		$this->assertContains( $existing_seo_link, $links );
 	}
 
 	/**
@@ -318,8 +340,22 @@ class Indexable_Link_Builder_Test extends TestCase {
 	 */
 	public function build_provider() {
 		return [
-			[ '<a href="https://link.com/newly-added-in-post">link</a>', SEO_Links::TYPE_EXTERNAL, false ],
-			[ '<img src="https://link.com/newly-added-in-post" />', SEO_Links::TYPE_EXTERNAL_IMAGE, true ],
+			[
+				'
+					<a href="https://link.com/newly-added-in-post">link</a>
+					<a href="https://link.com/already-existed-in-post">link</a>
+				',
+				SEO_Links::TYPE_EXTERNAL,
+				false,
+			],
+			[
+				'
+					<img src="https://link.com/newly-added-in-post" />
+					<img src="https://link.com/already-existed-in-post" />
+				',
+				SEO_Links::TYPE_EXTERNAL_IMAGE,
+				true,
+			],
 		];
 	}
 }

--- a/tests/unit/builders/indexable-link-builder-test.php
+++ b/tests/unit/builders/indexable-link-builder-test.php
@@ -87,6 +87,17 @@ class Indexable_Link_Builder_Test extends TestCase {
 			$this->post_helper
 		);
 		$this->instance->set_dependencies( $this->indexable_repository, $this->image_helper );
+
+		Functions\expect( 'wp_list_pluck' )->andReturnUsing(
+			static function ( $array, $prop ) {
+				return \array_map(
+					static function ( $e ) use ( $prop ) {
+						return $e->{$prop};
+					},
+					$array
+				);
+			}
+		);
 	}
 
 	/**
@@ -126,26 +137,27 @@ class Indexable_Link_Builder_Test extends TestCase {
 		$parsed_link_url = [
 			'scheme' => 'https',
 			'host'   => 'link.com',
+			'path'   => 'newly-added-in-post',
 		];
 
 		Functions\expect( 'home_url' )->once()->andReturn( 'https://site.com' );
 		Functions\expect( 'wp_parse_url' )->once()->with( 'https://site.com' )->andReturn( $parsed_home_url );
 		Functions\expect( 'wp_parse_url' )->once()->with( 'https://site.com/page' )->andReturn( $parsed_page_url );
-		Functions\expect( 'wp_parse_url' )->once()->with( 'https://link.com' )->andReturn( $parsed_link_url );
+		Functions\expect( 'wp_parse_url' )->once()->with( 'https://link.com/newly-added-in-post' )->andReturn( $parsed_link_url );
 
 		$this->url_helper->expects( 'get_link_type' )->with( $parsed_link_url, $parsed_home_url, $is_image )->andReturn( $link_type );
 
 		$query_mock             = Mockery::mock();
 		$seo_link               = Mockery::mock( SEO_Links_Mock::class );
 		$seo_link->type         = $link_type;
-		$seo_link->url          = 'https://link.com';
+		$seo_link->url          = 'https://link.com/newly-added-in-post';
 		$seo_link->indexable_id = $indexable->id;
 		$seo_link->post_id      = $indexable->object_id;
 
 		$this->seo_links_repository->expects( 'query' )->once()->andReturn( $query_mock );
 		$query_mock->expects( 'create' )->once()->with(
 			[
-				'url'          => 'https://link.com',
+				'url'          => 'https://link.com/newly-added-in-post',
 				'type'         => $link_type,
 				'indexable_id' => $indexable->id,
 				'post_id'      => $indexable->object_id,
@@ -154,9 +166,12 @@ class Indexable_Link_Builder_Test extends TestCase {
 
 		$old_seo_link                      = new SEO_Links_Mock();
 		$old_seo_link->target_indexable_id = 3;
+		$old_seo_link->url                 = 'https://link.com/no-longer-in-post/';
+		$old_seo_link->id                  = 567;
 		$this->seo_links_repository->expects( 'find_all_by_indexable_id' )->once()->with( $indexable->id )->andReturn( [ $old_seo_link ] );
-		$this->seo_links_repository->expects( 'delete_all_by_indexable_id' )->once()->with( $indexable->id );
-		$this->seo_links_repository->expects( 'delete_all_by_post_id' )->once()->with( $indexable->object_id );
+		$this->seo_links_repository->expects( 'delete_many_by_id' )->once()->with( [ 567 ] );
+		$this->seo_links_repository->expects( 'delete_all_by_post_id_where_indexable_id_null' )->once()->with( $indexable->object_id );
+		$this->seo_links_repository->expects( 'insert_many' )->once()->with( [ $seo_link ] );
 		$this->seo_links_repository
 			->expects( 'get_incoming_link_counts_for_indexable_ids' )
 			->once()
@@ -170,8 +185,6 @@ class Indexable_Link_Builder_Test extends TestCase {
 				]
 			);
 		$this->indexable_repository->expects( 'update_incoming_link_count' )->once()->with( 3, 0 );
-
-		$seo_link->expects( 'save' )->once();
 
 		$links = $this->instance->build( $indexable, $content );
 
@@ -244,6 +257,7 @@ class Indexable_Link_Builder_Test extends TestCase {
 		$seo_link->target_post_id      = $target_indexable->object_id;
 
 		$this->seo_links_repository->expects( 'query' )->once()->andReturn( $query_mock );
+		$this->seo_links_repository->expects( 'delete_many_by_id' )->once()->with( [ 567 ] );
 		$query_mock->expects( 'create' )->once()->with(
 			[
 				'url'          => $target_indexable->permalink,
@@ -255,9 +269,11 @@ class Indexable_Link_Builder_Test extends TestCase {
 
 		$old_seo_link                      = new SEO_Links_Mock();
 		$old_seo_link->target_indexable_id = 3;
+		$old_seo_link->url                 = 'https://link.com/no-longer-in-post/';
+		$old_seo_link->id                  = 567;
 		$this->seo_links_repository->expects( 'find_all_by_indexable_id' )->once()->with( $indexable->id )->andReturn( [ $old_seo_link ] );
-		$this->seo_links_repository->expects( 'delete_all_by_indexable_id' )->once()->with( $indexable->id );
-		$this->seo_links_repository->expects( 'delete_all_by_post_id' )->once()->with( $indexable->object_id );
+		$this->seo_links_repository->expects( 'delete_all_by_post_id_where_indexable_id_null' )->once()->with( $indexable->object_id );
+		$this->seo_links_repository->expects( 'insert_many' )->once()->with( [ $seo_link ] );
 		$this->seo_links_repository->expects( 'get_incoming_link_counts_for_indexable_ids' )
 			->with( [ 2, 3 ] )
 			->andReturn(
@@ -287,8 +303,6 @@ class Indexable_Link_Builder_Test extends TestCase {
 			->with( $target_indexable->permalink )
 			->andReturn( $target_indexable->object_id );
 
-		$seo_link->expects( 'save' )->once();
-
 		$links = $this->instance->build( $indexable, $content );
 
 		self::assertCount( 1, $links );
@@ -304,8 +318,8 @@ class Indexable_Link_Builder_Test extends TestCase {
 	 */
 	public function build_provider() {
 		return [
-			[ '<a href="https://link.com">link</a>', SEO_Links::TYPE_EXTERNAL, false ],
-			[ '<img src="https://link.com" />', SEO_Links::TYPE_EXTERNAL_IMAGE, true ],
+			[ '<a href="https://link.com/newly-added-in-post">link</a>', SEO_Links::TYPE_EXTERNAL, false ],
+			[ '<img src="https://link.com/newly-added-in-post" />', SEO_Links::TYPE_EXTERNAL_IMAGE, true ],
 		];
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the performance of saving posts, especially on posts with a lot of links.

## Relevant technical choices:

* [Added `delete_all_by_post_id_where_indexable_id_null` function. ](https://github.com/Yoast/wordpress-seo/pull/17357/files#diff-3b3c3fe90f75b2e93fe8ed4d29c14aebd7f0924f5b198c9cea29f9ccbce90b86R375) The seo links column did not have a reference to an indexable before, now that we only save new links and delete old ones, we do not want to delete all links by post id, because it would delete the seo links that properly link to an indexable as well.
* I moved the function call to the start of the function, so all old seo links are removed before we retrieve the seo links for the post so we save all seo-links in the new format (with an indexable id).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install `yoast-test-helper` from github and check out the `query-logger` branch.
* Copy a few links of posts to a separate file.
* Create new post with links to these posts.
* Save the post.
* Run the following query to find out if the links were saved (in one query).
  ```sql
  SELECT REQ.id, REQ.url, QUE.query, QUE.`time`
  FROM wp_wpseo_query_log_requests REQ
  JOIN wp_wpseo_query_log_queries QUE
  on REQ.id = QUE.request_id
  WHERE REQ.url LIKE '%post%'
  AND QUE.query LIKE '%wp_yoast_seo_links%'
  ORDER BY REQ.id DESC
  ```
* Write down the link's id's and their corresponding urls.
* Remove two of the links and add two others (can also be an external links).
* Run the query above and verify that the removed links were deleted (in one query by id), use the data you've written down to check that they were the right ids.
* Also check that the two new links were inserted.
* Repeat the same test with 
  ```php
  add_filter( "wpseo_chunk_bulk_insert_queries", function() {
        return 2;
     }
  );
  ```
  applied (and make sure you have more than 2 links in the post-to-be-saved).
* Check if above tested behavior stays the same


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Create 2 new posts called `Internal linking post 1` and `Internal linking post 2`.
* Create a new post called `Internal linking post 3` with links to the previous posts.
* Make sure the internal linking is correctly saved:
  <img width="1040" alt="Screenshot 2021-08-19 at 15 05 32" src="https://user-images.githubusercontent.com/5389513/130073546-b6760cd1-4234-471c-808e-554378f7f755.png">
* Remove the links from the third post.
* Make sure the outgoing and incoming links are updated.
* Repeat the same test with 
  ```php
  add_filter( "wpseo_chunk_bulk_insert_queries", function() {
       return 2;
    }
  );
  ```
  applied (and make sure you have more than 2 unique links in the post-to-be-saved).
* Check if above tested behavior stays the same
**Note:** I found [a bug](https://yoast.atlassian.net/browse/P2-1227) that's not caused bu this PR: The incoming links are not updated as they should.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
