### PR TITLE
Adds time-related words to English, Dutch, Indonesian, Russian and Spanish function words

### DIFF
--- a/packages/yoastseo/src/languageProcessing/languages/en/config/functionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/en/config/functionWords.js
@@ -159,7 +159,7 @@ export const all = [].concat( articles, cardinalNumerals, ordinalNumerals, demon
 	pronominalAdverbs, locativeAdverbs, adverbialGenitives, prepositionalAdverbs, filteredPassiveAuxiliaries, notFilteredPassiveAuxiliaries,
 	otherAuxiliaries, copula, prepositions, coordinatingConjunctions, correlativeConjunctions, subordinatingConjunctions, interviewVerbs,
 	transitionWords, additionalTransitionWords, intensifiers, delexicalizedVerbs, interjections, generalAdjectivesAdverbs,
-	recipeWords, vagueNouns, miscellaneous, titlesPreceding, titlesFollowing );
+	recipeWords, vagueNouns, miscellaneous, timeWords, titlesPreceding, titlesFollowing );
 
 export default {
 	filteredAtEnding,

--- a/packages/yoastseo/src/languageProcessing/languages/es/config/functionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/es/config/functionWords.js
@@ -305,7 +305,7 @@ export const all = [].concat( articles, cardinalNumerals, ordinalNumerals, demon
 	interrogativeProAdverbs, locativeAdverbs, prepositionalAdverbs, otherAuxiliaries, otherAuxiliariesInfinitive, copulaEstar, copulaSer,
 	copulaEstarInfinitive, copulaSerInfinitive, prepositions, coordinatingConjunctions, correlativeConjunctions,
 	subordinatingConjunctions, interviewVerbs, transitionWords, additionalTransitionWords, intensifiers, delexicalizedVerbs,
-	delexicalizedVerbsInfinitive, interjections, generalAdjectivesAdverbs, recipeWords, vagueNouns, miscellaneous,
+	delexicalizedVerbsInfinitive, interjections, generalAdjectivesAdverbs, recipeWords, vagueNouns, miscellaneous, timeWords,
 	titlesPreceding, titlesFollowing );
 
 export default {

--- a/packages/yoastseo/src/languageProcessing/languages/id/config/functionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/id/config/functionWords.js
@@ -185,7 +185,7 @@ export const all = [].concat( articles, cardinalNumerals, ordinalNumerals, demon
 	personalPronounsNominative, quantifiers, indefinitePronouns, interrogativeDeterminers, interrogativePronouns, interrogativeAdverbs,
 	locativeAdverbs, adverbialGenitives, auxiliaries, copula, prepositions, coordinatingConjunctions, correlativeConjunctions,
 	subordinatingConjunctions, interviewVerbs, additionalTransitionWords, intensifiers, delexicalizedVerbs, interjections,
-	generalAdjectivesAndAdverbs, recipeWords, vagueNouns, miscellaneous, titlesPreceding, relativePronoun, transitionWords );
+	generalAdjectivesAndAdverbs, recipeWords, vagueNouns, miscellaneous, titlesPreceding, relativePronoun, transitionWords, timeWords );
 
 /**
  * Returns function words for Indonesian.

--- a/packages/yoastseo/src/languageProcessing/languages/nl/config/functionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nl/config/functionWords.js
@@ -220,7 +220,7 @@ export const all = [].concat( articles, cardinalNumerals, ordinalNumerals, demon
 	otherAuxiliaries, otherAuxiliariesInfinitive, copula, copulaInfinitive, prepositions, coordinatingConjunctions,
 	correlativeConjunctions, subordinatingConjunctions, interviewVerbs,
 	transitionWords, additionalTransitionWords, intensifiers, delexicalizedVerbs, delexicalizedVerbsInfinitive,
-	interjections, generalAdjectivesAdverbs, recipeWords, vagueNouns, miscellaneous, titlesPreceding, titlesFollowing );
+	interjections, generalAdjectivesAdverbs, recipeWords, vagueNouns, miscellaneous, timeWords, titlesPreceding, titlesFollowing );
 
 export default {
 	filteredAtEnding,

--- a/packages/yoastseo/src/languageProcessing/languages/ru/config/functionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ru/config/functionWords.js
@@ -507,7 +507,7 @@ export const all = [].concat( cardinalNumerals, ordinalNumerals, demonstrativePr
 	locativeAdverbs, adverbialGenitives, filteredPassiveAuxiliaries,
 	otherAuxiliaries, copula, prepositions, coordinatingConjunctions, subordinatingConjunctions, interviewVerbs,
 	transitionWords, intensifiers, delexicalizedVerbs, interjections, generalAdjectivesAdverbs,
-	recipeWords, vagueNouns, miscellaneous, titlesPreceding, titlesFollowing );
+	recipeWords, vagueNouns, miscellaneous, titlesPreceding, titlesFollowing, timeWords );
 
 export default {
 	filteredAtEnding,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds a missing array entry that caused time-related words in Dutch, English, Indonesian, Russian, and Spanish to not be counted as function words.
* Improves the filtering out of function words in Dutch, English, Indonesian, Russian, and Spanish by including time-related words like 'minute'.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set your site to English, open a post and set `minute` as your keyphrase. Make sure that the Function words in keyphrase assessment gets triggered.
* Set your site to Dutch, open a post and set `minuut` as your keyphrase. Make sure that the Function words in keyphrase assessment gets triggered.
 * Set your site to Indonesian, open a post and set `detik` as your keyphrase. Make sure that the Function words in keyphrase assessment gets triggered.
 * Set your site to Russian, open a post and set `секунд` as your keyphrase. Make sure that the Function words in keyphrase assessment gets triggered.
 * Set your site to Spanish, open a post and set `minuto` as your keyphrase. Make sure that the Function words in keyphrase assessment gets triggered.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
