### PR TITLE
P2 1229 insert many dirty fields

### DIFF
--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2235,9 +2235,9 @@ class ORM implements \ArrayAccess {
 		 *
 		 * @api int The chunk size of the bulked INSERT queries.
 		 */
-		$chunk = \apply_filters( 'wpseo_chunk_bulked_insert_queries', 1000 );
-		$chunk = ! \is_int( $chunk ) ? 1000 : $chunk;
-		$chunk = ( $chunk <= 0 ) ? 1000 : $chunk;
+		$chunk = \apply_filters( 'wpseo_chunk_bulked_insert_queries', 100 );
+		$chunk = ! \is_int( $chunk ) ? 100 : $chunk;
+		$chunk = ( $chunk <= 0 ) ? 100 : $chunk;
 
 		$model_count = ( \count( $models ) );
 		while ( $model_count > 0 ) {

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2210,7 +2210,7 @@ class ORM implements \ArrayAccess {
 	 */
 	public function insert_many( $models ) {
 		// Validate the input first.
-		if ( ! \is_array( $models )  ) {
+		if ( ! \is_array( $models ) ) {
 			throw new \InvalidArgumentException( 'Invalid instances to be inserted' );
 		}
 

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2242,7 +2242,7 @@ class ORM implements \ArrayAccess {
 		}
 
 		if ( empty( $models ) ) {
-			return false;
+			return true;
 		}
 
 		$success = true;

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2259,13 +2259,12 @@ class ORM implements \ArrayAccess {
 		$chunk = ! \is_int( $chunk ) ? 100 : $chunk;
 		$chunk = ( $chunk <= 0 ) ? 100 : $chunk;
 
-		$model_count = ( \count( $models ) );
-		while ( $model_count > 0 ) {
-			$values        = [];
-			$models_to_use = \array_slice( $models, 0, $chunk );
+		$chunked_models = \array_chunk( $models, $chunk );
+		foreach ( $chunked_models as $models_chunk ) {
+			$values = [];
 
 			// Now, we're creating all dirty fields throughout the models and setting them to null if they don't exist in each model.
-			foreach ( $models_to_use as $model ) {
+			foreach ( $models_chunk as $model ) {
 				$model_values = [];
 				foreach ( $dirty_column_names as $dirty_field ) {
 					$model->orm->dirty_fields[ $dirty_field ] = ( isset( $model->orm->dirty_fields[ $dirty_field ] ) ) ? $model->orm->dirty_fields[ $dirty_field ] : null;
@@ -2277,12 +2276,8 @@ class ORM implements \ArrayAccess {
 			}
 			// We now have the same dirty fields in all our models and also gathered all values.
 
-			$query   = $this->build_insert_many( $models_to_use, $dirty_column_names );
+			$query   = $this->build_insert_many( $models_chunk, $dirty_column_names );
 			$success = $success && (bool) self::execute( $query, $values );
-
-			$models = \array_slice( $models, $chunk );
-
-			$model_count = ( \count( $models ) );
 		}
 
 		return $success;

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2205,13 +2205,17 @@ class ORM implements \ArrayAccess {
 	 *
 	 * @example From the Indexable_Link_Builder class: $this->seo_links_repository->query()->insert_many( $links );
 	 *
-	 * @throws \Exception Invalid or no instances to be inserted.
-	 * @throws \Exception Instance to be inserted is not a new one.
+	 * @throws \InvalidArgumentException Invalid instances to be inserted.
+	 * @throws \InvalidArgumentException Instance to be inserted is not a new one.
 	 */
 	public function insert_many( $models ) {
 		// Validate the input first.
-		if ( ! \is_array( $models ) || empty( $models ) ) {
-			throw new \Exception( 'Invalid or no instances to be inserted' );
+		if ( ! \is_array( $models )  ) {
+			throw new \InvalidArgumentException( 'Invalid instances to be inserted' );
+		}
+
+		if ( empty( $models ) ) {
+			return false;
 		}
 
 		$total_dirty_fields = [];
@@ -2220,7 +2224,7 @@ class ORM implements \ArrayAccess {
 		// First, we'll gather all the dirty fields throughout the models to be inserted.
 		foreach ( $models as $model ) {
 			if ( ! $model->orm->is_new ) {
-				throw new \Exception( 'Instance to be inserted is not a new one' );
+				throw new \InvalidArgumentException( 'Instance to be inserted is not a new one' );
 			}
 
 			// Remove any expression fields as they are already baked into the query.

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -48,7 +48,6 @@ use Yoast\WP\SEO\Config\Migration_Status;
  * @see http://www.php-fig.org/psr/psr-1/
  */
 class ORM implements \ArrayAccess {
-
 	/*
 	 * --- CLASS CONSTANTS ---
 	 */

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2205,9 +2205,15 @@ class ORM implements \ArrayAccess {
 	 *
 	 * @example From the Indexable_Link_Builder class: $this->seo_links_repository->query()->save_many( $links );
 	 *
+	 * @throws \Exception Invalid or no instances to be inserted.
 	 * @throws \Exception Instance to be inserted is not a new one.
 	 */
 	public function insert_many( $models ) {
+		// Validate the input first.
+		if ( ! \is_array( $models ) || empty( $models ) ) {
+			throw new \Exception( 'Invalid or no instances to be inserted' );
+		}
+
 		$values  = [];
 		$success = true;
 

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2246,9 +2246,6 @@ class ORM implements \ArrayAccess {
 
 		$success = true;
 
-		// First, we'll gather all the dirty fields throughout the models to be inserted.
-		$dirty_column_names = $this->get_dirty_column_names( $models );
-
 		/**
 		 * Filter: 'wpseo_chunk_bulked_insert_queries' - Allow filtering the chunk size of each bulked INSERT query.
 		 *

--- a/tests/unit/doubles/lib/orm-double.php
+++ b/tests/unit/doubles/lib/orm-double.php
@@ -4,6 +4,9 @@ namespace doubles\lib;
 
 use Yoast\WP\Lib\ORM;
 
+/**
+ * Class Orm_Double.
+ */
 class Orm_Double extends ORM {
 
 	/**

--- a/tests/unit/doubles/lib/orm-double.php
+++ b/tests/unit/doubles/lib/orm-double.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace doubles\lib;
+
+use Yoast\WP\Lib\ORM;
+
+class Orm_Double extends ORM {
+
+	/**
+	 * "Public" constructor; shouldn't be called directly.
+	 * Use the ORM::for_table factory method instead.
+	 *
+	 * @param string $table_name Table name.
+	 * @param array  $data Data to populate table.
+	 */
+	public function __construct( $table_name, $data = [] ) {
+		$this->table_name = $table_name;
+		$this->data       = $data;
+	}
+}

--- a/tests/unit/repositories/orm-test.php
+++ b/tests/unit/repositories/orm-test.php
@@ -1,0 +1,66 @@
+<?php
+
+use doubles\lib\Orm_Double;
+use Yoast\WP\Lib\ORM;
+use Yoast\WP\SEO\Models\Indexable;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+class Orm_Test extends TestCase {
+
+	/**
+	 * @var Orm_Double
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the test.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Orm_Double( 'test', [] );
+	}
+
+	public function test_insert_many_throws_on_invalid_argument() {
+		// Arrange.
+		$models = $this;
+		$this->expectException( \InvalidArgumentException::class );
+
+		// Act.
+		$result = $this->instance->insert_many( $models );
+
+		// Assert.
+	}
+
+	public function test_insert_many_early_return_for_empty_array() {
+		// Arrange.
+		$models = [];
+
+		// Act.
+		$result = $this->instance->insert_many( $models );
+
+		// Assert.
+		$this->assertTrue( $result );
+	}
+
+	public function test_insert_many_throws_on_not_new_model() {
+		// Arrange.
+		$orm = Mockery::mock( ORM::class );
+		$orm->expects( 'is_new' )
+			->withNoArgs()
+			->andReturn( false );
+		$indexable      = Mockery::mock( Indexable::class );
+		$indexable->orm = $orm;
+
+		$models = [
+			$indexable,
+		];
+
+		$this->expectException( \InvalidArgumentException::class );
+
+		// Act.
+		$result = $this->instance->insert_many( $models );
+
+		// Assert.
+	}
+}

--- a/tests/unit/repositories/orm-test.php
+++ b/tests/unit/repositories/orm-test.php
@@ -5,9 +5,16 @@ use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
+/**
+ * Class Orm_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\Lib\ORM
+ */
 class Orm_Test extends TestCase {
 
 	/**
+	 * The instance to test.
+	 *
 	 * @var Orm_Double
 	 */
 	protected $instance;
@@ -21,6 +28,11 @@ class Orm_Test extends TestCase {
 		$this->instance = new Orm_Double( 'test', [] );
 	}
 
+	/**
+	 * Test_insert_many_throws_on_invalid_argument.
+	 *
+	 * @covers ::insert_many
+	 */
 	public function test_insert_many_throws_on_invalid_argument() {
 		// Arrange.
 		$models = $this;
@@ -32,6 +44,11 @@ class Orm_Test extends TestCase {
 		// Assert.
 	}
 
+	/**
+	 * Test_insert_many_early_return_for_empty_array.
+	 *
+	 * @covers ::insert_many
+	 */
 	public function test_insert_many_early_return_for_empty_array() {
 		// Arrange.
 		$models = [];
@@ -43,6 +60,11 @@ class Orm_Test extends TestCase {
 		$this->assertTrue( $result );
 	}
 
+	/**
+	 * Test_insert_many_throws_on_not_new_model.
+	 *
+	 * @covers ::insert_many
+	 */
 	public function test_insert_many_throws_on_not_new_model() {
 		// Arrange.
 		$orm = Mockery::mock( ORM::class );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix insert_many() to cover cases where model instances are having different set of dirty_values among them, as per Herre's input on https://github.com/Yoast/wordpress-seo/pull/17353
* We also improve exception handling as per Hans Christiaan's input on https://github.com/Yoast/wordpress-seo/pull/17360

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enhances our database access layer to allow batch inserts.

## Relevant technical choices:

* The new `insert_many()` function takes an array of model instances as params
* If one of those model instances is not new (so, it's to be **updated** instead of **inserted**), throw an `InvalidArgumentException` as this function should be used only for INSERT queries.
* The reason we made it into a pure INSERT function is that if things went wrong somewhere we wouldnt be able to identify if it was the fault of any UPDATE queries or INSERT ones.
* The new `insert_many()` function doesn't throw exception for invalid Primary key IDs, unlike the similar save() function. The reason for that is that it looks like the save() function is doing that so that it can store the id of the last inserted row (`$wpdb->insert_id`) in the data of the processed instance. With bulk INSERTS we're inherently not able to retrieve the ids of the inserted rows, so we're not doing that at all. 
* We gather all dirty fields in the passed instances and go through each dirty field of each instance, to make sure we have a unified set of dirty fields to pass placeholders for and values for.
* We also throw `InvalidArgumentException` if the param given in `insert_many()` function is not an array. If it's an empty array, we return false, as it's a no-op.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* After Code Review is passed, this can be merged (as per our team meeting), as it "just" adds two new functions in the ORM without using them elsewhere
* After this is merged, please close the P2-1205 too, as we packed any needed changes for that task in the current PR


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* This can be passed when one of the PRs for P2-1131 or P2-1165 is passed, as those two tasks are actually gonna be using the new functions


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
