### PR TITLE
Hide SEO Optimization notification on non-prod sites

### DIFF
--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -7,6 +7,7 @@ use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
+use Yoast\WP\SEO\Helpers\Environment_Helper;
 use Yoast\WP\SEO\Helpers\Notification_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
@@ -113,6 +114,13 @@ class Indexing_Notification_Integration implements Integration_Interface {
 	protected $addon_manager;
 
 	/**
+	 * The Environment Helper.
+	 *
+	 * @var Environment_Helper
+	 */
+	protected $environment_helper;
+
+	/**
 	 * Indexing_Notification_Integration constructor.
 	 *
 	 * @param Yoast_Notification_Center $notification_center The notification center.
@@ -122,6 +130,7 @@ class Indexing_Notification_Integration implements Integration_Interface {
 	 * @param Notification_Helper       $notification_helper The notification helper.
 	 * @param Indexing_Helper           $indexing_helper     The indexing helper.
 	 * @param WPSEO_Addon_Manager       $addon_manager       The addon manager.
+	 * @param Environment_Helper        $environment_helper  The environment helper.
 	 */
 	public function __construct(
 		Yoast_Notification_Center $notification_center,
@@ -130,7 +139,8 @@ class Indexing_Notification_Integration implements Integration_Interface {
 		Short_Link_Helper $short_link_helper,
 		Notification_Helper $notification_helper,
 		Indexing_Helper $indexing_helper,
-		WPSEO_Addon_Manager $addon_manager
+		WPSEO_Addon_Manager $addon_manager,
+		Environment_Helper $environment_helper
 	) {
 		$this->notification_center = $notification_center;
 		$this->product_helper      = $product_helper;
@@ -139,6 +149,7 @@ class Indexing_Notification_Integration implements Integration_Interface {
 		$this->notification_helper = $notification_helper;
 		$this->indexing_helper     = $indexing_helper;
 		$this->addon_manager       = $addon_manager;
+		$this->environment_helper  = $environment_helper;
 	}
 
 	/**
@@ -211,6 +222,9 @@ class Indexing_Notification_Integration implements Integration_Interface {
 	 * @return bool If the notification should be shown.
 	 */
 	protected function should_show_notification() {
+		if ( ! $this->environment_helper->is_production_mode() ) {
+			return false;
+		}
 		// Don't show a notification if the indexing has already been started earlier.
 		if ( $this->indexing_helper->get_started() > 0 ) {
 			return false;

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -8,6 +8,7 @@ use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Config\Indexing_Reasons;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
+use Yoast\WP\SEO\Helpers\Environment_Helper;
 use Yoast\WP\SEO\Helpers\Notification_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
@@ -85,6 +86,13 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	protected $addon_manager;
 
 	/**
+	 * The environment Helper.
+	 *
+	 * @var Mockery\MockInterface|Environment_Helper
+	 */
+	protected $environment_helper;
+
+	/**
 	 * The instance under test.
 	 *
 	 * @var Indexing_Notification_Integration
@@ -104,6 +112,7 @@ class Indexing_Notification_Integration_Test extends TestCase {
 		$this->notification_helper = Mockery::mock( Notification_Helper::class );
 		$this->indexing_helper     = Mockery::mock( Indexing_Helper::class );
 		$this->addon_manager       = Mockery::mock( WPSEO_Addon_Manager::class );
+		$this->environment_helper  = Mockery::mock( Environment_Helper::class );
 
 
 		$this->instance = new Indexing_Notification_Integration(
@@ -113,7 +122,8 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			$this->short_link_helper,
 			$this->notification_helper,
 			$this->indexing_helper,
-			$this->addon_manager
+			$this->addon_manager,
+			$this->environment_helper
 		);
 	}
 
@@ -146,6 +156,10 @@ class Indexing_Notification_Integration_Test extends TestCase {
 		$this->assertInstanceOf(
 			Indexing_Helper::class,
 			$this->getPropertyValue( $this->instance, 'indexing_helper' )
+		);
+		$this->assertInstanceOf(
+			Environment_Helper::class,
+			$this->getPropertyValue( $this->instance, 'environment_helper' )
 		);
 	}
 
@@ -240,6 +254,10 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	 * @covers ::should_show_notification
 	 */
 	public function test_create_notification_no_unindexed_items() {
+		$this->environment_helper
+			->expects( 'is_production_mode' )
+			->andReturn( true );
+
 		$this->indexing_helper
 			->expects( 'get_started' )
 			->andReturn( 0 );
@@ -264,6 +282,10 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	 * @covers ::should_show_notification
 	 */
 	public function test_create_notification_with_having_indexing_started() {
+		$this->environment_helper
+			->expects( 'is_production_mode' )
+			->andReturn( true );
+
 		$this->indexing_helper
 			->expects( 'get_started' )
 			->andReturn( 123456789 );
@@ -287,6 +309,10 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	 * @covers ::notification
 	 */
 	public function test_maybe_create_notification_with_indexing_failed_reason() {
+		$this->environment_helper
+			->expects( 'is_production_mode' )
+			->andReturn( true );
+
 		$this->indexing_helper
 			->expects( 'get_started' )
 			->andReturn( 0 );
@@ -333,6 +359,10 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	 * @param string $reason The reason for indexing.
 	 */
 	public function test_maybe_create_notification_with_indexing_reasons( $reason ) {
+		$this->environment_helper
+			->expects( 'is_production_mode' )
+			->andReturn( true );
+
 		$this->indexing_helper
 			->expects( 'get_started' )
 			->andReturn( 0 );
@@ -406,6 +436,10 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	 * @covers ::should_show_notification
 	 */
 	public function test_maybe_cleanup_notification_when_there_is_something_to_index() {
+		$this->environment_helper
+			->expects( 'is_production_mode' )
+			->andReturn( true );
+
 		$this->notification_center
 			->expects( 'get_notification_by_id' )
 			->once()
@@ -436,6 +470,10 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	 * @covers ::should_show_notification
 	 */
 	public function test_maybe_cleanup_notification_when_the_user_has_started_indexing_without_finishing() {
+		$this->environment_helper
+			->expects( 'is_production_mode' )
+			->andReturn( true );
+
 		$this->notification_center
 			->expects( 'get_notification_by_id' )
 			->once()
@@ -464,6 +502,10 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	 * @covers ::maybe_cleanup_notification
 	 */
 	public function test_maybe_cleanup_notification() {
+		$this->environment_helper
+			->expects( 'is_production_mode' )
+			->andReturn( true );
+
 		$this->notification_center
 			->expects( 'get_notification_by_id' )
 			->once()
@@ -485,5 +527,23 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->once();
 
 		$this->instance->maybe_cleanup_notification();
+	}
+
+	/**
+	 * Tests creating the notification when it's not a prod site.
+	 *
+	 * @covers ::maybe_create_notification
+	 * @covers ::should_show_notification
+	 */
+	public function test_create_notification_no_prod_site() {
+		$this->environment_helper
+			->expects( 'is_production_mode' )
+			->andReturn( false );
+
+		$this->notification_center
+			->expects( 'add_notification' )
+			->never();
+
+		$this->instance->maybe_create_notification();
 	}
 }

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -530,7 +530,7 @@ class Indexing_Notification_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests creating the notification when it's not a prod site.
+	 * Tests that no notification is created when it's not a prod site.
 	 *
 	 * @covers ::maybe_create_notification
 	 * @covers ::should_show_notification


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to show the SEO optimization notification when we're not on a production site.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Stops showing the SEO Optimization notification on non-production sites.

## Relevant technical choices:

* Added a `Environment_Helper` param in the `Indexing_Notification_Integration` constructor, to be able to use the helper's method in the latter's `should_show_notification()` function 
* Checked that we don't construct the `Indexing_Notification_Integration` anywhere in the code that would break by the above addition. Also checked Premium and the add-ons

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

With trunk/last plugin version:
* Go to Tools->Yoast Test and **Reset Indexables tables & migrations**
* Add `define( 'WP_ENVIRONMENT_TYPE', 'staging' );` in your wp-config.php
* Go to SEO->General
* You get a notification there prompting you to **Start SEO data optimization** but you shouldn't

With this PR/RC:
* Go to Tools->Yoast Test and **Reset Indexables tables & migrations**
* Add `define( 'WP_ENVIRONMENT_TYPE', 'staging' );` in your wp-config.php
* Go to SEO->General
* You now don't get a notification there prompting you to **Start SEO data optimization**  


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

To verify that on production sites, we still get the notification like before:

* Go to Tools->Yoast Test and **Reset Indexables tables & migrations**
* Remove `define( 'WP_ENVIRONMENT_TYPE', 'staging' );` fromyour wp-config.php
* Go to SEO->General
* You now get a notification there prompting you to **Start SEO data optimization**  

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
