### PR TITLE
P1-535 Update text colors, sizes and separators on Google preview

### DIFF
--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -31,21 +31,22 @@ import { DEFAULT_MODE, MODE_DESKTOP, MODE_MOBILE, MODES } from "./constants";
  */
 // Was #1e0fbe
 const colorTitleDesktop         = "#1a0dab";
-const colorTitleMobile          = "#1967d2";
+const colorTitleMobile          = "#1558d6";
 const colorUrlBaseDesktop       = "#202124";
 const colorUrlRestDesktop       = "#5f6368";
-const colorUrlMobile            = "#3c4043";
+const colorUrlBaseMobile		= "#202124";
+const colorUrlRestMobile		= "#70757a";
 const colorDescriptionDesktop   = "#4d5156";
 const colorDescriptionMobile    = "#3c4043";
 // Changed to have 4.5:1 contrast.
-const colorGeneratedDescription = "#767676";
+const colorGeneratedDescription = "4d5156";
 // Was #70757f for both desktop and mobile
 const colorDateDesktop          = "#777";
 const colorDateMobile           = "#70757a";
 
 // Font sizes and line-heights.
-const fontSizeTitleMobile    = "16px";
-const lineHeightTitleMobile  = "20px";
+const fontSizeTitleMobile    = "20px";
+const lineHeightTitleMobile  = "26px";
 
 const fontSizeTitleDesktop   = "20px";
 const lineHeightTitleDesktop = "1.3";
@@ -166,11 +167,11 @@ const BaseUrlOverflowContainer = styled( BaseUrl )`
 const UrlContentContainer = styled.span`
 	font-size: ${ props => props.screenMode === MODE_DESKTOP ? fontSizeUrlDesktop : fontSizeUrlMobile };
 	line-height: ${ props => props.screenMode === MODE_DESKTOP ? lineHeightUrlDesktop : lineHeightUrlMobile };
-	color: ${ props => props.screenMode === MODE_DESKTOP ? colorUrlRestDesktop : colorUrlMobile };
+	color: ${ props => props.screenMode === MODE_DESKTOP ? colorUrlRestDesktop : colorUrlRestMobile };
 `;
 
 const UrlBaseContainer = styled.span`
-	color: ${ props => props.screenMode === MODE_DESKTOP ? colorUrlBaseDesktop : colorUrlMobile };
+	color: ${ props => props.screenMode === MODE_DESKTOP ? colorUrlBaseDesktop : colorUrlBaseMobile };
 `;
 
 BaseUrlOverflowContainer.displayName = "SnippetPreview__BaseUrlOverflowContainer";
@@ -488,8 +489,8 @@ export default class SnippetPreview extends PureComponent {
 	 * @returns {?ReactElement} The rendered date.
 	 */
 	renderDate() {
-		// The u22C5 is the unicode character "dot operator" equivalent to `&sdot;`.
-		const separator = this.props.mode === MODE_DESKTOP ? "-" : "\u22C5";
+		// The u2014 and uFF0D unicode characters represent the ßdashes / minus signs.
+		const separator = this.props.mode === MODE_DESKTOP ? "\u2014" : "\uFF0D";
 
 		return this.props.date &&
 			<DatePreview screenMode={ this.props.mode }>{ this.props.date } { separator } </DatePreview>;

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -34,8 +34,8 @@ const colorTitleDesktop         = "#1a0dab";
 const colorTitleMobile          = "#1558d6";
 const colorUrlBaseDesktop       = "#202124";
 const colorUrlRestDesktop       = "#5f6368";
-const colorUrlBaseMobile		= "#202124";
-const colorUrlRestMobile		= "#70757a";
+const colorUrlBaseMobile        = "#202124";
+const colorUrlRestMobile        = "#70757a";
 const colorDescriptionDesktop   = "#4d5156";
 const colorDescriptionMobile    = "#3c4043";
 // Changed to have 4.5:1 contrast.
@@ -489,7 +489,7 @@ export default class SnippetPreview extends PureComponent {
 	 * @returns {?ReactElement} The rendered date.
 	 */
 	renderDate() {
-		// The u2014 and uFF0D unicode characters represent the ßdashes / minus signs.
+		// The u2014 and uFF0D unicode characters represent the em-dashes / minus signs.
 		const separator = this.props.mode === MODE_DESKTOP ? "\u2014" : "\uFF0D";
 
 		return this.props.date &&


### PR DESCRIPTION
⚠️ Please rebase this PR to the `release/17.1` branch before merging it ⚠️ 

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Google changed the look of their search results, so we update our preview to closer resemble that current look.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/search-metadata-preview] Updates the styling of our Google preview to reflect the updated styling of the Google search results.
*  Updates the styling of our Google preview to reflect the updated styling of the Google search results.

## Relevant technical choices:

* Couldn't find the exact separator for mobile, so picked the closest looking one for now.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Compare our Google preview to both the desktop an mobile results from Google
    * The color and font size of the Title on mobile should now be the same
    * The description color should be the same or very close
    * The breadcrumbs on mobile should now have the same two-tone color scheme
    * The separator between Date and Description should be a close match (mobile slightly differs)


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-535
