### PR TITLE
P2 1140 cleanup auto draft indexibles

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -837,6 +837,7 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_172() {
 		\wp_unschedule_hook( 'wpseo_cleanup_orphaned_indexables' );
+		\wp_unschedule_hook( 'wpseo_cleanup_indexables' );
 
 		\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK );
 	}

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -73,7 +73,7 @@ class WPSEO_Upgrade {
 			'15.9.1-RC0' => 'upgrade_1591',
 			'16.2-RC0'   => 'upgrade_162',
 			'16.5-RC0'   => 'upgrade_165',
-			'17.1-RC0'   => 'upgrade_171',
+			'17.2-RC0'   => 'upgrade_172',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -831,11 +831,11 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Performs the 17.1 upgrade. Cleans out any unnecessary indexables. See $cleanup_integration->get_cleanup_tasks() to see what will be cleaned out.
+	 * Performs the 17.2 upgrade. Cleans out any unnecessary indexables. See $cleanup_integration->get_cleanup_tasks() to see what will be cleaned out.
 	 *
 	 * @return void
 	 */
-	private function upgrade_171() {
+	private function upgrade_172() {
 		\wp_unschedule_hook( 'wpseo_cleanup_orphaned_indexables' );
 
 		$cleanup_integration = YoastSEO()->classes->get( \Yoast\WP\SEO\Integrations\Cleanup_Integration::class );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -6,6 +6,8 @@
  */
 
 use Yoast\WP\Lib\Model;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 /**
  * This code handles the option upgrades.
@@ -73,8 +75,7 @@ class WPSEO_Upgrade {
 			'15.9.1-RC0' => 'upgrade_1591',
 			'16.2-RC0'   => 'upgrade_162',
 			'16.5-RC0'   => 'upgrade_165',
-			'16.9-RC0'   => 'upgrade_169',
-			'17.0-RC0'   => 'upgrade_170',
+			'17.1-RC0'   => 'upgrade_171',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -832,42 +833,15 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Performs the 16.9 upgrade. shop_order indexables stopped being added in the db since 16.7, so we have to clean out older entries from the indexable table.
+	 * Performs the 17.1 upgrade. Cleans out any unnecessary indexables. See $cleanup_integration->get_cleanup_tasks() to see what will be cleaned out.
 	 *
-	 * @return void
+	 * @return void 
 	 */
-	private function upgrade_169() {
+	private function upgrade_171() {
+		\wp_unschedule_hook( 'wpseo_cleanup_orphaned_indexables' );
+
 		$cleanup_integration = YoastSEO()->classes->get( \Yoast\WP\SEO\Integrations\Cleanup_Integration::class );
-	
-		$number_of_deletions = $cleanup_integration->clean_indexables_with_object_type( 'post', 'shop_order', 1000 );
-		if ( ! empty( $number_of_deletions ) ) {
-			$indexables_to_clean = [ 'post', 'shop_order' ];
-
-			if ( ! wp_next_scheduled( 'wpseo_cleanup_indexables', $indexables_to_clean ) ) {
-				wp_schedule_event(
-					time(),
-					'hourly',
-					'wpseo_cleanup_indexables',
-					$indexables_to_clean
-				);
-			}
-		}
-	}
-
-	/**
-	 * Performs the 17.0 upgrade. shop_order indexables were cleaned from the indexable table in 16.9, so we have to clean out the orphaned entries from the rest of the tables.
-	 *
-	 * @return void
-	 */
-	private function upgrade_170() {
-		// Sets a scheduled job to do the cleanup eventually and not in the upgrade process itself. When that cleanup is completed, the job will de-register itself.
-		if ( ! wp_next_scheduled( 'wpseo_cleanup_orphaned_indexables' ) ) {
-			wp_schedule_event(
-				time(),
-				'hourly',
-				'wpseo_cleanup_orphaned_indexables'
-			);
-		}
+		$cleanup_integration->run_cleanup();
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -6,8 +6,6 @@
  */
 
 use Yoast\WP\Lib\Model;
-use YoastSEO_Vendor\Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
-use YoastSEO_Vendor\Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 /**
  * This code handles the option upgrades.

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -838,7 +838,7 @@ class WPSEO_Upgrade {
 	private function upgrade_172() {
 		\wp_unschedule_hook( 'wpseo_cleanup_orphaned_indexables' );
 
-		\wp_schedule_single_event( time(), \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK );
+		\wp_schedule_single_event( time() + HOUR_IN_SECONDS, \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -838,8 +838,8 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_169() {
 		$cleanup_integration = YoastSEO()->classes->get( \Yoast\WP\SEO\Integrations\Cleanup_Integration::class );
+	
 		$number_of_deletions = $cleanup_integration->clean_indexables_with_object_type( 'post', 'shop_order', 1000 );
-
 		if ( ! empty( $number_of_deletions ) ) {
 			$indexables_to_clean = [ 'post', 'shop_order' ];
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -839,7 +839,9 @@ class WPSEO_Upgrade {
 		\wp_unschedule_hook( 'wpseo_cleanup_orphaned_indexables' );
 		\wp_unschedule_hook( 'wpseo_cleanup_indexables' );
 
-		\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK );
+		if ( ! \wp_next_scheduled( \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK ) ) {
+			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK );
+		}
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -838,7 +838,7 @@ class WPSEO_Upgrade {
 	private function upgrade_172() {
 		\wp_unschedule_hook( 'wpseo_cleanup_orphaned_indexables' );
 
-		\wp_schedule_single_event( time(), \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK );
+		\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -835,7 +835,7 @@ class WPSEO_Upgrade {
 	/**
 	 * Performs the 17.1 upgrade. Cleans out any unnecessary indexables. See $cleanup_integration->get_cleanup_tasks() to see what will be cleaned out.
 	 *
-	 * @return void 
+	 * @return void
 	 */
 	private function upgrade_171() {
 		\wp_unschedule_hook( 'wpseo_cleanup_orphaned_indexables' );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -838,8 +838,7 @@ class WPSEO_Upgrade {
 	private function upgrade_172() {
 		\wp_unschedule_hook( 'wpseo_cleanup_orphaned_indexables' );
 
-		$cleanup_integration = YoastSEO()->classes->get( \Yoast\WP\SEO\Integrations\Cleanup_Integration::class );
-		$cleanup_integration->run_cleanup();
+		\wp_schedule_single_event( time(), \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -838,7 +838,7 @@ class WPSEO_Upgrade {
 	private function upgrade_172() {
 		\wp_unschedule_hook( 'wpseo_cleanup_orphaned_indexables' );
 
-		\wp_schedule_single_event( time() + HOUR_IN_SECONDS, \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK );
+		\wp_schedule_single_event( time(), \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK );
 	}
 
 	/**

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -82,8 +82,8 @@ class Cleanup_Integration implements Integration_Interface {
 	protected function get_cleanup_tasks() {
 		return \array_merge(
 			[
-				'clean_indexables_with_object_type_and_object_sub_type_shop-order' => function( $limit ) {
-					return $this->clean_indexables_with_object_type_and_object_sub_type( 'post', 'shop-order', $limit );
+				'clean_indexables_with_object_type_and_object_sub_type_shop_order' => function( $limit ) {
+					return $this->clean_indexables_with_object_type_and_object_sub_type( 'post', 'shop_order', $limit );
 				},
 				'clean_indexables_by_post_status_auto-draft' => function( $limit ) {
 					return $this->clean_indexables_with_post_status( 'auto-draft', $limit );

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -83,14 +83,6 @@ class Cleanup_Integration implements Integration_Interface {
 	 * @return Closure[] The cleanup tasks.
 	 */
 	protected function get_cleanup_tasks() {
-
-		/**
-		 * Filter: Adds the possibility to add addition cleanup functions.
-		 *
-		 * @api array Associative array with unique keys. Value should be a cleanup function that receives a limit.
-		 */
-		$additional_tasks = \apply_filters( 'wpseo_cleanup_tasks', [] );
-
 		return \array_merge(
 			[
 				'clean_indexables_with_object_type_and_object_sub_type_shop_order' => function( $limit ) {

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -20,6 +20,11 @@ class Cleanup_Integration implements Integration_Interface {
 	const CRON_HOOK = 'wpseo_cleanup_cron';
 
 	/**
+	 * Identifier for starting the cleanup.
+	 */
+	const START_HOOK = 'wpseo_start_cleanup_indexables';
+
+	/**
 	 * Initializes the integration.
 	 *
 	 * This is the place to register hooks and filters.
@@ -27,6 +32,7 @@ class Cleanup_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
+		\add_action( self::START_HOOK, [ $this, 'run_cleanup' ] );
 		\add_action( self::CRON_HOOK, [ $this, 'run_cleanup_cron' ] );
 		\add_action( 'wpseo_deactivate', [ $this, 'reset_cleanup' ] );
 	}

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -81,7 +81,7 @@ class Cleanup_Integration implements Integration_Interface {
 	 */
 	protected function get_cleanup_tasks() {
 		return [
-			'clean_indexables_by_object_sub_type_shop-order' => function( $limit ) {
+			'clean_indexables_with_object_type_and_object_sub_type_shop-order' => function( $limit ) {
 				return $this->clean_indexables_with_object_type_and_object_sub_type( 'post', 'shop-order', $limit );
 			},
 			'clean_indexables_by_post_status_auto-draft' => function( $limit ) {

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -11,10 +11,13 @@ class Cleanup_Integration implements Integration_Interface {
 
 	/**
 	 * Identifier used to determine the current task.
-	 *
-	 * @var string
 	 */
 	const CURRENT_TASK_OPTION = 'wpseo-cleanup-current-task';
+
+	/**
+	 * Identifier for the cron job.
+	 */
+	const CRON_HOOK = 'wpseo_cleanup_cron';
 
 	/**
 	 * Initializes the integration.
@@ -24,7 +27,7 @@ class Cleanup_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_action( 'wpseo_cleanup_cron', [ $this, 'run_cleanup_cron' ] );
+		\add_action( self::CRON_HOOK, [ $this, 'run_cleanup_cron' ] );
 		\add_action( 'wpseo_deactivate', [ $this, 'reset_cleanup' ] );
 	}
 
@@ -114,7 +117,7 @@ class Cleanup_Integration implements Integration_Interface {
 	 */
 	public function reset_cleanup() {
 		\delete_option( self::CURRENT_TASK_OPTION );
-		\wp_unschedule_hook( 'wpseo_cleanup_cron' );
+		\wp_unschedule_hook( self::CRON_HOOK );
 	}
 
 	/**
@@ -129,7 +132,7 @@ class Cleanup_Integration implements Integration_Interface {
 		\wp_schedule_event(
 			time(),
 			'hourly',
-			'wpseo_cleanup_cron'
+			self::CRON_HOOK
 		);
 	}
 
@@ -139,7 +142,7 @@ class Cleanup_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function run_cleanup_cron() {
-		$current_task_name = \get_option( self::CURRENT_TASK_OPTION, '' );
+		$current_task_name = \get_option( self::CURRENT_TASK_OPTION );
 
 		if ( $current_task_name === false ) {
 			$this->reset_cleanup();

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -32,7 +32,7 @@ class Cleanup_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Returns the conditionals based in which this loadable should be active.
+	 * Returns the conditionals based on which this loadable should be active.
 	 *
 	 * @return array The array of conditionals.
 	 */
@@ -81,7 +81,7 @@ class Cleanup_Integration implements Integration_Interface {
 			'clean_indexables_by_post_status_auto-draft' => function( $limit ) {
 				return $this->clean_indexables_with_post_status( 'auto-draft', $limit );
 			},
-			/* These should always be the last one to be called */
+			/* These should always be the last ones to be called. */
 			'clean_orphaned_content_indexable_hierarchy' => function( $limit ) {
 				return $this->cleanup_orphaned_from_table( 'Indexable_Hierarchy', 'indexable_id', $limit );
 			},
@@ -101,7 +101,7 @@ class Cleanup_Integration implements Integration_Interface {
 	 */
 	private function get_limit() {
 		/**
-		 * Filter: Adds the possibility to limit the number of items are deleted from the database on cleanup.
+		 * Filter: Adds the possibility to limit the number of items that are deleted from the database on cleanup.
 		 *
 		 * @api int $limit Maximum number of indexables to be cleaned up per query.
 		 */
@@ -134,7 +134,7 @@ class Cleanup_Integration implements Integration_Interface {
 	private function start_cron_job( $task_name ) {
 		\update_option( self::CURRENT_TASK_OPTION, $task_name );
 		\wp_schedule_event(
-			( time() + HOUR_IN_SECONDS ),
+			( \time() + HOUR_IN_SECONDS ),
 			'hourly',
 			self::CRON_HOOK
 		);
@@ -164,6 +164,7 @@ class Cleanup_Integration implements Integration_Interface {
 				continue;
 			}
 
+			// Call the cleanup callback function that accompanies the current task.
 			$items_cleaned = $current_task( $limit );
 
 			if ( $items_cleaned === false ) {
@@ -172,7 +173,7 @@ class Cleanup_Integration implements Integration_Interface {
 			}
 
 			if ( $items_cleaned === 0 ) {
-				// Check if we are finshed with all tasks.
+				// Check if we are finished with all tasks.
 				if ( \next( $tasks ) === false ) {
 					$this->reset_cleanup();
 					return;
@@ -210,8 +211,8 @@ class Cleanup_Integration implements Integration_Interface {
 	/**
 	 * Deletes rows from the indexable table depending on the post_status.
 	 *
-	 * @param string $post_status     The post status to query.
-	 * @param int    $limit           The limit we'll apply to the delete query.
+	 * @param string $post_status The post status to query.
+	 * @param int    $limit       The limit we'll apply to the delete query.
 	 *
 	 * @return int|bool The number of rows that was deleted or false if the query failed.
 	 */
@@ -229,7 +230,7 @@ class Cleanup_Integration implements Integration_Interface {
 	/**
 	 * Cleans orphaned rows from a yoast table.
 	 *
-	 * @param string $table  The table to cleanup.
+	 * @param string $table  The table to clean up.
 	 * @param string $column The table column the cleanup will rely on.
 	 * @param int    $limit  The limit we'll apply to the queries.
 	 *

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -2,10 +2,7 @@
 
 namespace Yoast\WP\SEO\Integrations;
 
-use Brain\Monkey\Hook\Exception\InvalidHookArgument;
-use Brain\Monkey\Hook\Exception\InvalidAddedHookArgument;
 use Closure;
-use UnexpectedValueException;
 use Yoast\WP\Lib\Model;
 /**
  * Adds cleanup hooks.

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -130,7 +130,7 @@ class Cleanup_Integration implements Integration_Interface {
 	private function start_cron_job( $task_name ) {
 		\update_option( self::CURRENT_TASK_OPTION, $task_name );
 		\wp_schedule_event(
-			time(),
+			time() + HOUR_IN_SECONDS,
 			'hourly',
 			self::CRON_HOOK
 		);

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -130,7 +130,7 @@ class Cleanup_Integration implements Integration_Interface {
 	private function start_cron_job( $task_name ) {
 		\update_option( self::CURRENT_TASK_OPTION, $task_name );
 		\wp_schedule_event(
-			time() + HOUR_IN_SECONDS,
+			( time() + HOUR_IN_SECONDS ),
 			'hourly',
 			self::CRON_HOOK
 		);

--- a/tests/unit/integrations/cleanup-integration-test.php
+++ b/tests/unit/integrations/cleanup-integration-test.php
@@ -95,7 +95,7 @@ class Cleanup_Integration_Test extends TestCase {
 			->andReturn( $query_limit );
 
 		/* Clean up of indexables with object_sub_type shop-order */
-		$this->setup_clean_indexables_with_object_type_and_object_sub_type_mocks( 50, 'post', 'shop-order', $query_limit );
+		$this->setup_clean_indexables_with_object_type_and_object_sub_type_mocks( 50, 'post', 'shop_order', $query_limit );
 
 		/* Clean up of indexables with post_status auto-draft */
 		$this->setup_clean_indexables_with_post_status_mocks( 50, 'auto-draft', $query_limit );
@@ -138,7 +138,7 @@ class Cleanup_Integration_Test extends TestCase {
 			->andReturn( $query_limit );
 
 		/* Clean up of indexables with object_sub_type shop-order */
-		$this->setup_clean_indexables_with_object_type_and_object_sub_type_mocks( false, 'post', 'shop-order', $query_limit );
+		$this->setup_clean_indexables_with_object_type_and_object_sub_type_mocks( false, 'post', 'shop_order', $query_limit );
 
 		$this->instance->run_cleanup();
 	}
@@ -168,11 +168,11 @@ class Cleanup_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $query_limit );
 
-		$this->setup_clean_indexables_with_object_type_and_object_sub_type_mocks( 1000, 'post', 'shop-order', $query_limit );
+		$this->setup_clean_indexables_with_object_type_and_object_sub_type_mocks( 1000, 'post', 'shop_order', $query_limit );
 
 		Monkey\Functions\expect( 'update_option' )
 			->once()
-			->with( Cleanup_Integration::CURRENT_TASK_OPTION, 'clean_indexables_with_object_type_and_object_sub_type_shop-order' );
+			->with( Cleanup_Integration::CURRENT_TASK_OPTION, 'clean_indexables_with_object_type_and_object_sub_type_shop_order' );
 
 		Monkey\Functions\expect( 'wp_schedule_event' )
 			->once()
@@ -191,11 +191,11 @@ class Cleanup_Integration_Test extends TestCase {
 	 * @covers ::get_limit
 	 * @covers ::start_cron_job
 	 */
-	public function test_run_cleanup_cron() {
+	public function test_run_cleanup_cron_next_task() {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
 			->with( Cleanup_Integration::CURRENT_TASK_OPTION )
-			->andReturn( 'clean_indexables_with_object_type_and_object_sub_type_shop-order' );
+			->andReturn( 'clean_indexables_with_object_type_and_object_sub_type_shop_order' );
 
 		$query_limit = 1000;
 
@@ -203,30 +203,11 @@ class Cleanup_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $query_limit );
 
-		$this->setup_clean_indexables_with_object_type_and_object_sub_type_mocks( 0, 'post', 'shop-order', $query_limit );
+		$this->setup_clean_indexables_with_object_type_and_object_sub_type_mocks( 0, 'post', 'shop_order', $query_limit );
 
 		Monkey\Functions\expect( 'update_option' )
 			->once()
 			->with( Cleanup_Integration::CURRENT_TASK_OPTION, 'clean_indexables_by_post_status_auto-draft' );
-
-		$this->instance->run_cleanup_cron();
-	}
-
-	/**
-	 * Tests the run_cleanup_cron function.
-	 *
-	 * Specifically tests whether the option is set to the next task when the current task is finished.
-	 *
-	 * @covers ::run_cleanup_cron
-	 * @covers ::get_cleanup_tasks
-	 * @covers ::get_limit
-	 * @covers ::start_cron_job
-	 */
-	public function test_run_cleanup_cron_no_tasks() {
-		Monkey\Functions\expect( 'get_option' )
-			->once()
-			->with( Cleanup_Integration::CURRENT_TASK_OPTION )
-			->andReturn( [] );
 
 		$this->instance->run_cleanup_cron();
 	}
@@ -242,7 +223,7 @@ class Cleanup_Integration_Test extends TestCase {
 	 * @covers ::cleanup_orphaned_from_table
 	 * @covers ::start_cron_job
 	 */
-	public function test_run_cleanup_cron_last_tasks() {
+	public function test_run_cleanup_cron_last_task() {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
 			->with( Cleanup_Integration::CURRENT_TASK_OPTION )

--- a/tests/unit/integrations/cleanup-integration-test.php
+++ b/tests/unit/integrations/cleanup-integration-test.php
@@ -50,7 +50,7 @@ class Cleanup_Integration_Test extends TestCase {
 	/**
 	 * Tests calling test_run_cleanup.
 	 *
-	 * @covers ::test_run_cleanup
+	 * @covers ::run_cleanup
 	 * @covers ::get_cleanup_tasks
 	 * @covers ::clean_indexables_with_object_type
 	 * @covers ::clean_indexables_with_post_status
@@ -191,7 +191,7 @@ class Cleanup_Integration_Test extends TestCase {
 	/**
 	 * Tests whether run_cleanup starts the cron-job.
 	 *
-	 * @covers ::test_run_cleanup
+	 * @covers ::run_cleanup
 	 * @covers ::get_cleanup_tasks
 	 * @covers ::get_limit
 	 * @covers ::reset_cleanup

--- a/tests/unit/integrations/cleanup-integration-test.php
+++ b/tests/unit/integrations/cleanup-integration-test.php
@@ -6,7 +6,6 @@ use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Integrations\Cleanup_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
-use Yoast\WP\Lib\Model;
 
 /**
  * Class Cleanup_Integration_Test.

--- a/tests/unit/integrations/cleanup-integration-test.php
+++ b/tests/unit/integrations/cleanup-integration-test.php
@@ -195,7 +195,7 @@ class Cleanup_Integration_Test extends TestCase {
 	 * @covers ::get_cleanup_tasks
 	 * @covers ::get_limit
 	 * @covers ::reset_cleanup
-	 * @covers ::clean_indexables_with_object_type
+	 * @covers ::clean_indexables_with_object_type_and_object_sub_type
 	 * @covers ::start_cron_job
 	 */
 	public function test_run_cleanup_starts_cron_job() {
@@ -211,7 +211,7 @@ class Cleanup_Integration_Test extends TestCase {
 			->once()
 			->andReturn( 1000 );
 
-		$this->instance->expects( 'clean_indexables_with_object_type' )
+		$this->instance->expects( 'clean_indexables_with_object_type_and_object_sub_type' )
 			->once()
 			->with( 'post', 'shop-order', 1000 )
 			->andReturn( 1000 );
@@ -252,7 +252,7 @@ class Cleanup_Integration_Test extends TestCase {
 		$wpdb         = Mockery::mock( 'wpdb' );
 		$wpdb->prefix = 'wp_';
 
-		$this->instance->expects( 'clean_indexables_with_object_type' )
+		$this->instance->expects( 'clean_indexables_with_object_type_and_object_sub_type' )
 			->once()
 			->with( 'post', 'shop-order', 1000 )
 			->andReturn( 0 );
@@ -272,7 +272,7 @@ class Cleanup_Integration_Test extends TestCase {
 	 * @covers ::run_cleanup_cron
 	 * @covers ::get_cleanup_tasks
 	 * @covers ::get_limit
-	 * @covers ::clean_indexables_with_object_type
+	 * @covers ::clean_indexables_with_object_type_and_object_sub_type
 	 * @covers ::start_cron_job
 	 */
 	public function test_run_cleanup_cron_last_tasks() {

--- a/tests/unit/integrations/cleanup-integration-test.php
+++ b/tests/unit/integrations/cleanup-integration-test.php
@@ -55,6 +55,7 @@ class Cleanup_Integration_Test extends TestCase {
 	public function test_register_hooks() {
 		$this->instance->register_hooks();
 
+		$this->assertNotFalse( Monkey\Actions\has( 'wpseo_start_cleanup_indexables', [ $this->instance, 'run_cleanup' ] ), 'Does not have expected wpseo_cleanup filter' );
 		$this->assertNotFalse( Monkey\Actions\has( 'wpseo_cleanup_cron', [ $this->instance, 'run_cleanup_cron' ] ), 'Does not have expected run_cleanup_cron filter' );
 		$this->assertNotFalse( Monkey\Actions\has( 'wpseo_deactivate', [ $this->instance, 'reset_cleanup' ] ), 'Does not have expected reset_cleanup filter' );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Cleans up indexables for posts with `auto-draft` post-status.

## Relevant technical choices:

* Refactored the way that indexables are cleaned up, all responsibility for cleaning up the indexable now lies with the `Cleanup_integration`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have the yoast test helper installed and activated.
* Make sure you have `wordpress-seo-premium`'s `P2-1140-add-cleanup-tasks` branch checked out, built and activated.
* Check-out this branch and build the plugin, and make sure you visit an admin-page.
* Run the following query to add some invalid entries into the database that should be cleaned up by this PR (You should be able to the run the entire query at once):

```sql
# Posts with post_status auto-draft
INSERT INTO wp_yoast_indexable
( post_status, object_type, object_sub_type )
VALUES
( 'auto-draft', 'post', 'post' ),
( 'auto-draft', 'post', 'post' ),
( 'auto-draft', 'post', 'post' ),
( 'auto-draft', 'post', 'post' ),
( 'auto-draft', 'post', 'post' );

# Posts with object_sub_type shop-order
INSERT INTO wp_yoast_indexable
( post_status, object_type, object_sub_type )
VALUES
( 'publish', 'post', 'shop_order' ),
( 'publish', 'post', 'shop_order' ),
( 'publish', 'post', 'shop_order' ),
( 'publish', 'post', 'shop_order' ),
( 'publish', 'post', 'shop_order' );

SET @nonexistentid = (
	SELECT MAX( id ) + 1
	FROM wp_yoast_indexable
);

# Prominent word items that point to non-existant indexables
INSERT INTO wp_yoast_prominent_words
( indexable_id )
VALUES
( @nonexistentid),
( @nonexistentid + 1 ),
( @nonexistentid + 2 ),
( @nonexistentid + 3 ),
( @nonexistentid + 4 );

# Indexable hierarchy items for non-existent indexables
INSERT INTO wp_yoast_indexable_hierarchy
( indexable_id, ancestor_id )
VALUES
( @nonexistentid, 0 ),
( @nonexistentid + 1, 0 ),
( @nonexistentid + 2, 0 ),
( @nonexistentid + 3, 0 ),
( @nonexistentid + 4, 0 );

# SEO link items for non-existent indexables
INSERT INTO wp_yoast_seo_links
( indexable_id )
VALUES
( @nonexistentid),
( @nonexistentid + 1 ),
( @nonexistentid + 2 ),
( @nonexistentid + 3 ),
( @nonexistentid + 4 );

# SEO link items that point to non-existant indexables
INSERT INTO wp_yoast_seo_links
( target_indexable_id )
VALUES
( @nonexistentid),
( @nonexistentid + 1 ),
( @nonexistentid + 2 ),
( @nonexistentid + 3 ),
( @nonexistentid + 4 );
```
* To run the upgrade routine, go to `Tools` > `Yoast Test`, set Yoast SEO DB version to `17.1-RC1`, and click `Save`.
* The upgrade routine should have added a cron action, `wpseo_start_cleanup_indexables`, scheduled to run in 5 minutes. To check and run that, make sure you have installed and activated wp-crontrol, go to Tools->Cron Events, find that hook and hit `Run`. After it's run, it should clean the relevant items from your db.
* Now to check if all the relevant items have been deleted you can use the following SQL queries:
```sql
# Check if there are no more posts with status 'auto-draft'.
SELECT * FROM wp_yoast_indexable
WHERE post_status = 'auto-draft';

# Check if there are no more posts with object_sub_type 'shop_order'.
SELECT * FROM wp_yoast_indexable
WHERE object_sub_type = 'shop-order';

# Check if there are no more orphaned prominent-words items.
SELECT *
FROM wp_yoast_prominent_words table_to_clean
LEFT JOIN wp_yoast_indexable AS indexable_table
ON table_to_clean.indexable_id = indexable_table.id
WHERE indexable_table.id IS NULL
AND table_to_clean.indexable_id IS NOT NULL;

# Check if there are no more orphaned indexable-hierarchy items.
SELECT *
FROM wp_yoast_indexable_hierarchy table_to_clean
LEFT JOIN wp_yoast_indexable AS indexable_table
ON table_to_clean.indexable_id = indexable_table.id
WHERE indexable_table.id IS NULL
AND table_to_clean.indexable_id IS NOT NULL;

# Check if there are no more orphaned seo link items.		
SELECT *
FROM wp_yoast_seo_links table_to_clean
LEFT JOIN wp_yoast_indexable AS indexable_table
ON table_to_clean.indexable_id = indexable_table.id
WHERE indexable_table.id IS NULL
AND table_to_clean.indexable_id IS NOT NULL;

# Check if there are no more orphaned seo link items that target a non-existent indexible.
SELECT *
FROM wp_yoast_seo_links table_to_clean
LEFT JOIN wp_yoast_indexable AS indexable_table
ON table_to_clean.target_indexable_id = indexable_table.id
WHERE indexable_table.id IS NULL
AND table_to_clean.target_indexable_id IS NOT NULL;
```
* Now to test the cron job: Make sure you have installed and activated wp-crontrol.
* Add the following filter to your `functions.php`:
```php
\add_filter( 'wpseo_cron_query_limit_size', function() { return 2; } ); 
```
* Run the first script again that inserts invalid data.
* To run the upgrade routine, go to `Tools` > `Yoast Test`, set Yoast SEO DB version to `17.1-RC1`, and click `Save`.
* Again, this should have added a cron action, `wpseo_start_cleanup_indexables`, scheduled to run in 5 minutes. When we run that in `Tools` > `Cron Events`, this time will clean just the 2 rows in the indexable table with shop_order as object_sub_type. (Just because we ran that cron manually, make sure to `Delete` that from that  `Tools` > `Cron Events` table.
* Under `Tools` > `Cron Events`, notice that the `wpseo_clean_cron` task has been added. Its next execution should be scheduled approx. 1 hour from now.
* Check your db to verify that there are still 3 indexables with object_sub_type shop-order left to remove. This is the first cleanup task that will be run.
* Now if you run the cron even manually by clicking `Run now` on the `Cron Events` page, you will notice that 2 more indexables with `object_sub_type` `shop_order` have been removed.
* Important to note is that everytime when there are no more items to remove, the cron job will try to delete items one more time as a sanity check. So if for example there are no more indexables with `object_sub_type` `shop_order`, and you run the cron job one more time, nothing will happen. After that it will start deleting items for the next task (indexables with `post-status` `auto-draft`. 
* The order of those cleanup tasks is: `1->shop_order subtype 2->auto-draft post_status 3->orphaned prominent words 4->orphaned hierarchies 5-> orphaned indexable_ids from SEO links 6-> orphaned target_indexable_id from SEO links`
* Keep running the cron job manually (you can remove the filter now if you want to speed up the process), until all items have been cleaned up.
* When everything has been deleted, the cron-job will remove itself from the `Tools` > `Cron Events` list.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
