### PR TITLE
Reduce update queries on shutdown

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -62,6 +62,13 @@ class Yoast_Notification_Center {
 	private $notifications_retrieved = false;
 
 	/**
+	 * Internal flag for whether notifications need to be updated in storage.
+	 *
+	 * @var bool
+	 */
+	private $notifications_need_storage = false;
+
+	/**
 	 * Construct.
 	 */
 	private function __construct() {
@@ -321,6 +328,8 @@ class Yoast_Notification_Center {
 
 		// Add to list.
 		$this->notifications[ $user_id ][] = $notification;
+
+		$this->notifications_need_storage = true;
 	}
 
 	/**
@@ -432,6 +441,8 @@ class Yoast_Notification_Center {
 
 		unset( $notifications[ $index ] );
 		$this->notifications[ $user_id ] = array_values( $notifications );
+
+		$this->notifications_need_storage = true;
 	}
 
 	/**
@@ -450,6 +461,7 @@ class Yoast_Notification_Center {
 		}
 
 		$this->remove_notification( $notification, $resolve );
+		$this->notifications_need_storage = true;
 	}
 
 	/**
@@ -582,7 +594,13 @@ class Yoast_Notification_Center {
 		 *
 		 * @api Yoast_Notification[] $notifications
 		 */
-		$merged_notifications = apply_filters( 'yoast_notifications_before_storage', $merged_notifications );
+		$filtered_merged_notifications = apply_filters( 'yoast_notifications_before_storage', $merged_notifications );
+
+		// The notifications were filtered and therefore need to be stored.
+		if ( $merged_notifications !== $filtered_merged_notifications ){
+			$merged_notifications = $filtered_merged_notifications;
+			$this->notifications_need_storage = true;
+		}
 
 		$notifications = $this->split_on_user_id( $merged_notifications );
 
@@ -593,7 +611,10 @@ class Yoast_Notification_Center {
 			return;
 		}
 
-		array_walk( $notifications, [ $this, 'store_notifications_for_user' ] );
+		// Only store notifications if changes are made.
+		if ( $this->notifications_need_storage ){
+			array_walk( $notifications, [ $this, 'store_notifications_for_user' ] );
+		}
 	}
 
 	/**

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -597,8 +597,8 @@ class Yoast_Notification_Center {
 		$filtered_merged_notifications = apply_filters( 'yoast_notifications_before_storage', $merged_notifications );
 
 		// The notifications were filtered and therefore need to be stored.
-		if ( $merged_notifications !== $filtered_merged_notifications ){
-			$merged_notifications = $filtered_merged_notifications;
+		if ( $merged_notifications !== $filtered_merged_notifications ) {
+			$merged_notifications             = $filtered_merged_notifications;
 			$this->notifications_need_storage = true;
 		}
 
@@ -612,7 +612,7 @@ class Yoast_Notification_Center {
 		}
 
 		// Only store notifications if changes are made.
-		if ( $this->notifications_need_storage ){
+		if ( $this->notifications_need_storage ) {
 			array_walk( $notifications, [ $this, 'store_notifications_for_user' ] );
 		}
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Another attempt at reducing the UPDATE queries on every shutdown. Previous attempt was https://github.com/Yoast/wordpress-seo/pull/17297 and this failed because it did not account for live notifications like the premium redirects.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Non-user-facing: prevents updating the user notifications if there were no changes.

## Relevant technical choices:

* I chose another approach than the `$new` array and `$resolved` int checks. Instead, every method that updates notifications will now set `$notifications_need_storage` to true, which is used to check if storage needs updating.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Because the update happens on shutdown, it isn't easily tested with plugins like query monitor. So this is a small workaround.

* In the file `wordpress-seo/admin/class-yoast-notification-center.php` on line 597 / 598 you will find the code `array_walk( $notifications, ...`. Just before that line, add the line `var_dump( $notifications );`
* When this is done *without* this PR, you will see an array being dumped on every page when logged in (even frontpages). This indicates that the code actually gets to this point and enters the next `array_walk()` where all updates are done.
* When this is done *with* this PR, the array will not be dumped on every page, because the code first checks for changes.  

To verify that the update still works with this PR:
* Visit the plugins page
* Enable auto updates for Yoast -> the notification about auto-updates will have disappeared from your dashboard
* Disable auto-updates again -> The notification re-appears
* If this is done while the `var_dump()` from the previous test was still in your code, you will notice a small error box when enabling or disabling the notifications. This is because the `var_dump()` is polluting the JSON that is returned from the AJAX call, and WordPress does not know what to do with this. Though this is again an indication that the update will happen because the code does now hit this point. It also does not prevent the option from being saved correctly.  
  ![image](https://user-images.githubusercontent.com/34372510/127621278-86e75c8c-d138-4230-ae47-c9eeb4c4486d.png)

My previous attempt to fix this failed because Premium notifications (like the redirect notifications on a post delete) did break with that fix. I verified that these still work with this fix, but please double check.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Verify that all notifications from our plugins still work as expected.
* QA has a document with a lot of notification examples (I can not link that document here as I am not sure it's publicly available).

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Yoast dashboard notifications for users.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
