### PR TITLE
Added unit test for surface api

### DIFF
--- a/lib/abstract-main.php
+++ b/lib/abstract-main.php
@@ -17,7 +17,7 @@ abstract class Abstract_Main {
 	 *
 	 * @var ContainerInterface|null
 	 */
-	private $container;
+	protected $container;
 
 	/**
 	 * Loads the plugin.

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -123,15 +123,13 @@ class Elementor implements Integration_Interface {
 		Capability_Helper $capability,
 		Estimated_Reading_Time_Conditional $estimated_reading_time_conditional
 	) {
-		$this->asset_manager = $asset_manager;
-		$this->options       = $options;
-		$this->capability    = $capability;
-
-		$this->seo_analysis                       = new WPSEO_Metabox_Analysis_SEO();
-		$this->readability_analysis               = new WPSEO_Metabox_Analysis_Readability();
-		$this->social_is_enabled                  = $this->options->get( 'opengraph', false ) || $this->options->get( 'twitter', false );
-		$this->is_advanced_metadata_enabled       = $this->capability->current_user_can( 'wpseo_edit_advanced_metadata' ) || $this->options->get( 'disableadvanced_meta' ) === false;
+		$this->asset_manager                      = $asset_manager;
+		$this->options                            = $options;
+		$this->capability                         = $capability;
 		$this->estimated_reading_time_conditional = $estimated_reading_time_conditional;
+
+		$this->seo_analysis         = new WPSEO_Metabox_Analysis_SEO();
+		$this->readability_analysis = new WPSEO_Metabox_Analysis_Readability();
 	}
 
 	/**
@@ -174,6 +172,9 @@ class Elementor implements Integration_Interface {
 	 * @return void
 	 */
 	public function init() {
+		$this->social_is_enabled            = $this->options->get( 'opengraph', false ) || $this->options->get( 'twitter', false );
+		$this->is_advanced_metadata_enabled = $this->capability->current_user_can( 'wpseo_edit_advanced_metadata' ) || $this->options->get( 'disableadvanced_meta' ) === false;
+
 		$this->asset_manager->register_assets();
 		$this->enqueue();
 		$this->render_hidden_fields();

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -65,20 +65,6 @@ class Elementor implements Integration_Interface {
 	protected $capability;
 
 	/**
-	 * Holds whether the socials are enabled.
-	 *
-	 * @var bool
-	 */
-	protected $social_is_enabled;
-
-	/**
-	 * Holds whether the advanced settings are enabled.
-	 *
-	 * @var bool
-	 */
-	protected $is_advanced_metadata_enabled;
-
-	/**
 	 * Helper to determine whether or not the SEO analysis is enabled.
 	 *
 	 * @var WPSEO_Metabox_Analysis_SEO
@@ -172,9 +158,6 @@ class Elementor implements Integration_Interface {
 	 * @return void
 	 */
 	public function init() {
-		$this->social_is_enabled            = $this->options->get( 'opengraph', false ) || $this->options->get( 'twitter', false );
-		$this->is_advanced_metadata_enabled = $this->capability->current_user_can( 'wpseo_edit_advanced_metadata' ) || $this->options->get( 'disableadvanced_meta' ) === false;
-
 		$this->asset_manager->register_assets();
 		$this->enqueue();
 		$this->render_hidden_fields();
@@ -266,7 +249,7 @@ class Elementor implements Integration_Interface {
 		WPSEO_Meta::init();
 
 		$social_fields = [];
-		if ( $this->social_is_enabled ) {
+		if ( $this->is_social_enabled() ) {
 			$social_fields = WPSEO_Meta::get_meta_field_defs( 'social', $post->post_type );
 		}
 
@@ -466,7 +449,7 @@ class Elementor implements Integration_Interface {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: Meta_Fields_Presenter->present is considered safe.
 		echo new Meta_Fields_Presenter( $this->get_metabox_post(), 'general' );
 
-		if ( $this->is_advanced_metadata_enabled ) {
+		if ( $this->is_advanced_metadata_enabled() ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: Meta_Fields_Presenter->present is considered safe.
 			echo new Meta_Fields_Presenter( $this->get_metabox_post(), 'advanced' );
 		}
@@ -474,7 +457,7 @@ class Elementor implements Integration_Interface {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: Meta_Fields_Presenter->present is considered safe.
 		echo new Meta_Fields_Presenter( $this->get_metabox_post(), 'schema', $this->get_metabox_post()->post_type );
 
-		if ( $this->social_is_enabled ) {
+		if ( $this->is_social_enabled() ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Reason: Meta_Fields_Presenter->present is considered safe.
 			echo new Meta_Fields_Presenter( $this->get_metabox_post(), 'social' );
 		}
@@ -714,5 +697,35 @@ class Elementor implements Integration_Interface {
 		}
 
 		return $shortcode_tags;
+	}
+
+	/**
+	 * Checks if social metadata is enabled.
+	 *
+	 * @return bool Whether or not social metadata is enabled.
+	 */
+	protected function is_social_enabled() {
+		static $is_social_enabled;
+
+		if ( $is_social_enabled === null ) {
+			$is_social_enabled = $this->options->get( 'opengraph', false ) || $this->options->get( 'twitter', false );
+		}
+
+		return $is_social_enabled;
+	}
+
+	/**
+	 * Checks if advanced metadata is enabled, and whether the current user can edit it.
+	 *
+	 * @return bool Whether or not advanced metadata is enabled.
+	 */
+	protected function is_advanced_metadata_enabled() {
+		static $is_advanced_metadata_enabled;
+
+		if ( $is_advanced_metadata_enabled === null ) {
+			$is_advanced_metadata_enabled = $this->capability->current_user_can( 'wpseo_edit_advanced_metadata' ) || $this->options->get( 'disableadvanced_meta' ) === false;
+		}
+
+		return $is_advanced_metadata_enabled;
 	}
 }

--- a/tests/unit/doubles/main-double.php
+++ b/tests/unit/doubles/main-double.php
@@ -32,7 +32,7 @@ class Main_Double extends Main {
 	/**
 	 * Loads the plugin.
 	 *
-	 * Overloaded to prevent the loader from being initialized.
+	 * Overridden to prevent the loader from being initialized.
 	 *
 	 * @return void
 	 */
@@ -46,5 +46,17 @@ class Main_Double extends Main {
 		} catch ( \Exception $e ) {
 			return;
 		}
+	}
+
+	/**
+	 * Returns whether or not we're in an environment for Yoast development.
+	 *
+	 * Overridden to prevent the di container being compiled instead of being fetched from cache,
+	 * this is needed for running the unit-tests in PHP 5.6.
+	 *
+	 * @return bool Whether or not to load in development mode.
+	 */
+	protected function is_development() {
+		return false;
 	}
 }

--- a/tests/unit/doubles/main-double.php
+++ b/tests/unit/doubles/main-double.php
@@ -40,8 +40,11 @@ class Main_Double extends Main {
 		if ( $this->container ) {
 			return;
 		}
-
-		$this->container = $this->get_container();
-		Container_Registry::register( $this->get_name(), $this->container );
+		try {
+			$this->container = $this->get_container();
+			Container_Registry::register( $this->get_name(), $this->container );
+		} catch ( \Exception $e ) {
+			return;
+		}
 	}
 }

--- a/tests/unit/doubles/main-double.php
+++ b/tests/unit/doubles/main-double.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Doubles;
+
+use Yoast\WP\Lib\Dependency_Injection\Container_Registry;
+use Yoast\WP\SEO\Main;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class Main_Double.
+ */
+class Main_Double extends Main {
+
+	/**
+	 * Loads the DI container.
+	 *
+	 * @return ContainerInterface|null The DI container.
+	 */
+	public function get_container() {
+		return parent::get_container();
+	}
+
+	/**
+	 * Gets the name of the plugin.
+	 *
+	 * @return string The name.
+	 */
+	public function get_name() {
+		return parent::get_name();
+	}
+
+	/**
+	 * Loads the plugin.
+	 *
+	 * Overloaded to prevent the loader from being initialized.
+	 *
+	 * @return void
+	 */
+	public function load() {
+		if ( $this->container ) {
+			return;
+		}
+
+		$this->container = $this->get_container();
+		Container_Registry::register( $this->get_name(), $this->container );
+	}
+}

--- a/tests/unit/main-test.php
+++ b/tests/unit/main-test.php
@@ -5,6 +5,9 @@ namespace Yoast\WP\SEO\Tests\Unit;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Main_Double;
 use Brain\Monkey;
 use Mockery;
+use Yoast\WP\SEO\Integrations\Third_Party\Elementor;
+use Yoast\WP\SEO\Integrations\Watchers\Indexable_Category_Permalink_Watcher;
+use Yoast\WP\SEO\Integrations\Watchers\Indexable_Permalink_Watcher;
 
 /**
  * Class Loader_Test
@@ -30,6 +33,17 @@ class Main_Test extends TestCase {
 	];
 
 	/**
+	 * Classes that are excluded from the test because they have logic in their constructor.
+	 *
+	 * @var string[] Array of classes.
+	 */
+	private $excluded_classes = [
+		Indexable_Category_Permalink_Watcher::class,
+		Indexable_Permalink_Watcher::class,
+		Elementor::class,
+	];
+
+	/**
 	 * Sets an instance for test purposes.
 	 */
 	protected function set_up() {
@@ -46,9 +60,6 @@ class Main_Test extends TestCase {
 			->andReturn( $this->instance );
 		// Deprecated classes call _deprecated_function in the constructor.
 		Monkey\Functions\expect( '_deprecated_function' );
-		// Permalink watcher calls wp_next_scheduled in the constructor.
-		Monkey\Functions\expect( 'wp_next_scheduled' )
-			->andReturn( true );
 	}
 
 	/**
@@ -60,6 +71,9 @@ class Main_Test extends TestCase {
 		$container = $this->instance->get_container();
 
 		foreach ( $container->getServiceIds() as $service_id ) {
+			if ( in_array( $service_id, $this->excluded_classes, true ) ) {
+				continue;
+			}
 			if ( isset( $this->aliasses[ $service_id ] ) ) {
 				$service_id = $this->aliasses[ $service_id ];
 			}

--- a/tests/unit/main-test.php
+++ b/tests/unit/main-test.php
@@ -63,7 +63,7 @@ class Main_Test extends TestCase {
 			if ( isset( $this->aliasses[ $service_id ] ) ) {
 				$service_id = $this->aliasses[ $service_id ];
 			}
-			if ( str_starts_with( $service_id, 'YoastSEO_Vendor' ) ) {
+			if ( strpos( $service_id, 'YoastSEO_Vendor' ) === 0 ) {
 				continue;
 			}
 

--- a/tests/unit/main-test.php
+++ b/tests/unit/main-test.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit;
+
+use Yoast\WP\SEO\Tests\Unit\Doubles\Main_Double;
+use Brain\Monkey;
+use Mockery;
+
+/**
+ * Class Loader_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Main;
+ */
+class Main_Test extends TestCase {
+
+	/**
+	 * Represents the instance we are testing.
+	 *
+	 * @var Main_Double The Main class double.
+	 */
+	private $instance;
+
+	/**
+	 * Aliasses set in the DI container.
+	 *
+	 * @var array
+	 */
+	private $aliasses = [
+		'service_container' => 'YoastSEO_Vendor\\YoastSEO_Vendor\\Symfony\\Component\\DependencyInjection\\ContainerInterface',
+	];
+
+	/**
+	 * Sets an instance for test purposes.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Main_Double();
+		$this->instance->load();
+
+		global $wpdb;
+		$wpdb = Mockery::mock( '\wpdb' );
+
+		// Some classes call the YoastSEO function in the constructor.
+		Monkey\Functions\expect( 'YoastSEO' )
+			->andReturn( $this->instance );
+		// Deprecated classes call _deprecated_function in the constructor.
+		Monkey\Functions\expect( '_deprecated_function' );
+		// Permalink watcher calls wp_next_scheduled in the constructor.
+		Monkey\Functions\expect( 'wp_next_scheduled' )
+			->andReturn( true );
+	}
+
+	/**
+	 * Tests the DI container.
+	 *
+	 * @covers ::get_container
+	 */
+	public function test_surfaces() {
+		$container = $this->instance->get_container();
+
+		foreach ( $container->getServiceIds() as $service_id ) {
+			if ( isset( $this->aliasses[ $service_id ] ) ) {
+				$service_id = $this->aliasses[ $service_id ];
+			}
+			if ( str_starts_with( $service_id, 'YoastSEO_Vendor' ) ) {
+				continue;
+			}
+
+			$this->assertInstanceOf( $service_id, $container->get( $service_id ) );
+		}
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Added unit-tests for the surface API.

## Relevant technical choices:

* Moved the initialization of `$social_is_enabled` and `$is_advanced_metadata_enabled` in the elementor integration to `init` instead of the constructor.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run `composer test`.
* Now add an exception to the constructor of a random helper to see it fail.
```
public function __construct() { throw new \Exception( "nope" ); }
```
* Run `composer test` and make sure it fails.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
