### PR TITLE
Make Consecutive sentence, Passive voice and Transition words assessments available for Farsi

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/testTexts/index.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/index.js
@@ -78,9 +78,7 @@ import indonesianPaper3 from "./id/indonesianPaper3";
 
 
 // Farsi papers
-import farsiPaper1 from "./fa/farsiPaper1";
-import farsiPaper2 from "./fa/farsiPaper2";
-import farsiPaper3 from "./fa/farsiPaper3";
+// TO_DO: Import back the Farsi papers after Consecutive sentences, Passive voice and Transition words assessment for Farsi are implemented.
 
 // Portuguese papers
 import portuguesePaper1 from "./pt/portuguesePaper1";
@@ -104,6 +102,9 @@ import slovakPaper3 from "./sk/slovakPaper3";
 /**
  * FrenchPaper1 & portuguesePaper3 are temporarily disabled until we figure out why there are small differences
  * in passive voice detection since upgrading from node v10 to the lts version.
+ *
+ * All Farsi papers are also temporarily disabled until the Consecutive sentences, Passive voice and Transition words assessments
+ * for Farsi are implemented.
  */
 export default [
 	englishPaper1,
@@ -130,9 +131,6 @@ export default [
 	russianPaper2,
 	russianPaper3,
 	arabicPaper1,
-	farsiPaper1,
-	farsiPaper2,
-	farsiPaper3,
 	englishPaperForPerformanceTest,
 	spanishPaperForPerformanceTest,
 	polishPaperForPerformanceTest,

--- a/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
+++ b/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 // External dependencies
 import { forEach, isArray, isNumber, isObject } from "lodash-es";
 import { getLogger } from "loglevel";

--- a/packages/yoastseo/src/languageProcessing/languages/fa/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/fa/Researcher.js
@@ -23,9 +23,6 @@ export default class Researcher extends AbstractResearcher {
 
 		// Delete the researches from the Abstract Researcher that currently are not available for Farsi.
 		delete this.defaultResearches.getFleschReadingScore;
-		delete this.defaultResearches.findTransitionWords;
-		delete this.defaultResearches.getPassiveVoiceResult;
-		delete this.defaultResearches.getSentenceBeginnings;
 
 		Object.assign( this.config, {
 			language: "fa",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Makes Consecutive sentence, Passive voice and Transition words assessments available for Farsi when the Feature flag is enabled.

## Relevant technical choices:

* The Farsi papers for full text tests are skipped for now. This is because they will fail for Transition words, Consecutive sentences and passive voice assessments since we still don't have the necessary configs and helpers for those assessments in Farsi. 
* The Farsi papers should be added back when the Transition words, Consecutive sentences and passive voice assessments are already implemented. I add the step to check for this in [this issue to remove the feature flag](https://yoast.atlassian.net/browse/LINGO-1010).
* Currently, when we enable the feature, there are going to be errors in the console related to the fact that at this point we haven't added the necessary configs and helpers for the assessments in the Farsi Researcher. These errors will be fixed when we implement the the related assessments.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable the `FARSI_SUPPORT` feature by adding `define( 'YOAST_SEO_FARSI_SUPPORT', true );` in `plugin-development-docker/config/basic-wordpress-config.php` file 
* Set your site to Farsi (فارسى)
* Open a post with at least 200 words
* Confirm that the Passive Voice, Consecutive Sentences and Transition Words Assessments are being loaded in the metabox (currently, the assessments will look like in the screenshot as we still haven't implemented the necessary configs and helpers for these assessments in release 17.1):
  
<img width="274" alt="Screenshot 2021-08-31 at 13 54 59" src="https://user-images.githubusercontent.com/48715883/131498426-8600f86a-fae5-4f06-bd6b-f68be0beab65.png">

* Disable the feature by setting the feature to `false` `define( 'YOAST_SEO_FARSI_SUPPORT', false );` in `plugin-development-docker/config/basic-wordpress-config.php` file
* Save your changes and reload your post
* Confirm that the Passive Voice, Consecutive Sentences, and Transition Words Assessments are NOT being loaded in the metabox anymore
* Change the site language to English
* Confirm that the Passive Voice, Consecutive Sentences, and Transition Words Assessments are always being loaded in the metabox regardless whether the Farsi Support is `true` or `false`.


* Install and activate Premium
* Switch to the site to Farsi again
* Enable the `FARSI_SUPPORT` feature by adding `define( 'YOAST_SEO_FARSI_SUPPORT', true );` in `plugin-development-docker/config/basic-wordpress-config.php` file
* Create/open a post
* In your console, confirm that the morphology request returns with `404`:
<img width="362" alt="Screenshot 2021-07-19 at 11 30 48" src="https://user-images.githubusercontent.com/48715883/126129462-d9e3862b-72bd-41c2-8669-877e68fe2660.png">

* Disable the `FARSI_SUPPORT` by adding this  `define( 'YOAST_SEO_FARSI_SUPPORT', false );` from `plugin-development-docker/config/basic-wordpress-config.php` file
* Save your changes and reload your post
* Confirm that you get the Farsi Researcher by entering `window.yoast.Researcher` in the console:
<img width="569" alt="Screenshot 2021-08-16 at 15 17 31" src="https://user-images.githubusercontent.com/48715883/129569945-49102402-b7de-47a5-9e1d-7b0fe8f812aa.png">

* Confirm that there is no morphology request


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-1013
