### PR TITLE
Remove pipe and tilde separators

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -75,6 +75,7 @@ class WPSEO_Upgrade {
 			'16.5-RC0'   => 'upgrade_165',
 			'16.9-RC0'   => 'upgrade_169',
 			'17.0-RC0'   => 'upgrade_170',
+			'17.1-RC0'   => 'upgrade_171',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -867,6 +868,18 @@ class WPSEO_Upgrade {
 				'hourly',
 				'wpseo_cleanup_orphaned_indexables'
 			);
+		}
+	}
+
+	/**
+	 * Performs the 17.1 upgrade. Removes the pipe and tilde separators and replaces them with the dash separator.
+	 *
+	 * @return void
+	 */
+	private function upgrade_171() {
+		$separator = WPSEO_Options::get( 'separator' );
+		if ( $separator === 'sc-pipe' || $separator === 'sc-tilde' ) {
+			WPSEO_Options::set( 'separator', 'sc-dash' );
 		}
 	}
 

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -973,14 +973,6 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				'option' => '&#8902;',
 				'label'  => __( 'Low asterisk', 'wordpress-seo' ),
 			],
-			'sc-pipe'   => [
-				'option' => '|',
-				'label'  => __( 'Vertical bar', 'wordpress-seo' ),
-			],
-			'sc-tilde'  => [
-				'option' => '~',
-				'label'  => __( 'Small tilde', 'wordpress-seo' ),
-			],
 			'sc-laquo'  => [
 				'option' => '&laquo;',
 				'label'  => __( 'Left angle quotation mark', 'wordpress-seo' ),


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the `|` and `~` separators.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Yoast SEO 17.0.
* Set your separator to either `|` or `~`.
* Upgrade to Yoast SEO 17.1
* Your separator should now be set to `-`.
* Visit the frontend
* There should be no `|` or `~` in your `<title>` element.
* Visit the separator settings
* You should not be able to select either `|` or `~`.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The separator settings
* The 17.1 upgrade routine.
* Check if the separator replacement variable still works in the previews (Google, Facebook (Premium), Twitter (Premium)).

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-1254
