### PR TITLE
Do not penalize short title

### DIFF
--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
@@ -55,7 +55,11 @@ const CloseEditorButton = styled( SnippetEditorButton )`
  */
 function getTitleProgress( title ) {
 	const titleWidth = measureTextWidth( title );
-	const pageTitleWidthAssessment = new PageTitleWidthAssessment();
+	const pageTitleWidthAssessment = new PageTitleWidthAssessment( {
+		scores: {
+			widthTooShort: 9,
+		},
+	}, true );
 	const score = pageTitleWidthAssessment.calculateScore( titleWidth );
 	const maximumLength = pageTitleWidthAssessment.getMaximumLength();
 

--- a/packages/yoastseo/spec/scoring/collectionPages/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/cornerstone/seoAssessorSpec.js
@@ -217,7 +217,7 @@ describe( "running assessments in the collection page cornerstone SEO assessor",
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.scores ).toBeDefined();
-			expect( assessment._config.scores.widthTooShort ).toBe( 6 );
+			expect( assessment._config.scores.widthTooShort ).toBe( 9 );
 			expect( assessment._config.scores.widthTooLong ).toBe( 3 );
 			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify52' target='_blank'>" );
 			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify53' target='_blank'>" );

--- a/packages/yoastseo/spec/scoring/collectionPages/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/seoAssessorSpec.js
@@ -236,7 +236,7 @@ describe( "running assessments in the collection page SEO assessor", function() 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.scores ).toBeDefined();
-			expect( assessment._config.scores.widthTooShort ).toBe( 6 );
+			expect( assessment._config.scores.widthTooShort ).toBe( 9 );
 			expect( assessment._config.scores.widthTooLong ).toBe( 3 );
 			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify52' target='_blank'>" );
 			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify53' target='_blank'>" );

--- a/packages/yoastseo/spec/scoring/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/cornerstone/seoAssessorSpec.js
@@ -252,8 +252,7 @@ describe( "running assessments in the assessor", function() {
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.scores ).toBeDefined();
-			expect( assessment._config.scores.widthTooShort ).toBe( 3 );
-			expect( assessment._config.scores.widthTooLong ).toBe( 3 );
+			expect( assessment._config.scores.widthTooShort ).toBe( 9 );
 		} );
 
 		test( "UrlKeywordAssessment", () => {

--- a/packages/yoastseo/spec/scoring/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/seoAssessorSpec.js
@@ -218,4 +218,15 @@ describe( "running assessments in the assessor", function() {
 			"titleWidth",
 		] );
 	} );
+
+	describe( "has configuration overrides", () => {
+		test( "PageTitleWidthAssesment", () => {
+			const assessment = assessor.getAssessment( "titleWidth" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.widthTooShort ).toBe( 9 );
+		} );
+	} );
 } );

--- a/packages/yoastseo/spec/scoring/storeBlog/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/storeBlog/cornerstone/seoAssessorSpec.js
@@ -206,7 +206,7 @@ describe( "running assessments in the store blog SEO assessor", function() {
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.scores ).toBeDefined();
-			expect( assessment._config.scores.widthTooShort ).toBe( 3 );
+			expect( assessment._config.scores.widthTooShort ).toBe( 9 );
 			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify52' target='_blank'>" );
 			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify53' target='_blank'>" );
 		} );

--- a/packages/yoastseo/spec/scoring/storeBlog/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/storeBlog/seoAssessorSpec.js
@@ -214,6 +214,8 @@ describe( "running assessments in the store blog cornerstone SEO assessor", func
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.widthTooShort ).toBe( 9 );
 			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify52' target='_blank'>" );
 			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify53' target='_blank'>" );
 		} );

--- a/packages/yoastseo/spec/scoring/storePostsAndPages/cornerstone/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/storePostsAndPages/cornerstone/seoAssessorSpec.js
@@ -304,7 +304,7 @@ describe( "running assessments in the assessor", function() {
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
 			expect( assessment._config.scores ).toBeDefined();
-			expect( assessment._config.scores.widthTooShort ).toBe( 3 );
+			expect( assessment._config.scores.widthTooShort ).toBe( 9 );
 			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify52' target='_blank'>" );
 			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify53' target='_blank'>" );
 		} );

--- a/packages/yoastseo/spec/scoring/storePostsAndPages/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/storePostsAndPages/seoAssessorSpec.js
@@ -309,6 +309,8 @@ describe( "running assessments in the assessor", function() {
 
 			expect( assessment ).toBeDefined();
 			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.widthTooShort ).toBe( 9 );
 			expect( assessment._config.urlTitle ).toBe( "<a href='https://yoa.st/shopify52' target='_blank'>" );
 			expect( assessment._config.urlCallToAction ).toBe( "<a href='https://yoa.st/shopify53' target='_blank'>" );
 		} );

--- a/packages/yoastseo/spec/scoring/taxonomyAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/taxonomyAssessorSpec.js
@@ -151,4 +151,15 @@ describe( "running assessments in the assessor", function() {
 			"titleWidth",
 		] );
 	} );
+
+	describe( "has configuration overrides", () => {
+		test( "PageTitleWidthAssesment", () => {
+			const assessment = assessor.getAssessment( "titleWidth" );
+
+			expect( assessment ).toBeDefined();
+			expect( assessment._config ).toBeDefined();
+			expect( assessment._config.scores ).toBeDefined();
+			expect( assessment._config.scores.widthTooShort ).toBe( 9 );
+		} );
+	} );
 } );

--- a/packages/yoastseo/src/scoring/collectionPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/collectionPages/cornerstone/seoAssessor.js
@@ -85,9 +85,12 @@ const CollectionCornerstoneSEOAssessor = function( i18n, researcher, options ) {
 			}
 		),
 		new PageTitleWidthAssessment( {
+			scores: {
+				widthTooShort: 9,
+			},
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify52" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify53" ),
-		} ),
+		}, true ),
 		new UrlKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify26" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify27" ),

--- a/packages/yoastseo/src/scoring/collectionPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/collectionPages/seoAssessor.js
@@ -71,9 +71,12 @@ const CollectionSEOAssessor = function( i18n, researcher, options ) {
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify25" ),
 		} ),
 		new PageTitleWidthAssessment( {
+			scores: {
+				widthTooShort: 9,
+			},
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify52" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify53" ),
-		} ),
+		}, true ),
 		new UrlKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify26" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify27" ),

--- a/packages/yoastseo/src/scoring/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/cornerstone/seoAssessor.js
@@ -76,10 +76,10 @@ const CornerstoneSEOAssessor = function( i18n, options ) {
 		new TitleWidth(
 			{
 				scores: {
-					widthTooShort: 3,
-					widthTooLong: 3,
+					widthTooShort: 9,
 				},
-			}
+			},
+			true
 		),
 		new UrlKeywordAssessment(
 			{

--- a/packages/yoastseo/src/scoring/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/seoAssessor.js
@@ -46,7 +46,11 @@ const SEOAssessor = function( i18n, researcher,  options ) {
 		new OutboundLinks(),
 		new TitleKeywordAssessment(),
 		new InternalLinksAssessment(),
-		new TitleWidth(),
+		new TitleWidth( {
+			scores: {
+				widthTooShort: 9,
+			},
+		}, true ),
 		new UrlKeywordAssessment(),
 		new FunctionWordsInKeyphrase(),
 		new SingleH1Assessment(),

--- a/packages/yoastseo/src/scoring/storeBlog/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storeBlog/cornerstone/seoAssessor.js
@@ -47,12 +47,11 @@ const StoreBlogCornerstoneSEOAssessor = function( i18n, options ) {
 		} ),
 		new TitleWidth( {
 			scores: {
-				widthTooShort: 3,
-				widthTooLong: 3,
+				widthTooShort: 9,
 			},
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify52" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify53" ),
-		} ),
+		}, true ),
 		new UrlKeywordAssessment(
 			{
 				scores: {

--- a/packages/yoastseo/src/scoring/storeBlog/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storeBlog/seoAssessor.js
@@ -41,9 +41,12 @@ const StoreBlogSEOAssessor = function( i18n, researcher, options ) {
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify25" ),
 		} ),
 		new TitleWidth( {
+			scores: {
+				widthTooShort: 9,
+			},
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify52" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify53" ),
-		} ),
+		}, true ),
 		new UrlKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify26" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify27" ),

--- a/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/seoAssessor.js
@@ -110,16 +110,13 @@ const StorePostsAndPagesCornerstoneSEOAssessor = function( i18n, options ) {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify60" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify61" ),
 		} ),
-		new TitleWidth(
-			{
-				scores: {
-					widthTooShort: 3,
-					widthTooLong: 3,
-				},
-				urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify52" ),
-				urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify53" ),
-			}
-		),
+		new TitleWidth( {
+			scores: {
+				widthTooShort: 9,
+			},
+			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify52" ),
+			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify53" ),
+		}, true ),
 		new UrlKeywordAssessment(
 			{
 				scores: {

--- a/packages/yoastseo/src/scoring/storePostsAndPages/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/seoAssessor.js
@@ -88,9 +88,12 @@ const StorePostsAndPagesSEOAssessor = function( i18n, researcher,  options ) {
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify61" ),
 		} ),
 		new TitleWidth( {
+			scores: {
+				widthTooShort: 9,
+			},
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify52" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify53" ),
-		} ),
+		}, true ),
 		new UrlKeywordAssessment( {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify26" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify27" ),

--- a/packages/yoastseo/src/scoring/taxonomyAssessor.js
+++ b/packages/yoastseo/src/scoring/taxonomyAssessor.js
@@ -51,7 +51,13 @@ const TaxonomyAssessor = function( i18n, researcher, options ) {
 		new MetaDescriptionLengthAssessment(),
 		getTextLengthAssessment(),
 		new TitleKeywordAssessment(),
-		new PageTitleWidthAssessment(),
+		new PageTitleWidthAssessment(
+			{
+				scores: {
+					widthTooShort: 9,
+				},
+			}, true
+		),
 		new UrlKeywordAssessment(),
 		new FunctionWordsInKeyphrase(),
 		new SingleH1Assessment(),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds custom config for TitleWidth assessment in all SEO assessors so that short title is not penalized with a bad score.
* [search-metadata-previews] Adds custom config for `PageTitleWidthAssessment` so that the bar indicator under SEO title field shows green when short SEO title is set.
* Gives short SEO title width a green bullet in all content types.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**In regular analysis and taxonomy analysis:**
* Create a new post
* Set two-word long title in SEO title field
* Make sure that SEO title width assessment returns with green bullet and gives feedback: `SEO title width: Good job!`
* Confirm that the indicator bar under the SEO title field also shows green
* Toggle the cornerstone content on
* Make sure that the SEO title width assessment still returns with green bullet and gives feedback: `SEO title width: Good job!` and confirm that the indicator bar under the SEO title field also shows green
* Repeat these steps for a taxonomy page.

**In store content**
* In Blogs content type:
    * Create a content
    * Expand `Google preview` tab in the metabox
    * Set two-word long title in SEO title field
    * Make sure that SEO title width assessment returns with green bullet and gives feedback: `SEO title width: Good job!`
    * Confirm that the indicator bar under the SEO title field also shows green

*  In Collections, Pages, and Blog Posts:
    * Create a content
    * Expand `Google preview` tab in the metabox
    * Set two-word long title in SEO title field
    * Make sure that SEO title width assessment returns with green bullet and gives feedback: `SEO title width: Good job!`
    * Confirm that the indicator bar under the SEO title field also shows green
    * Toggle the cornerstone content on
    * Make sure that the SEO title width assessment still returns with green bullet and gives feedback: `SEO title width: Good job!`
    * Confirm that the indicator bar under the SEO title field still shows green

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-1015 & https://yoast.atlassian.net/browse/LINGO-1018
