### PR TITLE
Add missing researcher parameter in assessors

### DIFF
--- a/packages/yoastseo/spec/scoring/cornerstone/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/cornerstone/contentAssessorSpec.js
@@ -104,7 +104,7 @@ describe( "A content assessor", function() {
 		let points, results, contentAssessor;
 
 		beforeEach( function() {
-			contentAssessor = new ContentAssessor( i18n );
+			contentAssessor = new ContentAssessor( i18n, new EnglishResearcher() );
 			contentAssessor.getValidResults = function() {
 				return results;
 			};
@@ -284,7 +284,7 @@ describe( "A content assessor", function() {
 	} );
 
 	describe( "has configuration overrides", () => {
-		const assessor = new ContentAssessor( i18n );
+		const assessor = new ContentAssessor( i18n, new DefaultResearcher() );
 
 		test( "SubheadingsDistributionTooLong", () => {
 			const assessment = assessor.getAssessment( "subheadingsTooLong" );

--- a/packages/yoastseo/spec/scoring/storePostsAndPages/cornerstone/contentAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/storePostsAndPages/cornerstone/contentAssessorSpec.js
@@ -104,7 +104,7 @@ describe( "A content assessor", function() {
 		let points, results, contentAssessor;
 
 		beforeEach( function() {
-			contentAssessor = new ContentAssessor( i18n );
+			contentAssessor = new ContentAssessor( i18n, new EnglishResearcher() );
 			contentAssessor.getValidResults = function() {
 				return results;
 			};
@@ -284,7 +284,7 @@ describe( "A content assessor", function() {
 	} );
 
 	describe( "has configuration overrides", () => {
-		const assessor = new ContentAssessor( i18n );
+		const assessor = new ContentAssessor( i18n, new DefaultResearcher() );
 
 		test( "SubheadingsDistributionTooLong", () => {
 			const assessment = assessor.getAssessment( "subheadingsTooLong" );

--- a/packages/yoastseo/src/scoring/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/cornerstone/contentAssessor.js
@@ -19,14 +19,15 @@ import TextPresence from "../assessments/readability/TextPresenceAssessment.js";
 /**
  * Creates the Assessor
  *
- * @param {object} i18n The i18n object used for translations.
- * @param {Object} options The options for this assessor.
- * @param {Object} options.marker The marker to pass the list of marks to.
+ * @param {object} i18n             The i18n object used for translations.
+ * @param {object} researcher       The researcher used for the analysis.
+ * @param {Object} options          The options for this assessor.
+ * @param {Object} options.marker   The marker to pass the list of marks to.
  *
  * @constructor
  */
-const CornerStoneContentAssessor = function( i18n, options = {} ) {
-	Assessor.call( this, i18n, options );
+const CornerStoneContentAssessor = function( i18n, researcher, options = {} ) {
+	Assessor.call( this, i18n, researcher, options );
 	this.type = "CornerstoneContentAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/scoring/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/cornerstone/relatedKeywordAssessor.js
@@ -12,14 +12,15 @@ import ImageKeyphrase from "../assessments/seo/KeyphraseInImageTextAssessment";
 /**
  * Creates the Assessor
  *
- * @param {object} i18n The i18n object used for translations.
- * @param {Object} options The options for this assessor.
- * @param {Object} options.marker The marker to pass the list of marks to.
+ * @param {object} i18n             The i18n object used for translations.
+ * @param {object} researcher       The researcher used for the analysis.
+ * @param {Object} options          The options for this assessor.
+ * @param {Object} options.marker   The marker to pass the list of marks to.
  *
  * @constructor
  */
-const relatedKeywordAssessor = function( i18n, options ) {
-	Assessor.call( this, i18n, options );
+const relatedKeywordAssessor = function( i18n, researcher, options ) {
+	Assessor.call( this, i18n, researcher, options );
 	this.type = "cornerstoneRelatedKeywordAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/scoring/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/cornerstone/seoAssessor.js
@@ -23,14 +23,15 @@ import SingleH1Assessment from "../assessments/seo/SingleH1Assessment";
 /**
  * Creates the Assessor
  *
- * @param {Object} i18n The i18n object used for translations.
- * @param {Object} options The options for this assessor.
- * @param {Object} options.marker The marker to pass the list of marks to.
+ * @param {Object} i18n             The i18n object used for translations.
+ * @param {object} researcher       The researcher used for the analysis.
+ * @param {Object} options          The options for this assessor.
+ * @param {Object} options.marker   The marker to pass the list of marks to.
  *
  * @constructor
  */
-const CornerstoneSEOAssessor = function( i18n, options ) {
-	Assessor.call( this, i18n, options );
+const CornerstoneSEOAssessor = function( i18n, researcher, options ) {
+	Assessor.call( this, i18n, researcher, options );
 	this.type = "CornerstoneSEOAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/scoring/storeBlog/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storeBlog/cornerstone/seoAssessor.js
@@ -14,14 +14,15 @@ import FunctionWordsInKeyphrase from "../../assessments/seo/FunctionWordsInKeyph
 /**
  * Creates the Assessor
  *
- * @param {Object} i18n The i18n object used for translations.
- * @param {Object} options The options for this assessor.
- * @param {Object} options.marker The marker to pass the list of marks to.
+ * @param {Object} i18n             The i18n object used for translations.
+ * @param {object} researcher       The researcher used for the analysis.
+ * @param {Object} options          The options for this assessor.
+ * @param {Object} options.marker   The marker to pass the list of marks to.
  *
  * @constructor
  */
-const StoreBlogCornerstoneSEOAssessor = function( i18n, options ) {
-	Assessor.call( this, i18n, options );
+const StoreBlogCornerstoneSEOAssessor = function( i18n, researcher, options ) {
+	Assessor.call( this, i18n, researcher, options );
 	this.type = "storeBlogCornerstoneSEOAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/contentAssessor.js
@@ -19,14 +19,15 @@ import TextPresence from "../../assessments/readability/TextPresenceAssessment.j
 /**
  * Creates the Assessor
  *
- * @param {object} i18n The i18n object used for translations.
- * @param {Object} options The options for this assessor.
- * @param {Object} options.marker The marker to pass the list of marks to.
+ * @param {object} i18n             The i18n object used for translations.
+ * @param {object} researcher       The researcher used for the analysis.
+ * @param {Object} options          The options for this assessor.
+ * @param {Object} options.marker   The marker to pass the list of marks to.
  *
  * @constructor
  */
-const StorePostsAndPagesCornerstoneContentAssessor = function( i18n, options = {} ) {
-	Assessor.call( this, i18n, options );
+const StorePostsAndPagesCornerstoneContentAssessor = function( i18n, researcher, options = {} ) {
+	Assessor.call( this, i18n, researcher, options );
 	this.type = "storePostsAndPagesCornerstoneContentAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/relatedKeywordAssessor.js
@@ -13,14 +13,15 @@ import ImageKeyphrase from "../../assessments/seo/KeyphraseInImageTextAssessment
 /**
  * Creates the Assessor
  *
- * @param {object} i18n The i18n object used for translations.
- * @param {Object} options The options for this assessor.
- * @param {Object} options.marker The marker to pass the list of marks to.
+ * @param {object} i18n             The i18n object used for translations.
+ * @param {object} researcher       The researcher used for the analysis.
+ * @param {Object} options          The options for this assessor.
+ * @param {Object} options.marker   The marker to pass the list of marks to.
  *
  * @constructor
  */
-const StorePostsAndPagesCornerstoneRelatedKeywordAssessor = function( i18n, options ) {
-	Assessor.call( this, i18n, options );
+const StorePostsAndPagesCornerstoneRelatedKeywordAssessor = function( i18n, researcher, options ) {
+	Assessor.call( this, i18n, researcher, options );
 	this.type = "storePostsAndPagesCornerstoneRelatedKeywordAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/storePostsAndPages/cornerstone/seoAssessor.js
@@ -26,14 +26,15 @@ import KeyphraseDistribution from "../../assessments/seo/KeyphraseDistributionAs
 /**
  * Creates the Assessor
  *
- * @param {Object} i18n The i18n object used for translations.
- * @param {Object} options The options for this assessor.
- * @param {Object} options.marker The marker to pass the list of marks to.
+ * @param {Object} i18n             The i18n object used for translations.
+ * @param {object} researcher       The researcher used for the analysis.
+ * @param {Object} options          The options for this assessor.
+ * @param {Object} options.marker   The marker to pass the list of marks to.
  *
  * @constructor
  */
-const StorePostsAndPagesCornerstoneSEOAssessor = function( i18n, options ) {
-	Assessor.call( this, i18n, options );
+const StorePostsAndPagesCornerstoneSEOAssessor = function( i18n, researcher, options ) {
+	Assessor.call( this, i18n, researcher,  options );
 	this.type = "storePostsAndPagesCornerstoneSEOAssessor";
 
 	this._assessments = [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The parent class of the `Assessor` has three parameters, where the second one is the researcher. However, when we created the specific assessors based on the parent class, we didn't pass researcher in the parameter. So far we didn't have any bug reported in relation to this. But in principle we should also pass the researcher as the second parameter in all of the child classes.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds missing researcher parameter in assessors.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**In Free and Premium:**
* Turn on the cornerstone content toggle
* Smoke test some of the assessments (two or three) in SEO and Readability analysis
* Make sure there is no error in the console and that the assessments are working as expected

**In Premium:**
* Turn on the cornerstone content toggle
* Smoke test some assessments from Related keyphrase analysis
* Make sure there is no error in the console and that the assessments are working as expected

**In other app:**
* Turn on the cornerstone content toggle
* Smoke test the assessments in `Blog posts` and `Pages`  in SEO and Readability analysis
* Smoke test some assessments from Related keyphrase analysis
* Make sure there is no error in the console and that the assessments are working as expected


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
