### PR TITLE
P2-1259 fix default fallback of separator

### DIFF
--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -54,7 +54,7 @@ class Options_Helper {
 	 * @return string The title separator.
 	 */
 	public function get_title_separator() {
-		$replacement = $this->get_default( 'wpseo_titles', 'separator' );
+		$default = $this->get_default( 'wpseo_titles', 'separator' );
 
 		// Get the titles option and the separator options.
 		$separator         = $this->get( 'separator' );
@@ -64,6 +64,12 @@ class Options_Helper {
 		if ( isset( $seperator_options[ $separator ] ) ) {
 			// Set the new replacement.
 			$replacement = $seperator_options[ $separator ];
+		}
+		elseif ( isset( $seperator_options[ $default ] ) ) {
+			$replacement = $seperator_options[ $default ];
+		}
+		else {
+			$replacement = \reset( $seperator_options );
 		}
 
 		/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The default of the separator is `sc-dash`, which needs to be translated to `-` by doing a lookup in the separator options.
* If the real value wasn't present in the separator options then instead of doing a lookup for the default the default was immediately returned.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes "sc-dash" being used literally in cases where the chosen separator no longer exists.

## Relevant technical choices:

* A second fallback has been added to use the first separator in cases where `sc-dash` has also been removed from the separator options. This could occur if that value is filtered out.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See https://yoast.atlassian.net/browse/P2-1259


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* https://yoast.atlassian.net/browse/P2-1254

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-1259
