### PR TITLE
Expand list of irregular plurals for Russian

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/languages/ru/helpers/internal/stemSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ru/helpers/internal/stemSpec.js
@@ -2,7 +2,6 @@ import stem from "../../../../../../src/languageProcessing/languages/ru/helpers/
 import getMorphologyData from "../../../../../specHelpers/getMorphologyData";
 
 const morphologyDataRU = getMorphologyData( "ru" ).ru;
-
 // The first word in each array is the word, the second one is the expected stem.
 
 const wordsToStem = [
@@ -57,13 +56,23 @@ const wordsToStem = [
 	[ "бездыханность",  "бездыхан" ],
 	[ "восторженностью", "восторжен" ],
 	// Irregular plurals.
-	[ "курицу", "куриц" ],
-	[ "кур", "куриц" ],
+	[ "курицу", "кур" ],
+	[ "куры", "кур" ],
 	[ "ребёнок", "ребёнк" ],
 	[ "детей", "ребёнк" ],
 	[ "ребята", "ребёнк" ],
 	[ "уху", "ухо" ],
 	[ "ушами", "ухо" ],
+	[ "мать", "ма" ],
+	[ "матерей", "ма" ],
+	[ "славяне", "славян" ],
+	[ "славянин", "славян" ],
+	[ "cудна", "cуд" ],
+	[ "суднами", "суд" ],
+	[ "сыновья", "сы" ],
+	[ "церковью", "церкв" ],
+	[ "церкви", "церкв" ],
+	[ "щенками", "щенк" ],
 	// Words that belong to doNotStemSuffix exceptions
 	[ "космодром", "космодром" ],
 	[ "детдом", "детдом" ],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Expands Russian irregular nouns exception list.
* [Yoast SEO premium] Introduces word form support for more Russian irregular nouns.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run `yarn test` and make sure that everything passes.

**In Content-analysis app:**
* Set your website to Russian (ru)
* Add a text of min 300 words in the text field
* Turn the `Use morphology` on
* Set `мать` as the focus keyphrase
* Add these other forms of the word in the text: _матери, матерями, матерью_ and make sure that all 3 forms are recognised.
* Set `щенок` as the focus keyphrase
* Add these other forms of the word in the text: _щенята, щенка, щенке, щенятами_ and make sure that all 4 forms are recognised.
* Set `христиане` as the focus keyphrase
* Add these other forms of the word in the text: _христианин, христианка, христианами_ and make sure that all 3 forms are recognised.

**In Docker:**
Repeat the same steps as above


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Accompanying premium-configuration PR: https://github.com/Yoast/YoastSEO.js-premium-configuration/pull/239

Fixes #https://yoast.atlassian.net/secure/RapidBoard.jspa?rapidView=99&modal=detail&selectedIssue=LINGO-227
