### PR TITLE
Removes hyphens from the keyphrase before checking if slug contains keyphrase

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/testTexts/id/indonesianPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/id/indonesianPaper1.js
@@ -78,8 +78,8 @@ const expectedResults = {
 	},
 	urlKeyword: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: (Part of) your keyphrase does not appear in the slug. <a href='https://yoa.st/33p' target='_blank'>Change that</a>!",
+		score: 9,
+		resultText: "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: Great work!",
 	},
 	urlLength: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
@@ -222,9 +222,9 @@ describe( "test to check url for keyword", function() {
 	} );
 
 	it( "works with dash within the keyword in url", function() {
-	 	const paper = new Paper( "", { url: "two-room-apartment", keyword: "two-room apartment" } );
+		const paper = new Paper( "", { url: "two-room-apartment", keyword: "two-room apartment" } );
 		const researcher = new EnglishResearcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
-	 	expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
+		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
@@ -23,11 +23,25 @@ describe( "test to check url for keyword", function() {
 		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 2, percentWordMatches: 100 } );
 	} );
 
-	it( "returns no matches for dashed words", function() {
+	it( "returns no matches for differently dashed words", function() {
 		const paper = new Paper( "", { url: "url-with-key-word", keyword: "keyword" } );
 		const researcher = new EnglishResearcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
 		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 0 } );
+	} );
+
+	it( "returns matches for equally dashed words", function() {
+		const paper = new Paper( "", { url: "url-with-key-word", keyword: "key-word" } );
+		const researcher = new EnglishResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 2, percentWordMatches: 100 } );
+	} );
+
+	it( "returns matches for equally dashed words with more words around", function() {
+		const paper = new Paper( "", { url: "url-with-key-word", keyword: "exciting key-word exciting" } );
+		const researcher = new EnglishResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 4, percentWordMatches: 50 } );
 	} );
 
 	it( "returns matches with diacritics", function() {
@@ -197,21 +211,20 @@ describe( "test to check url for keyword", function() {
 		const paper = new Paper( "", { url: "buku-buku", keyword: "buku-buku" } );
 		const researcher = new EnglishResearcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
-		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 100 } );
+		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 2, percentWordMatches: 100 } );
 	} );
 
 	it( "works with dash within the keyword in url", function() {
 		const paper = new Paper( "", { url: "on-the-go", keyword: "on-the-go" } );
 		const researcher = new EnglishResearcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
-		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 100 } );
+		expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
 	} );
 
-	// eslint-disable-next-line capitalized-comments
-	 /* it( "works with dash within the keyword in url", function() {
+	it( "works with dash within the keyword in url", function() {
 	 	const paper = new Paper( "", { url: "two-room-apartment", keyword: "two-room apartment" } );
 		const researcher = new EnglishResearcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
-	 	expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 1, percentWordMatches: 100 } );
-	 } );*/
+	 	expect( urlKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
+	} );
 } );

--- a/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
+++ b/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
@@ -16,7 +16,6 @@ function dehyphenateKeyphraseForms( topicForms ) {
 	const dehyphenatedKeyphraseForms = [];
 
 	topicForms.keyphraseForms.forEach( function( wordForms ) {
-
 		// If a word doesn't contain hyphens, don't split it.
 		if ( wordForms[ 0 ].indexOf( "-" ) === -1 ) {
 			dehyphenatedKeyphraseForms.push( wordForms );
@@ -25,7 +24,7 @@ function dehyphenateKeyphraseForms( topicForms ) {
 
 		// Split each form of a hyphenated word and add each compound to the array of dehyphenated keyphrase forms.
 		wordForms.forEach( function( wordForm ) {
-			const splitWordForm = wordForm.split( "-" )
+			const splitWordForm = wordForm.split( "-" );
 			splitWordForm.forEach( compound => dehyphenatedKeyphraseForms.push( [ compound ] ) );
 		} );
 	} );
@@ -46,7 +45,7 @@ export default function( paper, researcher ) {
 	const topicForms = dehyphenateKeyphraseForms( researcher.getResearch( "morphology" ) );
 	const parsedSlug = parseSlug( paper.getUrl() );
 
-	let keyphraseInSlug = findTopicFormsInString( topicForms, parsedSlug, false, paper.getLocale() );
+	const keyphraseInSlug = findTopicFormsInString( topicForms, parsedSlug, false, paper.getLocale() );
 
 	return {
 		keyphraseLength: topicForms.keyphraseForms.length,

--- a/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
+++ b/packages/yoastseo/src/languageProcessing/researches/keywordCountInUrl.js
@@ -3,6 +3,38 @@ import parseSlug from "../helpers/url/parseSlug";
 import { findTopicFormsInString } from "../helpers/match/findKeywordFormsInString.js";
 
 /**
+ * Splits hyphenated keyphrases so that each compound is an individual word, e.g. 'pop-art' becomes 'pop' and 'art'.
+ * Splitting the keyphrase forms allows for hyphenated keyphrases to be detected in the slug. The slug is parsed on hyphens, and the words from
+ * the keyphrase are compared with the words from the slug to find a match. Without dehyphenating the keyphrase, the word from the keyphrase would be
+ * 'pop-art' while the words from the slug would be 'pop' and 'art', and a match would not be detected.
+ *
+ * @param {Array} topicForms The keyphraseForms and synonymsForms of the paper.
+ *
+ * @returns {Array} topicForms with split compounds.
+ */
+function dehyphenateKeyphraseForms( topicForms ) {
+	const dehyphenatedKeyphraseForms = [];
+
+	topicForms.keyphraseForms.forEach( function( wordForms ) {
+
+		// If a word doesn't contain hyphens, don't split it.
+		if ( wordForms[ 0 ].indexOf( "-" ) === -1 ) {
+			dehyphenatedKeyphraseForms.push( wordForms );
+			return;
+		}
+
+		// Split each form of a hyphenated word and add each compound to the array of dehyphenated keyphrase forms.
+		wordForms.forEach( function( wordForm ) {
+			const splitWordForm = wordForm.split( "-" )
+			splitWordForm.forEach( compound => dehyphenatedKeyphraseForms.push( [ compound ] ) );
+		} );
+	} );
+	topicForms.keyphraseForms = dehyphenatedKeyphraseForms;
+
+	return topicForms;
+}
+
+/**
  * Matches the keyword in the URL. Replaces dashes and underscores with whitespaces and uses whitespace as wordboundary.
  *
  * @param {Paper} paper the Paper object to use in this count.
@@ -11,17 +43,11 @@ import { findTopicFormsInString } from "../helpers/match/findKeywordFormsInStrin
  * @returns {int} Number of times the keyword is found.
  */
 export default function( paper, researcher ) {
-	const topicForms = researcher.getResearch( "morphology" );
+	const topicForms = dehyphenateKeyphraseForms( researcher.getResearch( "morphology" ) );
 	const parsedSlug = parseSlug( paper.getUrl() );
 
 	let keyphraseInSlug = findTopicFormsInString( topicForms, parsedSlug, false, paper.getLocale() );
-	/* In case we deal with a language where dashes are part of the word (e.g., in Indonesian: buku-buku),
-	 * Try looking for the keywords in the unparsed slug.
-	 */
-	if ( keyphraseInSlug.percentWordMatches === 0 ) {
-		const unparsedSlug = paper.getUrl();
-		keyphraseInSlug = findTopicFormsInString( topicForms, unparsedSlug, false, paper.getLocale() );
-	}
+
 	return {
 		keyphraseLength: topicForms.keyphraseForms.length,
 		percentWordMatches: keyphraseInSlug.percentWordMatches,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The changes in this PR are adapted from this PR: https://github.com/Yoast/javascript/pull/19. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Removes hyphens from a keyphrase for the Keyphrase in slug assessment. Also removes the functionality that would look for the keyphrase in the unparsed slug if it was not found in the parsed slug, as it is made redundant by the new functionality.
* Improves the accuracy of the Keyphrase in slug assessment by correctly detecting multi-word keyphrases with at least one hyphenated word in the slug.

## Relevant technical choices:

* The functionality for searching for a keyphrase in the unparsed slug was removed because it is made redundant by the dehyphenating functionality.
* The function for dehyphenating keyphrases from the original PR was adapted so that words with more than one hyphen (e.g. _mother-in-law_) are also fully dehyphenated.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure that the Keyphrase in slug assessment returns a green bullet in all the following cases:
     * Both the keyphrase and the slug are `pop-art`.
     * The keyphrase is `modern pop-art` and the slug is `modern-pop-art`.
     * Both the keyphrase and the slug are `mother-in-law`.
     * The keyphrase is `gift ideas for mother-in-law and father-in-law` and the slug is `gifts-for-mother-and-father-in-law`


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-209
