### PR TITLE
P2-1299 deprecate ensure_permalink method

### DIFF
--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -475,6 +475,7 @@ class Indexable_Repository {
 			->update_many();
 	}
 
+	 * @return bool|Indexable The indexable.
 	/**
 	 * Checks if an Indexable is outdated, and rebuilds it when necessary.
 	 *

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -475,7 +475,24 @@ class Indexable_Repository {
 			->update_many();
 	}
 
+	/**
+	 * Ensures that the given indexable has a permalink.
+	 *
+	 * @param Indexable $indexable The indexable.
+	 *
+	 * will be deprecated in 17.3 - Use upgrade_indexable instead.
+	 * @codeCoverageIgnore
+	 *
 	 * @return bool|Indexable The indexable.
+	 */
+	public function ensure_permalink( $indexable ) {
+		// @phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- self::class is safe.
+		// @phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+		// _deprecated_function( __METHOD__, 'WPSEO 17.3', self::class . '::upgrade_indexable' );
+
+		return $this->upgrade_indexable( $indexable );
+	}
+
 	/**
 	 * Checks if an Indexable is outdated, and rebuilds it when necessary.
 	 *


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where calling a removed method would cause errors.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

see https://github.com/Yoast/wordpress-seo-premium/blame/95056ecc0b5030ac7ea54297a78cf1d1a35278f8/src/integrations/admin/workouts-integration.php#L193

* run premium workouts; they use the method that was removed.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* any code using `ensure_permalinks` will now get a deprecation warning.
This is an internal method used by _far too much_ external code, but with the deprecation added in this PR, the correct (new) behavior of upgrading the requested indexable (p2-1161) is executed.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
