### PR TITLE
P2-1308 Moved post_helper->is_post_indexable condition to the post-builder to ensure posts that shouldn't be indexed are never indexed

### DIFF
--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -73,6 +73,7 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 	 * @param Indexable_Repository       $repository       The indexable repository.
 	 * @param wpdb                       $wpdb             The WordPress database instance.
 	 * @param Indexable_Builder_Versions $builder_versions The latest versions for each Indexable type.
+	 * @param Post_Helper                $post_helper      The post helper.
 	 */
 	public function __construct(
 		Post_Type_Helper $post_type_helper,
@@ -146,8 +147,8 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			$post_types,
 			$excluded_post_statusses
 		);
-	
-		$replacements[]       = $this->version;
+
+		$replacements[] = $this->version;
 
 		// Warning: If this query is changed, makes sure to update the query in get_select_query as well.
 		// @phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
@@ -155,8 +156,8 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			"
 			SELECT COUNT(P.ID)
 			FROM {$this->wpdb->posts} AS P
-			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ")
-			AND I.post_status NOT IN (" . \implode( ', ', \array_fill( 0, \count( $excluded_post_statusses ), '%s' ) ) . ")
+			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')
+			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statusses ), '%s' ) ) . ")
 			AND P.ID not in (
 				SELECT I.object_id from $indexable_table as I
 				WHERE I.object_type = 'post'
@@ -181,8 +182,8 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			$post_types,
 			$excluded_post_statusses
 		);
-	
-		$replacements[]       = $this->version;
+
+		$replacements[] = $this->version;
 
 		$limit_query = '';
 		if ( $limit ) {
@@ -196,8 +197,8 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			"
 			SELECT P.ID
 			FROM {$this->wpdb->posts} AS P
-			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ")
-			AND P.post_status NOT IN (" . \implode( ', ', \array_fill( 0, \count( $excluded_post_statusses ), '%s' ) ) . ")
+			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')
+			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statusses ), '%s' ) ) . ")
 			AND P.ID not in (
 				SELECT I.object_id from $indexable_table as I
 				WHERE I.object_type = 'post'

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -141,11 +141,11 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 	protected function get_count_query() {
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$post_types              = $this->get_post_types();
-		$excluded_post_statusses = $this->post_helper->get_excluded_post_statuses();
-		$replacements            = array_merge(
+		$post_types             = $this->get_post_types();
+		$excluded_post_statuses = $this->post_helper->get_excluded_post_statuses();
+		$replacements           = array_merge(
 			$post_types,
-			$excluded_post_statusses
+			$excluded_post_statuses
 		);
 
 		$replacements[] = $this->version;
@@ -157,7 +157,7 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			SELECT COUNT(P.ID)
 			FROM {$this->wpdb->posts} AS P
 			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')
-			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statusses ), '%s' ) ) . ")
+			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statuses ), '%s' ) ) . ")
 			AND P.ID not in (
 				SELECT I.object_id from $indexable_table as I
 				WHERE I.object_type = 'post'
@@ -176,11 +176,11 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 	protected function get_select_query( $limit = false ) {
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$post_types              = $this->get_post_types();
-		$excluded_post_statusses = $this->post_helper->get_excluded_post_statuses();
-		$replacements            = array_merge(
+		$post_types             = $this->get_post_types();
+		$excluded_post_statuses = $this->post_helper->get_excluded_post_statuses();
+		$replacements           = array_merge(
 			$post_types,
-			$excluded_post_statusses
+			$excluded_post_statuses
 		);
 
 		$replacements[] = $this->version;
@@ -198,7 +198,7 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			SELECT P.ID
 			FROM {$this->wpdb->posts} AS P
 			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')
-			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statusses ), '%s' ) ) . ")
+			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statuses ), '%s' ) ) . ")
 			AND P.ID not in (
 				SELECT I.object_id from $indexable_table as I
 				WHERE I.object_type = 'post'

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Actions\Indexing;
 
 use wpdb;
 use Yoast\WP\Lib\Model;
+use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -38,6 +39,13 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 	protected $post_type_helper;
 
 	/**
+	 * The post helper.
+	 *
+	 * @var Post_Helper
+	 */
+	protected $post_helper;
+
+	/**
 	 * The indexable repository.
 	 *
 	 * @var Indexable_Repository
@@ -70,12 +78,14 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 		Post_Type_Helper $post_type_helper,
 		Indexable_Repository $repository,
 		wpdb $wpdb,
-		Indexable_Builder_Versions $builder_versions
+		Indexable_Builder_Versions $builder_versions,
+		Post_Helper $post_helper
 	) {
 		$this->post_type_helper = $post_type_helper;
 		$this->repository       = $repository;
 		$this->wpdb             = $wpdb;
 		$this->version          = $builder_versions->get_latest_version_for_type( 'post' );
+		$this->post_helper      = $post_helper;
 	}
 
 	/**
@@ -130,9 +140,14 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 	protected function get_count_query() {
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$replacements    = $this->get_post_types();
-		$post_type_count = \count( $replacements );
-		$replacements[]  = $this->version;
+		$post_types              = $this->get_post_types();
+		$excluded_post_statusses = $this->post_helper->get_excluded_post_statuses();
+		$replacements            = array_merge(
+			$post_types,
+			$excluded_post_statusses
+		);
+	
+		$replacements[]       = $this->version;
 
 		// Warning: If this query is changed, makes sure to update the query in get_select_query as well.
 		// @phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
@@ -140,7 +155,8 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			"
 			SELECT COUNT(P.ID)
 			FROM {$this->wpdb->posts} AS P
-			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, $post_type_count, '%s' ) ) . ")
+			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ")
+			AND I.post_status NOT IN (" . \implode( ', ', \array_fill( 0, \count( $excluded_post_statusses ), '%s' ) ) . ")
 			AND P.ID not in (
 				SELECT I.object_id from $indexable_table as I
 				WHERE I.object_type = 'post'
@@ -158,9 +174,15 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 	 */
 	protected function get_select_query( $limit = false ) {
 		$indexable_table = Model::get_table_name( 'Indexable' );
-		$post_types      = $this->get_post_types();
-		$replacements    = $post_types;
-		$replacements[]  = $this->version;
+
+		$post_types              = $this->get_post_types();
+		$excluded_post_statusses = $this->post_helper->get_excluded_post_statuses();
+		$replacements            = array_merge(
+			$post_types,
+			$excluded_post_statusses
+		);
+	
+		$replacements[]       = $this->version;
 
 		$limit_query = '';
 		if ( $limit ) {
@@ -175,6 +197,7 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			SELECT P.ID
 			FROM {$this->wpdb->posts} AS P
 			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ")
+			AND P.post_status NOT IN (" . \implode( ', ', \array_fill( 0, \count( $excluded_post_statusses ), '%s' ) ) . ")
 			AND P.ID not in (
 				SELECT I.object_id from $indexable_table as I
 				WHERE I.object_type = 'post'

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -88,6 +88,10 @@ class Indexable_Post_Builder {
 	 * @throws Post_Not_Found_Exception When the post could not be found.
 	 */
 	public function build( $post_id, $indexable ) {
+		if ( ! $this->post_helper->is_post_indexable( $post_id ) ) {
+			return false;
+		}
+
 		$post = $this->post_helper->get_post( $post_id );
 
 		if ( $post === null ) {

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -164,8 +164,8 @@ class Post_Helper {
 	 * @return bool True if the post can be indexed.
 	 */
 	public function is_post_indexable( $post_id ) {
-		// Don't index auto-drafts.
-		if ( in_array( \get_post_status( $post_id ), $this->get_excluded_post_statuses() ) ) {
+		// Don't index excluded post statuses.
+		if ( in_array( \get_post_status( $post_id ), $this->get_excluded_post_statuses(), true ) ) {
 			return false;
 		}
 
@@ -183,7 +183,7 @@ class Post_Helper {
 	}
 
 	/**
-	 * Retrieves the list of excluded posts statuses.
+	 * Retrieves the list of excluded post statuses.
 	 *
 	 * @return array The excluded post statuses.
 	 */

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -165,7 +165,7 @@ class Post_Helper {
 	 */
 	public function is_post_indexable( $post_id ) {
 		// Don't index auto-drafts.
-		if ( \get_post_status( $post_id ) === 'auto-draft' ) {
+		if ( in_array( \get_post_status( $post_id ), $this->get_excluded_post_statuses() ) ) {
 			return false;
 		}
 
@@ -180,6 +180,15 @@ class Post_Helper {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Retrieves the list of excluded posts statuses.
+	 *
+	 * @return array The excluded post statuses.
+	 */
+	public function get_excluded_post_statuses() {
+		return [ 'auto-draft' ];
 	}
 
 	/**

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -190,10 +190,6 @@ class Indexable_Post_Watcher implements Integration_Interface {
 			return;
 		}
 
-		if ( ! $this->post->is_post_indexable( $post_id ) ) {
-			return;
-		}
-
 		try {
 			$indexable = $this->repository->find_by_id_and_type( $post_id, 'post', false );
 			$indexable = $this->builder->build_for_id_and_type( $post_id, 'post', $indexable );

--- a/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
@@ -7,6 +7,7 @@ use Brain\Monkey\Functions;
 use Mockery;
 use wpdb;
 use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
+use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
@@ -30,6 +31,13 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	 * @var Post_Type_Helper|Mockery\MockInterface
 	 */
 	protected $post_type_helper;
+
+	/**
+	 * The post helper mock.
+	 *
+	 * @var Post_Helper|Mockery\MockInterface
+	 */
+	protected $post_helper;
 
 	/**
 	 * The builder mock.
@@ -69,6 +77,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 		$wpdb = (object) [ 'prefix' => 'wp_' ];
 
 		$this->post_type_helper = Mockery::mock( Post_Type_Helper::class );
+		$this->post_helper      = Mockery::mock( Post_Helper::class );
 		$this->repository       = Mockery::mock( Indexable_Repository::class );
 		$this->wpdb             = Mockery::mock( 'wpdb' );
 		$this->wpdb->posts      = 'wp_posts';
@@ -83,7 +92,8 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 			$this->post_type_helper,
 			$this->repository,
 			$this->wpdb,
-			$this->builder_versions
+			$this->builder_versions,
+			$this->post_helper
 		);
 	}
 
@@ -100,6 +110,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 			SELECT COUNT(P.ID)
 			FROM wp_posts AS P
 			WHERE P.post_type IN (%s)
+			AND P.post_status NOT IN (%s)
 			AND P.ID not in (
 				SELECT I.object_id from wp_yoast_indexable as I
 				WHERE I.object_type = 'post'
@@ -110,12 +121,13 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 
 		$this->wpdb->expects( 'prepare' )
 			->once()
-			->with( $expected_query, [ 'public_post_type', 2 ] )
+			->with( $expected_query, [ 'public_post_type', 'auto-draft', 2 ] )
 			->andReturn( 'query' );
 		$this->wpdb->expects( 'get_var' )->once()->with( 'query' )->andReturn( '10' );
 
 		$this->post_type_helper->expects( 'get_public_post_types' )->once()->andReturn( [ 'public_post_type' ] );
 		$this->post_type_helper->expects( 'get_excluded_post_types_for_indexables' )->once()->andReturn( [] );
+		$this->post_helper->expects( 'get_excluded_post_statuses' )->once()->andReturn( [ 'auto-draft' ] );
 
 		$this->assertEquals( 10, $this->instance->get_total_unindexed() );
 	}
@@ -134,6 +146,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 			SELECT P.ID
 			FROM wp_posts AS P
 			WHERE P.post_type IN (%s)
+			AND P.post_status NOT IN (%s)
 			AND P.ID not in (
 				SELECT I.object_id from wp_yoast_indexable as I
 				WHERE I.object_type = 'post'
@@ -151,12 +164,13 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 
 		$this->wpdb->expects( 'prepare' )
 			->once()
-			->with( $expected_query, [ 'public_post_type', 2, $limit ] )
+			->with( $expected_query, [ 'public_post_type', 'auto-draft', 2, $limit ] )
 			->andReturn( 'query' );
 		$this->wpdb->expects( 'get_col' )->once()->with( 'query' )->andReturn( $query_result );
 
 		$this->post_type_helper->expects( 'get_public_post_types' )->once()->andReturn( [ 'public_post_type' ] );
 		$this->post_type_helper->expects( 'get_excluded_post_types_for_indexables' )->once()->andReturn( [] );
+		$this->post_helper->expects( 'get_excluded_post_statuses' )->once()->andReturn( [ 'auto-draft' ] );
 
 		$this->assertEquals( count( $query_result ), $this->instance->get_limited_unindexed_count( $limit ) );
 	}
@@ -186,6 +200,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 
 		$this->post_type_helper->expects( 'get_public_post_types' )->once()->andReturn( [ 'public_post_type' ] );
 		$this->post_type_helper->expects( 'get_excluded_post_types_for_indexables' )->once()->andReturn( [] );
+		$this->post_helper->expects( 'get_excluded_post_statuses' )->once()->andReturn( [ 'auto-draft' ] );
 
 		$this->wpdb->expects( 'prepare' )->once()->andReturn( 'query' );
 		$this->wpdb->expects( 'get_var' )->once()->with( 'query' )->andReturn( null );
@@ -205,12 +220,13 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	public function test_get_total_unindexed_with_excluded_post_types() {
 		$public_post_types   = [ 'public_post_type', 'excluded_post_type' ];
 		$excluded_post_types = [ 'excluded_post_type' ];
-		$query_params        = [ 'public_post_type', 2 ];
+		$query_params        = [ 'public_post_type', 'auto-draft', 2 ];
 
 		$expected_query = "
 			SELECT COUNT(P.ID)
 			FROM wp_posts AS P
 			WHERE P.post_type IN (%s)
+			AND P.post_status NOT IN (%s)
 			AND P.ID not in (
 				SELECT I.object_id from wp_yoast_indexable as I
 				WHERE I.object_type = 'post'
@@ -221,6 +237,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 
 		$this->post_type_helper->expects( 'get_public_post_types' )->once()->andReturn( $public_post_types );
 		$this->post_type_helper->expects( 'get_excluded_post_types_for_indexables' )->once()->andReturn( $excluded_post_types );
+		$this->post_helper->expects( 'get_excluded_post_statuses' )->once()->andReturn( [ 'auto-draft' ] );
 
 		$this->wpdb->expects( 'prepare' )
 			->once()
@@ -245,6 +262,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 			SELECT P.ID
 			FROM wp_posts AS P
 			WHERE P.post_type IN (%s)
+			AND P.post_status NOT IN (%s)
 			AND P.ID not in (
 				SELECT I.object_id from wp_yoast_indexable as I
 				WHERE I.object_type = 'post'
@@ -261,13 +279,16 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 			->expects( 'get_excluded_post_types_for_indexables' )
 			->once()
 			->andReturn( [] );
+		$this->post_helper->expects( 'get_excluded_post_statuses' )
+			->once()
+			->andReturn( [ 'auto-draft' ] );
 
 		$this->wpdb
 			->expects( 'prepare' )
 			->once()
 			->with(
 				$expected_query,
-				[ 'public_post_type', 2, 25 ]
+				[ 'public_post_type', 'auto-draft', 2, 25 ]
 			)
 			->andReturn( 'query' );
 		$this->wpdb
@@ -297,6 +318,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 
 		$this->post_type_helper->expects( 'get_public_post_types' )->once()->andReturn( [ 'public_post_type' ] );
 		$this->post_type_helper->expects( 'get_excluded_post_types_for_indexables' )->once()->andReturn( [] );
+		$this->post_helper->expects( 'get_excluded_post_statuses' )->once()->andReturn( [ 'auto-draft' ] );
 
 		$this->wpdb->expects( 'prepare' )->once()->andReturn( 'query' );
 		$this->wpdb->expects( 'get_col' )->once()->with( 'query' )->andReturn( [ '1', '3', '8' ] );
@@ -328,6 +350,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 			SELECT P.ID
 			FROM wp_posts AS P
 			WHERE P.post_type IN (%s)
+			AND P.post_status NOT IN (%s)
 			AND P.ID not in (
 				SELECT I.object_id from wp_yoast_indexable as I
 				WHERE I.object_type = 'post'
@@ -344,12 +367,16 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 			->expects( 'get_excluded_post_types_for_indexables' )
 			->once()
 			->andReturn( $excluded_post_types );
+		$this->post_helper
+			->expects( 'get_excluded_post_statuses' )
+			->once()
+			->andReturn( [ 'auto-draft' ] );
 
 		$this->wpdb->expects( 'prepare' )
 			->once()
 			->with(
 				$expected_query,
-				[ 'public_post_type', 2, 25 ]
+				[ 'public_post_type', 'auto-draft', 2, 25 ]
 			)
 			->andReturn( 'query' );
 		$this->wpdb
@@ -382,6 +409,7 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 			SELECT P.ID
 			FROM wp_posts AS P
 			WHERE P.post_type IN (%s)
+			AND P.post_status NOT IN (%s)
 			AND P.ID not in (
 				SELECT I.object_id from wp_yoast_indexable as I
 				WHERE I.object_type = 'post'
@@ -398,13 +426,17 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 			->expects( 'get_excluded_post_types_for_indexables' )
 			->once()
 			->andReturn( [] );
+		$this->post_helper
+			->expects( 'get_excluded_post_statuses' )
+			->once()
+			->andReturn( [ 'auto-draft' ] );
 
 		$this->wpdb
 			->expects( 'prepare' )
 			->once()
 			->with(
 				$expected_query,
-				[ 'public_post_type', 2, 25 ]
+				[ 'public_post_type', 'auto-draft', 2, 25 ]
 			)
 			->andReturn( 'query' );
 		$this->wpdb

--- a/tests/unit/builders/indexable-post-builder-test.php
+++ b/tests/unit/builders/indexable-post-builder-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Builders;
 
 use Brain\Monkey;
 use Mockery;
+use PHPUnit_Framework_ExpectationFailedException;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Post_Builder;
 use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
@@ -254,6 +255,11 @@ class Indexable_Post_Builder_Test extends TestCase {
 			->with( 'post' )
 			->andReturn( false );
 
+		$this->post
+			->expects( 'is_post_indexable' )
+			->with( 1 )
+			->andReturn( true );
+
 		$indexable_expectations = [
 			'object_id'                      => 1,
 			'object_type'                    => 'post',
@@ -359,6 +365,22 @@ class Indexable_Post_Builder_Test extends TestCase {
 		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 
 		$this->instance->build( 1, $this->indexable );
+	}
+
+	/**
+	 * Tests if the build function returns false when the options_helper->is_post_indexable criterium is not met.
+	 *
+	 * @covers ::build
+	 */
+	public function test_build_post_not_indexable() {
+		$this->indexable = Mockery::mock( Indexable::class );
+
+		$this->post
+			->expects( 'is_post_indexable' )
+			->with( 1 )
+			->andReturn( false );
+
+		$this->assertEquals( false, $this->instance->build( 1, $this->indexable ) );
 	}
 
 	/**
@@ -846,6 +868,11 @@ class Indexable_Post_Builder_Test extends TestCase {
 	 * @covers ::build
 	 */
 	public function test_build_term_null() {
+		$this->post
+			->expects( 'is_post_indexable' )
+			->with( 1 )
+			->andReturn( true );
+
 		$this->post->expects( 'get_post' )->once()->with( 1 )->andReturn( null );
 
 		$this->expectException( Post_Not_Found_Exception::class );
@@ -862,6 +889,11 @@ class Indexable_Post_Builder_Test extends TestCase {
 	 */
 	public function test_build_post_type_excluded() {
 		$post_id = 1;
+
+		$this->post
+			->expects( 'is_post_indexable' )
+			->with( $post_id )
+			->andReturn( true );
 
 		$this->post->expects( 'get_post' )
 			->once()

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -230,12 +230,6 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->andReturn( $post );
 
 		$this->post
-			->expects( 'is_post_indexable' )
-			->once()
-			->with( $post_id )
-			->andReturn( true );
-
-		$this->post
 			->expects( 'get_public_post_statuses' )
 			->once()
 			->andReturn( [ 'publish' ] );
@@ -246,23 +240,6 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->with( $indexable_mock, $post_content );
 
 		$this->instance->build_indexable( $post_id );
-	}
-
-	/**
-	 * Tests the early return for non-indexable post.
-	 *
-	 * @covers ::build_indexable
-	 */
-	public function test_build_indexable_is_not_indexable() {
-		$id = 1;
-
-		$this->post
-			->expects( 'is_post_indexable' )
-			->once()
-			->with( $id )
-			->andReturn( false );
-
-		$this->instance->build_indexable( $id );
 	}
 
 	/**
@@ -300,12 +277,6 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->once()
 			->andReturnFalse();
 
-		$this->post
-			->expects( 'is_post_indexable' )
-			->with( $post_id )
-			->once()
-			->andReturnTrue();
-
 		$indexable_mock = Mockery::mock( Indexable_Mock::class );
 		$indexable_mock->expects( 'save' )->never();
 
@@ -331,12 +302,6 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			'post_content' => $post_content,
 			'post_status'  => 'publish',
 		];
-
-		$this->post
-			->expects( 'is_post_indexable' )
-			->with( $post_id )
-			->once()
-			->andReturnTrue();
 
 		$indexable_mock = Mockery::mock( Indexable_Mock::class );
 		$indexable_mock->expects( 'save' )->once();


### PR DESCRIPTION
… ensure posts that shouldn't be indexed are never indexed

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where indexables would be created for `auto-draft` indexables when the SEO optimization is run.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
