### PR TITLE
P2 1308 dont index autodraft posts

### DIFF
--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -48,7 +48,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 	 * @return void
 	 */
 	public function render() {
-		$url  = WPSEO_Shortlinker::get( 'https://yoa.st/17h' );
+		$url = WPSEO_Shortlinker::get( 'https://yoa.st/17h' );
 
 		$arguments = [
 			'<strong>' . esc_html__( 'Multiple keyphrases', 'wordpress-seo' ) . '</strong>: ' . esc_html__( 'Increase your SEO reach', 'wordpress-seo' ),

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -134,21 +134,20 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			$post_types,
 			$excluded_post_statusses
 		);
-	
-		$replacements[]       = $this->version;
 
 		// Warning: If this query is changed, makes sure to update the query in get_select_query as well.
+		// @phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		return $this->wpdb->prepare(
 			"
 			SELECT COUNT(P.ID)
 			FROM {$this->wpdb->posts} AS P
-			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ")
-			AND I.post_status NOT IN (" . \implode( ', ', \array_fill( 0, \count( $excluded_post_statusses ), '%s' ) ) . ")
+			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')
+			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statusses ), '%s' ) ) . ")
 			AND P.ID not in (
 				SELECT I.object_id from $indexable_table as I
 				WHERE I.object_type = 'post'
 				AND I.permalink_hash IS NOT NULL)",
-			$post_types
+			$replacements
 		);
 	}
 
@@ -168,8 +167,6 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			$post_types,
 			$excluded_post_statusses
 		);
-	
-		$replacements[]       = $this->version;
 
 		$limit_query = '';
 		if ( $limit ) {
@@ -178,12 +175,13 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 		}
 
 		// Warning: If this query is changed, makes sure to update the query in get_count_query as well.
+		// @phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		return $this->wpdb->prepare(
 			"
 			SELECT P.ID
 			FROM {$this->wpdb->posts} AS P
-			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ")
-			AND P.post_status NOT IN (" . \implode( ', ', \array_fill( 0, \count( $excluded_post_statusses ), '%s' ) ) . ")
+			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')
+			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statusses ), '%s' ) ) . ")
 			AND P.ID not in (
 				SELECT I.object_id from $indexable_table as I
 				WHERE I.object_type = 'post'

--- a/src/actions/indexing/indexable-post-indexation-action.php
+++ b/src/actions/indexing/indexable-post-indexation-action.php
@@ -128,11 +128,11 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 	protected function get_count_query() {
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$post_types              = $this->get_post_types();
-		$excluded_post_statusses = $this->post_helper->get_excluded_post_statuses();
-		$replacements            = array_merge(
+		$post_types             = $this->get_post_types();
+		$excluded_post_statuses = $this->post_helper->get_excluded_post_statuses();
+		$replacements           = array_merge(
 			$post_types,
-			$excluded_post_statusses
+			$excluded_post_statuses
 		);
 
 		// Warning: If this query is changed, makes sure to update the query in get_select_query as well.
@@ -142,7 +142,7 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			SELECT COUNT(P.ID)
 			FROM {$this->wpdb->posts} AS P
 			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')
-			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statusses ), '%s' ) ) . ")
+			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statuses ), '%s' ) ) . ")
 			AND P.ID not in (
 				SELECT I.object_id from $indexable_table as I
 				WHERE I.object_type = 'post'
@@ -161,11 +161,11 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 	protected function get_select_query( $limit = false ) {
 		$indexable_table = Model::get_table_name( 'Indexable' );
 
-		$post_types              = $this->get_post_types();
-		$excluded_post_statusses = $this->post_helper->get_excluded_post_statuses();
-		$replacements            = array_merge(
+		$post_types             = $this->get_post_types();
+		$excluded_post_statuses = $this->post_helper->get_excluded_post_statuses();
+		$replacements           = array_merge(
 			$post_types,
-			$excluded_post_statusses
+			$excluded_post_statuses
 		);
 
 		$limit_query = '';
@@ -181,7 +181,7 @@ class Indexable_Post_Indexation_Action extends Abstract_Indexing_Action {
 			SELECT P.ID
 			FROM {$this->wpdb->posts} AS P
 			WHERE P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $post_types ), '%s' ) ) . ')
-			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statusses ), '%s' ) ) . ")
+			AND P.post_status NOT IN (' . \implode( ', ', \array_fill( 0, \count( $excluded_post_statuses ), '%s' ) ) . ")
 			AND P.ID not in (
 				SELECT I.object_id from $indexable_table as I
 				WHERE I.object_type = 'post'

--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -77,6 +77,10 @@ class Indexable_Post_Builder {
 	 * @throws Post_Not_Found_Exception When the post could not be found.
 	 */
 	public function build( $post_id, $indexable ) {
+		if ( ! $this->post_helper->is_post_indexable( $post_id ) ) {
+			return false;
+		}
+
 		$post = $this->post_helper->get_post( $post_id );
 
 		if ( $post === null ) {

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -164,8 +164,8 @@ class Post_Helper {
 	 * @return bool True if the post can be indexed.
 	 */
 	public function is_post_indexable( $post_id ) {
-		// Don't index auto-drafts.
-		if ( in_array( \get_post_status( $post_id ), $this->get_excluded_post_statuses() ) ) {
+		// Don't index excluded post statuses.
+		if ( in_array( \get_post_status( $post_id ), $this->get_excluded_post_statuses(), true ) ) {
 			return false;
 		}
 
@@ -183,7 +183,7 @@ class Post_Helper {
 	}
 
 	/**
-	 * Retrieves the list of excluded posts statuses.
+	 * Retrieves the list of excluded post statuses.
 	 *
 	 * @return array The excluded post statuses.
 	 */

--- a/src/helpers/post-helper.php
+++ b/src/helpers/post-helper.php
@@ -165,7 +165,7 @@ class Post_Helper {
 	 */
 	public function is_post_indexable( $post_id ) {
 		// Don't index auto-drafts.
-		if ( \get_post_status( $post_id ) === 'auto-draft' ) {
+		if ( in_array( \get_post_status( $post_id ), $this->get_excluded_post_statuses() ) ) {
 			return false;
 		}
 
@@ -180,6 +180,15 @@ class Post_Helper {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Retrieves the list of excluded posts statuses.
+	 *
+	 * @return array The excluded post statuses.
+	 */
+	public function get_excluded_post_statuses() {
+		return [ 'auto-draft' ];
 	}
 
 	/**

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -190,10 +190,6 @@ class Indexable_Post_Watcher implements Integration_Interface {
 			return;
 		}
 
-		if ( ! $this->post->is_post_indexable( $post_id ) ) {
-			return;
-		}
-
 		try {
 			$indexable = $this->repository->find_by_id_and_type( $post_id, 'post', false );
 			$indexable = $this->builder->build_for_id_and_type( $post_id, 'post', $indexable );

--- a/tests/unit/builders/indexable-post-builder-test.php
+++ b/tests/unit/builders/indexable-post-builder-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Builders;
 
 use Brain\Monkey;
 use Mockery;
+use PHPUnit_Framework_ExpectationFailedException;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Post_Builder;
 use Yoast\WP\SEO\Exceptions\Indexable\Post_Not_Found_Exception;
@@ -252,6 +253,11 @@ class Indexable_Post_Builder_Test extends TestCase {
 			->with( 'post' )
 			->andReturn( false );
 
+		$this->post
+			->expects( 'is_post_indexable' )
+			->with( 1 )
+			->andReturn( true );
+
 		$indexable_expectations = [
 			'object_id'                      => 1,
 			'object_type'                    => 'post',
@@ -356,6 +362,22 @@ class Indexable_Post_Builder_Test extends TestCase {
 		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 
 		$this->instance->build( 1, $this->indexable );
+	}
+
+	/**
+	 * Tests if the build function returns false when the options_helper->is_post_indexable criterium is not met.
+	 *
+	 * @covers ::build
+	 */
+	public function test_build_post_not_indexable() {
+		$this->indexable = Mockery::mock( Indexable::class );
+
+		$this->post
+			->expects( 'is_post_indexable' )
+			->with( 1 )
+			->andReturn( false );
+
+		$this->assertEquals( false, $this->instance->build( 1, $this->indexable ) );
 	}
 
 	/**
@@ -843,6 +865,11 @@ class Indexable_Post_Builder_Test extends TestCase {
 	 * @covers ::build
 	 */
 	public function test_build_term_null() {
+		$this->post
+			->expects( 'is_post_indexable' )
+			->with( 1 )
+			->andReturn( true );
+
 		$this->post->expects( 'get_post' )->once()->with( 1 )->andReturn( null );
 
 		$this->expectException( Post_Not_Found_Exception::class );
@@ -859,6 +886,11 @@ class Indexable_Post_Builder_Test extends TestCase {
 	 */
 	public function test_build_post_type_excluded() {
 		$post_id = 1;
+
+		$this->post
+			->expects( 'is_post_indexable' )
+			->with( $post_id )
+			->andReturn( true );
 
 		$this->post->expects( 'get_post' )
 			->once()

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -230,12 +230,6 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->andReturn( $post );
 
 		$this->post
-			->expects( 'is_post_indexable' )
-			->once()
-			->with( $post_id )
-			->andReturn( true );
-
-		$this->post
 			->expects( 'get_public_post_statuses' )
 			->once()
 			->andReturn( [ 'publish' ] );
@@ -246,23 +240,6 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->with( $indexable_mock, $post_content );
 
 		$this->instance->build_indexable( $post_id );
-	}
-
-	/**
-	 * Tests the early return for non-indexable post.
-	 *
-	 * @covers ::build_indexable
-	 */
-	public function test_build_indexable_is_not_indexable() {
-		$id = 1;
-
-		$this->post
-			->expects( 'is_post_indexable' )
-			->once()
-			->with( $id )
-			->andReturn( false );
-
-		$this->instance->build_indexable( $id );
 	}
 
 	/**
@@ -300,12 +277,6 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->once()
 			->andReturnFalse();
 
-		$this->post
-			->expects( 'is_post_indexable' )
-			->with( $post_id )
-			->once()
-			->andReturnTrue();
-
 		$indexable_mock = Mockery::mock( Indexable_Mock::class );
 		$indexable_mock->expects( 'save' )->never();
 
@@ -331,12 +302,6 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			'post_content' => $post_content,
 			'post_status'  => 'publish',
 		];
-
-		$this->post
-			->expects( 'is_post_indexable' )
-			->with( $post_id )
-			->once()
-			->andReturnTrue();
 
 		$indexable_mock = Mockery::mock( Indexable_Mock::class );
 		$indexable_mock->expects( 'save' )->once();


### PR DESCRIPTION
… ensure posts that shouldn't be indexed are never indexed

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where indexables would be created for `auto-draft` indexables when the SEO optimization is run.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have auto-draft posts in your posts table. (Create a new post, add some content, DO NOT save it and refresh te page). If you get the message to revert to a back-up the auto-draft was succesfully created.
* Check the database that no indexable was created for the auto-draft post.
* Reset the indexables tables using the Yoast Test Helper.
* Run the SEO Optimization.
* Check the database that no indexables were created for auto-draft posts.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* SEO Optimization
* Saving posts in the editor

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
