### PR TITLE
P2-1324 - Fix import of custom post types with a hyphen

### DIFF
--- a/admin/import/plugins/class-import-aioseo-v4.php
+++ b/admin/import/plugins/class-import-aioseo-v4.php
@@ -151,7 +151,7 @@ class WPSEO_Import_AIOSEO_V4 extends WPSEO_Plugin_Importer {
 
 			/*
 			 * `$matches[1]` contain the captured matches of the
-			 * first capturing group (the `(\w+)` in the regex above).
+			 * first capturing group (the `([\w-]+)` in the regex above).
 			 */
 			$custom_fields_or_taxonomies = $matches[1];
 

--- a/admin/import/plugins/class-import-aioseo-v4.php
+++ b/admin/import/plugins/class-import-aioseo-v4.php
@@ -144,7 +144,7 @@ class WPSEO_Import_AIOSEO_V4 extends WPSEO_Plugin_Importer {
 		foreach ( $meta_values as $meta_value ) {
 			// Find all custom field replace vars, store them in `$matches`.
 			\preg_match_all(
-				"/#$aioseo_prefix-(\w+)/",
+				"/#$aioseo_prefix-([\w-]+)/",
 				$meta_value,
 				$matches
 			);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixed a bug where custom post types with a hyphen were not imported properly.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure the custom post types and custom taxonomies in the Yoast Test Helper are active.
* Make sure AIOSEO is activated and Yoast SEO is deactivated.
* Create a new Book, add a replacement variable "Taxonomy Name" with value `book-genre` to the meta title or description.
* Activate Yoast SEO.
* Import AIOSEO data.
* Save the post.
* Check the front-end if it has the right value.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Import custom fields from AIOSEO

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
