### PR TITLE
P2 1325 update indexables after import

### DIFF
--- a/admin/import/class-import-plugin.php
+++ b/admin/import/class-import-plugin.php
@@ -41,6 +41,11 @@ class WPSEO_Import_Plugin {
 				break;
 			case 'import':
 				$this->status = $this->importer->run_import();
+
+				if ( $this->status->get_status() === true ) {
+					// Import was a success, time to notify users to re-index.
+					YoastSEO()->helpers->indexing->retrigger_indexing_notification();
+				}
 				break;
 			case 'detect':
 			default:

--- a/admin/import/class-import-status.php
+++ b/admin/import/class-import-status.php
@@ -110,6 +110,15 @@ class WPSEO_Import_Status {
 	}
 
 	/**
+	 * Gets the importer status.
+	 *
+	 * @return WPSEO_Import_Status The current object.
+	 */
+	public function get_status() {
+		return $this->status;
+	}
+
+	/**
 	 * Returns a success message depending on the action.
 	 *
 	 * @return string Returns a success message for the current action.

--- a/admin/import/plugins/class-abstract-plugin-importer.php
+++ b/admin/import/plugins/class-abstract-plugin-importer.php
@@ -87,9 +87,9 @@ abstract class WPSEO_Plugin_Importer {
 	 * @return bool Import success status.
 	 */
 	protected function import() {
-		$status         = $this->meta_keys_clone( $this->clone_keys );
+		$status = $this->meta_keys_clone( $this->clone_keys );
 
-		// Time to reset the indexables for posts that were affected by the import
+		// Time to reset the indexables for posts that were affected by the import.
 		$imported_posts = array_unique( $this->post_ids );
 		YoastSEO()->helpers->indexable->reset_indexables_by_post_ids( $imported_posts );
 
@@ -234,8 +234,10 @@ abstract class WPSEO_Plugin_Importer {
 
 		$this->meta_key_clone_replace( $replace_values );
 
-		$ids = $wpdb->get_col( 'SELECT post_id FROM tmp_meta_table' );
-		$this->post_ids = array_merge( $this->post_ids, $ids );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$affected_post_ids = $wpdb->get_col( 'SELECT post_id FROM tmp_meta_table' );
+		$this->post_ids    = array_merge( $this->post_ids, $affected_post_ids );
+
 		// With everything done, we insert all our newly cloned lines into the postmeta table.
 		$wpdb->query( "INSERT INTO {$wpdb->postmeta} SELECT * FROM tmp_meta_table" );
 

--- a/admin/import/plugins/class-abstract-plugin-importer.php
+++ b/admin/import/plugins/class-abstract-plugin-importer.php
@@ -88,8 +88,10 @@ abstract class WPSEO_Plugin_Importer {
 	 */
 	protected function import() {
 		$status         = $this->meta_keys_clone( $this->clone_keys );
-		$imported_posts = array_unique ( $this->post_ids );
-		// @TODO: use those ids to set their indexable version to 0, so we can rebuild them.
+
+		// Time to reset the indexables for posts that were affected by the import
+		$imported_posts = array_unique( $this->post_ids );
+		YoastSEO()->helpers->indexable->reset_indexables_by_post_ids( $imported_posts );
 
 		return $status;
 	}

--- a/admin/import/plugins/class-abstract-plugin-importer.php
+++ b/admin/import/plugins/class-abstract-plugin-importer.php
@@ -41,6 +41,13 @@ abstract class WPSEO_Plugin_Importer {
 	protected $clone_keys;
 
 	/**
+	 * Array of post ids whose meta are to be imported.
+	 *
+	 * @var array
+	 */
+	protected $post_ids = [];
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {}
@@ -80,7 +87,11 @@ abstract class WPSEO_Plugin_Importer {
 	 * @return bool Import success status.
 	 */
 	protected function import() {
-		return $this->meta_keys_clone( $this->clone_keys );
+		$status         = $this->meta_keys_clone( $this->clone_keys );
+		$imported_posts = array_unique ( $this->post_ids );
+		// @TODO: use those ids to set their indexable version to 0, so we can rebuild them.
+
+		return $status;
 	}
 
 	/**
@@ -221,6 +232,8 @@ abstract class WPSEO_Plugin_Importer {
 
 		$this->meta_key_clone_replace( $replace_values );
 
+		$ids = $wpdb->get_col( 'SELECT post_id FROM tmp_meta_table' );
+		$this->post_ids = array_merge( $this->post_ids, $ids );
 		// With everything done, we insert all our newly cloned lines into the postmeta table.
 		$wpdb->query( "INSERT INTO {$wpdb->postmeta} SELECT * FROM tmp_meta_table" );
 

--- a/src/config/indexing-reasons.php
+++ b/src/config/indexing-reasons.php
@@ -31,4 +31,9 @@ class Indexing_Reasons {
 	 * Represents the reason that the home url option is changed.
 	 */
 	const REASON_HOME_URL_OPTION = 'home_url_option_changed';
+
+	/**
+	 * Represents the reason that an import has been completed.
+	 */
+	const REASON_IMPORT_COMPLETED = 'import_completed';
 }

--- a/src/helpers/indexable-helper.php
+++ b/src/helpers/indexable-helper.php
@@ -135,7 +135,7 @@ class Indexable_Helper {
 	 */
 	public function reset_indexables_by_post_ids( $post_ids, $reason = Indexing_Reasons::REASON_IMPORT_COMPLETED ) {
 		$result = 0;
-		 /**
+		/**
 		 * Filter: 'wpseo_chunk_bulk_reset_post_indexables' - Allow filtering the chunk size of each bulked reset post indexable query.
 		 *
 		 * @api int The chunk size of the bulked reset post indexable query.

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -291,13 +291,16 @@ class Indexing_Helper {
 		// First, let's delete all count transients.
 		\delete_transient( Indexable_General_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
 		\delete_transient( Indexable_Post_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
+		\delete_transient( Indexable_Post_Indexation_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT );
 		\delete_transient( Indexable_Post_Type_Archive_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
 		\delete_transient( Indexable_Term_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
+		\delete_transient( Indexable_Term_Indexation_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT );
 		\delete_transient( Post_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT );
+		\delete_transient( Post_Link_Indexing_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT );
 		\delete_transient( Term_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT );
+		\delete_transient( Term_Link_Indexing_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT );
 
 		// Then, let's set a reason for indexing, so that the notification for indexing pops up.
-		
 		$this->set_reason( $reason );
 	}
 }

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -302,5 +302,8 @@ class Indexing_Helper {
 
 		// Then, let's set a reason for indexing, so that the notification for indexing pops up.
 		$this->set_reason( $reason );
+
+		// Also, clear the indexing_started option so we cover the case where an SEO optimization might already be running at the time of the import. 
+		$this->set_started( null );
 	}
 }

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -294,7 +294,7 @@ class Indexing_Helper {
 		// Then, let's set a reason for indexing, so that the notification for indexing pops up.
 		$this->set_reason( $reason );
 
-		// Also, clear the indexing_started option so we cover the case where an SEO optimization might already be running at the time of the import. 
+		// Also, clear the indexing_started option so we cover the case where an SEO optimization might already be running at the time of the import.
 		$this->set_started( null );
 	}
 

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -279,4 +279,25 @@ class Indexing_Helper {
 		 */
 		return \apply_filters( 'wpseo_indexing_get_limited_unindexed_count', $unindexed_count, $limit );
 	}
+
+	/**
+	 * Retriggers the indexing notification.
+	 *
+	 * @param string $reason The reason for which we need re-indexing.
+	 * 
+	 * @return void.
+	 */
+	public function retrigger_indexing_notification( $reason = Indexing_Reasons::REASON_IMPORT_COMPLETED ) {
+		// First, let's delete all count transients.
+		\delete_transient( Indexable_General_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
+		\delete_transient( Indexable_Post_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
+		\delete_transient( Indexable_Post_Type_Archive_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
+		\delete_transient( Indexable_Term_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
+		\delete_transient( Post_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT );
+		\delete_transient( Term_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT );
+
+		// Then, let's set a reason for indexing, so that the notification for indexing pops up.
+		
+		$this->set_reason( $reason );
+	}
 }

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -289,6 +289,21 @@ class Indexing_Helper {
 	 */
 	public function retrigger_indexing_notification( $reason = Indexing_Reasons::REASON_IMPORT_COMPLETED ) {
 		// First, let's delete all count transients.
+		$this->clear_count_transients();
+
+		// Then, let's set a reason for indexing, so that the notification for indexing pops up.
+		$this->set_reason( $reason );
+
+		// Also, clear the indexing_started option so we cover the case where an SEO optimization might already be running at the time of the import. 
+		$this->set_started( null );
+	}
+
+	/**
+	 * Clears all count transients.
+	 *
+	 * @return void.
+	 */
+	public function clear_count_transients() {
 		\delete_transient( Indexable_General_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
 		\delete_transient( Indexable_Post_Indexation_Action::UNINDEXED_COUNT_TRANSIENT );
 		\delete_transient( Indexable_Post_Indexation_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT );
@@ -299,11 +314,5 @@ class Indexing_Helper {
 		\delete_transient( Post_Link_Indexing_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT );
 		\delete_transient( Term_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT );
 		\delete_transient( Term_Link_Indexing_Action::UNINDEXED_LIMITED_COUNT_TRANSIENT );
-
-		// Then, let's set a reason for indexing, so that the notification for indexing pops up.
-		$this->set_reason( $reason );
-
-		// Also, clear the indexing_started option so we cover the case where an SEO optimization might already be running at the time of the import. 
-		$this->set_started( null );
 	}
 }

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -284,7 +284,7 @@ class Indexing_Helper {
 	 * Retriggers the indexing notification.
 	 *
 	 * @param string $reason The reason for which we need re-indexing.
-	 * 
+	 *
 	 * @return void.
 	 */
 	public function retrigger_indexing_notification( $reason = Indexing_Reasons::REASON_IMPORT_COMPLETED ) {

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -294,7 +294,7 @@ class Indexing_Helper {
 		// Then, let's set a reason for indexing, so that the notification for indexing pops up.
 		$this->set_reason( $reason );
 
-		// Also, clear the indexing_started option so we cover the case where an SEO optimization might already be running at the time of the import.
+		// Also, clear the indexing_started option so we cover the case where an SEO optimization was started but hadn't been finished.
 		$this->set_started( null );
 	}
 

--- a/src/presenters/admin/indexing-notification-presenter.php
+++ b/src/presenters/admin/indexing-notification-presenter.php
@@ -83,6 +83,9 @@ class Indexing_Notification_Presenter extends Abstract_Presenter {
 			case Indexing_Reasons::REASON_TAG_BASE_PREFIX:
 				$text = \esc_html__( 'Because of a change in your tag base setting, some of your SEO data needs to be reprocessed.', 'wordpress-seo' );
 				break;
+			case Indexing_Reasons::REASON_IMPORT_COMPLETED:
+				$text = \esc_html__( 'Because of a recent import of data from another SEO plugin, some of your SEO data needs to be reprocessed.', 'wordpress-seo' );
+				break;
 			default:
 				$text = \esc_html__( 'You can speed up your site and get insight into your internal linking structure by letting us perform a few optimizations to the way SEO data is stored. ', 'wordpress-seo' );
 		}

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -548,7 +548,7 @@ class Indexable_Repository {
 				'version' => 0,
 			]
 		);
-		
+
 		$query->where_in( 'object_id', $post_ids );
 		$query->where( 'object_type', 'post' );
 

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -534,4 +534,24 @@ class Indexable_Repository {
 
 		return $query->update_many();
 	}
+
+	/**
+	 * Resets the indexables of the passed post ids.
+	 *
+	 * @param array $post_ids The ids of the posts that need their indexables reset.
+	 *
+	 * @return int|bool The number of post indexables changed if the query was succesful. False otherwise.
+	 */
+	public function reset_posts( $post_ids ) {
+		$query = $this->query()->set(
+			[
+				'version' => 0,
+			]
+		);
+		
+		$query->where_in( 'object_id', $post_ids );
+		$query->where( 'object_type', 'post' );
+
+		return $query->update_many();
+	}
 }

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -436,7 +436,6 @@ class Indexing_Helper_Test extends TestCase {
 	 * @covers ::set_started
 	 */
 	public function test_retrigger_indexing_notification() {
-		$start_time = 160934509;
 		Monkey\Functions\expect( 'delete_transient' )
 			->times( 10 )
 			->withAnyArgs();

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -426,4 +426,36 @@ class Indexing_Helper_Test extends TestCase {
 
 		static::assertEquals( 30, $this->instance->get_limited_filtered_unindexed_count( 25 ) );
 	}
+
+	/**
+	 * Tests getting the indexing start time.
+	 *
+	 * @covers ::retrigger_indexing_notification
+	 * @covers ::clear_count_transients
+	 * @covers ::set_reason
+	 * @covers ::set_started
+	 */
+	public function test_retrigger_indexing_notification() {
+		$start_time = 160934509;
+		Monkey\Functions\expect( 'delete_transient' )
+			->times( 10 )
+			->withAnyArgs();
+
+		$this->options_helper
+			->expects( 'set' )
+			->once()
+			->with( 'indexing_reason', 'import_completed' );
+
+		$this->options_helper
+			->expects( 'set' )
+			->once()
+			->with( 'indexing_started', null );
+
+		$this->notification_center
+			->expects( 'remove_notification_by_id' )
+			->once()
+			->with( Indexing_Notification_Integration::NOTIFICATION_ID );
+
+		$this->instance->retrigger_indexing_notification();
+	}
 }

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -407,6 +407,7 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			[ 'permalink_settings_changed' ],
 			[ 'category_base_changed' ],
 			[ 'home_url_option_changed' ],
+			[ 'import_completed' ],
 		];
 	}
 

--- a/tests/unit/repositories/indexable-repository-test.php
+++ b/tests/unit/repositories/indexable-repository-test.php
@@ -465,6 +465,47 @@ class Indexable_Repository_Test extends TestCase {
 	}
 
 	/**
+	 * Tests if the reset_permalink method fires when type and subtype are passed.
+	 *
+	 * @covers ::reset_posts
+	 */
+	public function test_reset_posts() {
+		$orm_object = Mockery::mock();
+		$post_ids   = [ 1, 2, 3 ];
+
+		$this->instance
+			->expects( 'query' )
+			->andReturn( $orm_object );
+
+		$orm_object
+			->expects( 'set' )
+			->with(
+				[
+					'version' => 0,
+				]
+			)
+			->once()
+			->andReturnSelf();
+
+		$orm_object
+			->expects( 'where_in' )
+			->with( 'object_id', $post_ids )
+			->andReturnSelf();
+
+		$orm_object
+			->expects( 'where' )
+			->with( 'object_type', 'post' )
+			->andReturnSelf();
+
+		$orm_object
+			->expects( 'update_many' )
+			->once()
+			->andReturn( 3 );
+
+		$this->assertSame( 3, $this->instance->reset_posts( $post_ids ) );
+	}
+
+	/**
 	 * Tests if ensure_permalink sets the permalink to 'unindexed' when the post_status is 'unindexed'.
 	 *
 	 * @covers ::upgrade_indexable


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When importing from other SEO plugins, we add meta data in the _postmeta table. In order for those to be properly added in the indexable table, the SEO optimization needs to be ran.
* For that reason, we prompt users to run an SEO optimization upon a successful import. A new text was added to explain that the SEO optimization is needed because of a recent import.
* Also, posts that already had an indexable prior to the import, would not have their indexable updated with the imported meta data.
* For that reason, we reset the version of the existing indexables for the affected posts, so that the next SEO optimization will add the new meta data in those indexables

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where imported data wouldn't show in the frontend until SEO optimization occurred by prompting the user to trigger SEO optimization upon successful import and also covers the case where already existing indexables wouldn't be updated by the SEO optimization.

## Relevant technical choices:

* Upon successful import, we clear all count transients and set a new reason for SEO optimization, so that the user will get prompted to run the SEO optimization. 
* During import, we gather the ids of posts that are affected by the import.
* Once the import is done, we query the indexable table for indexables for those posts and set their version to `0`, so that the next SEO optimization will update them accordingly.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have AIOSEO and Yoast SEO active
* In 4 posts, add a Meta Description in the AIOSEO metabox (but leave the Meta Description in the Yoast SEO metabox as blank).
* Reset the indexables using the Yoast Test helper.
* Save again 2 of those 4 posts above (so that an indexable for those posts is created in the indexable table, note its id so you can easily check them later on)
* To ensure we're not letting previous attempts of testing this PR affect our results, delete every entry in the _postmeta table that begins with `_yoast_`
* Import the AIOSEO data from the **SEO->Tools** page
* Once the import is done, confirm that a page load will show a notification to the User to run an SEO optimization,
* **Confirm** that the above notification will cite `Because some of your SEO data was reset by the Yoast Test Helper, your SEO data needs to be reprocessed` as the reason that the SEO optimization is required.
* Check the db for those 2 indexables you previously took a note for. The `version` column for those indexables needs to be `0` now.
* Run the SEO optimization.
* Confirm that the 4 posts that had the AIOSEO meta description, now have the same meta description in Yoast SEO as well. You can do that by visiting the post editor for that post and check the Yoast metabox or you can check the frontend and note the Yoast meta tags in <head>. It's advisable to use both methods, so the first one for some posts and the second one for the rest of the posts.
* Give special attention to the 2 posts that used to have a Yoast indexable created. **Confirm** that their indexable in the db have now a version of `1` and that their Yoast meta desc in <head> are the same with the AIOSEO's meta desc.

Also, to test the chunked update of the above:
* Repeat the above steps with the 
```add_filter( 'wpseo_chunk_bulk_reset_post_indexables', 'chunk_bulk_reset_post_indexables', 1 );
function chunk_bulk_reset_post_indexables() {
    return 1;
}
``` 
code applied in your theme.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Repeat the above Test Instructions with another plugin import, other than AIOSEO (no need to do the `test the chunked update of the above` part of those instructions, just once will do)
* As we touch code for Imports in general, regression testing regarding imports is advisable.
* As we reset the indexable for posts that already had indexables prior to the import, regression testing around the indexable functionality is advised. So, once we run the SEO optimization after the import, check if things are running as expected for the posts that had indexables prior to the import, eg. Internal linking is still running as before.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
