### PR TITLE
Fix duplicate canonical tags for web stories

### DIFF
--- a/src/integrations/third-party/web-stories.php
+++ b/src/integrations/third-party/web-stories.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Integrations\Third_Party;
 
-use Google\Web_Stories as Google_Web_Stories;
 use WP_Screen;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Web_Stories_Conditional;
@@ -53,11 +52,21 @@ class Web_Stories implements Integration_Interface {
 		\add_action( 'web_stories_enable_schemaorg_metadata', '__return_false' );
 		\add_action( 'web_stories_enable_open_graph_metadata', '__return_false' );
 		\add_action( 'web_stories_enable_twitter_metadata', '__return_false' );
-		\remove_action( 'web_stories_story_head', 'rel_canonical' );
-		\add_action( 'web_stories_story_head', [ $this->front_end, 'call_wpseo_head' ], 9 );
+
+		\add_action( 'web_stories_story_head', [ $this, 'web_stories_story_head' ], 1 );
 		\add_filter( 'wpseo_schema_article_post_types', [ $this, 'filter_schema_article_post_types' ] );
 		\add_filter( 'wpseo_schema_article_type', [ $this, 'filter_schema_article_type' ], 10, 2 );
 		\add_filter( 'wpseo_metadesc', [ $this, 'filter_meta_description' ], 10, 2 );
+	}
+
+	/**
+	 * Hooks into web story <head> generation to modify output.
+	 *
+	 * @return void
+	 */
+	public function web_stories_story_head() {
+		\remove_action( 'web_stories_story_head', 'rel_canonical' );
+		\add_action( 'web_stories_story_head', [ $this->front_end, 'call_wpseo_head' ], 9 );
 	}
 
 	/**
@@ -67,7 +76,7 @@ class Web_Stories implements Integration_Interface {
 	 * @return string[] Array of post types.
 	 */
 	public function filter_schema_article_post_types( $post_types ) {
-		$post_types[] = Google_Web_Stories\Story_Post_Type::POST_TYPE_SLUG;
+		$post_types[] = 'web-story';
 		return $post_types;
 	}
 
@@ -79,7 +88,7 @@ class Web_Stories implements Integration_Interface {
 	 * @return string The description sentence.
 	 */
 	public function filter_meta_description( $description, $presentation ) {
-		if ( $description || $presentation->model->object_sub_type !== Google_Web_Stories\Story_Post_Type::POST_TYPE_SLUG ) {
+		if ( $description || $presentation->model->object_sub_type !== 'web-story' ) {
 			return $description;
 		}
 
@@ -94,7 +103,7 @@ class Web_Stories implements Integration_Interface {
 	 * @return string|string[] Article type.
 	 */
 	public function filter_schema_article_type( $type, $indexable ) {
-		if ( $indexable->object_sub_type !== Google_Web_Stories\Story_Post_Type::POST_TYPE_SLUG ) {
+		if ( $indexable->object_sub_type !== 'web-story' ) {
 			return $type;
 		}
 

--- a/tests/unit/integrations/third-party/web-stories-test.php
+++ b/tests/unit/integrations/third-party/web-stories-test.php
@@ -66,20 +66,26 @@ class Web_Stories_Test extends TestCase {
 	public function test_register_hooks() {
 		$this->instance->register_hooks();
 
-		\add_action( 'web_stories_enable_metadata', '__return_false' );
-		\add_action( 'web_stories_enable_schemaorg_metadata', '__return_false' );
-		\add_action( 'web_stories_enable_open_graph_metadata', '__return_false' );
-		\add_action( 'web_stories_enable_twitter_metadata', '__return_false' );
-
 		$this->assertNotFalse( \has_action( 'web_stories_enable_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
 		$this->assertNotFalse( \has_action( 'web_stories_enable_schemaorg_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
 		$this->assertNotFalse( \has_action( 'web_stories_enable_open_graph_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
 		$this->assertNotFalse( \has_action( 'web_stories_enable_twitter_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
-		$this->assertFalse( \has_action( 'web_stories_story_head', 'rel_canonical' ), 'The rel canonical action is not registered' );
-		$this->assertNotFalse( \has_action( 'web_stories_story_head', [ $this->front_end, 'call_wpseo_head' ] ), 'The wpseo head action is registered.' );
+		$this->assertNotFalse( \has_action( 'web_stories_story_head', [ $this->instance, 'web_stories_story_head' ] ), 'The web-story head action is not registered' );
 		$this->assertNotFalse( \has_filter( 'wpseo_schema_article_post_types', [ $this->instance, 'filter_schema_article_post_types' ] ), 'The filter schema article post types function is registered.' );
 		$this->assertNotFalse( \has_filter( 'wpseo_schema_article_type', [ $this->instance, 'filter_schema_article_type' ] ), 'The filter schema article type function is registered.' );
 		$this->assertNotFalse( \has_filter( 'wpseo_metadesc', [ $this->instance, 'filter_meta_description' ] ), 'The metadesc action is registered.' );
+	}
+
+	/**
+	 * Tests web_stories_story_head integration.
+	 *
+	 * @covers ::web_stories_story_head
+	 */
+	public function test_web_stories_story_head() {
+		$this->instance->web_stories_story_head();
+
+		$this->assertFalse( \has_action( 'web_stories_story_head', 'rel_canonical' ), 'The rel canonical action is not registered' );
+		$this->assertNotFalse( \has_action( 'web_stories_story_head', [ $this->front_end, 'call_wpseo_head' ] ), 'The wpseo head action is registered.' );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* There's an issue with duplicate canonical tags for web stories.
* Duplicates https://github.com/Yoast/wordpress-seo/pull/17435 to make sure that the Travis build is able to pass.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a duplicate canonical tag was output for web stories created with the Web Stories plugin. Props to [swissspidey](https://github.com/swissspidy).

## Relevant technical choices:

* Move hook (un)registration to a later stage

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install the Web Stories plugin
* Publish a story
* View the story
* Verify that there's only one canonical tag


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #17419