### PR TITLE
Move the initialization of keyphrase distribution assessment

### DIFF
--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -31,8 +31,6 @@ import wrapTryCatchAroundAction from "./wrapTryCatchAroundAction";
 // Tree assessor functionality.
 import { ReadabilityScoreAggregator, SEOScoreAggregator } from "../parsedPaper/assess/scoreAggregators";
 
-const keyphraseDistribution = new assessments.seo.KeyphraseDistributionAssessment();
-
 const logger = getLogger( "yoast-analysis-worker" );
 logger.setDefaultLevel( "error" );
 
@@ -458,6 +456,7 @@ export default class AnalysisWebWorker {
 	 * @returns {null|Assessor} The chosen SEO assessor.
 	 */
 	createSEOAssessor() {
+		const keyphraseDistribution = new assessments.seo.KeyphraseDistributionAssessment();
 		const {
 			keywordAnalysisActive,
 			useCornerstone,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The shortlinks of the Keyphrase distribution assessment omit the tracking parameters even though the correct helper function for adding the parameters was used. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Moves the initialization of Keyphrase distribution assessment inside `AnalysisWebWorker.js`.
* Fixes a bug where the shortlinks of Keyphrase distribution assessment omit the tracking parameters.

## Relevant technical choices:

* The omission of the tracking parameters in Keyphrase distribution was caused by a timing issue when initializing the assessment within the worker. The assessment was initialized when the data for the tracking parameters weren't available yet. This is fixed when the initialization is done when the parameters are available inside `createSEOAssessor` method.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Build the Free and Premium plugin
* Create a post
* Set a keyphrase
* Hover over the Keyphrase distribution assessment url title and url call to action
* Confirm that the url title don't omit the tracking parameters:
> `<a href='https://yoa.st/33q?php_version=7.4&platform=wordpress&platform_version=5.8.1&software=premium&software_version=17.3-RC5&days_active=6-30&user_language=en_US' target='_blank'>`

* Confirm that the url call to action don't omit the tracking parameters:
> `<a href='https://yoa.st/33u?php_version=7.4&platform=wordpress&platform_version=5.8.1&software=premium&software_version=17.3-RC5&days_active=6-30&user_language=en_US' target='_blank'>`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Install and activate Free and Premium plugin
* Create a post
* Set a keyphrase
* Hover over the Keyphrase distribution assessment url title and url call to action
* Confirm that the url title don't omit the tracking parameters:
> `<a href='https://yoa.st/33q?php_version=7.4&platform=wordpress&platform_version=5.8.1&software=premium&software_version=17.3-RC5&days_active=6-30&user_language=en_US' target='_blank'>`

* Confirm that the url call to action don't omit the tracking parameters:
> `<a href='https://yoa.st/33u?php_version=7.4&platform=wordpress&platform_version=5.8.1&software=premium&software_version=17.3-RC5&days_active=6-30&user_language=en_US' target='_blank'>`

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1026
