### PR TITLE
Disable the AiOSEO v4 import functionality

### DIFF
--- a/admin/import/plugins/class-importers.php
+++ b/admin/import/plugins/class-importers.php
@@ -19,7 +19,7 @@ class WPSEO_Plugin_Importers {
 	 */
 	private static $importers = [
 		'WPSEO_Import_AIOSEO',
-		'WPSEO_Import_AIOSEO_V4',
+//		'WPSEO_Import_AIOSEO_V4',
 		'WPSEO_Import_Greg_SEO',
 		'WPSEO_Import_HeadSpace',
 		'WPSEO_Import_Jetpack_SEO',

--- a/admin/import/plugins/class-importers.php
+++ b/admin/import/plugins/class-importers.php
@@ -19,7 +19,6 @@ class WPSEO_Plugin_Importers {
 	 */
 	private static $importers = [
 		'WPSEO_Import_AIOSEO',
-//		'WPSEO_Import_AIOSEO_V4',
 		'WPSEO_Import_Greg_SEO',
 		'WPSEO_Import_HeadSpace',
 		'WPSEO_Import_Jetpack_SEO',

--- a/tests/integration/admin/import/test-class-importers.php
+++ b/tests/integration/admin/import/test-class-importers.php
@@ -16,6 +16,6 @@ class WPSEO_Plugin_Importers_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Plugin_Importers::get
 	 */
 	public function test_importers() {
-		$this->assertCount( 16, WPSEO_Plugin_Importers::get() );
+		$this->assertCount( 15, WPSEO_Plugin_Importers::get() );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* It was decided that we're not releasing the AiOSEO v4 importer in 17.3.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the AiOSEO v4 importer.

## Relevant technical choices:

* Just commenting out the class that is responsible for the import functionality seems to be all there is to this.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate AiOSEO.
* Make sure you have at least one post with some data filled in in the AiOSEO metabox.
* Without this PR / without this code in the RC, on the `Import from other SEO plugins` page in `Tools` you should see the option to import.
* With this PR / with this code in the RC, you should see the message "Yoast SEO did not detect any plugin data from plugins it can import from.".

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Just the plugin import page.
* This PR does not revert the introduction of the new (hidden) replace vars. So that functionality is not expected to change (the new replace vars should still work, but should not be suggested to users when they are typing in the metabox).

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
