### PR TITLE
Replaces partial mock in URL helper tests.

### DIFF
--- a/tests/unit/helpers/url-helper-test.php
+++ b/tests/unit/helpers/url-helper-test.php
@@ -32,7 +32,7 @@ class Url_Helper_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->instance = Mockery::mock( Url_Helper::class )->makePartial();
+		$this->instance = new Url_Helper();
 	}
 
 	/**
@@ -70,14 +70,14 @@ class Url_Helper_Test extends TestCase {
 	 */
 	public function test_build_absolute_url_relative_url() {
 		Monkey\Functions\expect( 'home_url' )
-			->andReturn( 'home_url' );
+			->andReturn( 'https://example.com' );
 
 		Monkey\Functions\expect( 'wp_parse_url' )
 			->withArgs( [ 'https://example.com/my-page', \PHP_URL_PATH ] )
 			->andReturn( '/my-page' );
 
 		Monkey\Functions\expect( 'wp_parse_url' )
-			->withArgs( [ 'home_url' ] )
+			->withArgs( [ 'https://example.com' ] )
 			->andReturn(
 				[
 					'scheme' => 'https',
@@ -240,35 +240,36 @@ class Url_Helper_Test extends TestCase {
 	 * Tests the ensure absolute url with a relative url given as argument.
 	 *
 	 * @covers ::ensure_absolute_url
+	 * @covers ::is_relative
+	 *
 	 */
 	public function test_ensure_absolute_url_with_relative_url_given() {
-		$this->instance
-			->expects( 'is_relative' )
-			->once()
-			->with( 'page' )
-			->andReturnTrue();
+		Monkey\Functions\expect( 'home_url' )
+			->andReturn( 'https://example.com' );
 
-		$this->instance
-			->expects( 'build_absolute_url' )
-			->once()
-			->with( 'page' )
-			->andReturn( 'https://example.org/page' );
+		Monkey\Functions\expect( 'wp_parse_url' )
+			->withArgs( [ 'page', \PHP_URL_PATH ] )
+			->andReturn( 'page' );
 
-		$this->assertEquals( 'https://example.org/page', $this->instance->ensure_absolute_url( 'page' ) );
+		Monkey\Functions\expect( 'wp_parse_url' )
+			->withArgs( [ 'https://example.com' ] )
+			->andReturn(
+				[
+					'scheme' => 'https',
+					'host'   => 'example.com',
+				]
+			);
+
+		$this->assertEquals( 'https://example.com/page', $this->instance->ensure_absolute_url( 'page' ) );
 	}
 
 	/**
 	 * Tests the ensure absolute url with an absolute url given as argument.
 	 *
 	 * @covers ::ensure_absolute_url
+	 * @covers ::is_relative
 	 */
 	public function test_ensure_absolute_url_with_absolute_url_given() {
-		$this->instance
-			->expects( 'is_relative' )
-			->once()
-			->with( 'https://example.org/page' )
-			->andReturnFalse();
-
 		$this->assertEquals( 'https://example.org/page', $this->instance->ensure_absolute_url( 'https://example.org/page' ) );
 	}
 

--- a/tests/unit/helpers/url-helper-test.php
+++ b/tests/unit/helpers/url-helper-test.php
@@ -241,7 +241,6 @@ class Url_Helper_Test extends TestCase {
 	 *
 	 * @covers ::ensure_absolute_url
 	 * @covers ::is_relative
-	 *
 	 */
 	public function test_ensure_absolute_url_with_relative_url_given() {
 		Monkey\Functions\expect( 'home_url' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We do not want to test partial mocks of classes, since they may lead to false negatives in the unit tests (e.g. a test passes, but it does not actually test the thing it should be testing, since it is mocked).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Replaces a partial mock in the URL helper unit tests.

## Relevant technical choices:

* Replaced some home URLs with actual URLs (e.g. `'home_url'` with `'https://example.com'`) for better tests.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Unit tests should pass.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A: this PR only changes some unit tests.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A: this PR only changes some unit tests.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
