### PR TITLE
QA: fix incorrectly named test classes

### DIFF
--- a/tests/integration/admin/test-class-admin-asset-dev-server-location.php
+++ b/tests/integration/admin/test-class-admin-asset-dev-server-location.php
@@ -10,7 +10,7 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
 /**
  * Tests WPSEO_Admin_Asset_Dev_Server_Location.
  */
-final class Test_Admin_Asset_Dev_Server_Location extends TestCase {
+final class Admin_Asset_Dev_Server_Location_Test extends TestCase {
 
 	/**
 	 * Default arguments to use for creating a new Admin_Asset.

--- a/tests/integration/admin/test-class-admin-asset-seo-location.php
+++ b/tests/integration/admin/test-class-admin-asset-seo-location.php
@@ -10,7 +10,7 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
 /**
  * Tests WPSEO_Admin_Asset.
  */
-final class Test_WPSEO_Admin_Asset_SEO_Location extends TestCase {
+final class WPSEO_Admin_Asset_SEO_Location_Test extends TestCase {
 
 	/**
 	 * Tests the get_url function.

--- a/tests/integration/capabilities/test-class-capability-manager-factory.php
+++ b/tests/integration/capabilities/test-class-capability-manager-factory.php
@@ -10,7 +10,7 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
 /**
  * Unit Test Class.
  */
-class WPSEO_Capability_Manager_Factory_Tests extends TestCase {
+class WPSEO_Capability_Manager_Factory_Test extends TestCase {
 
 	/**
 	 * Tests whether the same factory instance is returned when the get function is called twice.

--- a/tests/integration/capabilities/test-class-capability-manager.php
+++ b/tests/integration/capabilities/test-class-capability-manager.php
@@ -10,7 +10,7 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
 /**
  * Unit Test Class.
  */
-class Capability_Manager_Tests extends TestCase {
+class Capability_Manager_Test extends TestCase {
 
 	/**
 	 * Tests whether capabilities are correctly registered.

--- a/tests/integration/capabilities/test-class-register-capabilities.php
+++ b/tests/integration/capabilities/test-class-register-capabilities.php
@@ -8,7 +8,7 @@
 /**
  * Unit Test Class.
  */
-class WPSEO_Register_Capabilities_Tests extends WPSEO_UnitTestCase {
+class WPSEO_Register_Capabilities_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Tests whether the list of registered capabilities contains the correct capabilities.

--- a/tests/integration/config-ui/test-class-configuration-components.php
+++ b/tests/integration/config-ui/test-class-configuration-components.php
@@ -8,9 +8,9 @@
 use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /**
- * Class WPSEO_Configuration_Components_Tests.
+ * Class WPSEO_Configuration_Components_Test.
  */
-class WPSEO_Configuration_Components_Tests extends TestCase {
+class WPSEO_Configuration_Components_Test extends TestCase {
 
 	use Yoast_SEO_ReflectionToString_Deprecation_Handler;
 

--- a/tests/integration/notifications/test-class-yoast-notification.php
+++ b/tests/integration/notifications/test-class-yoast-notification.php
@@ -6,11 +6,11 @@
  */
 
 /**
- * Class Test_Yoast_Notification.
+ * Class Yoast_Notification_Test.
  *
  * @covers Yoast_Notification
  */
-class Test_Yoast_Notification extends WPSEO_UnitTestCase {
+class Yoast_Notification_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Test capability filters get set.

--- a/tests/integration/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/integration/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -6,11 +6,11 @@
  */
 
 /**
- * Class Test_WPSEO_Author_Sitemap_Provider.
+ * Class WPSEO_Author_Sitemap_Provider_Test.
  *
  * @group sitemaps
  */
-class Test_WPSEO_Author_Sitemap_Provider extends WPSEO_UnitTestCase {
+class WPSEO_Author_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Holds the instance of the class being tested.

--- a/tests/integration/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
@@ -6,13 +6,13 @@
  */
 
 /**
- * Class Test_WPSEO_Sitemap_Provider_Overlap.
+ * Class WPSEO_Sitemap_Provider_Overlap_Test.
  *
  * @group sitemaps
  *
  * @covers WPSEO_Sitemaps
  */
-class Test_WPSEO_Sitemap_Provider_Overlap extends WPSEO_UnitTestCase {
+class WPSEO_Sitemap_Provider_Overlap_Test extends WPSEO_UnitTestCase {
 
 	/**
 	 * Holds the instance of the class being tested.


### PR DESCRIPTION
## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

Test classes should be suffixed with `Test`. Not `Tests`, not prefixed.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
