### PR TITLE
Docs: various fixes

### DIFF
--- a/admin/class-admin-asset-seo-location.php
+++ b/admin/class-admin-asset-seo-location.php
@@ -20,15 +20,15 @@ final class WPSEO_Admin_Asset_SEO_Location implements WPSEO_Admin_Asset_Location
 	/**
 	 * Whether or not to add the file suffix to the asset.
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	protected $add_suffix = true;
 
 	/**
 	 * The plugin file to base the asset location upon.
 	 *
-	 * @param string  $plugin_file The plugin file string.
-	 * @param boolean $add_suffix  Optional. Whether or not a file suffix should be added.
+	 * @param string $plugin_file The plugin file string.
+	 * @param bool   $add_suffix  Optional. Whether or not a file suffix should be added.
 	 */
 	public function __construct( $plugin_file, $add_suffix = true ) {
 		$this->plugin_file = $plugin_file;

--- a/admin/class-suggested-plugins.php
+++ b/admin/class-suggested-plugins.php
@@ -76,8 +76,8 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	/**
 	 * Build Yoast SEO suggested plugins notification.
 	 *
-	 * @param string $name            The plugin name to use for the unique ID.
-	 * @param array  $plugin          The plugin to retrieve the data from.
+	 * @param string $name   The plugin name to use for the unique ID.
+	 * @param array  $plugin The plugin to retrieve the data from.
 	 *
 	 * @return Yoast_Notification The notification containing the suggested plugin.
 	 */
@@ -101,7 +101,7 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	/**
 	 * Creates a message to suggest the installation of a particular plugin.
 	 *
-	 * @param array $suggested_plugin   The suggested plugin.
+	 * @param array $suggested_plugin The suggested plugin.
 	 *
 	 * @return string The install suggested plugin message.
 	 */
@@ -140,7 +140,7 @@ class WPSEO_Suggested_Plugins implements WPSEO_WordPress_Integration {
 	/**
 	 * Creates a message to suggest the activation of a particular plugin.
 	 *
-	 * @param array $suggested_plugin   The suggested plugin.
+	 * @param array $suggested_plugin The suggested plugin.
 	 *
 	 * @return string The activate suggested plugin message.
 	 */

--- a/admin/views/class-yoast-feature-toggle.php
+++ b/admin/views/class-yoast-feature-toggle.php
@@ -27,7 +27,7 @@ class Yoast_Feature_Toggle {
 	/**
 	 * Whether the feature is premium or not.
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	protected $premium = false;
 

--- a/config/dependency-injection/renamed-classes.php
+++ b/config/dependency-injection/renamed-classes.php
@@ -36,7 +36,7 @@ foreach ( $renamed_classes as $original_class => $replacement ) {
 		->setDeprecated( true, "%service_id% is deprecated since version $version! Use $renamed_class instead." );
 }
 
-// If the DI container is built by composer this WordPress function will not exist.
+// If the DI container is built by Composer this WordPress function will not exist.
 if ( ! function_exists( '_deprecated_file' ) ) {
 	function _deprecated_file( $file, $version, $replacement = '', $message = '' ) {}
 }

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -127,7 +127,7 @@ class WPSEO_Addon_Manager {
 	 * @param string $plugin_slug The plugin slug to search.
 	 *
 	 * @return bool|string Plugin file when installed, False when plugin isn't installed.
-	 **/
+	 */
 	public function get_plugin_file( $plugin_slug ) {
 		$plugins            = $this->get_plugins();
 		$plugin_files       = array_keys( $plugins );

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -126,7 +126,7 @@ class WPSEO_Addon_Manager {
 	 *
 	 * @param string $plugin_slug The plugin slug to search.
 	 *
-	 * @return boolean|string Plugin file when installed, False when plugin isn't installed.
+	 * @return bool|string Plugin file when installed, False when plugin isn't installed.
 	 **/
 	public function get_plugin_file( $plugin_slug ) {
 		$plugins            = $this->get_plugins();

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2378,7 +2378,7 @@ class ORM implements \ArrayAccess {
 	/**
 	 * Builds a bulk INSERT query.
 	 *
-	 * @param array $models Array of model instances to be inserted.
+	 * @param array $models             Array of model instances to be inserted.
 	 * @param array $dirty_column_names Array of dirty fields to be used in INSERT.
 	 *
 	 * @return string The insert query.

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -302,8 +302,8 @@ class Indexable_Builder {
 	/**
 	 * Rebuilds an Indexable from scratch.
 	 *
-	 * @param Indexable $indexable The Indexable to (re)build.
-	 * @param array     $defaults  The object type of the Indexable.
+	 * @param Indexable  $indexable The Indexable to (re)build.
+	 * @param array|null $defaults  The object type of the Indexable.
 	 *
 	 * @return Indexable|false The resulting Indexable.
 	 */

--- a/src/conditionals/admin/licenses-page-conditional.php
+++ b/src/conditionals/admin/licenses-page-conditional.php
@@ -12,7 +12,7 @@ class Licenses_Page_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		global $pagenow;

--- a/src/conditionals/news-conditional.php
+++ b/src/conditionals/news-conditional.php
@@ -10,7 +10,7 @@ class News_Conditional implements Conditional {
 	/**
 	 * Returns whether or not this conditional is met.
 	 *
-	 * @return boolean Whether or not the conditional is met.
+	 * @return bool Whether or not the conditional is met.
 	 */
 	public function is_met() {
 		return \defined( 'WPSEO_NEWS_VERSION' );

--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -268,10 +268,10 @@ class Schema_Generator implements Generator_Interface {
 	 * Note: We removed the Abstract_Schema_Piece type-hint from the $graph_piece_generator argument, because
 	 *       it caused conflicts with old code, Yoast SEO Video specifically.
 	 *
-	 * @param array                   $graph_piece The graph piece we're filtering.
-	 * @param string                  $identifier  The identifier of the graph piece that is being filtered.
-	 * @param Meta_Tags_Context       $context     The meta tags context.
-	 * @param Abstract_Schema_Piece   $graph_piece_generator A value object with context variables.
+	 * @param array                   $graph_piece            The graph piece we're filtering.
+	 * @param string                  $identifier             The identifier of the graph piece that is being filtered.
+	 * @param Meta_Tags_Context       $context                The meta tags context.
+	 * @param Abstract_Schema_Piece   $graph_piece_generator  A value object with context variables.
 	 * @param Abstract_Schema_Piece[] $graph_piece_generators A value object with context variables.
 	 *
 	 * @return array The filtered graph piece.

--- a/src/helpers/asset-helper.php
+++ b/src/helpers/asset-helper.php
@@ -29,7 +29,7 @@ class Asset_Helper {
 	 *
 	 * @param string $handle The handle.
 	 *
-	 * @return string[] All dependencies of the given handle.
+	 * @return string[]|bool All dependencies of the given handle.
 	 */
 	public function get_dependency_handles( $handle ) {
 		$scripts = wp_scripts();

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -61,7 +61,7 @@ class Workouts_Integration implements Integration_Interface {
 	 *
 	 * @param array $submenu_pages The Yoast SEO submenu pages.
 	 *
-	 * @return array the filtered submenu pages.
+	 * @return array The filtered submenu pages.
 	 */
 	public function add_submenu_page( $submenu_pages ) {
 		// this inserts the workouts menu page at the correct place in the array without overriding that position.

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -326,8 +326,8 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * Returns all presenters for this page.
 	 *
-	 * @param string            $page_type The page type.
-	 * @param Meta_Tags_Context $context   The meta tags context for the current page.
+	 * @param string                 $page_type The page type.
+	 * @param Meta_Tags_Context|null $context   The meta tags context for the current page.
 	 *
 	 * @return Abstract_Indexable_Presenter[] The presenters.
 	 */
@@ -349,8 +349,8 @@ class Front_End_Integration implements Integration_Interface {
 		/**
 		 * Filter 'wpseo_frontend_presenters' - Allow filtering the presenter instances in or out of the request.
 		 *
-		 * @param $presenters array The presenters.
-		 * @param Meta_Tags_Context The meta tags context for the current page.
+		 * @param array             $presenters The presenters.
+		 * @param Meta_Tags_Context $context    The meta tags context for the current page.
 		 *
 		 * @api Abstract_Indexable_Presenter[] List of presenter instances.
 		 */

--- a/src/presenters/abstract-indexable-presenter.php
+++ b/src/presenters/abstract-indexable-presenter.php
@@ -49,7 +49,7 @@ abstract class Abstract_Indexable_Presenter extends Abstract_Presenter {
 	/**
 	 * Transforms an indexable presenter's key to a json safe key string.
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	public function escape_key() {
 		if ( $this->key === 'NO KEY PROVIDED' ) {

--- a/src/presenters/admin/indexing-failed-notification-presenter.php
+++ b/src/presenters/admin/indexing-failed-notification-presenter.php
@@ -72,7 +72,7 @@ class Indexing_Failed_Notification_Presenter extends Abstract_Presenter {
 				$notification_text .= \esc_html__( 'If the problem persists, please contact support.', 'wordpress-seo' );
 			}
 			else {
-				// premium plugin with inactive addon; overwrite the entire error message.
+				// Premium plugin with inactive addon; overwrite the entire error message.
 				$notification_text = \sprintf(
 					/* Translators: %1$s expands to an opening anchor tag for a link leading to the Premium installation page, %2$s expands to a closing anchor tag. */
 					\esc_html__(

--- a/src/routes/yoast-head-rest-field.php
+++ b/src/routes/yoast-head-rest-field.php
@@ -206,7 +206,7 @@ class Yoast_Head_REST_Field implements Route_Interface {
 	 * @param stdObject $head   The Yoast head.
 	 * @param string    $format The format to return.
 	 *
-	 * @return string|array The output value. String if HTML was requested, array otherwise.
+	 * @return string|array|null The output value. String if HTML was requested, array otherwise.
 	 */
 	protected function render_object( $head, $format = self::YOAST_HEAD_ATTRIBUTE_NAME ) {
 		if ( $head->status === 404 ) {

--- a/src/services/indexables/indexable-version-manager.php
+++ b/src/services/indexables/indexable-version-manager.php
@@ -13,7 +13,7 @@ class Indexable_Version_Manager {
 	/**
 	 * Stores the version of each Indexable type.
 	 *
-	 * @var $indexable_builder_versions Indexable_Builder_Versions The current versions of all indexable builders.
+	 * @var Indexable_Builder_Versions The current versions of all indexable builders.
 	 */
 	protected $indexable_builder_versions;
 

--- a/src/services/indexables/indexable-version-manager.php
+++ b/src/services/indexables/indexable-version-manager.php
@@ -31,7 +31,7 @@ class Indexable_Version_Manager {
 	 *
 	 * @param Indexable $indexable The Indexable to check.
 	 *
-	 * @return boolean True if the given version is older than the current latest version.
+	 * @return bool True if the given version is older than the current latest version.
 	 */
 	public function indexable_needs_upgrade( $indexable ) {
 		if ( ( ! $indexable ) ||
@@ -48,7 +48,7 @@ class Indexable_Version_Manager {
 	 * @param string $object_type       The Indexable's object type.
 	 * @param int    $indexable_version The Indexable's version.
 	 *
-	 * @return boolean True if the given version is older than the current latest version.
+	 * @return bool True if the given version is older than the current latest version.
 	 */
 	protected function needs_upgrade( $object_type, $indexable_version ) {
 		$current_indexable_builder_version = $this->indexable_builder_versions->get_latest_version_for_type( $object_type );

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -233,7 +233,7 @@ class Meta {
 			/**
 			 * Define a filter that removes objects of type Rel_Next_Presenter or Rel_Prev_Presenter from a list.
 			 *
-			 * @param $presenter The presenter to verify.
+			 * @param object $presenter The presenter to verify.
 			 *
 			 * @return bool True if the presenter is not a Rel_Next or Rel_Prev presenter.
 			 */
@@ -267,7 +267,7 @@ class Meta {
 	 *
 	 * @param Abstract_Indexable_Presenter $presenter The presenter whose key and value are to be converted to JSON.
 	 *
-	 * @return object
+	 * @return object|null
 	 */
 	protected function create_json_field( $presenter ) {
 		if ( $presenter->get_key() === 'NO KEY PROVIDED' ) {

--- a/tests/unit/actions/addon-installation/addon-install-action-test.php
+++ b/tests/unit/actions/addon-installation/addon-install-action-test.php
@@ -28,7 +28,7 @@ class Addon_Install_Action_Test extends TestCase {
 	/**
 	 * The require file helper.
 	 *
-	 * @var Mockery\MockInterface|Require_File_Helper;
+	 * @var Mockery\MockInterface|Require_File_Helper
 	 */
 	protected $require_file_helper;
 

--- a/tests/unit/doubles/lib/orm-double.php
+++ b/tests/unit/doubles/lib/orm-double.php
@@ -14,7 +14,7 @@ class Orm_Double extends ORM {
 	 * Use the ORM::for_table factory method instead.
 	 *
 	 * @param string $table_name Table name.
-	 * @param array  $data Data to populate table.
+	 * @param array  $data       Data to populate table.
 	 */
 	public function __construct( $table_name, $data = [] ) {
 		$this->table_name = $table_name;

--- a/tests/unit/repositories/indexable-repository-test.php
+++ b/tests/unit/repositories/indexable-repository-test.php
@@ -515,9 +515,9 @@ class Indexable_Repository_Test extends TestCase {
 	/**
 	 * Setup a version check to steer the upgrade routine.
 	 *
-	 * @param Indexable $indexable        The mocked indexable.
-	 * @param Indexable $indexable_result The mocked indexable after the upgrade routine is run.
-	 *                                    If not provided, or set to `null`, we expect the upgrade routine to not be triggered.
+	 * @param Indexable      $indexable        The mocked indexable.
+	 * @param Indexable|null $indexable_result The mocked indexable after the upgrade routine is run.
+	 *                                         If not provided, or set to `null`, we expect the upgrade routine to not be triggered.
 	 */
 	private function mock_version_check( $indexable, $indexable_result = null ) {
 		$this->version_manager


### PR DESCRIPTION
## Context

* Code documentation consistency 

## Summary

This PR can be summarized in the following changelog entry:

* Code documentation consistency 

## Relevant technical choices:

*  Docs: use short form types
    * `bool` not `boolean`
    * `int` not `integer`
* Docs: fix param description alignment
* Docs: fix incorrect docblock closing tag
* Docs: fix incorrect @var tags
* Docs: add missing types to param/return tags
    ... and fix type vs param name order.
* Docs: various punctuation 


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a docs-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
