### PR TITLE
Composer: update to YoastCS 2.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,6 @@
 	"require-dev": {
 		"humbug/php-scoper": "^0.13.4",
 		"league/oauth2-client": "2.4.1",
-		"php-parallel-lint/php-console-highlighter": "^0.5",
-		"php-parallel-lint/php-parallel-lint": "^1.3.0",
 		"phpunit/phpunit": "^5.7",
 		"psr/container": "1.0.0",
 		"psr/log": "^1.0",
@@ -38,7 +36,7 @@
 		"symfony/dependency-injection": "^3.4",
 		"yoast/php-development-environment": "^1.0",
 		"yoast/wp-test-utils": "^0.2.1",
-		"yoast/yoastcs": "^2.1.0"
+		"yoast/yoastcs": "^2.2.0"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d09fa69b5b81c3c82bce600a8194a987",
+    "content-hash": "f0c5c9c9e682617720e8721f84bd715a",
     "packages": [
         {
             "name": "composer/installers",
@@ -1299,16 +1299,16 @@
         },
         {
             "name": "php-parallel-lint/php-parallel-lint",
-            "version": "v1.3.0",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-parallel-lint/PHP-Parallel-Lint.git",
-                "reference": "772a954e5f119f6f5871d015b23eabed8cbdadfb"
+                "reference": "761f3806e30239b5fcd90a0a45d41dc2138de192"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/772a954e5f119f6f5871d015b23eabed8cbdadfb",
-                "reference": "772a954e5f119f6f5871d015b23eabed8cbdadfb",
+                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/761f3806e30239b5fcd90a0a45d41dc2138de192",
+                "reference": "761f3806e30239b5fcd90a0a45d41dc2138de192",
                 "shasum": ""
             },
             "require": {
@@ -1322,7 +1322,7 @@
             "require-dev": {
                 "nette/tester": "^1.3 || ^2.0",
                 "php-parallel-lint/php-console-highlighter": "~0.3",
-                "squizlabs/php_codesniffer": "^3.5"
+                "squizlabs/php_codesniffer": "^3.6"
             },
             "suggest": {
                 "php-parallel-lint/php-console-highlighter": "Highlight syntax in code snippet"
@@ -1350,9 +1350,9 @@
             "homepage": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
             "support": {
                 "issues": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/issues",
-                "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/v1.3.0"
+                "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/v1.3.1"
             },
-            "time": "2021-04-07T14:42:48+00:00"
+            "time": "2021-08-13T05:35:13+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -1474,16 +1474,16 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e"
+                "reference": "a792ab623069f0ce971b2417edef8d9632e32f75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
-                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/a792ab623069f0ce971b2417edef8d9632e32f75",
+                "reference": "a792ab623069f0ce971b2417edef8d9632e32f75",
                 "shasum": ""
             },
             "require": {
@@ -1524,7 +1524,7 @@
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2021-02-15T12:58:46+00:00"
+            "time": "2021-07-21T11:09:57+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -4092,29 +4092,29 @@
         },
         {
             "name": "yoast/yoastcs",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "8cc5cb79b950588f05a45d68c3849ccfcfef6298"
+                "reference": "0b82e890bda80571fe054166ef2535cb9cb54a13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/8cc5cb79b950588f05a45d68c3849ccfcfef6298",
-                "reference": "8cc5cb79b950588f05a45d68c3849ccfcfef6298",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/0b82e890bda80571fe054166ef2535cb9cb54a13",
+                "reference": "0b82e890bda80571fe054166ef2535cb9cb54a13",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6.2 || ^0.7",
                 "php": ">=5.4",
+                "php-parallel-lint/php-console-highlighter": "^0.5.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
                 "phpcompatibility/phpcompatibility-wp": "^2.1.0",
-                "squizlabs/php_codesniffer": "^3.5.0",
-                "wp-coding-standards/wpcs": "^2.2.0"
+                "squizlabs/php_codesniffer": "^3.6.0",
+                "wp-coding-standards/wpcs": "^2.3.0"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpcompatibility/php-compatibility": "^9.2.0",
+                "phpcompatibility/php-compatibility": "^9.3.5",
                 "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
                 "roave/security-advisories": "dev-master"
@@ -4143,7 +4143,7 @@
                 "issues": "https://github.com/Yoast/yoastcs/issues",
                 "source": "https://github.com/Yoast/yoastcs"
             },
-            "time": "2020-10-27T09:51:49+00:00"
+            "time": "2021-09-22T14:11:31+00:00"
         }
     ],
     "aliases": [],
@@ -4155,5 +4155,5 @@
         "php": "^5.6.20||^7.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -172,18 +172,11 @@
 		<exclude-pattern>/lib/*</exclude-pattern>
 	</rule>
 
-	<!-- Exclude php-codeshift from being checked too roughly. -->
-	<rule ref="Yoast.NamingConventions.ObjectNameDepth">
+	<!-- Exclude select directories from the object depth naming convention check. -->
+	<rule ref="Yoast.NamingConventions.ObjectNameDepth.MaxExceeded">
 		<exclude-pattern>/config/php-codeshift/*</exclude-pattern>
-	</rule>
-
-	<!-- Exclude conditionals from being checked too roughly. -->
-	<rule ref="Yoast.NamingConventions.ObjectNameDepth.MaxExceeded">
 		<exclude-pattern>/src/conditionals/*</exclude-pattern>
-	</rule>
-
-	<!-- Exclude third-party from being checked too roughly. -->
-	<rule ref="Yoast.NamingConventions.ObjectNameDepth.MaxExceeded">
+		<exclude-pattern>/src/config/migrations/*</exclude-pattern>
 		<exclude-pattern>/src/generators/schema/third-party/*</exclude-pattern>
 	</rule>
 

--- a/src/integrations/third-party/wpml.php
+++ b/src/integrations/third-party/wpml.php
@@ -7,6 +7,8 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
  * WPML integration.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Known false positive with acronyms. Fix expected in YoastCS 3.x.
  */
 class WPML implements Integration_Interface {
 

--- a/src/integrations/xmlrpc.php
+++ b/src/integrations/xmlrpc.php
@@ -6,6 +6,8 @@ use Yoast\WP\SEO\Conditionals\XMLRPC_Conditional;
 
 /**
  * Noindexes the xmlrpc.php file and all ways to request it.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Known false positive with acronyms. Fix expected in YoastCS 3.x.
  */
 class XMLRPC implements Integration_Interface {
 


### PR DESCRIPTION
## Context

* Update dev tools

## Summary

This PR can be summarized in the following changelog entry:

* Update dev tools

## Relevant technical choices:

### Composer: update to YoastCS 2.2.0

... which includes PHP Parallel Lint by design, so no need to require it separately anymore.

Refs:
* https://github.com/Yoast/yoastcs/releases
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases
* https://github.com/PHPCompatibility/PHPCompatibilityWP/releases

### PHPCS: minor ruleset tweaks and adding two ignore annotations 


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a tooling-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
