### PR TITLE
Composer/actions: simplify the PHPCS threshold check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,9 +82,6 @@
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=222",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
-		"check-cs-summary": [
-			"@check-cs-warnings --report=summary"
-		],
 		"check-cs": [
 			"@check-cs-warnings -n"
 		],

--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -166,7 +166,7 @@ class Actions {
 	/**
 	 * Runs PHPCS on the staged files.
 	 *
-	 * Used the composer check-staged-cs command.
+	 * Used by the composer check-branch-cs command.
 	 *
 	 * @param Event $event Composer event that triggered this script.
 	 *
@@ -328,114 +328,17 @@ TPL;
 	}
 
 	/**
-	 * Extract the number of errors, warnings and affected files from the phpcs summary
-	 *
-	 * Thanks for the inspiration from https://github.com/OXID-eSales/coding_standards_wrapper
-	 *
-	 * @param array $output Raw console output of the PHPCS command.
-	 *
-	 * @return array ['error_count' = (int), 'warning_count' = (int)] Errors and warnings found by PHPCS.
-	 */
-	private static function extract_cs_statistics( $output ) {
-		$result  = false;
-		$matches = [];
-
-		/**
-		 * The only key of the filtered array already holds the summary.
-		 * $summary is NULL, if the summary was not present in the output
-		 */
-		$summary = \array_filter(
-			$output,
-			static function( $value ) {
-				return \strpos( $value, 'A TOTAL OF' ) !== false;
-			}
-		);
-
-		// Extract the stats for the summary.
-		if ( $summary ) {
-			\preg_match(
-				'/A TOTAL OF (?P<error_count>\d+) ERRORS AND (?P<warning_count>\d+) WARNINGS WERE FOUND IN \d+ FILES/',
-				\end( $summary ),
-				$matches
-			);
-		}
-
-		// Validate the result of extraction.
-		if ( isset( $matches['error_count'] ) && isset( $matches['warning_count'] ) ) {
-			// We need integers for the further processing.
-			$result = \array_map( 'intval', $matches );
-		}
-
-		return $result;
-	}
-
-	/**
 	 * Checks if the CS errors and warnings are below or at thresholds.
 	 *
-	 * Thanks for the inspiration from https://github.com/OXID-eSales/coding_standards_wrapper
+	 * @return void
 	 */
 	public static function check_cs_thresholds() {
-		$error_threshold   = (int) \getenv( 'YOASTCS_THRESHOLD_ERRORS' );
-		$warning_threshold = (int) \getenv( 'YOASTCS_THRESHOLD_WARNINGS' );
-
 		echo 'Running coding standards checks, this may take some time.', \PHP_EOL;
-		$command = 'composer check-cs-summary';
+		$command = 'composer check-cs-warnings -- -mq --report="YoastCS\\Yoast\\Reports\\Threshold"';
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Non-WP context, this is fine.
-		@\exec( $command, $phpcs_output, $return );
+		@\passthru( $command, $return );
 
-		$statistics = self::extract_cs_statistics( $phpcs_output );
-		if ( ! $statistics ) {
-			echo 'Error occurred when parsing the coding standards results.', \PHP_EOL;
-			exit( 1 );
-		}
-
-		echo \PHP_EOL;
-		echo 'CODE SNIFFER RESULTS', \PHP_EOL;
-		echo '--------------------', \PHP_EOL;
-
-		$error_count   = $statistics['error_count'];
-		$warning_count = $statistics['warning_count'];
-
-		self::color_line_success(
-			"Coding standards errors: $error_count/$error_threshold." . \PHP_EOL,
-			( $error_count <= $error_threshold )
-		);
-
-		self::color_line_success(
-			"Coding standards warnings: $warning_count/$warning_threshold." . \PHP_EOL,
-			( $warning_count <= $warning_threshold )
-		);
-
-		$above_threshold = false;
-
-		if ( $error_count > $error_threshold ) {
-			echo 'Please fix any errors introduced in your code and run composer check-cs-warnings to verify.', \PHP_EOL;
-			$above_threshold = true;
-		}
-
-		if ( $error_count < $error_threshold ) {
-			echo \PHP_EOL;
-			echo 'Found less errors than the threshold, great job!', \PHP_EOL;
-			echo "Please update the error threshold in the composer.json file to $error_count.", \PHP_EOL;
-		}
-
-		if ( $warning_count > $warning_threshold ) {
-			echo 'Please fix any warnings introduced in your code and run check-cs-thresholds to verify.', \PHP_EOL;
-			$above_threshold = true;
-		}
-
-		if ( $warning_count < $warning_threshold ) {
-			echo \PHP_EOL;
-			echo 'Found less warnings than the threshold, great job!', \PHP_EOL;
-			echo "Please update the warning threshold in the composer.json file to $warning_count.", \PHP_EOL;
-		}
-
-		if ( ! $above_threshold ) {
-			echo \PHP_EOL;
-			echo 'Coding standards checks have passed!', \PHP_EOL;
-		}
-
-		if ( $above_threshold ) {
+		if ( \defined( 'YOASTCS_ABOVE_THRESHOLD' ) && \YOASTCS_ABOVE_THRESHOLD === true ) {
 			echo \PHP_EOL;
 			echo 'Running check-branch-cs.', \PHP_EOL;
 			echo 'This might show problems on untouched lines. Focus on the lines you\'ve changed first.', \PHP_EOL;
@@ -445,31 +348,7 @@ TPL;
 			@\passthru( 'composer check-branch-cs' );
 		}
 
-		exit( ( $above_threshold ) ? 1 : 0 );
-	}
-
-	/**
-	 * Color the output of the line.
-	 *
-	 * @param string $line  Line to output.
-	 * @param string $color Color to give the line.
-	 *
-	 * @return void
-	 */
-	private static function color_line( $line, $color ) {
-		echo $color . $line . "\e[0m";
-	}
-
-	/**
-	 * Color the line based on success status.
-	 *
-	 * @param string $line    Line to output.
-	 * @param bool   $success Success status.
-	 *
-	 * @return void
-	 */
-	private static function color_line_success( $line, $success ) {
-		self::color_line( $line, ( $success ) ? "\e[32m" : "\e[31m" );
+		exit( ( ( \defined( 'YOASTCS_ABOVE_THRESHOLD' ) && \YOASTCS_ABOVE_THRESHOLD === true ) || $return > 2 ) ? $return : 0 );
 	}
 
 	/**

--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -336,9 +336,17 @@ TPL;
 		echo 'Running coding standards checks, this may take some time.', \PHP_EOL;
 		$command = 'composer check-cs-warnings -- -mq --report="YoastCS\\Yoast\\Reports\\Threshold"';
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Non-WP context, this is fine.
-		@\passthru( $command, $return );
+		@\exec( $command, $phpcs_output, $return );
 
-		if ( \defined( 'YOASTCS_ABOVE_THRESHOLD' ) && \YOASTCS_ABOVE_THRESHOLD === true ) {
+		$phpcs_output = \implode( \PHP_EOL, $phpcs_output );
+		echo $phpcs_output;
+
+		$above_threshold = true;
+		if ( \strpos( $phpcs_output, 'Coding standards checks have passed!' ) !== false ) {
+			$above_threshold = false;
+		}
+
+		if ( $above_threshold === true ) {
 			echo \PHP_EOL;
 			echo 'Running check-branch-cs.', \PHP_EOL;
 			echo 'This might show problems on untouched lines. Focus on the lines you\'ve changed first.', \PHP_EOL;
@@ -348,7 +356,7 @@ TPL;
 			@\passthru( 'composer check-branch-cs' );
 		}
 
-		exit( ( ( \defined( 'YOASTCS_ABOVE_THRESHOLD' ) && \YOASTCS_ABOVE_THRESHOLD === true ) || $return > 2 ) ? $return : 0 );
+		exit( ( $above_threshold === true || $return > 2 ) ? $return : 0 );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Update dev tools

## Summary

This PR can be summarized in the following changelog entry:

* Update dev tools

## Relevant technical choices:

### Composer/actions: simplify the PHPCS threshold check

As of YoastCS 2.2.0, the Yoast standard contains a custom `Threshold` report.

This switches out the custom logic for comparing the PHPCS run results against thresholds in the `Yoast\WP\SEO\Composer\Actions` class to use this new report instead.

The report will now also respect the error code returned by PHPCS if the threshold is not met.

Notes:
* The `-m` parameter directs PHPCS to not record the error messages, which saves a lot of memory usage during this run.
* The -q parameter makes it so no progress is being shown during this run.
* The `exec()` function has been switched out in favour of the `passthru()` to allow for the report to be displayed directly.
    The downside of this is that the progress of the run will also be displayed, but IMO that's a small price to pay for the convenience of not having to go through the output and manually display the report.

Includes:
* Removing the now redundant `check-cs-summary` command.
* Minor documentation fix in one of the other Composer CS related functions.

### Composer/actions: update the PHPCS threshold check for GHA compatibility

While running some tests with GitHub Actions, one of the findings was that GHA has much better process isolation than Travis.
In practice, this means that querying the `YOASTCS_ABOVE_THRESHOLD` constant as set by the YoastCS `Threshold` report is not going to work as the calling process does not have access to it.

The result of this would be that the branch report would not be run when needed and that the exit code would always be `0`, which would prevent GHA from failing the build when the violations do not comply with the set thresholds.

I've also tested to see if using an environment variable would work better, but no luck there either.
You can see various experiments I've run here: https://github.com/jrfnl/composer-script-poc/actions

The short of it is, that for the script to be compatible with both Travis, as well as GH Actions, the content of the report needs to be examined instead.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

**NOTE**: **THIS PR NEEDS TESTING ON MULTIPLE OS-es USED BY THE TEAM**

This PR can be acceptance tested by following these steps:

* Run `composer cs`
* Choose option 6
* Verify that the report runs and the output looks similar to the below:
```
> @putenv YOASTCS_THRESHOLD_ERRORS=75
> @putenv YOASTCS_THRESHOLD_WARNINGS=40
> Yoast\WP\SEO\Premium\Config\Composer\Actions::check_cs_thresholds
Running coding standards checks, this may take some time.
> @php ./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcs.xml.dist "--report=summary"
Script @php ./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcs.xml.dist handling the check-cs-warnings event returned with error code 1
Script @check-cs-warnings --report=summary was called via check-cs-summary

CODE SNIFFER RESULTS
--------------------
Coding standards errors: 62/75.
Coding standards warnings: 40/40.

Found less errors than the threshold, great job!
Please update the error threshold in the composer.json file to 62.

Coding standards checks have passed!
```

I have personally tested this against Windows 10, but as slashes are handled differently on different OS-es, Mac and Linux should be tested too.