### PR TITLE
Add filtering for schema article types

### DIFF
--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -319,6 +319,8 @@ class WPSEO_Meta {
 		}
 		unset( $subset, $field_group, $key, $field_def );
 
+		self::filter_schema_article_types();
+
 		add_filter( 'update_post_metadata', [ __CLASS__, 'remove_meta_if_default' ], 10, 5 );
 		add_filter( 'add_post_metadata', [ __CLASS__, 'dont_save_meta_if_default' ], 10, 4 );
 	}
@@ -1048,5 +1050,21 @@ class WPSEO_Meta {
 		}
 
 		return $post_ids;
+	}
+
+	/**
+	 * Filter the schema article types.
+	 *
+	 * @return void
+	 */
+	public static function filter_schema_article_types() {
+		/**
+		 * Filter: 'wpseo_schema_article_types' - Allow developers to filter the available article types.
+		 *
+		 * Make sure when you filter this to also filter `wpseo_schema_article_types_labels`.
+		 *
+		 * @api array $schema_article_types The available schema article types.
+		 */
+		self::$meta_fields['schema']['schema_article_type']['options'] = apply_filters( 'wpseo_schema_article_types', self::$meta_fields['schema']['schema_article_type']['options'] );
 	}
 }

--- a/src/config/schema-types.php
+++ b/src/config/schema-types.php
@@ -112,7 +112,14 @@ class Schema_Types {
 	 * @return array[] The schema article type options.
 	 */
 	public function get_article_type_options() {
-		return [
+		/**
+		 * Filter: 'wpseo_schema_article_types_labels' - Allow developers to filter the available article types and their labels.
+		 *
+		 * Make sure when you filter this to also filter `wpseo_schema_article_types`.
+		 *
+		 * @api array $schema_article_types_labels The available schema article types and their labels.
+		 */
+		return apply_filters( 'wpseo_schema_article_types_labels', [
 			[
 				'name'  => \__( 'Article', 'wordpress-seo' ),
 				'value' => 'Article',
@@ -149,6 +156,6 @@ class Schema_Types {
 				'name'  => \__( 'None', 'wordpress-seo' ),
 				'value' => 'None',
 			],
-		];
+		] );
 	}
 }

--- a/src/config/schema-types.php
+++ b/src/config/schema-types.php
@@ -119,43 +119,46 @@ class Schema_Types {
 		 *
 		 * @api array $schema_article_types_labels The available schema article types and their labels.
 		 */
-		return apply_filters( 'wpseo_schema_article_types_labels', [
+		return \apply_filters(
+			'wpseo_schema_article_types_labels',
 			[
-				'name'  => \__( 'Article', 'wordpress-seo' ),
-				'value' => 'Article',
-			],
-			[
-				'name'  => \__( 'Social Media Posting', 'wordpress-seo' ),
-				'value' => 'SocialMediaPosting',
-			],
-			[
-				'name'  => \__( 'News Article', 'wordpress-seo' ),
-				'value' => 'NewsArticle',
-			],
-			[
-				'name'  => \__( 'Advertiser Content Article', 'wordpress-seo' ),
-				'value' => 'AdvertiserContentArticle',
-			],
-			[
-				'name'  => \__( 'Satirical Article', 'wordpress-seo' ),
-				'value' => 'SatiricalArticle',
-			],
-			[
-				'name'  => \__( 'Scholary Article', 'wordpress-seo' ),
-				'value' => 'ScholarlyArticle',
-			],
-			[
-				'name'  => \__( 'Tech Article', 'wordpress-seo' ),
-				'value' => 'TechArticle',
-			],
-			[
-				'name'  => \__( 'Report', 'wordpress-seo' ),
-				'value' => 'Report',
-			],
-			[
-				'name'  => \__( 'None', 'wordpress-seo' ),
-				'value' => 'None',
-			],
-		] );
+				[
+					'name'  => \__( 'Article', 'wordpress-seo' ),
+					'value' => 'Article',
+				],
+				[
+					'name'  => \__( 'Social Media Posting', 'wordpress-seo' ),
+					'value' => 'SocialMediaPosting',
+				],
+				[
+					'name'  => \__( 'News Article', 'wordpress-seo' ),
+					'value' => 'NewsArticle',
+				],
+				[
+					'name'  => \__( 'Advertiser Content Article', 'wordpress-seo' ),
+					'value' => 'AdvertiserContentArticle',
+				],
+				[
+					'name'  => \__( 'Satirical Article', 'wordpress-seo' ),
+					'value' => 'SatiricalArticle',
+				],
+				[
+					'name'  => \__( 'Scholary Article', 'wordpress-seo' ),
+					'value' => 'ScholarlyArticle',
+				],
+				[
+					'name'  => \__( 'Tech Article', 'wordpress-seo' ),
+					'value' => 'TechArticle',
+				],
+				[
+					'name'  => \__( 'Report', 'wordpress-seo' ),
+					'value' => 'Report',
+				],
+				[
+					'name'  => \__( 'None', 'wordpress-seo' ),
+					'value' => 'None',
+				],
+			]
+		);
 	}
 }

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -494,6 +494,10 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			$additional_type = $this->options->get( 'schema-article-type-' . $this->indexable->object_sub_type );
 		}
 
+		if ( stripos( $additional_type, 'Article' ) !== false ) {
+			return $additional_type;
+		}
+
 		$type = 'Article';
 
 		/*

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -494,8 +494,15 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			$additional_type = $this->options->get( 'schema-article-type-' . $this->indexable->object_sub_type );
 		}
 
+		// If the additional type is a subtype of Article, we're fine, and we can bail here.
 		if ( stripos( $additional_type, 'Article' ) !== false ) {
-			return $additional_type;
+			/**
+			 * Filter: 'wpseo_schema_article_type' - Allow changing the Article type.
+			 *
+			 * @param string|string[] $type      The Article type.
+			 * @param Indexable       $indexable The indexable.
+			 */
+			return \apply_filters( 'wpseo_schema_article_type', $additional_type, $this->indexable );
 		}
 
 		$type = 'Article';
@@ -512,12 +519,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			$type = [ $type, $additional_type ];
 		}
 
-		/**
-		 * Filter: 'wpseo_schema_article_type' - Allow changing the Article type.
-		 *
-		 * @param string|string[] $type      The Article type.
-		 * @param Indexable       $indexable The indexable.
-		 */
+		// Filter documented on line 499 above.
 		return \apply_filters( 'wpseo_schema_article_type', $type, $this->indexable );
 	}
 

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -495,7 +495,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		}
 
 		// If the additional type is a subtype of Article, we're fine, and we can bail here.
-		if ( stripos( $additional_type, 'Article' ) !== false ) {
+		if ( \stripos( $additional_type, 'Article' ) !== false ) {
 			/**
 			 * Filter: 'wpseo_schema_article_type' - Allow changing the Article type.
 			 *


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add filtering for schema article types.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Please test in conjunction with https://github.com/Yoast/wpseo-news/pull/718

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.


## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Relates to PRODUCT-166 
