### PR TITLE
Fix bug in search page schema

### DIFF
--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -35,7 +35,7 @@ class WebPage extends Abstract_Schema_Piece {
 			],
 		];
 
-		if ( empty( $this->context->canonical ) && is_search() ) {
+		if ( empty( $this->context->canonical ) && \is_search() ) {
 			$data['url'] = $this->build_search_url();
 		}
 
@@ -125,7 +125,7 @@ class WebPage extends Abstract_Schema_Piece {
 	 */
 	private function add_potential_action( $data ) {
 		$url = $this->context->canonical;
-		if ( empty( $url ) && is_search() ) {
+		if ( empty( $url ) && \is_search() ) {
 			$url = $this->build_search_url();
 		}
 
@@ -150,6 +150,6 @@ class WebPage extends Abstract_Schema_Piece {
 	 * @return string Search URL.
 	 */
 	private function build_search_url() {
-		return trailingslashit( $this->context->site_url ) . '?s=' . get_search_query();
+		return $this->context->site_url . '?s=' . \get_search_query();
 	}
 }

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -35,6 +35,10 @@ class WebPage extends Abstract_Schema_Piece {
 			],
 		];
 
+		if ( empty( $this->context->canonical ) && is_search() ) {
+			$data['url'] = $this->build_search_url();
+		}
+
 		if ( $this->helpers->current_page->is_front_page() ) {
 			if ( $this->context->site_represents_reference ) {
 				$data['about'] = $this->context->site_represents_reference;
@@ -120,12 +124,17 @@ class WebPage extends Abstract_Schema_Piece {
 	 * @return array The WebPage data with the potential action added.
 	 */
 	private function add_potential_action( $data ) {
+		$url = $this->context->canonical;
+		if ( empty( $url ) && is_search() ) {
+			$url = $this->build_search_url();
+		}
+
 		/**
 		 * Filter: 'wpseo_schema_webpage_potential_action_target' - Allows filtering of the schema WebPage potentialAction target.
 		 *
 		 * @api array $targets The URLs for the WebPage potentialAction target.
 		 */
-		$targets = \apply_filters( 'wpseo_schema_webpage_potential_action_target', [ $this->context->canonical ] );
+		$targets = \apply_filters( 'wpseo_schema_webpage_potential_action_target', [ $url ] );
 
 		$data['potentialAction'][] = [
 			'@type'  => 'ReadAction',
@@ -133,5 +142,14 @@ class WebPage extends Abstract_Schema_Piece {
 		];
 
 		return $data;
+	}
+
+	/**
+	 * Creates the search URL for use when if there is no canonical.
+	 *
+	 * @return string Search URL.
+	 */
+	private function build_search_url() {
+		return trailingslashit( $this->context->site_url ) . '?s=' . get_search_query();
 	}
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `url` property in the search page schema would be empty.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to a search URL, see the `url` property in the schema on the `WebPage` piece is no longer empty.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

