### PR TITLE
Added AiOSEO V4 feature flag.

### DIFF
--- a/admin/import/plugins/class-importers.php
+++ b/admin/import/plugins/class-importers.php
@@ -5,6 +5,8 @@
  * @package WPSEO\Admin\Import\Plugins
  */
 
+use Yoast\WP\SEO\Conditionals\AIOSEO_V4_Importer_Conditional;
+
 /**
  * Class WPSEO_Plugin_Importers.
  *
@@ -19,7 +21,6 @@ class WPSEO_Plugin_Importers {
 	 */
 	private static $importers = [
 		'WPSEO_Import_AIOSEO',
-		'WPSEO_Import_AIOSEO_V4',
 		'WPSEO_Import_Greg_SEO',
 		'WPSEO_Import_HeadSpace',
 		'WPSEO_Import_Jetpack_SEO',
@@ -42,6 +43,10 @@ class WPSEO_Plugin_Importers {
 	 * @return array Available importers.
 	 */
 	public static function get() {
+		$aioseo_importer_conditional = \YoastSEO()->classes->get( AIOSEO_V4_Importer_Conditional::class );
+		if ( $aioseo_importer_conditional->is_met() ) {
+			return \array_merge( self::$importers, [ 'WPSEO_Import_AIOSEO_V4' ] );
+		}
 		return self::$importers;
 	}
 }

--- a/src/conditionals/aioseo-v4-importer-conditional.php
+++ b/src/conditionals/aioseo-v4-importer-conditional.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Feature flag conditional for the AIOSEO V4 importer.
+ */
+class AIOSEO_V4_Importer_Conditional extends Feature_Flag_Conditional {
+
+	/**
+	 * Returns the name of the AiOSEO feature flag.
+	 *
+	 * @return string The name of the feature flag.
+	 */
+	protected function get_feature_flag() {
+		return 'AIOSEO_V4_IMPORTER';
+	}
+}

--- a/tests/unit/admin/import/plugins/importers-test.php
+++ b/tests/unit/admin/import/plugins/importers-test.php
@@ -1,0 +1,103 @@
+<?php
+// @phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- This namespace should reflect the namespace of the tested class.
+namespace Yoast\WP\SEO\Tests\Unit\Admin\Import\Plugins;
+
+use Yoast\WP\SEO\Conditionals\AIOSEO_V4_Importer_Conditional;
+use Yoast\WP\SEO\Surfaces\Classes_Surface;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+
+/**
+ * Tests the list of importers.
+ *
+ * @coversDefaultClass WPSEO_Plugin_Importers
+ */
+class Importers_Test extends TestCase {
+
+	/**
+	 * Tests that the AiOSEO V4 importer is not added to the list of
+	 * active importers when the AiOSEO V4 feature flag is disabled.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get_importers_with_aioseo_v4_importer_feature_disabled() {
+		$aioseo_v4_importer_conditional = Mockery::mock( AIOSEO_V4_Importer_Conditional::class );
+		$aioseo_v4_importer_conditional->expects( 'is_met' )
+			->andReturnFalse();
+
+		$this->mock_classes_surface( $aioseo_v4_importer_conditional );
+
+		self::assertEquals(
+			[
+				'WPSEO_Import_AIOSEO',
+				'WPSEO_Import_Greg_SEO',
+				'WPSEO_Import_HeadSpace',
+				'WPSEO_Import_Jetpack_SEO',
+				'WPSEO_Import_WP_Meta_SEO',
+				'WPSEO_Import_Platinum_SEO',
+				'WPSEO_Import_Premium_SEO_Pack',
+				'WPSEO_Import_RankMath',
+				'WPSEO_Import_SEOPressor',
+				'WPSEO_Import_SEO_Framework',
+				'WPSEO_Import_Smartcrawl_SEO',
+				'WPSEO_Import_Squirrly',
+				'WPSEO_Import_Ultimate_SEO',
+				'WPSEO_Import_WooThemes_SEO',
+				'WPSEO_Import_WPSEO',
+			],
+			WPSEO_Plugin_Importers::get()
+		);
+	}
+
+	/**
+	 * Tests that the AiOSEO V4 importer is added to the list of
+	 * active importers when the AiOSEO V4 feature flag is enabled.
+	 *
+	 * @covers ::get
+	 */
+	public function test_get_importers_with_aioseo_v4_importer_feature_enabled() {
+		$aioseo_v4_importer_conditional = Mockery::mock( AIOSEO_V4_Importer_Conditional::class );
+		$aioseo_v4_importer_conditional->expects( 'is_met' )
+			->andReturnTrue();
+
+		$this->mock_classes_surface( $aioseo_v4_importer_conditional );
+
+		self::assertEquals(
+			[
+				'WPSEO_Import_AIOSEO',
+				'WPSEO_Import_Greg_SEO',
+				'WPSEO_Import_HeadSpace',
+				'WPSEO_Import_Jetpack_SEO',
+				'WPSEO_Import_WP_Meta_SEO',
+				'WPSEO_Import_Platinum_SEO',
+				'WPSEO_Import_Premium_SEO_Pack',
+				'WPSEO_Import_RankMath',
+				'WPSEO_Import_SEOPressor',
+				'WPSEO_Import_SEO_Framework',
+				'WPSEO_Import_Smartcrawl_SEO',
+				'WPSEO_Import_Squirrly',
+				'WPSEO_Import_Ultimate_SEO',
+				'WPSEO_Import_WooThemes_SEO',
+				'WPSEO_Import_WPSEO',
+				'WPSEO_Import_AIOSEO_V4',
+			],
+			WPSEO_Plugin_Importers::get()
+		);
+	}
+
+	/**
+	 * Sets the mocked importer conditional on the mocked classes surface.
+	 *
+	 * @param AIOSEO_V4_Importer_Conditional $aioseo_v4_importer_conditional The importer conditional.
+	 */
+	protected function mock_classes_surface( $aioseo_v4_importer_conditional ) {
+		$classes_surface = Mockery::mock( Classes_Surface::class );
+		$classes_surface->expects( 'get' )
+			->with( AIOSEO_V4_Importer_Conditional::class )
+			->andReturn( $aioseo_v4_importer_conditional );
+
+		Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'classes' => $classes_surface ] );
+	}
+}

--- a/tests/unit/admin/import/plugins/importers-test.php
+++ b/tests/unit/admin/import/plugins/importers-test.php
@@ -2,6 +2,8 @@
 // @phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- This namespace should reflect the namespace of the tested class.
 namespace Yoast\WP\SEO\Tests\Unit\Admin\Import\Plugins;
 
+use Mockery;
+use WPSEO_Plugin_Importers;
 use Yoast\WP\SEO\Conditionals\AIOSEO_V4_Importer_Conditional;
 use Yoast\WP\SEO\Surfaces\Classes_Surface;
 use Yoast\WP\SEO\Tests\Unit\TestCase;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to set the new AiOSEO importer behind a feature flag.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Puts the new AiOSEO V4 importer behind the `YOAST_SEO_AIOSEO_V4_IMPORTER` feature flag.

## Relevant technical choices:

* Added unit tests for the `WPSEO_Plugin_Importers` class.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Without the `YOAST_SEO_AIOSEO_V4_IMPORTER` feature flag
* Install and activate the All-in-One SEO plugin.
* Create or open a post.
* Add All-in-One SEO metadata in their metabox (e.g. title, meta description).
* Save the post.
* Disable the All-in-One SEO plugin.
* Install and activate the Yoast SEO plugin.
* In the WordPress admin, go to the _Import from other SEO plugins_ tab in the import and export tool.
	* Located in _Yoast_ > _Tools_ > _Import and Export_ > _Import from other SEO plugins_.
* You should see the message that "Yoast SEO did not detect any plugin data from plugins it can import from.".
	* This means that the new All-in-One SEO importer IS NOT loaded.

#### With the `YOAST_SEO_AIOSEO_V4_IMPORTER` feature flag enabled
* In your WordPress configuration file, add this line of code to enable the feature flag:
  ```php
  define( 'YOAST_SEO_AIOSEO_V4_IMPORTER', true );
  ```
* Install and activate the All-in-One SEO plugin.
* Create or open a post.
* Add All-in-One SEO metadata in their metabox (e.g. title, meta description).
* Save the post.
* Disable the All-in-One SEO plugin.
* Install and activate the Yoast SEO plugin.
* In the WordPress admin, go to the _Import from other SEO plugins_ tab in the import and export tool.
	* Located in _Yoast_ > _Tools_ > _Import and Export_ > _Import from other SEO plugins_.
* You should see the message "We've detected data from one or more SEO plugins on your site. Please follow the following steps to import that data:".
	* The dropdown box in step 2 of the form that is shown should contain "All-in-One SEO".
		* This means that the new All-in-One SEO importer IS loaded and recognizes that there is All-in-One SEO metadata that can be imported.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Please test that the existing importers still get recognized.
	* E.g. that, when there is Rank Math metadata, that it gets recognized and the option to import Rank Math data is shown in the _Import from other SEO plugins_ tab.  

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
