### PR TITLE
Fix complete count queries in notification and upgrade routine

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -887,7 +887,7 @@ class WPSEO_Upgrade {
 	 * else to `false`.
 	 */
 	public function set_indexation_completed_option_for_145() {
-		WPSEO_Options::set( 'indexables_indexation_completed', YoastSEO()->helpers->indexing->get_unindexed_count() === 0 );
+		WPSEO_Options::set( 'indexables_indexation_completed', YoastSEO()->helpers->indexing->get_limited_filtered_unindexed_count( 1 ) === 0 );
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "typescript": "^4.2.4"
   },
   "yoast": {
-    "pluginVersion": "17.4-RC1"
+    "pluginVersion": "17.4-RC2"
   },
   "version": "0.0.0"
 }

--- a/src/actions/indexing/abstract-indexing-action.php
+++ b/src/actions/indexing/abstract-indexing-action.php
@@ -76,6 +76,10 @@ abstract class Abstract_Indexing_Action implements Indexation_Action_Interface, 
 			return (int) $transient;
 		}
 
+		// Store transient before doing the query so multiple requests won't make multiple queries.
+		// Only store this for 15 minutes to ensure that if the query doesn't complete a wrong count is not kept too long.
+		\set_transient( static::UNINDEXED_COUNT_TRANSIENT, 0, ( \MINUTE_IN_SECONDS * 15 ) );
+
 		$query = $this->get_count_query();
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.

--- a/src/integrations/admin/indexing-notification-integration.php
+++ b/src/integrations/admin/indexing-notification-integration.php
@@ -231,7 +231,7 @@ class Indexing_Notification_Integration implements Integration_Interface {
 		}
 
 		// Never show a notification when nothing should be indexed.
-		return $this->indexing_helper->get_filtered_unindexed_count() > 0;
+		return $this->indexing_helper->get_limited_filtered_unindexed_count( 1 ) > 0;
 	}
 
 	/**

--- a/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-post-indexation-action-test.php
@@ -195,6 +195,10 @@ class Indexable_Post_Indexation_Action_Test extends TestCase {
 	 */
 	public function test_get_total_unindexed_failed_query() {
 		Functions\expect( 'get_transient' )->once()->with( 'wpseo_total_unindexed_posts' )->andReturnFalse();
+		Functions\expect( 'set_transient' )
+			->once()
+			->with( 'wpseo_total_unindexed_posts', 0, ( \MINUTE_IN_SECONDS * 15 ) )
+			->andReturnFalse();
 
 		$this->post_type_helper->expects( 'get_public_post_types' )->once()->andReturn( [ 'public_post_type' ] );
 		$this->post_type_helper->expects( 'get_excluded_post_types_for_indexables' )->once()->andReturn( [] );

--- a/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
+++ b/tests/unit/actions/indexing/indexable-term-indexation-action-test.php
@@ -189,6 +189,11 @@ class Indexable_Term_Indexation_Action_Test extends TestCase {
 			->with( 'wpseo_total_unindexed_terms' )
 			->andReturnFalse();
 
+		Functions\expect( 'set_transient' )
+			->once()
+			->with( 'wpseo_total_unindexed_terms', 0, ( \MINUTE_IN_SECONDS * 15 ) )
+			->andReturn( true );
+
 		$this->taxonomy
 			->expects( 'get_public_taxonomies' )
 			->once()

--- a/tests/unit/actions/indexing/post-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/post-link-indexing-action-test.php
@@ -108,6 +108,11 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->with( Post_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT )
 			->andReturn( false );
 
+		Functions\expect( 'set_transient' )
+			->once()
+			->with( Post_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT, 0, ( \MINUTE_IN_SECONDS * 15 ) )
+			->andReturn( true );
+
 		$this->post_type_helper
 			->expects( 'get_accessible_post_types' )
 			->once()
@@ -157,6 +162,11 @@ class Post_Link_Indexing_Action_Test extends TestCase {
 			->once()
 			->with( Post_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT )
 			->andReturn( false );
+
+		Functions\expect( 'set_transient' )
+			->once()
+			->with( Post_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT, 0, ( \MINUTE_IN_SECONDS * 15 ) )
+			->andReturn( true );
 
 		$this->post_type_helper
 			->expects( 'get_accessible_post_types' )

--- a/tests/unit/actions/indexing/term-link-indexing-action-test.php
+++ b/tests/unit/actions/indexing/term-link-indexing-action-test.php
@@ -216,6 +216,11 @@ class Term_Link_Indexing_Action_Test extends TestCase {
 			->with( Term_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT )
 			->andReturn( false );
 
+		Functions\expect( 'set_transient' )
+			->once()
+			->with( Term_Link_Indexing_Action::UNINDEXED_COUNT_TRANSIENT, 0, ( \MINUTE_IN_SECONDS * 15 ) )
+			->andReturn( true );
+
 		$this->taxonomy_helper
 			->expects( 'get_public_taxonomies' )
 			->once()

--- a/tests/unit/integrations/admin/indexing-notification-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-notification-integration-test.php
@@ -263,8 +263,9 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->andReturn( 0 );
 
 		$this->indexing_helper
-			->expects( 'get_filtered_unindexed_count' )
+			->expects( 'get_limited_filtered_unindexed_count' )
 			->once()
+			->with( 1 )
 			->andReturn( 0 );
 
 		$this->notification_center
@@ -318,9 +319,10 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->andReturn( 0 );
 
 		$this->indexing_helper
-			->expects( 'get_filtered_unindexed_count' )
+			->expects( 'get_limited_filtered_unindexed_count' )
 			->once()
-			->andReturn( 40 );
+			->with( 1 )
+			->andReturn( 1 );
 
 		$this->notification_center
 			->expects( 'get_notification_by_id' )
@@ -368,8 +370,14 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->andReturn( 0 );
 
 		$this->indexing_helper
+			->expects( 'get_limited_filtered_unindexed_count' )
+			->once()
+			->with( 1 )
+			->andReturn( 1 );
+
+		$this->indexing_helper
 			->expects( 'get_filtered_unindexed_count' )
-			->twice()
+			->once()
 			->andReturn( 40 );
 
 		$this->notification_center
@@ -451,9 +459,10 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->andReturn( 0 );
 
 		$this->indexing_helper
-			->expects( 'get_filtered_unindexed_count' )
+			->expects( 'get_limited_filtered_unindexed_count' )
 			->once()
-			->andReturn( 40 );
+			->with( 1 )
+			->andReturn( 1 );
 
 		$this->notification_center
 			->expects( 'remove_notification_by_id' )
@@ -517,8 +526,9 @@ class Indexing_Notification_Integration_Test extends TestCase {
 			->andReturn( 0 );
 
 		$this->indexing_helper
-			->expects( 'get_filtered_unindexed_count' )
+			->expects( 'get_limited_filtered_unindexed_count' )
 			->once()
+			->with( 1 )
 			->andReturn( 0 );
 
 		$this->notification_center

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -15,7 +15,7 @@ if ( ! function_exists( 'add_filter' ) ) {
  * {@internal Nobody should be able to overrule the real version number as this can cause
  *            serious issues with the options, so no if ( ! defined() ).}}
  */
-define( 'WPSEO_VERSION', '17.4-RC1' );
+define( 'WPSEO_VERSION', '17.4-RC2' );
 
 
 if ( ! defined( 'WPSEO_PATH' ) ) {

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -8,7 +8,7 @@
  *
  * @wordpress-plugin
  * Plugin Name: Yoast SEO
- * Version:     17.4-RC1
+ * Version:     17.4-RC2
  * Plugin URI:  https://yoa.st/1uj
  * Description: The first true all-in-one SEO solution for WordPress, including on-page content analysis, XML sitemaps and much more.
  * Author:      Team Yoast


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
