### PR TITLE
Bring wpseo_image_image_weight_limit in line with latest FB requirements

### DIFF
--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -157,7 +157,7 @@ class WPSEO_Image_Utils {
 
 		/**
 		 * Filter: 'wpseo_image_image_weight_limit' - Determines what the maximum weight
-		 * (in bytes) of an image is allowed to be, default is 2 MB.
+		 * (in bytes) of an image is allowed to be, default is 8 MB.
 		 *
 		 * @api int - The maximum weight (in bytes) of an image.
 		 */


### PR DESCRIPTION
## Context
Facebook has clear requirements on the weight and size of an open graph image. The `wpseo_image_image_weight_limit` seems to be outdated. The rest of the requirement checks are still up to date.

## Summary
The maximum size for Yoast to consider an image valid as Open Graph image is limited to 2 MB, but Facebook lists 8 MB as maximum size on https://developers.facebook.com/docs/sharing/webmasters/images/

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allow images up to 8 MB to be used as Open Graph image

## Relevant technical choices:
The requirements for open graph images should be leading. So the limit is bumped.

## Test instructions
- Install latest WP, Yoast and a theme that doesn't register any image sizes (I used BlankSlate)
- Only let WordPress generate a thumbnail that's 150x150 in the media settings. Disable medium and large size.
- Set the -scaled image threshold from 2500px to none
- Create a post with a featured image that is close to but not over the `wpseo_image_image_weight_limit`
- The original image should be in the `og:image` tag
- Create a post with a featured image that is over the `wpseo_image_image_weight_limit`
- The original image should not be in the `og:image` tag and since there are no other valid images the site favicon should be in the `og:image` tag.

## Impact check
It's doesn't seem likely that there is any performance impact.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #17298