### PR TITLE
Copy over the code from Premium

### DIFF
--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -344,6 +344,7 @@ class Cleanup_Integration implements Integration_Interface {
 			)
 		);
 	}
+
 	// phpcs:enable
 
 	/**

--- a/tests/unit/integrations/cleanup-integration-test.php
+++ b/tests/unit/integrations/cleanup-integration-test.php
@@ -530,7 +530,6 @@ class Cleanup_Integration_Test extends TestCase {
 				WHERE tt.term_taxonomy_id IN ( 1, 4, 32 )'
 			)
 			->andReturn( 10 );
-
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Cleans up old unused database items related to a previous version of the internal linking suggestion feature. This will reduce the size of your website's database and make your site a little bit faster.


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Adjusted instructions from https://github.com/Yoast/wordpress-seo-premium/pull/3452** 
* We need to create 'old style' prominent words to clean up later.
* Install an earlier version of WordPress (I tried 5.4, which seems to work).
* Install [Yoast SEO Premium 14.0](https://github.com/Yoast/wordpress-seo-premium/releases/tag/14.0) (or an earlier version).
	* Note that Premium was not an add-on at the time, so you will only need to install and activate Premium. 
* Make sure that you have a couple of posts with content on your website.
* Run the internal linking suggestions tool to generate 'old style' prominent words (located on the _Yoast_ > _Tools_ admin page).
* Check the contents of the `term_taxonomy` table in your database. It SHOULD contain items where the taxonomy column contains the string `yst_prominent_words`.
	* You can check if there are any `yst_prominent_words` related items in your database by executing this SQL query:
		```sql
		SELECT * FROM wp_terms t 
		INNER JOIN wp_term_taxonomy tt ON t.term_id = tt.term_id 
		INNER JOIN wp_term_relationships tr ON tt.term_taxonomy_id = tr.term_taxonomy_id 
		WHERE tt.taxonomy = 'yst_prominent_words'
		```
		This will also check for related items in the `terms` and `term_relationships` tables.
		**Note**: The above query uses the `wp` prefix for the WordPress database tables, change the prefix in your query if your installation uses a different one.  

Afterwards, we can test that the PR cleans up the prominent words.
* Install the latest (stable) version of WordPress.
* Install a version of Yoast SEO Free that has the current change.
	* E.g. switch to this branch for acceptance testers, or install the RC you need to test for QA.
* Manually trigger the upgrade routine by setting the version number of the plugin to a version before 17.4-RC1 (e.g. 17.2), by using the Yoast Test Helper plugin.
* Wait five minutes for the clean up routine to execute.
* Load an admin page to trigger the clean up routine after the five minutes have passed.
	* You can also use a plugin like [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) to run the `wpseo_start_cleanup_indexables` cron job (which triggers the clean up) immediately.
* Check the contents of the `term_taxonomy` table in your database. It SHOULD NOT contain items where the taxonomy column contains the string `yst_prominent_words`.
	* You can check if there are any `yst_prominent_words` related items left in your database by executing this SQL query:
		```sql
		SELECT * FROM wp_terms t 
		INNER JOIN wp_term_taxonomy tt ON t.term_id = tt.term_id 
		INNER JOIN wp_term_relationships tr ON tt.term_taxonomy_id = tr.term_taxonomy_id 
		WHERE tt.taxonomy = 'yst_prominent_words'
		```
		This will also check for related items in the `terms` and `term_relationships` tables.
		**Note**: The above query uses the `wp` prefix for the WordPress database tables, change the prefix in your query if your installation uses a different one. 

**and adjusted instructions from https://github.com/Yoast/wordpress-seo-premium/pull/3476**
* We need to create 'old style' prominent words to clean up later.
* Install an earlier version of WordPress (I tried 5.4, which seems to work).
    * You can use the WP Downgrade plugin for this. Don't forget to visit Dashboard > Updates to do the actual install after you've set the new version.
* Install [Yoast SEO Premium 14.0](https://github.com/Yoast/wordpress-seo-premium/releases/tag/14.0) (or an earlier version).
	* Note that Premium was not an add-on at the time, so you will only need to install and activate Premium. 
* Make sure that you have a couple of posts with content on your website.
* Run the internal linking suggestions tool to generate 'old style' prominent words (located on the _Yoast_ > _Tools_ admin page).
* Check the contents of the `term_taxonomy` table in your database. It SHOULD contain items where the taxonomy column contains the string `yst_prominent_words`.
	* You can check if there are any `yst_prominent_words` related items in your database by executing this SQL query:
		```sql
		SELECT * FROM wp_terms t 
		INNER JOIN wp_term_taxonomy tt ON t.term_id = tt.term_id 
		INNER JOIN wp_term_relationships tr ON tt.term_taxonomy_id = tr.term_taxonomy_id 
		WHERE tt.taxonomy = 'yst_prominent_words'
		```
		This will also check for related items in the `terms` and `term_relationships` tables.
		**Note**: The above query uses the `wp` prefix for the WordPress database tables, change the prefix in your query if your installation uses a different one.  

Afterwards, we can test that the PR cleans up the prominent words.
* In your database, remove the rows from the `term_relationships` table that connect the prominent word taxonomies to terms.
	* You can use this SQL query:
	  ```sql
	  DELETE FROM wp_term_relationships tt 
	  WHERE tt.term_taxonomy_id IN ( 
		  SELECT term_taxonomy_id FROM wp_term_taxonomy 
		  WHERE taxonomy = 'yst_prominent_words' 
	  )
	  ``` 
* Install the latest (stable) version of WordPress.
* Install a version of Yoast SEO Free that has the current change.
	* E.g. switch to this branch for acceptance testers, or install the RC you need to test for QA.
* Manually trigger the upgrade routine by setting the version number of the plugin to a version before 17.4-RC1 (e.g. 17.2), by using the Yoast Test Helper plugin.
* Wait five minutes for the clean up routine to execute.
	* You can also use a plugin like [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) to run the `wpseo_start_cleanup_indexables` cron job (which triggers the clean up) immediately.
* Load an admin page to trigger the clean up routine after the five minutes have passed.
* Check the contents of the `term_taxonomy` table in your database. It SHOULD NOT contain items where the taxonomy column contains the string `yst_prominent_words`.
	* You can check if there are any `yst_prominent_words` related items left in your database by executing this SQL query:
		```sql
		SELECT * FROM wp_terms t 
		INNER JOIN wp_term_taxonomy tt ON t.term_id = tt.term_id 
		INNER JOIN wp_term_relationships tr ON tt.term_taxonomy_id = tr.term_taxonomy_id 
		WHERE tt.taxonomy = 'yst_prominent_words'
		```
		This will also check for related items in the `terms` and `term_relationships` tables.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Test upgrading from a pre-17.1 version of Premium to the latest (RC) version.
	* Both the 17.2 and 17.4 upgrade routines trigger the clean up. It would be worthwhile to check if they play well together. 
* Please test with a large installation (1000+ `yst_prominent_words` taxonomy entries in the `term_taxonomy` table) as well. This should make the cleanup job clean the prominent words in batches of 1000 each, every hour.
	* You can speed up the process by manually triggering the `wpseo_start_cleanup_indexables` cron job multiple times using a plugin like WP Crontrol. Each time should clean up one batch from the database.
* Since this PR re-triggers the entire clean up, it could be worthwhile to check whether the clean up tasks still work as expected. Do note that the previous clean up tasks have not been touched, a new one has been added, so it may be enough to test whether the other clean up tasks are still run.
	* It should remove rows in the indexables table that have `shop_order` sub type (in batches of 1000). (See https://github.com/Yoast/wordpress-seo/pull/17234)
	* It should remove rows in the indexables table that have an `autodraft` post status. (See https://github.com/Yoast/wordpress-seo/pull/17373)
	* It should remove rows in the `seo_links`, `indexables_hierarchy` and the `prominent_words` tables that reference a non-existing indexable. (See https://github.com/Yoast/wordpress-seo/pull/17314)

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
