### PR TITLE
P2 1369 revert prominent from free

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -74,8 +74,7 @@ class WPSEO_Upgrade {
 			'16.2-RC0'   => 'upgrade_162',
 			'16.5-RC0'   => 'upgrade_165',
 			'17.1-RC0'   => 'upgrade_171',
-			'17.2-RC0'   => 'retrigger_cleanup',
-			'17.4-RC0'   => 'retrigger_cleanup',
+			'17.2-RC0'   => 'upgrade_172',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -833,10 +832,11 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Schedules a cleanup of the database, cleaning out unused data.
+	 * Performs the 17.2 upgrade. Cleans out any unnecessary indexables. See $cleanup_integration->get_cleanup_tasks() to see what will be cleaned out.
+	 *
+	 * @return void
 	 */
-	private function retrigger_cleanup() {
-		// The hooks that are unscheduled here have since been renamed.
+	private function upgrade_172() {
 		\wp_unschedule_hook( 'wpseo_cleanup_orphaned_indexables' );
 		\wp_unschedule_hook( 'wpseo_cleanup_indexables' );
 

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -89,9 +89,6 @@ class Cleanup_Integration implements Integration_Interface {
 				'clean_indexables_by_post_status_auto-draft' => function( $limit ) {
 					return $this->clean_indexables_with_post_status( 'auto-draft', $limit );
 				},
-				'clean_old_prominent_word_version_numbers' => function( $limit ) {
-					return $this->cleanup_old_prominent_word_version_numbers( $limit );
-				},
 			],
 			$this->get_additional_tasks(),
 			[
@@ -316,26 +313,5 @@ class Cleanup_Integration implements Integration_Interface {
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
 		return $wpdb->query( "DELETE FROM $table WHERE {$column} IN( " . \implode( ',', $orphans ) . ' )' );
-	}
-
-	/**
-	 * Cleans up the old prominent word versions from the postmeta table in the database.
-	 *
-	 * @param int $limit The maximum number of prominent word version numbers to clean in one go.
-	 *
-	 * @return bool|int The number of cleaned up prominent word version numbers, or `false` if the query failed.
-	 */
-	protected function cleanup_old_prominent_word_version_numbers( $limit ) {
-		global $wpdb;
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: There is no unescaped user input.
-		$query = $wpdb->prepare(
-			"DELETE FROM {$wpdb->postmeta} WHERE meta_key = %s LIMIT %d",
-			[ '_yst_prominent_words_version', $limit ]
-		);
-		// phpcs:enable
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: Already prepared.
-		return $wpdb->query( $query );
 	}
 }

--- a/tests/unit/integrations/cleanup-integration-test.php
+++ b/tests/unit/integrations/cleanup-integration-test.php
@@ -78,7 +78,6 @@ class Cleanup_Integration_Test extends TestCase {
 	 * @covers ::clean_indexables_with_object_type_and_object_sub_type
 	 * @covers ::clean_indexables_with_post_status
 	 * @covers ::cleanup_orphaned_from_table
-	 * @covers ::cleanup_old_prominent_word_version_numbers
 	 * @covers ::get_limit
 	 * @covers ::reset_cleanup
 	 */
@@ -110,8 +109,6 @@ class Cleanup_Integration_Test extends TestCase {
 
 		/* Clean up of seo links target ids for deleted indexables */
 		$this->setup_cleanup_orphaned_from_table_mocks( 50, 'SEO_Links', 'target_indexable_id', $query_limit );
-
-		$this->setup_cleanup_old_prominent_words_versions( $query_limit );
 
 		$this->instance->run_cleanup();
 	}
@@ -356,30 +353,6 @@ class Cleanup_Integration_Test extends TestCase {
 		$this->setup_clean_indexables_with_post_status_mocks( 50, 'auto-draft', 1000 );
 
 		$this->instance->run_cleanup_cron();
-	}
-
-	/**
-	 * Sets up the expectations for the cleanup old prominent words versions task.
-	 *
-	 * @param int $limit The query limit.
-	 *
-	 * @return void
-	 */
-	private function setup_cleanup_old_prominent_words_versions( $limit ) {
-		$this->wpdb->postmeta = $this->wpdb->prefix . 'postmeta';
-
-		$this->wpdb->expects( 'prepare' )
-			->with(
-				'DELETE FROM wp_postmeta WHERE meta_key = %s LIMIT %d',
-				[ '_yst_prominent_words_version', $limit ]
-			)
-			->andReturn(
-				'DELETE FROM wp_postmeta WHERE meta_key = \'_yst_prominent_words_version\' LIMIT ' . $limit
-			);
-
-		$this->wpdb->expects( 'query' )
-			->with( 'DELETE FROM wp_postmeta WHERE meta_key = \'_yst_prominent_words_version\' LIMIT ' . $limit )
-			->andReturn( 3 );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* PR 17494 was made to free while we were moving cleanup code from Premium to Free. Meanwhile, it was decided to keep these cleanup actions in Premium, so the move was abandoned and PR 17494 needs to be ported to Premium. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
