### PR TITLE
QA: fix inconsistent translator comment style

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -318,7 +318,7 @@ class WPSEO_Addon_Manager {
 		$subscription = $this->get_subscription( $plugin_data['slug'] );
 		if ( $subscription && $this->has_subscription_expired( $subscription ) ) {
 			echo '<br><br>';
-			// translators: %1$s is the plugin name, %2$s and %3$s are a link.
+			/* translators: %1$s is the plugin name, %2$s and %3$s are a link. */
 			echo '<strong><span class="wp-ui-text-notification alert dashicons dashicons-warning"></span> ' . sprintf( esc_html__( 'A new version of %1$s is available. %2$sRenew your subscription%3$s if you want to update to the latest version.', 'wordpress-seo' ), esc_html( $plugin_data['name'] ), '<a href="' . esc_attr( WPSEO_Shortlinker::get( 'https://yoa.st/4ey' ) ) . '">', '</a>' ) . '</strong>';
 		}
 	}

--- a/src/integrations/admin/addon-installation/installation-integration.php
+++ b/src/integrations/admin/addon-installation/installation-integration.php
@@ -141,13 +141,13 @@ class Installation_Integration implements Integration_Interface {
 		try {
 			$this->addon_activate_action->activate_addon( $addon_slug );
 
-			// Translators: %s expands to the name of the addon.
+			/* Translators: %s expands to the name of the addon. */
 			$output[] = \__( 'Addon activated.', 'wordpress-seo' );
 		} catch ( User_Cannot_Activate_Plugins_Exception $exception ) {
 			$output[] = \__( 'You are not allowed to activate plugins.', 'wordpress-seo' );
 		} catch ( Addon_Activation_Error_Exception $exception ) {
 			$output[] = \sprintf(
-			// Translators:%s expands to the error message.
+				/* Translators:%s expands to the error message. */
 				\__( 'Addon activation failed because of an error: %s.', 'wordpress-seo' ),
 				$exception->getMessage()
 			);
@@ -171,7 +171,7 @@ class Installation_Integration implements Integration_Interface {
 		try {
 			$installed = $this->addon_install_action->install_addon( $addon_slug, $addon_download );
 		} catch ( Addon_Already_Installed_Exception $exception ) {
-			// Translators: %s expands to the name of the addon.
+			/* Translators: %s expands to the name of the addon. */
 			$output[] = \__( 'Addon installed.', 'wordpress-seo' );
 
 			$installed = true;
@@ -179,7 +179,7 @@ class Installation_Integration implements Integration_Interface {
 			$output[] = \__( 'You are not allowed to install plugins.', 'wordpress-seo' );
 		} catch ( Addon_Installation_Error_Exception $exception ) {
 			$output[] = \sprintf(
-			// Translators: %s expands to the error message.
+				/* Translators: %s expands to the error message. */
 				\__( 'Addon installation failed because of an error: %s.', 'wordpress-seo' ),
 				$exception->getMessage()
 			);

--- a/src/presenters/admin/indexing-error-presenter.php
+++ b/src/presenters/admin/indexing-error-presenter.php
@@ -72,7 +72,7 @@ class Indexing_Error_Presenter extends Abstract_Presenter {
 			}
 			else {
 				$message = \sprintf(
-					// translators: %1$s expands to an opening anchor tag for a link leading to the Premium installation page, %2$s expands to a closing anchor tag.
+					/* translators: %1$s expands to an opening anchor tag for a link leading to the Premium installation page, %2$s expands to a closing anchor tag. */
 					\__(
 						'Oops, something has gone wrong and we couldn\'t complete the optimization of your SEO data. Please make sure to activate your subscription in MyYoast by completing %1$sthese steps%2$s.',
 						'wordpress-seo'
@@ -98,7 +98,7 @@ class Indexing_Error_Presenter extends Abstract_Presenter {
 	 */
 	protected function generate_second_paragraph( $is_premium, $has_valid_premium_subscription ) {
 		return \sprintf(
-			// translators: %1$s expands to an opening anchor tag for a link leading to the Premium installation page, %2$s expands to a closing anchor tag.
+			/* translators: %1$s expands to an opening anchor tag for a link leading to the Premium installation page, %2$s expands to a closing anchor tag. */
 			\__(
 				'Below are the technical details for the error. See %1$sthis page%2$s for a more detailed explanation.',
 				'wordpress-seo'


### PR DESCRIPTION
## Context

* Code style consistency
* Improve translatability

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency
* Improve translatability

## Relevant technical choices:

Not all `pot` file generators can handle a code base with translators comments using different comment styles, so always better to consistently use one style for these comments.

## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
