### PR TITLE
Use UPLOADS/WP_CONTENT_DIR instead of hardcoded wp-content/uploads

### DIFF
--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -368,8 +368,12 @@ class WPSEO_Sitemap_Image_Parser {
 		if ( strpos( $file, $uploads['basedir'] ) === 0 ) {
 			$src = str_replace( $uploads['basedir'], $uploads['baseurl'], $file );
 		}
-		elseif ( strpos( $file, 'wp-content/uploads' ) !== false ) {
-			$src = $uploads['baseurl'] . substr( $file, ( strpos( $file, 'wp-content/uploads' ) + 18 ) );
+		elseif ( defined( 'UPLOADS' ) && strpos( $file, UPLOADS ) !== false ) {
+			$src = $uploads['baseurl'] . substr( $file, ( strpos( $file, UPLOADS ) + strlen( UPLOADS ) ) );
+		}
+		elseif ( strpos( $file, str_replace( ABSPATH, '', WP_CONTENT_DIR ) . '/uploads' ) !== false ) {
+			$uploads_rel_path = str_replace( ABSPATH, '', WP_CONTENT_DIR ) . '/uploads';
+			$src              = $uploads['baseurl'] . substr( $file, ( strpos( $file, $uploads_rel_path ) + strlen( $uploads_rel_path ) ) );
 		}
 		else {
 			// It's a newly uploaded file, therefore $file is relative to the baseurl.


### PR DESCRIPTION
## Context

https://github.com/Yoast/wordpress-seo/issues/17492

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Use UPLOADS/WP_CONTENT_DIR instead of hardcoded wp-content/uploads

I don't know how to add labels to the PR in github. Applicable labels: `changelog: bugfix`, `changelog: non-user-facing`

## Relevant technical choices:

* change hardcoded string to dynamic code

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* view sitemap, if src is there correctly it works.


### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

* sitemap

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #17492
