### PR TITLE
Links to fragments on the same page are now recognized as links within the same page.

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/researches/getLinkStatisticsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getLinkStatisticsSpec.js
@@ -102,6 +102,23 @@ describe( "Tests a string for anchors and its attributes", function() {
 		expect( foundLinks.keyword.totalKeyword ).toBe( 0 );
 	} );
 
+	it( "should not detect the keyword in link text which links to a fragment on the same page", function() {
+		const attributes = {
+			keyword: "focuskeyword",
+			url: "http://yoast.com/this-page/",
+			permalink: "http://yoast.com/this-page/",
+		};
+
+		const mockPaper = new Paper( "string <a href='#some-fragment'>focuskeyword</a>", attributes );
+		const researcher = new EnglishResearcher( mockPaper );
+		researcher.addResearchData( "morphology", morphologyData );
+		foundLinks = linkCount( mockPaper, researcher );
+
+		expect( foundLinks.total ).toBe( 1 );
+		expect( foundLinks.otherTotal ).toBe( 1 );
+		expect( foundLinks.keyword.totalKeyword ).toBe( 0 );
+	} );
+
 	it( "should detect nofollow as rel attribute", function() {
 		let mockPaper = new Paper( "string <a href='http://example.com' rel='nofollow'>link</a>", paperAttributes );
 		let researcher = new EnglishResearcher( mockPaper );

--- a/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getLinkStatistics.js
@@ -24,6 +24,11 @@ let functionWords = [];
 const linkToSelf = function( anchor, permalink ) {
 	const anchorLink = urlHelper.getFromAnchorTag( anchor );
 
+	// Relative fragment links always point to the page itself.
+	if ( urlHelper.isRelativeFragmentURL( anchorLink ) ) {
+		return true;
+	}
+
 	return urlHelper.areEqual( anchorLink, permalink );
 };
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Relative fragment links (`#some-id`) always point to an (HTML) element on the page itself, so it should be counted as a link to the same page.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Counts relative fragment links (`#some-id`) as a link to the same page.
* Fixes a bug where links to items on the same page were incorrectly identified as links to other pages, leading to an incorrect result on the Link keyphrase assessment.

## Relevant technical choices:

* Decided to not exclude the table-of-contents block but fix fragment links not being seen as links to the same page.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate WordPress SEO Premium.
* Create a new post.
* Add a subheading that contains the focus keyphrase.
* Add the Yoast table-of-contents block.
* You SHOULD NOT get a red bullet in the SEO analysis telling you you shouldn’t link to another page with your keyphrase.
	* In other words: the fragment link in the table-of-content block gets recognized as a link to (an element on) the same page and does not get counted as a link to another page that has the focus keyphrase.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR only impacts the Link keyphrase assessment.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
