### PR TITLE
Yoast sidebar chevron / et al symbols are misaligned

### DIFF
--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -788,6 +788,10 @@ div.interface-pinned-items button.components-button.is-pressed[aria-label="Yoast
 	mask-image: var(--yoast-svg-icon-chevron-up);
 }
 
+.yoast .components-panel__body-toggle {
+	padding-right: 16px;
+}
+
 /* FormTokenField ("gutenberg tag selectors") used inside the .yoast metabox will be Yoast purple. */
 .yoast .components-form-token-field__token-text,
 .yoast .components-form-token-field__remove-token.components-button {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* To match the collapsibles of gutenberg 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reduces the right padding of the collapsible sidebar buttons to match Gutenberg's new styling.

## Relevant technical choices:

* Fixed it by adjusting the right padding as most users of our latest version will use the recent WordPress version as well.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post
* Open the Yoast sidebar
* Verify that the chevrons of the collapsibles are aligned correctly.

![image](https://user-images.githubusercontent.com/20287474/137103697-a8f82bcc-b3f4-4413-9685-874dc9168e8e.png)
![image](https://user-images.githubusercontent.com/20287474/137103811-5b997c0a-7e49-4979-977c-8521aebdf4c5.png)


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] ~I have added unittests to verify the code works as intended~
* [ ] ~If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.~

Fixes P1-768
