### PR TITLE
Hide mark buttons on taxonomies

### DIFF
--- a/packages/js/src/initializers/term-scraper.js
+++ b/packages/js/src/initializers/term-scraper.js
@@ -42,6 +42,7 @@ import { refreshSnippetEditor, updateData } from "../redux/actions/snippetEditor
 import { setWordPressSeoL10n, setYoastComponentsL10n } from "../helpers/i18n";
 import { setFocusKeyword } from "../redux/actions/focusKeyword";
 import { setCornerstoneContent } from "../redux/actions/cornerstoneContent";
+import { setMarkerStatus } from "../redux/actions/markerButtons";
 import initializeUsedKeywords from "./used-keywords-assessment";
 
 setYoastComponentsL10n();
@@ -290,6 +291,9 @@ export default function initTermScraper( $, store, editorData ) {
 		}
 
 		if ( isContentAnalysisActive() ) {
+			// Hide marker buttons.
+			store.dispatch( setMarkerStatus( "hidden" ) );
+
 			args.callbacks.saveContentScore = termScraper.saveContentScore.bind( termScraper );
 			args.callbacks.updatedContentResults = function( results ) {
 				store.dispatch( setReadabilityResults( results ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Currently, we disable the mark (eye icon) button on taxonomies. This leads to confusion with users. Let's remove the mark button on taxonomies.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the analysis highlight button would be visible on tags, categories, and custom taxonomies even though we don't support highlighting for those types.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install & activate
  * Yoast SEO 17.5-RC1 (or higher / this branch)
* Edit/Add a new `category`
* Add some text and use a transition word. I used:
<details><summary><b>Expand</b></summary>
<p>

```txt
Culpa natus dolores blanditiis perspiciatis. Voluptas ut corporis deserunt sapiente blanditiis aut voluptas id. Beatae sapiente eum debitis tempora ex praesentium. Iure doloribus qui dicta vel.

Non minima itaque labore et qui dolorem ullam fugit. Placeat cum deleniti vitae rerum autem voluptas dignissimos quo.

Provident nesciunt accusamus ducimus ut fugit aliquid. Accusantium commodi rerum ex et et explicabo.

Iusto illo sit voluptates animi. Quo dolores veritatis veritatis dolore velit possimus quod. Inventore quos et distinctio ipsum. Sit eum maiores neque atque.

Sunt neque sunt excepturi. Est est quo suscipit id neque voluptates beatae. Ad autem et facere dolorem asperiores.

Nesciunt quia tempora et et. Magni a voluptatem nostrum consequatur magni officia voluptatem. Qui minus est corporis ex velit. Beatae adipisci voluptas ad et nobis.

Saepe hic fuga magnam ea quis dolores labore. Esse voluptate ratione tenetur sunt occaecati. Illo ad deleniti cumque labore quo facere accusantium.

Quisquam adipisci maiores excepturi rerum rerum. Quia dicta exercitationem sit nobis. Veniam facere a perferendis quae eos molestiae. Et ut iure ut cumque officia. As a result, it fell over.

Id pariatur ex cum atque quas voluptas. Animi consectetur ab consectetur assumenda. Quo ut voluptatem dolorem aut rem est est. Consequatur et quo numquam neque et sapiente.
```

</p>
</details>

* Go to the readability analysis results
* Verify there is no eye icon anymore next to the transition word improvement.
  * Before:
![before](https://user-images.githubusercontent.com/20287474/137461906-209c16d7-a483-48a9-bc64-ee8107a46075.png)
  * After:
![after](https://user-images.githubusercontent.com/20287474/137462180-06c594c4-612f-42f9-97e1-0345e15ca37f.png)


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Test in default/classic editor on WordPress taxonomies (tags/categories/custom taxonomies).
* Quick check that the mark (eye icon) button works as before for posts/pages/CPT.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes P1-428
