### PR TITLE
Abstract plugin import route

### DIFF
--- a/src/actions/importing/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo-posts-importing-action.php
@@ -108,6 +108,15 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 		return $this->wpdb->prefix . 'aioseo_posts';
 	}
 
+	/**
+	 * Determines if the AIOSEO database table exists.
+	 *
+	 * @return bool True if the table is found.
+	 */
+	protected function aioseo_exists() {
+		return $this->wpdb_helper->table_exists( $this->get_table() ) === true;
+	}
+
 	// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: They are already prepared.
 
 	/**
@@ -116,7 +125,7 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 	 * @return int The total number of unimported objects.
 	 */
 	public function get_total_unindexed() {
-		if ( ! $this->wpdb_helper->table_exists( $this->get_table() ) ) {
+		if ( ! $this->aioseo_exists() ) {
 			return 0;
 		}
 
@@ -135,7 +144,7 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 	 * @return int|false The limited number of unindexed posts. False if the query fails.
 	 */
 	public function get_limited_unindexed_count( $limit ) {
-		if ( ! $this->wpdb_helper->table_exists( $this->get_table() ) ) {
+		if ( ! $this->aioseo_exists() ) {
 			return 0;
 		}
 
@@ -151,7 +160,7 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 	 * @return Indexable[]|false An array of created indexables or false if aioseo data was not found.
 	 */
 	public function index() {
-		if ( ! $this->wpdb_helper->table_exists( $this->get_table() ) ) {
+		if ( ! $this->aioseo_exists() ) {
 			return false;
 		}
 

--- a/src/actions/importing/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo-posts-importing-action.php
@@ -148,15 +148,16 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 	/**
 	 * Imports AIOSEO meta data and creates the respective Yoast indexables and postmeta.
 	 *
-	 * @return void
+	 * @return Indexable[]|false An array of created indexables or false if aioseo data was not found.
 	 */
 	public function index() {
 		if ( ! $this->wpdb_helper->table_exists( $this->get_table() ) ) {
-			return;
+			return false;
 		}
 
-		$limit             = $this->get_limit();
-		$aioseo_indexables = $this->wpdb->get_results( $this->query( $limit ), ARRAY_A );
+		$limit              = $this->get_limit();
+		$aioseo_indexables  = $this->wpdb->get_results( $this->query( $limit ), ARRAY_A );
+		$created_indexables = [];
 
 		$last_indexed_aioseo_id = 0;
 		foreach ( $aioseo_indexables as $aioseo_indexable ) {
@@ -174,10 +175,14 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 			$this->indexable_to_postmeta->map_to_postmeta( $indexable );
 
 			$last_indexed_aioseo_id = $aioseo_indexable['id'];
+
+			$created_indexables[] = $indexable;
 		}
 
 		$cursor_id = $this->get_cursor_id();
 		$this->set_cursor( $this->options, $cursor_id, $last_indexed_aioseo_id );
+
+		return $created_indexables;
 	}
 
 	// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared

--- a/src/routes/abstract-action-route.php
+++ b/src/routes/abstract-action-route.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Yoast\WP\SEO\Routes;
+
+use WP_REST_Response;
+
+/**
+ * Abstract_Action_Route class.
+ *
+ * Abstract class for action routes.
+ */
+abstract class Abstract_Action_Route implements Route_Interface {
+
+	/**
+	 * Responds to an indexing request.
+	 *
+	 * @param array  $objects  The objects that have been indexed.
+	 * @param string $next_url The url that should be called to continue reindexing. False if done.
+	 *
+	 * @return WP_REST_Response The response.
+	 */
+	protected function respond_with( $objects, $next_url ) {
+		return new WP_REST_Response(
+			[
+				'objects'  => $objects,
+				'next_url' => $next_url,
+			]
+		);
+	}
+}

--- a/src/routes/abstract-indexation-route.php
+++ b/src/routes/abstract-indexation-route.php
@@ -10,24 +10,7 @@ use Yoast\WP\SEO\Actions\Indexing\Indexation_Action_Interface;
  *
  * Reindexing route for indexables.
  */
-abstract class Abstract_Indexation_Route implements Route_Interface {
-
-	/**
-	 * Responds to an indexing request.
-	 *
-	 * @param array  $objects  The objects that have been indexed.
-	 * @param string $next_url The url that should be called to continue reindexing. False if done.
-	 *
-	 * @return WP_REST_Response The response.
-	 */
-	protected function respond_with( $objects, $next_url ) {
-		return new WP_REST_Response(
-			[
-				'objects'  => $objects,
-				'next_url' => $next_url,
-			]
-		);
-	}
+abstract class Abstract_Indexation_Route extends Abstract_Action_Route {
 
 	/**
 	 * Runs an indexing action and returns the response.

--- a/src/routes/importing-route.php
+++ b/src/routes/importing-route.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Routes;
 
+use Exception;
 use WP_Error;
 use WP_REST_Response;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
@@ -49,7 +50,7 @@ class Importing_Route extends Abstract_Action_Route {
 			[
 				'callback'            => [ $this, 'execute' ],
 				'permission_callback' => [ $this, 'can_import' ],
-				'methods'             => [ 'GET' ],
+				'methods'             => [ 'POST' ],
 			]
 		);
 	}
@@ -59,17 +60,21 @@ class Importing_Route extends Abstract_Action_Route {
 	 *
 	 * @param mixed $data The request parameters.
 	 *
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|false Response or false on non-existent route.
 	 */
 	public function execute( $data ) {
 		$plugin = (string) $data['plugin'];
 		$type   = (string) $data['type'];
 
-		$method = "import_{$plugin}_{$type}";
+		$method   = "import_{$plugin}_{$type}";
+		$next_url = "import/{$plugin}/{$type}";
 
 		try {
-			$result   = $this->{ $method }();
-			$next_url = "import/{$plugin}/{$type}";
+			if ( ! method_exists( $this, $method ) ) {
+				return false;
+			}
+
+			$result = $this->{ $method }();
 
 			if ( count( $result['objects'] ) === 0 ) {
 				$next_url = $result['next_url'];
@@ -95,7 +100,7 @@ class Importing_Route extends Abstract_Action_Route {
 	 */
 	protected function import_aioseo_posts() {
 		return [
-			'objects'  => [],
+			'objects'  => [ 'test' ],
 			'next_url' => self::IMPORT_AIOSEO_TERMS_ROUTE,
 		];
 	}

--- a/src/routes/importing-route.php
+++ b/src/routes/importing-route.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Yoast\WP\SEO\Routes;
+
+use WP_Error;
+use WP_REST_Response;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Main;
+
+/**
+ * Importing_Route class.
+ *
+ * Importing route for importing from other SEO plugins.
+ */
+class Importing_Route implements Route_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * The import route constant.
+	 *
+	 * @var string
+	 */
+	const ROUTE = '/import/(?P<plugin>\w+)/(?P<type>\w+)';
+
+	/**
+	 * The aioseo posts import route constant.
+	 *
+	 * @var string
+	 */
+	const IMPORT_AIOSEO_POSTS_ROUTE = '/import/aioseo/posts';
+
+	/**
+	 * The aioseo terms import route constant.
+	 *
+	 * @var string
+	 */
+	const IMPORT_AIOSEO_TERMS_ROUTE = '/import/aioseo/terms';
+
+	/**
+	 * Registers routes with WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_routes() { 
+		register_rest_route(
+			Main::API_V1_NAMESPACE,
+			self::ROUTE,
+			[
+				'callback'            => [ $this, 'execute' ],
+				'permission_callback' => [ $this, 'can_import' ],
+				'methods'             => [ "GET" ],
+			]
+		);
+	}
+
+	/**
+	 * Executes the rest request.
+	 *
+	 * @param mixed $data The request parameters.
+	 *
+	 * @return WP_REST_Response 
+	 */
+	public function execute( $data ) {
+		$plugin = (string) $data[ 'plugin' ];
+		$type   = (string) $data[ 'type' ];
+
+		$method = "import_{$plugin}_{$type}";
+
+		try {
+			$result  = $this->{ $method }();
+			$next_url = "import/{$plugin}/{$type}";
+
+			if ( count( $result[ 'objects' ] ) === 0 ) {
+				$next_url = $result[ 'next_url' ];
+			}
+
+			return new WP_REST_Response(
+				[
+					'objects'  => $result[ 'objects' ],
+					'next_url' => $next_url,
+				]
+			);
+		} catch ( \Exception $exception ) {
+			return new WP_Error(
+				'wpseo_error_indexing',
+				$exception->getMessage(),
+				[ 'stackTrace' => $exception->getTraceAsString() ]
+			);
+		}
+	}
+
+	/**
+	 * Runs the aioseo post importer.
+	 *
+	 * @return array
+	 */
+	protected function import_aioseo_posts() {
+		return [
+			'objects'  => [],
+			'next_url' => self::IMPORT_AIOSEO_TERMS_ROUTE,
+		];
+	}
+
+	/**
+	 * Whether or not the current user is allowed to import.
+	 *
+	 * @return bool Whether or not the current user is allowed to import.
+	 */
+	public function can_import() {
+		return \current_user_can( 'edit_posts' );
+	}
+}

--- a/src/routes/importing-route.php
+++ b/src/routes/importing-route.php
@@ -37,7 +37,7 @@ class Importing_Route extends Abstract_Action_Route {
 	/**
 	 * Importing_Route constructor.
 	 *
-	 * @param Importing_Action_Interface $importers All available importers.
+	 * @param Importing_Action_Interface ...$importers All available importers.
 	 */
 	public function __construct( Importing_Action_Interface ...$importers ) {
 		$this->importers = $importers;

--- a/src/routes/importing-route.php
+++ b/src/routes/importing-route.php
@@ -12,7 +12,7 @@ use Yoast\WP\SEO\Main;
  *
  * Importing route for importing from other SEO plugins.
  */
-class Importing_Route implements Route_Interface {
+class Importing_Route extends Abstract_Action_Route {
 
 	use No_Conditionals;
 
@@ -42,14 +42,14 @@ class Importing_Route implements Route_Interface {
 	 *
 	 * @return void
 	 */
-	public function register_routes() { 
+	public function register_routes() {
 		register_rest_route(
 			Main::API_V1_NAMESPACE,
 			self::ROUTE,
 			[
 				'callback'            => [ $this, 'execute' ],
 				'permission_callback' => [ $this, 'can_import' ],
-				'methods'             => [ "GET" ],
+				'methods'             => [ 'GET' ],
 			]
 		);
 	}
@@ -59,27 +59,25 @@ class Importing_Route implements Route_Interface {
 	 *
 	 * @param mixed $data The request parameters.
 	 *
-	 * @return WP_REST_Response 
+	 * @return WP_REST_Response
 	 */
 	public function execute( $data ) {
-		$plugin = (string) $data[ 'plugin' ];
-		$type   = (string) $data[ 'type' ];
+		$plugin = (string) $data['plugin'];
+		$type   = (string) $data['type'];
 
 		$method = "import_{$plugin}_{$type}";
 
 		try {
-			$result  = $this->{ $method }();
+			$result   = $this->{ $method }();
 			$next_url = "import/{$plugin}/{$type}";
 
-			if ( count( $result[ 'objects' ] ) === 0 ) {
-				$next_url = $result[ 'next_url' ];
+			if ( count( $result['objects'] ) === 0 ) {
+				$next_url = $result['next_url'];
 			}
 
-			return new WP_REST_Response(
-				[
-					'objects'  => $result[ 'objects' ],
-					'next_url' => $next_url,
-				]
+			return $this->respond_with(
+				$result['objects'],
+				$next_url
 			);
 		} catch ( \Exception $exception ) {
 			return new WP_Error(

--- a/tests/unit/routes/importing-route-test.php
+++ b/tests/unit/routes/importing-route-test.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Routes;
+
+use Brain\Monkey;
+use Exception;
+use Mockery;
+use PHPUnit_Framework_Exception;
+use PHPUnit_Framework_ExpectationFailedException;
+use WP_REST_Response;
+use Yoast\WP\SEO\Routes\Importing_Route;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Importing_Route_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Routes\Importing_Route
+ *
+ * @group routes
+ * @group import
+ */
+class Importing_Route_Test extends TestCase {
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Indexing_Route
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Importing_Route();
+	}
+
+	/**
+	 * Tests the registration of the routes.
+	 *
+	 * @covers ::register_routes
+	 */
+	public function test_register_routes() {
+		Monkey\Functions\expect( 'register_rest_route' )
+			->with(
+				'yoast/v1',
+				'/import/(?P<plugin>\w+)/(?P<type>\w+)',
+				[
+					'methods'             => [ 'POST' ],
+					'callback'            => [ $this->instance, 'execute' ],
+					'permission_callback' => [ $this->instance, 'can_import' ],
+				]
+			);
+
+		$this->instance->register_routes();
+	}
+
+	/**
+	 * Tests whether a handler exists for all existing routes.
+	 *
+	 * @param string $plugin The plugin.
+	 * @param string $type   The type of entity to import.
+	 *
+	 * @dataProvider all_routes
+	 *
+	 * @covers ::execute
+	 * @covers ::import_aioseo_posts
+	 */
+	public function test_execute_import_aioseo_posts( $plugin, $type ) {
+		Mockery::mock( 'overload:WP_REST_Response' );
+
+		$wp_rest_response = $this->instance->execute(
+			[
+				'plugin' => $plugin,
+				'type'   => $type,
+			]
+		);
+
+		$this->assertInstanceOf( 'WP_Rest_Response', $wp_rest_response );
+	}
+
+	/**
+	 * Data provider for test_execute_import_aioseo_posts.
+	 *
+	 * @return array
+	 */
+	public function all_routes() {
+		return [
+			[
+				'aioseo',
+				'posts',
+			],
+		];
+	}
+
+	/**
+	 * Tests whether a WP_Error object is returned on a non-existing rount.
+	 *
+	 * @covers ::execute
+	 */
+	public function test_execute_non_existent_route() {
+		$response = $this->instance->execute(
+			[
+				'plugin' => 'non',
+				'type'   => 'existent',
+			]
+		);
+
+		$this->assertEquals( false, $response );
+	}
+}

--- a/tests/unit/routes/importing-route-test.php
+++ b/tests/unit/routes/importing-route-test.php
@@ -3,13 +3,11 @@
 namespace Yoast\WP\SEO\Tests\Unit\Routes;
 
 use Brain\Monkey;
-use Exception;
 use Mockery;
-use PHPUnit_Framework_Exception;
-use PHPUnit_Framework_ExpectationFailedException;
-use WP_REST_Response;
+use Yoast\WP\SEO\Actions\Importing\Aioseo_Posts_Importing_Action;
 use Yoast\WP\SEO\Routes\Importing_Route;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Actions\Importing\Importing_Action_Interface;
 
 /**
  * Class Importing_Route_Test.
@@ -24,7 +22,7 @@ class Importing_Route_Test extends TestCase {
 	/**
 	 * Represents the instance to test.
 	 *
-	 * @var Indexing_Route
+	 * @var Importing_Route
 	 */
 	protected $instance;
 
@@ -34,7 +32,32 @@ class Importing_Route_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->instance = new Importing_Route();
+		Mockery::mock( '\WP_Error' );
+
+		$importers = [
+			$this->mockImporter( Aioseo_Posts_Importing_Action::class, 'aioseo', 'posts' ),
+		];
+
+		$this->instance = new Importing_Route( ...$importers );
+	}
+
+	/**
+	 * Creates a mock importing action.
+	 * 
+	 * @param string $class  The class.
+	 * @param string $plugin The plugin.
+	 * @param string $type   The type.
+	 *
+	 * @return Importing_Action_Interface The indexing action.
+	 */
+	private function mockImporter( $class, $plugin, $type ) {
+		$importing_action = Mockery::mock( $class )
+			->shouldAllowMockingProtectedMethods();
+
+		$importing_action->allows( 'get_plugin' )->andReturn( $plugin );
+		$importing_action->allows( 'get_type' )->andReturn( $type );
+
+		return $importing_action;
 	}
 
 	/**
@@ -108,6 +131,6 @@ class Importing_Route_Test extends TestCase {
 			]
 		);
 
-		$this->assertEquals( false, $response );
+		$this->assertInstanceOf( 'WP_Error', $response );
 	}
 }

--- a/tests/unit/routes/importing-route-test.php
+++ b/tests/unit/routes/importing-route-test.php
@@ -50,7 +50,7 @@ class Importing_Route_Test extends TestCase {
 
 	/**
 	 * Creates a mock importing action.
-	 * 
+	 *
 	 * @param string $class  The class.
 	 * @param string $plugin The plugin.
 	 * @param string $type   The type.
@@ -103,7 +103,7 @@ class Importing_Route_Test extends TestCase {
 		$importer = array_values( $this->importers )[0];
 		$importer->expects( 'index' )
 			->once()
-			->andReturn( [ "test" ] );
+			->andReturn( [ 'test' ] );
 
 		$wp_rest_response = $this->instance->execute(
 			[

--- a/tests/unit/routes/importing-route-test.php
+++ b/tests/unit/routes/importing-route-test.php
@@ -27,6 +27,13 @@ class Importing_Route_Test extends TestCase {
 	protected $instance;
 
 	/**
+	 * Represents the importers to use.
+	 *
+	 * @var Importing_Action_Interface
+	 */
+	protected $importers;
+
+	/**
 	 * Sets up the tests.
 	 */
 	protected function set_up() {
@@ -34,11 +41,11 @@ class Importing_Route_Test extends TestCase {
 
 		Mockery::mock( '\WP_Error' );
 
-		$importers = [
+		$this->importers = [
 			$this->mockImporter( Aioseo_Posts_Importing_Action::class, 'aioseo', 'posts' ),
 		];
 
-		$this->instance = new Importing_Route( ...$importers );
+		$this->instance = new Importing_Route( ...$this->importers );
 	}
 
 	/**
@@ -89,10 +96,14 @@ class Importing_Route_Test extends TestCase {
 	 * @dataProvider all_routes
 	 *
 	 * @covers ::execute
-	 * @covers ::import_aioseo_posts
 	 */
 	public function test_execute_import_aioseo_posts( $plugin, $type ) {
 		Mockery::mock( 'overload:WP_REST_Response' );
+
+		$importer = array_values( $this->importers )[0];
+		$importer->expects( 'index' )
+			->once()
+			->andReturn( [ "test" ] );
 
 		$wp_rest_response = $this->instance->execute(
 			[


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an abstract import route, that can be expanded with new routes in the near future.

## Relevant technical choices:

The code calls the `yoast/v1/import/aioseo/posts` wp rest api end-point. Each API call to `yoast/v1/import` shoud refer to a class that extends the Importing interface. 
Each import function should return an object with an `objects` property and a `next_url` property. The `next_url` property is used to determine whether the next endpoint should be called when the current endpoint is finished importing all entities.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you are logged in as an admin.
* On the WordPress dashboard page run the following code in the JS command-line:
```js
( async function() {
    const a = await fetch( "/wp-json/yoast/v1/import/aioseo/posts" ,
        {
            method: "POST",
            headers: { "X-WP-Nonce": wpApiSettings.nonce }
        }
    );
    console.log( await a.json() );
} )();
```
* You should get the following response:
```json
{
    "objects": [ ...indexables ],
    "next_url": "/import/aioseo/posts" or `false`
}
```
`objects` is a list of indexables created for aioseo posts.
`next_url` should be a string (if there are more than 1 posts left to be imported or `false` if no posts are left to be imported.
* Create 26 posts with aioseo active and Yoast SEO inactive (no other pages or custom post types should exist).
* Activate Yoast SEO and deactivate AIOSEO
* Run the code snippet above. You should get the following response:
```json
{
    "objects": [ 25 indexable objects ],
    "next_url": "/import/aioseo/posts"
}
```
* Run the code snippet above. You should get the following response:
```json
{
    "objects": [ 1 indexable object ],
    "next_url": "/import/aioseo/posts"
}
```
* Run the code snippet above. You should get the following response:
```json
{
    "objects": [],
    "next_url": false
}
```

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The PR edits the abstract class for indexation routes a bit, so some regression testing on the SEO Optimization process is advisable.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
