### PR TITLE
DUPP-19 Create WorkoutUpsell modal

### DIFF
--- a/css/src/workouts.css
+++ b/css/src/workouts.css
@@ -198,3 +198,127 @@ table.yoast_help th.divider {
 .yoast__redirect-suggestions {
 	line-height: 2;
 }
+
+/* Duplicated from style.css?ver=5.8.1 (from the block editor) in order to apply styling to the WorkoutUpsell modal. */
+.components-modal__screen-overlay {
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	background-color: rgba(0, 0, 0, 0.35);
+	z-index: 100000;
+	animation: edit-post__fade-in-animation 0.2s ease-out 0s;
+	animation-fill-mode: forwards;
+}
+@media (prefers-reduced-motion: reduce) {
+	.components-modal__screen-overlay {
+		animation-duration: 1ms;
+		animation-delay: 0s;
+	}
+}
+
+.components-modal__frame {
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	box-sizing: border-box;
+	margin: 0;
+	background: #fff;
+	box-shadow: 0 10px 10px rgba(0, 0, 0, 0.25);
+	border-radius: 2px;
+	overflow: auto;
+}
+@media (min-width: 600px) {
+	.components-modal__frame {
+		top: 50%;
+		right: auto;
+		bottom: auto;
+		left: 50%;
+		min-width: 360px;
+		max-width: calc(100% - 16px - 16px);
+		max-height: 90%;
+		transform: translate(-50%, -50%);
+		animation: components-modal__appear-animation 0.1s ease-out;
+		animation-fill-mode: forwards;
+	}
+}
+@media (min-width: 600px) and (prefers-reduced-motion: reduce) {
+	.components-modal__frame {
+		animation-duration: 1ms;
+		animation-delay: 0s;
+	}
+}
+
+@keyframes components-modal__appear-animation {
+	from {
+		margin-top: 32px;
+	}
+	to {
+		margin-top: 0;
+	}
+}
+.components-modal__header {
+	box-sizing: border-box;
+	border-bottom: 1px solid #ddd;
+	padding: 0 32px;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	background: #fff;
+	align-items: center;
+	height: 60px;
+	z-index: 10;
+	position: relative;
+	position: sticky;
+	top: 0;
+	margin: 0 -32px 24px;
+}
+@supports (-ms-ime-align: auto) {
+	.components-modal__header {
+		position: fixed;
+		width: 100%;
+	}
+}
+.components-modal__header .components-modal__header-heading {
+	font-size: 1rem;
+	font-weight: 600;
+}
+.components-modal__header h1 {
+	line-height: 1;
+	margin: 0;
+}
+.components-modal__header .components-button {
+	position: relative;
+	left: 8px;
+}
+
+.components-modal__header-heading-container {
+	align-items: center;
+	flex-grow: 1;
+	display: flex;
+	flex-direction: row;
+	justify-content: left;
+}
+
+.components-modal__header-icon-container {
+	display: inline-block;
+}
+.components-modal__header-icon-container svg {
+	max-width: 36px;
+	max-height: 36px;
+	padding: 8px;
+}
+
+.components-modal__content {
+	box-sizing: border-box;
+	height: 100%;
+	padding: 0 32px 24px;
+}
+@supports (-ms-ime-align: auto) {
+	.components-modal__content {
+		padding-top: 60px;
+	}
+}

--- a/packages/js/src/workouts/components/WorkoutUpsell.js
+++ b/packages/js/src/workouts/components/WorkoutUpsell.js
@@ -1,0 +1,72 @@
+// External dependencies.
+import PropTypes from "prop-types";
+import { Modal } from "@wordpress/components";
+import { __, sprintf } from "@wordpress/i18n";
+
+// Yoast dependencies.
+import { makeOutboundLink } from "@yoast/helpers";
+
+/**
+ * The WorkoutUpsell component
+ *
+ * @param {object} props The props object.
+ *
+ * @returns {object} The WorkoutUpsell component.
+ */
+const WorkoutUpsell = ( props ) => {
+	const {
+		title,
+		upsellLink,
+		addOn,
+		additionalClassNames,
+		onRequestClose,
+		...wpModalProps
+	} = props;
+
+	const Link = makeOutboundLink();
+
+	return (
+		<Modal
+			title={ title }
+			className={ additionalClassNames }
+			onRequestClose={ onRequestClose }
+			{ ...wpModalProps }
+		>
+			<div className="yoast-content-container">
+				<div className="yoast-modal-content">
+					{ props.children }
+				</div>
+			</div>
+			<div className="yoast-notice-container">
+				<hr />
+				<div className="yoast-button-container">
+					<Link href={ upsellLink } className="yoast-button-upsell">
+						{
+							sprintf(
+								/* translators: %s : Expands to the add-on name. */
+								__( "Buy %s", "wordpress-seo" ),
+								addOn
+							)
+						}
+					</Link>
+				</div>
+			</div>
+		</Modal>
+	);
+};
+
+WorkoutUpsell.propTypes = {
+	title: PropTypes.string.isRequired,
+	upsellLink: PropTypes.string.isRequired,
+	addOn: PropTypes.string.isRequired,
+	onRequestClose: PropTypes.func.isRequired,
+	additionalClassNames: PropTypes.string,
+	children: PropTypes.oneOfType( [ PropTypes.node, PropTypes.arrayOf( PropTypes.node ) ] ),
+};
+
+WorkoutUpsell.defaultProps = {
+	additionalClassNames: "",
+	children: null,
+};
+
+export default WorkoutUpsell;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* We want to add an upsell to some of the Workouts in Free when Premium is not active.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a WorkoutUpsell modal component.

## Relevant technical choices:

* I have not completely fixed the styling, since we still need to wait for a final design so I did not want to waste too much time. 
* I have kept the implementation of the modal similar to the editorModal, this can always be changed if needed for the design.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Checkout this branch.
* In `WorkoutsPage.js` add the following:
  Just before the `return (` (line 81) add:
  ```js
  const [ isOpen, setOpen ] = useState( false );
  const openModal = () => setOpen( true );
  const closeModal = () => setOpen( false );
  ```
  And on line 117-119 replace:
  ```js
  <span>
	  <WorkoutButton workout={ WORKOUTS.orphaned } />
  </span>
  ```
  with (alter any of the props as you desire):
  ```js
  <span>
	  <Button onClick={ openModal }>Start Workout!</Button>
	  { isOpen && (
		  <WorkoutUpsell
			  upsellLink="https://yoast.com/"
			  addOn="Yoast SEO Premium"
			  title="This is my modal"
			  onRequestClose={ closeModal }
		  >
			  <p>Some content bla di bla.</p>
		  </WorkoutUpsell>
	  ) }
  </span>
  ```
* Build the branch.
* In the backend, make sure you have disabled Premium.
* Navigate to SEO > Workouts.
* When you click on `Start Workout` for the Cornerstone approach, you should see an upsell modal (see image below).
  <img width="329" alt="Screenshot 2021-10-21 at 08 56 00" src="https://user-images.githubusercontent.com/43582255/138227285-6911e597-cb94-4dd6-8b0b-e560e699b79d.png">




### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A can be tested when the upsell has been added to the Workout Cards.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
