### PR TITLE
Composer: allow installation on PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"source": "https://github.com/Yoast/wordpress-seo"
 	},
 	"require": {
-		"php": "^5.6.20||^7.0",
+		"php": "^5.6.20 || ^7.0 || ^8.0",
 		"composer/installers": "^1.9.0",
 		"yoast/i18n-module": "^3.1.1"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b8e67e779aadb838335f8110a6e72f6",
+    "content-hash": "cb5484f7e8974e4e70b2ebf89c1add85",
     "packages": [
         {
             "name": "composer/installers",
@@ -863,7 +863,7 @@
                 "shasum": ""
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "@stable",
+                "friendsofphp/php-cs-fixer": "dev-master",
                 "nikic/php-parser": "@stable",
                 "php": "^8.0",
                 "phpdocumentor/reflection-docblock": "@stable",
@@ -4152,7 +4152,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6.20||^7.0"
+        "php": "^5.6.20 || ^7.0 || ^8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.1.0"


### PR DESCRIPTION
## Context

* Simplify CI for add-on plugins

## Summary

This PR can be summarized in the following changelog entry:

* The plugin will no longer block installation on PHP 8.0+ when installed via Composer.

## Relevant technical choices:

With the previous version constraints, the YoastSEO plugin would be blocked from being installed on PHP 8, unless `--ignore-platform-req=php` would be added.

I propose changing this for the following reasons:
* While there may still be PHP 8.x issues to be found/fixed, without running on PHP 8, it will be more difficult to find those.
* As YoastSEO is a (Composer `dev`) dependency for the add-on plugins, not allowing installation on PHP 8 is an unnecessary complicating factor for the CI for those add-on plugins.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Try running `composer install` on PHP 8.0/8.1 for the YoastSEO News plugin.
    It will fail with a message saying that `yoast/wordpress-seo` does not meet the version constraints (and similar messages about PHPUnit).
* Next, switch `"yoast/wordpress-seo": "dev-trunk"` in the `composer.json` for the News plugin to `"yoast/wordpress-seo": "dev-JRF/QA/composer-allow-install-on-php-8"`.
* Try running `composer install` on PHP 8.0/8.1 for the YoastSEO News plugin again.
    The "version constraint not met" messages reqarding `yoast/wordpress-seo` should no longer show. (the messages regarding PHPUnit still will)

