### PR TITLE
PHP 8.1: fix "missing return type" deprecation warnings

### DIFF
--- a/lib/model.php
+++ b/lib/model.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Lib;
 
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * Make Model compatible with WordPress.
@@ -557,6 +558,7 @@ class Model implements JsonSerializable {
 	 *
 	 * @return array The data of this object.
 	 */
+	#[ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return $this->orm->as_array();
 	}

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\Lib;
 
 use wpdb;
+use ReturnTypeWillChange;
 use Yoast\WP\SEO\Config\Migration_Status;
 
 /**
@@ -2454,6 +2455,7 @@ class ORM implements \ArrayAccess {
 	 *
 	 * @return bool Whether the data has the key.
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetExists( $key ) {
 		return \array_key_exists( $key, $this->data );
 	}
@@ -2465,6 +2467,7 @@ class ORM implements \ArrayAccess {
 	 *
 	 * @return array|mixed|null The value.
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetGet( $key ) {
 		return $this->get( $key );
 	}
@@ -2475,6 +2478,7 @@ class ORM implements \ArrayAccess {
 	 * @param string|int $key   Key.
 	 * @param mixed      $value Value.
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetSet( $key, $value ) {
 		if ( \is_null( $key ) ) {
 			return;
@@ -2487,6 +2491,7 @@ class ORM implements \ArrayAccess {
 	 *
 	 * @param mixed $key Key.
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetUnset( $key ) {
 		unset( $this->data[ $key ] );
 		unset( $this->dirty_fields[ $key ] );


### PR DESCRIPTION
## Context

* Preparation for PHP 8.1 compatibility.

## Summary

This PR can be summarized in the following changelog entry:

* prevents many deprecation warnings in preparation for PHP 8.1 compatibility. Thanks @jrfnl ! 

## Relevant technical choices:

As of PHP 8.1, PHP will start throwing deprecation warnings along the lines of:
```
Deprecated:  Return type of [CLASS]::[METHOD]() should either be compatible with [PHP NATIVE INTERFACE]::[METHOD](): [TYPE], or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

These type of deprecation notices relate to the [Return types for internal methods RFC](https://wiki.php.net/rfc/internal_method_return_types) in PHP 8.1.

Basically, as of PHP 8.1, these methods in classes which implement PHP native interfaces are expected to have a return type declared.
The return type can be the same as used in PHP itself or a more specific type. This complies with the Liskov principle of covariance, which allows the return type of a child overloaded method to be more specific than that of the parent.

As this plugin still has a minimum PHP requirement of PHP 5.6 based on the `composer.json` file, the return type (PHP 7.0 feature) can not be added, so I've added the attribute instead.

While attributes are a PHP 8.0 feature only, due to the syntax choice for `#[]`, they will ignored in PHP < 8 and can be safely added.


## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Jump through hoops to get the tests running on PHP 8.1, run them against `trunk` and see the deprecation notices.
* Switch to this branch and take note that _these_ deprecation notices no longer show, 

**_In all reality - I suggest not testing this and trusting me for having tested this as getting the tests running on PHP 8.1 is not that straight-forward at this time, what with some of the test tooling not being fully ready yet either._**