### PR TITLE
Revert "Remove pipe and tilde separators"

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -73,7 +73,6 @@ class WPSEO_Upgrade {
 			'15.9.1-RC0' => 'upgrade_1591',
 			'16.2-RC0'   => 'upgrade_162',
 			'16.5-RC0'   => 'upgrade_165',
-			'17.1-RC0'   => 'upgrade_171',
 			'17.2-RC0'   => 'upgrade_172',
 		];
 
@@ -842,18 +841,6 @@ class WPSEO_Upgrade {
 
 		if ( ! \wp_next_scheduled( \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK ) ) {
 			\wp_schedule_single_event( ( time() + ( MINUTE_IN_SECONDS * 5 ) ), \Yoast\WP\SEO\Integrations\Cleanup_Integration::START_HOOK );
-		}
-	}
-
-	/**
-	 * Performs the 17.1 upgrade. Removes the pipe and tilde separators and replaces them with the dash separator.
-	 *
-	 * @return void
-	 */
-	private function upgrade_171() {
-		$separator = WPSEO_Options::get( 'separator' );
-		if ( $separator === 'sc-pipe' || $separator === 'sc-tilde' ) {
-			WPSEO_Options::set( 'separator', 'sc-dash' );
 		}
 	}
 

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -980,6 +980,14 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				'option' => '&#8902;',
 				'label'  => __( 'Low asterisk', 'wordpress-seo' ),
 			],
+			'sc-pipe'   => [
+				'option' => '|',
+				'label'  => __( 'Vertical bar', 'wordpress-seo' ),
+			],
+			'sc-tilde'  => [
+				'option' => '~',
+				'label'  => __( 'Small tilde', 'wordpress-seo' ),
+			],
 			'sc-laquo'  => [
 				'option' => '&laquo;',
 				'label'  => __( 'Left angle quotation mark', 'wordpress-seo' ),


### PR DESCRIPTION
This reverts commit b6ab94335015c2ed5bce501cb1509e0a7e7d1c0b.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Reverts the removal of the `|` and `~` separators.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Restores the `|` and `~` separators.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* You should be able to select the `|` and `~` separators again.
* If updating from 17.0 to this version and you have one of the above separators they should not be changed.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The separator.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
