### PR TITLE
P2 1380 detect importable plugins

### DIFF
--- a/src/actions/importing/abstract-importing-action.php
+++ b/src/actions/importing/abstract-importing-action.php
@@ -8,7 +8,7 @@ use Yoast\WP\SEO\Actions\Indexing\Limited_Indexing_Action_Interface;
 /**
  * Importing action interface.
  */
-abstract class Abstract_Importing_Action implements Indexation_Action_Interface, Limited_Indexing_Action_Interface {
+abstract class Abstract_Importing_Action implements Importing_Action_Interface {
 
 	/**
 	 * The plugin the class deals with.
@@ -23,6 +23,25 @@ abstract class Abstract_Importing_Action implements Indexation_Action_Interface,
 	 * @var string
 	 */
 	const TYPE = null;
+
+	/**
+	 * The name of the plugin we import from.
+	 *
+	 * @return string The plugin we import from.
+	 */
+	public function get_plugin()
+	{
+		return self::PLUGIN;
+	}
+
+	/**
+	 * The data type we import from the plugin.
+	 *
+	 * @return string The data type we import from the plugin.
+	 */
+	public function get_type() {
+		return self::TYPE;
+	}
 
 	/**
 	 * Gets the cursor id.

--- a/src/actions/importing/importing-action-interface.php
+++ b/src/actions/importing/importing-action-interface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Yoast\WP\SEO\Actions\Importing;
+
+use Yoast\WP\SEO\Actions\Indexing\Indexation_Action_Interface;
+use Yoast\WP\SEO\Actions\Indexing\Limited_Indexing_Action_Interface;
+
+interface Importing_Action_Interface extends Indexation_Action_Interface, Limited_Indexing_Action_Interface {
+
+	/**
+	 * Returns the name of the plugin we import from.
+	 *
+	 * @return string The plugin name.
+	 */
+	function get_plugin();
+
+	/**
+	 * Returns the type of data we import.
+	 *
+	 * @return string The type of data.
+	 */
+	function get_type();
+}

--- a/src/services/importing/import-action-filter-trait.php
+++ b/src/services/importing/import-action-filter-trait.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Services\Importing;
 
+use Yoast\WP\SEO\Actions\Importing\Importing_Action_Interface;
+
 /**
  * Trait for filtering a set of importer actions based on plugin and type.
  *
@@ -12,9 +14,9 @@ trait Importer_Action_Filter_Trait {
 	/**
 	 * Filters all import actions from a list that do not match the given Plugin or Type.
 	 *
-	 * @param $all_actions Import_Action The complete list of actions.
-	 * @param $plugin      string        The Plugin name whose actions to keep.
-	 * @param $type        string        The type of actions to keep.
+	 * @param $all_actions Importing_Action_Interface[] The complete list of actions.
+	 * @param $plugin      string                       The Plugin name whose actions to keep.
+	 * @param $type        string                       The type of actions to keep.
 	 *
 	 * @return array
 	 */

--- a/src/services/importing/importer-detector.php
+++ b/src/services/importing/importer-detector.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Services\Importing;
 
+use Yoast\WP\SEO\Actions\Importing\Importing_Action_Interface;
+
 /**
  * Detects if any data from other SEO plugins is available for importing.
  */
@@ -12,19 +14,19 @@ class Importable_Detector {
 	/**
 	 * All known import actions
 	 *
-	 * @var array
+	 * @var array|Importing_Action_Interface[]
 	 */
-	protected Indexable_Import_Action[] $importers;
+	protected $importers;
 
 	public function __construct(
-		Indexable_Import_Action ...$importers
+		Importing_Action_Interface ...$importers
 	)
 	{
 		$this->importers = $importers;
 	}
 
 	public function detect( $plugin = null, $type = null ) {
-		$detectors = filter_actions( $this->importers, $plugin, $type );
+		$detectors = $this->filter_actions( $this->importers, $plugin, $type );
 
 		$detected = [];
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds automatic detection of importable SEO data.

## Relevant technical choices:

* added a filter trait that can be reused in many more places.
* added an interface to the abstract importer action so that we can use the splat constructor to inject all implementations at once.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
