### PR TITLE
Make sure we allow for article schema on pages and any post type supporting `author`

### DIFF
--- a/admin/views/tabs/metas/paper-content/post_type/post-type.php
+++ b/admin/views/tabs/metas/paper-content/post_type/post-type.php
@@ -56,7 +56,7 @@ $article_helper             = new Article_Helper();
 $schema_page_type_option    = 'schema-page-type-' . $wpseo_post_type->name;
 $schema_article_type_option = 'schema-article-type-' . $wpseo_post_type->name;
 $yform->hidden( $schema_page_type_option );
-if ( $article_helper->is_article_post_type( $wpseo_post_type->name ) && $article_helper->is_author_supported( $wpseo_post_type->name ) ) {
+if ( $article_helper->is_article_post_type( $wpseo_post_type->name ) ) {
 	$schema_article_type_option_value = WPSEO_Options::get( $schema_article_type_option );
 
 	/** This filter is documented in inc/options/class-wpseo-option-titles.php */

--- a/admin/views/tabs/metas/paper-content/post_type/post-type.php
+++ b/admin/views/tabs/metas/paper-content/post_type/post-type.php
@@ -56,7 +56,7 @@ $article_helper             = new Article_Helper();
 $schema_page_type_option    = 'schema-page-type-' . $wpseo_post_type->name;
 $schema_article_type_option = 'schema-article-type-' . $wpseo_post_type->name;
 $yform->hidden( $schema_page_type_option );
-if ( $wpseo_post_type->name !== 'page' && $article_helper->is_author_supported( $wpseo_post_type->name ) ) {
+if ( $article_helper->is_author_supported( $wpseo_post_type->name ) ) {
 	$schema_article_type_option_value = WPSEO_Options::get( $schema_article_type_option );
 
 	/** This filter is documented in inc/options/class-wpseo-option-titles.php */

--- a/admin/views/tabs/metas/paper-content/post_type/post-type.php
+++ b/admin/views/tabs/metas/paper-content/post_type/post-type.php
@@ -56,7 +56,7 @@ $article_helper             = new Article_Helper();
 $schema_page_type_option    = 'schema-page-type-' . $wpseo_post_type->name;
 $schema_article_type_option = 'schema-article-type-' . $wpseo_post_type->name;
 $yform->hidden( $schema_page_type_option );
-if ( $article_helper->is_author_supported( $wpseo_post_type->name ) ) {
+if ( $article_helper->is_article_post_type( $wpseo_post_type->name ) && $article_helper->is_author_supported( $wpseo_post_type->name ) ) {
 	$schema_article_type_option_value = WPSEO_Options::get( $schema_article_type_option );
 
 	/** This filter is documented in inc/options/class-wpseo-option-titles.php */

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -392,7 +392,7 @@ class WPSEO_Meta {
 				$field_defs['schema_page_type']['default'] = WPSEO_Options::get( 'schema-page-type-' . $post_type );
 
 				$article_helper = new Article_Helper();
-				if ( $post_type !== 'page' && $article_helper->is_author_supported( $post_type ) ) {
+				if ( $article_helper->is_author_supported( $post_type ) ) {
 					$default_schema_article_type = WPSEO_Options::get( 'schema-article-type-' . $post_type );
 
 					/** This filter is documented in inc/options/class-wpseo-option-titles.php */

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -392,7 +392,7 @@ class WPSEO_Meta {
 				$field_defs['schema_page_type']['default'] = WPSEO_Options::get( 'schema-page-type-' . $post_type );
 
 				$article_helper = new Article_Helper();
-				if ( $article_helper->is_author_supported( $post_type ) ) {
+				if ( $article_helper->is_article_post_type( $post_type ) && $article_helper->is_author_supported( $post_type ) ) {
 					$default_schema_article_type = WPSEO_Options::get( 'schema-article-type-' . $post_type );
 
 					/** This filter is documented in inc/options/class-wpseo-option-titles.php */

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -392,7 +392,7 @@ class WPSEO_Meta {
 				$field_defs['schema_page_type']['default'] = WPSEO_Options::get( 'schema-page-type-' . $post_type );
 
 				$article_helper = new Article_Helper();
-				if ( $article_helper->is_article_post_type( $post_type ) && $article_helper->is_author_supported( $post_type ) ) {
+				if ( $article_helper->is_article_post_type( $post_type ) ) {
 					$default_schema_article_type = WPSEO_Options::get( 'schema-article-type-' . $post_type );
 
 					/** This filter is documented in inc/options/class-wpseo-option-titles.php */

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -289,7 +289,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				$enriched_defaults[ 'display-metabox-pt-' . $pt->name ]      = true;
 				$enriched_defaults[ 'post_types-' . $pt->name . '-maintax' ] = 0; // Select box.
 				$enriched_defaults[ 'schema-page-type-' . $pt->name ]        = 'WebPage';
-				$enriched_defaults[ 'schema-article-type-' . $pt->name ]     = ( YoastSEO()->helpers->schema->article->is_article_post_type( $pt->name ) ) ? 'Article' : 'None';
+				$enriched_defaults[ 'schema-article-type-' . $pt->name ]     = ( $pt->name === 'post' ) ? 'Article' : 'None';
 
 				if ( $pt->name !== 'attachment' ) {
 					$enriched_defaults[ 'social-title-' . $pt->name ]       = '%%title%%'; // Text field.

--- a/src/helpers/schema/article-helper.php
+++ b/src/helpers/schema/article-helper.php
@@ -22,11 +22,13 @@ class Article_Helper {
 		/**
 		 * Filter: 'wpseo_schema_article_post_types' - Allow changing for which post types we output Article schema.
 		 *
+		 * @deprecated 17.6 - Just enable support for authors for the desired post type.
+		 *
 		 * @api string[] $post_types The post types for which we output Article.
 		 */
-		$post_types = \apply_filters( 'wpseo_schema_article_post_types', [ 'post' ] );
+		\apply_filters_deprecated( 'wpseo_schema_article_post_types', [ 'post' ], 'WPSEO 17.6', '' );
 
-		return \in_array( $post_type, $post_types, true );
+		return $this->is_author_supported( $post_type );
 	}
 
 	/**

--- a/src/integrations/third-party/web-stories.php
+++ b/src/integrations/third-party/web-stories.php
@@ -52,7 +52,6 @@ class Web_Stories implements Integration_Interface {
 		\add_action( 'web_stories_enable_twitter_metadata', '__return_false' );
 
 		\add_action( 'web_stories_story_head', [ $this, 'web_stories_story_head' ], 1 );
-		\add_filter( 'wpseo_schema_article_post_types', [ $this, 'filter_schema_article_post_types' ] );
 		\add_filter( 'wpseo_schema_article_type', [ $this, 'filter_schema_article_type' ], 10, 2 );
 		\add_filter( 'wpseo_metadesc', [ $this, 'filter_meta_description' ], 10, 2 );
 	}
@@ -65,17 +64,6 @@ class Web_Stories implements Integration_Interface {
 	public function web_stories_story_head() {
 		\remove_action( 'web_stories_story_head', 'rel_canonical' );
 		\add_action( 'web_stories_story_head', [ $this->front_end, 'call_wpseo_head' ], 9 );
-	}
-
-	/**
-	 * Adds web story post type to list of which post types to output Article schema  for.
-	 *
-	 * @param string[] $post_types Array of post types.
-	 * @return string[] Array of post types.
-	 */
-	public function filter_schema_article_post_types( $post_types ) {
-		$post_types[] = 'web-story';
-		return $post_types;
 	}
 
 	/**

--- a/tests/unit/helpers/schema/article-helper-test.php
+++ b/tests/unit/helpers/schema/article-helper-test.php
@@ -36,8 +36,13 @@ class Article_Helper_Test extends TestCase {
 	 * Tests the happy path.
 	 *
 	 * @covers ::is_article_post_type
+	 * @covers ::is_author_supported
 	 */
 	public function test_is_article_post_type() {
+		Monkey\Functions\expect( 'post_type_supports' )
+			->with( 'post', 'author' )
+			->andReturnTrue();
+
 		$this->assertTrue( $this->instance->is_article_post_type( 'post' ) );
 	}
 
@@ -45,11 +50,16 @@ class Article_Helper_Test extends TestCase {
 	 * Tests the case where the post type is retrieved within the method.
 	 *
 	 * @covers ::is_article_post_type
+	 * @covers ::is_author_supported
 	 */
 	public function test_is_article_post_type_with_no_post_type_given() {
 		Monkey\Functions\expect( 'get_post_type' )
 			->once()
 			->andReturn( 'post' );
+
+		Monkey\Functions\expect( 'post_type_supports' )
+			->with( 'post', 'author' )
+			->andReturnTrue();
 
 		$this->assertTrue( $this->instance->is_article_post_type() );
 	}
@@ -58,8 +68,13 @@ class Article_Helper_Test extends TestCase {
 	 * Tests the case where false is given as argumennt.
 	 *
 	 * @covers ::is_article_post_type
+	 * @covers ::is_author_supported
 	 */
 	public function test_is_article_post_type_with_false_given_as_post_type() {
+		Monkey\Functions\expect( 'post_type_supports' )
+			->with( false, 'author' )
+			->andReturnFalse();
+
 		$this->assertFalse( $this->instance->is_article_post_type( false ) );
 	}
 
@@ -67,22 +82,13 @@ class Article_Helper_Test extends TestCase {
 	 * Tests the case where the post is not supported.
 	 *
 	 * @covers ::is_article_post_type
+	 * @covers ::is_author_supported
 	 */
 	public function test_is_article_post_type_with_post_type_not_supported() {
+		Monkey\Functions\expect( 'post_type_supports' )
+			->with( 'page', 'author' )
+			->andReturnFalse();
+
 		$this->assertFalse( $this->instance->is_article_post_type( 'page' ) );
-	}
-
-	/**
-	 * Tests the case where the post type is added by a filter.
-	 *
-	 * @covers ::is_article_post_type
-	 */
-	public function test_is_article_post_type_with_post_type_added_by_filter() {
-		Monkey\Filters\expectApplied( 'wpseo_schema_article_post_types' )
-			->once()
-			->with( [ 'post' ] )
-			->andReturn( [ 'post', 'page' ] );
-
-		$this->assertTrue( $this->instance->is_article_post_type( 'page' ) );
 	}
 }

--- a/tests/unit/integrations/third-party/web-stories-test.php
+++ b/tests/unit/integrations/third-party/web-stories-test.php
@@ -71,7 +71,6 @@ class Web_Stories_Test extends TestCase {
 		$this->assertNotFalse( \has_action( 'web_stories_enable_open_graph_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
 		$this->assertNotFalse( \has_action( 'web_stories_enable_twitter_metadata', '__return_false' ), 'The enable metadata filter is registered.' );
 		$this->assertNotFalse( \has_action( 'web_stories_story_head', [ $this->instance, 'web_stories_story_head' ] ), 'The web-story head action is not registered' );
-		$this->assertNotFalse( \has_filter( 'wpseo_schema_article_post_types', [ $this->instance, 'filter_schema_article_post_types' ] ), 'The filter schema article post types function is registered.' );
 		$this->assertNotFalse( \has_filter( 'wpseo_schema_article_type', [ $this->instance, 'filter_schema_article_type' ] ), 'The filter schema article type function is registered.' );
 		$this->assertNotFalse( \has_filter( 'wpseo_metadesc', [ $this->instance, 'filter_meta_description' ] ), 'The metadesc action is registered.' );
 	}
@@ -86,18 +85,6 @@ class Web_Stories_Test extends TestCase {
 
 		$this->assertFalse( \has_action( 'web_stories_story_head', 'rel_canonical' ), 'The rel canonical action is not registered' );
 		$this->assertNotFalse( \has_action( 'web_stories_story_head', [ $this->front_end, 'call_wpseo_head' ] ), 'The wpseo head action is registered.' );
-	}
-
-	/**
-	 * Tests filter schema article post types.
-	 *
-	 * @covers ::filter_schema_article_post_types
-	 */
-	public function test_filter_schema_article_post_types() {
-		Mockery::namedMock( '\Google\Web_Stories\Story_Post_Type', Story_Post_Type_Stub::class );
-
-		$actual = $this->instance->filter_schema_article_post_types( [ 'post' ] );
-		$this->assertEquals( [ 'post', 'web-story' ], $actual );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `page` post type wasn't allowed to display an `Article` piece in the Schema.
* Makes sure that the Schema Article type is enabled for any post type supporting authors.
* Deprecates `wpseo_schema_article_post_types` filter.

## Relevant technical choices:

* The default `Article` type is `Article` for posts, `None` (→ no `Article` piece is in the Schema output) for any other post type.

notes by @enricobattocchi:
* I decided to make `is_article_post_type()` synonym to `is_author_supported()`  to avoid major changes + adding deprecations to the API, and allow for an easy refactoring, should the requirements for an `Article` type change in the future.
* I've also removed an unnecessary use of the deprecated filter in our Web Stories integration.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* install and activate the Google Web Stories plugin
* visit `SEO` > `Search Appearance`, tab `Content types`
  * check that both under `Pages` and `Web Stories` you can see the `Article type` select, with `None` as default
  * set a new default type for both and save
* create a new Page
  * check that you can see the `Article` type in the Schema tab of the Yoast SEO Metabox and it's using the default
  * choose any type and publish
  * check the Schema in the frontend, it should display the right Article piece
* create a new Web Story and publish it
  * check the Schema in the frontend, it should display the right Article piece
* edit `functions.php` of your theme, add the following snippet and save:
```
function disable_author_for_pages() {
remove_post_type_support( 'page', 'author' );
}
add_action('init', 'disable_author_for_pages', 20);
```
* visit `Search Appearance` again
  * you should not see the `Article` type select for pages anymore
* visit the page you just created in the front-end
  * you shouldn't see any `Article` piece in the Schema anymore
* create a new Page
  * check that you can't see the `Article` type in the Schema tab of the Yoast SEO Metabox anymore

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Documentation

* [x] I have written documentation for this change.
* ⚠️ Please make sure to delete [this line](https://github.com/Yoast/developer-docs/blob/master/docs/features/schema/api.md?plain=1#L307) once this is released.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

