### PR TITLE
Add temporary badge to upsell

### DIFF
--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -7,6 +7,10 @@
 
 $wpseo_plugin_dir_url = plugin_dir_url( WPSEO_FILE );
 $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
+
+$time				  = time();
+$time_start			  = gmmktime( 11, 00, 00, 11, 25, 2021 );
+$time_end			  = gmmktime( 11, 00, 00, 11, 30, 2021 );
 ?>
 <div class="wpseo_content_cell" id="sidebar-container">
 	<div id="sidebar" class="yoast-sidebar">
@@ -37,7 +41,11 @@ $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 				<li><strong><?php esc_html_e( '24/7 email support', 'wordpress-seo' ); ?></strong></li>
 				<li><strong><?php esc_html_e( 'No ads!', 'wordpress-seo' ); ?></strong></li>
 			</ul>
-
+			<?php if ( ( $time > $time_start ) && ( $time < $time_end ) ) : ?>
+				<span class="yoast-badge yoast-badge--sale">
+					<?php _e( '30% off!', 'wordpress-seo' ) ?>
+				</span>
+			<?php endif ?>
 			<a id="wpseo-premium-button" class="yoast-button-upsell"
 				href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jj' ); ?>" target="_blank">
 				<?php

--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -9,8 +9,8 @@ $wpseo_plugin_dir_url = plugin_dir_url( WPSEO_FILE );
 $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 
 $time       = time();
-$time_start	= gmmktime( 11, 00, 00, 11, 25, 2021 );
-$time_end	= gmmktime( 11, 00, 00, 11, 30, 2021 );
+$time_start = gmmktime( 11, 00, 00, 11, 25, 2021 );
+$time_end   = gmmktime( 11, 00, 00, 11, 30, 2021 );
 ?>
 <div class="wpseo_content_cell" id="sidebar-container">
 	<div id="sidebar" class="yoast-sidebar">

--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -8,9 +8,9 @@
 $wpseo_plugin_dir_url = plugin_dir_url( WPSEO_FILE );
 $new_tab_message      = WPSEO_Admin_Utils::get_new_tab_message();
 
-$time				  = time();
-$time_start			  = gmmktime( 11, 00, 00, 11, 25, 2021 );
-$time_end			  = gmmktime( 11, 00, 00, 11, 30, 2021 );
+$time       = time();
+$time_start	= gmmktime( 11, 00, 00, 11, 25, 2021 );
+$time_end	= gmmktime( 11, 00, 00, 11, 30, 2021 );
 ?>
 <div class="wpseo_content_cell" id="sidebar-container">
 	<div id="sidebar" class="yoast-sidebar">
@@ -43,7 +43,7 @@ $time_end			  = gmmktime( 11, 00, 00, 11, 30, 2021 );
 			</ul>
 			<?php if ( ( $time > $time_start ) && ( $time < $time_end ) ) : ?>
 				<span class="yoast-badge yoast-badge--sale">
-					<?php _e( '30% off!', 'wordpress-seo' ) ?>
+					<?php esc_html_e( '30% off!', 'wordpress-seo' ); ?>
 				</span>
 			<?php endif ?>
 			<a id="wpseo-premium-button" class="yoast-button-upsell"

--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -45,7 +45,7 @@ $time_end	= gmmktime( 11, 00, 00, 11, 30, 2021 );
 				<span class="yoast-badge yoast-badge--sale">
 					<?php esc_html_e( '30% off!', 'wordpress-seo' ); ?>
 				</span>
-			<?php endif ?>
+			<?php endif; ?>
 			<a id="wpseo-premium-button" class="yoast-button-upsell"
 				href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jj' ); ?>" target="_blank">
 				<?php

--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -42,9 +42,7 @@ $time_end	= gmmktime( 11, 00, 00, 11, 30, 2021 );
 				<li><strong><?php esc_html_e( 'No ads!', 'wordpress-seo' ); ?></strong></li>
 			</ul>
 			<?php if ( ( $time > $time_start ) && ( $time < $time_end ) ) : ?>
-				<span class="yoast-badge yoast-badge--sale">
-					<?php esc_html_e( '30% off!', 'wordpress-seo' ); ?>
-				</span>
+				<span class="yoast-badge yoast-badge--sale"><?php esc_html_e( '30% off!', 'wordpress-seo' ); ?></span>
 			<?php endif; ?>
 			<a id="wpseo-premium-button" class="yoast-button-upsell"
 				href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jj' ); ?>" target="_blank">

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -599,12 +599,14 @@ body.folded .wpseo-admin-submit-fixed {
 }
 
 .yoast-badge--sale {
-  float: right;
-  margin-top: -16px;
-  margin-bottom: 10px;
-  transform: rotate( 20deg );
-  background-color: #a4286a;
-  color: white;
+	float: right;
+	margin-top: -16px;
+	margin-bottom: 10px;
+	transform: rotate(14deg);
+	background-color: #a4286a;
+	color: white;
+	font-size: 12px;
+	border-radius: 999px;
 }
 
 .yoast-badge__is-link:hover,

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -598,6 +598,23 @@ body.folded .wpseo-admin-submit-fixed {
 	font-size: 10px;
 }
 
+.yoast-badge--sale {
+  float: right;
+  margin-top: -16px;
+  margin-bottom: 10px;
+  transform: rotate( 20deg );
+  background-color: #a4286a;
+  color: white;
+}
+
+.yoast-badge__is-link:hover,
+.yoast-badge__is-link:focus {
+  background-color: #004973;
+  color: #fff;
+  outline: none;
+  box-shadow: none;
+}
+
 #wpadminbar .yoast-badge, .wp-submenu .yoast-badge {
 	min-height: 14px;
 	font-size: 9px;
@@ -616,14 +633,6 @@ body.folded .wpseo-admin-submit-fixed {
 
 .yoast-badge__is-link {
 	text-decoration: none;
-}
-
-.yoast-badge__is-link:hover,
-.yoast-badge__is-link:focus {
-	background-color: #004973;
-	color: #fff;
-	outline: none;
-	box-shadow: none;
 }
 
 .switch-container .yoast-badge {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to show a badge in our upsells at certain times.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a sale badge to the upsell on our main settings page, that is temporarily shown.

## Relevant technical choices:

* All times in UTC for certainty

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Either change the time of you php (dev) server, or change the date and time in the code
* _Please be aware that all times are in UTC / GMT, so you should add one hour for Western European time_
* When that time is within the set time window, there should be a badge visible on our main settings page / dashboard
* This badge should look like the design

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes P1-992