### PR TITLE
Avoid double-title elements when using a custom single-page block template

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -232,6 +232,7 @@ class Front_End_Integration implements Integration_Interface {
 		\remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head' );
 		\remove_action( 'wp_head', 'noindex', 1 );
 		\remove_action( 'wp_head', '_wp_render_title_tag', 1 );
+		\remove_action( 'wp_head', '_block_template_render_title_tag', 1 );
 		\remove_action( 'wp_head', 'gutenberg_render_title_tag', 1 );
 	}
 


### PR DESCRIPTION
## Context
Backports changes from https://github.com/WordPress/gutenberg/pull/36133

## Summary

Removes the `_block_template_render_title_tag` hook 

## Test instructions

Steps to reproduce the issue available on https://github.com/WordPress/gutenberg/issues/34106

### Test instructions for QA when the code is in the RC

QA can test this PR by following these steps:

* Create a new page. Add some content and save.
* On the sidebar of the post, select to create a new template for the post. 
* Save the template
* Visit the frontend and check the page source

There should only be a single `<title>` element in the `<head>` of the document. Needs to be tested both with Gutenberg active, and inactive.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
