### PR TITLE
P1-1063 undo aspect ratio for non landscape social previews

### DIFF
--- a/packages/social-metadata-previews/src/facebook/FacebookImage.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookImage.js
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
+import { noop } from "lodash";
 
 /* Yoast dependencies */
 import { colors } from "@yoast/style-guide";
@@ -186,10 +187,10 @@ FacebookImage.propTypes = {
 FacebookImage.defaultProps = {
 	src: "",
 	alt: "",
-	onImageLoaded: () => {},
-	onImageClick: () => {},
-	onMouseEnter: () => {},
-	onMouseLeave: () => {},
+	onImageLoaded: noop,
+	onImageClick: noop,
+	onMouseEnter: noop,
+	onMouseLeave: noop,
 };
 
 export default FacebookImage;

--- a/packages/social-metadata-previews/src/facebook/FacebookImage.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookImage.js
@@ -166,6 +166,9 @@ class FacebookImage extends Component {
 					alt: this.props.alt,
 					aspectRatio: FACEBOOK_IMAGE_SIZES.aspectRatio,
 				} }
+				width={ imageProperties.width }
+				height={ imageProperties.height }
+				imageMode={ imageProperties.mode }
 			/>
 		</FacebookImageContainer>;
 	}

--- a/packages/social-metadata-previews/src/shared/SocialImage.js
+++ b/packages/social-metadata-previews/src/shared/SocialImage.js
@@ -1,5 +1,6 @@
-import React from "react";
 import PropTypes from "prop-types";
+import React from "react";
+import styled from "styled-components";
 
 // Adding && for specificity, competing styles coming from blockeditor.
 const StyledImage = styled.img`
@@ -19,7 +20,7 @@ const StyledImage = styled.img`
  *
  * @param {Object} props The component's props.
  *
- * @returns {SocialImage} The SocialImage component.
+ * @returns {JSX.Element} The SocialImage component.
  */
 export const SocialImage = ( props ) => {
 	const { imageProps, width, height, imageMode } = props;

--- a/packages/social-metadata-previews/src/shared/SocialImage.js
+++ b/packages/social-metadata-previews/src/shared/SocialImage.js
@@ -1,6 +1,19 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+// Adding && for specificity, competing styles coming from blockeditor.
+const StyledImage = styled.img`
+	&& {
+		max-width: ${ props => props.width }px;
+		height: ${ props => props.height }px;
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		max-width: none;
+	}
+`;
+
 /**
  * Renders the SocialImage.
  *
@@ -9,17 +22,25 @@ import PropTypes from "prop-types";
  * @returns {SocialImage} The SocialImage component.
  */
 export const SocialImage = ( props ) => {
-	const { imageProps } = props;
+	const { imageProps, width, height, imageMode } = props;
 
-	const imageStyle = {
-		background: `url(${ imageProps.src }) center / cover no-repeat`,
-		paddingBottom: `${ imageProps.aspectRatio }%`,
-	};
+	if ( imageMode === "landscape" ) {
+		return <div
+			style={ {
+				background: `url(${ imageProps.src }) center / cover no-repeat`,
+				paddingBottom: `${ imageProps.aspectRatio }%`,
+			} }
+			role="img"
+			aria-label={ imageProps.alt }
+		/>;
+	}
 
-	return <div
-		style={ imageStyle }
-		role="img"
-		aria-label={ imageProps.alt }
+	return <StyledImage
+		src={ imageProps.src }
+		alt={ imageProps.alt }
+		width={ width }
+		height={ height }
+		imageProperties={ imageProps }
 	/>;
 };
 
@@ -29,4 +50,11 @@ SocialImage.propTypes = {
 		alt: PropTypes.string.isRequired,
 		aspectRatio: PropTypes.number.isRequired,
 	} ).isRequired,
+	width: PropTypes.number.isRequired,
+	height: PropTypes.number.isRequired,
+	imageMode: PropTypes.string,
+};
+
+SocialImage.defaultProps = {
+	imageMode: "landscape",
 };

--- a/packages/social-metadata-previews/src/twitter/TwitterImage.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterImage.js
@@ -142,7 +142,7 @@ export default class TwitterImage extends React.Component {
 	 * the TwitterImageContainer.
 	 */
 	render() {
-		const { status } = this.state;
+		const { status, imageProperties } = this.state;
 
 		if ( status === "loading" || this.props.src === "" || status === "errored" ) {
 			return <PlaceholderImage
@@ -167,6 +167,9 @@ export default class TwitterImage extends React.Component {
 					alt: this.props.alt,
 					aspectRatio: TWITTER_IMAGE_SIZES.aspectRatio,
 				} }
+				width={ imageProperties.width }
+				height={ imageProperties.height }
+				imageMode={ imageProperties.mode }
 			/>
 		</TwitterImageContainer>;
 	}

--- a/packages/social-metadata-previews/src/twitter/TwitterImage.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterImage.js
@@ -3,6 +3,7 @@ import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
+import { noop } from "lodash";
 
 /* Internal dependencies */
 import { SocialImage } from "../shared/SocialImage";
@@ -187,7 +188,7 @@ TwitterImage.propTypes = {
 TwitterImage.defaultProps = {
 	src: "",
 	alt: "",
-	onMouseEnter: () => {},
-	onImageClick: () => {},
-	onMouseLeave: () => {},
+	onMouseEnter: noop,
+	onImageClick: noop,
+	onMouseLeave: noop,
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Applies the aspect ratio fix from https://github.com/Yoast/wordpress-seo/pull/17544 only when in landscape mode.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Developers: pre test setup

* Checkout this branch
* In your terminal cd into: `packages/social-metadata-previews/`
* Enter `yarn link`
* Open the `wordpress-seo-premium` repo
* Open the terminal and enter `yarn link "@yoast/social-metadata-previews"`
* Execute the grunt build command `grunt build:js`

#### Test instructions

* Change the Twitter card type to `Summary`: Yoast SEO -> Social -> Twitter
* Add/edit a post
* Open the Yoast SEO `social` tab
* Add a Facebook and Twitter image that has a bigger width than height
  * Verify the Facebook image looks the same as before (17.6-RC1): centered and proper aspect ratio
  * Verify the Twitter image now uses the full square, this should work like the previous release (17.5)
* Change the Twitter card type to `Summary with large image`: Yoast SEO -> Social -> Twitter
  * Verify the Twitter image looks the same as before (17.6-RC1): centered and proper aspect ratio
* Add a Facebook and Twitter image that has a bigger height than width
  * Verify the Facebook image now uses the full square, this should work like the previous release (17.5)
  * Verify the Twitter image looks the same as before (17.6-RC1): centered and proper aspect ratio
* Change the Twitter card type to `Summary`: Yoast SEO -> Social -> Twitter
  * Verify the Twitter image now uses the full square, this should work like the previous release (17.5)
* Add a Facebook and Twitter image that has the same width as height
  * Verify the Facebook image now uses the full square, this should work like the previous release (17.5)
  * Verify the Twitter image now uses the full square, this should work like the previous release (17.5)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Same as above, but skip the pre test setup.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/P1-1063
