### PR TITLE
Sale badge styling fixes

### DIFF
--- a/admin/views/sidebar.php
+++ b/admin/views/sidebar.php
@@ -41,9 +41,6 @@ $time_end   = gmmktime( 11, 00, 00, 11, 30, 2021 );
 				<li><strong><?php esc_html_e( '24/7 email support', 'wordpress-seo' ); ?></strong></li>
 				<li><strong><?php esc_html_e( 'No ads!', 'wordpress-seo' ); ?></strong></li>
 			</ul>
-			<?php if ( ( $time > $time_start ) && ( $time < $time_end ) ) : ?>
-				<span class="yoast-badge yoast-badge--sale"><?php esc_html_e( '30% off!', 'wordpress-seo' ); ?></span>
-			<?php endif; ?>
 			<a id="wpseo-premium-button" class="yoast-button-upsell"
 				href="<?php WPSEO_Shortlinker::show( 'https://yoa.st/jj' ); ?>" target="_blank">
 				<?php
@@ -53,7 +50,11 @@ $time_end   = gmmktime( 11, 00, 00, 11, 30, 2021 );
 				echo $new_tab_message;
 				echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 				?>
-			</a><br>
+			</a>
+			<?php if ( ( $time > $time_start ) && ( $time < $time_end ) ) : ?>
+				<span class="yoast-badge yoast-badge--sale"><?php esc_html_e( '30% off!', 'wordpress-seo' ); ?></span>
+			<?php endif; ?>
+			<br>
 		</div>
 		<div class="yoast-sidebar__section">
 			<h2>

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -599,14 +599,22 @@ body.folded .wpseo-admin-submit-fixed {
 }
 
 .yoast-badge--sale {
-	float: right;
-	margin-top: -16px;
-	margin-bottom: 10px;
+  position: absolute;
+	margin-top: -24px;
+	right: 30px;
 	transform: rotate(14deg);
 	background-color: #a4286a;
 	color: white;
-	font-size: 12px;
-	border-radius: 999px;
+	font-size: 12px !important;
+	border-radius: 999px !important;
+}
+
+@media(max-width: 1024px) {
+  .yoast-badge--sale {
+    display: inline-block;
+    position: unset;
+    vertical-align: top;
+  }
 }
 
 .yoast-badge__is-link:hover,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Font size was too small on some pages and it was too far away from the button in wide wrappers

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the sale badge wasn't styled and or positioned right on certain pages and screen sizes

## Relevant technical choices:

* Fixing it really nice was quite difficult, so just did a nasty piece of mediascript for now

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Please refer to the test instructions in the [original PR](https://github.com/Yoast/wordpress-seo/pull/17583)
* Confirm that on all pages where the badge is shown, the font size is the same
* Confirm that on tablet view, the badge is show besides the button, not on the right of the white wrapper 'box'


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes P1-1064