### PR TITLE
Fix duplicate indexables in step

### DIFF
--- a/packages/js/src/workouts/redux/container.js
+++ b/packages/js/src/workouts/redux/container.js
@@ -17,7 +17,7 @@ const purgeIndexables = function( workouts ) {
 	Object.keys( workouts ).forEach( function( workout ) {
 		Object.keys( workouts[ workout ].indexablesByStep ).forEach( function( step ) {
 			purgedWorkouts[ workout ].indexablesByStep[ step ] = purgedWorkouts[ workout ].indexablesByStep[ step ].filter( function( indexable ) {
-				return !! indexable.purge;
+				return ! indexable.purge;
 			} );
 		} );
 	} );

--- a/packages/js/src/workouts/redux/container.js
+++ b/packages/js/src/workouts/redux/container.js
@@ -17,7 +17,7 @@ const purgeIndexables = function( workouts ) {
 	Object.keys( workouts ).forEach( function( workout ) {
 		Object.keys( workouts[ workout ].indexablesByStep ).forEach( function( step ) {
 			purgedWorkouts[ workout ].indexablesByStep[ step ] = purgedWorkouts[ workout ].indexablesByStep[ step ].filter( function( indexable ) {
-				return typeof indexable.purge === "undefined";
+				return !! indexable.purge;
 			} );
 		} );
 	} );

--- a/packages/js/src/workouts/redux/reducer.js
+++ b/packages/js/src/workouts/redux/reducer.js
@@ -58,7 +58,7 @@ const workoutsReducer = ( state = initialState, action ) => {
 			newState.workouts[ action.payload.key ].priority = action.payload.priority;
 			return newState;
 		case FINISH_STEPS:
-			newState.workouts[ action.workout ].finishedSteps =  union( state.workouts[ action.workout ].finishedSteps, action.steps );
+			newState.workouts[ action.workout ].finishedSteps = union( state.workouts[ action.workout ].finishedSteps, action.steps );
 			return newState;
 		case TOGGLE_STEP:
 			if ( state.workouts[ action.workout ].finishedSteps.includes( action.step ) ) {
@@ -101,7 +101,16 @@ const workoutsReducer = ( state = initialState, action ) => {
 					newState.workouts[ action.workout ].indexablesByStep[ action.fromStep ][ oldLocation ].movedTo = action.toStep;
 				}
 				if ( action.toStep !== "" ) {
-					newState.workouts[ action.workout ].indexablesByStep[ action.toStep ].push( indexable );
+					const oldLocation = newState.workouts[ action.workout ].indexablesByStep[ action.toStep ].findIndex(
+						storedIndexable => storedIndexable.id === indexable.id
+					);
+					// If the indexable is not yet in the toStep, add it. Else, simply reactivate it.
+					if ( oldLocation === -1 ) {
+						newState.workouts[ action.workout ].indexablesByStep[ action.toStep ].push( indexable );
+					} else {
+						newState.workouts[ action.workout ].indexablesByStep[ action.toStep ][ oldLocation ].purge = false;
+						newState.workouts[ action.workout ].indexablesByStep[ action.toStep ][ oldLocation ].movedTo = "";
+					}
 				}
 			} );
 			return newState;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In the Cornerstone workout, it was possible to get the same indexable in the addLinks step multiple times, leading to weird looking UI and console errors (duplicate keys).
* Test together with https://github.com/Yoast/wordpress-seo-premium/pull/3495

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Fixes a bug where the same indexable could be added to the same workout step multiple times.

## Relevant technical choices:

* Replaced `typeof indexable.purge === "undefined"` by `! indexable.purge` in order to also be able to set `indexable.purge` to `false`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test together with premium https://github.com/Yoast/wordpress-seo-premium/pull/3495
* For all the below tests, note that if you refresh very quickly after moving/skipping/finishing indexables, they may not be removed as described, but instead stay present. Make sure that if you then refresh after some pause (sometimes after reapplying your move/finish/skip action), they do disappear. This behaviour is also present on `feature/free-workouts` (and `trunk`, which contains the workouts that have not been moved to free yet).
* Cornerstone workout
	* Select a few articles to be cornerstones if you haven't already.
	* Add at least one internal link to one of your posts.
	* Run indexation if you haven't already.
	* In step 2: For one of the cornerstones click `optimize`.
	* In step 3: Click `finish optimizing`. Note that in step 2, the `optimize` button becomes available again.
	* In step 2: Click `optimize` again, for the cornerstone you have in step 3.
	* Note that in step 3, the cornerstone can now be optimized again.
	* Before (on the feature branch), this would actually cause warnings in the console, and make the cornerstone appear in step 3 twice (or more).
	* Make sure that All posts in step 3 that have `You've finished adding links to this article.` disappear after a refresh.
* Orphaned workout.
	* Add some orphaned content to step 2 by clicking `improve`. Refresh and see that they are still there.
	* In step 2: Check the `is it up-to-date?` box for some. Note they move to Step 3, but stay in step 2 with the text "You've moved this article to the next step.". That stays until you refresh.
	* In step 3: Click "skip" for some. Note that they move to Step 4, but stay in Step 3 until you refresh. Then they should be gone from step 2, but not step 4.
	* In step 4: click Clear summary. The summary should disappear, and remain gone after a refresh.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-42
