### PR TITLE
Remove i18n argument when initializing taxonomy assessor

### DIFF
--- a/packages/js/src/initializers/term-scraper.js
+++ b/packages/js/src/initializers/term-scraper.js
@@ -351,7 +351,7 @@ export default function initTermScraper( $, store, editorData ) {
 		store.subscribe( handleStoreChange.bind( null, store, app.refresh ) );
 
 		if ( isKeywordAnalysisActive() ) {
-			app.seoAssessor = new TaxonomyAssessor( app.i18n, app.config.researcher );
+			app.seoAssessor = new TaxonomyAssessor( app.config.researcher );
 			app.seoAssessorPresenter.assessor = app.seoAssessor;
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the SEO and readability analyses wouldn't load on taxonomy pages.

## Relevant technical choices:

* In a [recent PR,](https://github.com/Yoast/wordpress-seo/pull/17526) jed was removed. Before that `i18n` used to be the first argument of all assessors. This was changed for all essors and also for (almost) all places wher the assessors were instantiated.
* In the current PR, I change once instance in which the taxonomy assessor was still called with the `i18n` object as the first parameter. When the assessors was instantiated like that, the fact that the parameters had changed on the taxonomy assessor class itself meant that it couldn't be correctly instantiated anymore.
* I didn't dive into it, but I think that the piece of code affected in this PR might actually be legacy code that's not really used anymore. Nonetheless, incorrectly instantiating the class caused the error.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
* To reproduce the initial bug:
  * Build the plugin on `trunk`.
  * Open a category page.
  * You will see that the analysis isn't loading and if you open your console you'll see an error message:
  <img width="651" alt="error message" src="https://user-images.githubusercontent.com/27805437/140519213-317f253c-5b11-429a-8b55-3a7ad97cf08f.png">
<img width="772" alt="analysis not loading" src="https://user-images.githubusercontent.com/27805437/140519217-07dc61e6-975f-4662-97a7-f49102b2b781.png">

* Testing the fix:
* Build the plugin with this branch.
  * Open a category page.
  * Confirm that both the SEO and the readability analysis load.
  * Confirm that the analysis updates when you change content.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.
For QA testing, you can test the `Testing the fix` part of the steps outlined above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:



## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1149
