### PR TITLE
Expand indexable on the meta surface

### DIFF
--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -6,6 +6,7 @@ use Exception;
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Integrations\Front_End_Integration;
+use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 use Yoast\WP\SEO\Presenters\Rel_Next_Presenter;
 use Yoast\WP\SEO\Presenters\Rel_Prev_Presenter;
@@ -21,6 +22,7 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
  * @property int         $company_logo_id                   The attachment ID for the company logo.
  * @property string      $description                       The meta description for the current page, if set.
  * @property int         $estimated_reading_time_minutes    The estimated reading time in minutes for posts.
+ * @property Indexable   $indexable							The indexable object.
  * @property string      $main_schema_id                    Schema ID that points to the main Schema thing on the page, usually the webpage or article Schema piece.
  * @property string      $meta_description                  The meta description for the current page, if set.
  * @property string      $open_graph_article_author         The article:author value.

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -22,7 +22,7 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
  * @property int         $company_logo_id                   The attachment ID for the company logo.
  * @property string      $description                       The meta description for the current page, if set.
  * @property int         $estimated_reading_time_minutes    The estimated reading time in minutes for posts.
- * @property Indexable   $indexable							The indexable object.
+ * @property Indexable   $indexable                         The indexable object.
  * @property string      $main_schema_id                    Schema ID that points to the main Schema thing on the page, usually the webpage or article Schema piece.
  * @property string      $meta_description                  The meta description for the current page, if set.
  * @property string      $open_graph_article_author         The article:author value.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This code is fully functional, because `indexable` exists on the `Meta_Tags_Context`, but isn't tab-completed by the IDE because the comment in this pull is missing:

```php
YoastSEO()->meta->for_current_page()->indexable->primary_focus_keyword
```

## Summary

This PR can be summarized in the following changelog entry:

* None needed.