### PR TITLE
Adapt getSubheadingTextLengths for Japanese

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/researches/getSubheadingTextLengthSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getSubheadingTextLengthSpec.js
@@ -1,29 +1,97 @@
 import subHeadingTextLength from "../../../src/languageProcessing/researches/getSubheadingTextLengths.js";
 import Paper from "../../../src/values/Paper.js";
+import JapaneseResearcher from "../../../src/languageProcessing/languages/ja/Researcher.js";
+import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher.js";
 
 describe( "gets the length of text segments", function() {
-	it( "returns an array with lengths for a text with one subheading", function() {
+	const englishResearcher = new EnglishResearcher();
+
+	it( "returns an array with text segments for a text with one subheading", function() {
 		const mockPaper = new Paper( "<h1>test</h1>one two three" );
-		expect( subHeadingTextLength( mockPaper )[ 0 ].wordCount ).toBe( 3 );
+		// Check the total number of text segments.
+		expect( subHeadingTextLength( mockPaper, englishResearcher ).length ).toBe( 1 );
+		// Check the content and length of each individual text segment.
+		expect( subHeadingTextLength( mockPaper, englishResearcher )[ 0 ].text ).toBe( "one two three" );
+		expect( subHeadingTextLength( mockPaper, englishResearcher )[ 0 ].countLength ).toBe( 3 );
 	} );
 
-	it( "returns an array with text length (1 value) for a text without subheadings", function() {
+	it( "returns an array with one text segment length for a text without subheadings", function() {
 		const mockPaper = new Paper( "one two three" );
-		expect( subHeadingTextLength( mockPaper ).length ).toBe( 1 );
+		// Check the total number of text segments.
+		expect( subHeadingTextLength( mockPaper, englishResearcher ).length ).toBe( 1 );
+		// Check the content and length of each individual text segment.
+		expect( subHeadingTextLength( mockPaper, englishResearcher )[ 0 ].text ).toBe( "one two three" );
+		expect( subHeadingTextLength( mockPaper, englishResearcher )[ 0 ].countLength ).toBe( 3 );
 	} );
 
 	it( "returns an array with 2 entries for a text with two subheadings and two text segments", function() {
 		const mockPaper = new Paper( "<h2>one</h2> two three<h3>four</h3>this is a text string with a number of words" );
-		expect( subHeadingTextLength( mockPaper )[ 0 ].wordCount ).toBe( 2 );
-		expect( subHeadingTextLength( mockPaper )[ 1 ].wordCount ).toBe( 10 );
-		expect( subHeadingTextLength( mockPaper ).length ).toBe( 2 );
+		// Check the total number of text segments.
+		expect( subHeadingTextLength( mockPaper, englishResearcher ).length ).toBe( 2 );
+		// Check the length of each individual text segment.
+		expect( subHeadingTextLength( mockPaper, englishResearcher )[ 0 ].text ).toBe( " two three" );
+		expect( subHeadingTextLength( mockPaper, englishResearcher )[ 0 ].countLength ).toBe( 2 );
+		expect( subHeadingTextLength( mockPaper, englishResearcher )[ 1 ].text ).toBe( "this is a text string with a number of words" );
+		expect( subHeadingTextLength( mockPaper, englishResearcher )[ 1 ].countLength ).toBe( 10 );
 	} );
 
 	it( "returns an array with 3 entries for a text with two subheadings, two text segments, and one introductory segment", function() {
 		const mockPaper = new Paper( "some text<h2>one</h2> two three<h3>four</h3>this is a text string with a number of words" );
-		expect( subHeadingTextLength( mockPaper )[ 0 ].wordCount ).toBe( 2 );
-		expect( subHeadingTextLength( mockPaper )[ 1 ].wordCount ).toBe( 2 );
-		expect( subHeadingTextLength( mockPaper )[ 2 ].wordCount ).toBe( 10 );
-		expect( subHeadingTextLength( mockPaper ).length ).toBe( 3 );
+		// Check the total number of text segments.
+		expect( subHeadingTextLength( mockPaper, englishResearcher ).length ).toBe( 3 );
+		// Check the length of each individual text segment.
+		expect( subHeadingTextLength( mockPaper, englishResearcher )[ 0 ].text ).toBe( "some text" );
+		expect( subHeadingTextLength( mockPaper, englishResearcher )[ 0 ].countLength ).toBe( 2 );
+		expect( subHeadingTextLength( mockPaper, englishResearcher )[ 1 ].text ).toBe( " two three" );
+		expect( subHeadingTextLength( mockPaper, englishResearcher )[ 1 ].countLength ).toBe( 2 );
+		expect( subHeadingTextLength( mockPaper, englishResearcher )[ 2 ].text ).toBe( "this is a text string with a number of words" );
+		expect( subHeadingTextLength( mockPaper, englishResearcher )[ 2 ].countLength ).toBe( 10 );
+	} );
+} );
+
+describe( "gets the length of text segments expressed in characters " +
+	"when there is a character count function helper available on the researcher", function() {
+	// The Japanese researcher has a charachterCount help function that overwrites the default word count help function.
+	const japaneseResearcher = new JapaneseResearcher();
+
+	it( "returns an array with lengths for a text with one subheading", function() {
+		const mockPaper = new Paper( "<h1>タイトル</h1>文章です。" );
+		// Check the total number of text segments.
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher ).length ).toBe( 1 );
+		// Check the content and length of each individual text segment.
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 0 ].text ).toBe( "文章です。" );
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 0 ].countLength ).toBe( 5 );
+	} );
+
+	it( "returns an array with one text segment for a text without subheadings", function() {
+		const mockPaper = new Paper( "文章です。" );
+		// Check the total number of text segments.
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher ).length ).toBe( 1 );
+		// Check the content and length of each individual text segment.
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 0 ].text ).toBe( "文章です。" );
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 0 ].countLength ).toBe( 5 );
+	} );
+
+	it( "returns an array with 2 text segments for a text with two subheadings and two text segments", function() {
+		const mockPaper = new Paper( "<h2>犬</h2>犬はかわいいです。<h3>子犬</h3>子犬が特にかわいいです。" );
+		// Check the total number of text segments.
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher ).length ).toBe( 2 );
+		// Check the content and length of each individual text segment.
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 0 ].text ).toBe( "犬はかわいいです。" );
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 0 ].countLength ).toBe( 9 );
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 1 ].text ).toBe( "子犬が特にかわいいです。" );
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 1 ].countLength ).toBe( 12 );
+	} );
+
+	it( "returns an array with 3 entries for a text with two subheadings, two text segments, and one introductory segment", function() {
+		const mockPaper = new Paper( "トピックは犬です。<h2>犬</h2>犬はかわいいです。<h3>子犬</h3>子犬が特にかわいいです。" );
+		// Check the total number of text segments.
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher ).length ).toBe( 3 );
+		// Check the length of each individual text segment.
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 0 ].text ).toBe( "トピックは犬です。" );
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 1 ].text ).toBe( "犬はかわいいです。" );
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 1 ].countLength ).toBe( 9 );
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 2 ].text ).toBe( "子犬が特にかわいいです。" );
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 2 ].countLength ).toBe( 12 );
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/researches/getSubheadingTextLengthSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getSubheadingTextLengthSpec.js
@@ -51,7 +51,7 @@ describe( "gets the length of text segments", function() {
 
 describe( "gets the length of text segments expressed in characters " +
 	"when there is a character count function helper available on the researcher", function() {
-	// The Japanese researcher has a charachterCount help function that overwrites the default word count help function.
+	// The Japanese researcher has a customCountLength help function that overwrites the default word count help function.
 	const japaneseResearcher = new JapaneseResearcher();
 
 	it( "returns an array with lengths for a text with one subheading", function() {

--- a/packages/yoastseo/spec/languageProcessing/researches/getSubheadingTextLengthSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getSubheadingTextLengthSpec.js
@@ -89,6 +89,7 @@ describe( "gets the length of text segments expressed in characters " +
 		expect( subHeadingTextLength( mockPaper, japaneseResearcher ).length ).toBe( 3 );
 		// Check the length of each individual text segment.
 		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 0 ].text ).toBe( "トピックは犬です。" );
+		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 0 ].countLength ).toBe( 9 );
 		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 1 ].text ).toBe( "犬はかわいいです。" );
 		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 1 ].countLength ).toBe( 9 );
 		expect( subHeadingTextLength( mockPaper, japaneseResearcher )[ 2 ].text ).toBe( "子犬が特にかわいいです。" );

--- a/packages/yoastseo/spec/scoring/assessments/readability/SubheadingDistributionTooLongAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SubheadingDistributionTooLongAssessmentSpec.js
@@ -14,7 +14,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 	it( "Scores a short text (<300 words), which does not have subheadings.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( shortText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 200 } ] )
+			Factory.buildMockResearcher( [ { text: "", countLength: 200 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
@@ -24,7 +24,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 	it( "Scores a short text (<300 words), which has subheadings.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( "a " + subheading + shortText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 1 }, { text: "", wordCount: 200 } ] )
+			Factory.buildMockResearcher( [ { text: "", countLength: 1 }, { text: "", countLength: 200 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: Great job!" );
@@ -33,7 +33,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 	it( "Scores a long text (>300 words), which does not have subheadings.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( longText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 330 } ] )
+			Factory.buildMockResearcher( [ { text: "", countLength: 330 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 2 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
@@ -44,7 +44,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 	it( "Scores a long text (>300 words), which has subheadings and all sections of the text are <300 words.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( shortText + subheading + shortText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 200 } ] )
+			Factory.buildMockResearcher( [ { text: "", countLength: 200 }, { text: "", countLength: 200 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: Great job!" );
@@ -54,7 +54,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 		"which is between 300 and 350 words long.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( shortText + subheading + longText + subheading + shortText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 330 }, { text: "", wordCount: 200 } ] )
+			Factory.buildMockResearcher( [ { text: "", countLength: 200 }, { text: "", countLength: 330 }, { text: "", countLength: 200 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
@@ -66,7 +66,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 		"which are between 300 and 350 words long.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( shortText + subheading + longText + subheading + longText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 330 }, { text: "", wordCount: 330 } ] )
+			Factory.buildMockResearcher( [ { text: "", countLength: 200 }, { text: "", countLength: 330 }, { text: "", countLength: 330 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
@@ -78,7 +78,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 		"which is above 350 words long.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( shortText + subheading + veryLongText + subheading + shortText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 360 }, { text: "", wordCount: 200 } ] )
+			Factory.buildMockResearcher( [ { text: "", countLength: 200 }, { text: "", countLength: 360 }, { text: "", countLength: 200 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
@@ -89,7 +89,7 @@ describe( "An assessment for scoring too long text fragments without a subheadin
 	it( "Scores a long text (>300 words), which has subheadings and some sections of the text are above 350 words long.", function() {
 		const assessment = subheadingDistributionTooLong.getResult(
 			new Paper( shortText + subheading + longText + subheading + longText ),
-			Factory.buildMockResearcher( [ { text: "", wordCount: 200 }, { text: "", wordCount: 360 }, { text: "", wordCount: 330 } ] )
+			Factory.buildMockResearcher( [ { text: "", countLength: 200 }, { text: "", countLength: 360 }, { text: "", countLength: 330 } ] )
 		);
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34x' target='_blank'>Subheading distribution</a>: " +
@@ -141,7 +141,7 @@ describe.skip( "A test for marking too long text segments not separated by a sub
 	it( "returns markers for too long text segments", function() {
 		const paper = new Paper( longText + subheading + veryLongText );
 		const textFragment = Factory.buildMockResearcher( [ { text: "This is a too long fragment. It contains 330 words.",
-			wordCount: 330 }, { text: "This is another too long fragment. It contains 360 words.", wordCount: 360 } ] );
+			countLength: 330 }, { text: "This is another too long fragment. It contains 360 words.", countLength: 360 } ] );
 		const expected = [
 			new Mark( {
 				original: "This is another too long fragment. It contains 360 words.",
@@ -157,7 +157,7 @@ describe.skip( "A test for marking too long text segments not separated by a sub
 
 	it( "returns no markers if no text segments is too long", function() {
 		const paper = new Paper( shortText );
-		const textFragment = Factory.buildMockResearcher( [ { text: "This is a short segment.", wordCount: 200 } ] );
+		const textFragment = Factory.buildMockResearcher( [ { text: "This is a short segment.", countLength: 200 } ] );
 		expect( subheadingDistributionTooLong.getResult( paper, textFragment )._hasMarks ).toEqual( false );
 	} );
 } );

--- a/packages/yoastseo/src/languageProcessing/languages/ja/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/Researcher.js
@@ -6,7 +6,7 @@ import getStemmer from "./helpers/getStemmer";
 import matchWordCustomHelper from "./helpers/matchTextWithWord";
 import getWordsCustomHelper from "./helpers/getWords";
 import wordsCharacterCount from "./helpers/wordsCharacterCount";
-import countCharacters from "./helpers/countCharacters";
+import customCountLength from "./helpers/countCharacters";
 import matchTransitionWordsHelper from "./helpers/matchTransitionWords";
 
 // All config
@@ -47,7 +47,7 @@ export default class Researcher extends AbstractResearcher {
 			matchWordCustomHelper,
 			getWordsCustomHelper,
 			wordsCharacterCount,
-			countCharacters,
+			customCountLength,
 			matchTransitionWordsHelper,
 		} );
 	}

--- a/packages/yoastseo/src/languageProcessing/researches/getParagraphLength.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getParagraphLength.js
@@ -16,12 +16,12 @@ export default function( paper, researcher ) {
 	const paragraphs = matchParagraphs( text );
 	const paragraphsLength = [];
 
-	// A helper to count characters for languages that don't count number of words for text length.
-	const countCharacters = researcher.getHelper( "countCharacters" );
+	// An optional custom helper to count length to use instead of countWords.
+	const customCountLength = researcher.getHelper( "customCountLength" );
 
 	paragraphs.map( function( paragraph ) {
 		paragraphsLength.push( {
-			countLength: countCharacters ? countCharacters( paragraph ) : countWords( paragraph ),
+			countLength: customCountLength ? customCountLength( paragraph ) : countWords( paragraph ),
 			text: paragraph,
 		} );
 	} );

--- a/packages/yoastseo/src/languageProcessing/researches/getSubheadingTextLengths.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getSubheadingTextLengths.js
@@ -5,18 +5,24 @@ import { forEach } from "lodash-es";
 
 /**
  * Gets the subheadings from the text and returns the length of these subheading in an array.
- * @param {Paper} paper The Paper object to get the text from.
+ *
+ * @param {Paper}       paper       The Paper object to get the text from.
+ * @param {Researcher}  researcher  The researcher to use for analysis.
+ *
  * @returns {Array} The array with the length of each subheading.
  */
-export default function( paper ) {
+export default function( paper, researcher ) {
 	const text = excludeTableOfContentsTag( paper.getText() );
 	const matches = getSubheadingTexts( text );
+
+	// A helper to count characters for languages that don't count number of words for text length.
+	const countCharacters = researcher.getHelper( "countCharacters" );
 
 	const subHeadingTexts = [];
 	forEach( matches, function( subHeading ) {
 		subHeadingTexts.push( {
 			text: subHeading,
-			wordCount: countWords( subHeading ),
+			countLength: countCharacters ? countCharacters( subHeading ) : countWords( subHeading ),
 		} );
 	} );
 	return subHeadingTexts;

--- a/packages/yoastseo/src/languageProcessing/researches/getSubheadingTextLengths.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getSubheadingTextLengths.js
@@ -15,14 +15,14 @@ export default function( paper, researcher ) {
 	const text = excludeTableOfContentsTag( paper.getText() );
 	const matches = getSubheadingTexts( text );
 
-	// A helper to count characters for languages that don't count number of words for text length.
-	const countCharacters = researcher.getHelper( "countCharacters" );
+	// An optional custom helper to count length to use instead of countWords.
+	const customCountLength = researcher.getHelper( "customCountLength" );
 
 	const subHeadingTexts = [];
 	forEach( matches, function( subHeading ) {
 		subHeadingTexts.push( {
 			text: subHeading,
-			countLength: countCharacters ? countCharacters( subHeading ) : countWords( subHeading ),
+			countLength: customCountLength ? customCountLength( subHeading ) : countWords( subHeading ),
 		} );
 	} );
 	return subHeadingTexts;

--- a/packages/yoastseo/src/scoring/assessments/readability/SubheadingDistributionTooLongAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/SubheadingDistributionTooLongAssessment.js
@@ -57,7 +57,7 @@ class SubheadingsDistributionTooLong extends Assessment {
 		this._subheadingTextsLength = researcher.getResearch( "getSubheadingTextLengths" );
 
 		this._subheadingTextsLength = this._subheadingTextsLength.sort( function( a, b ) {
-			return b.wordCount - a.wordCount;
+			return b.countLength - a.countLength;
 		} );
 
 		this._tooLongTextsNumber = this.getTooLongSubheadingTexts().length;
@@ -108,7 +108,7 @@ class SubheadingsDistributionTooLong extends Assessment {
 	 */
 	getTooLongSubheadingTexts() {
 		return filter( this._subheadingTextsLength, function( subheading ) {
-			return subheading.wordCount > this._config.parameters.recommendedMaximumWordCount;
+			return subheading.countLength > this._config.parameters.recommendedMaximumWordCount;
 		}.bind( this ) );
 	}
 
@@ -120,7 +120,7 @@ class SubheadingsDistributionTooLong extends Assessment {
 	calculateResult() {
 		if ( this._textLength > 300 ) {
 			if ( this._hasSubheadings ) {
-				const longestSubheadingTextLength = this._subheadingTextsLength[ 0 ].wordCount;
+				const longestSubheadingTextLength = this._subheadingTextsLength[ 0 ].countLength;
 				if ( longestSubheadingTextLength <= this._config.parameters.slightlyTooMany ) {
 					// Green indicator.
 					return {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adapts `getSubheadingTextLengths` for Japanese.

## Relevant technical choices:

* I've changed the naming of the `countCharacters` helper, importing it in the researcher as `customCountLength`. That's to keep the language-independent side of the analysis independent in a more straightforward way: I think it makes more sense to formulate a general rule like "custom count length overwrites count words" than a specific rule such as "character count overwrites count words". The fact that a custom method can overwrite a default method is relatively self-explanatory, whereas you need to know more context to understand why character count would overwrite word count.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check if the specs run successfully.
* The changes can't not be tested as we also need to adapt the assessment.

#### Regression test
* Make sure the feature flag is switched off,  by adding `define( 'YOAST_SEO_JAPANESE_SUPPORT', false );` the in `basic-wordpress-config.php` file
* Set the language in WordPress to Japanese (日本語).
* Open a new post and confirm that the subheading distribution assessment behaves in line with the default scoring: https://github.com/Yoast/javascript/wiki/Scoring-readability-analysis#1-subheading-distribution

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.
  * Test the Regression steps.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1097
