### PR TITLE
Adapt keyphrase distribution research for Japanese

### DIFF
--- a/packages/yoastseo/spec/specHelpers/factory.js
+++ b/packages/yoastseo/spec/specHelpers/factory.js
@@ -30,7 +30,7 @@ FactoryProto.prototype.buildMockElement = function() {
  */
 FactoryProto.prototype.buildMockResearcher = function( expectedValue, multiValue = false, hasMorphologyData = false,
 	config = false, helpers = false ) {
-	if ( ( multiValue && typeof expectedValue === "object" ) || ( multiValue && typeof helpers === "object" ) ) {
+	if ( multiValue && ( typeof expectedValue === "object" || typeof helpers === "object" || typeof config === "object" ) ) {
 		return {
 			/**
 			 * Return research results by research name for multi-value mock researchers.
@@ -60,6 +60,16 @@ FactoryProto.prototype.buildMockResearcher = function( expectedValue, multiValue
 			 */
 			getHelper: function( name ) {
 				return helpers[ name ];
+			},
+
+			/**
+			 * Return the config to be used for the assessment.
+			 * @param {string} name The name of the config.
+			 *
+			 * @returns {function} The config for the assessment.
+			 */
+			getConfig: function( name ) {
+				return config[ name ];
 			},
 		};
 	}

--- a/packages/yoastseo/src/languageProcessing/languages/ja/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/Researcher.js
@@ -8,6 +8,7 @@ import getWordsCustomHelper from "./helpers/getWords";
 import wordsCharacterCount from "./helpers/wordsCharacterCount";
 import countCharacters from "./helpers/countCharacters";
 import matchTransitionWordsHelper from "./helpers/matchTransitionWords";
+import getContentWords from "./helpers/getContentWords";
 
 // All config
 import functionWords from "./config/functionWords";
@@ -51,6 +52,7 @@ export default class Researcher extends AbstractResearcher {
 			wordsCharacterCount,
 			countCharacters,
 			matchTransitionWordsHelper,
+			getContentWords,
 		} );
 	}
 }

--- a/packages/yoastseo/src/languageProcessing/languages/ja/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/Researcher.js
@@ -12,6 +12,7 @@ import matchTransitionWordsHelper from "./helpers/matchTransitionWords";
 // All config
 import functionWords from "./config/functionWords";
 import transitionWords from "./config/transitionWords";
+import topicLength from "./config/topicLength";
 
 // All custom researches
 import getKeywordDensity from "./customResearches/getKeywordDensity";
@@ -40,6 +41,7 @@ export default class Researcher extends AbstractResearcher {
 			language: "ja",
 			functionWords,
 			transitionWords,
+			topicLength,
 		} );
 
 		Object.assign( this.helpers, {

--- a/packages/yoastseo/src/languageProcessing/languages/ja/config/topicLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/config/topicLength.js
@@ -1,0 +1,5 @@
+// The criteria for determining whether a topic is long or short. In Japanese, a topic is short if it’s < 7 characters,
+// And is long if it’s ≥ 7 characters.
+const topicLength = 7;
+
+export default topicLength;

--- a/packages/yoastseo/src/languageProcessing/languages/ja/config/topicLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/config/topicLength.js
@@ -1,5 +1,5 @@
 // The criteria for determining whether a topic is long or short. In Japanese, a topic is short if it’s < 7 characters,
 // And is long if it’s ≥ 7 characters.
-const topicLength = 7;
-
-export default topicLength;
+export default {
+	lengthCriteria: 7,
+};


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adapts `keyphraseDistribution` research for Japanese and adds Japanese topic length criteria config.

## Relevant technical choices:

* The highlighting is still not yet working for this research since `markWordsInSentences` is not yet adapted for Japanese. Hence the current unit tests for `sentencesToHighlight` is always an empty array. [An issue](https://yoast.atlassian.net/browse/LINGO-1138) to adjust the highlighting functionality was already created in Jira.
* I also add a new method to get the config in `buildMockResearcher` so that we can pass more than one configs when we create a mock researcher.
* The criteria for determining whether a topic is long or short is passed through the Japanese researcher. In Japanese, a topic is short if it’s < 7 characters and is long if it’s ≥ 7 characters. If the config for this criteria is not available in a researcher, the default value of 4 is used, where a topic is considered short if it's less than 4 word long, and otherwise long.
* I add a check if a custom `getContentWords` helper is available, the original topic form (keyphrase and synonyms) with the function words filtered out will be saved in an array. Then the `wordsCharacterCount` helper is used to calculate the characters length of the original topic form in which the result is further compared to the topic length criteria.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run `yarn test` and make sure that everything passes.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1098
