### PR TITLE
Rename parameters with reserved names class-yoast-network-settings-api.php

### DIFF
--- a/admin/class-yoast-network-settings-api.php
+++ b/admin/class-yoast-network-settings-api.php
@@ -120,20 +120,20 @@ class Yoast_Network_Settings_API {
 	 * This function is added as a filter to `default_site_option_{$option}` for network options that
 	 * are registered with a default.
 	 *
-	 * @param mixed  $default Existing default value to return.
-	 * @param string $option  The option name.
+	 * @param mixed  $default_value Existing default value to return.
+	 * @param string $option        The option name.
 	 *
 	 * @return mixed The filtered default value.
 	 */
-	public function filter_default_option( $default, $option ) {
+	public function filter_default_option( $default_value, $option ) {
 
 		// If a default value was manually passed to the function, allow it to override.
-		if ( $default !== false ) {
-			return $default;
+		if ( $default_value !== false ) {
+			return $default_value;
 		}
 
 		if ( empty( $this->registered_settings[ $option ] ) ) {
-			return $default;
+			return $default_value;
 		}
 
 		return $this->registered_settings[ $option ]['default'];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes parameter names in the `Yoast_Network_Settings_API` class to avoid breaking changes in PHP 8+

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* N/A


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->


<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Check for regressions in multisite's settings

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
