### PR TITLE
Rename parameters with reserved names class-wpseo-replace-vars.php

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -87,7 +87,7 @@ class WPSEO_Replace_Vars {
 	 *
 	 * @see wpseo_register_var_replacement() for a usage example.
 	 *
-	 * @param string $var              The name of the variable to replace, i.e. '%%var%%'.
+	 * @param string $var_to_replace   The name of the variable to replace, i.e. '%%var%%'.
 	 *                                 Note: the surrounding %% are optional.
 	 * @param mixed  $replace_function Function or method to call to retrieve the replacement value for the variable.
 	 *                                 Uses the same format as add_filter/add_action function parameter and
@@ -97,22 +97,22 @@ class WPSEO_Replace_Vars {
 	 *
 	 * @return bool Whether the replacement function was succesfully registered.
 	 */
-	public static function register_replacement( $var, $replace_function, $type = 'advanced', $help_text = '' ) {
+	public static function register_replacement( $var_to_replace, $replace_function, $type = 'advanced', $help_text = '' ) {
 		$success = false;
 
-		if ( is_string( $var ) && $var !== '' ) {
-			$var = self::remove_var_delimiter( $var );
+		if ( is_string( $var_to_replace ) && $var_to_replace !== '' ) {
+			$var_to_replace = self::remove_var_delimiter( $var_to_replace );
 
-			if ( preg_match( '`^[A-Z0-9_-]+$`i', $var ) === false ) {
+			if ( preg_match( '`^[A-Z0-9_-]+$`i', $var_to_replace ) === false ) {
 				trigger_error( esc_html__( 'A replacement variable can only contain alphanumeric characters, an underscore or a dash. Try renaming your variable.', 'wordpress-seo' ), E_USER_WARNING );
 			}
-			elseif ( strpos( $var, 'cf_' ) === 0 || strpos( $var, 'ct_' ) === 0 ) {
+			elseif ( strpos( $var_to_replace, 'cf_' ) === 0 || strpos( $var_to_replace, 'ct_' ) === 0 ) {
 				trigger_error( esc_html__( 'A replacement variable can not start with "%%cf_" or "%%ct_" as these are reserved for the WPSEO standard variable variables for custom fields and custom taxonomies. Try making your variable name unique.', 'wordpress-seo' ), E_USER_WARNING );
 			}
-			elseif ( ! method_exists( __CLASS__, 'retrieve_' . $var ) ) {
-				if ( $var !== '' && ! isset( self::$external_replacements[ $var ] ) ) {
-					self::$external_replacements[ $var ] = $replace_function;
-					$replacement_variable                = new WPSEO_Replacement_Variable( $var, $var, $help_text );
+			elseif ( ! method_exists( __CLASS__, 'retrieve_' . $var_to_replace ) ) {
+				if ( $var_to_replace !== '' && ! isset( self::$external_replacements[ $var_to_replace ] ) ) {
+					self::$external_replacements[ $var_to_replace ] = $replace_function;
+					$replacement_variable                           = new WPSEO_Replacement_Variable( $var_to_replace, $var_to_replace, $help_text );
 					self::register_help_text( $type, $replacement_variable );
 					$success = true;
 				}
@@ -131,20 +131,20 @@ class WPSEO_Replace_Vars {
 	/**
 	 * Replace `%%variable_placeholders%%` with their real value based on the current requested page/post/cpt/etc.
 	 *
-	 * @param string $string The string to replace the variables in.
+	 * @param string $text   The string to replace the variables in.
 	 * @param array  $args   The object some of the replacement values might come from,
 	 *                       could be a post, taxonomy or term.
 	 * @param array  $omit   Variables that should not be replaced by this function.
 	 *
 	 * @return string
 	 */
-	public function replace( $string, $args, $omit = [] ) {
+	public function replace( $text, $args, $omit = [] ) {
 
-		$string = wp_strip_all_tags( $string );
+		$text = wp_strip_all_tags( $text );
 
 		// Let's see if we can bail super early.
-		if ( strpos( $string, '%%' ) === false ) {
-			return YoastSEO()->helpers->string->standardize_whitespace( $string );
+		if ( strpos( $text, '%%' ) === false ) {
+			return YoastSEO()->helpers->string->standardize_whitespace( $text );
 		}
 
 		$args = (array) $args;
@@ -162,7 +162,7 @@ class WPSEO_Replace_Vars {
 		}
 
 		$replacements = [];
-		if ( preg_match_all( '`%%([^%]+(%%single)?)%%?`iu', $string, $matches ) ) {
+		if ( preg_match_all( '`%%([^%]+(%%single)?)%%?`iu', $text, $matches ) ) {
 			$replacements = $this->set_up_replacements( $matches, $omit );
 		}
 
@@ -178,11 +178,11 @@ class WPSEO_Replace_Vars {
 
 		// Do the actual replacements.
 		if ( is_array( $replacements ) && $replacements !== [] ) {
-			$string = str_replace(
+			$text = str_replace(
 				array_keys( $replacements ),
 				// Make sure to exclude replacement values that are arrays e.g. coming from a custom field serialized value.
 				array_filter( array_values( $replacements ), 'is_scalar' ),
-				$string
+				$text
 			);
 		}
 
@@ -198,25 +198,25 @@ class WPSEO_Replace_Vars {
 			// Remove non-replaced variables.
 			$remove = array_diff( $matches[1], $omit ); // Make sure the $omit variables do not get removed.
 			$remove = array_map( [ __CLASS__, 'add_var_delimiter' ], $remove );
-			$string = str_replace( $remove, '', $string );
+			$text   = str_replace( $remove, '', $text );
 		}
 
 		// Undouble separators which have nothing between them, i.e. where a non-replaced variable was removed.
 		if ( isset( $replacements['%%sep%%'] ) && ( is_string( $replacements['%%sep%%'] ) && $replacements['%%sep%%'] !== '' ) ) {
 			$q_sep  = preg_quote( $replacements['%%sep%%'], '`' );
-			$string = preg_replace( '`' . $q_sep . '(?:\s*' . $q_sep . ')*`u', $replacements['%%sep%%'], $string );
+			$text   = preg_replace( '`' . $q_sep . '(?:\s*' . $q_sep . ')*`u', $replacements['%%sep%%'], $text );
 		}
 
 		// Remove superfluous whitespace.
-		$string = YoastSEO()->helpers->string->standardize_whitespace( $string );
+		$text = YoastSEO()->helpers->string->standardize_whitespace( $text );
 
-		return $string;
+		return $text;
 	}
 
 	/**
 	 * Register a new replacement variable if it has not been registered already.
 	 *
-	 * @param string $var              The name of the variable to replace, i.e. '%%var%%'.
+	 * @param string $var_to_replace   The name of the variable to replace, i.e. '%%var%%'.
 	 *                                 Note: the surrounding %% are optional.
 	 * @param mixed  $replace_function Function or method to call to retrieve the replacement value for the variable.
 	 *                                 Uses the same format as add_filter/add_action function parameter and
@@ -226,9 +226,9 @@ class WPSEO_Replace_Vars {
 	 *
 	 * @return bool `true` if the replace var has been registered, `false` if not.
 	 */
-	public function safe_register_replacement( $var, $replace_function, $type = 'advanced', $help_text = '' ) {
-		if ( ! $this->has_been_registered( $var ) ) {
-			return self::register_replacement( $var, $replace_function, $type, $help_text );
+	public function safe_register_replacement( $var_to_replace, $replace_function, $type = 'advanced', $help_text = '' ) {
+		if ( ! $this->has_been_registered( $var_to_replace ) ) {
+			return self::register_replacement( $var_to_replace, $replace_function, $type, $help_text );
 		}
 		return false;
 	}
@@ -760,16 +760,16 @@ class WPSEO_Replace_Vars {
 	/**
 	 * Retrieve a post/page/cpt's custom field value for use as replacement string.
 	 *
-	 * @param string $var The complete variable to replace which includes the name of
-	 *                    the custom field which value is to be retrieved.
+	 * @param string $var_to_replace The complete variable to replace which includes the name of
+	 *                               the custom field which value is to be retrieved.
 	 *
 	 * @return string|null
 	 */
-	private function retrieve_cf_custom_field_name( $var ) {
+	private function retrieve_cf_custom_field_name( $var_to_replace ) {
 		$replacement = null;
 
-		if ( is_string( $var ) && $var !== '' ) {
-			$field = substr( $var, 3 );
+		if ( is_string( $var_to_replace ) && $var_to_replace !== '' ) {
+			$field = substr( $var_to_replace, 3 );
 			if ( ! empty( $this->args->ID ) ) {
 				// Post meta can be arrays and in this case we need to exclude them.
 				$name = get_post_meta( $this->args->ID, $field, true );
@@ -791,17 +791,17 @@ class WPSEO_Replace_Vars {
 	/**
 	 * Retrieve a post/page/cpt's custom taxonomies for use as replacement string.
 	 *
-	 * @param string $var    The complete variable to replace which includes the name of
-	 *                       the custom taxonomy which value(s) is to be retrieved.
-	 * @param bool   $single Whether to retrieve only the first or all values for the taxonomy.
+	 * @param string $var_to_replace    The complete variable to replace which includes the name of
+	 *                                  the custom taxonomy which value(s) is to be retrieved.
+	 * @param bool   $single            Whether to retrieve only the first or all values for the taxonomy.
 	 *
 	 * @return string|null
 	 */
-	private function retrieve_ct_custom_tax_name( $var, $single = false ) {
+	private function retrieve_ct_custom_tax_name( $var_to_replace, $single = false ) {
 		$replacement = null;
 
-		if ( ( is_string( $var ) && $var !== '' ) && ! empty( $this->args->ID ) ) {
-			$tax  = substr( $var, 3 );
+		if ( ( is_string( $var_to_replace ) && $var_to_replace !== '' ) && ! empty( $this->args->ID ) ) {
+			$tax  = substr( $var_to_replace, 3 );
 			$name = $this->get_terms( $this->args->ID, $tax, $single );
 			if ( $name !== '' ) {
 				$replacement = $name;
@@ -814,16 +814,16 @@ class WPSEO_Replace_Vars {
 	/**
 	 * Retrieve a post/page/cpt's custom taxonomies description for use as replacement string.
 	 *
-	 * @param string $var The complete variable to replace which includes the name of
-	 *                    the custom taxonomy which description is to be retrieved.
+	 * @param string $var_to_replace The complete variable to replace which includes the name of
+	 *                               the custom taxonomy which description is to be retrieved.
 	 *
 	 * @return string|null
 	 */
-	private function retrieve_ct_desc_custom_tax_name( $var ) {
+	private function retrieve_ct_desc_custom_tax_name( $var_to_replace ) {
 		$replacement = null;
 
-		if ( is_string( $var ) && $var !== '' ) {
-			$tax = substr( $var, 8 );
+		if ( is_string( $var_to_replace ) && $var_to_replace !== '' ) {
+			$tax = substr( $var_to_replace, 8 );
 			if ( ! empty( $this->args->ID ) ) {
 				$terms = get_the_terms( $this->args->ID, $tax );
 				if ( is_array( $terms ) && $terms !== [] ) {
@@ -1503,23 +1503,23 @@ class WPSEO_Replace_Vars {
 	/**
 	 * Remove the '%%' delimiters from a variable string.
 	 *
-	 * @param string $string Variable string to be cleaned.
+	 * @param string $text Variable string to be cleaned.
 	 *
 	 * @return string
 	 */
-	private static function remove_var_delimiter( $string ) {
-		return trim( $string, '%' );
+	private static function remove_var_delimiter( $text ) {
+		return trim( $text, '%' );
 	}
 
 	/**
 	 * Add the '%%' delimiters to a variable string.
 	 *
-	 * @param string $string Variable string to be delimited.
+	 * @param string $text Variable string to be delimited.
 	 *
 	 * @return string
 	 */
-	private static function add_var_delimiter( $string ) {
-		return '%%' . $string . '%%';
+	private static function add_var_delimiter( $text ) {
+		return '%%' . $text . '%%';
 	}
 
 	/**

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -203,8 +203,8 @@ class WPSEO_Replace_Vars {
 
 		// Undouble separators which have nothing between them, i.e. where a non-replaced variable was removed.
 		if ( isset( $replacements['%%sep%%'] ) && ( is_string( $replacements['%%sep%%'] ) && $replacements['%%sep%%'] !== '' ) ) {
-			$q_sep  = preg_quote( $replacements['%%sep%%'], '`' );
-			$text   = preg_replace( '`' . $q_sep . '(?:\s*' . $q_sep . ')*`u', $replacements['%%sep%%'], $text );
+			$q_sep = preg_quote( $replacements['%%sep%%'], '`' );
+			$text  = preg_replace( '`' . $q_sep . '(?:\s*' . $q_sep . ')*`u', $replacements['%%sep%%'], $text );
 		}
 
 		// Remove superfluous whitespace.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes parameter names in the `WPSEO_Replace_Vars` class to avoid breaking changes in PHP 8+

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* N/A


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Check for regressions with replace vars

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*  

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
