### PR TITLE
Rename parameters with reserved names class-sitemaps.php

### DIFF
--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -151,12 +151,12 @@ class WPSEO_Sitemaps {
 	/**
 	 * Register your own sitemap. Call this during 'init'.
 	 *
-	 * @param string   $name     The name of the sitemap.
-	 * @param callback $function Function to build your sitemap.
-	 * @param string   $rewrite  Optional. Regular expression to match your sitemap with.
+	 * @param string   $name              The name of the sitemap.
+	 * @param callback $building_function Function to build your sitemap.
+	 * @param string   $rewrite           Optional. Regular expression to match your sitemap with.
 	 */
-	public function register_sitemap( $name, $function, $rewrite = '' ) {
-		add_action( 'wpseo_do_sitemap_' . $name, $function );
+	public function register_sitemap( $name, $building_function, $rewrite = '' ) {
+		add_action( 'wpseo_do_sitemap_' . $name, $building_function );
 		if ( ! empty( $rewrite ) ) {
 			add_rewrite_rule( $rewrite, 'index.php?sitemap=' . $name, 'top' );
 		}
@@ -167,12 +167,12 @@ class WPSEO_Sitemaps {
 	 *
 	 * @since 1.4.23
 	 *
-	 * @param string   $name     The name of the XSL file.
-	 * @param callback $function Function to build your XSL file.
-	 * @param string   $rewrite  Optional. Regular expression to match your sitemap with.
+	 * @param string   $name              The name of the XSL file.
+	 * @param callback $building_function Function to build your XSL file.
+	 * @param string   $rewrite           Optional. Regular expression to match your sitemap with.
 	 */
-	public function register_xsl( $name, $function, $rewrite = '' ) {
-		add_action( 'wpseo_xsl_' . $name, $function );
+	public function register_xsl( $name, $building_function, $rewrite = '' ) {
+		add_action( 'wpseo_xsl_' . $name, $building_function );
 		if ( ! empty( $rewrite ) ) {
 			add_rewrite_rule( $rewrite, 'index.php?yoast-sitemap-xsl=' . $name, 'top' );
 		}
@@ -202,10 +202,10 @@ class WPSEO_Sitemaps {
 	/**
 	 * Set as true to make the request 404. Used stop the display of empty sitemaps or invalid requests.
 	 *
-	 * @param bool $bool Is this a bad request. True or false.
+	 * @param bool $is_bad Is this a bad request. True or false.
 	 */
-	public function set_bad_sitemap( $bool ) {
-		$this->bad_sitemap = (bool) $bool;
+	public function set_bad_sitemap( $is_bad ) {
+		$this->bad_sitemap = (bool) $is_bad;
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes parameter names in the `WPSEO_Sitemaps` class to avoid breaking changes in PHP 8+

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* N/A


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->


<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Check for regressions when registering sitemaps in the /sitemap_index.xml page
* Check for regressions when handling xsl files
* Check for regressions when handling bad sitemaps (404 when requesting empty sitemaps)

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
