### PR TITLE
P1-1000 add hooks around analysis

### DIFF
--- a/apps/seo-integration/craco.config.js
+++ b/apps/seo-integration/craco.config.js
@@ -7,6 +7,8 @@ module.exports = {
 		alias: {
 			"react": path.resolve( "./node_modules/react" ),
 			"@wordpress/data": path.resolve( "./node_modules/@wordpress/data" ),
+			"@wordpress/element": path.resolve( "./node_modules/@wordpress/element" ),
+			"@wordpress/hooks": path.resolve( "./node_modules/@wordpress/hooks" ),
 		},
 		configure: ( webpackConfig, { env, paths } ) => {
 			// const { hasFoundAny, matches } = getLoaders( webpackConfig, loaderByName( "babel-loader" ) );

--- a/apps/seo-integration/package.json
+++ b/apps/seo-integration/package.json
@@ -22,6 +22,7 @@
     "@testing-library/user-event": "^12.1.10",
     "@wordpress/data": "^6.1.2",
     "@wordpress/element": "^4.0.3",
+    "@wordpress/hooks": "^3.2.1",
     "@yoast/seo-store": "file:../../packages/seo-store",
     "@yoast/replacement-variables": "file:../../packages/replacement-variables",
     "react-scripts": "4.0.3"

--- a/apps/seo-integration/src/app.js
+++ b/apps/seo-integration/src/app.js
@@ -1,5 +1,6 @@
 import { select, useDispatch, useSelect } from "@wordpress/data";
 import { useCallback } from "@wordpress/element";
+import { addFilter } from "@wordpress/hooks";
 import createReplacementVariables from "@yoast/replacement-variables";
 import registerAnalysisStore, { SEO_STORE_NAME, useAnalyze } from "@yoast/seo-store";
 import { debounce, reduce } from "lodash";
@@ -15,7 +16,7 @@ const useDebounce = ( callback, dependencies, debounceTimeInMs = 500 ) => {
 // Add wrapper around these packages that exports a magic createYoastSeoIntegration function
 // First candidate classic editor with WooCommerce
 
-const preparePaper = ( paper ) => {
+const applyReplacevars = ( paper ) => {
 	const replacementVariables = createReplacementVariables( [
 		{
 			name: "title",
@@ -37,8 +38,10 @@ const preparePaper = ( paper ) => {
 	);
 };
 
+// Applying the replacevars with a prio of 10, so that other functions can go before (< 10) or after (> 10) the replaced variables.
+addFilter( "yoast.seoStore.analysis.preparePaper", "yoast/seo-integration-app/applyReplacevars", applyReplacevars, 10 );
+
 registerAnalysisStore( {
-	preparePaper,
 	analyze: async ( paper, keyphrases, config ) => {
 		console.log( "analyze", paper, keyphrases, config );
 		await new Promise( resolve => setTimeout( resolve, 1000 ) );

--- a/apps/seo-integration/src/app.js
+++ b/apps/seo-integration/src/app.js
@@ -5,6 +5,7 @@ import createReplacementVariables from "@yoast/replacement-variables";
 import registerAnalysisStore, { SEO_STORE_NAME, useAnalyze } from "@yoast/seo-store";
 import { debounce, reduce } from "lodash";
 import "./app.css";
+import { measureTextWidth } from "./helpers";
 
 const useDebounce = ( callback, dependencies, debounceTimeInMs = 500 ) => {
 	// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -40,6 +41,10 @@ const applyReplacevars = ( paper ) => {
 
 // Applying the replacevars with a prio of 10, so that other functions can go before (< 10) or after (> 10) the replaced variables.
 addFilter( "yoast.seoStore.analysis.preparePaper", "yoast/seo-integration-app/applyReplacevars", applyReplacevars, 10 );
+addFilter( "yoast.seoStore.analysis.preparePaper", "yoast/seo-integration-app/measureSeoTitleWidth", paper => ( {
+	...paper,
+	seoTitleWidth: measureTextWidth( paper.seoTitle ),
+} ), 11 );
 
 registerAnalysisStore( {
 	analyze: async ( paper, keyphrases, config ) => {

--- a/apps/seo-integration/src/helpers.js
+++ b/apps/seo-integration/src/helpers.js
@@ -1,0 +1,45 @@
+const MEASUREMENT_ELEMENT_ID = "yoast-measurement-element";
+
+/**
+ * Creates an hidden element with the purpose to calculate the sizes of elements and adds these elements to the body.
+ *
+ * @param {string} [elementId] The ID of the HTML element.
+ *
+ * @returns {HTMLElement} The created hidden element.
+ */
+const createMeasurementElement = ( elementId = MEASUREMENT_ELEMENT_ID ) => {
+	const hiddenElement = document.createElement( "div" );
+
+	hiddenElement.id = elementId;
+	hiddenElement.style.position = "absolute";
+	hiddenElement.style.left = "-9999em";
+	hiddenElement.style.top = "0";
+	hiddenElement.style.height = "0";
+	hiddenElement.style.overflow = "hidden";
+	hiddenElement.style.fontFamily = "arial, sans-serif";
+	hiddenElement.style.fontSize = "18px";
+	hiddenElement.style.fontWeight = "400";
+
+	document.body.appendChild( hiddenElement );
+
+	return hiddenElement;
+};
+
+/**
+ * Measures the width of the text, using a hidden element.
+ *
+ * @param {string} text The text to measure the width for.
+ * @param {string} [elementId] The ID of the HTML element.
+ *
+ * @returns {number} The width in pixels.
+ */
+export const measureTextWidth = ( text, elementId = MEASUREMENT_ELEMENT_ID ) => {
+	let element = document.getElementById( elementId );
+	if ( ! element ) {
+		element = createMeasurementElement();
+	}
+
+	element.innerHTML = text;
+
+	return element.offsetWidth;
+};

--- a/packages/seo-store/gists/interfaces.js
+++ b/packages/seo-store/gists/interfaces.js
@@ -9,7 +9,8 @@ const paper = {
 	content: "",
 	// No more locale here: needs analysis worker adaptation.
 	isCornerstone: false,
-//	IsTaxonomy: false,  -- Replaced by analysisType.
+	// IsTaxonomy: false,  -- Replaced by analysisType.
+	seoTitleWidth: 0,
 };
 const keyphrases = {
 	focus: {
@@ -93,9 +94,7 @@ const wrapperConfig = {
 	//	CustomAnalysisType: "",
 	translations: {},
 	assessorOptions: {
-		[ analysisType ]: {
-
-		},
+		[ analysisType ]: {},
 	}, // Mostly used for shortlinks per analysisType.
 	defaultQueryParams: {},
 	logLevel: "",

--- a/packages/seo-store/package.json
+++ b/packages/seo-store/package.json
@@ -34,6 +34,7 @@
   "peerDependencies": {
     "@wordpress/data": "^6.1.2",
     "@wordpress/element": "^4.0.3",
+    "@wordpress/hooks": "^3.2.1",
     "react": "^17.0.1"
   }
 }

--- a/packages/seo-store/src/analysis/hooks.js
+++ b/packages/seo-store/src/analysis/hooks.js
@@ -28,7 +28,10 @@ export const useAnalyze = ( debounceTimeInMs = ANALYZE_DEBOUNCE_TIME_IN_MS ) => 
 	const keyphrases = useSelect( select => select( STORE_NAME ).selectKeyphrases() );
 	const config = useSelect( select => select( STORE_NAME ).selectConfig() );
 	const editor = useSelect( select => select( STORE_NAME ).selectEditor() );
-	const debouncedAnalyze = useCallback( () => debounce( analyze, debounceTimeInMs ), [ analyze, debounceTimeInMs ] );
+	const debouncedAnalyze = useCallback(
+		debounce( analyze, debounceTimeInMs ),
+		[ analyze, debounceTimeInMs ],
+	);
 
 	useEffectWithCompare( () => {
 		debouncedAnalyze();

--- a/packages/seo-store/src/analysis/slice/index.js
+++ b/packages/seo-store/src/analysis/slice/index.js
@@ -17,7 +17,7 @@ export const analysisSelectors = {
 		formSelectors.selectSlug,
 		editorSelectors.selectPermalink,
 		editorSelectors.selectDate,
-		( content, title, description, slug, permalink, date ) => ( { content, title, description, slug, permalink, date } ),
+		( content, seoTitle, metaDescription, slug, permalink, date ) => ( { content, seoTitle, metaDescription, slug, permalink, date } ),
 	),
 };
 

--- a/packages/seo-store/src/analysis/slice/results.js
+++ b/packages/seo-store/src/analysis/slice/results.js
@@ -30,7 +30,6 @@ function* analyze() {
 		const config = yield select( STORE_NAME ).selectConfig();
 
 		const preparedPaper = yield applyFilters( "yoast.seoStore.analysis.preparePaper", paper );
-		// Add seoTitleWidth to paper here in some smart way (after preparePaper/replaceVars)
 
 		const results = yield {
 			type: ANALYZE_ACTION_NAME,

--- a/packages/seo-store/src/index.js
+++ b/packages/seo-store/src/index.js
@@ -1,7 +1,6 @@
 import { combineReducers, createReduxStore, register } from "@wordpress/data";
-import { identity } from "lodash";
 import analysisReducer, { ANALYSIS_SLICE_NAME, analysisActions, analysisSelectors } from "./analysis/slice";
-import { ANALYZE_ACTION_NAME, PREPARE_PAPER_ACTION_NAME, PROCESS_RESULTS_ACTION_NAME } from "./analysis/slice/results";
+import { ANALYZE_ACTION_NAME } from "./analysis/slice/results";
 import { STORE_NAME } from "./common/constants";
 import editorReducer, { EDITOR_SLICE_NAME, editorActions, editorSelectors } from "./editor/slice";
 import formReducer, { formActions, formSelectors } from "./form/slice";
@@ -29,17 +28,10 @@ export const selectors = {
  *
  * @param {Object} initialState Initial state.
  * @param {function} analyze Runs an analysis.
- * @param {function} preparePaper Prepares the paper data for analysis.
- * @param {function} processResults Processes the analysis results for storing.
  *
  * @returns {WPDataStore} The WP data store.
  */
-const createSeoStore = ( {
-	initialState,
-	analyze,
-	preparePaper = identity,
-	processResults = identity,
-} ) => {
+const createSeoStore = ( { initialState, analyze } ) => {
 	return createReduxStore( STORE_NAME, {
 		actions,
 		selectors,
@@ -51,8 +43,6 @@ const createSeoStore = ( {
 		} ),
 		controls: {
 			[ ANALYZE_ACTION_NAME ]: async ( { payload: { paper, keyphrases, config } } ) => analyze( paper, keyphrases, config ),
-			[ PREPARE_PAPER_ACTION_NAME ]: async ( { payload } ) => preparePaper( payload ),
-			[ PROCESS_RESULTS_ACTION_NAME ]: async ( { payload } ) => processResults( payload ),
 		},
 	} );
 };
@@ -62,18 +52,11 @@ const createSeoStore = ( {
  *
  * @param {Object} [initialState] Initial state.
  * @param {function} analyze Runs an analysis.
- * @param {function} [preparePaper] Prepares the paper data for analysis.
- * @param {function} [processResults] Processes the analysis results for storing.
  *
  * @returns {void}
  */
-const registerSeoStore = ( {
-	initialState = {},
-	analyze,
-	preparePaper = identity,
-	processResults = identity,
-} = {} ) => {
-	register( createSeoStore( { initialState, analyze, preparePaper, processResults } ) );
+const registerSeoStore = ( { initialState = {}, analyze } = {} ) => {
+	register( createSeoStore( { initialState, analyze } ) );
 };
 
 export default registerSeoStore;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces the `yoast.seoStore.analysis.preparePaper` filter to change the paper before the analysis.
* Introduces the `yoast.seoStore.analysis.processResults` filter to change the results before storing them.
* Removes the `preparePaper` and `processedResults` initialize functions.
* Fixes a bug where the analyze hook would not work.
* Fixes a bug where the paper data was not as designed: `title` -> `seoTitle` and `description` -> `metaDescription.
* Adds `seoTitleWidth` to the paper in the `seo-integration` app, via the `preparePaper` filter.

## Relevant technical choices:

* Discussed the possibilities for the `seoTitleWidth`. We would really like to prevent the element creation part in the `seo-store` package.
  * Solution 1, as done now: use the filter to add it later. Downside: not clear this needs to be done right now, but could perhaps be fine for something in phase 2 (which we don't have now).
  * Solution 2, the ugly: just add it to the `seo-store` package. Side effects and just presume to have a DOM available? Blegh.
  * Solution 3, in between: could provide a hook that takes the `measureTextWidth` function that dispatches the returned value to the store. Downside: the implementation side needs to add this hook on top of the `useAnalyze` hook as well as provide the measure method. But at least the data and watching is taken care of?
  * Probably more...

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* You could test with the `seo-integration` app.
  * Hint to get that working: you should link the `seo-store` and `replacement-variables` packages and build those individually. Then `yarn install && yarn start` as usual.
* Changing the content to include `%%title%%` should output the getReplacement in the console.
* Changing the title should change the content that is sent to the paper (also visible in the console.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/P1-1000
