### PR TITLE
Improve indexing performance

### DIFF
--- a/patchwork.json
+++ b/patchwork.json
@@ -1,0 +1,5 @@
+{
+    "redefinable-internals": [
+        "usleep"
+    ]
+}

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,5 +1,0 @@
-{
-    "redefinable-internals": [
-        "usleep"
-    ]
-}

--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -234,6 +234,8 @@ class Index_Command implements Command_Interface {
 				$indexables = $indexation_action->index();
 				$count      = \count( $indexables );
 				$progress->tick( $count );
+				sleep( 1 );
+				Utils\wp_clear_object_cache();
 			} while ( $count >= $limit );
 			$progress->finish();
 		}

--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -232,6 +232,7 @@ class Index_Command implements Command_Interface {
 		 * @api int $sleep Number of microseconds (millionths of a second) to wait between index actions.
 		 */
 		$interval = (int) apply_filters( 'wpseo_cli_index_usleep_interval', 1000000 );
+
 		$total = $indexation_action->get_total_unindexed();
 		if ( $total > 0 ) {
 			$limit    = $indexation_action->get_limit();

--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -226,6 +226,12 @@ class Index_Command implements Command_Interface {
 	 * @return void
 	 */
 	protected function run_indexation_action( $name, Indexation_Action_Interface $indexation_action ) {
+		/**
+		 * Filter: Allows for modifying the cool off interval between indexing actions on the CLI.
+		 *
+		 * @api int $sleep Number of microseconds (millionths of a second) to wait between index actions.
+		 */
+		$interval = (int) apply_filters( 'wpseo_cli_index_usleep_interval', 1000000 );
 		$total = $indexation_action->get_total_unindexed();
 		if ( $total > 0 ) {
 			$limit    = $indexation_action->get_limit();
@@ -234,7 +240,7 @@ class Index_Command implements Command_Interface {
 				$indexables = $indexation_action->index();
 				$count      = \count( $indexables );
 				$progress->tick( $count );
-				sleep( 1 );
+				usleep( $interval );
 				Utils\wp_clear_object_cache();
 			} while ( $count >= $limit );
 			$progress->finish();

--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -182,9 +182,6 @@ class Index_Command_Test extends TestCase {
 			->times( 6 )
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
-		Monkey\Functions\expect( 'usleep' )
-			->times( 12 )
-			->with( 5000 );
 		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
 			->times( 12 );
 		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 25 );
@@ -233,9 +230,6 @@ class Index_Command_Test extends TestCase {
 			->times( 6 )
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
-		Monkey\Functions\expect( 'usleep' )
-			->times( 12 )
-			->with( 5000 );
 		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
 			->times( 12 );
 		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 25 );
@@ -350,9 +344,6 @@ class Index_Command_Test extends TestCase {
 			->andReturn( $progress_bar_mock );
 		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
 			->times( 24 );
-		Monkey\Functions\expect( 'usleep' )
-			->times( 24 )
-			->with( 5000 );
 		$progress_bar_mock->expects( 'tick' )->times( 12 )->with( 25 );
 		$progress_bar_mock->expects( 'tick' )->times( 12 )->with( 5 );
 		$progress_bar_mock->expects( 'finish' )->times( 12 );

--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -183,9 +183,7 @@ class Index_Command_Test extends TestCase {
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
 		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
-			->times( 12 )
-			->withNoArgs()
-			->justReturn();
+			->times( 12 );
 		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 25 );
 		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 5 );
 		$progress_bar_mock->expects( 'finish' )->times( 6 );
@@ -233,9 +231,7 @@ class Index_Command_Test extends TestCase {
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
 		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
-			->times( 12 )
-			->withNoArgs()
-			->justReturn();
+			->times( 12 );
 		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 25 );
 		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 5 );
 		$progress_bar_mock->expects( 'finish' )->times( 6 );
@@ -347,9 +343,7 @@ class Index_Command_Test extends TestCase {
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
 		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
-			->times( 24 )
-			->withNoArgs()
-			->justReturn();
+			->times( 24 );
 		$progress_bar_mock->expects( 'tick' )->times( 12 )->with( 25 );
 		$progress_bar_mock->expects( 'tick' )->times( 12 )->with( 5 );
 		$progress_bar_mock->expects( 'finish' )->times( 12 );

--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -175,17 +175,13 @@ class Index_Command_Test extends TestCase {
 		Monkey\Filters\expectApplied( 'wpseo_cli_index_usleep_interval' )
 			->with( 1000000 )
 			->once()
-			->andReturn( 5000 );
+			->andReturn( 1000000 );
 
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
 			->times( 6 )
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
-		Monkey\Functions\expect( 'usleep' )
-			->times( 12 )
-			->with( 5000 )
-			->justReturn();
 		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
 			->times( 12 )
 			->withNoArgs()
@@ -229,17 +225,13 @@ class Index_Command_Test extends TestCase {
 		Monkey\Filters\expectApplied( 'wpseo_cli_index_usleep_interval' )
 			->with( 1000000 )
 			->once()
-			->andReturn( 5000 );
+			->andReturn( 1000000 );
 
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
 			->times( 6 )
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
-		Monkey\Functions\expect( 'usleep' )
-			->times( 12 )
-			->with( 5000 )
-			->justReturn();
 		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
 			->times( 12 )
 			->withNoArgs()
@@ -347,17 +339,13 @@ class Index_Command_Test extends TestCase {
 		Monkey\Filters\expectApplied( 'wpseo_cli_index_usleep_interval' )
 			->with( 1000000 )
 			->once()
-			->andReturn( 5000 );
+			->andReturn( 1000000 );
 
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
 			->times( 12 )
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
-		Monkey\Functions\expect( 'usleep' )
-			->times( 24 )
-			->with( 5000 )
-			->justReturn();
 		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
 			->times( 24 )
 			->withNoArgs()

--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -172,11 +172,24 @@ class Index_Command_Test extends TestCase {
 
 		$this->complete_indexation_action->expects( 'complete' )->once();
 
+		Monkey\Filters\expectApplied( 'wpseo_cli_index_usleep_interval' )
+			->with( 1000000 )
+			->once()
+			->andReturn( 5000 );
+
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
 			->times( 6 )
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
+		Monkey\Functions\expect( 'usleep' )
+			->times( 12 )
+			->with( 5000 )
+			->justReturn();
+		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
+			->times( 12 )
+			->withNoArgs()
+			->justReturn();
 		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 25 );
 		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 5 );
 		$progress_bar_mock->expects( 'finish' )->times( 6 );
@@ -213,11 +226,24 @@ class Index_Command_Test extends TestCase {
 
 		$this->prepare_indexing_action->expects( 'prepare' )->once();
 
+		Monkey\Filters\expectApplied( 'wpseo_cli_index_usleep_interval' )
+			->with( 1000000 )
+			->once()
+			->andReturn( 5000 );
+
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
 			->times( 6 )
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
+		Monkey\Functions\expect( 'usleep' )
+			->times( 12 )
+			->with( 5000 )
+			->justReturn();
+		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
+			->times( 12 )
+			->withNoArgs()
+			->justReturn();
 		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 25 );
 		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 5 );
 		$progress_bar_mock->expects( 'finish' )->times( 6 );
@@ -318,11 +344,24 @@ class Index_Command_Test extends TestCase {
 		$this->complete_indexation_action->expects( 'complete' )->twice();
 		$this->prepare_indexing_action->expects( 'prepare' )->twice();
 
+		Monkey\Filters\expectApplied( 'wpseo_cli_index_usleep_interval' )
+			->with( 1000000 )
+			->once()
+			->andReturn( 5000 );
+
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
 			->times( 12 )
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
+		Monkey\Functions\expect( 'usleep' )
+			->times( 24 )
+			->with( 5000 )
+			->justReturn();
+		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
+			->times( 24 )
+			->withNoArgs()
+			->justReturn();
 		$progress_bar_mock->expects( 'tick' )->times( 12 )->with( 25 );
 		$progress_bar_mock->expects( 'tick' )->times( 12 )->with( 5 );
 		$progress_bar_mock->expects( 'finish' )->times( 12 );

--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -174,14 +174,17 @@ class Index_Command_Test extends TestCase {
 
 		Monkey\Filters\expectApplied( 'wpseo_cli_index_usleep_interval' )
 			->with( 1000000 )
-			->once()
-			->andReturn( 1000000 );
+			->times( 6 )
+			->andReturn( 5000 );
 
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
 			->times( 6 )
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
+		Monkey\Functions\expect( 'usleep' )
+			->times( 12 )
+			->with( 5000 );
 		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
 			->times( 12 );
 		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 25 );
@@ -222,14 +225,17 @@ class Index_Command_Test extends TestCase {
 
 		Monkey\Filters\expectApplied( 'wpseo_cli_index_usleep_interval' )
 			->with( 1000000 )
-			->once()
-			->andReturn( 1000000 );
+			->times( 6 )
+			->andReturn( 5000 );
 
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
 			->times( 6 )
 			->with( Mockery::type( 'string' ), 30 )
 			->andReturn( $progress_bar_mock );
+		Monkey\Functions\expect( 'usleep' )
+			->times( 12 )
+			->with( 5000 );
 		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
 			->times( 12 );
 		$progress_bar_mock->expects( 'tick' )->times( 6 )->with( 25 );
@@ -334,8 +340,8 @@ class Index_Command_Test extends TestCase {
 
 		Monkey\Filters\expectApplied( 'wpseo_cli_index_usleep_interval' )
 			->with( 1000000 )
-			->once()
-			->andReturn( 1000000 );
+			->times( 12 )
+			->andReturn( 5000 );
 
 		$progress_bar_mock = Mockery::mock( 'cli\progress\Bar' );
 		Monkey\Functions\expect( '\WP_CLI\Utils\make_progress_bar' )
@@ -344,6 +350,9 @@ class Index_Command_Test extends TestCase {
 			->andReturn( $progress_bar_mock );
 		Monkey\Functions\expect( '\WP_CLI\Utils\wp_clear_object_cache' )
 			->times( 24 );
+		Monkey\Functions\expect( 'usleep' )
+			->times( 24 )
+			->with( 5000 );
 		$progress_bar_mock->expects( 'tick' )->times( 12 )->with( 25 );
 		$progress_bar_mock->expects( 'tick' )->times( 12 )->with( 5 );
 		$progress_bar_mock->expects( 'finish' )->times( 12 );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

This is a basic effort to get indexing working without crashing or maxing out CPU usage for large sites.

Ideally what is needed is the ability to do bulk inserts / updates as well as periodically clearing object cache memory.

* Indexing posts on a large site via CLI slows down and can crash
* CPU usage spikes to 100% during indexing
* Each post can trigger 4 db inserts / updates during indexing so indexing 10k posts can theoretically result in up to 40k db queries

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Added a usleep interval to the WP CLI index command to limit server load while this command is running. Props to [roborourke](https://github.com/roborourke)

## Relevant technical choices:

* `usleep` allows for intervals less than a second for more powerful servers while also allowing for times greater than 1 second for platforms that support it.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

1. On a new WordPress install generate many posts e.g. `wp post generate --count=5000`
2. Run the indexing command with a clean db: `wp yoast index --reindex`
3. See CPU usage spiking (in activity monitor or if using Docker via `docker stats`) and command slowing down, database may or may not crash depending on set up

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Adds a sleep interval
* CPU usage does not spike when indexing many posts


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Indexing WP CLI command

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
