### PR TITLE
Fix Meta_Surface::for_home_page()

### DIFF
--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -91,7 +91,7 @@ class Meta_Surface {
 	 * @return Meta|false The meta values. False if none could be found.
 	 */
 	public function for_home_page() {
-		$front_page_id = \get_option( 'page_on_front' );
+		$front_page_id = (int) \get_option( 'page_on_front' );
 		if ( \get_option( 'show_on_front' ) === 'page' && $front_page_id !== 0 ) {
 			$indexable = $this->repository->find_by_id_and_type( $front_page_id, 'post' );
 

--- a/tests/unit/surfaces/meta-surface-test.php
+++ b/tests/unit/surfaces/meta-surface-test.php
@@ -173,6 +173,23 @@ class Meta_Surface_Test extends TestCase {
 	 *
 	 * @covers ::for_home_page
 	 */
+	public function test_for_home_page_0_page_on_front() {
+		$this->container->expects( 'get' )->times( 3 )->andReturn( null );
+		Monkey\Functions\expect( 'get_option' )->once()->with( 'page_on_front' )->andReturn( '0' );
+		Monkey\Functions\expect( 'get_option' )->once()->with( 'show_on_front' )->andReturn( 'page' );
+		$this->repository->expects( 'find_for_home_page' )->once()->andReturn( $this->indexable );
+		$this->context_memoizer->expects( 'get' )->with( $this->indexable, 'Home_Page' )->andReturn( $this->context );
+
+		$meta = $this->instance->for_home_page();
+
+		$this->assertEquals( 'succeeds', $meta->test );
+	}
+
+	/**
+	 * Tests the current page function.
+	 *
+	 * @covers ::for_home_page
+	 */
 	public function test_for_home_page_static_page_no_indexable() {
 		Monkey\Functions\expect( 'get_option' )->once()->with( 'page_on_front' )->andReturn( 1 );
 		Monkey\Functions\expect( 'get_option' )->once()->with( 'show_on_front' )->andReturn( 'page' );


### PR DESCRIPTION
## Context

When `page_on_front` is 0 in database (which happens if you check `show_on_front`, select a `page_for_posts` but no `page_on_front`), `get_option('page_on_front')` will return 0 **as a string**.

The following condition (see next line after `get_option('page_on_front')`) will then be evaluated to true (it shouldn't) causing `$indexable = $this->repository->find_by_id_and_type( $front_page_id, 'post' );` to be called with `$front_page_id` to 0 and finally resulting in upgrading some random post in the indexable table with a 0 object_id.

There may be a related issue with `Indexable_Repository::find_by_id_and_type()` because it will call `upgrade_indexable` to be called with an $object_id set to 0 corrupting a post indexable.

## Summary

* Fixes a bug where the meta surface could return the wrong result for the home page. Props to [nlemoine](https://github.com/nlemoine).

## Relevant technical choices:

* Cast `get_option('page_on_front')` to int to ensure strict comparison works fine

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have multiple posts
* Set `page_on_front` to `0`
* Set `show_on_front` to `page`
* Call `YoastSEO()->meta->for_home_page()->indexable`

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

