### PR TITLE
Only import Japanese morphology data when the feature flag is turned on.

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/languages/ja/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ja/ResearcherSpec.js
@@ -3,6 +3,7 @@ import Paper from "../../../../src/values/Paper.js";
 import functionWords from "../../../../src/languageProcessing/languages/ja/config/functionWords";
 
 import getMorphologyData from "../../../specHelpers/getMorphologyData";
+import { isFeatureEnabled } from "@yoast/feature-flag";
 
 const morphologyDataJA = getMorphologyData( "ja" );
 
@@ -29,11 +30,15 @@ describe( "a test for Japanese Researcher", function() {
 		expect( researcher.getConfig( "functionWords" ) ).toEqual( functionWords );
 	} );
 
-	it( "creates the word forms when the Japanese morphology data is available", function() {
-		researcher.addResearchData( "morphology", morphologyDataJA );
-		expect( researcher.getHelper( "getStemmer" )( researcher )( "日帰り" ) ).toEqual(
-			[ "日帰る", "日帰り", "日帰ら", "日帰れ", "日帰ろ", "日帰っ", "日帰れる", "日帰らせ",
-				"日帰らせる", "日帰られ", "日帰られる", "日帰ろう" ]
-		);
-	} );
+	if ( isFeatureEnabled( "JAPANESE_SUPPORT" ) ) {
+		it( "creates the word forms when the Japanese morphology data is available", function() {
+			researcher.addResearchData( "morphology", morphologyDataJA );
+			expect( researcher.getHelper( "getStemmer" )( researcher )( "日帰り" ) ).toEqual(
+				[
+					"日帰る", "日帰り", "日帰ら", "日帰れ", "日帰ろ", "日帰っ", "日帰れる", "日帰らせ",
+					"日帰らせる", "日帰られ", "日帰られる", "日帰ろう",
+				]
+			);
+		} );
+	}
 } );

--- a/packages/yoastseo/spec/languageProcessing/languages/ja/helpers/getStemmerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ja/helpers/getStemmerSpec.js
@@ -2,18 +2,23 @@ import Researcher from "../../../../../src/languageProcessing/languages/it/Resea
 import getStemmer from "../../../../../src/languageProcessing/languages/ja/helpers/getStemmer";
 import Paper from "../../../../../src/values/Paper";
 import getMorphologyData from "../../../../specHelpers/getMorphologyData";
+import { isFeatureEnabled } from "@yoast/feature-flag";
 
 const morphologyDataJA = getMorphologyData( "ja" );
 
 const paper = new Paper(  "これは日本語のテキストです。", { keyword: "日本語のテキスト", locale: "ja" }  );
 
 describe( "Test for getting the helper to create word forms for Japanese word", () => {
-	it( "returns the forms created when the Japanese morphology data is available", function() {
-		const mockResearcher = new Researcher( paper );
-		mockResearcher.addResearchData( "morphology", morphologyDataJA );
-		expect( getStemmer( mockResearcher )( "日帰り" ) ).toEqual( [ "日帰る", "日帰り", "日帰ら", "日帰れ", "日帰ろ", "日帰っ", "日帰れる", "日帰らせ",
-			"日帰らせる", "日帰られ", "日帰られる", "日帰ろう" ] );
-	} );
+	if ( isFeatureEnabled( "JAPANESE_SUPPORT" ) ) {
+		it( "returns the forms created when the Japanese morphology data is available", function() {
+			const mockResearcher = new Researcher( paper );
+			mockResearcher.addResearchData( "morphology", morphologyDataJA );
+			expect( getStemmer( mockResearcher )( "日帰り" ) ).toEqual( [
+				"日帰る", "日帰り", "日帰ら", "日帰れ", "日帰ろ", "日帰っ", "日帰れる", "日帰らせ",
+				"日帰らせる", "日帰られ", "日帰られる", "日帰ろう",
+			] );
+		} );
+	}
 	it( "returns the input word if no morphology data is available", () => {
 		const mockResearcher = new Researcher( paper );
 

--- a/packages/yoastseo/spec/languageProcessing/languages/ja/helpers/internal/createWordFormsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ja/helpers/internal/createWordFormsSpec.js
@@ -1,10 +1,16 @@
 import createWordForms from "../../../../../../src/languageProcessing/languages/ja/helpers/internal/createWordForms";
 import getMorphologyData from "../../../../../specHelpers/getMorphologyData";
+import { isFeatureEnabled } from "@yoast/feature-flag";
 
 const morphologyDataJA = getMorphologyData( "ja" ).ja;
 
 
 describe( "test for creating word forms for Japanese", function() {
+	if ( ! isFeatureEnabled( "JAPANESE_SUPPORT" ) ) {
+		it( "is not run when the Japanese feature flag is disabled", function() {} );
+		return;
+	}
+
 	it( "returns an array with the original word if the word is one character long", function() {
 		let words = createWordForms( "猫", morphologyDataJA );
 		expect( words ).toEqual( [ "猫" ] );

--- a/packages/yoastseo/spec/specHelpers/getMorphologyData.js
+++ b/packages/yoastseo/spec/specHelpers/getMorphologyData.js
@@ -17,7 +17,8 @@ import tr from "../../premium-configuration/data/morphologyData-tr-v1.json";
 import cs from "../../premium-configuration/data/morphologyData-cs-v1.json";
 import sk from "../../premium-configuration/data/morphologyData-sk-v1.json";
 import el from "../../premium-configuration/data/morphologyData-el-v1.json";
-import ja from "../../premium-configuration/data/morphologyData-ja-v1.json";
+
+import { isFeatureEnabled } from "@yoast/feature-flag";
 
 const morphologyData = {
 	en,
@@ -39,8 +40,12 @@ const morphologyData = {
 	cs,
 	sk,
 	el,
-	ja,
 };
+
+if ( isFeatureEnabled( "JAPANESE_SUPPORT" ) ) {
+	// eslint-disable-next-line global-require
+	morphologyData.ja = require( "../../premium-configuration/data/morphologyData-ja-v1.json" );
+}
 
 /**
  * Requires morphology data. To be used in the analysis to recognize different word forms.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Disables tests that use Japanese language data when the feature flag for the Japanese language is disabled.

## Relevant technical choices:

* Uses `require` instead of `import` to be able to conditionally import the Japanese language data.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure that the Travis build succeeds.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A: The changes only concerns unit tests.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A: The changes only concerns unit tests.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
