### PR TITLE
P1-1032 document replacement variables package

### DIFF
--- a/apps/seo-integration/src/replacement-variables.js
+++ b/apps/seo-integration/src/replacement-variables.js
@@ -5,7 +5,7 @@ import { SEO_STORE_NAME } from "@yoast/seo-store";
 import { reduce } from "lodash";
 
 const registerReplacementVariables = () => {
-	const { replacementVariables, apply } = createReplacementVariables( [
+	const { variables, apply } = createReplacementVariables( [
 		{
 			name: "title",
 			label: "Title",
@@ -97,7 +97,7 @@ const registerReplacementVariables = () => {
 			},
 		},
 	] );
-	console.log("you can try the following replacement variables:", replacementVariables.map( replacevar => replacevar.name ) );
+	console.log("you can try the following replacement variables:", variables.map( variable => variable.name ) );
 
 	const applyReplacementVariables = ( paper ) => {
 		return reduce(

--- a/packages/replacement-variables/__tests__/index.test.js
+++ b/packages/replacement-variables/__tests__/index.test.js
@@ -86,12 +86,41 @@ describe( "Apply function", () => {
 		// The first replacement makes it so the second will no longer match, due to the singular `%`.
 		expect( result ).toEqual( "%%hello%TEST" );
 	} );
+
+	test( "should replace differently based on context.", () => {
+		const { apply } = createReplacementVariables( [
+			{
+				name: "test",
+				label: "Test",
+				getReplacement: ( { replacement } ) => replacement,
+			},
+		] );
+
+		const result1 = apply( "this is %%test%%", { replacement: "replacement 1" } );
+		expect( result1 ).toEqual( "this is replacement 1" );
+
+		const result2 = apply( "this is %%test%%", { replacement: "replacement 2" } );
+		expect( result2 ).toEqual( "this is replacement 2" );
+	} );
+
+	test( "should replace with undefined on missing context.", () => {
+		const { apply } = createReplacementVariables( [
+			{
+				name: "test",
+				label: "Test",
+				getReplacement: ( { replacement } ) => replacement,
+			},
+		] );
+
+		const result = apply( "this is %%test%%" );
+		expect( result ).toEqual( "this is undefined" );
+	} );
 } );
 
 describe( "Replacement variables", () => {
 	test( "should create multiple replacement variables", () => {
 		const getReplacement = () => {};
-		const { replacementVariables } = createReplacementVariables( [
+		const { variables } = createReplacementVariables( [
 			{
 				name: "test1",
 				label: "Test 1",
@@ -104,12 +133,12 @@ describe( "Replacement variables", () => {
 			},
 		] );
 
-		expect( replacementVariables.length ).toBe( 2 );
+		expect( variables.length ).toBe( 2 );
 	} );
 
 	test( "should create a regexp", () => {
 		const getReplacement = () => {};
-		const { replacementVariables } = createReplacementVariables( [
+		const { variables } = createReplacementVariables( [
 			{
 				name: "test",
 				label: "Test",
@@ -117,6 +146,6 @@ describe( "Replacement variables", () => {
 			},
 		] );
 
-		expect( replacementVariables ).toContainEqual( { name: "test", label: "Test", getReplacement, regexp: /%%test%%/g } );
+		expect( variables ).toContainEqual( { name: "test", label: "Test", getReplacement, regexp: /%%test%%/g } );
 	} );
 } );

--- a/packages/replacement-variables/readme.md
+++ b/packages/replacement-variables/readme.md
@@ -1,0 +1,83 @@
+# Replacement variables
+
+This package aims to provide the easiest possible solution for replacing variables in a text based on a set of replacement variables. It exposes a single factory function `createReplacementVariables` for configuring a set of replacement variables and returns an interface for applying these replacement variables to a text.
+
+## Installation
+
+To install this package run the following command in your terminal:
+
+```shell
+yarn add @yoast/replacement-variables
+```
+
+## Configuration
+
+The `createReplacementVariables` factory accepts a single argument: an array of replacement variable configurations with the following props:
+
+**`name`** `String`\
+The `snake_case` name of the replacement variable.
+
+**`label`** `String`\
+The label of the replacement variable to display in UI.
+
+**`getReplacement`** `Function` \
+A pure function that returns the replacement for the replacement variable. The function can accept arguments and must return a string.
+
+**`regexp`** `RegExp` - *Optional*\
+Optional custom Regular Expression for locating the variable in a string. Defaults to `%%name%%`.
+
+### Example
+
+An example configuration may look like this:
+
+```js
+import createReplacementVariables from "@yoast/replacement-variables";
+
+const configurations = [
+    {
+        name: "title",
+        label: "Title",
+        getReplacement: () => "Replaced title",
+    },
+    {
+        name: "global_variable",
+        label: "Global Variable",
+        getReplacement: ( key ) => window[ key ], // getReplacement accepts one argument
+    },
+    {
+        name: "redux_store_state",
+        label: "Redux Store State",
+        getReplacement: () => selectFromReduxStore( "path.in.state" ),
+        regexp: new RegExp( `{{${ name }}}`, "g" ), // Using Handlebars style template tags
+    },
+];
+
+const replacementVariables = createReplacementVariables( configurations );
+```
+
+## Usage
+
+
+### Example
+
+```js
+import createReplacementVariables from "@yoast/replacement-variables";
+
+const replacementVariables = [
+    {
+        name: "title",
+        getReplacement: () => "Replaced title",
+    },
+    {
+        name: "global_variable",
+        getReplacement: () => window.variable,
+    },
+    {
+        name: "store_state",
+        getReplacement: () => selectFromReduxStore( "path.in.state" ),
+    },
+];
+
+console.log(  );
+```
+

--- a/packages/replacement-variables/readme.md
+++ b/packages/replacement-variables/readme.md
@@ -1,83 +1,103 @@
-# Replacement variables
+# Replacement Variables
 
-This package aims to provide the easiest possible solution for replacing variables in a text based on a set of replacement variables. It exposes a single factory function `createReplacementVariables` for configuring a set of replacement variables and returns an interface for applying these replacement variables to a text.
+This package aims to provide a simple solution for replacing *variables* with their corresponding *values* in a text based on a set of *replacement variables*. Use this package to configure what variables are supported and how these should be replaced when the variable is encountered in a text.
 
 ## Installation
 
 To install this package run the following command in your terminal:
 
-```shell
+```sh
+# Yarn
 yarn add @yoast/replacement-variables
+
+# NPM
+npm install @yoast/replacement-variables
 ```
 
-## Configuration
+## Configuration using `createReplacementVariables`
 
-The `createReplacementVariables` factory accepts a single argument: an array of replacement variable configurations with the following props:
+This package exports a single factory function called `createReplacementVariables` which accepts an array of replacement variable configuratinos and return an interface for applying the variables to a text.
 
-**`name`** `String`\
-The `snake_case` name of the replacement variable.
+### Arguments
 
-**`label`** `String`\
-The label of the replacement variable to display in UI.
+**`configurations`** `Object[]`\
+An array of replacement variable configurations containing the following props:
 
-**`getReplacement`** `Function` \
-A pure function that returns the replacement for the replacement variable. The function can accept arguments and must return a string.
+- **`name`** `String`\
+The name of the replacement variable. The convention here is to use `snake_case` naming.
 
-**`regexp`** `RegExp` - *Optional*\
+- **`label`** `String`\
+The label of the replacement variable to display in user interface if needed.
+
+- **`getReplacement`** `Function` \
+A pure function that returns the replacement value for the variable. The function can accept a single **`context`** `Object` argument and must return a `String`. This function can get data from anyhwere, ie. a Redux store selector, a global variable or just a static string.
+
+- **`regexp`** `RegExp` - *Optional*\
 Optional custom Regular Expression for locating the variable in a string. Defaults to `%%name%%`.
 
-### Example
+### Returns
 
-An example configuration may look like this:
+**`replacementVariables`** `Object`\
+An interface for applying replacement variables to a text containing the following props:
+
+- **`variables`** `Object[]`\
+An array of enriched replacement variables. The difference from the variables passed as an argument is that, if not specified specifically, the `regexp` prop has been added to each variable for locating the variable in a string. The template tag used in the default `regexp` is based on the variables `name` prop and looks like this: `%%name%%` (surrounding the `name` with double percent chars).
+
+- **`apply`** `Function`\
+A function that accepts a `String` and returns a `String` in which all supported variables have been replaced with their corresponding values. An *optional* second **`context`** `Object` argument is supported, which will be passed as the first and only argument to all `getReplacement` functions in the configured set of replacement variables.
+
+## Example implementation
+
+In this example we'll configure a set of three replacement variables and apply them to three example strings to demonstrate the flexibility of the variables `getReplacement` function.
 
 ```js
 import createReplacementVariables from "@yoast/replacement-variables";
+
+// Some utilities from Lodash
+import { get, map } from "lodash";
+
+// Some state
+window.fooBar = "Foo Bar";
+const selectFromReduxStore = () => "State from Redux Store";
 
 const configurations = [
     {
         name: "title",
         label: "Title",
-        getReplacement: () => "Replaced title",
+        getReplacement: () => "Title",
     },
     {
         name: "global_variable",
         label: "Global Variable",
-        getReplacement: ( key ) => window[ key ], // getReplacement accepts one argument
+        // getReplacement with context
+        getReplacement: ( context ) => window[ context.globalKey ],
     },
     {
         name: "redux_store_state",
         label: "Redux Store State",
-        getReplacement: () => selectFromReduxStore( "path.in.state" ),
-        regexp: new RegExp( `{{${ name }}}`, "g" ), // Using Handlebars style template tags
+        getReplacement: () => selectFromReduxStore(),
+        // Using a custom template tag
+        regexp: new RegExp( `{{custom_template_tag}}`, "g" ),
     },
 ];
 
 const replacementVariables = createReplacementVariables( configurations );
+
+const string1 = "There is no %%title%% without %%global_variable%%";
+const string2 = "There is no %%title%% without %%redux_store_state%%";
+const string3 = "There is no {{title}} without {{custom_template_tag}}";
+
+console.log(
+    replacementVariables.apply( string1 ),
+    replacementVariables.apply( string1, { globalKey: fooBar } ),
+    replacementVariables.apply( string2 ),
+    replacementVariables.apply( string3 ),
+);
+
+// Expected Output
+// ---
+// "There is no Title without undefined"
+// "There is no Title without Foo Bar"
+// "There is no Title without %%redux_store_state%%"
+// "There is no {{title}} without State from Redux Store"
 ```
-
-## Usage
-
-
-### Example
-
-```js
-import createReplacementVariables from "@yoast/replacement-variables";
-
-const replacementVariables = [
-    {
-        name: "title",
-        getReplacement: () => "Replaced title",
-    },
-    {
-        name: "global_variable",
-        getReplacement: () => window.variable,
-    },
-    {
-        name: "store_state",
-        getReplacement: () => selectFromReduxStore( "path.in.state" ),
-    },
-];
-
-console.log(  );
-```
-

--- a/packages/replacement-variables/readme.md
+++ b/packages/replacement-variables/readme.md
@@ -29,7 +29,7 @@ The name of the replacement variable. The convention here is to use `snake_case`
 - **`label`** `String`\
 The label of the replacement variable to display in user interface if needed.
 
-- **`getReplacement`** `Function` \
+- **`getReplacement`** `Function`\
 A pure function that returns the replacement value for the variable. The function can accept a single **`context`** `Object` argument and must return a `String`. This function can get data from anyhwere, ie. a Redux store selector, a global variable or just a static string.
 
 - **`regexp`** `RegExp` - *Optional*\
@@ -52,9 +52,6 @@ In this example we'll configure a set of three replacement variables and apply t
 
 ```js
 import createReplacementVariables from "@yoast/replacement-variables";
-
-// Some utilities from Lodash
-import { get, map } from "lodash";
 
 // Some state
 window.fooBar = "Foo Bar";

--- a/packages/replacement-variables/readme.md
+++ b/packages/replacement-variables/readme.md
@@ -14,7 +14,7 @@ yarn add @yoast/replacement-variables
 npm install @yoast/replacement-variables
 ```
 
-## Configuration using `createReplacementVariables`
+## Using `createReplacementVariables`
 
 This package exports a single factory function called `createReplacementVariables` which accepts an array of replacement variable configuratinos and return an interface for applying the variables to a text.
 
@@ -89,7 +89,7 @@ const string3 = "There is no {{title}} without {{custom_template_tag}}";
 
 console.log(
     replacementVariables.apply( string1 ),
-    replacementVariables.apply( string1, { globalKey: fooBar } ),
+    replacementVariables.apply( string1, { globalKey: "fooBar" } ),
     replacementVariables.apply( string2 ),
     replacementVariables.apply( string3 ),
 );

--- a/packages/replacement-variables/src/index.js
+++ b/packages/replacement-variables/src/index.js
@@ -37,11 +37,11 @@ const createReplacementVariables = ( configurations ) => {
 	 * Applies the replacement variables to a string.
 	 *
 	 * @param {string} input The input string.
-	 * @param {Object} context The single context argument for the `getReplacement` functions.
+	 * @param {Object} [context] Optional single context argument for the `getReplacement` functions.
 	 *
 	 * @returns {string} The input, but with any replacement variables replaced.
 	 */
-	const apply = ( input, context ) => reduce(
+	const apply = ( input, context = {} ) => reduce(
 		variables,
 		( replaced, { regexp, getReplacement } ) => (
 			regexp.test( replaced )

--- a/packages/replacement-variables/src/index.js
+++ b/packages/replacement-variables/src/index.js
@@ -23,10 +23,10 @@ import { reduce } from "lodash";
  *
  * @param {ReplacementVariableConfiguration[]} configurations The replacement variable configurations.
  *
- * @returns {{replacementVariables: ReplacementVariable[], apply: function}} The replacement variables and an apply function.
+ * @returns {{variables: ReplacementVariable[], apply: function}} The replacement variables and an apply function.
  */
 const createReplacementVariables = ( configurations ) => {
-	const replacementVariables = configurations.map( ( { name, label, getReplacement, regexp = null } = {} ) => ( {
+	const variables = configurations.map( ( { name, label, getReplacement, regexp = null } = {} ) => ( {
 		name,
 		label,
 		getReplacement,
@@ -37,22 +37,22 @@ const createReplacementVariables = ( configurations ) => {
 	 * Applies the replacement variables to a string.
 	 *
 	 * @param {string} input The input string.
-	 * @param {*} getReplacementArguments The arguments for the `getReplacement` function.
+	 * @param {Object} context The single context argument for the `getReplacement` functions.
 	 *
 	 * @returns {string} The input, but with any replacement variables replaced.
 	 */
-	const apply = ( input, ...getReplacementArguments ) => reduce(
-		replacementVariables,
+	const apply = ( input, context ) => reduce(
+		variables,
 		( replaced, { regexp, getReplacement } ) => (
 			regexp.test( replaced )
-				? replaced.replace( regexp, getReplacement( ...getReplacementArguments ) )
+				? replaced.replace( regexp, getReplacement( context ) )
 				: replaced
 		),
 		input,
 	);
 
 	return {
-		replacementVariables,
+		variables,
 		apply,
 	};
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds documentation for the `@yoast/replacement-variables` JavaScript package.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds documentation for the `@yoast/replacement-variables` JavaScript package.

## Relevant technical choices:

* Adds documentation for the `@yoast/replacement-variables` JavaScript package.
* Replace support for multiple args for `getReplacement` functions with a single `context` args to be able to pass multiple variables (as props of `context`) to the `getReplacement` functions in the configured set of replacement variables.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Read the documentation and check if that makes sense.
* You could try the the example for real for fun I guess (I haven't).


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
