### PR TITLE
DUPP-81 Fix indexation in configuration workout

### DIFF
--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -74,9 +74,9 @@ class Configuration_Workout_Integration implements Integration_Interface {
 			'firstTime'    => ( YoastSEO()->helpers->indexing->is_initial_indexing() === true ),
 			'errorMessage' => '',
 			'restApi'      => [
-				'root'      => \esc_url_raw( \rest_url() ),
-				'endpoints' => $this->get_endpoints(),
-				'nonce'     => \wp_create_nonce( 'wp_rest' ),
+				'root'               => \esc_url_raw( \rest_url() ),
+				'indexing_endpoints' => $this->get_endpoints(),
+				'nonce'              => \wp_create_nonce( 'wp_rest' ),
 			],
 		];
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The indexation in the conf. workout is broken, we have to update the endpoint name

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the indexation in the configuration workout was failing.

## Relevant technical choices:

* [this is the commit](https://github.com/Yoast/wordpress-seo/commit/7f7a0bbede785397e8ebde37907961deec416cbd) where the endpoint names changed

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* change your permalinks settings so indexation can be restarted
* Visit the conf. workout and start the indexation, check it works
* change your permalinks settings so indexation can be restarted
* Visit SEO > Tools  and start the indexation, check it works (it shouldn't be affected but let's check)


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
