### PR TITLE
Pass a third state for the tracking option on selected condition

### DIFF
--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -170,7 +170,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	 * @returns {Promise|bool} A promise, or false if the call fails.
 	 */
 	const updateTracking = async function() {
-		if ( state.tracking !== 0 || state.tracking !== 1 ) {
+		if ( state.tracking !== 0 && state.tracking !== 1 ) {
 			throw "Value not set!";
 		}
 

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -104,6 +104,8 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 
 	const steps = STEPS.configuration;
 
+	const isTrackingOptionSelected = state.tracking === 0 || state.tracking === 1;
+
 	/**
 	 * Updates the site representation in the database.
 	 *
@@ -170,7 +172,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	 * @returns {Promise|bool} A promise, or false if the call fails.
 	 */
 	const updateTracking = async function() {
-		if ( state.tracking !== 0 && state.tracking !== 1 ) {
+		if ( ! isTrackingOptionSelected ) {
 			throw "Value not set!";
 		}
 
@@ -263,13 +265,11 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 		if ( isStepFinished( "configuration", steps.enableTracking ) ) {
 			toggleStepEnableTracking();
 		} else {
-			if ( ( state.tracking === 0 || state.tracking === 1 ) ) {
-				updateTracking()
-					.then( toggleStepEnableTracking )
-					.catch( ( e ) => {
-						console.error( e );
-					} );
-			}
+			updateTracking()
+				.then( toggleStepEnableTracking )
+				.catch( ( e ) => {
+					console.error( e );
+				} );
 		}
 	}
 
@@ -577,7 +577,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 							__( "Important: We will never sell this data. And of course, as always, we won't collect any personal data about you or your visitors!", "wordpress-seo" )
 						}</i>
 					</p>
-					{ ( state.tracking !== 0 && state.tracking !== 1 ) && <Alert type="warning">
+					{ ! isTrackingOptionSelected && <Alert type="warning">
 						{ __(
 							// eslint-disable-next-line max-len
 							"In order to complete this step please select if we are allowed to improve Yoast SEO with your data.",
@@ -589,7 +589,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						finishText={ "Save and continue" }
 						onFinishClick={ updateOnFinishEnableTracking }
 						isFinished={ isStepFinished( "configuration", steps.enableTracking ) }
-						additionalButtonProps={ { disabled: state.tracking !== 0 && state.tracking !== 1 } }
+						additionalButtonProps={ { disabled: ! isTrackingOptionSelected } }
 					/>
 				</Step>
 				<Step
@@ -601,7 +601,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						finishText={ "Finish this workout" }
 						onFinishClick={ toggleConfigurationWorkout }
 						isFinished={ isStepFinished( "configuration", steps.newsletterSignup ) }
-						additionalButtonProps={ { disabled: ( ( indexingState !== "completed" ) || ( state.tracking !== 0 && state.tracking !== 1 ) ) } }
+						additionalButtonProps={ { disabled: indexingState !== "completed" || ! isTrackingOptionSelected } }
 					>
 						{ indexingState !== "completed" && <Alert type="warning">
 							{ indexingState === "idle" && __( "Before you finish this workout, please start the SEO data optimization in step 1 and wait until it is completed...", "wordpress-seo" ) }

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -263,11 +263,13 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 		if ( isStepFinished( "configuration", steps.enableTracking ) ) {
 			toggleStepEnableTracking();
 		} else {
-			updateTracking()
-				.then( toggleStepEnableTracking )
-				.catch( ( e ) => {
-					console.error( e );
-				} );
+			if ( ( state.tracking === 0 || state.tracking === 1 ) ) {
+				updateTracking()
+					.then( toggleStepEnableTracking )
+					.catch( ( e ) => {
+						console.error( e );
+					} );
+			}
 		}
 	}
 
@@ -575,11 +577,19 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 							__( "Important: We will never sell this data. And of course, as always, we won't collect any personal data about you or your visitors!", "wordpress-seo" )
 						}</i>
 					</p>
+					{ ( state.tracking !== 0 && state.tracking !== 1 ) && <Alert type="warning">
+						{ __(
+							// eslint-disable-next-line max-len
+							"In order to complete this step please select if we are allowed to improve Yoast SEO with your data.",
+							"wordpress-seo"
+						) }
+					</Alert> }
 					<FinishStepSection
 						hasDownArrow={ true }
 						finishText={ "Save and continue" }
 						onFinishClick={ updateOnFinishEnableTracking }
 						isFinished={ isStepFinished( "configuration", steps.enableTracking ) }
+						additionalButtonProps={ { disabled: state.tracking !== 0 && state.tracking !== 1 } }
 					/>
 				</Step>
 				<Step
@@ -591,7 +601,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						finishText={ "Finish this workout" }
 						onFinishClick={ toggleConfigurationWorkout }
 						isFinished={ isStepFinished( "configuration", steps.newsletterSignup ) }
-						additionalButtonProps={ { disabled: indexingState !== "completed" } }
+						additionalButtonProps={ { disabled: ( ( indexingState !== "completed" ) || ( state.tracking !== 0 && state.tracking !== 1 ) ) } }
 					>
 						{ indexingState !== "completed" && <Alert type="warning">
 							{ indexingState === "idle" && __( "Before you finish this workout, please start the SEO data optimization in step 1 and wait until it is completed...", "wordpress-seo" ) }

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -170,22 +170,20 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	 * @returns {Promise|bool} A promise, or false if the call fails.
 	 */
 	const updateTracking = async function() {
+		if ( state.tracking !== 0 || state.tracking !== 1 ) {
+			throw "Value not set!";
+		}
+
 		const tracking = {
 			tracking: state.tracking,
 		};
 
-		try {
-			const response = await apiFetch( {
-				path: "yoast/v1/workouts/enable_tracking",
-				method: "POST",
-				data: tracking,
-			} );
-			return await response.json;
-		} catch ( e ) {
-			// URL() constructor throws a TypeError exception if url is malformed.
-			console.error( e.message );
-			return false;
-		}
+		const response = await apiFetch( {
+			path: "yoast/v1/workouts/enable_tracking",
+			method: "POST",
+			data: tracking,
+		} );
+		return await response.json;
 	};
 
 	const onFinishOptimizeSeoData = useCallback(
@@ -265,7 +263,11 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 		if ( isStepFinished( "configuration", steps.enableTracking ) ) {
 			toggleStepEnableTracking();
 		} else {
-			updateTracking().then( toggleStepEnableTracking );
+			updateTracking()
+				.then( toggleStepEnableTracking )
+				.catch( ( e ) => {
+					console.error( e );
+				} );
 		}
 	}
 

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -562,7 +562,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						options={ [
 							{
 								value: 0,
-								label: __( "No, I don’t want to allow you to track my site data", "wordpress-seo" ),
+								label: __( "No, don’t track my site data", "wordpress-seo" ),
 							},
 							{
 								value: 1,

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -7,6 +7,7 @@ use WPSEO_Admin_Asset_Manager;
 use WPSEO_Utils;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Routes\Indexing_Route;
 
@@ -37,6 +38,13 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	private $options_helper;
 
 	/**
+	 * The product helper.
+	 *
+	 * @var \Yoast\WP\SEO\Helpers\Product_Helper
+	 */
+	private $product_helper;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
@@ -49,15 +57,18 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	 * @param WPSEO_Admin_Asset_Manager $admin_asset_manager The admin asset manager.
 	 * @param WPSEO_Addon_Manager       $addon_manager       The addon manager.
 	 * @param Options_Helper            $options_helper      The options helper.
+	 * @param Product_Helper            $product_helper      The product helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $admin_asset_manager,
 		WPSEO_Addon_Manager $addon_manager,
-		Options_Helper $options_helper
+		Options_Helper $options_helper,
+		Product_Helper $product_helper
 	) {
 		$this->admin_asset_manager = $admin_asset_manager;
 		$this->addon_manager       = $addon_manager;
 		$this->options_helper      = $options_helper;
+		$this->product_helper      = $product_helper;
 	}
 
 	/**
@@ -292,10 +303,27 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	/**
 	 * Checks whether tracking is enabled.
 	 *
-	 * @return bool True if tracking is enabled, false otherwise.
+	 * @return int True if tracking is enabled, false otherwise, null if in Free and conf. workout step not finished.
 	 */
 	private function has_tracking_enabled() {
-		return $this->options_helper->get( 'tracking', false );
+		$tracking = -1;
+		// If in Premium, use the current setting.
+		if ( $this->product_helper->is_premium() ) {
+			$tracking = $this->options_helper->get( 'tracking', false );
+		}
+
+		// If in Free and the "tracking" step of the configuration workout is marked as finished, use the current setting.
+		$workouts_option = $this->options_helper->get( 'workouts_data' );
+		$finished_steps  = (array) $workouts_option['configuration']['finishedSteps'];
+		if ( \in_array( 'enableTracking', $finished_steps, true ) ) {
+			$tracking = $this->options_helper->get( 'tracking', false );
+		}
+
+		if ( \is_bool( $tracking ) ) {
+			$tracking = (int) $tracking;
+		}
+
+		return $tracking;
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

New behaviour surrounding Step 4 tracking:
* When step 4 tracking has no selected value, the “Finish this workout” button is disabled
* So: the “Finish this workout” button can only be used, when step 1 data optimization has finished and a user has selected a tracking value 
* Step 4 tracking has a disabled “Save and continue” button and an alert when no value has been selected. 
* For premium users the tracking value from the database will be used. 
* For Free users, the tracking value is not selected when you start the workout. It will be saved when you finish the step. When the step is not finished, and you reload the page, the value will be set back to null.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Displays empty radiobuttons for the tracking step of the Configuration Workout when on Free.

## Relevant technical choices:

* **NOTE** it doesn't address the validation, so you can still complete the step and try to send the value. Will be addressed in a next issue

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* install and activate Yoast SEO without Premium active
* visit the Configuration Workout
* finish data optimization ( step 1 )
* if the 4th step is not marked as finished, no radio button should be selected: the "Continue and save" button should be disabled and you should see an alert
  * check that the "Finish this workout" button is disabled
  * if so, choose a value: the alert should disappear and the "Continue and save" as well as the "Finish this workout" button should become active
  * finish the step, then reload the page
  * now you should see the option you chose
* if it's marked as finished, you should see your current option (check if it's the same as SEO > General)
  * if so, unset the step as finished: you should NOT see an alert and the "Continue and save" and "Finish this workout" button should be active
  * reload
  * now you should see empty radiobuttons, you should also see the alert and the buttons should again be disabled
* install and activate Premium
* visit the Configuration Workout
* the 4th step should always display the right radiobutton as selected.

  


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-84]

[DUPP-84]: https://yoast.atlassian.net/browse/DUPP-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ