### PR TITLE
Validate email and give feedback in newsletter signup

### DIFF
--- a/css/src/workouts.css
+++ b/css/src/workouts.css
@@ -432,8 +432,35 @@ table.yoast_help th.divider {
 	top: 3px;
 }
 
-.yoast-list--usp.yoast-newsletter-result li {
+.yoast-validated-text-input--explanation {
+	font-size: 10px;
+}
+
+.yoast-validated-text-input--feedback::before {
+	display: inline-block;
+	content: "";
+	width: 18px;
+	height: 13px;
+}
+
+.yoast-validated-text-input--feedback.success::before {
+	background: var(--yoast-svg-icon-check);
+	background-size: 18px 13px;
+}
+
+.yoast-validated-text-input--feedback.success {
+	position: relative;
 	color: rgb(110, 160, 41);
+}
+
+.yoast-validated-text-input--feedback.error::before {
+	background: url( "../../images/error-icon.svg" );
+	background-size: 18px 16px;
+}
+
+.yoast-validated-text-input--feedback.error {
+	position: relative;
+	color: rgb(204, 0, 0);
 }
 
 .workflow .yoast-newsletter-signup {
@@ -444,13 +471,15 @@ table.yoast_help th.divider {
 }
 
 .workflow .yoast-newsletter-signup .yoast-field-group {
-	flex-grow: 6;
+	flex-grow: 0;
 	margin: 0;
 }
 
 .workflow .yoast-newsletter-signup button {
-	align-self: end;
+	margin-top: 1.8rem;
+	align-self: flex-start;
 	flex-grow: 1;
+	flex-shrink: 0;
 }
 
 .workflow .yoast-privacy-policy {

--- a/css/src/workouts.css
+++ b/css/src/workouts.css
@@ -432,6 +432,10 @@ table.yoast_help th.divider {
 	top: 3px;
 }
 
+.workflow .yoast-validated-text-input {
+	flex-grow: 1;
+}
+
 .yoast-validated-text-input--explanation {
 	font-size: 10px;
 }
@@ -478,7 +482,7 @@ table.yoast_help th.divider {
 .workflow .yoast-newsletter-signup button {
 	margin-top: 1.8rem;
 	align-self: flex-start;
-	flex-grow: 1;
+	flex-grow: 0;
 	flex-shrink: 0;
 }
 

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -155,7 +155,6 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 			youtube_url: state.socialProfiles.youtubeUrl,
 			// eslint-disable-next-line camelcase
 			wikipedia_url: state.socialProfiles.wikipediaUrl,
-			// eslint-enable camelcase
 		};
 
 		try {
@@ -354,13 +353,13 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						<Indexation
 							indexingStateCallback={ setIndexingState }
 						/>
-						<FinishStepSection
-							hasDownArrow={ true }
-							finishText={ __( "Continue", "wordpress-seo" ) }
-							onFinishClick={ onFinishOptimizeSeoData }
-							isFinished={ isStepFinished( "configuration", steps.optimizeSeoData ) }
-						/>
 					</div>
+					<FinishStepSection
+						hasDownArrow={ true }
+						finishText={ __( "Continue", "wordpress-seo" ) }
+						onFinishClick={ onFinishOptimizeSeoData }
+						isFinished={ isStepFinished( "configuration", steps.optimizeSeoData ) }
+					/>
 				</Step>
 				<p className="extra-list-content">
 					{

--- a/packages/js/src/workouts/components/NewsletterSignup.js
+++ b/packages/js/src/workouts/components/NewsletterSignup.js
@@ -1,8 +1,8 @@
-import { useCallback, useState, useEffect, Fragment } from "@wordpress/element";
+import { useCallback, useState, Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { isURL, isEmail } from "@wordpress/url";
+import { isEmail } from "@wordpress/url";
 
-import { NewButton as Button, TextInput } from "@yoast/components";
+import { NewButton as Button } from "@yoast/components";
 import { addLinkToString } from "../../helpers/stringHelpers";
 import ValidatedTextInput from "../components/ValidatedTextInput";
 

--- a/packages/js/src/workouts/components/NewsletterSignup.js
+++ b/packages/js/src/workouts/components/NewsletterSignup.js
@@ -1,8 +1,10 @@
-import { useCallback, useState, Fragment } from "@wordpress/element";
+import { useCallback, useState, useEffect, Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
+import { isURL, isEmail } from "@wordpress/url";
 
 import { NewButton as Button, TextInput } from "@yoast/components";
 import { addLinkToString } from "../../helpers/stringHelpers";
+import ValidatedTextInput from "../components/ValidatedTextInput";
 
 /**
  * A function to request a sign up to the newsletter.
@@ -35,6 +37,14 @@ async function postSignUp( email ) {
 	return response.json();
 }
 
+const genericErrorFeedback = __( "Oops! Something went wrong. Check your email address and try again.", "wordpress-seo" );
+const invalidEmailFeedback = __( "That is not a valid email address. Check your email address and try again.", "wordpress-seo" );
+const alreadySubscribedFeedback = __( "That email address has already been subscribed.", "wordpress-seo" );
+const subscribedFeedback = __(
+	"Thanks! Please click the link in the email we just sent you to confirm your newsletter subscription.",
+	"wordpress-seo"
+);
+
 /**
  * The newsletter signup section.
  *
@@ -43,12 +53,26 @@ async function postSignUp( email ) {
 export function NewsletterSignup() {
 	const [ newsletterEmail, setNewsletterEmail ] = useState( "" );
 	const [ signUpState, setSignUpState ] = useState( "waiting" );
+	const [ emailFeedback, setEmailFeedback ] = useState( "" );
 
 	const onSignUpClick = useCallback(
 		async function() {
+			if ( ! isEmail( newsletterEmail ) ) {
+				setSignUpState( "error" );
+				setEmailFeedback( invalidEmailFeedback );
+				return;
+			}
 			setSignUpState( "loading" );
-			await postSignUp( newsletterEmail );
-			setSignUpState( "ready" );
+			const response = await postSignUp( newsletterEmail );
+			if ( response.error ) {
+				setSignUpState( "error" );
+				setEmailFeedback( genericErrorFeedback );
+			} else {
+				setSignUpState( "success" );
+				setEmailFeedback(
+					response.status === "alreadySubscribed" ? alreadySubscribedFeedback : subscribedFeedback
+				);
+			}
 		},
 		[ newsletterEmail ]
 	);
@@ -61,13 +85,29 @@ export function NewsletterSignup() {
 				<li>{ __( "Get guidance on how to use Yoast SEO to the fullest", "wordpress-seo" ) }</li>
 			</ul>
 			<div className="yoast-newsletter-signup">
-				<TextInput
+				<ValidatedTextInput
 					label={ __( "Email address", "wordpress-seo" ) }
 					id="newsletter-email"
 					name="newsletter email"
 					value={ newsletterEmail }
 					onChange={ setNewsletterEmail }
 					type="email"
+					feedbackState={ signUpState }
+					feedbackMessage={ emailFeedback }
+					inputExplanation={
+						addLinkToString(
+							sprintf(
+								// translators: %1$s and %2$s are replaced by opening and closing anchor tags.
+								__(
+									"Yoast respects your privacy. Read %1$sour privacy policy%2$s on how we handle your personal information.",
+									"wordpress-seo"
+								),
+								"<a>",
+								"</a>"
+							),
+							"https://yoa.st/gdpr-config-workout"
+						)
+					}
 				/>
 				<Button
 					variant="primary"
@@ -77,25 +117,6 @@ export function NewsletterSignup() {
 					{ __( "Sign up!", "wordpress-seo" ) }
 				</Button>
 			</div>
-			<p className="yoast-privacy-policy">
-				{
-					addLinkToString(
-						sprintf(
-							// translators: %1$s and %2$s are replaced by opening and closing anchor tags.
-							__(
-								"Yoast respects your privacy. Read %1$sour privacy policy%2$s on how we handle your personal information.",
-								"wordpress-seo"
-							),
-							"<a>",
-							"</a>"
-						),
-						"https://yoa.st/gdpr-config-workout"
-					)
-				}
-			</p>
-			{ signUpState === "ready" && <ul className="yoast-list--usp yoast-newsletter-result">
-				<li>{ __( "Thanks! Check your inbox for the confirmation email.", "wordpress-seo" ) }</li>
-			</ul> }
 		</Fragment>
 	);
 }

--- a/packages/js/src/workouts/components/ValidatedTextInput.js
+++ b/packages/js/src/workouts/components/ValidatedTextInput.js
@@ -1,0 +1,27 @@
+import { TextInput } from "@yoast/components";
+
+/**
+ * A wrapper for the TextInput that can handle validation feedback.
+ *
+ * @param {Object} props The props object.
+ *
+ * @returns {WPElement} The ValidationTextInput element.
+ */
+export default function ValidatedTextInput( { inputExplanation, feedbackState, feedbackMessage, ...textInputProps } ) {
+	return (
+		<div className="yoast-validated-text-input">
+			<TextInput
+				{ ...textInputProps }
+			/>
+			{ inputExplanation && <p className="yoast-validated-text-input--explanation">
+				{ inputExplanation }
+			</p>
+			}
+			{
+				[ "error", "success" ].includes( feedbackState ) && <p className={ `yoast-validated-text-input--feedback ${ feedbackState }` }>
+					{ feedbackMessage }
+				</p>
+			}
+		</div>
+	);
+}

--- a/packages/js/src/workouts/components/ValidatedTextInput.js
+++ b/packages/js/src/workouts/components/ValidatedTextInput.js
@@ -1,4 +1,5 @@
 import { TextInput } from "@yoast/components";
+import PropTypes from "prop-types";
 
 /**
  * A wrapper for the TextInput that can handle validation feedback.
@@ -25,3 +26,15 @@ export default function ValidatedTextInput( { inputExplanation, feedbackState, f
 		</div>
 	);
 }
+
+ValidatedTextInput.propTypes = {
+	inputExplanation: PropTypes.string,
+	feedbackState: PropTypes.string,
+	feedbackMessage: PropTypes.string,
+};
+
+ValidatedTextInput.defaultProps = {
+	inputExplanation: "",
+	feedbackState: "",
+	feedbackMessage: "",
+};

--- a/packages/js/src/workouts/components/ValidatedTextInput.js
+++ b/packages/js/src/workouts/components/ValidatedTextInput.js
@@ -28,7 +28,7 @@ export default function ValidatedTextInput( { inputExplanation, feedbackState, f
 }
 
 ValidatedTextInput.propTypes = {
-	inputExplanation: PropTypes.string,
+	inputExplanation: PropTypes.any,
 	feedbackState: PropTypes.string,
 	feedbackMessage: PropTypes.string,
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add a way to display validation results near our TextInput components.
* Validate email client-side

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the newsletter signup in the configuration workout would always return a success message, despite inputs being invalid or even absent.
* Fixes an unreleased bug where the continue button in the indexation step was misaligned.

## Relevant technical choices:

* Decided to keep the wrapped TextInput inside the workouts/components despite potential wider use cases, since we are on the clock with this feature.
* Also, the TextInput here may be superseded at some point by the TextInput in admin-ui.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In the newsletter configuration workout, go to the newsletter signup at the bottom.
* Try the following scenario's:
	* Click sign-up without entering an email.
		* Should not send a network request (check network tab) and display a message about the email not being valid.
	* Click sign-up with an invalid email (leave out @ or something)
		*  As above. Should not send a network request (check network tab) and display a message about the email not being valid.
	* Enter a valid email.
		* Should disable the button for a while.
		* After a while, the button should become available again and a success message should appear.
	* Enter that same email again.
		* Should disable the button for a while.
		* After a while, the button should become available again and a message should appear that that email is already subscribed.
	* Enter a new email.
		* Should behave as the first time you entered a valid email.
	* There is another case where a server error causes a generic message about trying again. This is hard to test, don't know how to trigger this in QA testing. Believe me if I say it works.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

DUPP-82
