### PR TITLE
P1-991 fix social untranslatables

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,6 +82,7 @@ module.exports = function( grunt ) {
 				yoastJsHelpers: "<%= paths.languages %>yoast-js-helpers.pot",
 				yoastJsSearchMetadataPreviews: "<%= paths.languages %>yoast-js-search-metadata-previews.pot",
 				yoastJsSocialMetadataForms: "<%= paths.languages %>yoast-js-social-metadata-forms.pot",
+				yoastJsReplacementVariableEditor: "<%= paths.languages %>yoast-js-replacement-variable-editor.pot",
 
 				yoastseojs: "<%= paths.languages %>yoast-seo-js.pot",
 				yoastComponents: "<%= paths.languages %>yoast-components.pot",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,6 +81,7 @@ module.exports = function( grunt ) {
 				yoastJsConfigurationWizard: "<%= paths.languages %>yoast-js-configuration-wizard.pot",
 				yoastJsHelpers: "<%= paths.languages %>yoast-js-helpers.pot",
 				yoastJsSearchMetadataPreviews: "<%= paths.languages %>yoast-js-search-metadata-previews.pot",
+				yoastJsSocialMetadataForms: "<%= paths.languages %>yoast-js-social-metadata-forms.pot",
 
 				yoastseojs: "<%= paths.languages %>yoast-seo-js.pot",
 				yoastComponents: "<%= paths.languages %>yoast-components.pot",

--- a/config/grunt/task-config/aliases.yaml
+++ b/config/grunt/task-config/aliases.yaml
@@ -59,6 +59,8 @@
   - 'copy:makepot-yoast-js-helpers'
   - 'shell:makepot-yoast-js-search-metadata-previews'
   - 'copy:makepot-yoast-js-search-metadata-previews'
+  - 'shell:makepot-yoast-js-social-metadata-forms'
+  - 'copy:makepot-yoast-js-social-metadata-forms'
   - 'shell:makepot-yoast-components-remaining'
   - 'shell:combine-pots-yoast-components'
   - 'shell:makepot-yoastseojs'

--- a/config/grunt/task-config/aliases.yaml
+++ b/config/grunt/task-config/aliases.yaml
@@ -61,6 +61,8 @@
   - 'copy:makepot-yoast-js-search-metadata-previews'
   - 'shell:makepot-yoast-js-social-metadata-forms'
   - 'copy:makepot-yoast-js-social-metadata-forms'
+  - 'shell:makepot-yoast-js-replacement-variable-editor'
+  - 'copy:makepot-yoast-js-replacement-variable-editor'
   - 'shell:makepot-yoast-components-remaining'
   - 'shell:combine-pots-yoast-components'
   - 'shell:makepot-yoastseojs'

--- a/config/grunt/task-config/copy.js
+++ b/config/grunt/task-config/copy.js
@@ -79,6 +79,10 @@ module.exports = {
 		src: "gettext.pot",
 		dest: "<%= files.pot.yoastJsSearchMetadataPreviews %>",
 	},
+	"makepot-yoast-js-social-metadata-forms": {
+		src: "gettext.pot",
+		dest: "<%= files.pot.yoastJsSocialMetadataForms %>",
+	},
 	"makepot-yoastseojs": {
 		src: "gettext.pot",
 		dest: "<%= files.pot.yoastseojs %>",

--- a/config/grunt/task-config/copy.js
+++ b/config/grunt/task-config/copy.js
@@ -83,6 +83,10 @@ module.exports = {
 		src: "gettext.pot",
 		dest: "<%= files.pot.yoastJsSocialMetadataForms %>",
 	},
+	"makepot-yoast-js-replacement-variable-editor": {
+		src: "gettext.pot",
+		dest: "<%= files.pot.yoastJsReplacementVariableEditor %>",
+	},
 	"makepot-yoastseojs": {
 		src: "gettext.pot",
 		dest: "<%= files.pot.yoastseojs %>",

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -52,6 +52,7 @@ module.exports = function( grunt ) {
 				"<%= files.pot.yoastJsConfigurationWizard %>",
 				"<%= files.pot.yoastJsHelpers %>",
 				"<%= files.pot.yoastJsSearchMetadataPreviews %>",
+				"<%= files.pot.yoastJsSocialMetadataForms %>",
 				"<%= files.pot.yoastComponentsConfigurationWizard %>",
 				"<%= files.pot.yoastComponentsRemaining %>",
 			],
@@ -84,6 +85,9 @@ module.exports = function( grunt ) {
 		},
 		"makepot-yoast-js-search-metadata-previews": {
 			command: "yarn i18n-yoast-js-search-metadata-previews",
+		},
+		"makepot-yoast-js-social-metadata-forms": {
+			command: "yarn i18n-yoast-js-social-metadata-forms",
 		},
 
 		"makepot-yoast-components-configuration-wizard": {

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -53,6 +53,7 @@ module.exports = function( grunt ) {
 				"<%= files.pot.yoastJsHelpers %>",
 				"<%= files.pot.yoastJsSearchMetadataPreviews %>",
 				"<%= files.pot.yoastJsSocialMetadataForms %>",
+				"<%= files.pot.yoastJsReplacementVariableEditor %>",
 				"<%= files.pot.yoastComponentsConfigurationWizard %>",
 				"<%= files.pot.yoastComponentsRemaining %>",
 			],
@@ -88,6 +89,9 @@ module.exports = function( grunt ) {
 		},
 		"makepot-yoast-js-social-metadata-forms": {
 			command: "yarn i18n-yoast-js-social-metadata-forms",
+		},
+		"makepot-yoast-js-replacement-variable-editor": {
+			command: "yarn i18n-yoast-js-replacement-variable-editor",
 		},
 
 		"makepot-yoast-components-configuration-wizard": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "i18n-yoast-js-helpers": "cross-env NODE_ENV=production babel packages/helpers --ignore packages/helpers/node_modules --plugins=@wordpress/babel-plugin-makepot | shusher",
     "i18n-yoast-js-search-metadata-previews": "cross-env NODE_ENV=production babel packages/search-metadata-previews --ignore packages/search-metadata-previews/node_modules,__mocks__/*.js --plugins=@wordpress/babel-plugin-makepot | shusher",
     "i18n-yoast-js-social-metadata-forms": "cross-env NODE_ENV=production babel packages/social-metadata-forms --ignore packages/social-metadata-forms/node_modules,__mocks__/*.js --plugins=@wordpress/babel-plugin-makepot | shusher",
+    "i18n-yoast-js-replacement-variable-editor": "cross-env NODE_ENV=production babel packages/replacement-variable-editor --ignore packages/replacement-variable-editor/node_modules,__mocks__/*.js --plugins=@wordpress/babel-plugin-makepot | shusher",
     "prestart": "grunt build:css && grunt copy:js-dependencies",
     "start": "webpack-dev-server --config ./config/webpack/webpack.config.js --progress --env.environment=development"
   },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "i18n-yoast-js-configuration-wizard": "cross-env NODE_ENV=production babel packages/configuration-wizard --ignore packages/configuration-wizard/node_modules --plugins=@wordpress/babel-plugin-makepot | shusher",
     "i18n-yoast-js-helpers": "cross-env NODE_ENV=production babel packages/helpers --ignore packages/helpers/node_modules --plugins=@wordpress/babel-plugin-makepot | shusher",
     "i18n-yoast-js-search-metadata-previews": "cross-env NODE_ENV=production babel packages/search-metadata-previews --ignore packages/search-metadata-previews/node_modules,__mocks__/*.js --plugins=@wordpress/babel-plugin-makepot | shusher",
+    "i18n-yoast-js-social-metadata-forms": "cross-env NODE_ENV=production babel packages/social-metadata-forms --ignore packages/social-metadata-forms/node_modules,__mocks__/*.js --plugins=@wordpress/babel-plugin-makepot | shusher",
     "prestart": "grunt build:css && grunt copy:js-dependencies",
     "start": "webpack-dev-server --config ./config/webpack/webpack.config.js --progress --env.environment=development"
   },

--- a/packages/replacement-variable-editor/src/shared.js
+++ b/packages/replacement-variable-editor/src/shared.js
@@ -56,14 +56,12 @@ export const StandardButton = styled( Button )`
 	font-weight: 400;
 	line-height: 1.5;
 	margin-bottom: 5px;
-	width: 112px;
-	height: 40px;
+	max-width: 200px;
+	padding: 0 0.5em;
 `;
 
 export const TriggerReplacementVariableSuggestionsButton = styled( StandardButton )`
 	font-size: 13px;
-	width: 103px;
-	height: 28px;
 	margin-left: auto;
 	& svg {
 		${ getDirectionalStyle( "margin-right", "margin-left" ) }: 7px;

--- a/packages/social-metadata-forms/tests/__snapshots__/ImageSelectTest.js.snap
+++ b/packages/social-metadata-forms/tests/__snapshots__/ImageSelectTest.js.snap
@@ -150,8 +150,8 @@ exports[`The ImageSelect component displays warnings 1`] = `
   font-weight: 400;
   line-height: 1.5;
   margin-bottom: 5px;
-  width: 112px;
-  height: 40px;
+  max-width: 200px;
+  padding: 0 0.5em;
 }
 
 .c16 {
@@ -386,8 +386,8 @@ exports[`The ImageSelect component renders 1`] = `
   font-weight: 400;
   line-height: 1.5;
   margin-bottom: 5px;
-  width: 112px;
-  height: 40px;
+  max-width: 200px;
+  padding: 0 0.5em;
 }
 
 .c0 {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Goal: all strings are translated.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where certain text in the Google, Facebook and Twitter previews would not be translated.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* For developers: build this branch, including the translations (will be done if you use `grunt build`, or run `grunt build:i18n` on top of your normal steps)
* Set your site language to something other than `English (United State)` (I tested with Dutch): Settings -> General -> Site Language
* Download the latest translations: Dashboard -> Updates -> Download translations
* Edit a post
* Verify the strings are now translated
  * Check the Facebook preview
    * `Facebook image` label
    * `Facebook title` label
    * `Facebook description` label
  * Check the Twitter preview
    * `Twitter image` label
    * `Twitter title` label
    * `Twitter description` label
  * Check the Google preview
    * `Insert variable` button of the SEO title and meta description.
  * Please pay some extra attention to the styling of the `Insert variable` button, as well as the social preview's select and replace buttons. This has been adjusted a bit to be able to handle longer text. 
* Go to the Yoast search appearance settings
* Verify the strings are now translated:
  * Check the Search appearance settings
    * The `Insert variable` button of the SEO title and meta description.

#### Notes
* For completeness, these are the strings that are now added.
_Some strings might be translated already due to them not being unique_
<details>
<summary>Social metadata forms translations</summary>

```txt
#: packages/social-metadata-forms/src/ImageSelect.js:72
msgid "Replace image"
msgstr ""

#: packages/social-metadata-forms/src/ImageSelect.js:73
msgid "Select image"
msgstr ""

#: packages/social-metadata-forms/src/ImageSelect.js:81
msgid "Remove image"
msgstr ""

#: packages/social-metadata-forms/src/SocialMetadataPreviewForm.js:176
#. %s expands to the social medium name, i.e. Facebook.
msgid "%s image"
msgstr ""

#: packages/social-metadata-forms/src/SocialMetadataPreviewForm.js:178
#. %s expands to the social medium name, i.e. Facebook.
msgid "%s title"
msgstr ""

#: packages/social-metadata-forms/src/SocialMetadataPreviewForm.js:180
#. %s expands to the social medium name, i.e. Facebook.
msgid "%s description"
msgstr ""
```

</details>

<details>
<summary>Replacement variable editor translations</summary>

```txt
#: packages/replacement-variable-editor/src/ReplacementVariableEditor.js:97
msgid "Insert variable"
msgstr ""

#: packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js:312
msgid "%d result found, use up and down arrow keys to navigate"
msgid_plural "%d results found, use up and down arrow keys to navigate"
msgstr[0] ""
msgstr[1] ""

#: packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js:323
msgid "No results"
msgstr ""

#: packages/replacement-variable-editor/src/SettingsSnippetEditorFields.js:201
msgid "SEO title"
msgstr ""

#: packages/replacement-variable-editor/src/SettingsSnippetEditorFields.js:219
msgid "Meta description"
msgstr ""
```

</details>

* In premium, the label above the social previews (`Facebook share preview`) are not translated currently (they actually are translated in the issue screenshot, apparently `Facebook-preview` is deemed Dutch).
The cause of that is different than this PR and should be fixed by https://github.com/Yoast/wordpress-seo/pull/17672

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [P1-991](https://yoast.atlassian.net/browse/P1-991)
