### PR TITLE
replace function arguments in wpseo-functions.php

### DIFF
--- a/inc/wpseo-functions.php
+++ b/inc/wpseo-functions.php
@@ -74,17 +74,17 @@ if ( ! function_exists( 'yoast_get_primary_term' ) ) {
 /**
  * Replace `%%variable_placeholders%%` with their real value based on the current requested page/post/cpt.
  *
- * @param string $string The string to replace the variables in.
- * @param object $args   The object some of the replacement values might come from,
- *                       could be a post, taxonomy or term.
- * @param array  $omit   Variables that should not be replaced by this function.
+ * @param string $text The string to replace the variables in.
+ * @param object $args The object some of the replacement values might come from,
+ *                     could be a post, taxonomy or term.
+ * @param array  $omit Variables that should not be replaced by this function.
  *
  * @return string
  */
-function wpseo_replace_vars( $string, $args, $omit = [] ) {
+function wpseo_replace_vars( $text, $args, $omit = [] ) {
 	$replacer = new WPSEO_Replace_Vars();
 
-	return $replacer->replace( $string, $args, $omit );
+	return $replacer->replace( $text, $args, $omit );
 }
 
 /**
@@ -120,7 +120,7 @@ function wpseo_replace_vars( $string, $args, $omit = [] ) {
  *
  * @since 1.5.4
  *
- * @param string $var              The name of the variable to replace, i.e. '%%var%%'.
+ * @param string $replacevar_name  The name of the variable to replace, i.e. '%%var%%'.
  *                                 Note: the surrounding %% are optional, name can only contain [A-Za-z0-9_-].
  * @param mixed  $replace_function Function or method to call to retrieve the replacement value for the variable.
  *                                 Uses the same format as add_filter/add_action function parameter and
@@ -130,8 +130,8 @@ function wpseo_replace_vars( $string, $args, $omit = [] ) {
  *
  * @return bool Whether the replacement function was successfully registered.
  */
-function wpseo_register_var_replacement( $var, $replace_function, $type = 'advanced', $help_text = '' ) {
-	return WPSEO_Replace_Vars::register_replacement( $var, $replace_function, $type, $help_text );
+function wpseo_register_var_replacement( $replacevar_name, $replace_function, $type = 'advanced', $help_text = '' ) {
+	return WPSEO_Replace_Vars::register_replacement( $replacevar_name, $replace_function, $type, $help_text );
 }
 
 /**
@@ -202,13 +202,13 @@ if ( ! function_exists( 'ctype_digit' ) ) {
 	 * Emulate PHP native ctype_digit() function for when the ctype extension would be disabled *sigh*.
 	 * Only emulates the behaviour for when the input is a string, does not handle integer input as ascii value.
 	 *
-	 * @param string $string String input to validate.
+	 * @param string $text String input to validate.
 	 *
 	 * @return bool
 	 */
-	function ctype_digit( $string ) {
+	function ctype_digit( $text ) {
 		$return = false;
-		if ( ( is_string( $string ) && $string !== '' ) && preg_match( '`^\d+$`', $string ) === 1 ) {
+		if ( ( is_string( $text ) && $text !== '' ) && preg_match( '`^\d+$`', $text ) === 1 ) {
 			$return = true;
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Renamed function parameters that use reserved keywords to prevent unnecessarily high cognitive load with named parameters.

## Relevant technical choices:

* `wpseo_replace_vars()`: Rename $string parameter to $text.
* `wpseo_register_var_replacement()`: Rename $var parameter to $replacevar_name.
* `ctype_digit()`: Rename $string parameter to $text.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* General smoke testing.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
