### PR TITLE
Disable button for not started and unfinished indexation

### DIFF
--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -634,9 +634,11 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						finishText={ "Finish this workout" }
 						onFinishClick={ toggleConfigurationWorkout }
 						isFinished={ isStepFinished( "configuration", steps.newsletterSignup ) }
+						additionalButtonProps={ { disabled: indexingState !== "completed" } }
 					>
 						{ indexingState !== "completed" && <Alert type="warning">
-							{ __( "Before you finish this workout, please wait on this page until the SEO data optimization in step 1 is completed...", "wordpress-seo" ) }
+							{ indexingState === "idle" && __( "Before you finish this workout, please start the SEO data optimization in step 1 and wait until it is completed...", "wordpress-seo" ) }
+							{ indexingState === "in_progress" && __( "Before you finish this workout, please wait on this page until the SEO data optimization in step 1 is completed...", "wordpress-seo" ) }
 						</Alert> }
 					</FinishStepSection>
 				</Step>

--- a/packages/js/src/workouts/components/Steps.js
+++ b/packages/js/src/workouts/components/Steps.js
@@ -29,12 +29,16 @@ Steps.propTypes = {
  *
  * @returns {WPElement} The FinishStepSection element.
  */
-export function FinishStepSection( { onFinishClick, finishText, hasDownArrow, isFinished, children } ) {
+export function FinishStepSection( { onFinishClick, finishText, hasDownArrow, isFinished, additionalButtonProps, children } ) {
 	return (
 		<Fragment>
 			<hr />
 			{ children }
-			<Button className={ `yoast-button yoast-button--secondary${ isFinished ? " yoast-button--finished" : "" }` } onClick={ onFinishClick }>
+			<Button
+				className={ `yoast-button yoast-button--secondary${ isFinished ? " yoast-button--finished" : "" }` }
+				onClick={ onFinishClick }
+				{ ...additionalButtonProps }
+			>
 				{ finishText }
 				{ hasDownArrow && <ArrowDown className="yoast-button--arrow-down" /> }
 			</Button>
@@ -47,12 +51,14 @@ FinishStepSection.propTypes = {
 	onFinishClick: PropTypes.func.isRequired,
 	hasDownArrow: PropTypes.bool,
 	isFinished: PropTypes.bool,
+	additionalButtonProps: PropTypes.object,
 	children: PropTypes.any,
 };
 
 FinishStepSection.defaultProps = {
 	hasDownArrow: false,
 	isFinished: false,
+	additionalButtonProps: {},
 	children: null,
 };
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Disable finishing of the workout before indexation is finished.
* Update notification for when indexation hasn't even started.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables finish workout button when indexation has not yet finished.
* Adjusts notification about finishing the workout before Indexation is finished to reflect whether the indexation has started or not. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Use yoast-test-helper or change permalink settings to reset indexation states.
* Before indexation has started:
	* Finish workout button should be disabled
	* Notification reads: `Before you finish this workout, please start the SEO data optimization in step 1 and wait until it is completed...`
* When indexation has started:
	* Finish workout button should be disabled
	* Notification reads: `Before you finish this workout, please wait on this page until the SEO data optimization in step 1 is completed...`
* When indexation has stopped (by clicking "stop indexation"):
	* Finish workout button should be disabled:
	* Notification reads: `Before you finish this workout, please start the SEO data optimization in step 1 and wait until it is completed...`
* When indexation has finished:
	* Finish workout button should be enabled
	* Notification should be gone.



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.


## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-87
