### PR TITLE
Fix the setTextDomainL10n API

### DIFF
--- a/packages/js/src/helpers/i18n.js
+++ b/packages/js/src/helpers/i18n.js
@@ -15,11 +15,15 @@ import { get } from "lodash-es";
 export function setTextdomainL10n( textdomain, l10nNamespace = "wpseoYoastJSL10n" ) {
 	const translations = get( window, [ l10nNamespace, textdomain, "locale_data", textdomain ], false );
 
+	if ( textdomain === "yoast-components" ) {
+		textdomain = "wordpress-seo";
+	}
+
 	if ( translations === false ) {
 		// Jed needs to have meta information in the object keyed by an empty string.
-		setLocaleData( { "": {} }, "wordpress-seo" );
+		setLocaleData( { "": {} }, textdomain );
 	} else {
-		setLocaleData( translations, "wordpress-seo" );
+		setLocaleData( translations, textdomain );
 	}
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Revert the `setTextdomainL10n` change of https://github.com/Yoast/wordpress-seo/pull/17526
While keeping the intended change for the `yoast-components` domain.

The problem is that this helper function is being used in our other add-ons, through the `editorModules` API.
For the translations to work for those add-ons, they need to be able to keep their own text domain.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the translations for domains other than `wordpress-seo` would no longer be loaded in properly.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate our add-ons: Premium, Video and News
* Switch the site language to something other than English (United States) (I tested with Dutch): Settings -> General -> Site Language
* Download the latest translations: Dashboard -> Updates -> Download translations
* Edit a post
* Open the social tab in the metabox
* Verify the `Facebook share preview`, above the preview image, is now translated.
  * Note that this is just one of the premium translations, feel free to check more. But there are too many to list here. You could search for `__(` (or other translation functions from `@wordpress/i18n`) in the JS files.
* Open the news tab in the metabox
* Verify the strings in there are all translated (they are not in the 17.7 RC before this PR)
* Open the video tab in the metabox
* Verify the strings in there are all translated (they are not in the 17.7 RC before this PR)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Check if the Free translations are still working as before. Specifically, the string that came in from the `yoast-components` textdomain. Check the textdomain changes in the original PR https://github.com/Yoast/wordpress-seo/pull/17526/files to see which strings should still work for this.
  * Example are the headings in the SEO & readability analysis: `Problems` etc. 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes bug caused by https://github.com/Yoast/wordpress-seo/pull/17526
