### PR TITLE
DUPP-87 Allow registering of indexing actions in the Workout indexation

### DIFF
--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -10,12 +10,12 @@ import { Alert, RadioButtonGroup, SingleSelect, TextInput } from "@yoast/compone
 import { ReactComponent as WorkoutImage } from "../../../images/motivated_bubble_woman_1_optim.svg";
 import { addLinkToString } from "../../helpers/stringHelpers.js";
 import { Step, Steps, FinishStepSection } from "./Steps";
-import Indexation from "../../components/Indexation";
 import { STEPS, WORKOUTS } from "../config";
 import { OrganizationSection } from "./OrganizationSection";
 import { PersonSection } from "./PersonSection";
 import { SocialInput } from "./SocialInput";
 import { NewsletterSignup } from "./NewsletterSignup";
+import { WorkoutIndexation } from "./WorkoutIndexation";
 
 window.wpseoScriptData = window.wpseoScriptData || {};
 window.wpseoScriptData.searchAppearance = {
@@ -351,7 +351,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					isFinished={ isStepFinished( "configuration", steps.optimizeSeoData ) }
 				>
 					<div className="indexation-container">
-						<Indexation
+						<WorkoutIndexation
 							indexingStateCallback={ setIndexingState }
 						/>
 						<FinishStepSection

--- a/packages/js/src/workouts/components/WorkoutIndexation.js
+++ b/packages/js/src/workouts/components/WorkoutIndexation.js
@@ -1,0 +1,60 @@
+import Indexation from "../../components/Indexation";
+import PropTypes from "prop-types";
+
+const preIndexingActions = {};
+const indexingActions = {};
+
+window.yoast = window.yoast || {};
+window.yoast.indexing = window.yoast.indexing || {};
+
+/**
+ * A wrapped Indexation for the configuration workout.
+ *
+ * @param {function} indexingStateCallback   The function to call back on state updates.
+ * @returns {WPElement} A wrapped Indexation for the configuration workout.
+ */
+export function WorkoutIndexation( { indexingStateCallback } ) {
+	return <Indexation
+		preIndexingActions={ preIndexingActions }
+		indexingActions={ indexingActions }
+		indexingStateCallback={ indexingStateCallback }
+	/>;
+}
+
+/**
+ * Registers a pre-indexing action on the given indexing endpoint.
+ *
+ * This action is executed before the endpoint is first called with the indexing
+ * settings as its first argument.
+ *
+ * @param {string}   endpoint The endpoint on which to register the action.
+ * @param {function} action   The action to register.
+ *
+ * @returns {void}
+ */
+window.yoast.indexing.registerPreIndexingAction = ( endpoint, action ) => {
+	preIndexingActions[ endpoint ] = action;
+};
+
+/**
+ * Registers an action on the given indexing endpoint.
+ *
+ * This action is executed each time after the endpoint is called, with the objects
+ * returned from the endpoint as its first argument and the indexing settings as its second argument.
+ *
+ * @param {string}                       endpoint The endpoint on which to register the action.
+ * @param {function(Object[], Object[])} action   The action to register.
+ *
+ * @returns {void}
+ */
+window.yoast.indexing.registerIndexingAction = ( endpoint, action ) => {
+	indexingActions[ endpoint ] = action;
+};
+
+WorkoutIndexation.propTypes = {
+	indexingStateCallback: PropTypes.any,
+};
+
+WorkoutIndexation.defaultProps = {
+	indexingStateCallback: null,
+};


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to run the indexing actions added by Premium when indexing in the conf. workout

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where indexing from inside the conf. workout resulted in an endless loop with Premium

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* test with https://github.com/Yoast/wordpress-seo-premium/pull/3499
* then, disable premium
* reset indexables, link count and prominent words in the Test helper
* visit the conf. workout and start the optimization, see it finishes
* reset indexables, link count and prominent words in the Test helper
* visit SEO > Tools and start the indexation from there, see it works (it's not been touched)


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-87]


[DUPP-87]: https://yoast.atlassian.net/browse/DUPP-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ