### PR TITLE
[DUPP-94][DUPP-93][DUPP-100] dont show configuration workout and notice without wpseo manage options

### DIFF
--- a/packages/js/src/workouts.js
+++ b/packages/js/src/workouts.js
@@ -37,7 +37,9 @@ function registerWorkout( key, priority, Component ) {
 window.wpseoWorkoutsData = window.wpseoWorkoutsData || {};
 window.wpseoWorkoutsData.registerWorkout = registerWorkout;
 
-registerWorkout( "configuration", 1, () => <ConfigurationWorkoutCard /> );
+if ( window.wpseoWorkoutsData.canDoConfigurationWorkout ) {
+	registerWorkout( "configuration", 1, () => <ConfigurationWorkoutCard /> );
+}
 
 domReady( () => {
 	renderReactRoot( "wpseo-workouts-container-free", <Workouts /> );

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -110,12 +110,13 @@ class Workouts_Integration implements Integration_Interface {
 			'workouts',
 			'wpseoWorkoutsData',
 			[
-				'workouts'     => $workouts_option,
-				'homeUrl'      => \home_url(),
-				'pluginUrl'    => \esc_url( \plugins_url( '', WPSEO_FILE ) ),
-				'toolsPageUrl' => \esc_url( \admin_url( 'admin.php?page=wpseo_tools' ) ),
-				'usersPageUrl' => \esc_url( \admin_url( 'users.php' ) ),
-				'isPremium'    => YoastSEO()->helpers->product->is_premium(),
+				'workouts'                  => $workouts_option,
+				'homeUrl'                   => \home_url(),
+				'pluginUrl'                 => \esc_url( \plugins_url( '', WPSEO_FILE ) ),
+				'toolsPageUrl'              => \esc_url( \admin_url( 'admin.php?page=wpseo_tools' ) ),
+				'usersPageUrl'              => \esc_url( \admin_url( 'users.php' ) ),
+				'isPremium'                 => YoastSEO()->helpers->product->is_premium(),
+				'canDoConfigurationWorkout' => $this->user_can_do_configuration_workout(),
 			]
 		);
 	}
@@ -139,6 +140,10 @@ class Workouts_Integration implements Integration_Interface {
 	 */
 	public function should_display_configuration_workout_notice() {
 		if ( ! $this->options_helper->get( 'dismiss_configuration_workout_notice', false ) === false ) {
+			return false;
+		}
+
+		if ( ! $this->user_can_do_configuration_workout() ) {
 			return false;
 		}
 
@@ -240,6 +245,15 @@ class Workouts_Integration implements Integration_Interface {
 	private function should_update_premium() {
 		$premium_version = YoastSEO()->helpers->product->get_premium_version();
 		return $premium_version !== null && version_compare( $premium_version, '17.7-RC1', '<' );
+	}
+
+	/**
+	 * Whether the user can do the configuration workout.
+	 *
+	 * @return bool Whether the current user can do the configuration workout.
+	 */
+	private function user_can_do_configuration_workout() {
+		return \current_user_can( 'wpseo_manage_options' );;
 	}
 
 	/**

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -253,7 +253,7 @@ class Workouts_Integration implements Integration_Interface {
 	 * @return bool Whether the current user can do the configuration workout.
 	 */
 	private function user_can_do_configuration_workout() {
-		return \current_user_can( 'wpseo_manage_options' );;
+		return \current_user_can( 'wpseo_manage_options' );
 	}
 
 	/**
@@ -263,6 +263,9 @@ class Workouts_Integration implements Integration_Interface {
 	 */
 	private function on_wpseo_admin_page_or_dashboard() {
 		$pagenow = $GLOBALS['pagenow'];
-		return ( $pagenow === 'admin.php' && strpos( filter_input( INPUT_GET, 'page' ), 'wpseo' ) === 0 ) || $pagenow === 'index.php';
+		return ( ( $pagenow === 'index.php' ) ||
+				( $pagenow === 'admin.php' &&
+				strpos( filter_input( INPUT_GET, 'page' ), 'wpseo' ) === 0 &&
+				filter_input( INPUT_GET, 'page' ) !== 'wpseo_workouts' ) );
 	}
 }

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -263,9 +263,26 @@ class Workouts_Integration implements Integration_Interface {
 	 */
 	private function on_wpseo_admin_page_or_dashboard() {
 		$pagenow = $GLOBALS['pagenow'];
-		return ( ( $pagenow === 'index.php' ) ||
-				( $pagenow === 'admin.php' &&
-				strpos( filter_input( INPUT_GET, 'page' ), 'wpseo' ) === 0 &&
-				filter_input( INPUT_GET, 'page' ) !== 'wpseo_workouts' ) );
+
+		// Show on the WP Dashboard.
+		if ( $pagenow === 'index.php' ) {
+			return true;
+		}
+
+		$page_from_get = filter_input( INPUT_GET, 'page' );
+
+		// Show on Yoast SEO pages, with some exceptions.
+		if ( $pagenow === 'admin.php' && strpos( $page_from_get, 'wpseo' ) === 0 ) {
+			$exceptions = [
+				'wpseo_workouts',
+				'wpseo_installation_successful',
+			];
+
+			if ( ! \in_array( $page_from_get, $exceptions, true ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Only those who can actually do the configuration workout should be bothered with notifications and see the workout.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where users without the wpseo_manage_options capability saw the Configurtion Workout and accompanying notification.
* Hides the configuration workout notification in the workouts page.

## Relevant technical choices:

* Exposed the variable to JS via the localized object rather than creating a separate integration for the configuration workout.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Test for DUPP-94 "17.7 Configuration workout should not be shown for Editors"
* Use the user-switching plugin and switch to an editor/author/seo_editor if you can. Else, log in as an editor/author/seo_editor. Anyone without the `wpseo_manage_options` capability should do.
* Use the test helper to reset notifications.
* Visit the workouts page. There should be no configuration workout. Nor should there be a notice about it on the dashboard or the workoutspage (or any other Yoast SEO pages you may have).
* Switch to admin/seo_manager.
* Notice should be visible and configuration workout accessible.
* Think of some unhappy-paths that I can't think of now.

#### Test for DUPP-93 "[17.7-RC1] Double SEO configuration workout on the workouts overview"
* check also that as admin the notification for the conf. wizard can be seen in the Dashboard and in the Yoast SEO pages, *except* in the workouts page.

#### Test for DUPP-100 "[17.7-RC1 Premium] Installation successful + First time configuration"
* install premium
* visit {site}/wp-admin/admin.php?page=wpseo_installation_successful as admin
* check that you don't see the notification

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-94][DUPP-93][DUPP-100]


[DUPP-94]: https://yoast.atlassian.net/browse/DUPP-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ