### PR TITLE
Signal social profile validation

### DIFF
--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -239,7 +239,6 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 				} )
 				.catch(
 					( e ) => {
-						// URL() constructor throws a TypeError exception if url is malformed.
 						if ( e.failures ) {
 							setErrorFields( e.failures );
 						}

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -13,9 +13,9 @@ import { Step, Steps, FinishStepSection } from "./Steps";
 import { STEPS, WORKOUTS } from "../config";
 import { OrganizationSection } from "./OrganizationSection";
 import { PersonSection } from "./PersonSection";
-import { SocialInput } from "./SocialInput";
 import { NewsletterSignup } from "./NewsletterSignup";
 import { WorkoutIndexation } from "./WorkoutIndexation";
+import SocialInputSection from "./SocialInputSection";
 
 window.wpseoScriptData = window.wpseoScriptData || {};
 window.wpseoScriptData.searchAppearance = {
@@ -63,6 +63,9 @@ function configurationWorkoutReducer( state, action ) {
 		case "CHANGE_SOCIAL_PROFILE":
 			newState.socialProfiles[ action.payload.socialMedium ] = action.payload.value;
 			return newState;
+		case "SET_ERROR_FIELDS":
+			newState.errorFields = action.payload;
+			return newState;
 		case "CHANGE_SITE_TAGLINE":
 			newState.siteTagline = action.payload;
 			return newState;
@@ -84,12 +87,16 @@ function configurationWorkoutReducer( state, action ) {
  * @returns {WPElement} The ConfigurationWorkout component.
  */
 export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinished } ) {
-	const [ state, dispatch ] = useReducer( configurationWorkoutReducer, window.wpseoWorkoutsData.configuration );
+	const [ state, dispatch ] = useReducer( configurationWorkoutReducer, { ...window.wpseoWorkoutsData.configuration, errorFields: [] } );
 	const [ indexingState, setIndexingState ] = useState( () => window.yoastIndexingData.amount === "0" ? "completed" : "idle" );
 	const [ siteRepresentationEmpty, setSiteRepresentationEmpty ] = useState( false );
 
 	const setTracking = useCallback( ( value ) => {
 		dispatch( { type: "SET_TRACKING", payload: parseInt( value, 10 ) } );
+	} );
+
+	const setErrorFields = useCallback( ( value ) => {
+		dispatch( { type: "SET_ERROR_FIELDS", payload: value } );
 	} );
 
 	const steps = STEPS.configuration;
@@ -101,21 +108,16 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	 */
 	const updateSiteRepresentation = async function() {
 		const siteRepresentation = {
-			// eslint-disable-next-line camelcase
+			/* eslint-disable camelcase */
 			company_or_person: state.companyOrPerson,
-			// eslint-disable-next-line camelcase
 			company_name: state.companyName,
-			// eslint-disable-next-line camelcase
 			company_logo: state.companyLogo,
-			// eslint-disable-next-line camelcase
 			company_logo_id: state.companyLogoId ? state.companyLogoId : 0,
-			// eslint-disable-next-line camelcase
 			person_logo: state.personLogo,
-			// eslint-disable-next-line camelcase
 			person_logo_id: state.personLogoId ? state.personLogoId : 0,
-			// eslint-disable-next-line camelcase
 			company_or_person_user_id: state.personId,
 			description: state.siteTagline,
+			/* eslint-enable camelcase */
 		};
 
 		try {
@@ -139,36 +141,24 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	 */
 	const updateSocialProfiles = async function() {
 		const socialProfiles = {
-			// eslint-disable-next-line camelcase
+			/* eslint-disable camelcase */
 			facebook_site: state.socialProfiles.facebookUrl,
-			// eslint-disable-next-line camelcase
 			twitter_site: state.socialProfiles.twitterUsername,
-			// eslint-disable-next-line camelcase
 			instagram_url: state.socialProfiles.instagramUrl,
-			// eslint-disable-next-line camelcase
 			linkedin_url: state.socialProfiles.linkedinUrl,
-			// eslint-disable-next-line camelcase
 			myspace_url: state.socialProfiles.myspaceUrl,
-			// eslint-disable-next-line camelcase
 			pinterest_url: state.socialProfiles.pinterestUrl,
-			// eslint-disable-next-line camelcase
 			youtube_url: state.socialProfiles.youtubeUrl,
-			// eslint-disable-next-line camelcase
 			wikipedia_url: state.socialProfiles.wikipediaUrl,
+			/* eslint-enable camelcase */
 		};
 
-		try {
-			const response = await apiFetch( {
-				path: "yoast/v1/workouts/social_profiles",
-				method: "POST",
-				data: socialProfiles,
-			} );
-			return await response.json;
-		} catch ( e ) {
-			// URL() constructor throws a TypeError exception if url is malformed.
-			console.error( e.message );
-			return false;
-		}
+		const response = await apiFetch( {
+			path: "yoast/v1/workouts/social_profiles",
+			method: "POST",
+			data: socialProfiles,
+		} );
+		return await response.json;
 	};
 
 	/**
@@ -242,7 +232,20 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 		if ( isStepFinished( "configuration", steps.socialProfiles ) ) {
 			toggleStepSocialProfiles();
 		} else {
-			updateSocialProfiles().then( toggleStepSocialProfiles );
+			updateSocialProfiles()
+				.then( () => {
+					setErrorFields( [] );
+					toggleStepSocialProfiles();
+				} )
+				.catch(
+					( e ) => {
+						// URL() constructor throws a TypeError exception if url is malformed.
+						if ( e.failures ) {
+							setErrorFields( e.failures );
+						}
+						return false;
+					}
+				);
 		}
 	}
 
@@ -461,64 +464,13 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					subtitle={ state.companyOrPerson === "company" ?  __( "Do you have profiles for your site on social media? Then, add all of their URLs here, so your social profiles may also appear in a Google Knowledge Panel.", "wordpress-seo" ) : "" }
 					isFinished={ isStepFinished( "configuration", steps.socialProfiles ) }
 				>
-					{ state.companyOrPerson === "company" && <div className="yoast-social-profiles-input-fields">
-						<SocialInput
-							label={ __( "Facebook URL", "wordpress-seo" ) }
-							value={ state.socialProfiles.facebookUrl }
-							socialMedium="facebookUrl"
-							dispatch={ dispatch }
-							isDisabled={ isStepFinished( "configuration", steps.socialProfiles ) }
-						/>
-						<SocialInput
-							label={ __( "Twitter URL", "wordpress-seo" ) }
-							value={ state.socialProfiles.twitterUsername }
-							socialMedium="twitterUsername"
-							dispatch={ dispatch }
-							isDisabled={ isStepFinished( "configuration", steps.socialProfiles ) }
-						/>
-						<SocialInput
-							label={ __( "Instagram URL", "wordpress-seo" ) }
-							value={ state.socialProfiles.instagramUrl }
-							socialMedium="instagramUrl"
-							dispatch={ dispatch }
-							isDisabled={ isStepFinished( "configuration", steps.socialProfiles ) }
-						/>
-						<SocialInput
-							label={ __( "LinkedIn URL", "wordpress-seo" ) }
-							value={ state.socialProfiles.linkedinUrl }
-							socialMedium="linkedinUrl"
-							dispatch={ dispatch }
-							isDisabled={ isStepFinished( "configuration", steps.socialProfiles ) }
-						/>
-						<SocialInput
-							label={ __( "MySpace URL", "wordpress-seo" ) }
-							value={ state.socialProfiles.myspaceUrl }
-							socialMedium="myspaceUrl"
-							dispatch={ dispatch }
-							isDisabled={ isStepFinished( "configuration", steps.socialProfiles ) }
-						/>
-						<SocialInput
-							label={ __( "Pinterest URL", "wordpress-seo" ) }
-							value={ state.socialProfiles.pinterestUrl }
-							socialMedium="pinterestUrl"
-							dispatch={ dispatch }
-							isDisabled={ isStepFinished( "configuration", steps.socialProfiles ) }
-						/>
-						<SocialInput
-							label={ __( "YouTube URL", "wordpress-seo" ) }
-							value={ state.socialProfiles.youtubeUrl }
-							socialMedium="youtubeUrl"
-							dispatch={ dispatch }
-							isDisabled={ isStepFinished( "configuration", steps.socialProfiles ) }
-						/>
-						<SocialInput
-							label={ __( "Wikipedia URL", "wordpress-seo" ) }
-							value={ state.socialProfiles.wikipediaUrl }
-							socialMedium="wikipediaUrl"
-							dispatch={ dispatch }
-							isDisabled={ isStepFinished( "configuration", steps.socialProfiles ) }
-						/>
-					</div> }
+					{ state.companyOrPerson === "company" && <SocialInputSection
+						socialProfiles={ state.socialProfiles }
+						dispatch={ dispatch }
+						errorFields={ state.errorFields }
+						setErrorFields={ setErrorFields }
+						isDisabled={ isStepFinished( "configuration", steps.socialProfiles ) }
+					/> }
 					{ state.companyOrPerson === "person" && <div>
 						<p>
 							{

--- a/packages/js/src/workouts/components/SocialInput.js
+++ b/packages/js/src/workouts/components/SocialInput.js
@@ -1,7 +1,7 @@
+import PropTypes from "prop-types";
 import { useCallback } from "@wordpress/element";
 
-import { TextInput } from "@yoast/components";
-import PropTypes from "prop-types";
+import ValidatedTextInput from "./ValidatedTextInput";
 
 /**
  * A wrapped TextInput for the social inputs
@@ -12,13 +12,13 @@ import PropTypes from "prop-types";
  * @param {object}   restProps    The other props.
  * @returns {WPElement} A wrapped TextInput for the social inputs.
  */
-export function SocialInput( { dispatch, socialMedium, isDisabled, ...restProps } ) {
+export default function SocialInput( { onChange, socialMedium, isDisabled, ...restProps } ) {
 	const onChangeHandler = useCallback(
-		( newValue ) => dispatch( { type: "CHANGE_SOCIAL_PROFILE", payload: { socialMedium, value: newValue } } ),
+		( newValue ) => onChange( newValue, socialMedium ),
 		[ socialMedium ]
 	);
 
-	return <TextInput
+	return <ValidatedTextInput
 		onChange={ onChangeHandler }
 		readOnly={ isDisabled }
 		{ ...restProps }
@@ -26,7 +26,7 @@ export function SocialInput( { dispatch, socialMedium, isDisabled, ...restProps 
 }
 
 SocialInput.propTypes = {
-	dispatch: PropTypes.func.isRequired,
+	onChange: PropTypes.func.isRequired,
 	socialMedium: PropTypes.string,
 	isDisabled: PropTypes.bool,
 };

--- a/packages/js/src/workouts/components/SocialInputSection.js
+++ b/packages/js/src/workouts/components/SocialInputSection.js
@@ -1,0 +1,119 @@
+import { __ } from "@wordpress/i18n";
+import { useCallback } from "@wordpress/element";
+import PropTypes from "prop-types";
+
+import SocialInput from "./SocialInput";
+
+/* eslint-disable complexity */
+/**
+ * A wrapper that combines all the SocialInputs. Intended for use in the configuration workout.
+ *
+ * @param {Object} props The props object.
+ *
+ * @returns {WPElement} The SocialInputSection.
+ */
+export default function SocialInputSection( { socialProfiles, errorFields, dispatch, isDisabled } ) {
+	const onChangeHandler = useCallback(
+		( newValue, socialMedium ) => {
+			dispatch( { type: "CHANGE_SOCIAL_PROFILE", payload: { socialMedium, value: newValue } } );
+		},
+		[]
+	);
+
+	const getFeedback = useCallback(
+		( socialKey ) => {
+			if ( errorFields.includes( socialKey ) ) {
+				return {
+					feedbackState: "error",
+					feedbackMessage: socialKey === "twitter_site"
+						? __( "Could not save this value. Please check the URL or username.", "wordpress-seo" )
+						: __( "Could not save this value. Please check the URL.", "wordpress-seo" ),
+				};
+			}
+			return {};
+		},
+		[ errorFields ]
+	);
+
+	return (
+		<div className="yoast-social-profiles-input-fields">
+			<SocialInput
+				label={ __( "Facebook URL", "wordpress-seo" ) }
+				value={ socialProfiles.facebookUrl }
+				socialMedium="facebookUrl"
+				onChange={ onChangeHandler }
+				isDisabled={ isDisabled }
+				{ ...getFeedback( "facebook_site" ) }
+			/>
+			<SocialInput
+				label={ __( "Twitter URL", "wordpress-seo" ) }
+				value={ socialProfiles.twitterUsername }
+				socialMedium="twitterUsername"
+				onChange={ onChangeHandler }
+				isDisabled={ isDisabled }
+				{ ...getFeedback( "twitter_site" ) }
+			/>
+			<SocialInput
+				label={ __( "Instagram URL", "wordpress-seo" ) }
+				value={ socialProfiles.instagramUrl }
+				socialMedium="instagramUrl"
+				onChange={ onChangeHandler }
+				isDisabled={ isDisabled }
+				{ ...getFeedback( "instagram_url" ) }
+			/>
+			<SocialInput
+				label={ __( "LinkedIn URL", "wordpress-seo" ) }
+				value={ socialProfiles.linkedinUrl }
+				socialMedium="linkedinUrl"
+				onChange={ onChangeHandler }
+				isDisabled={ isDisabled }
+				{ ...getFeedback( "linkedin_url" ) }
+			/>
+			<SocialInput
+				label={ __( "MySpace URL", "wordpress-seo" ) }
+				value={ socialProfiles.myspaceUrl }
+				socialMedium="myspaceUrl"
+				onChange={ onChangeHandler }
+				isDisabled={ isDisabled }
+				{ ...getFeedback( "myspace_url" ) }
+			/>
+			<SocialInput
+				label={ __( "Pinterest URL", "wordpress-seo" ) }
+				value={ socialProfiles.pinterestUrl }
+				socialMedium="pinterestUrl"
+				onChange={ onChangeHandler }
+				isDisabled={ isDisabled }
+				{ ...getFeedback( "pinterest_url" ) }
+			/>
+			<SocialInput
+				label={ __( "YouTube URL", "wordpress-seo" ) }
+				value={ socialProfiles.youtubeUrl }
+				socialMedium="youtubeUrl"
+				onChange={ onChangeHandler }
+				isDisabled={ isDisabled }
+				{ ...getFeedback( "youtube_url" ) }
+			/>
+			<SocialInput
+				label={ __( "Wikipedia URL", "wordpress-seo" ) }
+				value={ socialProfiles.wikipediaUrl }
+				socialMedium="wikipediaUrl"
+				onChange={ onChangeHandler }
+				isDisabled={ isDisabled }
+				{ ...getFeedback( "wikipedia_url" ) }
+			/>
+		</div>
+	);
+}
+/* eslint-enable complexity */
+
+SocialInputSection.propTypes = {
+	socialProfiles: PropTypes.object.isRequired,
+	dispatch: PropTypes.func.isRequired,
+	errorFields: PropTypes.array,
+	isDisabled: PropTypes.bool,
+};
+
+SocialInputSection.defaultProps = {
+	errorFields: [],
+	isDisabled: false,
+};

--- a/src/actions/configuration/configuration-workout-action.php
+++ b/src/actions/configuration/configuration-workout-action.php
@@ -108,7 +108,19 @@ class Configuration_Workout_Action {
 			if ( isset( $params[ $field_name ] ) ) {
 				$result = $this->options_helper->set( $field_name, $params[ $field_name ] );
 				if ( ! $result ) {
-					$failures[] = $field_name;
+					/**
+					 * The value for Twitter might have been sanitised from URL to username.
+					 * If so, $result will be false. We should check if the option value is part of the received value.
+					 */
+					if ( $field_name === 'twitter_site' ) {
+						$current_option = $this->options_helper->get( $field_name );
+						if ( ! \strpos( $params[ $field_name ], 'twitter.com/' . $current_option ) ) {
+							$failures[] = $field_name;
+						}
+					}
+					else {
+						$failures[] = $field_name;
+					}
 				}
 			}
 		}

--- a/tests/unit/actions/configuration/configuration-workout-action-test.php
+++ b/tests/unit/actions/configuration/configuration-workout-action-test.php
@@ -245,12 +245,12 @@ class Configuration_Workout_Action_Test extends TestCase {
 				'wikipedia_url' => 'https://en.wikipedia.org/somepage',
 			],
 			'times'                 => 8,
-			'yoast_options_results' => [ true, false, true, false, true, false, true, false ],
+			'yoast_options_results' => [ true, true, false, false, true, false, true, false ],
 			'expected'              => (object) [
 				'success'  => false,
 				'status'   => 500,
 				'error'    => 'Could not save some options in the database',
-				'failures' => [ 'twitter_site', 'linkedin_url', 'pinterest_url', 'wikipedia_url' ],
+				'failures' => [ 'instagram_url', 'linkedin_url', 'pinterest_url', 'wikipedia_url' ],
 			],
 		];
 
@@ -259,6 +259,86 @@ class Configuration_Workout_Action_Test extends TestCase {
 			'Successful call with some params' => $success_some,
 			'Some failures'                    => $some_failures,
 		];
+	}
+
+	/**
+	 * Tests setting the social profiles options in the database when Twitter value is a URL.
+	 *
+	 * @covers ::set_social_profiles
+	 */
+	public function test_set_social_profiles_twitter_url() {
+		$params = [
+			'facebook_site' => 'https://facebook.com/somepage',
+			'twitter_site'  => 'https://twitter.com/somenick',
+			'instagram_url' => 'https://instagram.com/somepage',
+			'linkedin_url'  => 'https://linked.in/somepage',
+			'myspace_url'   => 'https://myspace.com/somepage',
+			'pinterest_url' => 'https://pinterest.com/somepage',
+			'youtube_url'   => 'https://youtube.com/somepage',
+			'wikipedia_url' => 'https://en.wikipedia.org/somepage',
+		];
+
+		$yoast_options_results = [ true, false, false, false, true, false, true, false ];
+
+		$this->options_helper
+			->expects( 'set' )
+			->times( 8 )
+			->andReturn( ...$yoast_options_results );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'twitter_site' )
+			->andReturn( 'somenick' );
+
+		$this->assertEquals(
+			(object) [
+				'success'  => false,
+				'status'   => 500,
+				'error'    => 'Could not save some options in the database',
+				'failures' => [ 'instagram_url', 'linkedin_url', 'pinterest_url', 'wikipedia_url' ],
+			],
+			$this->instance->set_social_profiles( $params )
+		);
+	}
+
+	/**
+	 * Tests setting the social profiles options in the database when Twitter value is a URL and saving fails.
+	 *
+	 * @covers ::set_social_profiles
+	 */
+	public function test_set_social_profiles_twitter_url_failure() {
+		$params = [
+			'facebook_site' => 'https://facebook.com/somepage',
+			'twitter_site'  => 'https://twitter.com/somenick',
+			'instagram_url' => 'https://instagram.com/somepage',
+			'linkedin_url'  => 'https://linked.in/somepage',
+			'myspace_url'   => 'https://myspace.com/somepage',
+			'pinterest_url' => 'https://pinterest.com/somepage',
+			'youtube_url'   => 'https://youtube.com/somepage',
+			'wikipedia_url' => 'https://en.wikipedia.org/somepage',
+		];
+
+		$yoast_options_results = [ true, false, false, false, true, false, true, false ];
+
+		$this->options_helper
+			->expects( 'set' )
+			->times( 8 )
+			->andReturn( ...$yoast_options_results );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'twitter_site' )
+			->andReturn( 'someothernick' );
+
+		$this->assertEquals(
+			(object) [
+				'success'  => false,
+				'status'   => 500,
+				'error'    => 'Could not save some options in the database',
+				'failures' => [ 'twitter_site', 'instagram_url', 'linkedin_url', 'pinterest_url', 'wikipedia_url' ],
+			],
+			$this->instance->set_social_profiles( $params )
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We need to signal to users when some social profiles values are not saved.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* 

## Relevant technical choices:

* Valid URLs are always saved
* Invalid URLs are never saved
* Feedback is server side (so there is a request to save at least the valid URLs)
* Step can only be finished if there are no invalid fields

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Use these parameters and see if all the cases are caught.
* Valid URLs are always saved
* Invalid URLs are never saved
* Feedback is server side (so there is a request to save at least the valid URLs)
* Step can only be finished if there are no invalid fields

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

DUPP-83
