### PR TITLE
DUPP-96 Change select with textinput when company or person choice is disabled

### DIFF
--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -37,7 +37,7 @@ function configurationWorkoutReducer( state, action ) {
 	switch ( action.type ) {
 		case "SET_COMPANY_OR_PERSON":
 			newState.companyOrPerson = action.payload;
-			newState.companyOrPersonLabel = state.companyOrPersonOptions.filter( ( item ) => {
+			newState.companyOrPersonLabel = window.wpseoWorkoutsData.configuration.companyOrPersonOptions.filter( ( item ) => {
 				return item.value === action.payload;
 			} ).pop().name;
 			return newState;
@@ -387,8 +387,8 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					subtitle={ __( "Tell Google what kind of site you have and increase the chance it gets features in a Google Knowledge Panel. Select ‘Organization’ if you are working on a site for a business or an organization. Select ‘Person’ if you have, say, a personal blog.", "wordpress-seo" ) }
 					isFinished={ isStepFinished( "configuration", steps.siteRepresentation ) }
 				>
-					{ state.knowledgeGraphMessage &&  <Alert type="warning">
-						{ state.knowledgeGraphMessage }
+					{  window.wpseoWorkoutsData.configuration.knowledgeGraphMessage &&  <Alert type="warning">
+						{  window.wpseoWorkoutsData.configuration.knowledgeGraphMessage }
 					</Alert> }
 					{ ! state.shouldForceCompany && ! isStepFinished( "configuration", steps.siteRepresentation ) &&
 					<SingleSelect
@@ -398,9 +398,9 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						label={ __( "Does you site represent an Organization or Person?", "wordpress-seo" ) }
 						selected={ state.companyOrPerson }
 						onChange={ onOrganizationOrPersonChange }
-						options={ state.companyOrPersonOptions }
+						options={  window.wpseoWorkoutsData.configuration.companyOrPersonOptions }
 					/> }
-					{ ( state.shouldForceCompany || isStepFinished( "configuration", steps.siteRepresentation ) ) &&
+					{ (  window.wpseoWorkoutsData.configuration.shouldForceCompany || isStepFinished( "configuration", steps.siteRepresentation ) ) &&
 					<TextInput
 						id="organization-forced-readonly-text"
 						name="organization"

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -405,7 +405,6 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						id="organization-forced-readonly-text"
 						name="organization"
 						label={ __( "Does you site represent an Organization or Person?", "wordpress-seo" ) }
-						// translators: %1$s expands to Yoast
 						value={ state.companyOrPersonLabel }
 						readOnly={ true }
 					/> }
@@ -443,7 +442,6 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						id="site-tagline-input"
 						name="site-tagline"
 						label={ __( "Site tagline", "wordpress-seo" ) }
-						// translators: %1$s expands to Yoast
 						description={ sprintf( __( "Add a catchy tagline that describes your site in the best light. Use the keywords you want people to find your site with. Example: %1$s’s tagline is ‘SEO for everyone.’", "wordpress-seo" ), "Yoast" ) }
 						value={ state.siteTagline }
 						onChange={ onSiteTaglineChange }

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -390,7 +390,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					{  window.wpseoWorkoutsData.configuration.knowledgeGraphMessage &&  <Alert type="warning">
 						{  window.wpseoWorkoutsData.configuration.knowledgeGraphMessage }
 					</Alert> }
-					{ ! state.shouldForceCompany && ! isStepFinished( "configuration", steps.siteRepresentation ) &&
+					{ ! window.wpseoWorkoutsData.configuration.shouldForceCompany && ! isStepFinished( "configuration", steps.siteRepresentation ) &&
 					<SingleSelect
 						id="organization-person-select"
 						htmlFor="organization-person-select"

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -37,6 +37,9 @@ function configurationWorkoutReducer( state, action ) {
 	switch ( action.type ) {
 		case "SET_COMPANY_OR_PERSON":
 			newState.companyOrPerson = action.payload;
+			newState.companyOrPersonLabel = state.companyOrPersonOptions.filter( ( item ) => {
+				return item.value === action.payload;
+			} ).pop().name;
 			return newState;
 		case "CHANGE_COMPANY_NAME":
 			newState.companyName = action.payload;
@@ -384,6 +387,10 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					subtitle={ __( "Tell Google what kind of site you have and increase the chance it gets features in a Google Knowledge Panel. Select ‘Organization’ if you are working on a site for a business or an organization. Select ‘Person’ if you have, say, a personal blog.", "wordpress-seo" ) }
 					isFinished={ isStepFinished( "configuration", steps.siteRepresentation ) }
 				>
+					{ state.knowledgeGraphMessage &&  <Alert type="warning">
+						{ state.knowledgeGraphMessage }
+					</Alert> }
+					{ ! state.shouldForceCompany && ! isStepFinished( "configuration", steps.siteRepresentation ) &&
 					<SingleSelect
 						id="organization-person-select"
 						htmlFor="organization-person-select"
@@ -391,17 +398,17 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						label={ __( "Does you site represent an Organization or Person?", "wordpress-seo" ) }
 						selected={ state.companyOrPerson }
 						onChange={ onOrganizationOrPersonChange }
-						options={ [ {
-							name: "Organization",
-							value: "company",
-						},
-						{
-							name: "Person",
-							value: "person",
-						} ] }
-						readOnly={ isStepFinished( "configuration", steps.siteRepresentation ) }
-
-					/>
+						options={ state.companyOrPersonOptions }
+					/> }
+					{ ( state.shouldForceCompany || isStepFinished( "configuration", steps.siteRepresentation ) ) &&
+					<TextInput
+						id="organization-forced-readonly-text"
+						name="organization"
+						label={ __( "Does you site represent an Organization or Person?", "wordpress-seo" ) }
+						// translators: %1$s expands to Yoast
+						value={ state.companyOrPersonLabel }
+						readOnly={ true }
+					/> }
 					{ state.companyOrPerson === "company" && <Fragment>
 						{ ( ! state.companyName || ! state.companyLogo ) && <Alert type="warning">
 							{ __(

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -299,9 +299,10 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Return a JSON string with the
+	 * Gets the options for the Company or Person select.
+	 * Returns only the company option if it is forced (by Local SEO), otherwise returns company and person option.
 	 *
-	 * @return array True if tracking is enabled, false otherwise.
+	 * @return array The options for the company-or-person select.
 	 */
 	private function get_company_or_person_options() {
 		$options = [

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -2,7 +2,9 @@
 
 namespace Yoast\WP\SEO\Integrations\Admin;
 
+use WPSEO_Addon_Manager;
 use WPSEO_Admin_Asset_Manager;
+use WPSEO_Utils;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -19,6 +21,13 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	 * @var WPSEO_Admin_Asset_Manager
 	 */
 	private $admin_asset_manager;
+
+	/**
+	 * The addon manager.
+	 *
+	 * @var WPSEO_Addon_Manager
+	 */
+	private $addon_manager;
 
 	/**
 	 * The options' helper.
@@ -38,13 +47,16 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	 * Configuration_Workout_Integration constructor.
 	 *
 	 * @param WPSEO_Admin_Asset_Manager $admin_asset_manager The admin asset manager.
+	 * @param WPSEO_Addon_Manager       $addon_manager       The addon manager.
 	 * @param Options_Helper            $options_helper      The options helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $admin_asset_manager,
+		WPSEO_Addon_Manager $addon_manager,
 		Options_Helper $options_helper
 	) {
 		$this->admin_asset_manager = $admin_asset_manager;
+		$this->addon_manager       = $addon_manager;
 		$this->options_helper      = $options_helper;
 	}
 
@@ -91,11 +103,28 @@ class Configuration_Workout_Integration implements Integration_Interface {
 
 		$social_profiles = $this->get_social_profiles();
 
+		// This filter is documented in admin/views/tabs/metas/paper-content/general/knowledge-graph.php.
+		$knowledge_graph_message = apply_filters( 'wpseo_knowledge_graph_setting_msg', '' );
+
+		$options               = $this->get_company_or_person_options();
+		$selected_option_label = '';
+		$filtered_options      = \array_filter(
+			$options,
+			function ( $item ) {
+				return $item['value'] === $this->is_company_or_person();
+			}
+		);
+		$selected_option       = \reset( $filtered_options );
+		if ( \is_array( $selected_option ) ) {
+			$selected_option_label = $selected_option['name'];
+		}
+
 		$this->admin_asset_manager->add_inline_script(
 			'workouts',
 			\sprintf(
 				'window.wpseoWorkoutsData["configuration"] = {
 					"companyOrPerson": "%s",
+					"companyOrPersonLabel": "%s",
 					"companyName": "%s",
 					"companyLogo": "%s",
 					"companyLogoId": %d,
@@ -114,8 +143,12 @@ class Configuration_Workout_Integration implements Integration_Interface {
 						"wikipediaUrl": "%s",
 					},
 					"tracking": %d,
+					"companyOrPersonOptions": %s,
+					"shouldForceCompany": %d,
+					"knowledgeGraphMessage": "%s",
 				};',
 				$this->is_company_or_person(),
+				$selected_option_label,
 				$this->get_company_name(),
 				$this->get_company_logo(),
 				$this->get_company_logo_id(),
@@ -131,7 +164,10 @@ class Configuration_Workout_Integration implements Integration_Interface {
 				$social_profiles['pinterest_url'],
 				$social_profiles['youtube_url'],
 				$social_profiles['wikipedia_url'],
-				$this->has_tracking_enabled()
+				$this->has_tracking_enabled(),
+				WPSEO_Utils::format_json_encode( $options ),
+				$this->should_force_company(),
+				$knowledge_graph_message
 			),
 			'before'
 		);
@@ -260,5 +296,36 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	 */
 	private function has_tracking_enabled() {
 		return $this->options_helper->get( 'tracking', false );
+	}
+
+	/**
+	 * Return a JSON string with the
+	 *
+	 * @return array True if tracking is enabled, false otherwise.
+	 */
+	private function get_company_or_person_options() {
+		$options = [
+			[
+				'name'  => __( 'Organization', 'wordpress-seo' ),
+				'value' => 'company',
+			],
+		];
+		if ( ! $this->should_force_company() ) {
+			$options[] = [
+				'name'  => __( 'Person', 'wordpress-seo' ),
+				'value' => 'person',
+			];
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Checks whether we should force "Organization".
+	 *
+	 * @return bool
+	 */
+	private function should_force_company() {
+		return $this->addon_manager->is_installed( WPSEO_Addon_Manager::LOCAL_SLUG );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to disable the "Organization or person" select when the step is finished or when Local SEO forces the choice.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the "Organization or person" select in the configuration workout when the step is complete or when Local SEO is active.

## Relevant technical choices:

* Also moves the definition of the choices in the PHP side to make them translatable.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### without Local SEO
* visit the configuration workout
* in the second step, choose "Organization" and fill the other stuff, then click "Save and continue"
  * check that the step is greyed out, and the select becomes a readonly textbox with the Option you selected
  * reload, or visit SEO > Search Appearance, to check that your choice was saved
* un-grey the step by clicking on the button again, choose "Person" and fill the other stuff, then click "Save and continue"
  * check that the step is greyed out, and the select becomes a readonly textbox with the Option you selected
  * reload, or visit SEO > Search Appearance, to check that your choice was saved
* please also install another language, visit the workout and check that the select options are translated (just as they are translated in SEO > Search Appearance)
* please try to leave "person" as the saved choice, before going on with the next section

#### with Local SEO
* activate Local SEO
* visit the configuration workout
* in the second step, you should see an alert with the same copy as the one that you can find in SEO > Search Appearance: "In order to make full use of Yoast SEO: Local functionality, we force the setting for 'Person or Organization' here to 'Organization'."
* check that the select has become a readonly textbox with "Organization", regardless of your previous choice
* fill the other stuff, then click "Save and continue"
* reload, or visit SEO > Search Appearance, to check that your choice was saved
* disable Local SEO to see the select reappear again 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-96] [DUPP-88]

[DUPP-96]: https://yoast.atlassian.net/browse/DUPP-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DUPP-88]: https://yoast.atlassian.net/browse/DUPP-88