### PR TITLE
inject parent dependencies through child's constructor

### DIFF
--- a/src/actions/importing/abstract-importing-action.php
+++ b/src/actions/importing/abstract-importing-action.php
@@ -3,11 +3,7 @@
 namespace Yoast\WP\SEO\Actions\Importing;
 
 use Exception;
-use wpdb;
-use Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Helpers\Wpdb_Helper;
-use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
  * Importing action interface.
@@ -29,27 +25,6 @@ abstract class Abstract_Importing_Action implements Importing_Action_Interface {
 	const TYPE = null;
 
 	/**
-	 * Represents the indexables repository.
-	 *
-	 * @var Indexable_Repository
-	 */
-	protected $indexable_repository;
-
-	/**
-	 * The WordPress database instance.
-	 *
-	 * @var wpdb
-	 */
-	protected $wpdb;
-
-	/**
-	 * The indexable_to_postmeta helper.
-	 *
-	 * @var Indexable_To_Postmeta_Helper
-	 */
-	protected $indexable_to_postmeta;
-
-	/**
 	 * The options helper.
 	 *
 	 * @var Options_Helper
@@ -57,32 +32,12 @@ abstract class Abstract_Importing_Action implements Importing_Action_Interface {
 	protected $options;
 
 	/**
-	 * The wpdb helper.
-	 *
-	 * @var Wpdb_Helper
-	 */
-	protected $wpdb_helper;
-
-	/**
 	 * Abstract_Importing_Action constructor.
 	 *
-	 * @param Indexable_Repository         $indexable_repository  The indexables repository.
-	 * @param wpdb                         $wpdb                  The WordPress database instance.
-	 * @param Indexable_To_Postmeta_Helper $indexable_to_postmeta The indexable_to_postmeta helper.
-	 * @param Options_Helper               $options               The options helper.
-	 * @param Wpdb_Helper                  $wpdb_helper           The wpdb_helper helper.
+	 * @param Options_Helper $options The options helper.
 	 */
-	public function __construct(
-		Indexable_Repository $indexable_repository,
-		wpdb $wpdb,
-		Indexable_To_Postmeta_Helper $indexable_to_postmeta,
-		Options_Helper $options,
-		Wpdb_Helper $wpdb_helper ) {
-		$this->indexable_repository  = $indexable_repository;
-		$this->wpdb                  = $wpdb;
-		$this->indexable_to_postmeta = $indexable_to_postmeta;
-		$this->options               = $options;
-		$this->wpdb_helper           = $wpdb_helper;
+	public function __construct( Options_Helper $options ) {
+		$this->options = $options;
 	}
 
 	/**

--- a/src/actions/importing/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo-posts-importing-action.php
@@ -2,8 +2,13 @@
 
 namespace Yoast\WP\SEO\Actions\Importing;
 
-use Yoast\WP\SEO\Models\Indexable;
+use wpdb;
 use Yoast\WP\SEO\Conditionals\AIOSEO_V4_Importer_Conditional;
+use Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Wpdb_Helper;
+use Yoast\WP\SEO\Models\Indexable;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
  * Importing action for AIOSEO post data.
@@ -37,6 +42,57 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 		'twitter_title'       => 'twitter_title',
 		'twitter_description' => 'twitter_description',
 	];
+
+	/**
+	 * Represents the indexables repository.
+	 *
+	 * @var Indexable_Repository
+	 */
+	protected $indexable_repository;
+
+	/**
+	 * The WordPress database instance.
+	 *
+	 * @var wpdb
+	 */
+	protected $wpdb;
+
+	/**
+	 * The indexable_to_postmeta helper.
+	 *
+	 * @var Indexable_To_Postmeta_Helper
+	 */
+	protected $indexable_to_postmeta;
+
+	/**
+	 * The wpdb helper.
+	 *
+	 * @var Wpdb_Helper
+	 */
+	protected $wpdb_helper;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param Indexable_Repository         $indexable_repository        The indexables repository.
+	 * @param wpdb                         $wpdb                        The WordPress database instance.
+	 * @param Indexable_To_Postmeta_Helper $indexable_to_postmeta       The indexable_to_postmeta helper.
+	 * @param Options_Helper               $options                     The options helper.
+	 * @param Wpdb_Helper                  $wpdb_helper                 The wpdb_helper helper.
+	 */
+	public function __construct(
+		Indexable_Repository $indexable_repository,
+		wpdb $wpdb,
+		Indexable_To_Postmeta_Helper $indexable_to_postmeta,
+		Options_Helper $options,
+		Wpdb_Helper $wpdb_helper ) {
+		parent::__construct( $options );
+
+		$this->indexable_repository  = $indexable_repository;
+		$this->wpdb                  = $wpdb;
+		$this->indexable_to_postmeta = $indexable_to_postmeta;
+		$this->wpdb_helper           = $wpdb_helper;
+	}
 
 	/**
 	 * Retrieves the AIOSEO table name along with the db prefix.

--- a/src/actions/importing/deactivate-conflicting-plugins-action.php
+++ b/src/actions/importing/deactivate-conflicting-plugins-action.php
@@ -5,10 +5,7 @@ namespace Yoast\WP\SEO\Actions\Importing;
 use wpdb;
 use Yoast\WP\SEO\Conditionals\AIOSEO_V4_Importer_Conditional;
 use Yoast\WP\SEO\Config\Conflicting_Plugins;
-use Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Helpers\Wpdb_Helper;
-use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Services\Importing\Conflicting_Plugins_Service;
 
 /**
@@ -49,21 +46,12 @@ class Deactivate_Conflicting_Plugins_Action extends Abstract_Importing_Action {
 	/**
 	 * Class constructor.
 	 *
-	 * @param Indexable_Repository         $indexable_repository        The indexables repository.
-	 * @param wpdb                         $wpdb                        The WordPress database instance.
-	 * @param Indexable_To_Postmeta_Helper $indexable_to_postmeta       The indexable_to_postmeta helper.
-	 * @param Options_Helper               $options                     The options helper.
-	 * @param Wpdb_Helper                  $wpdb_helper                 The wpdb_helper helper.
-	 * @param Conflicting_Plugins_Service  $conflicting_plugins_service The Conflicting plugins Service.
+	 * @param Options_Helper              $options                     The options helper.
+	 * @param Conflicting_Plugins_Service $conflicting_plugins_service The Conflicting plugins Service.
 	 */
-	public function __construct(
-		Indexable_Repository $indexable_repository,
-		wpdb $wpdb,
-		Indexable_To_Postmeta_Helper $indexable_to_postmeta,
-		Options_Helper $options,
-		Wpdb_Helper $wpdb_helper,
-		Conflicting_Plugins_Service $conflicting_plugins_service ) {
-		parent::__construct( $indexable_repository, $wpdb, $indexable_to_postmeta, $options, $wpdb_helper );
+	public function __construct( Options_Helper $options, Conflicting_Plugins_Service $conflicting_plugins_service ) {
+		parent::__construct( $options );
+
 		$this->conflicting_plugins = $conflicting_plugins_service;
 		$this->detected_plugins    = [];
 	}

--- a/src/actions/importing/deactivate-conflicting-plugins-action.php
+++ b/src/actions/importing/deactivate-conflicting-plugins-action.php
@@ -2,7 +2,12 @@
 
 namespace Yoast\WP\SEO\Actions\Importing;
 
+use wpdb;
 use Yoast\WP\SEO\Config\Conflicting_Plugins;
+use Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Wpdb_Helper;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Services\Importing\Conflicting_Plugins_Service;
 
 /**
@@ -43,9 +48,21 @@ class Deactivate_Conflicting_Plugins_Action extends Abstract_Importing_Action {
 	/**
 	 * Class constructor.
 	 *
-	 * @param Conflicting_Plugins_Service $conflicting_plugins_service The Conflicting plugins Service.
+	 * @param Indexable_Repository         $indexable_repository        The indexables repository.
+	 * @param wpdb                         $wpdb                        The WordPress database instance.
+	 * @param Indexable_To_Postmeta_Helper $indexable_to_postmeta       The indexable_to_postmeta helper.
+	 * @param Options_Helper               $options                     The options helper.
+	 * @param Wpdb_Helper                  $wpdb_helper                 The wpdb_helper helper.
+	 * @param Conflicting_Plugins_Service  $conflicting_plugins_service The Conflicting plugins Service.
 	 */
-	public function __construct( Conflicting_Plugins_Service $conflicting_plugins_service ) {
+	public function __construct(
+		Indexable_Repository $indexable_repository,
+		wpdb $wpdb,
+		Indexable_To_Postmeta_Helper $indexable_to_postmeta,
+		Options_Helper $options,
+		Wpdb_Helper $wpdb_helper,
+		Conflicting_Plugins_Service $conflicting_plugins_service ) {
+		parent::__construct( $indexable_repository, $wpdb, $indexable_to_postmeta, $options, $wpdb_helper );
 		$this->conflicting_plugins = $conflicting_plugins_service;
 		$this->detected_plugins    = [];
 	}

--- a/tests/unit/actions/importing/abstract-importing-action-test.php
+++ b/tests/unit/actions/importing/abstract-importing-action-test.php
@@ -32,34 +32,6 @@ class Abstract_Importing_Action_Test extends TestCase {
 	protected $mock_instance;
 
 	/**
-	 * Represents the indexable repository.
-	 *
-	 * @var Mockery\MockInterface|Indexable_Repository
-	 */
-	protected $indexable_repository;
-
-	/**
-	 * The mocked WordPress database object.
-	 *
-	 * @var Mockery\MockInterface|\wpdb
-	 */
-	protected $wpdb;
-
-	/**
-	 * The mocked meta helper.
-	 *
-	 * @var Mockery\MockInterface|Meta_Helper
-	 */
-	protected $meta;
-
-	/**
-	 * The mocked indexable_to_postmeta helper.
-	 *
-	 * @var Mockery\MockInterface|Indexable_To_Postmeta_Helper
-	 */
-	protected $indexable_to_postmeta;
-
-	/**
 	 * The mocked options helper.
 	 *
 	 * @var Mockery\MockInterface|Options_Helper
@@ -67,36 +39,16 @@ class Abstract_Importing_Action_Test extends TestCase {
 	protected $options;
 
 	/**
-	 * The wpdb helper.
-	 *
-	 * @var Wpdb_Helper
-	 */
-	protected $wpdb_helper;
-
-	/**
 	 * Sets up the test class.
 	 */
 	protected function set_up() {
 		parent::set_up();
 
-		$this->indexable_repository  = Mockery::mock( Indexable_Repository::class );
-		$this->wpdb                  = Mockery::mock( 'wpdb' );
-		$this->meta                  = Mockery::mock( Meta_Helper::class );
-		$this->indexable_to_postmeta = Mockery::mock( Indexable_To_Postmeta_Helper::class, [ $this->meta ] );
-		$this->options               = Mockery::mock( Options_Helper::class );
-		$this->wpdb_helper           = Mockery::mock( Wpdb_Helper::class );
-		$this->mock_instance         = Mockery::mock(
+		$this->options       = Mockery::mock( Options_Helper::class );
+		$this->mock_instance = Mockery::mock(
 			Abstract_Importing_Action_Double::class,
-			[
-				$this->indexable_repository,
-				$this->wpdb,
-				$this->indexable_to_postmeta,
-				$this->options,
-				$this->wpdb_helper,
-			]
+			[ $this->options ]
 		)->makePartial()->shouldAllowMockingProtectedMethods();
-
-		$this->wpdb->prefix = 'wp_';
 	}
 
 	/**

--- a/tests/unit/actions/importing/deactivate-conflicting-plugins-action-test.php
+++ b/tests/unit/actions/importing/deactivate-conflicting-plugins-action-test.php
@@ -43,11 +43,7 @@ class Deactivate_Conflicting_Plugins_Action_Test extends TestCase {
 		$this->conflicting_plugins_service = Mockery::mock( Conflicting_Plugins_Service::class );
 
 		$this->deactivate_conflicting_plugins_action = new Deactivate_Conflicting_Plugins_Action(
-			Mockery::mock( Indexable_Repository::class ),
-			Mockery::mock( \wpdb::class ),
-			Mockery::mock( Indexable_To_Postmeta_Helper::class ),
 			Mockery::mock( Options_Helper::class ),
-			Mockery::mock( Wpdb_Helper::class ),
 			$this->conflicting_plugins_service
 		);
 	}

--- a/tests/unit/actions/importing/deactivate-conflicting-plugins-action-test.php
+++ b/tests/unit/actions/importing/deactivate-conflicting-plugins-action-test.php
@@ -4,6 +4,10 @@ namespace Yoast\WP\SEO\Tests\Unit\Actions\Importing;
 
 use Mockery;
 use Yoast\WP\SEO\Actions\Importing\Deactivate_Conflicting_Plugins_Action;
+use Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Wpdb_Helper;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Services\Importing\Conflicting_Plugins_Service;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -28,7 +32,7 @@ class Deactivate_Conflicting_Plugins_Action_Test extends TestCase {
 	/**
 	 * The service responsible for detecting conflicting plugins
 	 *
-	 * @var Mockery\MockInterface|Conflicting_Plugins_Service
+	 * @var Mockery::mockInterface|Conflicting_Plugins_Service
 	 */
 	protected $conflicting_plugins_service;
 
@@ -39,6 +43,11 @@ class Deactivate_Conflicting_Plugins_Action_Test extends TestCase {
 		$this->conflicting_plugins_service = Mockery::mock( Conflicting_Plugins_Service::class );
 
 		$this->deactivate_conflicting_plugins_action = new Deactivate_Conflicting_Plugins_Action(
+			Mockery::mock( Indexable_Repository::class ),
+			Mockery::mock( \wpdb::class ),
+			Mockery::mock( Indexable_To_Postmeta_Helper::class ),
+			Mockery::mock( Options_Helper::class ),
+			Mockery::mock( Wpdb_Helper::class ),
 			$this->conflicting_plugins_service
 		);
 	}

--- a/tests/unit/doubles/actions/importing/abstract-importing-action-double.php
+++ b/tests/unit/doubles/actions/importing/abstract-importing-action-double.php
@@ -2,12 +2,8 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Doubles\Actions\Importing;
 
-use wpdb;
 use Yoast\WP\SEO\Actions\Importing\Abstract_Importing_Action;
-use Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Helpers\Wpdb_Helper;
-use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
  * Class Abstract_Importing_Action_Double
@@ -17,27 +13,6 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
 abstract class Abstract_Importing_Action_Double extends Abstract_Importing_Action {
 
 	/**
-	 * Represents the indexables repository.
-	 *
-	 * @var Indexable_Repository
-	 */
-	protected $indexable_repository;
-
-	/**
-	 * The WordPress database instance.
-	 *
-	 * @var wpdb
-	 */
-	protected $wpdb;
-
-	/**
-	 * The indexable_to_postmeta helper.
-	 *
-	 * @var Indexable_To_Postmeta_Helper
-	 */
-	protected $indexable_to_postmeta;
-
-	/**
 	 * The options helper.
 	 *
 	 * @var Options_Helper
@@ -45,30 +20,12 @@ abstract class Abstract_Importing_Action_Double extends Abstract_Importing_Actio
 	protected $options;
 
 	/**
-	 * The wpdb helper.
-	 *
-	 * @var Wpdb_Helper
-	 */
-	protected $wpdb_helper;
-
-	/**
 	 * Gets the completed id (to be used as a key for the importing_completed option).
 	 *
 	 * @return string The completed id.
 	 */
-	public function __construct(
-		Indexable_Repository $indexable_repository,
-		wpdb $wpdb,
-		Indexable_To_Postmeta_Helper $indexable_to_postmeta,
-		Options_Helper $options,
-		Wpdb_Helper $wpdb_helper ) {
-		return parent::__construct(
-			$indexable_repository,
-			$wpdb,
-			$indexable_to_postmeta,
-			$options,
-			$wpdb_helper
-		);
+	public function __construct( Options_Helper $options ) {
+		return parent::__construct( $options );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes an error where a subclass would not properly initialize its parent

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an error where a subclass would not properly initialize its parent

## Relevant technical choices:

* Fixes an error where a subclass would not properly initialize its parent

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run SEO Optimization. It should complete normally.
* enable the YOAST_SEO_AIOSEO_V4_IMPORTER flag , set it to true
* Run SEO Optimization. It should complete normally.
 
### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Acceptance test https://github.com/Yoast/wordpress-seo/pull/17639 again
* Acceptance test https://github.com/Yoast/wordpress-seo/pull/17578 again

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
