### PR TITLE
Remove is_compatible() method of the deactivating plugins action class

### DIFF
--- a/src/actions/importing/deactivate-conflicting-plugins-action.php
+++ b/src/actions/importing/deactivate-conflicting-plugins-action.php
@@ -57,19 +57,6 @@ class Deactivate_Conflicting_Plugins_Action extends Abstract_Importing_Action {
 	}
 
 	/**
-	 * Can the current action import the data from plugin $plugin of type $type?
-	 *
-	 * @param string $plugin The plugin to import from.
-	 * @param string $type   The type of data to import.
-	 *
-	 * @return bool True if this action can handle the combination of Plugin and Type.
-	 */
-	public function is_compatible_with( $plugin = null, $type = null ) {
-		// This action can run on any plugin.
-		return true;
-	}
-
-	/**
 	 * Get the total number of conflicting plugins.
 	 */
 	public function get_total_unindexed() {

--- a/tests/unit/actions/importing/deactivate-conflicting-plugins-action-test.php
+++ b/tests/unit/actions/importing/deactivate-conflicting-plugins-action-test.php
@@ -83,17 +83,62 @@ class Deactivate_Conflicting_Plugins_Action_Test extends TestCase {
 
 			[
 				null,
-				'type',
+				'deactivation',
 			],
 
 			[
-				'plugin',
+				'conflicting-plugins',
 				null,
 			],
 
 			[
-				'plugin',
-				'type',
+				'conflicting-plugins',
+				'deactivation',
+			],
+		];
+	}
+
+	/**
+	 * Tests wether the tested class can import all data it should be able to handle
+	 *
+	 * @param string $plugin The plugin that's being imported.
+	 * @param string $type   The type of data being imported.
+	 *
+	 * @dataProvider is_compatible_with_wrong_testdata
+	 *
+	 * @covers ::is_compatible_with
+	 * @covers ::__construct
+	 */
+	public function test_is_not_compatible_with( $plugin, $type ) {
+		// Arrange.
+
+		// Act.
+		$result = $this->deactivate_conflicting_plugins_action->is_compatible_with( $plugin, $type );
+
+		// Assert.
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Testdata for test_is_compatible_with
+	 *
+	 * @return array
+	 */
+	public function is_compatible_with_wrong_testdata() {
+		return [
+			[
+				null,
+				'random_type',
+			],
+
+			[
+				'random_plugin',
+				null,
+			],
+
+			[
+				'random_plugin',
+				'random_type',
 			],
 
 			[


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where having any plugin from the conflcting plugins list as active would break all the other importing endpoints

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Without this PR:
* Have AIOSEO active
* Create a couple of posts. That way, we have AIOSEO post data to import to Yoast
* In the console, run
```
( async function() {
    const a = await fetch( "/wp-json/yoast/v1/import/aioseo/posts" ,
        {
            method: "POST",
            headers: { "X-WP-Nonce": wpApiSettings.nonce }
        }
    );
    console.log( await a.json() );
} )();
```
* This is a call in order to import AIOSEO post data, so it should have returned some imported data.
* Instead, it throws 404
Now, with this PR:
* Have AIOSEO active
* Create a couple of posts. That way, we have AIOSEO post data to import to Yoast
* In the console, run
```
( async function() {
    const a = await fetch( "/wp-json/yoast/v1/import/aioseo/posts" ,
        {
            method: "POST",
            headers: { "X-WP-Nonce": wpApiSettings.nonce }
        }
    );
    console.log( await a.json() );
} )();
```
* This is a call in order to import AIOSEO post data, so it should have returned some imported data.
* Instead of 404, now it returns a
```
{
    "objects": [ ...indexables ],
    "next_url": "/import/aioseo/posts" or `false`
}
```
response

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Acceptance test [PLUGIN-1362] Deactivate conflicting plugins #17639 again

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #


[PLUGIN-1362]: https://yoast.atlassian.net/browse/PLUGIN-1362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ