### PR TITLE
DUPP-109 change conditions configuration workout notice

### DIFF
--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Notice_Presenter;
@@ -28,11 +29,11 @@ class Workouts_Integration implements Integration_Interface {
 	private $options_helper;
 
 	/**
-	 * The indexing tool integration.
+	 * The indexing helper.
 	 *
-	 * @var Indexing_Tool_Integration
+	 * @var Indexing_Helper
 	 */
-	private $indexing_integration;
+	private $indexing_helper;
 
 	/**
 	 * {@inheritDoc}
@@ -46,16 +47,16 @@ class Workouts_Integration implements Integration_Interface {
 	 *
 	 * @param WPSEO_Admin_Asset_Manager $admin_asset_manager  The admin asset manager.
 	 * @param Options_Helper            $options_helper       The options helper.
-	 * @param Indexing_Tool_Integration $indexing_integration The indexing tool integration.
+	 * @param Indexing_Helper           $indexing_helper The indexing tool integration.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $admin_asset_manager,
 		Options_Helper $options_helper,
-		Indexing_Tool_Integration $indexing_integration
+		Indexing_Helper $indexing_helper
 	) {
-		$this->admin_asset_manager  = $admin_asset_manager;
-		$this->options_helper       = $options_helper;
-		$this->indexing_integration = $indexing_integration;
+		$this->admin_asset_manager = $admin_asset_manager;
+		$this->options_helper      = $options_helper;
+		$this->indexing_helper     = $indexing_helper;
 	}
 
 	/**
@@ -165,7 +166,7 @@ class Workouts_Integration implements Integration_Interface {
 			return false;
 		}
 
-		return ! $this->are_site_representation_name_and_logo_set() || $this->indexing_integration->get_unindexed_count() > 0;
+		return ! $this->are_site_representation_name_and_logo_set() || $this->indexing_helper->get_unindexed_count() > 0;
 	}
 
 	/**

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -28,6 +28,13 @@ class Workouts_Integration implements Integration_Interface {
 	private $options_helper;
 
 	/**
+	 * The indexing tool integration.
+	 *
+	 * @var Indexing_Tool_Integration
+	 */
+	private $indexing_integration;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
@@ -37,15 +44,18 @@ class Workouts_Integration implements Integration_Interface {
 	/**
 	 * Workouts_Integration constructor.
 	 *
-	 * @param WPSEO_Admin_Asset_Manager $admin_asset_manager The admin asset manager.
-	 * @param Options_Helper            $options_helper      The options helper.
+	 * @param WPSEO_Admin_Asset_Manager $admin_asset_manager  The admin asset manager.
+	 * @param Options_Helper            $options_helper       The options helper.
+	 * @param Indexing_Tool_Integration $indexing_integration The indexing tool integration.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $admin_asset_manager,
-		Options_Helper $options_helper
+		Options_Helper $options_helper,
+		Indexing_Tool_Integration $indexing_integration
 	) {
-		$this->admin_asset_manager = $admin_asset_manager;
-		$this->options_helper      = $options_helper;
+		$this->admin_asset_manager  = $admin_asset_manager;
+		$this->options_helper       = $options_helper;
+		$this->indexing_integration = $indexing_integration;
 	}
 
 	/**
@@ -147,11 +157,15 @@ class Workouts_Integration implements Integration_Interface {
 			return false;
 		}
 
-		$workouts_option = $this->options_helper->get( 'workouts_data', [] );
-		$finished_steps  = $workouts_option['configuration']['finishedSteps'];
+		if ( ! $this->on_wpseo_admin_page_or_dashboard() ) {
+			return false;
+		}
 
-		return count( $finished_steps ) < 5 &&
-			$this->on_wpseo_admin_page_or_dashboard();
+		if ( $this->is_configuration_workout_finished() ) {
+			return false;
+		}
+
+		return $this->are_site_representation_name_and_logo_set() || $this->indexing_integration->get_unindexed_count() > 0;
 	}
 
 	/**
@@ -284,5 +298,37 @@ class Workouts_Integration implements Integration_Interface {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Whether all steps of the configuration workout have been finished.
+	 *
+	 * @return bool Whether the configuration workout has been finished.
+	 */
+	private function is_configuration_workout_finished() {
+		$workouts_option = $this->options_helper->get( 'workouts_data', [] );
+
+		return count( $workouts_option['configuration']['finishedSteps'] ) === 5;
+	}
+
+	/**
+	 * Whether the site representation name and logo have been set.
+	 *
+	 * @return bool  Whether the site representation name and logo have been set.
+	 */
+	private function are_site_representation_name_and_logo_set() {
+		$company_or_person = $this->options_helper->get( 'company_or_person', '' );
+
+		if ( $company_or_person === '' ) {
+			return false;
+		}
+
+		if ( $company_or_person === 'company' ) {
+			return ! empty( $this->options_helper->get( 'company_name' ) )
+				&& ! empty( $this->options_helper->get( 'company_logo', '' ) );
+		}
+
+		return ! empty( $this->options_helper->get( 'company_or_person_user_id' ) )
+			&& ! empty( $this->options_helper->get( 'person_logo', '' ) );
 	}
 }

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -165,7 +165,7 @@ class Workouts_Integration implements Integration_Interface {
 			return false;
 		}
 
-		return $this->are_site_representation_name_and_logo_set() || $this->indexing_integration->get_unindexed_count() > 0;
+		return ! $this->are_site_representation_name_and_logo_set() || $this->indexing_integration->get_unindexed_count() > 0;
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes configuration notice when site representation name and logo have been set and the indexing has been done.

## Relevant technical choices:

* I moved some checks into their own private functions to improve readability of the `should_display_configuration_workout_notice` method, since it depends on quite a lot of factors. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you are an admin.
* Make sure you have not completed the Configuration Workout (the number of finished steps should be less than 5).
* Activate Yoast SEO and the Yoast Test Helper.
* Navigate to Tools > Yoast Test, and click the `Reset Indexables tables & migrations`, or make sure you need to re-run the indexation in some other way. 
* Do NOT run the indexation yet!
* Navigate to SEO > Search Appearance, choose Organization, set an organization name and logo, and save.
* You should see the First-time configuration workout notice. 
* Navigate to SEO > Tools and start the SEO Data Optimization.
* When it is complete, refresh the page: the notice should have disappeared.
* Navigate to SEO > Search Appearance.
* Remove the organization name but keep the logo and save.
* The notice should appear again.
* Set the organization name but remove the logo and save.
* The notice should still be there.
* Remove both the organization name and logo and save.
* The notice should still be there. 
* Now set your site to represent a person and set both a person name and logo.
* The notice should disappear.
* Remove the person logo and save.
* The notice should appear again.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
