### PR TITLE
Fix reading time functionality for languages other than English

### DIFF
--- a/packages/js/src/initializers/estimated-reading-time.js
+++ b/packages/js/src/initializers/estimated-reading-time.js
@@ -6,11 +6,12 @@ import { Paper } from "yoastseo";
  * Retrieves the estimated reading time.
  *
  * @param {string} content The content.
+ * @param {string} locale The content locale.
  *
  * @returns {void}
  */
-function getEstimatedReadingTime( content ) {
-	window.YoastSEO.analysis.worker.runResearch( "readingTime", new Paper( content, {} ) )
+function getEstimatedReadingTime( content, locale ) {
+	window.YoastSEO.analysis.worker.runResearch( "readingTime", new Paper( content, { locale: locale } ) )
 		.then( ( response ) => {
 			dispatch( "yoast-seo/editor" ).setEstimatedReadingTime( response.result );
 		} );

--- a/packages/js/src/initializers/estimated-reading-time.js
+++ b/packages/js/src/initializers/estimated-reading-time.js
@@ -46,6 +46,7 @@ function initializeEstimatedReadingTimeClassic() {
 // Used to trigger the initial reading time calculation for the block and Elementor editors.
 let previousContent = "";
 let previousRecord = null;
+let previousLocale = "";
 
 /**
  * Gets the estimated reading time in the block editor if the content has changed.
@@ -77,9 +78,12 @@ function getEstimatedReadingTimeBlockEditor() {
  */
 function getEstimatedReadingTimeElementor() {
 	const content = select( "yoast-seo/editor" ).getEditorDataContent();
-	if ( previousContent !== content ) {
+	const locale = select( "yoast-seo/editor" ).getContentLocale();
+
+	if ( previousContent !== content || previousLocale !== locale ) {
 		previousContent = content;
-		getEstimatedReadingTime( content );
+		previousLocale = locale;
+		getEstimatedReadingTime( content, locale );
 	}
 }
 

--- a/packages/js/src/initializers/estimated-reading-time.js
+++ b/packages/js/src/initializers/estimated-reading-time.js
@@ -5,8 +5,8 @@ import { Paper } from "yoastseo";
 /**
  * Retrieves the estimated reading time.
  *
- * @param {string} content The content.
- * @param {string} locale The content locale.
+ * @param {string} content  The content.
+ * @param {string} locale   The content locale.
  *
  * @returns {void}
  */
@@ -28,6 +28,7 @@ const debouncedGetEstimatedReadingTime = debounce( getEstimatedReadingTime, 1500
 function initializeEstimatedReadingTimeClassic() {
 	const tmceEvents = [ "input", "change", "cut", "paste" ];
 	const editorHandle = get( window, "wpseoScriptData.isPost", "0" ) === "1" ? "content" : "description";
+	const locale = select( "yoast-seo/editor" ).getContentLocale();
 
 	// Once tinyMCE is initialized, add the listeners.
 	jQuery( document ).on( "tinymce-editor-init", ( event, editor ) => {
@@ -37,7 +38,7 @@ function initializeEstimatedReadingTimeClassic() {
 
 		tmceEvents.forEach( ( eventName ) => {
 			editor.on( eventName, () => {
-				debouncedGetEstimatedReadingTime( editor.getContent() );
+				debouncedGetEstimatedReadingTime( editor.getContent(), locale );
 			} );
 		} );
 	} );
@@ -45,8 +46,8 @@ function initializeEstimatedReadingTimeClassic() {
 
 // Used to trigger the initial reading time calculation for the block and Elementor editors.
 let previousContent = "";
-let previousRecord = null;
 let previousLocale = "";
+let previousRecord = null;
 
 /**
  * Gets the estimated reading time in the block editor if the content has changed.
@@ -65,9 +66,12 @@ function getEstimatedReadingTimeBlockEditor() {
 	previousRecord = record;
 
 	const content = select( "core/editor" ).getEditedPostAttribute( "content" );
-	if ( previousContent !== content ) {
+	const locale = select( "yoast-seo/editor" ).getContentLocale();
+
+	if ( previousContent !== content || previousLocale !== locale ) {
 		previousContent = content;
-		getEstimatedReadingTime( content );
+		previousLocale = locale;
+		getEstimatedReadingTime( content, locale );
 	}
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The reading time functionality doesn't work for languages other than English. The research was never working for languages other than English because we run the research with the default config/attribute with `en_US` as the locale, and the locale was never overridden by the correct locale.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the reading time functionality was not working for languages other than English.

## Relevant technical choices:

* The locale is passed as part of the configuration when running the research in `estimated-reading-time.js`. 
* There are three different functions to get the estimated reading time for the three editors (i.e. Elementor, Block/Default, and Classic editor) where the functions for Block and Classic editors have their own editor-specific classes to get data from, instead of from `yoast-seo/editor`. I decided not to create an additional method in the aforementioned editor-specific classes to retrieve the content locale. This is because: (a) we already have a selector for that purpose from `"yoast-seo/editor"`, (b) using the selector  from `"yoast-seo/editor"` should be safe as the data retrieved by the method is always available in the store in all editors and that the locale wouldn't change across different editors, and (c) we want to avoid duplicate logic.
* The locale is then provided by using the `getContentLocale()` selector from `"yoast-seo/editor"` in all editors.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Requirement:
* Build Free plugin
* Run `composer require yoast/wordpress-seo:dev-LINGO-1179-fix-reading-time-functionality@dev` in `wordpress-seo-premium`
* Build Premium plugin
* Install and activate Elementor
* Install Classic editor (don't activate it yet)

**Test in English**
* Set the site language to English
* Create a post in default/block editor with 1000 words (tip: use the text generated by [this generator](https://generator.lorem-ipsum.info/_latin)
* Add `Yoast estimated reading time` block
* Confirm that it returns with `Estimated reading time: 5 minutes`
* Go to Insights tab and confirm that it also returns with `Estimated reading time: 5 minutes`
* Open the post in Elementor
* Go to Insights tab and confirm that it still returns with `Estimated reading time: 5 minutes`
* Activate Classic editor
* Go back to the post you created and edit it in Classic editor
* Go to Insights tab and confirm that it still returns with `Estimated reading time: 5 minutes`
* Deactivate Classic editor

**Test in Arabic** (the language with the least word per minute score)
* Set the site language to Arabic (العربية)
* Open the post that you previously created in block/default editor
* Confirm that it returns with `Estimated reading time: 8 minutes` or `الوقت المقدر للقراءة 8 دقائق`
* Go to Insights tab and confirm that it also returns with `Estimated reading time: 8 minutes` or `الوقت المقدر للقراءة 8 دقائق`
* Open the post in Elementor
* Go to Insights tab and confirm that it also returns with `Estimated reading time: 8 minutes` or `الوقت المقدر للقراءة 8 دقائق`
* Activate Classic editor
* Go back to the post you created and edit it in Classic editor
* Go to Insights tab and confirm that it also returns with `Estimated reading time: 8 minutes` or `الوقت المقدر للقراءة 8 دقائق`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Install and activate Free and Premium plugin

**Test in English**
* Set the site language to English
* Create a post in default/block editor with 1000 words (tip: use the text generated by [this generator](https://generator.lorem-ipsum.info/_latin)
* Add `Yoast estimated reading time` block
* Confirm that it returns with `Estimated reading time: 5 minutes`
* Go to Insights tab and confirm that it also returns with `Estimated reading time: 5 minutes`
* Open the post in Elementor
* Go to Insights tab and confirm that it still returns with `Estimated reading time: 5 minutes`
* Activate Classic editor
* Go back to the post you created and open it in Classic editor
* Go to Insights tab and confirm that it still returns with `Estimated reading time: 5 minutes`
* Deactivate Classic editor

**Test in Arabic** (the language with the least word per minute score)
* Set the site language to Arabic (`العربية`)
* Open the post that you previously created in block/default editor
* Confirm that it returns with `Estimated reading time: 8 minutes` or `الوقت المقدر للقراءة 8 دقائق`
* Go to Insights tab and confirm that it also returns with `Estimated reading time: 8 minutes` or `الوقت المقدر للقراءة 8 دقائق`
* Open the post in Elementor
* Go to Insights tab and confirm that it also returns with `Estimated reading time: 8 minutes` or `الوقت المقدر للقراءة 8 دقائق`
* Activate Classic editor
* Go back to the post you created and open it in Classic editor
* Go to Insights tab and confirm that it also returns with `Estimated reading time: 8 minutes` or `الوقت المقدر للقراءة 8 دقائق`


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1179
