### PR TITLE
DUPP-66 DUPP-106 Add different notifications for expired and unactivated Premium

### DIFF
--- a/css/src/notifications.css
+++ b/css/src/notifications.css
@@ -327,6 +327,7 @@
 	line-height: 1;
 	margin-left: 10px;
 	height: 60px;
+	width: auto;
 }
 
 .notice-yoast p {
@@ -334,4 +335,8 @@
 	font-weight: 400;
 	max-width: 600px;
 	line-height: 19px;
+}
+
+.notice-yoast .yoast-button--small {
+	min-height: unset;
 }

--- a/packages/js/src/workouts/components/CornerstoneWorkoutCard.js
+++ b/packages/js/src/workouts/components/CornerstoneWorkoutCard.js
@@ -17,9 +17,11 @@ import { WORKOUTS, FINISHABLE_STEPS } from "../config";
 export default function CornerstoneWorkoutCard( {
 	workout,
 	badges,
-	isPremiumUnactivated,
+	upsellLink,
+	upsellText,
 } ) {
 	const finishedSteps = useSelect( "yoast-seo/workouts" ).getFinishedSteps( WORKOUTS.cornerstone );
+	const actualUpsellLink = upsellLink ? upsellLink :  "https://yoa.st/workout-cornerstone-upsell";
 	return <WorkoutCard
 		name={ WORKOUTS.cornerstone }
 		title={ __( "The cornerstone approach", "wordpress-seo" ) }
@@ -31,7 +33,8 @@ export default function CornerstoneWorkoutCard( {
 		image={ CornerstoneImageBubble }
 		finishableSteps={ FINISHABLE_STEPS.cornerstone }
 		finishedSteps={ finishedSteps }
-		upsellLink={ isPremiumUnactivated ? "https://yoa.st/workouts-activate-notice-myyoast" : "https://yoa.st/workout-cornerstone-upsell" }
+		upsellLink={ actualUpsellLink }
+		upsellText={ upsellText }
 		workout={ workout }
 		badges={ badges }
 	/>;
@@ -40,11 +43,13 @@ export default function CornerstoneWorkoutCard( {
 CornerstoneWorkoutCard.propTypes = {
 	workout: PropTypes.func,
 	badges: PropTypes.arrayOf( PropTypes.element ),
-	isPremiumUnactivated: PropTypes.bool,
+	upsellLink: PropTypes.string,
+	upsellText: PropTypes.string,
 };
 
 CornerstoneWorkoutCard.defaultProps = {
 	workout: null,
 	badges: [],
-	isPremiumUnactivated: false,
+	upsellLink: null,
+	upsellText: null,
 };

--- a/packages/js/src/workouts/components/CornerstoneWorkoutCard.js
+++ b/packages/js/src/workouts/components/CornerstoneWorkoutCard.js
@@ -17,6 +17,7 @@ import { WORKOUTS, FINISHABLE_STEPS } from "../config";
 export default function CornerstoneWorkoutCard( {
 	workout,
 	badges,
+	isPremiumUnactivated,
 } ) {
 	const finishedSteps = useSelect( "yoast-seo/workouts" ).getFinishedSteps( WORKOUTS.cornerstone );
 	return <WorkoutCard
@@ -30,7 +31,7 @@ export default function CornerstoneWorkoutCard( {
 		image={ CornerstoneImageBubble }
 		finishableSteps={ FINISHABLE_STEPS.cornerstone }
 		finishedSteps={ finishedSteps }
-		upsellLink={ "https://yoa.st/workout-cornerstone-upsell" }
+		upsellLink={ isPremiumUnactivated ? "https://yoa.st/workouts-activate-notice-myyoast" : "https://yoa.st/workout-cornerstone-upsell" }
 		workout={ workout }
 		badges={ badges }
 	/>;
@@ -39,9 +40,11 @@ export default function CornerstoneWorkoutCard( {
 CornerstoneWorkoutCard.propTypes = {
 	workout: PropTypes.func,
 	badges: PropTypes.arrayOf( PropTypes.element ),
+	isPremiumUnactivated: PropTypes.bool,
 };
 
 CornerstoneWorkoutCard.defaultProps = {
 	workout: null,
 	badges: [],
+	isPremiumUnactivated: false,
 };

--- a/packages/js/src/workouts/components/OrphanedWorkoutCard.js
+++ b/packages/js/src/workouts/components/OrphanedWorkoutCard.js
@@ -17,6 +17,7 @@ import { FINISHABLE_STEPS, WORKOUTS } from "../config";
 export default function OrphanedWorkoutCard( {
 	workout,
 	badges,
+	isPremiumUnactivated,
 } ) {
 	const finishedSteps = useSelect( "yoast-seo/workouts" ).getFinishedSteps( WORKOUTS.orphaned );
 	return <WorkoutCard
@@ -30,7 +31,7 @@ export default function OrphanedWorkoutCard( {
 		image={ OrphanedImageBubble }
 		finishableSteps={ FINISHABLE_STEPS.orphaned }
 		finishedSteps={ finishedSteps }
-		upsellLink={ "https://yoa.st/workout-orphaned-content-upsell" }
+		upsellLink={ isPremiumUnactivated ? "https://yoa.st/workouts-activate-notice-myyoast" : "https://yoa.st/workout-orphaned-content-upsell" }
 		workout={ workout }
 		badges={ badges }
 	/>;
@@ -39,9 +40,11 @@ export default function OrphanedWorkoutCard( {
 OrphanedWorkoutCard.propTypes = {
 	workout: PropTypes.func,
 	badges: PropTypes.arrayOf( PropTypes.element ),
+	isPremiumUnactivated: PropTypes.bool,
 };
 
 OrphanedWorkoutCard.defaultProps = {
 	workout: null,
 	badges: [],
+	isPremiumUnactivated: false,
 };

--- a/packages/js/src/workouts/components/OrphanedWorkoutCard.js
+++ b/packages/js/src/workouts/components/OrphanedWorkoutCard.js
@@ -22,7 +22,7 @@ export default function OrphanedWorkoutCard( {
 } ) {
 	const finishedSteps = useSelect( select => select( "yoast-seo/workouts" ).getFinishedSteps( WORKOUTS.orphaned ) );
 	const actualUpsellLink = upsellLink ? upsellLink :  "https://yoa.st/workout-orphaned-content-upsell";
-  
+
 	return <WorkoutCard
 		name={ WORKOUTS.orphaned }
 		title={ __( "Orphaned content", "wordpress-seo" ) }

--- a/packages/js/src/workouts/components/OrphanedWorkoutCard.js
+++ b/packages/js/src/workouts/components/OrphanedWorkoutCard.js
@@ -17,9 +17,11 @@ import { FINISHABLE_STEPS, WORKOUTS } from "../config";
 export default function OrphanedWorkoutCard( {
 	workout,
 	badges,
-	isPremiumUnactivated,
+	upsellLink,
+	upsellText,
 } ) {
 	const finishedSteps = useSelect( "yoast-seo/workouts" ).getFinishedSteps( WORKOUTS.orphaned );
+	const actualUpsellLink = upsellLink ? upsellLink :  "https://yoa.st/workout-orphaned-content-upsell";
 	return <WorkoutCard
 		name={ WORKOUTS.orphaned }
 		title={ __( "Orphaned content", "wordpress-seo" ) }
@@ -31,7 +33,8 @@ export default function OrphanedWorkoutCard( {
 		image={ OrphanedImageBubble }
 		finishableSteps={ FINISHABLE_STEPS.orphaned }
 		finishedSteps={ finishedSteps }
-		upsellLink={ isPremiumUnactivated ? "https://yoa.st/workouts-activate-notice-myyoast" : "https://yoa.st/workout-orphaned-content-upsell" }
+		upsellLink={ actualUpsellLink }
+		upsellText={ upsellText }
 		workout={ workout }
 		badges={ badges }
 	/>;
@@ -40,11 +43,13 @@ export default function OrphanedWorkoutCard( {
 OrphanedWorkoutCard.propTypes = {
 	workout: PropTypes.func,
 	badges: PropTypes.arrayOf( PropTypes.element ),
-	isPremiumUnactivated: PropTypes.bool,
+	upsellLink: PropTypes.string,
+	upsellText: PropTypes.string,
 };
 
 OrphanedWorkoutCard.defaultProps = {
 	workout: null,
 	badges: [],
-	isPremiumUnactivated: false,
+	upsellLink: null,
+	upsellText: null,
 };

--- a/packages/js/src/workouts/components/WorkoutCard.js
+++ b/packages/js/src/workouts/components/WorkoutCard.js
@@ -24,6 +24,7 @@ export default function WorkoutCard( {
 	finishableSteps,
 	finishedSteps,
 	upsellLink,
+	upsellText,
 	workout,
 	badges,
 } ) {
@@ -67,6 +68,11 @@ export default function WorkoutCard( {
 	);
 
 	const UpsellButton = makeOutboundLink();
+	const actualUpsellText = upsellText ? upsellText : sprintf(
+		/* translators: %s : Expands to the add-on name. */
+		__( "Unlock with %s!", "wordpress-seo" ),
+		"Premium"
+	);
 	const disabled = workout ? "" : " card-disabled";
 
 	return ( <Fragment>
@@ -85,13 +91,7 @@ export default function WorkoutCard( {
 				{ workout && <Button onClick={ onClick }>{ buttonText }</Button> }
 				{ ! workout &&
 					<UpsellButton href={ upsellLink } className="yoast-button yoast-button-upsell">
-						{
-							sprintf(
-							/* translators: %s : Expands to the add-on name. */
-								__( "Unlock with %s!", "wordpress-seo" ),
-								"Premium"
-							)
-						}
+						{ actualUpsellText }
 						<span aria-hidden="true" className="yoast-button-upsell__caret" />
 					</UpsellButton>
 				}
@@ -131,16 +131,18 @@ WorkoutCard.propTypes = {
 	finishedSteps: PropTypes.arrayOf( PropTypes.string ),
 	image: PropTypes.func,
 	upsellLink: PropTypes.string,
+	upsellText: PropTypes.string,
 	workout: PropTypes.func,
 	badges: PropTypes.arrayOf( PropTypes.element ),
 };
 
 WorkoutCard.defaultProps = {
-	image: null,
-	upsellLink: null,
-	workout: null,
-	badges: [],
 	finishableSteps: null,
 	finishedSteps: null,
+	image: null,
+	upsellLink: null,
+	upsellText: null,
+	workout: null,
+	badges: [],
 };
 /* eslint-enable complexity */

--- a/packages/js/src/workouts/components/WorkoutsPage.js
+++ b/packages/js/src/workouts/components/WorkoutsPage.js
@@ -12,6 +12,7 @@ import { WORKOUTS } from "../config";
 
 const {
 	workouts: workoutsSetting,
+	isPremiumUnactivated,
 } = window.wpseoWorkoutsData;
 
 /**
@@ -22,6 +23,7 @@ const {
 const CornerstoneCard = () => {
 	return <CornerstoneWorkoutCard
 		badges={ [ <PremiumBadge key={ "premium-badge-cornerstone-workout" } /> ] }
+		isPremiumUnactivated={ isPremiumUnactivated }
 	/>;
 };
 
@@ -33,6 +35,7 @@ const CornerstoneCard = () => {
 const OrphanedCard = () => {
 	return <OrphanedWorkoutCard
 		badges={ [ <PremiumBadge key={ "premium-badge-orphaned-workout" } /> ] }
+		isPremiumUnactivated={ isPremiumUnactivated }
 	/>;
 };
 

--- a/packages/js/src/workouts/components/WorkoutsPage.js
+++ b/packages/js/src/workouts/components/WorkoutsPage.js
@@ -12,7 +12,8 @@ import { WORKOUTS } from "../config";
 
 const {
 	workouts: workoutsSetting,
-	isPremiumUnactivated,
+	upsellLink,
+	upsellText,
 } = window.wpseoWorkoutsData;
 
 /**
@@ -23,7 +24,8 @@ const {
 const CornerstoneCard = () => {
 	return <CornerstoneWorkoutCard
 		badges={ [ <PremiumBadge key={ "premium-badge-cornerstone-workout" } /> ] }
-		isPremiumUnactivated={ isPremiumUnactivated }
+		upsellLink={ upsellLink }
+		upsellText={ upsellText }
 	/>;
 };
 
@@ -35,7 +37,8 @@ const CornerstoneCard = () => {
 const OrphanedCard = () => {
 	return <OrphanedWorkoutCard
 		badges={ [ <PremiumBadge key={ "premium-badge-orphaned-workout" } /> ] }
-		isPremiumUnactivated={ isPremiumUnactivated }
+		upsellLink={ upsellLink }
+		upsellText={ upsellText }
 	/>;
 };
 

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -261,10 +261,11 @@ class Workouts_Integration implements Integration_Interface {
 	 * @return string The notification to update Premium.
 	 */
 	private function get_update_premium_notice() {
+		$url = $this->get_upsell_link();
+
 		if ( $this->has_premium_subscription_expired() ) {
 			/* translators: %s: expands to 'Yoast SEO Premium'. */
 			$title = \sprintf( \__( 'Renew your subscription of %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
-			$url   = $this->get_upsell_link();
 			$copy  = \sprintf(
 				/* translators: %s: expands to 'Yoast SEO Premium'. */
 				\esc_html__(
@@ -282,7 +283,6 @@ class Workouts_Integration implements Integration_Interface {
 		elseif ( $this->has_premium_subscription_activated() ) {
 			/* translators: %s: expands to 'Yoast SEO Premium'. */
 			$title = \sprintf( \__( 'Update to the latest version of %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
-			$url   = $this->get_upsell_link();
 			$copy  = \sprintf(
 				/* translators: 1: expands to 'Yoast SEO Premium', 2: Link start tag to the page to update Premium, 3: Link closing tag. */
 				\esc_html__( 'It looks like you\'re running an outdated version of %1$s, please %2$supdate to the latest version (at least 17.7)%3$s to gain access to our updated workouts section.', 'wordpress-seo' ),
@@ -296,7 +296,6 @@ class Workouts_Integration implements Integration_Interface {
 			/* translators: %s: expands to 'Yoast SEO Premium'. */
 			$title      = \sprintf( \__( 'Activate your subscription of %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 			$url_button = 'https://yoa.st/workouts-activate-notice-help';
-			$url        = $this->get_upsell_link();
 			$copy       = \sprintf(
 				/* translators: 1: expands to 'Yoast SEO Premium', 2: Link start tag to the page to update Premium, 3: Link closing tag. */
 				\esc_html__( 'It looks like you’re running an outdated and unactivated version of %1$s, please activate your subscription in %2$sMyYoast%3$s and update to the latest version (at least 17.7) to gain access to our updated workouts section.', 'wordpress-seo' ),
@@ -356,30 +355,29 @@ class Workouts_Integration implements Integration_Interface {
 	 * @return string Returns a string with the upsell/update copy for the card buttons.
 	 */
 	private function get_upsell_text() {
-		if ( $this->product_helper->is_premium() && $this->should_update_premium() ) {
-			if ( $this->has_premium_subscription_expired() ) {
-				return sprintf(
-					/* translators: %s: expands to 'Yoast SEO Premium'. */
-					__( 'Renew %s', 'wordpress-seo' ),
-					'Yoast SEO Premium'
-				);
-			}
-			if ( $this->has_premium_subscription_activated() ) {
-				return sprintf(
-					/* translators: %s: expands to 'Yoast SEO Premium'. */
-					__( 'Update %s', 'wordpress-seo' ),
-					'Yoast SEO Premium'
-				);
-			}
+		if ( ! $this->product_helper->is_premium() || ! $this->should_update_premium() ) {
+			// Use the default defined in the component.
+			return '';
+		}
+		if ( $this->has_premium_subscription_expired() ) {
 			return sprintf(
 				/* translators: %s: expands to 'Yoast SEO Premium'. */
-				__( 'Activate %s', 'wordpress-seo' ),
+				__( 'Renew %s', 'wordpress-seo' ),
 				'Yoast SEO Premium'
 			);
 		}
-
-		// Use the default defined in the component.
-		return '';
+		if ( $this->has_premium_subscription_activated() ) {
+			return sprintf(
+				/* translators: %s: expands to 'Yoast SEO Premium'. */
+				__( 'Update %s', 'wordpress-seo' ),
+				'Yoast SEO Premium'
+			);
+		}
+		return sprintf(
+			/* translators: %s: expands to 'Yoast SEO Premium'. */
+			__( 'Activate %s', 'wordpress-seo' ),
+			'Yoast SEO Premium'
+		);
 	}
 
 	/**
@@ -388,18 +386,17 @@ class Workouts_Integration implements Integration_Interface {
 	 * @return string Returns a string with the upsell/update link for the card buttons.
 	 */
 	private function get_upsell_link() {
-		if ( $this->product_helper->is_premium() && $this->should_update_premium() ) {
-			if ( $this->has_premium_subscription_expired() ) {
-				return 'https://yoa.st/workout-renew-notice';
-			}
-			if ( $this->has_premium_subscription_activated() ) {
-				return \wp_nonce_url( \self_admin_url( 'update.php?action=upgrade-plugin&plugin=wordpress-seo-premium/wp-seo-premium.php' ), 'upgrade-plugin_wordpress-seo-premium/wp-seo-premium.php' );
-			}
-			return 'https://yoa.st/workouts-activate-notice-myyoast';
+		if ( ! $this->product_helper->is_premium() || ! $this->should_update_premium() ) {
+			// Use the default defined in the component.
+			return '';
 		}
-
-		// Use the default defined in the component.
-		return '';
+		if ( $this->has_premium_subscription_expired() ) {
+			return 'https://yoa.st/workout-renew-notice';
+		}
+		if ( $this->has_premium_subscription_activated() ) {
+			return \wp_nonce_url( \self_admin_url( 'update.php?action=upgrade-plugin&plugin=wordpress-seo-premium/wp-seo-premium.php' ), 'upgrade-plugin_wordpress-seo-premium/wp-seo-premium.php' );
+		}
+		return 'https://yoa.st/workouts-activate-notice-myyoast';
 	}
 
 	/**

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -263,11 +263,11 @@ class Workouts_Integration implements Integration_Interface {
 	private function get_update_premium_notice() {
 		if ( $this->has_premium_subscription_expired() ) {
 			/* translators: %s: expands to 'Yoast SEO Premium'. */
-			$title  = \sprintf( \__( 'Renew your subscription of %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
-			$url    = $this->get_upsell_link();
-			$copy   = \sprintf(
+			$title = \sprintf( \__( 'Renew your subscription of %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+			$url   = $this->get_upsell_link();
+			$copy  = \sprintf(
+				/* translators: %s: expands to 'Yoast SEO Premium'. */
 				\esc_html__(
-					/* translators: %s: expands to 'Yoast SEO Premium'. */
 					'Accessing the latest workouts requires an updated version of %s (at least 17.7), but it looks like your subscription has expired. Please renew your subscription to update and gain access to all the latest features.',
 					'wordpress-seo'
 				),
@@ -281,10 +281,10 @@ class Workouts_Integration implements Integration_Interface {
 		}
 		elseif ( $this->has_premium_subscription_activated() ) {
 			/* translators: %s: expands to 'Yoast SEO Premium'. */
-			$title =  \sprintf( \__( 'Update to the latest version of %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+			$title = \sprintf( \__( 'Update to the latest version of %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 			$url   = $this->get_upsell_link();
 			$copy  = \sprintf(
-			    /* translators: 1: expands to 'Yoast SEO Premium', 2: Link start tag to the page to update Premium, 3: Link closing tag. */
+				/* translators: 1: expands to 'Yoast SEO Premium', 2: Link start tag to the page to update Premium, 3: Link closing tag. */
 				\esc_html__( 'It looks like you\'re running an outdated version of %1$s, please %2$supdate to the latest version (at least 17.7)%3$s to gain access to our updated workouts section.', 'wordpress-seo' ),
 				'Yoast SEO Premium',
 				'<a href="' . \esc_url( $url ) . '">',

--- a/src/presenters/admin/notice-presenter.php
+++ b/src/presenters/admin/notice-presenter.php
@@ -32,7 +32,7 @@ class Notice_Presenter extends Abstract_Presenter {
 	private $image_filename;
 
 	/**
-	 * The filename of the image for the notice. Should be a file in the 'images' folder.
+	 * HTML string to be displayed after the main content, usually a button.
 	 *
 	 * @var string
 	 */

--- a/src/presenters/admin/notice-presenter.php
+++ b/src/presenters/admin/notice-presenter.php
@@ -32,6 +32,13 @@ class Notice_Presenter extends Abstract_Presenter {
 	private $image_filename;
 
 	/**
+	 * The filename of the image for the notice. Should be a file in the 'images' folder.
+	 *
+	 * @var string
+	 */
+	private $button;
+
+	/**
 	 * Whether the notice should be dismissible.
 	 *
 	 * @var bool
@@ -61,10 +68,11 @@ class Notice_Presenter extends Abstract_Presenter {
 	 * @param bool   $is_dismissible Optional. Whether the admin notice should be dismissible.
 	 * @param string $id             Optional. The id of the notice.
 	 */
-	public function __construct( $title, $content, $image_filename = null, $is_dismissible = false, $id = '' ) {
+	public function __construct( $title, $content, $image_filename = null, $button = null, $is_dismissible = false, $id = '' ) {
 		$this->title          = $title;
 		$this->content        = $content;
 		$this->image_filename = $image_filename;
+		$this->button         = $button;
 		$this->is_dismissible = $is_dismissible;
 		$this->id             = $id;
 
@@ -85,7 +93,7 @@ class Notice_Presenter extends Abstract_Presenter {
 		$id          = ( $this->id ) ? ' id="' . $this->id . '"' : '';
 
 		// WordPress admin notice.
-		$out  = '<div' . $id . ' class="notice notice-yoast' . $dismissible . '">';
+		$out  = '<div' . $id . ' class="notice notice-yoast yoast' . $dismissible . '">';
 		$out .= '<div class="notice-yoast__container">';
 
 		// Header.
@@ -98,10 +106,13 @@ class Notice_Presenter extends Abstract_Presenter {
 		);
 		$out .= '</div>';
 		$out .= '<p>' . $this->content . '</p>';
+		if ( ! \is_null( $this->button ) ) {
+			$out .= '<p>' . $this->button . '</p>';
+		}
 		$out .= '</div>';
 
 		if ( ! \is_null( $this->image_filename ) ) {
-			$out .= '<img src="' . \esc_url( plugin_dir_url( WPSEO_FILE ) . 'images/' . $this->image_filename ) . '" alt="" />';
+			$out .= '<img src="' . \esc_url( plugin_dir_url( WPSEO_FILE ) . 'images/' . $this->image_filename ) . '" alt="" height="60" width="75"/>';
 		}
 
 		$out .= '</div>';

--- a/src/presenters/admin/notice-presenter.php
+++ b/src/presenters/admin/notice-presenter.php
@@ -65,6 +65,7 @@ class Notice_Presenter extends Abstract_Presenter {
 	 * @param string $title          Title of the admin notice.
 	 * @param string $content        Content of the admin notice.
 	 * @param string $image_filename Optional. The filename of the image of the admin notice, should be inside the 'images' folder.
+	 * @param string $button         Optional. An HTML string to be displayed after the main content, usually a button.
 	 * @param bool   $is_dismissible Optional. Whether the admin notice should be dismissible.
 	 * @param string $id             Optional. The id of the notice.
 	 */

--- a/tests/unit/presenters/admin/notice-presenter-test.php
+++ b/tests/unit/presenters/admin/notice-presenter-test.php
@@ -34,7 +34,7 @@ class Notice_Presenter_Test extends TestCase {
 	public function test_construct() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
 
-		$test = new Notice_Presenter( 'title', 'content', 'image.png', true );
+		$test = new Notice_Presenter( 'title', 'content', 'image.png', null, true );
 
 		$this->assertSame( 'title', $this->getPropertyValue( $test, 'title' ) );
 		$this->assertSame( 'content', $this->getPropertyValue( $test, 'content' ) );
@@ -57,7 +57,7 @@ class Notice_Presenter_Test extends TestCase {
 
 		$test = new Notice_Presenter( 'title', 'content' );
 
-		$expected = '<div class="notice notice-yoast"><div class="notice-yoast__container">'
+		$expected = '<div class="notice notice-yoast yoast"><div class="notice-yoast__container">'
 			. '<div>'
 			. '<div class="notice-yoast__header">'
 			. '<span class="yoast-icon"></span>'
@@ -83,7 +83,7 @@ class Notice_Presenter_Test extends TestCase {
 
 		$test = new Notice_Presenter( 'title', 'content', 'image.png' );
 
-		$expected = '<div class="notice notice-yoast"><div class="notice-yoast__container">'
+		$expected = '<div class="notice notice-yoast yoast"><div class="notice-yoast__container">'
 			. '<div>'
 			. '<div class="notice-yoast__header">'
 			. '<span class="yoast-icon"></span>'
@@ -91,7 +91,7 @@ class Notice_Presenter_Test extends TestCase {
 			. '</div>'
 			. '<p>content</p>'
 			. '</div>'
-			. '<img src="images/image.png" alt="" />'
+			. '<img src="images/image.png" alt="" height="60" width="75"/>'
 			. '</div></div>';
 
 		Monkey\Functions\expect( 'esc_html' )->andReturn( '' );
@@ -109,9 +109,9 @@ class Notice_Presenter_Test extends TestCase {
 	public function test_dismissble_notice() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
 
-		$test = new Notice_Presenter( 'title', 'content', null, true );
+		$test = new Notice_Presenter( 'title', 'content', null, null, true );
 
-		$expected = '<div class="notice notice-yoast is-dismissible"><div class="notice-yoast__container">'
+		$expected = '<div class="notice notice-yoast yoast is-dismissible"><div class="notice-yoast__container">'
 			. '<div>'
 			. '<div class="notice-yoast__header">'
 			. '<span class="yoast-icon"></span>'
@@ -136,9 +136,9 @@ class Notice_Presenter_Test extends TestCase {
 	public function test_dismissble_notice_with_image() {
 		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
 
-		$test = new Notice_Presenter( 'title', 'content', 'image.png', true );
+		$test = new Notice_Presenter( 'title', 'content', 'image.png', null, true );
 
-		$expected = '<div class="notice notice-yoast is-dismissible"><div class="notice-yoast__container">'
+		$expected = '<div class="notice notice-yoast yoast is-dismissible"><div class="notice-yoast__container">'
 			. '<div>'
 			. '<div class="notice-yoast__header">'
 			. '<span class="yoast-icon"></span>'
@@ -146,7 +146,38 @@ class Notice_Presenter_Test extends TestCase {
 			. '</div>'
 			. '<p>content</p>'
 			. '</div>'
-			. '<img src="images/image.png" alt="" />'
+			. '<img src="images/image.png" alt="" height="60" width="75"/>'
+			. '</div></div>';
+
+		Monkey\Functions\expect( 'esc_html' )->andReturn( '' );
+		Monkey\Functions\expect( 'esc_url' )->andReturn( '' );
+		Monkey\Functions\expect( 'plugin_dir_url' )->andReturn( '' );
+
+		$this->assertEquals( $expected, (string) $test );
+	}
+
+	/**
+	 * Test when the Notice is dismissible and has an image and a button.
+	 *
+	 * @covers ::present
+	 */
+	public function test_dismissble_notice_with_image_and_button() {
+		Monkey\Functions\expect( 'wp_enqueue_style' )->once();
+
+		$button = '<a class="yoast-button yoast-button-upsell" href="https://yoa.st/somewhere">Some text</a>';
+
+		$test = new Notice_Presenter( 'title', 'content', 'image.png', $button, true );
+
+		$expected = '<div class="notice notice-yoast yoast is-dismissible"><div class="notice-yoast__container">'
+			. '<div>'
+			. '<div class="notice-yoast__header">'
+			. '<span class="yoast-icon"></span>'
+			. '<h1 class="notice-yoast__header-heading">title</h1>'
+			. '</div>'
+			. '<p>content</p>'
+			. '<p><a class="yoast-button yoast-button-upsell" href="https://yoa.st/somewhere">Some text</a></p>'
+			. '</div>'
+			. '<img src="images/image.png" alt="" height="60" width="75"/>'
 			. '</div></div>';
 
 		Monkey\Functions\expect( 'esc_html' )->andReturn( '' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the notification to update Premium to be more meaningful depending on whether the user can upgrade or not based on their site's subscription status

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the notice to update Premium to see the new workouts, depending on the status of the subscription

## Relevant technical choices:

* Also solves an issue (DUPP-106) where the image in the notification was displayed as big as the screen for an instant.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Note**: there are some slight changes in the copy of the notifications (namely, adding the required version number) that are not yet in the design but were agreed to [here](https://yoast.slack.com/archives/C025T9L6B1R/p1637667934146400?thread_ts=1637334850.125600&cid=C025T9L6B1R)
**also note that the copy of the button is expected to change as detailed in the Jira issue**

### Premium outdated, valid subscription
* install
* install Premium 17.6 on a site with a valid subscription (e.g. the docker env mimicks a valid subscription)
* visit the Workouts page
* check that the notification hasn't change and the workouts cards display the right upsell links

### Premium outdated, non existing subscription
* install
* install Premium 17.6 on a site without any subscription (e.g. Local by Flywheel)
* visit the Workouts page
* check that the notification looks like [the expected design](https://www.sketch.com/s/bca4c60f-060e-495b-a157-8b05a9a402a8/a/nRGlwnd/play) and the workouts cards display different upsell links:
  * Shortlink for text in notice, and the button on the workout: https://yoa.st/workouts-activate-notice-myyoast 
  * Shortlink for the button in the notice: https://yoa.st/workouts-activate-notice-help 

### Premium outdated, expired subscription
* install
* install Premium 17.6 on a site with an expired subscription (ask devops, see [here](https://yoast.slack.com/archives/C99ENCYGY/p1637070669432600))
* visit the Workouts page
* check that the notification looks like [the expected design](https://www.sketch.com/s/bca4c60f-060e-495b-a157-8b05a9a402a8/a/9PjgeRz/play)
  * Shortlink for button(s): https://yoa.st/workout-renew-notice 
  * The workouts cards display the usual upsell links

### Premium not active
* install
* deactivate premium
* visit the Workouts page
* The premium workouts cards should display the usual upsell links
* check the JS console for errors

### Premium up-to-date and active
* install
* install premium 17.7 (latest RC) and activate it (in the plugins page, subscription isn't needed)
* visit the Workouts page
* the premium workouts should be working as usual
* check the JS console for errors
  
### Image glitch in the notification
* make sure you still have the configuration workout notification visible
* visit the SEO Dashboard or other Yoast SEO pages and make sure you don't see the glitch where the image is as big as the screen for a fraction of second.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-66][DUPP-106]


[DUPP-66]: https://yoast.atlassian.net/browse/DUPP-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ