### PR TITLE
Catch non existence of createReduxStore and provide alternative

### DIFF
--- a/packages/js/src/workouts.js
+++ b/packages/js/src/workouts.js
@@ -1,4 +1,4 @@
-import { register, dispatch, createReduxStore } from "@wordpress/data";
+import { register, dispatch, createReduxStore, registerStore } from "@wordpress/data";
 import { Fill } from "@wordpress/components";
 import domReady from "@wordpress/dom-ready";
 
@@ -12,13 +12,25 @@ import ConfigurationWorkoutCard from "./workouts/components/ConfigurationWorkout
 
 setWordPressSeoL10n();
 
-const store = createReduxStore( "yoast-seo/workouts", {
-	reducer: workoutsReducer,
-	actions,
-	selectors,
-} );
+if ( window.wp.data.createReduxStore ) {
+	const store = createReduxStore( "yoast-seo/workouts", {
+		reducer: workoutsReducer,
+		actions,
+		selectors,
+	} );
 
-register( store );
+	register( store );
+} else {
+	/*
+	* Compatibility fix for WP 5.6.
+	* Remove this and the related import when WP 5.6 is no longer supported.
+	*/
+	registerStore( "yoast-seo/workouts", {
+		reducer: workoutsReducer,
+		actions,
+		selectors,
+	} );
+}
 
 /**
  * Registers a workout-card component to render in free.

--- a/packages/js/src/workouts/components/ConfigurationWorkoutCard.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkoutCard.js
@@ -18,7 +18,7 @@ import { FINISHABLE_STEPS } from "../config";
 export default function ConfigurationWorkoutCard( {
 	badges,
 } ) {
-	const finishedSteps = useSelect( "yoast-seo/workouts" ).getFinishedSteps( "configuration" );
+	const finishedSteps = useSelect( select => select( "yoast-seo/workouts" ).getFinishedSteps( "configuration" ) );
 	return <WorkoutCard
 		name={ "configuration" }
 		title={ __( "Configuration", "wordpress-seo" ) }

--- a/packages/js/src/workouts/components/CornerstoneWorkoutCard.js
+++ b/packages/js/src/workouts/components/CornerstoneWorkoutCard.js
@@ -18,7 +18,7 @@ export default function CornerstoneWorkoutCard( {
 	workout,
 	badges,
 } ) {
-	const finishedSteps = useSelect( "yoast-seo/workouts" ).getFinishedSteps( WORKOUTS.cornerstone );
+	const finishedSteps = useSelect( select => select( "yoast-seo/workouts" ).getFinishedSteps( WORKOUTS.cornerstone ) );
 	return <WorkoutCard
 		name={ WORKOUTS.cornerstone }
 		title={ __( "The cornerstone approach", "wordpress-seo" ) }

--- a/packages/js/src/workouts/components/OrphanedWorkoutCard.js
+++ b/packages/js/src/workouts/components/OrphanedWorkoutCard.js
@@ -18,7 +18,7 @@ export default function OrphanedWorkoutCard( {
 	workout,
 	badges,
 } ) {
-	const finishedSteps = useSelect( "yoast-seo/workouts" ).getFinishedSteps( WORKOUTS.orphaned );
+	const finishedSteps = useSelect( select => select( "yoast-seo/workouts" ).getFinishedSteps( WORKOUTS.orphaned ) );
 	return <WorkoutCard
 		name={ WORKOUTS.orphaned }
 		title={ __( "Orphaned content", "wordpress-seo" ) }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Absence of correct Redux store on <5.7 caused workouts not to load.
* Incorrect function call on Redux useSelect <5.8 caused workouts not to load.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where workouts did not load on WordPress 5.6 due to errors with the Redux store.
* * Fixes an unreleased bug where workouts did not load on WordPress 5.7 due to errors with the Redux selectors.

## Relevant technical choices:

* Decided to prevent the createReduxStore call if the function is not present, and call an older function instead. That function is now deprecated though, so we should remove the code once we go to 5.6 (as well as upgrade our code in other places where we use the deprecated function).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* If needed, use the WP Downgrade plugin to switch WP versions.
* 17.7 free and premium should load workouts as intended, on WordPress 5.6.
* 17.7 free and premium should load workouts as intended, on WordPress 5.7.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-112
Fixes DUPP-113
