### PR TITLE
[IM-1616] Fix updating relations on index

### DIFF
--- a/src/integrations/watchers/indexable-ancestor-watcher.php
+++ b/src/integrations/watchers/indexable-ancestor-watcher.php
@@ -116,7 +116,8 @@ class Indexable_Ancestor_Watcher implements Integration_Interface {
 			return false;
 		}
 
-		if ( $indexable->permalink === $indexable_before->permalink ) {
+		// If the permalink was null it means it was reset instead of changed.
+		if ( $indexable->permalink === $indexable_before->permalink || \is_null( $indexable_before->permalink ) ) {
 			return false;
 		}
 

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -120,7 +120,6 @@ class Indexable_Post_Watcher implements Integration_Interface {
 	public function register_hooks() {
 		\add_action( 'wp_insert_post', [ $this, 'build_indexable' ], \PHP_INT_MAX );
 		\add_action( 'delete_post', [ $this, 'delete_indexable' ] );
-		\add_action( 'wpseo_save_indexable', [ $this, 'updated_indexable' ], \PHP_INT_MAX, 2 );
 
 		\add_action( 'edit_attachment', [ $this, 'build_indexable' ], \PHP_INT_MAX );
 		\add_action( 'add_attachment', [ $this, 'build_indexable' ], \PHP_INT_MAX );
@@ -154,21 +153,24 @@ class Indexable_Post_Watcher implements Integration_Interface {
 	/**
 	 * Updates the relations when the post indexable is built.
 	 *
-	 * @param Indexable $updated_indexable The updated indexable.
-	 * @param Indexable $old_indexable     The old indexable.
+	 * @param Indexable $indexable The indexable.
+	 * @param WP_Post   $post      The post.
 	 */
-	public function updated_indexable( $updated_indexable, $old_indexable ) {
+	public function updated_indexable( $indexable, $post ) {
 		// Only interested in post indexables.
-		if ( $updated_indexable->object_type !== 'post' ) {
+		if ( $indexable->object_type !== 'post' ) {
 			return;
 		}
 
-		$post = $this->post->get_post( $updated_indexable->object_id );
+		if ( is_a( $post, Indexable::class ) ) {
+			_deprecated_argument( __FUNCTION__, '17.7', 'The $old_indexable argument has been deprecated.' );
+			$post = $this->post->get_post( $indexable->object_id );
+		}
 
 		$this->update_relations( $post );
-		$this->update_has_public_posts( $updated_indexable );
+		$this->update_has_public_posts( $indexable );
 
-		$updated_indexable->save();
+		$indexable->save();
 	}
 
 	/**
@@ -195,6 +197,7 @@ class Indexable_Post_Watcher implements Integration_Interface {
 				$this->link_builder->build( $indexable, $post->post_content );
 				// Save indexable to persist the updated link count.
 				$indexable->save();
+				$this->updated_indexable( $indexable, $post );
 			}
 		} catch ( Exception $exception ) {
 			$this->logger->log( LogLevel::ERROR, $exception->getMessage() );

--- a/tests/unit/integrations/watchers/indexable-post-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-post-watcher-test.php
@@ -339,11 +339,11 @@ class Indexable_Post_Watcher_Test extends TestCase {
 			->expects( 'update_relations' )
 			->never();
 
-		$old_indexable                  = Mockery::mock( Indexable_Mock::class );
-		$updated_indexable              = Mockery::mock( Indexable_Mock::class );
-		$updated_indexable->object_type = 'term';
+		$post                   = Mockery::mock( 'WP_Post' );
+		$indexable              = Mockery::mock( Indexable_Mock::class );
+		$indexable->object_type = 'term';
 
-		$this->instance->updated_indexable( $updated_indexable, $old_indexable );
+		$this->instance->updated_indexable( $indexable, $post );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Prevents updating related indexables when an indexable is saved, instead it only updates them when the source object has changed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where memory issues could occur when indexing a site with large amounts of terms assigned to many posts.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Indexing your site after resetting permalinks should not lead to any OOM issues.
* Updating a post should still lead to the timestamps of it's terms being updated.
* Changing the slug of a page should still lead to the permalinks of child pages being updated.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Updating timestamps of related indexables.
* Updating the breadcrumb hierarchy of related indexables.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes IM-1616
