### PR TITLE
Configuration workout - Improve user flow and small design tweaks

### DIFF
--- a/css/src/workouts.css
+++ b/css/src/workouts.css
@@ -76,21 +76,26 @@
 	padding-bottom: 16px;
 }
 
-.workflow li.step > .finish-step-button-section {
+.workflow .finish-button-section {
 	display: inline-grid;
 	grid-template-columns: 1fr 1fr 1fr;
 	width: 100%;
 	align-items: center;
 }
 
-.workflow li.step > .finish-step-button-section .yoast-button {
+.workflow .finish-button-section .yoast-button {
 	width: fit-content;
 	justify-self: center;
 	grid-column-start: 2;
 	grid-column-end: 2;
 }
 
-.workflow li.step > .finish-step-button-section .finish-step-saved {
+.workflow .finish-workout-button-section .yoast-button {
+	width: fit-content;
+	margin: 0 auto;
+}
+
+.workflow .finish-button-section .finish-button-saved {
 	grid-column-start: 3;
 	grid-column-end: 3;
 	position: relative;
@@ -98,7 +103,7 @@
 	margin-left: 10px;
 }
 
-.workflow li.step > .finish-step-button-section .finish-step-saved::before {
+.workflow .finish-button-section .finish-button-saved::before {
 	position: absolute;
 	content: "";
 	background: var(--yoast-svg-icon-check);

--- a/css/src/workouts.css
+++ b/css/src/workouts.css
@@ -76,9 +76,37 @@
 	padding-bottom: 16px;
 }
 
-.workflow li.step > .yoast-button {
-	margin: 0 auto;
-	display: flex;
+.workflow li.step > .finish-step-button-section {
+	display: inline-grid;
+	grid-template-columns: 1fr 1fr 1fr;
+	width: 100%;
+	align-items: center;
+}
+
+.workflow li.step > .finish-step-button-section .yoast-button {
+	width: fit-content;
+	justify-self: center;
+	grid-column-start: 2;
+	grid-column-end: 2;
+}
+
+.workflow li.step > .finish-step-button-section .finish-step-saved {
+	grid-column-start: 3;
+	grid-column-end: 3;
+	position: relative;
+	color: #6EA029;
+	margin-left: 10px;
+}
+
+.workflow li.step > .finish-step-button-section .finish-step-saved::before {
+	position: absolute;
+	content: "";
+	background: var(--yoast-svg-icon-check);
+	background-size: 18px 13px;
+	width: 18px;
+	height: 13px;
+	left: -18px;
+	top: 2px;
 }
 
 .workflow li.step > .yoast-button.orphaned-summary {
@@ -412,13 +440,12 @@ table.yoast_help th.divider {
 	color: rgb(60, 67, 74);
 }
 
-/* duplicate */
 .yoast-list--usp {
 	padding-left: 24px;
 }
 
 .yoast-list--usp li {
-	position:relative;
+	position: relative;
 	margin-bottom: 16px;
 }
 

--- a/css/src/workouts.css
+++ b/css/src/workouts.css
@@ -32,7 +32,8 @@
 	padding: 24px;
 	border-radius: 8px;
 	box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-	border: 0;
+	border-width: 1px;
+	border-color: rgba(0, 0, 0, .2);
 }
 
 #wpseo-workouts-container-free div.card>h2 {

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -6,8 +6,9 @@ import { __, sprintf } from "@wordpress/i18n";
 import { cloneDeep } from "lodash";
 import PropTypes from "prop-types";
 
-import { Alert, RadioButtonGroup, SingleSelect, TextInput } from "@yoast/components";
-import { ReactComponent as WorkoutImage } from "../../../images/motivated_bubble_woman_1_optim.svg";
+import { Alert, NewButton as Button, RadioButtonGroup, SingleSelect, TextInput } from "@yoast/components";
+import { ReactComponent as WorkoutDoneImage } from "../../../../../images/mirrored_fit_bubble_woman_1_optim.svg";
+import { ReactComponent as WorkoutStartImage } from "../../../images/motivated_bubble_woman_1_optim.svg";
 import { addLinkToString } from "../../helpers/stringHelpers.js";
 import { Step, Steps, FinishButtonSection } from "./Steps";
 import { STEPS, WORKOUTS } from "../config";
@@ -184,7 +185,7 @@ async function updateTracking( state ) {
  * @param {string}    seoDataOptimizationNeeded The flag signaling if SEO optimization is needed.
  * @returns {WPElement} The ConfigurationWorkout component.
  */
-export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinished } ) {
+export function ConfigurationWorkout( { toggleStep, toggleWorkout, clearActiveWorkout, isStepFinished } ) {
 	const [ state, dispatch ] = useReducer( configurationWorkoutReducer, { ...window.wpseoWorkoutsData.configuration, errorFields: [] } );
 	const [ indexingState, setIndexingState ] = useState( () => window.yoastIndexingData.amount === "0" ? "completed" : "idle" );
 	const [ siteRepresentationEmpty, setSiteRepresentationEmpty ] = useState( false );
@@ -467,7 +468,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						),
 						"https://yoa.st/config-workout-index-data"
 					) }
-					ImageComponent={ WorkoutImage }
+					ImageComponent={ WorkoutStartImage }
 					isFinished={ isStep1Finished }
 				>
 					<div className="indexation-container">
@@ -730,14 +731,26 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 				</FinishButtonSection>
 			</Steps>
 			{ isWorkoutFinished && <div>
-				<h3>{ __( "Congratulations", "wordpress-seo" ) }</h3>
-				<p>
+				<hr />
+				<h3 style={ { marginBottom: 0 } }>{ __( "Congratulations!", "wordpress-seo" ) }</h3>
+				<div style={ { display: "flex" } }>
+					<div>
+						<p>
+							{
+								// translators: %1$s is replaced by "Yoast SEO"
+								sprintf( __( "Amazing! You’ve successfully finished the Configuration workout! %1$s now outputs the essential structured data for your site.", "wordpress-seo" ), "Yoast SEO" )
+							}
+						</p>
+						<p>{ __( "Make sure to also check out our other SEO workouts to really get your site into shape!", "wordpress-seo" ) }</p>
+					</div>
+					<WorkoutDoneImage style={ { height: "119px", width: "100px", flexShrink: 0 } } />
+				</div>
+				<Button onClick={ clearActiveWorkout } variant="primary">
 					{
-						// translators: %1$s is replaced by "Yoast SEO"
-						sprintf( __( "Amazing! You’ve successfully finished the Configuration workout! %1$s now outputs the essential structured data for your site.", "wordpress-seo" ), "Yoast SEO" )
+						// translators: %1$s translates to a rightward pointing arrow ( → )
+						sprintf( __( "View other SEO workouts%1$s", "wordpress-seo" ), " →" )
 					}
-				</p>
-				<p>{ __( "Make sure to also check out our other SEO workouts to really get your site into shape!", "wordpress-seo" ) }</p>
+				</Button>
 			</div> }
 		</div>
 		/* eslint-enable max-len */
@@ -748,6 +761,7 @@ ConfigurationWorkout.propTypes = {
 	toggleStep: PropTypes.func.isRequired,
 	toggleWorkout: PropTypes.func.isRequired,
 	isStepFinished: PropTypes.func.isRequired,
+	clearActiveWorkout: PropTypes.func.isRequired,
 };
 /* eslint-enable complexity */
 
@@ -775,12 +789,14 @@ export default compose(
 					toggleStep,
 					toggleWorkout,
 					moveIndexables,
+					clearActiveWorkout,
 				} = dispatch( "yoast-seo/workouts" );
 
 				return {
 					toggleStep,
 					toggleWorkout,
 					moveIndexables,
+					clearActiveWorkout,
 				};
 			}
 		),

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -121,7 +121,11 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	const steps = STEPS.configuration;
 
 	const isTrackingOptionSelected = state.tracking === 0 || state.tracking === 1;
-	const step4IsFinished = isStepFinished( "configuration", steps.enableTracking );
+	const isStep1Finished = isStepFinished( "configuration", steps.optimizeSeoData );
+	const isStep2Finished = isStepFinished( "configuration", steps.siteRepresentation );
+	const isStep3Finished = isStepFinished( "configuration", steps.socialProfiles );
+	const isStep4Finished = isStepFinished( "configuration", steps.enableTracking );
+	const isStep5Finished = isStepFinished( "configuration", steps.newsletterSignup );
 
 	/**
 	 * Updates the site representation in the database.
@@ -205,7 +209,6 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 		return await response.json;
 	};
 
-	const isStep1Finished = isStepFinished( "configuration", steps.optimizeSeoData );
 	const onFinishOptimizeSeoData = useCallback(
 		() => {
 			if ( ! isStep1Finished ) {
@@ -227,7 +230,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	 * @returns {void}
 	 */
 	function updateOnFinishSiteRepresentation() {
-		if ( isStepFinished( "configuration", steps.siteRepresentation ) ) {
+		if ( isStep2Finished ) {
 			toggleStepSiteRepresentation();
 		} else {
 			if ( ! siteRepresentationEmpty &&
@@ -259,7 +262,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	 * @returns {void}
 	 */
 	function updateOnFinishSocialProfiles() {
-		if ( isStepFinished( "configuration", steps.socialProfiles ) ) {
+		if ( isStep3Finished ) {
 			toggleStepSocialProfiles();
 		} else {
 			updateSocialProfiles()
@@ -291,7 +294,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	 * @returns {void}
 	 */
 	function updateOnFinishEnableTracking() {
-		if ( isStepFinished( "configuration", steps.enableTracking ) ) {
+		if ( isStep4Finished ) {
 			setSavedSteps( prevState => prevState.filter( step => step !== 4 ) );
 			toggleStepEnableTracking();
 		} else {
@@ -421,12 +424,12 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 				<Step
 					title={ __( "Site representation", "wordpress-seo" ) }
 					subtitle={ __( "Tell Google what kind of site you have and increase the chance it gets features in a Google Knowledge Panel. Select ‘Organization’ if you are working on a site for a business or an organization. Select ‘Person’ if you have, say, a personal blog.", "wordpress-seo" ) }
-					isFinished={ isStepFinished( "configuration", steps.siteRepresentation ) }
+					isFinished={ isStep2Finished }
 				>
 					{  window.wpseoWorkoutsData.configuration.knowledgeGraphMessage &&  <Alert type="warning">
 						{  window.wpseoWorkoutsData.configuration.knowledgeGraphMessage }
 					</Alert> }
-					{ ! window.wpseoWorkoutsData.configuration.shouldForceCompany && ! isStepFinished( "configuration", steps.siteRepresentation ) &&
+					{ ! window.wpseoWorkoutsData.configuration.shouldForceCompany && ! isStep2Finished &&
 					<SingleSelect
 						id="organization-person-select"
 						htmlFor="organization-person-select"
@@ -436,7 +439,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						onChange={ onOrganizationOrPersonChange }
 						options={  window.wpseoWorkoutsData.configuration.companyOrPersonOptions }
 					/> }
-					{ (  window.wpseoWorkoutsData.configuration.shouldForceCompany || isStepFinished( "configuration", steps.siteRepresentation ) ) &&
+					{ (  window.wpseoWorkoutsData.configuration.shouldForceCompany || isStep2Finished ) &&
 					<TextInput
 						id="organization-forced-readonly-text"
 						name="organization"
@@ -456,7 +459,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 							dispatch={ dispatch }
 							imageUrl={ state.companyLogo }
 							organizationName={ state.companyName }
-							isDisabled={ isStepFinished( "configuration", steps.siteRepresentation ) }
+							isDisabled={ isStep2Finished }
 						/>
 					</Fragment> }
 					{ state.companyOrPerson === "person" && <Fragment>
@@ -471,7 +474,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 							dispatch={ dispatch }
 							imageUrl={ state.personLogo }
 							personId={ state.personId }
-							isDisabled={ isStepFinished( "configuration", steps.siteRepresentation ) }
+							isDisabled={ isStep2Finished }
 						/>
 					</Fragment> }
 					<TextInput
@@ -481,7 +484,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						description={ sprintf( __( "Add a catchy tagline that describes your site in the best light. Use the keywords you want people to find your site with. Example: %1$s’s tagline is ‘SEO for everyone.’", "wordpress-seo" ), "Yoast" ) }
 						value={ state.siteTagline }
 						onChange={ onSiteTaglineChange }
-						readOnly={ isStepFinished( "configuration", steps.siteRepresentation ) }
+						readOnly={ isStep2Finished }
 					/>
 					{ siteRepresentationEmpty && <Alert type="warning">
 						{ __(
@@ -493,23 +496,23 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					<FinishStepSection
 						stepNumber={ 2 }
 						isSaved={ savedSteps.includes( 2 ) }
-						hasDownArrow={ true }
-						finishText={ __( "Save and continue", "wordpress-seo" ) }
+						hasDownArrow={ ! isStep2Finished }
+						finishText={ isStep2Finished ? __( "Revise the step", "wordpress-seo" ) : __( "Save and continue", "wordpress-seo" ) }
 						onFinishClick={ updateOnFinishSiteRepresentation }
-						isFinished={ isStepFinished( "configuration", steps.siteRepresentation ) }
+						isFinished={ isStep2Finished }
 					/>
 				</Step>
 				<Step
 					title={ __( "Social profiles", "wordpress-seo" ) }
 					subtitle={ state.companyOrPerson === "company" ?  __( "Do you have profiles for your site on social media? Then, add all of their URLs here, so your social profiles may also appear in a Google Knowledge Panel.", "wordpress-seo" ) : "" }
-					isFinished={ isStepFinished( "configuration", steps.socialProfiles ) }
+					isFinished={ isStep3Finished }
 				>
 					{ state.companyOrPerson === "company" && <SocialInputSection
 						socialProfiles={ state.socialProfiles }
 						dispatch={ dispatch }
 						errorFields={ state.errorFields }
 						setErrorFields={ setErrorFields }
-						isDisabled={ isStepFinished( "configuration", steps.socialProfiles ) }
+						isDisabled={ isStep3Finished }
 					/> }
 					{ state.companyOrPerson === "person" && <div>
 						<p>
@@ -562,15 +565,15 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					<FinishStepSection
 						stepNumber={ 3 }
 						isSaved={ savedSteps.includes( 3 ) }
-						hasDownArrow={ true }
-						finishText={ "Save and continue" }
+						hasDownArrow={ ! isStep3Finished }
+						finishText={ isStep3Finished ? __( "Revise the step", "wordpress-seo" ) : __( "Save and continue", "wordpress-seo" ) }
 						onFinishClick={ updateOnFinishSocialProfiles }
-						isFinished={ isStepFinished( "configuration", steps.socialProfiles ) }
+						isFinished={ isStep3Finished }
 					/>
 				</Step>
 				<Step
 					title={ __( "Help us improve Yoast SEO", "wordpress-seo" ) }
-					isFinished={ isStepFinished( "configuration", steps.enableTracking ) }
+					isFinished={ isStep4Finished }
 				>
 					<p>
 						{
@@ -621,24 +624,23 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					<FinishStepSection
 						stepNumber={ 4 }
 						isSaved={ savedSteps.includes( 4 ) }
-						hasDownArrow={ ! step4IsFinished }
-						finishText={ step4IsFinished ? "Revise the step" : "Save and continue" }
+						hasDownArrow={ ! isStep4Finished }
+						finishText={ isStep4Finished ? __( "Revise the step", "wordpress-seo" ) : __( "Save and continue", "wordpress-seo" ) }
 						onFinishClick={ updateOnFinishEnableTracking }
-						additionalButtonProps={ { disabled: ! isTrackingOptionSelected } }
-						isFinished={ step4IsFinished }
+						isFinished={ isStep4Finished }
 					/>
 				</Step>
 				<Step
 					title={ __( "Sign up for the Yoast newsletter!", "wordpress-seo" ) }
-					isFinished={ isStepFinished( "configuration", steps.newsletterSignup ) }
+					isFinished={ isStep5Finished }
 				>
 					<NewsletterSignup />
 					<FinishStepSection
 						stepNumber={ 5 }
-						finishText={ "Finish this workout" }
+						finishText={ isStep5Finished ? __( "Reset this workout", "wordpress-seo" ) : __( "Finish this workout", "wordpress-seo" ) }
 						onFinishClick={ toggleConfigurationWorkout }
-						isFinished={ isStepFinished( "configuration", steps.newsletterSignup ) }
 						additionalButtonProps={ { disabled: indexingState !== "completed" || ! isTrackingOptionSelected } }
+						isFinished={ isStep5Finished }
 					>
 						{ indexingState !== "completed" && <Alert type="warning">
 							{ indexingState === "idle" && __( "Before you finish this workout, please start the SEO data optimization in step 1 and wait until it is completed...", "wordpress-seo" ) }

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -192,7 +192,9 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	const isStep1Finished = isStepFinished( "configuration", steps.optimizeSeoData );
 	const onFinishOptimizeSeoData = useCallback(
 		() => {
-			scrollToStep( isStep1Finished ? 1 : 2 );
+			if ( ! isStep1Finished ) {
+				scrollToStep( 2 );
+			}
 			toggleStep( "configuration", steps.optimizeSeoData );
 		},
 		[ toggleStep, steps.optimizeSeoData, isStep1Finished ]
@@ -211,7 +213,6 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	function updateOnFinishSiteRepresentation() {
 		if ( isStepFinished( "configuration", steps.siteRepresentation ) ) {
 			toggleStepSiteRepresentation();
-			scrollToStep( 2 );
 		} else {
 			if ( ! siteRepresentationEmpty &&
 				state.companyOrPerson === "company" &&
@@ -274,7 +275,6 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	function updateOnFinishEnableTracking() {
 		if ( isStepFinished( "configuration", steps.enableTracking ) ) {
 			toggleStepEnableTracking();
-			scrollToStep( 4 );
 		} else {
 			updateTracking().then( toggleStepEnableTracking );
 			scrollToStep( 5 );
@@ -364,7 +364,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						"https://yoa.st/config-workout-index-data"
 					) }
 					ImageComponent={ WorkoutImage }
-					isFinished={ indexingState === "completed" }
+					isFinished={ isStep1Finished }
 				>
 					<div className="indexation-container">
 						<WorkoutIndexation
@@ -376,7 +376,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						hasDownArrow={ true }
 						finishText={ __( "Continue", "wordpress-seo" ) }
 						onFinishClick={	onFinishOptimizeSeoData }
-						isFinished={ indexingState === "completed" }
+						isFinished={ isStep1Finished }
 					/>
 				</Step>
 				<p className="extra-list-content">

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -396,12 +396,19 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	return (
 		<div className="card">
 			<h2>{ __( "Configuration", "wordpress-seo" ) }</h2>
-			<h3>{ __( "Configure Yoast SEO with optimal SEO settings for your site", "wordpress-seo" ) }</h3>
+			<h3>{
+				// translators: %1$s is replaced by "Yoast SEO"
+				sprintf( __( "Configure %1$s with optimal SEO settings for your site", "wordpress-seo" ), "Yoast SEO" )
+			}</h3>
 			<p>
 				{
-					__(
-						"Do the five steps in this workout to configure the essential Yoast SEO settings!",
-						"wordpress-seo"
+					sprintf(
+						// translators: %1$s is replaced by "Yoast SEO"
+						__(
+							"Do the five steps in this workout to configure the essential %1$s settings!",
+							"wordpress-seo"
+						),
+						"Yoast SEO"
 					)
 				}
 			</p>
@@ -411,11 +418,12 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						addLinkToString(
 							sprintf(
 								__(
-									// translators: %1$s and %2$s are replaced by opening and closing anchor tags.
-									"Need more guidance? We've covered every step in more detail in the %1$sYoast SEO configuration workout guide.%2$s",
+									// translators: %1$s and %3$s are replaced by opening and closing anchor tags. %2$s is replaced by "Yoast SEO"
+									"Need more guidance? We've covered every step in more detail in the %1$s%2$s configuration workout guide.%3$s",
 									"wordpress-seo"
 								),
 								"<a>",
+								"Yoast SEO",
 								"</a>"
 							),
 							"https://yoa.st/config-workout-guide"
@@ -721,6 +729,16 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					</Alert> }
 				</FinishButtonSection>
 			</Steps>
+			{ isWorkoutFinished && <div>
+				<h3>{ __( "Congratulations", "wordpress-seo" ) }</h3>
+				<p>
+					{
+						// translators: %1$s is replaced by "Yoast SEO"
+						sprintf( __( "Amazing! You’ve successfully finished the Configuration workout! %1$s now outputs the essential structured data for your site.", "wordpress-seo" ), "Yoast SEO" )
+					}
+				</p>
+				<p>{ __( "Make sure to also check out our other SEO workouts to really get your site into shape!", "wordpress-seo" ) }</p>
+			</div> }
 		</div>
 		/* eslint-enable max-len */
 	);

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -110,6 +110,19 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 		return;
 	};
 
+	/**
+	 * Sets a step to not saved.
+	 *
+	 * @param {number} stepNumber The number of the step to unsave.
+	 *
+	 * @returns {void}
+	 */
+	const setStepIsNotSaved = ( stepNumber ) => {
+		setSavedSteps( prevState => {
+			return prevState.filter( step => step !== stepNumber );
+		} );
+	};
+
 	const setTracking = useCallback( ( value ) => {
 		dispatch( { type: "SET_TRACKING", payload: parseInt( value, 10 ) } );
 	} );
@@ -231,6 +244,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	 */
 	function updateOnFinishSiteRepresentation() {
 		if ( isStep2Finished ) {
+			setStepIsNotSaved( 2 );
 			toggleStepSiteRepresentation();
 		} else {
 			if ( ! siteRepresentationEmpty &&
@@ -263,6 +277,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	 */
 	function updateOnFinishSocialProfiles() {
 		if ( isStep3Finished ) {
+			setStepIsNotSaved( 3 );
 			toggleStepSocialProfiles();
 		} else {
 			updateSocialProfiles()
@@ -295,7 +310,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	 */
 	function updateOnFinishEnableTracking() {
 		if ( isStep4Finished ) {
-			setSavedSteps( prevState => prevState.filter( step => step !== 4 ) );
+			setStepIsNotSaved( 4 );
 			toggleStepEnableTracking();
 		} else {
 			updateTracking()
@@ -497,7 +512,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						stepNumber={ 2 }
 						isSaved={ savedSteps.includes( 2 ) }
 						hasDownArrow={ ! isStep2Finished }
-						finishText={ isStep2Finished ? __( "Revise the step", "wordpress-seo" ) : __( "Save and continue", "wordpress-seo" ) }
+						finishText={ isStep2Finished ? __( "Revise this step", "wordpress-seo" ) : __( "Save and continue", "wordpress-seo" ) }
 						onFinishClick={ updateOnFinishSiteRepresentation }
 						isFinished={ isStep2Finished }
 					/>
@@ -566,7 +581,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						stepNumber={ 3 }
 						isSaved={ savedSteps.includes( 3 ) }
 						hasDownArrow={ ! isStep3Finished }
-						finishText={ isStep3Finished ? __( "Revise the step", "wordpress-seo" ) : __( "Save and continue", "wordpress-seo" ) }
+						finishText={ isStep3Finished ? __( "Revise this step", "wordpress-seo" ) : __( "Save and continue", "wordpress-seo" ) }
 						onFinishClick={ updateOnFinishSocialProfiles }
 						isFinished={ isStep3Finished }
 					/>
@@ -625,7 +640,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						stepNumber={ 4 }
 						isSaved={ savedSteps.includes( 4 ) }
 						hasDownArrow={ ! isStep4Finished }
-						finishText={ isStep4Finished ? __( "Revise the step", "wordpress-seo" ) : __( "Save and continue", "wordpress-seo" ) }
+						finishText={ isStep4Finished ? __( "Revise this step", "wordpress-seo" ) : __( "Save and continue", "wordpress-seo" ) }
 						onFinishClick={ updateOnFinishEnableTracking }
 						isFinished={ isStep4Finished }
 					/>

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -9,7 +9,7 @@ import PropTypes from "prop-types";
 import { Alert, RadioButtonGroup, SingleSelect, TextInput } from "@yoast/components";
 import { ReactComponent as WorkoutImage } from "../../../images/motivated_bubble_woman_1_optim.svg";
 import { addLinkToString } from "../../helpers/stringHelpers.js";
-import { Step, Steps, FinishStepSection } from "./Steps";
+import { Step, Steps, FinishButtonSection } from "./Steps";
 import { STEPS, WORKOUTS } from "../config";
 import { OrganizationSection } from "./OrganizationSection";
 import { PersonSection } from "./PersonSection";
@@ -410,7 +410,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 							indexingStateCallback={ setIndexingState }
 						/>
 					</div>
-					<FinishStepSection
+					<FinishButtonSection
 						stepNumber={ 1 }
 						hasDownArrow={ true }
 						finishText={ __( "Continue", "wordpress-seo" ) }
@@ -508,7 +508,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 							"wordpress-seo"
 						) }
 					</Alert> }
-					<FinishStepSection
+					<FinishButtonSection
 						stepNumber={ 2 }
 						isSaved={ savedSteps.includes( 2 ) }
 						hasDownArrow={ ! isStep2Finished }
@@ -577,7 +577,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						</p>
 					</div>
 					}
-					<FinishStepSection
+					<FinishButtonSection
 						stepNumber={ 3 }
 						isSaved={ savedSteps.includes( 3 ) }
 						hasDownArrow={ ! isStep3Finished }
@@ -636,7 +636,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 							"wordpress-seo"
 						) }
 					</Alert> }
-					<FinishStepSection
+					<FinishButtonSection
 						stepNumber={ 4 }
 						isSaved={ savedSteps.includes( 4 ) }
 						hasDownArrow={ ! isStep4Finished }
@@ -650,19 +650,18 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					isFinished={ isStep5Finished }
 				>
 					<NewsletterSignup />
-					<FinishStepSection
-						stepNumber={ 5 }
-						finishText={ isStep5Finished ? __( "Reset this workout", "wordpress-seo" ) : __( "Finish this workout", "wordpress-seo" ) }
-						onFinishClick={ toggleConfigurationWorkout }
-						additionalButtonProps={ { disabled: indexingState !== "completed" || ! isTrackingOptionSelected } }
-						isFinished={ isStep5Finished }
-					>
-						{ indexingState !== "completed" && <Alert type="warning">
-							{ indexingState === "idle" && __( "Before you finish this workout, please start the SEO data optimization in step 1 and wait until it is completed...", "wordpress-seo" ) }
-							{ indexingState === "in_progress" && __( "Before you finish this workout, please wait on this page until the SEO data optimization in step 1 is completed...", "wordpress-seo" ) }
-						</Alert> }
-					</FinishStepSection>
 				</Step>
+				<FinishButtonSection
+					finishText={ isStep5Finished ? __( "Do workout again", "wordpress-seo" ) : __( "Finish this workout", "wordpress-seo" ) }
+					onFinishClick={ toggleConfigurationWorkout }
+					isFinished={ isStep5Finished }
+					additionalButtonProps={ { disabled: indexingState !== "completed" || ! isTrackingOptionSelected } }
+				>
+					{ indexingState !== "completed" && <Alert type="warning">
+						{ indexingState === "idle" && __( "Before you finish this workout, please start the SEO data optimization in step 1 and wait until it is completed...", "wordpress-seo" ) }
+						{ indexingState === "in_progress" && __( "Before you finish this workout, please wait on this page until the SEO data optimization in step 1 is completed...", "wordpress-seo" ) }
+					</Alert> }
+				</FinishButtonSection>
 			</Steps>
 		</div>
 		/* eslint-enable max-len */

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -462,7 +462,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					</Alert> }
 					<FinishStepSection
 						hasDownArrow={ true }
-						finishText={ __( "Continue and save", "wordpress-seo" ) }
+						finishText={ __( "Save and continue", "wordpress-seo" ) }
 						onFinishClick={ updateOnFinishSiteRepresentation }
 						isFinished={ isStepFinished( "configuration", steps.siteRepresentation ) }
 					/>

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -121,6 +121,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	const steps = STEPS.configuration;
 
 	const isTrackingOptionSelected = state.tracking === 0 || state.tracking === 1;
+	const step4IsFinished = isStepFinished( "configuration", steps.enableTracking );
 
 	/**
 	 * Updates the site representation in the database.
@@ -291,6 +292,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	 */
 	function updateOnFinishEnableTracking() {
 		if ( isStepFinished( "configuration", steps.enableTracking ) ) {
+			setSavedSteps( prevState => prevState.filter( step => step !== 4 ) );
 			toggleStepEnableTracking();
 		} else {
 			updateTracking()
@@ -619,11 +621,11 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					<FinishStepSection
 						stepNumber={ 4 }
 						isSaved={ savedSteps.includes( 4 ) }
-						hasDownArrow={ true }
-						finishText={ "Save and continue" }
+						hasDownArrow={ ! step4IsFinished }
+						finishText={ step4IsFinished ? "Revise the step" : "Save and continue" }
 						onFinishClick={ updateOnFinishEnableTracking }
-						isFinished={ isStepFinished( "configuration", steps.enableTracking ) }
 						additionalButtonProps={ { disabled: ! isTrackingOptionSelected } }
+						isFinished={ step4IsFinished }
 					/>
 				</Step>
 				<Step

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -343,6 +343,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, clearActiveWo
 	const toggleConfigurationWorkout = useCallback(
 		() => {
 			if ( isWorkoutFinished ) {
+				setSavedSteps( [] );
 				toggleWorkout( "configuration" );
 				return;
 			}

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -94,6 +94,21 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	const [ state, dispatch ] = useReducer( configurationWorkoutReducer, { ...window.wpseoWorkoutsData.configuration, errorFields: [] } );
 	const [ indexingState, setIndexingState ] = useState( () => window.yoastIndexingData.amount === "0" ? "completed" : "idle" );
 	const [ siteRepresentationEmpty, setSiteRepresentationEmpty ] = useState( false );
+	const [ savedSteps, setSavedSteps ] = useState( [] );
+
+	/**
+	 * Sets the step to isSaved.
+	 *
+	 * @param {number} stepNumber The number of the step to save.
+	 *
+	 * @returns {void}
+	 */
+	const setStepIsSaved = ( stepNumber ) => {
+		setSavedSteps( ( prevState ) => {
+			return [ stepNumber, ...prevState ];
+		} );
+		return;
+	};
 
 	const setTracking = useCallback( ( value ) => {
 		dispatch( { type: "SET_TRACKING", payload: parseInt( value, 10 ) } );
@@ -224,7 +239,9 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 				setSiteRepresentationEmpty( true );
 			} else {
 				setSiteRepresentationEmpty( false );
-				updateSiteRepresentation().then( toggleStepSiteRepresentation );
+				updateSiteRepresentation()
+					.then( () => setStepIsSaved( 2 ) )
+					.then( toggleStepSiteRepresentation );
 				scrollToStep( 3 );
 			}
 		}
@@ -243,9 +260,9 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	function updateOnFinishSocialProfiles() {
 		if ( isStepFinished( "configuration", steps.socialProfiles ) ) {
 			toggleStepSocialProfiles();
-			scrollToStep( 3 );
 		} else {
 			updateSocialProfiles()
+				.then( () => setStepIsSaved( 3 ) )
 				.then( () => {
 					setErrorFields( [] );
 					toggleStepSocialProfiles();
@@ -276,7 +293,9 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 		if ( isStepFinished( "configuration", steps.enableTracking ) ) {
 			toggleStepEnableTracking();
 		} else {
-			updateTracking().then( toggleStepEnableTracking );
+			updateTracking()
+				.then( () => setStepIsSaved( 4 ) )
+				.then( toggleStepEnableTracking );
 			scrollToStep( 5 );
 		}
 	}
@@ -471,6 +490,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					</Alert> }
 					<FinishStepSection
 						stepNumber={ 2 }
+						isSaved={ savedSteps.includes( 2 ) }
 						hasDownArrow={ true }
 						finishText={ __( "Save and continue", "wordpress-seo" ) }
 						onFinishClick={ updateOnFinishSiteRepresentation }
@@ -539,6 +559,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					}
 					<FinishStepSection
 						stepNumber={ 3 }
+						isSaved={ savedSteps.includes( 3 ) }
 						hasDownArrow={ true }
 						finishText={ "Save and continue" }
 						onFinishClick={ updateOnFinishSocialProfiles }
@@ -597,6 +618,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					</Alert> }
 					<FinishStepSection
 						stepNumber={ 4 }
+						isSaved={ savedSteps.includes( 4 ) }
 						hasDownArrow={ true }
 						finishText={ "Save and continue" }
 						onFinishClick={ updateOnFinishEnableTracking }

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -16,6 +16,7 @@ import { PersonSection } from "./PersonSection";
 import { NewsletterSignup } from "./NewsletterSignup";
 import { WorkoutIndexation } from "./WorkoutIndexation";
 import SocialInputSection from "./SocialInputSection";
+import { scrollToStep } from "../helpers";
 
 window.wpseoScriptData = window.wpseoScriptData || {};
 window.wpseoScriptData.searchAppearance = {
@@ -188,10 +189,15 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 		return await response.json;
 	};
 
+	const isStep1Finished = isStepFinished( "configuration", steps.optimizeSeoData );
 	const onFinishOptimizeSeoData = useCallback(
-		toggleStep.bind( null, "configuration", steps.optimizeSeoData ),
-		[ toggleStep, steps.optimizeSeoData ]
+		() => {
+			scrollToStep( isStep1Finished ? 1 : 2 );
+			toggleStep( "configuration", steps.optimizeSeoData );
+		},
+		[ toggleStep, steps.optimizeSeoData, isStep1Finished ]
 	);
+
 	const toggleStepSiteRepresentation = useCallback(
 		toggleStep.bind( null, "configuration", steps.siteRepresentation ),
 		[ toggleStep, steps.siteRepresentation ]
@@ -205,6 +211,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	function updateOnFinishSiteRepresentation() {
 		if ( isStepFinished( "configuration", steps.siteRepresentation ) ) {
 			toggleStepSiteRepresentation();
+			scrollToStep( 2 );
 		} else {
 			if ( ! siteRepresentationEmpty &&
 				state.companyOrPerson === "company" &&
@@ -217,6 +224,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 			} else {
 				setSiteRepresentationEmpty( false );
 				updateSiteRepresentation().then( toggleStepSiteRepresentation );
+				scrollToStep( 3 );
 			}
 		}
 	}
@@ -234,11 +242,13 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	function updateOnFinishSocialProfiles() {
 		if ( isStepFinished( "configuration", steps.socialProfiles ) ) {
 			toggleStepSocialProfiles();
+			scrollToStep( 3 );
 		} else {
 			updateSocialProfiles()
 				.then( () => {
 					setErrorFields( [] );
 					toggleStepSocialProfiles();
+					scrollToStep( 4 );
 				} )
 				.catch(
 					( e ) => {
@@ -264,12 +274,10 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 	function updateOnFinishEnableTracking() {
 		if ( isStepFinished( "configuration", steps.enableTracking ) ) {
 			toggleStepEnableTracking();
+			scrollToStep( 4 );
 		} else {
-			updateTracking()
-				.then( toggleStepEnableTracking )
-				.catch( ( e ) => {
-					console.error( e );
-				} );
+			updateTracking().then( toggleStepEnableTracking );
+			scrollToStep( 5 );
 		}
 	}
 
@@ -356,7 +364,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						"https://yoa.st/config-workout-index-data"
 					) }
 					ImageComponent={ WorkoutImage }
-					isFinished={ isStepFinished( "configuration", steps.optimizeSeoData ) }
+					isFinished={ indexingState === "completed" }
 				>
 					<div className="indexation-container">
 						<WorkoutIndexation
@@ -364,10 +372,11 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						/>
 					</div>
 					<FinishStepSection
+						stepNumber={ 1 }
 						hasDownArrow={ true }
 						finishText={ __( "Continue", "wordpress-seo" ) }
-						onFinishClick={ onFinishOptimizeSeoData }
-						isFinished={ isStepFinished( "configuration", steps.optimizeSeoData ) }
+						onFinishClick={	onFinishOptimizeSeoData }
+						isFinished={ indexingState === "completed" }
 					/>
 				</Step>
 				<p className="extra-list-content">
@@ -461,6 +470,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						) }
 					</Alert> }
 					<FinishStepSection
+						stepNumber={ 2 }
 						hasDownArrow={ true }
 						finishText={ __( "Save and continue", "wordpress-seo" ) }
 						onFinishClick={ updateOnFinishSiteRepresentation }
@@ -528,6 +538,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 					</div>
 					}
 					<FinishStepSection
+						stepNumber={ 3 }
 						hasDownArrow={ true }
 						finishText={ "Save and continue" }
 						onFinishClick={ updateOnFinishSocialProfiles }
@@ -585,6 +596,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 						) }
 					</Alert> }
 					<FinishStepSection
+						stepNumber={ 4 }
 						hasDownArrow={ true }
 						finishText={ "Save and continue" }
 						onFinishClick={ updateOnFinishEnableTracking }
@@ -598,6 +610,7 @@ export function ConfigurationWorkout( { toggleStep, toggleWorkout, isStepFinishe
 				>
 					<NewsletterSignup />
 					<FinishStepSection
+						stepNumber={ 5 }
 						finishText={ "Finish this workout" }
 						onFinishClick={ toggleConfigurationWorkout }
 						isFinished={ isStepFinished( "configuration", steps.newsletterSignup ) }

--- a/packages/js/src/workouts/components/FinishButton.js
+++ b/packages/js/src/workouts/components/FinishButton.js
@@ -11,7 +11,7 @@ import { Button } from "@yoast/components";
  * @constructor
  */
 export default function FinishButton( { onClick, isFinished } ) {
-	const copy = isFinished ? __( "Revise this step", "wordpress-seo-premium" ) : __( "I've finished this step", "wordpress-seo-premium" );
+	const copy = isFinished ? __( "Revise this step", "wordpress-seo" ) : __( "I've finished this step", "wordpress-seo" );
 
 	return <Button onClick={ onClick }>{ copy }</Button>;
 }

--- a/packages/js/src/workouts/components/Steps.js
+++ b/packages/js/src/workouts/components/Steps.js
@@ -30,7 +30,7 @@ Steps.propTypes = {
  *
  * @returns {WPElement} The FinishStepSection element.
  */
-export function FinishStepSection( { stepNumber, onFinishClick, finishText, hasDownArrow, isFinished, additionalButtonProps, children } ) {
+export function FinishStepSection( { stepNumber, onFinishClick, finishText, hasDownArrow, isFinished, additionalButtonProps, isSaved, children } ) {
 	return (
 		<Fragment>
 			<hr id={ stepNumber ? `hr-scroll-target-step-${ stepNumber + 1 }` : null } />
@@ -44,7 +44,7 @@ export function FinishStepSection( { stepNumber, onFinishClick, finishText, hasD
 					{ finishText }
 					{ hasDownArrow && <ArrowDown className="yoast-button--arrow-down" /> }
 				</Button>
-				<span className="finish-step-saved">{ __( "Saved!", "wordpress-seo" ) }</span>
+				{ isSaved && <span className="finish-step-saved">{ __( "Saved!", "wordpress-seo" ) }</span> }
 			</div>
 		</Fragment>
 	);
@@ -57,6 +57,7 @@ FinishStepSection.propTypes = {
 	hasDownArrow: PropTypes.bool,
 	isFinished: PropTypes.bool,
 	additionalButtonProps: PropTypes.object,
+	isSaved: PropTypes.bool,
 	children: PropTypes.any,
 };
 
@@ -64,6 +65,7 @@ FinishStepSection.defaultProps = {
 	hasDownArrow: false,
 	isFinished: false,
 	additionalButtonProps: {},
+	isSaved: false,
 	children: null,
 };
 

--- a/packages/js/src/workouts/components/Steps.js
+++ b/packages/js/src/workouts/components/Steps.js
@@ -37,7 +37,7 @@ export function FinishStepSection( { stepNumber, onFinishClick, finishText, hasD
 			{ children }
 			<div className="finish-step-button-section">
 				<Button
-					className={ `yoast-button yoast-button--secondary${ isFinished ? " yoast-button--finished" : "" }` }
+					className={ `yoast-button yoast-button--${ isFinished ? "primary yoast-button--finished" : "secondary" }` }
 					onClick={ onFinishClick }
 					{ ...additionalButtonProps }
 				>

--- a/packages/js/src/workouts/components/Steps.js
+++ b/packages/js/src/workouts/components/Steps.js
@@ -2,6 +2,7 @@ import { Fragment } from "@wordpress/element";
 import { NewButton as Button } from "@yoast/components";
 import { ReactComponent as ArrowDown } from "../../../images/icon-arrow-down.svg";
 import PropTypes from "prop-types";
+import { __ } from "@wordpress/i18n";
 
 /**
  * The Steps component
@@ -34,14 +35,17 @@ export function FinishStepSection( { onFinishClick, finishText, hasDownArrow, is
 		<Fragment>
 			<hr />
 			{ children }
-			<Button
-				className={ `yoast-button yoast-button--secondary${ isFinished ? " yoast-button--finished" : "" }` }
-				onClick={ onFinishClick }
-				{ ...additionalButtonProps }
-			>
-				{ finishText }
-				{ hasDownArrow && <ArrowDown className="yoast-button--arrow-down" /> }
-			</Button>
+			<div className="finish-step-button-section">
+				<Button
+					className={ `yoast-button yoast-button--secondary${ isFinished ? " yoast-button--finished" : "" }` }
+					onClick={ onFinishClick }
+					{ ...additionalButtonProps }
+				>
+					{ finishText }
+					{ hasDownArrow && <ArrowDown className="yoast-button--arrow-down" /> }
+				</Button>
+				<span className="finish-step-saved">{ __( "Saved!", "wordpress-seo" ) }</span>
+			</div>
 		</Fragment>
 	);
 }

--- a/packages/js/src/workouts/components/Steps.js
+++ b/packages/js/src/workouts/components/Steps.js
@@ -37,7 +37,7 @@ export function FinishStepSection( { stepNumber, onFinishClick, finishText, hasD
 			{ children }
 			<div className="finish-step-button-section">
 				<Button
-					className={ `yoast-button yoast-button--${ isFinished ? "primary yoast-button--finished" : "secondary" }` }
+					className={ `yoast-button yoast-button--secondary${ isFinished ? " yoast-button--finished" : "" }` }
 					onClick={ onFinishClick }
 					{ ...additionalButtonProps }
 				>

--- a/packages/js/src/workouts/components/Steps.js
+++ b/packages/js/src/workouts/components/Steps.js
@@ -24,18 +24,18 @@ Steps.propTypes = {
 };
 
 /**
- * Returns a finish step section.
+ * Returns a finish button section.
  *
  * @param {Object} props The props.
  *
- * @returns {WPElement} The FinishStepSection element.
+ * @returns {WPElement} The FinishButtonSection element.
  */
-export function FinishStepSection( { stepNumber, onFinishClick, finishText, hasDownArrow, isFinished, additionalButtonProps, isSaved, children } ) {
+export function FinishButtonSection( { stepNumber, onFinishClick, finishText, hasDownArrow, isFinished, additionalButtonProps, isSaved, children } ) {
 	return (
 		<Fragment>
 			<hr id={ stepNumber ? `hr-scroll-target-step-${ stepNumber + 1 }` : null } />
 			{ children }
-			<div className="finish-step-button-section">
+			<div className="finish-button-section">
 				<Button
 					className={ `yoast-button yoast-button--secondary${ isFinished ? " yoast-button--finished" : "" }` }
 					onClick={ onFinishClick }
@@ -44,16 +44,16 @@ export function FinishStepSection( { stepNumber, onFinishClick, finishText, hasD
 					{ finishText }
 					{ hasDownArrow && <ArrowDown className="yoast-button--arrow-down" /> }
 				</Button>
-				{ isSaved && <span className="finish-step-saved">{ __( "Saved!", "wordpress-seo" ) }</span> }
+				{ isSaved && <span className="finish-button-saved">{ __( "Saved!", "wordpress-seo" ) }</span> }
 			</div>
 		</Fragment>
 	);
 }
 
-FinishStepSection.propTypes = {
+FinishButtonSection.propTypes = {
 	finishText: PropTypes.string.isRequired,
 	onFinishClick: PropTypes.func.isRequired,
-	stepNumber: PropTypes.number.isRequired,
+	stepNumber: PropTypes.number,
 	hasDownArrow: PropTypes.bool,
 	isFinished: PropTypes.bool,
 	additionalButtonProps: PropTypes.object,
@@ -61,7 +61,8 @@ FinishStepSection.propTypes = {
 	children: PropTypes.any,
 };
 
-FinishStepSection.defaultProps = {
+FinishButtonSection.defaultProps = {
+	stepNumber: NaN,
 	hasDownArrow: false,
 	isFinished: false,
 	additionalButtonProps: {},

--- a/packages/js/src/workouts/components/Steps.js
+++ b/packages/js/src/workouts/components/Steps.js
@@ -30,10 +30,10 @@ Steps.propTypes = {
  *
  * @returns {WPElement} The FinishStepSection element.
  */
-export function FinishStepSection( { onFinishClick, finishText, hasDownArrow, isFinished, additionalButtonProps, children } ) {
+export function FinishStepSection( { stepNumber, onFinishClick, finishText, hasDownArrow, isFinished, additionalButtonProps, children } ) {
 	return (
 		<Fragment>
-			<hr />
+			<hr id={ stepNumber ? `hr-scroll-target-step-${ stepNumber + 1 }` : null } />
 			{ children }
 			<div className="finish-step-button-section">
 				<Button
@@ -53,6 +53,7 @@ export function FinishStepSection( { onFinishClick, finishText, hasDownArrow, is
 FinishStepSection.propTypes = {
 	finishText: PropTypes.string.isRequired,
 	onFinishClick: PropTypes.func.isRequired,
+	stepNumber: PropTypes.number.isRequired,
 	hasDownArrow: PropTypes.bool,
 	isFinished: PropTypes.bool,
 	additionalButtonProps: PropTypes.object,

--- a/packages/js/src/workouts/components/WorkoutsPage.js
+++ b/packages/js/src/workouts/components/WorkoutsPage.js
@@ -102,7 +102,7 @@ export default function WorkoutsPage( props ) {
 	return (
 		<div>
 			<h1>
-				{ __( "SEO workouts", "wordpress-seo-premium" ) }
+				{ __( "SEO workouts", "wordpress-seo" ) }
 			</h1>
 			<p>
 				{ __(

--- a/packages/js/src/workouts/helpers.js
+++ b/packages/js/src/workouts/helpers.js
@@ -70,3 +70,23 @@ export async function search( term, setSearchResult ) {
 		return false;
 	}
 }
+
+/**
+ * Scrolls a target into view.
+ *
+ * @param {Int} stepNumber The number of the step to scroll to.
+ *
+ * @returns { void }
+ */
+export function scrollToStep( stepNumber ) {
+	if ( stepNumber === 1 ) {
+		window.scrollTo( { top: 0, behavior: "smooth" } );
+		return;
+	}
+
+	const element = document.getElementById( `hr-scroll-target-step-${ stepNumber }` );
+	const yOffset = -50;
+	const y = element.getBoundingClientRect().top + window.pageYOffset + yOffset;
+
+	window.scrollTo( { top: y, behavior: "smooth", block: "start" } );
+}

--- a/packages/js/src/workouts/redux/actions.js
+++ b/packages/js/src/workouts/redux/actions.js
@@ -35,7 +35,7 @@ export const finishSteps = ( workout, steps ) => {
 };
 
 /**
- * An action creator for finishing a workout step.
+ * An action creator for revising a finished workout step.
  *
  * @param {String} workout The workout key.
  * @param {string} step The step key.

--- a/packages/js/src/workouts/redux/actions.js
+++ b/packages/js/src/workouts/redux/actions.js
@@ -1,5 +1,6 @@
 export const REGISTER_WORKOUT = "REGISTER_WORKOUT";
 export const FINISH_STEPS = "FINISH_STEPS";
+export const REVISE_STEP = "REVISE_STEP";
 export const TOGGLE_WORKOUT = "TOGGLE_WORKOUT";
 export const SET_WORKOUTS = "SET_WORKOUTS";
 export const OPEN_WORKOUT = "OPEN_WORKOUT";
@@ -31,6 +32,18 @@ export const registerWorkout = ( key, priority ) => {
  */
 export const finishSteps = ( workout, steps ) => {
 	return { type: FINISH_STEPS, workout, steps };
+};
+
+/**
+ * An action creator for finishing a workout step.
+ *
+ * @param {String} workout The workout key.
+ * @param {string} step The step key.
+ *
+ * @returns {object} The action object.
+ */
+export const reviseStep = ( workout, step ) => {
+	return { type: REVISE_STEP, workout, step };
 };
 
 /**

--- a/packages/js/src/workouts/redux/reducer.js
+++ b/packages/js/src/workouts/redux/reducer.js
@@ -2,7 +2,7 @@ import { union, merge, get, cloneDeep } from "lodash";
 import {
 	CLEAR_ACTIVE_WORKOUT, CLEAR_INDEXABLES,
 	CLEAR_INDEXABLES_IN_STEPS,
-	FINISH_STEPS, MOVE_INDEXABLES, OPEN_WORKOUT,
+	FINISH_STEPS, REVISE_STEP, MOVE_INDEXABLES, OPEN_WORKOUT,
 	SET_WORKOUTS, TOGGLE_STEP, TOGGLE_WORKOUT, REGISTER_WORKOUT,
 } from "./actions";
 import { FINISHABLE_STEPS, STEPS } from "../config";
@@ -68,6 +68,11 @@ const workoutsReducer = ( state = initialState, action ) => {
 			return newState;
 		case FINISH_STEPS:
 			newState.workouts[ action.workout ].finishedSteps = union( state.workouts[ action.workout ].finishedSteps, action.steps );
+			return newState;
+		case REVISE_STEP:
+			newState.workouts[ action.workout ].finishedSteps = newState.workouts[ action.workout ].finishedSteps.filter(
+				step => step !== action.step
+			);
 			return newState;
 		case TOGGLE_STEP:
 			if ( state.workouts[ action.workout ].finishedSteps.includes( action.step ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* Adds 1px border around cards in overview and workouts.
* Adds scrolling to next step on clicking (save and) continue.
* Adds green saved checkmarks behind the save and continue buttons when step has been saved.
* When a step is finished,  “Save and continue” is changed to “Revise this step”.
* When “Finish this workout” is used, the copy changes to “Do workout again”.
* Saves all the settings when “Finish this workout” is used.
* Adds a “Congratulations” section when “Finish this workout” is used.
* Step 1 is only be completed when indexation is done, not on clicking continue.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on’s repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Saves all steps of the configuration workout when using the “Finish this workout” button.
* Adds some UI improvements to the configuration workout.

## Relevant technical choices:
*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
* Check there is a 1px border around cards in overview and workouts themselves.
* Check whether on clicking (save and) continue, you scroll to the next step.
* Check whether when you click “Save and continue”, a green saved checkmark is added behind the save and continue button.
* Check whether, when a step is finished,  “Save and continue” is changed to “Revise this step”.
* Check whether, when you use “Finish this workout”, the copy changes to “Do workout again”.
* Check whether, when “Finish this workout” is used, all settings of the steps that have not been saved yet are now saved.
* Check whether, when “Finish this workout” is used, a “Congratulations” section is added on the bottom of the workout.
* Check whether Step 1 being finished is only dependent on indexation being finished. It should also not be altered by clicking "Do workout again". 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren’t relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->
* [x] QA should use the same steps as above.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the ‘UI change’ label to this PR.
## Other environments
* [ ] This PR also affects other environments and needs to be tested there.
## Documentation
* [ ] I have written documentation for this change.
## Quality assurance
* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.


Fixes DUPP-103 and DUPP-86