### PR TITLE
IM-1614 Fix incoming link counts of zero

### DIFF
--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -474,9 +474,19 @@ class Indexable_Link_Builder {
 			return;
 		}
 
-		$counts = $this->seo_links_repository->get_incoming_link_counts_for_indexable_ids( $related_indexable_ids );
-		foreach ( $counts as $count ) {
-			$this->indexable_repository->update_incoming_link_count( $count['target_indexable_id'], $count['incoming'] );
+		// Get the counts of all incoming links for every indexable passed to this method.
+		$indexable_counts = $this->seo_links_repository->get_incoming_link_counts_for_indexable_ids( $related_indexable_ids );
+		// Convert the $indexable_counts to a more workable array with incoming count per indexable ID.
+		$counts_by_id = array_column( $indexable_counts, 'incoming', 'target_indexable_id' );
+
+		// For every passed indexable, check if it exists in the $counts_by_id array. If it does not exist, its incoming count is 0.
+		foreach ( $related_indexable_ids as $indexable_id ) {
+			if ( array_key_exists( $indexable_id, $counts_by_id ) ) {
+				$this->indexable_repository->update_incoming_link_count( $indexable_id, $indexable_counts[ $indexable_id] );
+			}
+			else {
+				$this->indexable_repository->update_incoming_link_count( $indexable_id, 0 );
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR aims to fix the incoming link counts of posts never being set to zero.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the incoming link count of a post would not return to zero, even if all incoming links were removed.

## Relevant technical choices:

* The query in `get_incoming_link_counts_for_indexable_ids()` is bugged in that it will not return the IDs of indexables that have 0 incoming links, therefore they would never get updated. I have opted to fix this in PHP rather than in the query. However, it may be more performant if the query would also return 0 counts on IDs.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create 2 posts (A and B)
* Make sure the SEO indexables optimization is completed so that you can see the incoming and outgoing link count columns in the post overview.
* Link to post A in post B
* Notice the link count columns for both posts where post A has 1 incoming link and post B 1 outgoing
* Remove the link in post B
* with the PR, both link counters should revert to 0, without this PR, the incoming count of post A would stay at 1


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Additionally to the steps above, make sure that:
  * Multiple outgoing link counts still work as expected
  * Multiple incoming link counts still work as expected.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Incoming link counters of posts.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/IM-1614
Fixes https://yoast.atlassian.net/browse/IM-1279
