### PR TITLE
DUPP-114 add ids to configuration workout

### DIFF
--- a/css/src/workouts.css
+++ b/css/src/workouts.css
@@ -445,6 +445,11 @@ table.yoast_help th.divider {
 	color: rgb(60, 67, 74);
 }
 
+.workflow .yoast-field-group label {
+	font-size: 13px;
+	color: rgb(60, 67, 74);
+}
+
 .yoast-list--usp {
 	padding-left: 24px;
 }

--- a/packages/js/src/helpers/stringHelpers.js
+++ b/packages/js/src/helpers/stringHelpers.js
@@ -31,15 +31,16 @@ export function stripHTML( string ) {
  *
  * @param {string} text   The text to add links to. Make sure it contains <a> and </a> tags surrounding the link part.
  * @param {string} linkTo The target URL for the link (href).
+ * @param {string} id     The id to attach to the link.
  *
  * @returns {WPElement} A Fragment with the text and a link.
  */
-export function addLinkToString( text, linkTo ) {
+export function addLinkToString( text, linkTo, id = "" ) {
 	return createInterpolateElement(
 		text,
 		{
 			// eslint-disable-next-line jsx-a11y/anchor-has-content
-			a: <a href={ linkTo } target="_blank" rel="noopener noreferrer" />,
+			a: <a id={ id } href={ linkTo } target="_blank" rel="noopener noreferrer" />,
 		}
 	);
 }

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -404,9 +404,9 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 
 	/* eslint-disable max-len */
 	return (
-		<div id="yoast-configuration-workout-card" className="card">
-			<h2 id="yoast-configuration-workout">{ __( "Configuration", "wordpress-seo" ) }</h2>
-			<h3 id="yoast-configuration-workout-title">{
+		<div id="yoast-configuration-workout" className="card">
+			<h2 id="yoast-configuration-workout-title">{ __( "Configuration", "wordpress-seo" ) }</h2>
+			<h3 id="yoast-configuration-workout-tagline">{
 				// translators: %1$s is replaced by "Yoast SEO"
 				sprintf( __( "Configure %1$s with optimal SEO settings for your site", "wordpress-seo" ), "Yoast SEO" )
 			}</h3>
@@ -489,7 +489,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 						/>
 					</div>
 					<FinishButtonSection
-						id="yoast-configuration-workout-step-optimize-seo-data-button"
+						buttonId="yoast-configuration-workout-step-optimize-seo-data-button"
 						stepNumber={ 1 }
 						hasDownArrow={ true }
 						finishText={ __( "Continue", "wordpress-seo" ) }
@@ -589,7 +589,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 						) }
 					</Alert> }
 					<FinishButtonSection
-						id="yoast-configuration-workout-step-site-representation-button"
+						buttonId="yoast-configuration-workout-step-site-representation-button"
 						stepNumber={ 2 }
 						isSaved={ savedSteps.includes( 2 ) }
 						hasDownArrow={ ! isStep2Finished }
@@ -629,7 +629,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 									{
 										b: <b />,
 										// eslint-disable-next-line jsx-a11y/anchor-has-content
-										a: <a href={ window.wpseoWorkoutsData.usersPageUrl } target="_blank" rel="noopener noreferrer" />,
+										a: <a id="yoast-configuration-workout-user-page-link-1" href={ window.wpseoWorkoutsData.usersPageUrl } target="_blank" rel="noopener noreferrer" />,
 									}
 								)
 							}
@@ -647,7 +647,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 										"</a>"
 									),
 									window.wpseoWorkoutsData.usersPageUrl,
-									"yoast-configuration-workout-user-page-link"
+									"yoast-configuration-workout-user-page-link-2"
 								)
 							}
 						</p>
@@ -661,7 +661,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					</div>
 					}
 					<FinishButtonSection
-						id="yoast-configuration-workout-step-social-profiles-button"
+						buttonId="yoast-configuration-workout-step-social-profiles-button"
 						stepNumber={ 3 }
 						isSaved={ savedSteps.includes( 3 ) }
 						hasDownArrow={ ! isStep3Finished }
@@ -723,7 +723,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 						) }
 					</Alert> }
 					<FinishButtonSection
-						id="yoast-configuration-workout-step-tracking-button"
+						buttonId="yoast-configuration-workout-step-tracking-button"
 						stepNumber={ 4 }
 						isSaved={ savedSteps.includes( 4 ) }
 						hasDownArrow={ ! isStep4Finished }
@@ -741,7 +741,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					<NewsletterSignup />
 				</Step>
 				<FinishButtonSection
-					id="yoast-configuration-workout-finish-workout-button"
+					buttonId="yoast-configuration-workout-finish-workout-button"
 					finishText={ isWorkoutFinished ? __( "Do workout again", "wordpress-seo" ) : __( "Finish this workout", "wordpress-seo" ) }
 					onFinishClick={ toggleConfigurationWorkout }
 					isFinished={ isWorkoutFinished }

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -741,7 +741,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					<NewsletterSignup />
 				</Step>
 				<FinishButtonSection
-					id="yoast-configuration-workout-step-newsletter-button"
+					id="yoast-configuration-workout-finish-workout-button"
 					finishText={ isWorkoutFinished ? __( "Do workout again", "wordpress-seo" ) : __( "Finish this workout", "wordpress-seo" ) }
 					onFinishClick={ toggleConfigurationWorkout }
 					isFinished={ isWorkoutFinished }

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -404,9 +404,9 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 
 	/* eslint-disable max-len */
 	return (
-		<div className="card">
-			<h2>{ __( "Configuration", "wordpress-seo" ) }</h2>
-			<h3>{
+		<div id="yoast-configuration-workout-card" className="card">
+			<h2 id="yoast-configuration-workout">{ __( "Configuration", "wordpress-seo" ) }</h2>
+			<h3 id="yoast-configuration-workout-title">{
 				// translators: %1$s is replaced by "Yoast SEO"
 				sprintf( __( "Configure %1$s with optimal SEO settings for your site", "wordpress-seo" ), "Yoast SEO" )
 			}</h3>
@@ -461,7 +461,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 				}
 			</p>
 			<br />
-			<Steps>
+			<Steps id="yoast-configuration-workout-steps">
 				<Step
 					title={ __( "Optimize SEO data", "wordpress-seo" ) }
 					subtitle={ addLinkToString(

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -464,6 +464,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 			<br />
 			<Steps id="yoast-configuration-workout-steps">
 				<Step
+					id="yoast-configuration-workout-step-optimize-seo-data"
 					title={ __( "Optimize SEO data", "wordpress-seo" ) }
 					subtitle={ addLinkToString(
 						sprintf(
@@ -514,6 +515,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					}
 				</p>
 				<Step
+					id="yoast-configuration-workout-step-site-representation"
 					title={ __( "Site representation", "wordpress-seo" ) }
 					subtitle={ __( "Tell Google what kind of site you have and increase the chance it gets features in a Google Knowledge Panel. Select ‘Organization’ if you are working on a site for a business or an organization. Select ‘Person’ if you have, say, a personal blog.", "wordpress-seo" ) }
 					isFinished={ isStep2Finished }
@@ -595,6 +597,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					/>
 				</Step>
 				<Step
+					id="yoast-configuration-workout-step-social-profiles"
 					title={ __( "Social profiles", "wordpress-seo" ) }
 					subtitle={ state.companyOrPerson === "company" ?  __( "Do you have profiles for your site on social media? Then, add all of their URLs here, so your social profiles may also appear in a Google Knowledge Panel.", "wordpress-seo" ) : "" }
 					isFinished={ isStep3Finished }
@@ -665,6 +668,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					/>
 				</Step>
 				<Step
+					id="yoast-configuration-workout-step-tracking"
 					title={ __( "Help us improve Yoast SEO", "wordpress-seo" ) }
 					isFinished={ isStep4Finished }
 				>
@@ -725,6 +729,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					/>
 				</Step>
 				<Step
+					id="yoast-configuration-workout-step-newsletter"
 					title={ __( "Sign up for the Yoast newsletter!", "wordpress-seo" ) }
 					isFinished={ isStep5Finished }
 				>

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -436,7 +436,8 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 								"Yoast SEO",
 								"</a>"
 							),
-							"https://yoa.st/config-workout-guide"
+							"https://yoa.st/config-workout-guide",
+							"yoast-configuration-workout-guide-link"
 						)
 					}
 				</i>
@@ -475,7 +476,8 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 							"<a>",
 							"</a>"
 						),
-						"https://yoa.st/config-workout-index-data"
+						"https://yoa.st/config-workout-index-data",
+						"yoast-configuration-workout-index-data-link"
 					) }
 					ImageComponent={ WorkoutStartImage }
 					isFinished={ isStep1Finished }
@@ -639,7 +641,8 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 										"<a>",
 										"</a>"
 									),
-									window.wpseoWorkoutsData.usersPageUrl
+									window.wpseoWorkoutsData.usersPageUrl,
+									"yoast-configuration-workout-user-page-link"
 								)
 							}
 						</p>

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -489,6 +489,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 						/>
 					</div>
 					<FinishButtonSection
+						id="yoast-configuration-workout-step-optimize-seo-data-button"
 						stepNumber={ 1 }
 						hasDownArrow={ true }
 						finishText={ __( "Continue", "wordpress-seo" ) }
@@ -588,6 +589,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 						) }
 					</Alert> }
 					<FinishButtonSection
+						id="yoast-configuration-workout-step-site-representation-button"
 						stepNumber={ 2 }
 						isSaved={ savedSteps.includes( 2 ) }
 						hasDownArrow={ ! isStep2Finished }
@@ -659,6 +661,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					</div>
 					}
 					<FinishButtonSection
+						id="yoast-configuration-workout-step-social-profiles-button"
 						stepNumber={ 3 }
 						isSaved={ savedSteps.includes( 3 ) }
 						hasDownArrow={ ! isStep3Finished }
@@ -719,6 +722,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 						) }
 					</Alert> }
 					<FinishButtonSection
+						id="yoast-configuration-workout-step-tracking-button"
 						stepNumber={ 4 }
 						isSaved={ savedSteps.includes( 4 ) }
 						hasDownArrow={ ! isStep4Finished }
@@ -736,6 +740,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					<NewsletterSignup />
 				</Step>
 				<FinishButtonSection
+					id="yoast-configuration-workout-step-newsletter-button"
 					finishText={ isWorkoutFinished ? __( "Do workout again", "wordpress-seo" ) : __( "Finish this workout", "wordpress-seo" ) }
 					onFinishClick={ toggleConfigurationWorkout }
 					isFinished={ isWorkoutFinished }

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -692,6 +692,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 						<li> { __( "always load our customer support window so we can immediately assist you when you need help.", "wordpress-seo" ) } </li>
 					</ul>
 					<RadioButtonGroup
+						id="yoast-configuration-workout-tracking-radio-button"
 						label={ __( "Can we collect anonymous information about your website and how you use it?", "wordpress-seo" ) }
 						groupName="yoast-configuration-workout-tracking"
 						selected={ state.tracking }

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -483,7 +483,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					ImageComponent={ WorkoutStartImage }
 					isFinished={ isStep1Finished }
 				>
-					<div className="indexation-container">
+					<div id="yoast-configuration-workout-indexing-container" className="indexation-container">
 						<WorkoutIndexation
 							indexingStateCallback={ setIndexingState }
 						/>
@@ -752,10 +752,10 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					</Alert> }
 				</FinishButtonSection>
 			</Steps>
-			{ isWorkoutFinished && <div>
+			{ isWorkoutFinished && <div id="yoast-configuration-workout-congratulations">
 				<hr />
-				<h3 style={ { marginBottom: 0 } }>{ __( "Congratulations!", "wordpress-seo" ) }</h3>
-				<div style={ { display: "flex" } }>
+				<h3 id="yoast-configuration-workout-congratulations-title" style={ { marginBottom: 0 } }>{ __( "Congratulations!", "wordpress-seo" ) }</h3>
+				<div id="yoast-configuration-workout-congratulations-content" style={ { display: "flex" } }>
 					<div>
 						<p>
 							{
@@ -767,7 +767,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					</div>
 					<WorkoutDoneImage style={ { height: "119px", width: "100px", flexShrink: 0 } } />
 				</div>
-				<Button onClick={ clearActiveWorkout } variant="primary">
+				<Button id="yoast-configuration-workout-congratulations-button" onClick={ clearActiveWorkout } variant="primary">
 					{
 						// translators: %1$s translates to a rightward pointing arrow ( → )
 						sprintf( __( "View other SEO workouts%1$s", "wordpress-seo" ), " →" )

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -218,7 +218,6 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 		setSavedSteps( ( prevState ) => {
 			return [ stepNumber, ...prevState ];
 		} );
-		return;
 	};
 
 	/**

--- a/packages/js/src/workouts/components/NewsletterSignup.js
+++ b/packages/js/src/workouts/components/NewsletterSignup.js
@@ -105,11 +105,13 @@ export function NewsletterSignup() {
 								"<a>",
 								"</a>"
 							),
-							"https://yoa.st/gdpr-config-workout"
+							"https://yoa.st/gdpr-config-workout",
+							"yoast-configuration-workout-gdpr-link"
 						)
 					}
 				/>
 				<Button
+					id="newsletter-sign-up-button"
 					variant="primary"
 					onClick={ onSignUpClick }
 					disabled={ signUpState === "loading" }

--- a/packages/js/src/workouts/components/OrganizationSection.js
+++ b/packages/js/src/workouts/components/OrganizationSection.js
@@ -47,6 +47,9 @@ export function OrganizationSection( { dispatch, imageUrl, organizationName, isD
 				hasPreview={ true }
 				label={ __( "Organization logo (important)", "wordpress-seo" ) }
 				isDisabled={ isDisabled }
+				replaceImageButtonId={ "organization-logo-replace-button" }
+				selectImageButtonId={ "organization-logo-select-button" }
+				removeImageButtonId={ "organization-logo-remove-button" }
 			/>
 		</Fragment>
 	);

--- a/packages/js/src/workouts/components/PersonSection.js
+++ b/packages/js/src/workouts/components/PersonSection.js
@@ -50,6 +50,9 @@ export function PersonSection( { dispatch, imageUrl, personId, isDisabled } ) {
 				hasPreview={ true }
 				label={ __( "Person logo / avatar (important)", "wordpress-seo" ) }
 				isDisabled={ isDisabled }
+				replaceImageButtonId={ "person-logo-replace-button" }
+				selectImageButtonId={ "person-logo-select-button" }
+				removeImageButtonId={ "person-logo-remove-button" }
 			/>
 		</Fragment>
 	);

--- a/packages/js/src/workouts/components/SocialInputSection.js
+++ b/packages/js/src/workouts/components/SocialInputSection.js
@@ -36,9 +36,10 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 	);
 
 	return (
-		<div className="yoast-social-profiles-input-fields">
+		<div id="social-input-section" className="yoast-social-profiles-input-fields">
 			<SocialInput
 				label={ __( "Facebook URL", "wordpress-seo" ) }
+				id="social-input-facebook-url"
 				value={ socialProfiles.facebookUrl }
 				socialMedium="facebookUrl"
 				onChange={ onChangeHandler }
@@ -47,6 +48,7 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 			/>
 			<SocialInput
 				label={ __( "Twitter URL", "wordpress-seo" ) }
+				id="social-input-twitter-url"
 				value={ socialProfiles.twitterUsername }
 				socialMedium="twitterUsername"
 				onChange={ onChangeHandler }
@@ -55,6 +57,7 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 			/>
 			<SocialInput
 				label={ __( "Instagram URL", "wordpress-seo" ) }
+				id="social-input-instagram-url"
 				value={ socialProfiles.instagramUrl }
 				socialMedium="instagramUrl"
 				onChange={ onChangeHandler }
@@ -63,6 +66,7 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 			/>
 			<SocialInput
 				label={ __( "LinkedIn URL", "wordpress-seo" ) }
+				id="social-input-linkedin-url"
 				value={ socialProfiles.linkedinUrl }
 				socialMedium="linkedinUrl"
 				onChange={ onChangeHandler }
@@ -71,6 +75,7 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 			/>
 			<SocialInput
 				label={ __( "MySpace URL", "wordpress-seo" ) }
+				id="social-input-myspace-url"
 				value={ socialProfiles.myspaceUrl }
 				socialMedium="myspaceUrl"
 				onChange={ onChangeHandler }
@@ -79,6 +84,7 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 			/>
 			<SocialInput
 				label={ __( "Pinterest URL", "wordpress-seo" ) }
+				id="social-input-pinterest-url"
 				value={ socialProfiles.pinterestUrl }
 				socialMedium="pinterestUrl"
 				onChange={ onChangeHandler }
@@ -87,6 +93,7 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 			/>
 			<SocialInput
 				label={ __( "YouTube URL", "wordpress-seo" ) }
+				id="social-input-youtube-url"
 				value={ socialProfiles.youtubeUrl }
 				socialMedium="youtubeUrl"
 				onChange={ onChangeHandler }
@@ -95,6 +102,7 @@ export default function SocialInputSection( { socialProfiles, errorFields, dispa
 			/>
 			<SocialInput
 				label={ __( "Wikipedia URL", "wordpress-seo" ) }
+				id="social-input-wikipedia-url"
 				value={ socialProfiles.wikipediaUrl }
 				socialMedium="wikipediaUrl"
 				onChange={ onChangeHandler }

--- a/packages/js/src/workouts/components/Steps.js
+++ b/packages/js/src/workouts/components/Steps.js
@@ -35,7 +35,7 @@ Steps.defaultProps = {
  *
  * @returns {WPElement} The FinishButtonSection element.
  */
-export function FinishButtonSection( { stepNumber, onFinishClick, finishText, hasDownArrow, isFinished, additionalButtonProps, isSaved, children } ) {
+export function FinishButtonSection( { id, stepNumber, onFinishClick, finishText, hasDownArrow, isFinished, additionalButtonProps, isSaved, children } ) {
 	return (
 		<Fragment>
 			<hr id={ stepNumber ? `hr-scroll-target-step-${ stepNumber + 1 }` : null } />
@@ -44,6 +44,7 @@ export function FinishButtonSection( { stepNumber, onFinishClick, finishText, ha
 				<Button
 					className={ `yoast-button yoast-button--secondary${ isFinished ? " yoast-button--finished" : "" }` }
 					onClick={ onFinishClick }
+					id={ id }
 					{ ...additionalButtonProps }
 				>
 					{ finishText }
@@ -58,6 +59,7 @@ export function FinishButtonSection( { stepNumber, onFinishClick, finishText, ha
 FinishButtonSection.propTypes = {
 	finishText: PropTypes.string.isRequired,
 	onFinishClick: PropTypes.func.isRequired,
+	id: PropTypes.string,
 	stepNumber: PropTypes.number,
 	hasDownArrow: PropTypes.bool,
 	isFinished: PropTypes.bool,
@@ -67,6 +69,7 @@ FinishButtonSection.propTypes = {
 };
 
 FinishButtonSection.defaultProps = {
+	id: "",
 	stepNumber: NaN,
 	hasDownArrow: false,
 	isFinished: false,

--- a/packages/js/src/workouts/components/Steps.js
+++ b/packages/js/src/workouts/components/Steps.js
@@ -82,10 +82,10 @@ FinishButtonSection.defaultProps = {
  *
  * @returns {WPElement} The Step component.
  */
-export function Step( { title, subtitle, isFinished, ImageComponent, children } ) {
+export function Step( { title, subtitle, isFinished, ImageComponent, id, children } ) {
 	const finished = isFinished ? " finished" : "";
 	return (
-		<li className={ `step${finished}` }>
+		<li id={ id } className={ `step${finished}` }>
 			<h4>{ title }</h4>
 			<div style={ { display: "flex" } }>
 				{ subtitle && <p>{ subtitle }</p> }
@@ -101,6 +101,7 @@ Step.propTypes = {
 	subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ),
 	isFinished: PropTypes.bool,
 	ImageComponent: PropTypes.func,
+	id: PropTypes.string,
 	children: PropTypes.any.isRequired,
 };
 
@@ -108,4 +109,5 @@ Step.defaultProps = {
 	subtitle: null,
 	ImageComponent: null,
 	isFinished: false,
+	id: "",
 };

--- a/packages/js/src/workouts/components/Steps.js
+++ b/packages/js/src/workouts/components/Steps.js
@@ -13,7 +13,7 @@ import { __ } from "@wordpress/i18n";
  */
 export function Steps( props ) {
 	return (
-		<ol className="workflow yoast">
+		<ol id={ props.id } className="workflow yoast">
 			{ props.children }
 		</ol>
 	);
@@ -21,6 +21,11 @@ export function Steps( props ) {
 
 Steps.propTypes = {
 	children: PropTypes.any.isRequired,
+	id: PropTypes.string,
+};
+
+Steps.defaultProps = {
+	id: "",
 };
 
 /**

--- a/packages/js/src/workouts/components/Steps.js
+++ b/packages/js/src/workouts/components/Steps.js
@@ -85,12 +85,12 @@ FinishButtonSection.defaultProps = {
  *
  * @returns {WPElement} The Step component.
  */
-export function Step( { title, subtitle, isFinished, ImageComponent, id, children } ) {
+export function Step( { id, title, subtitle, isFinished, ImageComponent, children } ) {
 	const finished = isFinished ? " finished" : "";
 	return (
 		<li id={ id } className={ `step${finished}` }>
-			<h4>{ title }</h4>
-			<div style={ { display: "flex" } }>
+			<h4 id={ `${id}-title` }>{ title }</h4>
+			<div id={ `${id}-subtitle` } style={ { display: "flex" } }>
 				{ subtitle && <p>{ subtitle }</p> }
 				{ ImageComponent && <ImageComponent style={ { height: "119px", width: "100px", flexShrink: 0 } } /> }
 			</div>

--- a/packages/js/src/workouts/components/Steps.js
+++ b/packages/js/src/workouts/components/Steps.js
@@ -20,12 +20,8 @@ export function Steps( props ) {
 }
 
 Steps.propTypes = {
+	id: PropTypes.string.isRequired,
 	children: PropTypes.any.isRequired,
-	id: PropTypes.string,
-};
-
-Steps.defaultProps = {
-	id: "",
 };
 
 /**
@@ -36,9 +32,9 @@ Steps.defaultProps = {
  * @returns {WPElement} The FinishButtonSection element.
  */
 export function FinishButtonSection( {
-	id,
 	stepNumber,
 	onFinishClick,
+	buttonId,
 	finishText,
 	hasDownArrow,
 	isFinished,
@@ -54,7 +50,7 @@ export function FinishButtonSection( {
 				<Button
 					className={ `yoast-button yoast-button--secondary${ isFinished ? " yoast-button--finished" : "" }` }
 					onClick={ onFinishClick }
-					id={ id }
+					id={ buttonId }
 					{ ...additionalButtonProps }
 				>
 					{ finishText }
@@ -69,7 +65,7 @@ export function FinishButtonSection( {
 FinishButtonSection.propTypes = {
 	finishText: PropTypes.string.isRequired,
 	onFinishClick: PropTypes.func.isRequired,
-	id: PropTypes.string,
+	buttonId: PropTypes.string.isRequired,
 	stepNumber: PropTypes.number,
 	hasDownArrow: PropTypes.bool,
 	isFinished: PropTypes.bool,
@@ -79,7 +75,6 @@ FinishButtonSection.propTypes = {
 };
 
 FinishButtonSection.defaultProps = {
-	id: "",
 	stepNumber: NaN,
 	hasDownArrow: false,
 	isFinished: false,
@@ -111,10 +106,10 @@ export function Step( { id, title, subtitle, isFinished, ImageComponent, childre
 
 Step.propTypes = {
 	title: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
 	subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ),
 	isFinished: PropTypes.bool,
 	ImageComponent: PropTypes.func,
-	id: PropTypes.string,
 	children: PropTypes.any.isRequired,
 };
 
@@ -122,5 +117,4 @@ Step.defaultProps = {
 	subtitle: null,
 	ImageComponent: null,
 	isFinished: false,
-	id: "",
 };

--- a/packages/js/src/workouts/components/Steps.js
+++ b/packages/js/src/workouts/components/Steps.js
@@ -35,7 +35,17 @@ Steps.defaultProps = {
  *
  * @returns {WPElement} The FinishButtonSection element.
  */
-export function FinishButtonSection( { id, stepNumber, onFinishClick, finishText, hasDownArrow, isFinished, additionalButtonProps, isSaved, children } ) {
+export function FinishButtonSection( {
+	id,
+	stepNumber,
+	onFinishClick,
+	finishText,
+	hasDownArrow,
+	isFinished,
+	additionalButtonProps,
+	isSaved,
+	children,
+} ) {
 	return (
 		<Fragment>
 			<hr id={ stepNumber ? `hr-scroll-target-step-${ stepNumber + 1 }` : null } />

--- a/packages/js/src/workouts/components/WorkoutsPage.js
+++ b/packages/js/src/workouts/components/WorkoutsPage.js
@@ -111,7 +111,7 @@ export default function WorkoutsPage( props ) {
 					"wordpress-seo"
 				) }
 			</p>
-			{ activeWorkout && <Button onClick={ clearActiveWorkout }>{
+			{ activeWorkout && <Button id="yoast-workouts-back-to-workouts-button" onClick={ clearActiveWorkout }>{
 				// translators: %1$s translates to a leftward pointing arrow ( ← )
 				sprintf( __( "%1$sBack to all workouts", "worpdress-seo" ), "← " )
 			}</Button> }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add ids for automated testing.

Update: @mrcuc360 has approved. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds ids to the elements of the configuration workout.

## Relevant technical choices:

* As a result, clicking the labels of the social input fields now focusses on the corresponding input field.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Do a smoke test of the Configuration workout.
* See the ids have been added.
* For the input fields: check that clicking the label focusses on the corresponding input field.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Do a smoke test of the Configuration workout.
* For the input fields: check that clicking the label focusses on the corresponding input field.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
