### PR TITLE
DUPP-115 tracking option not saved

### DIFF
--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -339,6 +339,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				case 'semrush_tokens':
 				case 'custom_taxonomy_slugs':
 				case 'zapier_subscription':
+				case 'workouts_data':
 					$clean[ $key ] = $old[ $key ];
 
 					if ( isset( $dirty[ $key ] ) ) {

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -467,7 +467,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 							__(
 								"Click the button below to optimize your SEO data. It will let us see your site as Google does, so we can give " +
 								"you the best SEO tips and improve technical SEO issues in the background! If you have a lot of content the " +
-								"optimization might take a while. But trust us, it's worth it! Learn more about the benefits of optimized SEO data.",
+								"optimization might take a while. But trust us, it's worth it! %1$sLearn more about the benefits of optimized SEO data.%2$s",
 								"wordpress-seo"
 							),
 							"<a>",

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -103,18 +103,12 @@ async function updateSiteRepresentation( state ) {
 		/* eslint-enable camelcase */
 	};
 
-	try {
-		const response = await apiFetch( {
-			path: "yoast/v1/workouts/site_representation",
-			method: "POST",
-			data: siteRepresentation,
-		} );
-		return await response.json;
-	} catch ( e ) {
-		// URL() constructor throws a TypeError exception if url is malformed.
-		console.error( e.message );
-		return false;
-	}
+	const response = await apiFetch( {
+		path: "yoast/v1/workouts/site_representation",
+		method: "POST",
+		data: siteRepresentation,
+	} );
+	return await response.json;
 }
 
 /**
@@ -154,26 +148,20 @@ async function updateSocialProfiles( state ) {
  * @returns {Promise|bool} A promise, or false if the call fails.
  */
 async function updateTracking( state ) {
-	try {
-		if ( state.tracking !== 0 && state.tracking !== 1 ) {
-			throw "Value not set!";
-		}
-
-		const tracking = {
-			tracking: state.tracking,
-		};
-
-		const response = await apiFetch( {
-			path: "yoast/v1/workouts/enable_tracking",
-			method: "POST",
-			data: tracking,
-		} );
-		return await response.json;
-	} catch ( e ) {
-		// URL() constructor throws a TypeError exception if url is malformed.
-		console.error( e.message );
-		return false;
+	if ( state.tracking !== 0 && state.tracking !== 1 ) {
+		throw "Value not set!";
 	}
+
+	const tracking = {
+		tracking: state.tracking,
+	};
+
+	const response = await apiFetch( {
+		path: "yoast/v1/workouts/enable_tracking",
+		method: "POST",
+		data: tracking,
+	} );
+	return await response.json;
 }
 
 /**
@@ -259,7 +247,6 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 	const toggleStepSiteRepresentation = makeStepToggle( steps.siteRepresentation );
 	const toggleStepSocialProfiles = makeStepToggle( steps.socialProfiles );
 	const toggleStepEnableTracking = makeStepToggle( steps.enableTracking );
-	const toggleStepNewsletterSignup = makeStepToggle( steps.newsletterSignup );
 
 	const setTracking = useCallback( ( value ) => {
 		dispatch( { type: "SET_TRACKING", payload: parseInt( value, 10 ) } );
@@ -350,7 +337,9 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 	}
 
 	const toggleConfigurationWorkout = useCallback(
-		() => {
+		async() => {
+			const stepsToFinish = [];
+
 			if ( isWorkoutFinished ) {
 				setSavedSteps( [] );
 				reviseStep( "configuration", steps.siteRepresentation );
@@ -360,35 +349,43 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 				return;
 			}
 			if ( ! isStep2Finished ) {
-				updateSiteRepresentation( state )
-					.then( () => setStepIsSaved( 2 ) )
-					.then( toggleStepSiteRepresentation );
+				try {
+					await updateSiteRepresentation( state );
+					setStepIsSaved( 2 );
+					stepsToFinish.push( steps.siteRepresentation );
+				} catch ( e ) {
+					console.error( e.message );
+					return false;
+				}
 			}
 			if ( ! isStep3Finished ) {
-				updateSocialProfiles( state )
-					.then( () => setStepIsSaved( 3 ) )
-					.then( () => {
-						setErrorFields( [] );
-						toggleStepSocialProfiles();
-					} )
-					.catch(
-						( e ) => {
-							if ( e.failures ) {
-								setErrorFields( e.failures );
-							}
-							scrollToStep( 3 );
-							return false;
-						}
-					);
+				try {
+					await updateSocialProfiles( state );
+					setStepIsSaved( 3 );
+					setErrorFields( [] );
+					stepsToFinish.push( steps.socialProfiles );
+				} catch ( e ) {
+					if ( e.failures ) {
+						setErrorFields( e.failures );
+					}
+					scrollToStep( 3 );
+					return false;
+				}
 			}
 			if ( ! isStep4Finished ) {
-				updateTracking( state )
-					.then( () => setStepIsSaved( 4 ) )
-					.then( toggleStepEnableTracking );
+				try {
+					await updateTracking( state );
+					setStepIsSaved( 4 );
+					stepsToFinish.push( steps.enableTracking );
+				} catch ( e ) {
+					console.error( e.message );
+					return false;
+				}
 			}
 			if ( ! isStep5Finished ) {
-				toggleStepNewsletterSignup();
+				stepsToFinish.push( steps.newsletterSignup );
 			}
+			finishSteps( "configuration", stepsToFinish );
 		},
 		[ toggleWorkout, isWorkoutFinished, isStep1Finished, isStep2Finished, isStep3Finished, isStep4Finished, isStep5Finished, state ]
 	);

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -355,7 +355,6 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					stepsToFinish.push( steps.siteRepresentation );
 				} catch ( e ) {
 					console.error( e.message );
-					return false;
 				}
 			}
 			if ( ! isStep3Finished ) {
@@ -369,7 +368,6 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 						setErrorFields( e.failures );
 					}
 					scrollToStep( 3 );
-					return false;
 				}
 			}
 			if ( ! isStep4Finished ) {
@@ -379,7 +377,6 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					stepsToFinish.push( steps.enableTracking );
 				} catch ( e ) {
 					console.error( e.message );
-					return false;
 				}
 			}
 			if ( ! isStep5Finished ) {

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -303,27 +303,16 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	/**
 	 * Checks whether tracking is enabled.
 	 *
-	 * @return int True if tracking is enabled, false otherwise, null if in Free and conf. workout step not finished.
+	 * @return bool True if tracking is enabled, false otherwise, null if in Free and conf. workout step not finished.
 	 */
 	private function has_tracking_enabled() {
-		$tracking = -1;
-		// If in Premium, use the current setting.
+		$default = false;
+
 		if ( $this->product_helper->is_premium() ) {
-			$tracking = $this->options_helper->get( 'tracking', false );
+			$default = true;
 		}
 
-		// If in Free and the "tracking" step of the configuration workout is marked as finished, use the current setting.
-		$workouts_option = $this->options_helper->get( 'workouts_data' );
-		$finished_steps  = (array) $workouts_option['configuration']['finishedSteps'];
-		if ( \in_array( 'enableTracking', $finished_steps, true ) ) {
-			$tracking = $this->options_helper->get( 'tracking', false );
-		}
-
-		if ( \is_bool( $tracking ) ) {
-			$tracking = (int) $tracking;
-		}
-
-		return $tracking;
+		return $this->options_helper->get( 'tracking', $default );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid a critical race when finishing all the steps in a workout together.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the default behaviour of the tracking radiobuttons in the configuration workout to display the actual value from the database.
* Fixes an unreleased bug where the tracking option would be overwritten by the previous value when finishing the full configuration workout.
* Adds the link to step one "Learn more about the benefits of optimized SEO data.".

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Visit the configuration workout and look at the tracking radiobuttons in step 4
   * it should always display the current value from the database (so "no" by default on a new Free installation, "yes" by default on a new Premium installation, and the user-chosen value otherwise)
* set the opposite value for the tracking option and click on "Finish workout"
  * all the steps should be marked as complete
  * reload (or visit SEO > General) to check that the value is changed
  * repeat it multiple times, also with some steps already finished on their own
  * try also to set a non-URL value for some of the social profiles field and check that the tracking option choice is saved  and the step is completed, but not the full workout (you should be "scrolled up" to the failing step)


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-115]


[DUPP-115]: https://yoast.atlassian.net/browse/DUPP-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ