### PR TITLE
Update Elementor introduction dialog styling

### DIFF
--- a/css/src/elementor.css
+++ b/css/src/elementor.css
@@ -199,17 +199,25 @@
 
 /* Introduction message */
 #yoast-introduction {
-	z-index: 1;
+	position: absolute !important;
 	top: 5px!important;
 	left: 41px!important;
+	z-index: 1;
+	background-color: #fff;
+	border-radius: 3px;
 	box-shadow: var(--yoast-shadow-default);
 	text-align: left;
 	padding: 20px;
 }
 
 #yoast-introduction::before {
+	content: "";
+	position: absolute;
 	left: -12px;
 	top: 8px;
+	border: solid transparent;
+	border-width: 7px 5px;
+	border-bottom-color: #fff;
 	transform: rotate(-90deg);
 }
 
@@ -222,9 +230,21 @@
 	line-height: 1.3;
 }
 
+#yoast-introduction > .dialog-message {
+	margin-top: 0.5em;
+}
+
 #yoast-introduction > .dialog-buttons-wrapper {
+	display: flex;
 	justify-content: flex-end;
 	margin-top: 12px;
+}
+
+#yoast-introduction .dialog-button {
+	background-color: var(--yoast-color-primary);
+	padding: 7px 17px;
+	font-size: 12px;
+	text-transform: capitalize;
 }
 
 /* All hover effects */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Elementor [changed the styling of their dialogs](https://github.com/elementor/elementor/blob/35887cb30964386cb9eaba449afb28e223ad5423/assets/dev/scss/editor/_introduction.scss) which has broken our introduction message dialog. To have a proper introduction message again we had to fix the styling.
* Currently it looks like this:
<img width="907" alt="Screenshot 2021-11-25 at 15 20 35" src="https://user-images.githubusercontent.com/69148430/143460291-9753f286-cb65-42da-898e-61e84d71ab06.png">

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the styling of our Introduction dialog in Elementor was broken due to changes in Elementor.

## Relevant technical choices:

* Had to overrule inline styled positioning using `!important`
* As we now have to style the button ourselves as well I took the liberty to make it slightly more Yoastie

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate this branch or 17.8RC
* Install and activate the latest version of Elementor
* Make sure you haven't yet acknowledged our Introduction message in Elementor. If not:
    * Deactivate Yoast SEO
    * Remove the `elementor_introduction` meta_key from the `wp_usermeta` table in your WP database
    * Activate Yoast SEO
* Edit a Post or Page with Elementor
* You should see our Introduction message Dialog
* The Dialog should look like this:
<img width="755" alt="Screenshot 2021-11-25 at 15 23 54" src="https://user-images.githubusercontent.com/69148430/143460152-ce56628d-2db1-49e8-b8f9-31b1b22eef69.png">

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes P1-1067
