### PR TITLE
P1 1036 support initial SEO store state

### DIFF
--- a/apps/seo-integration/src/app.js
+++ b/apps/seo-integration/src/app.js
@@ -1,6 +1,6 @@
 import { useDispatch, useSelect } from "@wordpress/data";
 import { useCallback } from "@wordpress/element";
-import { SEO_STORE_NAME, useAnalyze } from "@yoast/seo-store";
+import { SEO_STORE_NAME, useAnalyze } from "@yoast/seo-integration";
 import { debounce } from "lodash";
 import "./app.css";
 
@@ -29,10 +29,21 @@ const Editor = () => {
 			<h1>Editor</h1>
 			<label htmlFor="editor-title">Title</label>
 			<div className="inline-flex">
-				<input id="editor-title" name="title" onChange={ handleTitleChange } />
+				<input
+					id="editor-title"
+					name="title"
+					onChange={ handleTitleChange }
+					defaultValue="This is the initial title"
+				/>
 			</div>
 			<label htmlFor="editor-content">Content</label>
-			<textarea id="editor-content" name="content" rows="16" onChange={ handleContentChange } />
+			<textarea
+				id="editor-content"
+				name="content"
+				rows="16"
+				onChange={ handleContentChange }
+				defaultValue="This is the initial content and the initial title is: %%title%%"
+			/>
 			<label htmlFor="editor-permalink">Permalink</label>
 			<div className="inline-flex">
 				<input id="editor-permalink" name="permalink" type="url" pattern="https?://.*" onChange={ handlePermalinkChange } />

--- a/apps/seo-integration/src/index.js
+++ b/apps/seo-integration/src/index.js
@@ -17,6 +17,12 @@ const load = async () => {
 				replacementVariableConfigurations: createPostReplacementVariables( defaultReplacementVariableConfigurations ),
 			},
 		},
+		initialState: {
+			editor: {
+				title: "This is the initial title",
+				content: "This is the initial content and the initial title is: %%title%%"
+			}
+		},
 	} );
 
 	console.log( "replacement variables interface, per analysis type", analysisTypeReplacementVariables );

--- a/apps/seo-integration/src/replacement-variables.js
+++ b/apps/seo-integration/src/replacement-variables.js
@@ -1,5 +1,5 @@
 import { select } from "@wordpress/data";
-import { SEO_STORE_NAME } from "@yoast/seo-store";
+import { SEO_STORE_NAME } from "@yoast/seo-integration";
 
 const logReplacementVariable = config => ( {
 	...config,

--- a/packages/seo-integration/src/index.js
+++ b/packages/seo-integration/src/index.js
@@ -19,6 +19,8 @@ import { mapValues } from "lodash";
 import createAnalysisWorker from "./analysis";
 import createAnalysisTypeReplacementVariables from "./replacement-variables";
 
+export { SEO_STORE_NAME, useAnalyze } from "@yoast/seo-store";
+
 /*
  * The implementation is responsible for the replacement variable configurations per analysis type.
  * This provides a way to get the default configurations to pick from.
@@ -32,6 +34,7 @@ export { createDefaultReplacementVariableConfigurations } from "./replacement-va
  * @param {string} analysisResearcherUrl The URL of the analysis researcher.
  * @param {Object} [analysisConfiguration] The analysis configuration. Defaults to a English (US) locale.
  * @param {Object.<string, AnalysisType>} [analysisTypes] The different analysis types and their configuration.
+ * @param {Object.<string, Object>} [initialState] The initial state for the SEO store.
  *
  * @returns {Promise<SeoIntegrationInterface>} The promise of the SEO integration interface.
  */
@@ -49,6 +52,7 @@ const createSeoIntegration = async ( {
 			replacementVariableConfigurations: [],
 		},
 	},
+	initialState = {},
 } = {} ) => {
 	const analysisWorker = await createAnalysisWorker( {
 		workerUrl: analysisWorkerUrl,
@@ -56,7 +60,7 @@ const createSeoIntegration = async ( {
 		configuration: analysisConfiguration,
 	} );
 
-	registerSeoStore( { analyze: analysisWorker.analyze } );
+	registerSeoStore( { initialState, analyze: analysisWorker.analyze } );
 
 	const { set, unregister } = createAnalysisTypeReplacementVariables( mapValues( analysisTypes, "replacementVariableConfigurations" ) );
 

--- a/packages/seo-store/src/analysis/slice/config.js
+++ b/packages/seo-store/src/analysis/slice/config.js
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { get } from "lodash";
 
-const initialState = {
+export const initialConfigState = {
 	analysisType: "post",
 	isSeoActive: true,
 	isReadabilityActive: true,
@@ -10,7 +10,7 @@ const initialState = {
 
 const configSlice = createSlice( {
 	name: "config",
-	initialState,
+	initialState: initialConfigState,
 	reducers: {
 		updateAnalysisType: ( state, { payload } ) => {
 			state.analysisType = payload;

--- a/packages/seo-store/src/analysis/slice/config.js
+++ b/packages/seo-store/src/analysis/slice/config.js
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { get } from "lodash";
 
-export const initialConfigState = {
+export const defaultConfigState = {
 	analysisType: "post",
 	isSeoActive: true,
 	isReadabilityActive: true,
@@ -10,7 +10,7 @@ export const initialConfigState = {
 
 const configSlice = createSlice( {
 	name: "config",
-	initialState: initialConfigState,
+	initialState: defaultConfigState,
 	reducers: {
 		updateAnalysisType: ( state, { payload } ) => {
 			state.analysisType = payload;

--- a/packages/seo-store/src/analysis/slice/index.js
+++ b/packages/seo-store/src/analysis/slice/index.js
@@ -2,8 +2,13 @@ import { createSelector } from "@reduxjs/toolkit";
 import { combineReducers } from "@wordpress/data";
 import { editorSelectors } from "../../editor/slice";
 import { formSelectors } from "../../form/slice";
-import configReducer, { configActions, configSelectors } from "./config";
-import resultsReducer, { resultsActions, resultsSelectors } from "./results";
+import configReducer, { configActions, configSelectors, initialConfigState } from "./config";
+import resultsReducer, { resultsActions, resultsSelectors, initialResultsState } from "./results";
+
+export const initialAnalysisState = {
+	config: initialConfigState,
+	results: initialResultsState,
+};
 
 export const analysisSelectors = {
 	...resultsSelectors,

--- a/packages/seo-store/src/analysis/slice/index.js
+++ b/packages/seo-store/src/analysis/slice/index.js
@@ -2,12 +2,12 @@ import { createSelector } from "@reduxjs/toolkit";
 import { combineReducers } from "@wordpress/data";
 import { editorSelectors } from "../../editor/slice";
 import { formSelectors } from "../../form/slice";
-import configReducer, { configActions, configSelectors, initialConfigState } from "./config";
-import resultsReducer, { resultsActions, resultsSelectors, initialResultsState } from "./results";
+import configReducer, { configActions, configSelectors, defaultConfigState } from "./config";
+import resultsReducer, { resultsActions, resultsSelectors, defaultResultsState } from "./results";
 
-export const initialAnalysisState = {
-	config: initialConfigState,
-	results: initialResultsState,
+export const defaultAnalysisState = {
+	config: defaultConfigState,
+	results: defaultResultsState,
 };
 
 export const analysisSelectors = {

--- a/packages/seo-store/src/analysis/slice/results.js
+++ b/packages/seo-store/src/analysis/slice/results.js
@@ -44,7 +44,7 @@ export function* analyze() {
 	}
 }
 
-const initialState = {
+export const initialResultsState = {
 	status: ASYNC_STATUS.IDLE,
 	error: "",
 	seo: {
@@ -66,7 +66,7 @@ const initialState = {
 
 const resultsSlice = createSlice( {
 	name: "results",
-	initialState,
+	initialState: initialResultsState,
 	reducers: {
 		updateActiveMarker: ( state, { payload } ) => {
 			state.activeMarker.id = payload.id;

--- a/packages/seo-store/src/analysis/slice/results.js
+++ b/packages/seo-store/src/analysis/slice/results.js
@@ -44,7 +44,7 @@ export function* analyze() {
 	}
 }
 
-export const initialResultsState = {
+export const defaultResultsState = {
 	status: ASYNC_STATUS.IDLE,
 	error: "",
 	seo: {
@@ -66,7 +66,7 @@ export const initialResultsState = {
 
 const resultsSlice = createSlice( {
 	name: "results",
-	initialState: initialResultsState,
+	initialState: defaultResultsState,
 	reducers: {
 		updateActiveMarker: ( state, { payload } ) => {
 			state.activeMarker.id = payload.id;

--- a/packages/seo-store/src/editor/slice.js
+++ b/packages/seo-store/src/editor/slice.js
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { get } from "lodash";
 
-export const initialEditorState = {
+export const defaultEditorState = {
 	content: "",
 	title: "",
 	permalink: "",
@@ -12,7 +12,7 @@ export const initialEditorState = {
 
 const editorSlice = createSlice( {
 	name: "editor",
-	initialState: initialEditorState,
+	initialState: defaultEditorState,
 	reducers: {
 		updateContent: ( state, action ) => {
 			state.content = action.payload;

--- a/packages/seo-store/src/editor/slice.js
+++ b/packages/seo-store/src/editor/slice.js
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { get } from "lodash";
 
-const initialState = {
+export const initialEditorState = {
 	content: "",
 	title: "",
 	permalink: "",
@@ -12,7 +12,7 @@ const initialState = {
 
 const editorSlice = createSlice( {
 	name: "editor",
-	initialState,
+	initialState: initialEditorState,
 	reducers: {
 		updateContent: ( state, action ) => {
 			state.content = action.payload;

--- a/packages/seo-store/src/form/slice/index.js
+++ b/packages/seo-store/src/form/slice/index.js
@@ -1,6 +1,11 @@
 import { combineReducers } from "@wordpress/data";
-import keyphrasesReducer, { keyphrasesActions, keyphrasesSelectors } from "./keyphrases";
-import seoReducer, { seoActions, seoSelectors } from "./seo";
+import seoReducer, { seoActions, seoSelectors, initialSeoState } from "./seo";
+import keyphrasesReducer, { keyphrasesActions, keyphrasesSelectors, initialKeyphrasesState } from "./keyphrases";
+
+export const initialFormState = {
+	seo: initialSeoState,
+	keyphrases: initialKeyphrasesState,
+};
 
 export const formSelectors = {
 	...seoSelectors,

--- a/packages/seo-store/src/form/slice/index.js
+++ b/packages/seo-store/src/form/slice/index.js
@@ -1,10 +1,10 @@
 import { combineReducers } from "@wordpress/data";
-import seoReducer, { seoActions, seoSelectors, initialSeoState } from "./seo";
-import keyphrasesReducer, { keyphrasesActions, keyphrasesSelectors, initialKeyphrasesState } from "./keyphrases";
+import seoReducer, { seoActions, seoSelectors, defaultSeoState } from "./seo";
+import keyphrasesReducer, { keyphrasesActions, keyphrasesSelectors, defaultKeyphrasesState } from "./keyphrases";
 
-export const initialFormState = {
-	seo: initialSeoState,
-	keyphrases: initialKeyphrasesState,
+export const defaultFormState = {
+	seo: defaultSeoState,
+	keyphrases: defaultKeyphrasesState,
 };
 
 export const formSelectors = {

--- a/packages/seo-store/src/form/slice/keyphrases.js
+++ b/packages/seo-store/src/form/slice/keyphrases.js
@@ -4,7 +4,7 @@ import { FOCUS_KEYPHRASE_ID } from "../../common/constants";
 
 export const MAX_RELATED_KEYPHRASES = 4;
 
-const initialState = {
+export const initialKeyphrasesState = {
 	[ FOCUS_KEYPHRASE_ID ]: {
 		id: FOCUS_KEYPHRASE_ID,
 		keyphrase: "",
@@ -26,7 +26,7 @@ const prepareWithFocusKeyphraseIdFallback = ( payload ) => ( {
 
 const keyphrasesSlice = createSlice( {
 	name: "keyphrases",
-	initialState,
+	initialState: initialKeyphrasesState,
 	reducers: {
 		updateKeyphrase: {
 			// Fallback to focus keyphrase if no ID is given.

--- a/packages/seo-store/src/form/slice/keyphrases.js
+++ b/packages/seo-store/src/form/slice/keyphrases.js
@@ -4,7 +4,7 @@ import { FOCUS_KEYPHRASE_ID } from "../../common/constants";
 
 export const MAX_RELATED_KEYPHRASES = 4;
 
-export const initialKeyphrasesState = {
+export const defaultKeyphrasesState = {
 	[ FOCUS_KEYPHRASE_ID ]: {
 		id: FOCUS_KEYPHRASE_ID,
 		keyphrase: "",
@@ -26,7 +26,7 @@ const prepareWithFocusKeyphraseIdFallback = ( payload ) => ( {
 
 const keyphrasesSlice = createSlice( {
 	name: "keyphrases",
-	initialState: initialKeyphrasesState,
+	initialState: defaultKeyphrasesState,
 	reducers: {
 		updateKeyphrase: {
 			// Fallback to focus keyphrase if no ID is given.

--- a/packages/seo-store/src/form/slice/seo.js
+++ b/packages/seo-store/src/form/slice/seo.js
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { get } from "lodash";
 
-export const initialSeoState = {
+export const defaultSeoState = {
 	title: "",
 	description: "",
 	slug: "",
@@ -10,7 +10,7 @@ export const initialSeoState = {
 
 const seoSlice = createSlice( {
 	name: "seo",
-	initialState: initialSeoState,
+	initialState: defaultSeoState,
 	reducers: {
 		updateSeoTitle: ( state, action ) => {
 			state.title = action.payload;

--- a/packages/seo-store/src/form/slice/seo.js
+++ b/packages/seo-store/src/form/slice/seo.js
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { get } from "lodash";
 
-const initialState = {
+export const initialSeoState = {
 	title: "",
 	description: "",
 	slug: "",
@@ -10,7 +10,7 @@ const initialState = {
 
 const seoSlice = createSlice( {
 	name: "seo",
-	initialState,
+	initialState: initialSeoState,
 	reducers: {
 		updateSeoTitle: ( state, action ) => {
 			state.title = action.payload;

--- a/packages/seo-store/src/index.js
+++ b/packages/seo-store/src/index.js
@@ -1,13 +1,20 @@
 import { combineReducers, createReduxStore, register } from "@wordpress/data";
+import { merge } from "lodash";
 import { STORE_NAME } from "./common/constants";
 import { ANALYZE_ACTION_NAME } from "./analysis/constants";
-import analysisReducer, { analysisActions, analysisSelectors } from "./analysis/slice";
-import editorReducer, { editorActions, editorSelectors } from "./editor/slice";
-import formReducer, { formActions, formSelectors } from "./form/slice";
+import analysisReducer, { analysisActions, analysisSelectors, initialAnalysisState } from "./analysis/slice";
+import editorReducer, { editorActions, editorSelectors, initialEditorState } from "./editor/slice";
+import formReducer, { formActions, formSelectors, initialFormState } from "./form/slice";
 
 export { STORE_NAME as SEO_STORE_NAME };
 
 export { useAnalyze } from "./analysis/hooks";
+
+export const defaultInitialState = {
+	analysis: initialAnalysisState,
+	editor: initialEditorState,
+	form: initialFormState,
+};
 
 export const actions = {
 	...analysisActions,
@@ -19,6 +26,12 @@ export const selectors = {
 	...analysisSelectors,
 	...editorSelectors,
 	...formSelectors,
+};
+
+export const reducers = {
+	analysis: analysisReducer,
+	editor: editorReducer,
+	form: formReducer,
 };
 
 /** @typedef {import("@wordpress/data/src/types").WPDataStore} WPDataStore */
@@ -35,12 +48,8 @@ const createSeoStore = ( { initialState, analyze } ) => {
 	return createReduxStore( STORE_NAME, {
 		actions,
 		selectors,
-		initialState,
-		reducer: combineReducers( {
-			analysis: analysisReducer,
-			editor: editorReducer,
-			form: formReducer,
-		} ),
+		initialState: merge( {}, defaultInitialState, initialState ),
+		reducer: combineReducers( reducers ),
 		controls: {
 			[ ANALYZE_ACTION_NAME ]: async ( { payload: { paper, keyphrases, config } } ) => analyze( paper, keyphrases, config ),
 		},

--- a/packages/seo-store/src/index.js
+++ b/packages/seo-store/src/index.js
@@ -10,30 +10,6 @@ export { STORE_NAME as SEO_STORE_NAME };
 
 export { useAnalyze } from "./analysis/hooks";
 
-const defaultState = {
-	analysis: defaultAnalysisState,
-	editor: defaultEditorState,
-	form: defaultFormState,
-};
-
-const actions = {
-	...analysisActions,
-	...editorActions,
-	...formActions,
-};
-
-const selectors = {
-	...analysisSelectors,
-	...editorSelectors,
-	...formSelectors,
-};
-
-const reducers = {
-	analysis: analysisReducer,
-	editor: editorReducer,
-	form: formReducer,
-};
-
 /** @typedef {import("@wordpress/data/src/types").WPDataStore} WPDataStore */
 
 /**
@@ -46,10 +22,30 @@ const reducers = {
  */
 const createSeoStore = ( { initialState, analyze } ) => {
 	return createReduxStore( STORE_NAME, {
-		actions,
-		selectors,
-		initialState: merge( {}, defaultState, initialState ),
-		reducer: combineReducers( reducers ),
+		actions: {
+			...analysisActions,
+			...editorActions,
+			...formActions,
+		},
+		selectors: {
+			...analysisSelectors,
+			...editorSelectors,
+			...formSelectors,
+		},
+		initialState: merge(
+			{},
+			{
+				analysis: defaultAnalysisState,
+				editor: defaultEditorState,
+				form: defaultFormState,
+			},
+			initialState,
+		),
+		reducer: combineReducers( {
+			analysis: analysisReducer,
+			editor: editorReducer,
+			form: formReducer,
+		} ),
 		controls: {
 			[ ANALYZE_ACTION_NAME ]: async ( { payload: { paper, keyphrases, config } } ) => analyze( paper, keyphrases, config ),
 		},

--- a/packages/seo-store/src/index.js
+++ b/packages/seo-store/src/index.js
@@ -2,33 +2,33 @@ import { combineReducers, createReduxStore, register } from "@wordpress/data";
 import { merge } from "lodash";
 import { STORE_NAME } from "./common/constants";
 import { ANALYZE_ACTION_NAME } from "./analysis/constants";
-import analysisReducer, { analysisActions, analysisSelectors, initialAnalysisState } from "./analysis/slice";
-import editorReducer, { editorActions, editorSelectors, initialEditorState } from "./editor/slice";
-import formReducer, { formActions, formSelectors, initialFormState } from "./form/slice";
+import analysisReducer, { analysisActions, analysisSelectors, defaultAnalysisState } from "./analysis/slice";
+import editorReducer, { editorActions, editorSelectors, defaultEditorState } from "./editor/slice";
+import formReducer, { formActions, formSelectors, defaultFormState } from "./form/slice";
 
 export { STORE_NAME as SEO_STORE_NAME };
 
 export { useAnalyze } from "./analysis/hooks";
 
-export const defaultInitialState = {
-	analysis: initialAnalysisState,
-	editor: initialEditorState,
-	form: initialFormState,
+const defaultState = {
+	analysis: defaultAnalysisState,
+	editor: defaultEditorState,
+	form: defaultFormState,
 };
 
-export const actions = {
+const actions = {
 	...analysisActions,
 	...editorActions,
 	...formActions,
 };
 
-export const selectors = {
+const selectors = {
 	...analysisSelectors,
 	...editorSelectors,
 	...formSelectors,
 };
 
-export const reducers = {
+const reducers = {
 	analysis: analysisReducer,
 	editor: editorReducer,
 	form: formReducer,
@@ -48,7 +48,7 @@ const createSeoStore = ( { initialState, analyze } ) => {
 	return createReduxStore( STORE_NAME, {
 		actions,
 		selectors,
-		initialState: merge( {}, defaultInitialState, initialState ),
+		initialState: merge( {}, defaultState, initialState ),
 		reducer: combineReducers( reducers ),
 		controls: {
 			[ ANALYZE_ACTION_NAME ]: async ( { payload: { paper, keyphrases, config } } ) => analyze( paper, keyphrases, config ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds support for setting initial SEO store state via `seo-integration` package.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/seo-integration] Adds support for setting initial SEO store state via seo-integration package.

## Relevant technical choices:

* Combine all slice `defaultStates` into a general `defaultState` which will be merged with `initialState` from factory args to ensure entire state shape.
* Should we only support initial editor state?
* Re-export `SEO_STORE_NAME` and `useAnalyse` from `seo-store` in `seo-integration` package so that implementor only has to use imports from `seo-integration` package.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Fire up the example `seo-integration` app using `yarn start`.
* Immediately after render, check if the initial `title` and `content` states are in Redux store.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
