### PR TITLE
Increase priority of workouts to be above the priority of premium

### DIFF
--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -124,7 +124,7 @@ class Workouts_Integration implements Integration_Interface {
 		}
 
 		// Copy only the Workouts page item that comes first in the array.
-		$result_submenu_pages = [];
+		$result_submenu_pages      = [];
 		$workouts_page_encountered = false;
 		foreach ( $submenu_pages as $item ) {
 			if ( $item[4] !== 'wpseo_workouts' || ! $workouts_page_encountered ) {

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -86,6 +86,7 @@ class Workouts_Integration implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_filter( 'wpseo_submenu_pages', [ $this, 'add_submenu_page' ], 8 );
+		\add_filter( 'wpseo_submenu_pages', [ $this, 'remove_old_submenu_page' ], 10 );
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ], 11 );
 		\add_action( 'admin_notices', [ $this, 'configuration_workout_notice' ] );
 	}
@@ -95,20 +96,9 @@ class Workouts_Integration implements Integration_Interface {
 	 *
 	 * @param array $submenu_pages The Yoast SEO submenu pages.
 	 *
-	 * @return array the filtered submenu pages.
+	 * @return array The filtered submenu pages.
 	 */
 	public function add_submenu_page( $submenu_pages ) {
-		// If Premium has an outdated version, which also adds a 'workouts' submenu, don't show the Premium submenu.
-		if ( $this->should_update_premium() ) {
-			$submenu_pages = array_filter(
-				$submenu_pages,
-				function ( $item ) {
-					return $item[4] !== 'wpseo_workouts';
-				}
-			);
-		}
-
-		// This inserts the workouts menu page at the correct place in the array without overriding that position.
 		$submenu_pages[] = [
 			'wpseo_dashboard',
 			'',
@@ -119,6 +109,33 @@ class Workouts_Integration implements Integration_Interface {
 		];
 
 		return $submenu_pages;
+	}
+
+	/**
+	 * Removes the workouts submenu page from older Premium versions
+	 *
+	 * @param array $submenu_pages The Yoast SEO submenu pages.
+	 *
+	 * @return array The filtered submenu pages.
+	 */
+	public function remove_old_submenu_page( $submenu_pages ) {
+		if ( ! $this->should_update_premium() ) {
+			return $submenu_pages;
+		}
+
+		// Copy only the Workouts page item that comes first in the array.
+		$result_submenu_pages = [];
+		$workouts_page_encountered = false;
+		foreach ( $submenu_pages as $item ) {
+			if ( $item[4] !== 'wpseo_workouts' || ! $workouts_page_encountered ) {
+				$result_submenu_pages[] = $item;
+			}
+			if ( $item[4] === 'wpseo_workouts' ) {
+				$workouts_page_encountered = true;
+			}
+		}
+
+		return $result_submenu_pages;
 	}
 
 	/**

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -85,7 +85,7 @@ class Workouts_Integration implements Integration_Interface {
 	 * {@inheritDoc}
 	 */
 	public function register_hooks() {
-		\add_filter( 'wpseo_submenu_pages', [ $this, 'add_submenu_page' ], 9 );
+		\add_filter( 'wpseo_submenu_pages', [ $this, 'add_submenu_page' ], 8 );
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ], 11 );
 		\add_action( 'admin_notices', [ $this, 'configuration_workout_notice' ] );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Premium redirects submenu page coming it at priority 9 in the sibling PR in premium. This can put it above workouts, which is not what we want.
* Context https://yoast.slack.com/archives/C027BFR5L/p1637576075263300

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the workouts menu item could be below premium menu items.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test with the [sibling PR](https://github.com/Yoast/wordpress-seo-premium/pull/3503) in premium, and News SEO.
  * the order should be: Workouts, Redirects, News SEO

* check the behaviour with previous versions of Premium:
  * install Premium 17.6
  * you shouldn't see **two** Workouts pages
  * the order should be: Workouts, Redirects, News SEO
  * visiting the Workouts page you should get the notification inviting you to update Premium


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.slack.com/archives/C027BFR5L/p1637576075263300
