### PR TITLE
Fix compatibility indexation with premium <17.7

### DIFF
--- a/css/src/workouts.css
+++ b/css/src/workouts.css
@@ -70,6 +70,12 @@
 	margin-left:48px;
 }
 
+/* Override premium 17.6 workout styles */
+.workflow li li {
+	counter-increment: none;
+	padding-bottom: 0;
+}
+
 .workflow li.step {
 	position: relative;
 	counter-increment: line-number;
@@ -144,6 +150,7 @@
 
 .workflow .indexation-container {
 	padding: 8px 0;
+	margin-bottom: 8px;
 }
 
 .workflow .indexation-container > .yoast-button {
@@ -184,6 +191,10 @@
 	background-size: 20px 20px;
 	background-repeat: no-repeat;
 	background-position: center center;
+}
+
+.workflow li.step p.disabled {
+	opacity: 0.5;
 }
 
 .workflow li.step.finished p,

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -472,14 +472,37 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 						),
 						"https://yoa.st/config-workout-index-data"
 					) }
+					subtitleClass={ window.wpseoWorkoutsData.shouldUpdatePremium ? "disabled" : "" }
 					ImageComponent={ WorkoutStartImage }
 					isFinished={ isStep1Finished }
 				>
 					<div className="indexation-container">
 						<WorkoutIndexation
 							indexingStateCallback={ setIndexingState }
+							isEnabled={ ! window.wpseoWorkoutsData.shouldUpdatePremium }
+							indexingState={ indexingState }
 						/>
 					</div>
+					{ ( window.wpseoWorkoutsData.shouldUpdatePremium && indexingState !== "completed" ) && <Alert type="warning">
+						<p>{
+							sprintf( __( "This workout step is currently disabled, because you're not running the latest version of Yoast SEO Premium. " +
+							"Please update to the latest version (at least %1$s). ",
+							"wordpress-seo"
+							), "17.7"
+							)
+						}</p>
+						<p>{
+							addLinkToString(
+								sprintf(
+									__( "You can still run the SEO data optimization in the %1$sTools section%2$s. " +
+									"Once that is finished, please refresh this workout.", "wordpress-seo" ),
+									"<a>",
+									"</a>"
+								),
+								window.wpseoWorkoutsData.toolsPageUrl
+							) }
+						</p>
+					</Alert> }
 					<FinishButtonSection
 						stepNumber={ 1 }
 						hasDownArrow={ true }

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -485,6 +485,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 					</div>
 					{ ( window.wpseoWorkoutsData.shouldUpdatePremium && indexingState !== "completed" ) && <Alert type="warning">
 						<p>{
+							// translators: %1$s is replaced by a version number.
 							sprintf( __( "This workout step is currently disabled, because you're not running the latest version of Yoast SEO Premium. " +
 							"Please update to the latest version (at least %1$s). ",
 							"wordpress-seo"
@@ -494,6 +495,7 @@ export function ConfigurationWorkout( { toggleStep, finishSteps, reviseStep, tog
 						<p>{
 							addLinkToString(
 								sprintf(
+									// translators: %1$s and %2$s are replaced by anchor tags to make a link to the tool section.
 									__( "You can still run the SEO data optimization in the %1$sTools section%2$s. " +
 									"Once that is finished, please refresh this workout.", "wordpress-seo" ),
 									"<a>",

--- a/packages/js/src/workouts/components/Steps.js
+++ b/packages/js/src/workouts/components/Steps.js
@@ -77,13 +77,13 @@ FinishButtonSection.defaultProps = {
  *
  * @returns {WPElement} The Step component.
  */
-export function Step( { title, subtitle, isFinished, ImageComponent, children } ) {
+export function Step( { title, subtitle, subtitleClass, isFinished, ImageComponent, children } ) {
 	const finished = isFinished ? " finished" : "";
 	return (
 		<li className={ `step${finished}` }>
 			<h4>{ title }</h4>
 			<div style={ { display: "flex" } }>
-				{ subtitle && <p>{ subtitle }</p> }
+				{ subtitle && <p className={ subtitleClass }>{ subtitle }</p> }
 				{ ImageComponent && <ImageComponent style={ { height: "119px", width: "100px", flexShrink: 0 } } /> }
 			</div>
 			{ children }
@@ -94,6 +94,7 @@ export function Step( { title, subtitle, isFinished, ImageComponent, children } 
 Step.propTypes = {
 	title: PropTypes.string.isRequired,
 	subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ),
+	subtitleClass: PropTypes.string,
 	isFinished: PropTypes.bool,
 	ImageComponent: PropTypes.func,
 	children: PropTypes.any.isRequired,
@@ -101,6 +102,7 @@ Step.propTypes = {
 
 Step.defaultProps = {
 	subtitle: null,
+	subtitleClass: "",
 	ImageComponent: null,
 	isFinished: false,
 };

--- a/packages/js/src/workouts/components/WorkoutIndexation.js
+++ b/packages/js/src/workouts/components/WorkoutIndexation.js
@@ -22,7 +22,7 @@ window.yoast.indexing = window.yoast.indexing || {};
 export function WorkoutIndexation( { indexingStateCallback, indexingState, isEnabled } ) {
 	if ( ! isEnabled ) {
 		if ( indexingState === "completed" ) {
-			return <Alert style={ { opacity: "0.5" } }type="success">{ __( "SEO data optimization complete", "wordpress-seo" ) }</Alert>;
+			return <Alert type="success">{ __( "SEO data optimization complete", "wordpress-seo" ) }</Alert>;
 		}
 		return <button className="yoast-button yoast-button--primary" type="button" disabled={ true }>Start SEO data optimization</button>;
 	}

--- a/packages/js/src/workouts/components/WorkoutIndexation.js
+++ b/packages/js/src/workouts/components/WorkoutIndexation.js
@@ -35,8 +35,12 @@ export function WorkoutIndexation( { indexingStateCallback, indexingState, isEna
 
 WorkoutIndexation.propTypes = {
 	indexingStateCallback: PropTypes.func.isRequired,
-	indexingState: PropTypes.func.isRequired,
-	isEnabled: PropTypes.func.isRequired,
+	indexingState: PropTypes.string.isRequired,
+	isEnabled: PropTypes.bool,
+};
+
+WorkoutIndexation.defaultProps = {
+	isEnabled: true,
 };
 
 /**

--- a/packages/js/src/workouts/components/WorkoutIndexation.js
+++ b/packages/js/src/workouts/components/WorkoutIndexation.js
@@ -1,5 +1,7 @@
 import Indexation from "../../components/Indexation";
 import PropTypes from "prop-types";
+import { Alert } from "@yoast/components";
+import { __ } from "@wordpress/i18n";
 
 const preIndexingActions = {};
 const indexingActions = {};
@@ -10,16 +12,32 @@ window.yoast.indexing = window.yoast.indexing || {};
 /**
  * A wrapped Indexation for the configuration workout.
  *
- * @param {function} indexingStateCallback   The function to call back on state updates.
+ * @param {Object}   props                       The props object.
+ * @param {function} props.indexingStateCallback The function to call back on state updates.
+ * @param {Boolean}  props.isEnabled             Whether the indexation component should be real or a dummy.
+ * @param {string}   props.indexingState         The state of the indexation.
+ *
  * @returns {WPElement} A wrapped Indexation for the configuration workout.
  */
-export function WorkoutIndexation( { indexingStateCallback } ) {
+export function WorkoutIndexation( { indexingStateCallback, indexingState, isEnabled } ) {
+	if ( ! isEnabled ) {
+		if ( indexingState === "completed" ) {
+			return <Alert style={ { opacity: "0.5" } }type="success">{ __( "SEO data optimization complete", "wordpress-seo" ) }</Alert>;
+		}
+		return <button className="yoast-button yoast-button--primary" type="button" disabled={ true }>Start SEO data optimization</button>;
+	}
 	return <Indexation
 		preIndexingActions={ preIndexingActions }
 		indexingActions={ indexingActions }
 		indexingStateCallback={ indexingStateCallback }
 	/>;
 }
+
+WorkoutIndexation.propTypes = {
+	indexingStateCallback: PropTypes.func.isRequired,
+	indexingState: PropTypes.func.isRequired,
+	isEnabled: PropTypes.func.isRequired,
+};
 
 /**
  * Registers a pre-indexing action on the given indexing endpoint.
@@ -49,12 +67,4 @@ window.yoast.indexing.registerPreIndexingAction = ( endpoint, action ) => {
  */
 window.yoast.indexing.registerIndexingAction = ( endpoint, action ) => {
 	indexingActions[ endpoint ] = action;
-};
-
-WorkoutIndexation.propTypes = {
-	indexingStateCallback: PropTypes.any,
-};
-
-WorkoutIndexation.defaultProps = {
-	indexingStateCallback: null,
 };

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -166,6 +166,7 @@ class Workouts_Integration implements Integration_Interface {
 				'toolsPageUrl'              => \esc_url( \admin_url( 'admin.php?page=wpseo_tools' ) ),
 				'usersPageUrl'              => \esc_url( \admin_url( 'users.php' ) ),
 				'isPremium'                 => $this->product_helper->is_premium(),
+				'shouldUpdatePremium'       => $this->should_update_premium(),
 				'upsellText'                => $this->get_upsell_text(),
 				'upsellLink'                => $this->get_upsell_link(),
 				'canDoConfigurationWorkout' => $this->user_can_do_configuration_workout(),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* On Premium <17.7 indexation cannot be run from the workout.
* To prevent issues, we usher the user towards the Tools section and disable step 1.

New case: Indexation needed, Premium outdated
![image](https://user-images.githubusercontent.com/26220788/143586767-e4a36282-c89f-4f5d-ba8c-134e6549837f.png)

New case: Indexation done, Premium outdated
![image](https://user-images.githubusercontent.com/26220788/143586819-17fe91e8-a781-45af-9ab1-332ea5160f8c.png)

Fixed this bug too: Premium oudated, styling and step number issues:
![image](https://user-images.githubusercontent.com/26220788/143586843-af737339-aa44-44e0-a725-c9f6b0c39df3.png)


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where users who had updated Free to 17.7 but had Premium at an older version got caught in an indexation loop on the Configuration Workout.

## Relevant technical choices:

* Bug is prevented by not offering indexation in the workouts for users with an outdated premium. In stead, we send them to the tools page and ask them to refresh afterwards. Completion of the workout should be as in other cases.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* **Free 17.7 and Premium 17.7**
	* Indexation should work as in all previous RCs.
	* Steps should have correct numbers.
* **Free 17.7 only**
	* Should look exactly the same as in the previous case
* **Free 17.7 and Premium <17.7 (e.g. checkout master for devs)**
	* Indexation should be disabled in step 1, an Alert should be displayed.
	* A link should direct users to tools.
	* Upon completion of the indexation, a refresh of the workout should complete step 1.
	* Only then should the user be able to finish the workout with the button below.



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-118
