### PR TITLE
Wincher: ensure that collect_all_keyphrases does not collect from taxonomies

### DIFF
--- a/src/actions/wincher/wincher-keyphrases-action.php
+++ b/src/actions/wincher/wincher-keyphrases-action.php
@@ -300,6 +300,7 @@ class Wincher_Keyphrases_Action {
 				->query()
 				->select( 'primary_focus_keyword' )
 				->where_not_null( 'primary_focus_keyword' )
+				->where('object_type', 'post')
 				->distinct()
 				->find_array(),
 			'primary_focus_keyword'

--- a/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
+++ b/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
@@ -251,7 +251,7 @@ class Wincher_Keyphrases_Action_Test extends TestCase {
 			->andReturns( '12345' );
 
 		$this->indexable_repository
-			->expects( 'query->select->where_not_null->distinct->find_array' )
+			->expects( 'query->select->where_not_null->where->distinct->find_array' )
 			->andReturns(
 				[
 					[ 'primary_focus_keyword' => 'yoast seo' ],
@@ -507,7 +507,7 @@ class Wincher_Keyphrases_Action_Test extends TestCase {
 		);
 
 		$this->indexable_repository
-			->expects( 'query->select->where_not_null->distinct->find_array' )
+			->expects( 'query->select->where_not_null->where->distinct->find_array' )
 			->andReturns(
 				[
 					[ 'primary_focus_keyword' => 'yoast seo' ],
@@ -578,7 +578,7 @@ class Wincher_Keyphrases_Action_Test extends TestCase {
 		);
 
 		$this->indexable_repository
-			->expects( 'query->select->where_not_null->distinct->find_array' )
+			->expects( 'query->select->where_not_null->where->distinct->find_array' )
 			->andReturns(
 				[
 					[ 'primary_focus_keyword' => 'yoast seo' ],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Don't collect keyphrases from taxonomies when using the "Add existing keyphrases" functionality.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the "Add existing keyphrases" functionality of the Wincher integration would collect and add keyphrases from taxonomies as well.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Change the focus keyphrase of a taxonomy
* Use the "Add existing keyphrases" button
* Ensure that the focus keyphrase you set on the taxonomy was not added to Wincher.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
