### PR TITLE
PLUGIN-1421 fix route name + add some input validation

### DIFF
--- a/src/actions/importing/deactivate-conflicting-plugins-action.php
+++ b/src/actions/importing/deactivate-conflicting-plugins-action.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Actions\Importing;
 
-use wpdb;
 use Yoast\WP\SEO\Conditionals\AIOSEO_V4_Importer_Conditional;
 use Yoast\WP\SEO\Config\Conflicting_Plugins;
 use Yoast\WP\SEO\Helpers\Options_Helper;
@@ -27,7 +26,7 @@ class Deactivate_Conflicting_Plugins_Action extends Abstract_Importing_Action {
 	 *
 	 * @var string
 	 */
-	const TYPE = 'deactivation';
+	const TYPE = 'deactivate';
 
 	/**
 	 * Knows all plugins that might possibly conflict.

--- a/src/routes/importing-route.php
+++ b/src/routes/importing-route.php
@@ -65,9 +65,21 @@ class Importing_Route extends Abstract_Action_Route {
 	 *
 	 * @param mixed $data The request parameters.
 	 *
-	 * @return WP_REST_Response|false Response or false on non-existent route.
+	 * @return WP_REST_Response|WP_Error Response with next endpoint, or WP_Error on non-existent route.
 	 */
 	public function execute( $data ) {
+		if ( ! is_array( $data ) ||
+			 ! array_key_exists( 'plugin', $data ) ||
+			 ! array_key_exists( 'type', $data ) ) {
+			return new WP_Error(
+				'wpseo_missing_arguments',
+				'Plugin and/or type to import from were not specified',
+				[
+					'status' => 400,
+				]
+			);
+		}
+
 		$plugin = (string) $data['plugin'];
 		$type   = (string) $data['type'];
 

--- a/tests/unit/actions/importing/deactivate-conflicting-plugins-action-test.php
+++ b/tests/unit/actions/importing/deactivate-conflicting-plugins-action-test.php
@@ -83,7 +83,7 @@ class Deactivate_Conflicting_Plugins_Action_Test extends TestCase {
 
 			[
 				null,
-				'deactivation',
+				'deactivate',
 			],
 
 			[
@@ -93,7 +93,7 @@ class Deactivate_Conflicting_Plugins_Action_Test extends TestCase {
 
 			[
 				'conflicting-plugins',
-				'deactivation',
+				'deactivate',
 			],
 		];
 	}

--- a/tests/unit/routes/importing-route-test.php
+++ b/tests/unit/routes/importing-route-test.php
@@ -166,4 +166,55 @@ class Importing_Route_Test extends TestCase {
 
 		$this->assertInstanceOf( 'WP_Error', $response );
 	}
+
+	/**
+	 * Tests if invalid arguments are correctly refused.
+	 *
+	 * @param array $data The testcase.
+	 *
+	 *@covers ::execute
+	 *
+	 * @dataProvider invalid_input_provider
+	 */
+	public function test_invalid_input( $data ) {
+		// Act.
+		$result = $this->instance->execute( $data );
+
+		// Assert.
+		$this->assertTrue( is_wp_error( $result ) );
+	}
+
+	/**
+	 * Provides test data for test_invalid_input
+	 *
+	 * @return array The testcases.
+	 */
+	public function invalid_input_provider() {
+		return [
+			[
+				[
+					'plugin_missing' => 'plugin_id',
+					'type'           => 'data_type',
+				],
+			],
+			[
+				[
+					'plugin'       => 'plugin_id',
+					'type_missing' => 'data_type',
+				],
+			],
+			[
+				[
+					'plugin_missing' => 'plugin_id',
+					'type_missing'   => 'data_type',
+				],
+			],
+			[
+				[
+					'plugin' => 'plugin_id',
+					'type'   => 'data_type',
+				],
+			],
+		];
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* there was a discrepancy in the routing name. fixed it.
* there was very little input validation. added some.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* maintenance on the importing route

## Relevant technical choices:

* there was a discrepancy in the routing name. fixed it.
* there was very little input validation. added some.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* [re-run the tests for PR 17528](https://github.com/Yoast/wordpress-seo/pull/17528)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
