### PR TITLE
P1-1042 analysis results containers

### DIFF
--- a/apps/seo-integration/package.json
+++ b/apps/seo-integration/package.json
@@ -24,6 +24,7 @@
     "@wordpress/element": "^4.0.3",
     "@wordpress/hooks": "^3.2.1",
     "@wordpress/i18n": "^4.2.4",
+    "@yoast/analysis-report": "file:../../packages/analysis-report",
     "@yoast/search-metadata-previews": "file:../../packages/search-metadata-previews",
     "@yoast/seo-integration": "file:../../packages/seo-integration",
     "react-scripts": "4.0.3",

--- a/apps/seo-integration/public/worker-mock.js
+++ b/apps/seo-integration/public/worker-mock.js
@@ -1,3 +1,16 @@
+const createFakeResults = type => [
+	[ "error", -1 ],
+	[ "feedback", 0 ],
+	[ "bad", 4 ],
+	[ "ok", 5 ],
+	[ "good", 8 ],
+].map( ( [ name, score ] ) => ( {
+	identifier: `${ type }-${ name }-result`,
+	score,
+	marks: [],
+	text: `${ type } ${ name } result`,
+} ) );
+
 /* eslint-disable no-restricted-globals */
 self.onmessage = ( { data } ) => {
 	if ( ! data.type ) {
@@ -15,32 +28,12 @@ self.onmessage = ( { data } ) => {
 				seo: {
 					focus: {
 						score: 10,
-						results: [
-							{
-								score: -10,
-								rating: "bad",
-								hasMarks: false,
-								marker: [],
-								id: "test",
-								text: "Bad result text",
-								markerId: "testMarker",
-							},
-						],
+						results: createFakeResults( "SEO" ),
 					},
 				},
 				readability: {
 					score: 10,
-					results: [
-						{
-							score: -10,
-							rating: "bad",
-							hasMarks: false,
-							marker: [],
-							id: "test",
-							text: "Bad result text",
-							markerId: "testMarker",
-						},
-					],
+					results: createFakeResults( "Readability" ),
 				},
 				research: {
 					morphology: {},

--- a/apps/seo-integration/src/app.js
+++ b/apps/seo-integration/src/app.js
@@ -1,7 +1,8 @@
 import { useDispatch, useSelect } from "@wordpress/data";
 import { useCallback } from "@wordpress/element";
+import { ContentAnalysis } from "@yoast/analysis-report";
 import { SnippetEditor } from "@yoast/search-metadata-previews";
-import { SEO_STORE_NAME, useAnalyze, GooglePreviewContainer } from "@yoast/seo-integration";
+import { GooglePreviewContainer, ReadabilityResultsContainer, SEO_STORE_NAME, SeoResultsContainer, useAnalyze } from "@yoast/seo-integration";
 import { debounce } from "lodash";
 import "./app.css";
 
@@ -111,6 +112,10 @@ const Keyphrase = ( props ) => {
 				onChange={ handleSynonymsChange }
 				defaultValue={ initialSynonyms }
 			/>
+			{ props.id !== "focus" && <>
+				<h4>SEO Results</h4>
+				<SeoResultsContainer as={ ContentAnalysis } keyphraseId={ props.id } />
+			</> }
 		</fieldset>
 	);
 };
@@ -126,14 +131,14 @@ const App = () => {
 				<Keyphrases />
 				<GooglePreviewContainer as={ SnippetEditor } />
 				<h4>SEO Results</h4>
-				<div>...</div>
+				<SeoResultsContainer as={ ContentAnalysis } />
 				<h4>Readability Results</h4>
-				<div>...</div>
+				<ReadabilityResultsContainer as={ ContentAnalysis } />
 				<h4>Research Results</h4>
 				<div>...</div>
 			</aside>
 		</>
 	);
-}
+};
 
 export default App;

--- a/apps/seo-integration/src/index.js
+++ b/apps/seo-integration/src/index.js
@@ -20,8 +20,8 @@ const load = async () => {
 		initialState: {
 			editor: {
 				title: "This is the initial title",
-				content: "This is the initial content and the initial title is: %%title%%"
-			}
+				content: "This is the initial content and the initial title is: %%title%%",
+			},
 		},
 	} );
 

--- a/apps/seo-integration/yarn.lock
+++ b/apps/seo-integration/yarn.lock
@@ -2621,6 +2621,17 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yoast/analysis-report@file:../../packages/analysis-report":
+  version "1.21.0"
+  dependencies:
+    "@wordpress/i18n" "^1.1.0"
+    "@yoast/components" "^2.19.0"
+    "@yoast/helpers" "^0.16.0"
+    "@yoast/style-guide" "^0.13.0"
+    lodash "^4.17.11"
+    prop-types "^15.6.0"
+    styled-components "^5.2.1"
+
 "@yoast/components@^2.19.0":
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/@yoast/components/-/components-2.19.0.tgz#dcbf2478db88226c10f599b044df375c1e8ef6e6"
@@ -2697,8 +2708,8 @@
 "@yoast/seo-integration@file:../../packages/seo-integration":
   version "1.0.0"
   dependencies:
-    "@yoast/replacement-variables" "file:../../../../../../Library/Caches/Yarn/v6/npm-@yoast-seo-integration-1.0.0-7845cf08-fa83-4e3b-8b97-db2dce3d363a-1637841643144/node_modules/@yoast/replacement-variables"
-    "@yoast/seo-store" "file:../../../../../../Library/Caches/Yarn/v6/npm-@yoast-seo-integration-1.0.0-7845cf08-fa83-4e3b-8b97-db2dce3d363a-1637841643144/node_modules/@yoast/seo-store"
+    "@yoast/replacement-variables" "file:../../../../../../Library/Caches/Yarn/v6/npm-@yoast-seo-integration-1.0.0-d282093b-f0fe-4d19-b949-89594a0009d1-1638256462721/node_modules/@yoast/replacement-variables"
+    "@yoast/seo-store" "file:../../../../../../Library/Caches/Yarn/v6/npm-@yoast-seo-integration-1.0.0-d282093b-f0fe-4d19-b949-89594a0009d1-1638256462721/node_modules/@yoast/seo-store"
     lodash "^4.17.21"
 
 "@yoast/seo-store@file:../../packages/seo-store":

--- a/packages/seo-integration/src/analysis-result-containers/hooks.js
+++ b/packages/seo-integration/src/analysis-result-containers/hooks.js
@@ -1,0 +1,25 @@
+import { useDispatch, useSelect } from "@wordpress/data";
+import { useCallback } from "@wordpress/element";
+import { SEO_STORE_NAME } from "@yoast/seo-store";
+
+/**
+ * Provides the marker props.
+ *
+ * @returns {{handleMarkClick: function, markerId: string}} The markerId string and handleMarkClick function.
+ */
+export const useMarker = () => {
+	const markerId = useSelect( select => select( SEO_STORE_NAME ).selectActiveMarkerId() );
+	const { setMarker, resetMarker } = useDispatch( SEO_STORE_NAME );
+
+	const handleMarkClick = useCallback( ( id, marks ) => {
+		if ( id === markerId ) {
+			return resetMarker();
+		}
+		setMarker( id, marks );
+	}, [ markerId, setMarker, resetMarker ] );
+
+	return {
+		markerId,
+		handleMarkClick,
+	};
+};

--- a/packages/seo-integration/src/analysis-result-containers/index.js
+++ b/packages/seo-integration/src/analysis-result-containers/index.js
@@ -1,0 +1,2 @@
+export { default as ReadabilityResultsContainer } from "./readability";
+export { default as SeoResultsContainer } from "./seo";

--- a/packages/seo-integration/src/analysis-result-containers/readability.js
+++ b/packages/seo-integration/src/analysis-result-containers/readability.js
@@ -1,0 +1,48 @@
+import { useSelect } from "@wordpress/data";
+import { useMemo } from "@wordpress/element";
+import { SEO_STORE_NAME } from "@yoast/seo-store";
+import { PropTypes } from "prop-types";
+import { useMarker } from "./hooks";
+import { transformAnalysisResults } from "./transformers";
+
+/**
+ * Handles known data for a readability results component.
+ *
+ * @param {JSX.Element} as A readability results component.
+ * @param {Object} restProps Props to pass to the readability results component, that are unhandled by this container.
+ *
+ * @returns {JSX.Element} A wrapped readability results component.
+ */
+const ReadabilityResultsContainer = ( { as: Component, ...restProps } ) => {
+	const isReadabilityAnalysisActive = useSelect( select => select( SEO_STORE_NAME ).selectIsReadabilityAnalysisActive() );
+
+	// Render nothing when the readability analysis is not active.
+	if ( ! isReadabilityAnalysisActive ) {
+		return null;
+	}
+
+	const readabilityResults = useSelect( select => select( SEO_STORE_NAME ).selectReadabilityResults() );
+	const focusKeyphrase = useSelect( select => select( SEO_STORE_NAME ).selectKeyphrase() );
+
+	const transformedResults = useMemo( () => transformAnalysisResults( readabilityResults ), [ readabilityResults ] );
+
+	const { markerId, handleMarkClick } = useMarker();
+
+	return <Component
+		{ ...transformedResults }
+		keywordKey={ focusKeyphrase }
+		activeMarker={ markerId }
+		onMarkButtonClick={ handleMarkClick }
+		headingLevel={ restProps.headingLevel ?? 2 }
+		marksButtonClassName={ restProps.marksButtonClassName ?? "yoast-mark-button" }
+		{ ...restProps }
+	/>;
+};
+
+ReadabilityResultsContainer.propTypes = {
+	as: PropTypes.elementType.isRequired,
+};
+
+ReadabilityResultsContainer.defaultProps = {};
+
+export default ReadabilityResultsContainer;

--- a/packages/seo-integration/src/analysis-result-containers/seo.js
+++ b/packages/seo-integration/src/analysis-result-containers/seo.js
@@ -1,0 +1,56 @@
+import { useSelect } from "@wordpress/data";
+import { useMemo } from "@wordpress/element";
+import { SEO_STORE_NAME } from "@yoast/seo-store";
+import { FOCUS_KEYPHRASE_ID } from "@yoast/seo-store/build/common/constants";
+import { PropTypes } from "prop-types";
+import { useMarker } from "./hooks";
+import { transformAnalysisResults } from "./transformers";
+
+/**
+ * Handles known data for a SEO results component.
+ *
+ * @param {JSX.Element} as A SEO results component.
+ * @param {string} [keyphraseId] The keyphrase ID. Defaults to the ID of the focus keyphrase.
+ * @param {Object} restProps Props to pass to the SEO results component, that are unhandled by this container.
+ *
+ * @returns {JSX.Element} A wrapped SEO results component.
+ */
+const SeoResultsContainer = ( { as: Component, keyphraseId, ...restProps } ) => {
+	const isSeoAnalysisActive = useSelect( select => select( SEO_STORE_NAME ).selectIsSeoAnalysisActive() );
+
+	// Render nothing when the SEO analysis is not active.
+	if ( ! isSeoAnalysisActive ) {
+		return null;
+	}
+
+	const seoResults = useSelect( select => select( SEO_STORE_NAME ).selectSeoResults( keyphraseId ), [ keyphraseId ] );
+	const keyphrase = useSelect( select => select( SEO_STORE_NAME ).selectKeyphrase( keyphraseId ), [ keyphraseId ] );
+
+	const transformedResults = useMemo(
+		() => transformAnalysisResults( seoResults, keyphraseId === FOCUS_KEYPHRASE_ID ? "" : keyphraseId ),
+		[ seoResults ],
+	);
+
+	const { markerId, handleMarkClick } = useMarker();
+
+	return <Component
+		{ ...transformedResults }
+		keywordKey={ keyphrase }
+		activeMarker={ markerId }
+		onMarkButtonClick={ handleMarkClick }
+		headingLevel={ restProps.headingLevel ?? 2 }
+		marksButtonClassName={ restProps.marksButtonClassName ?? "yoast-mark-button" }
+		{ ...restProps }
+	/>;
+};
+
+SeoResultsContainer.propTypes = {
+	as: PropTypes.elementType.isRequired,
+	keyphraseId: PropTypes.string,
+};
+
+SeoResultsContainer.defaultProps = {
+	keyphraseId: FOCUS_KEYPHRASE_ID,
+};
+
+export default SeoResultsContainer;

--- a/packages/seo-integration/src/analysis-result-containers/transformers.js
+++ b/packages/seo-integration/src/analysis-result-containers/transformers.js
@@ -20,20 +20,21 @@
  * @property {AnalysisReportResult[]} considerationsResults The consideration results.
  */
 
-import { reduce } from "lodash";
-import { interpreters } from "yoastseo";
+import { isObject, reduce } from "lodash";
+import { AssessmentResult, interpreters } from "yoastseo";
 
 /**
  * Maps an AssessmentResult to an analysis report result.
  *
  * So that it can be used by @yoast/analysis-report's ContentAnalysis.
  *
- * @param {AssessmentResult} result Result provided by the analysis worker.
+ * @param {AssessmentResult|Object} assessmentResult Result provided by the analysis worker.
  * @param {string} idPrefix Prefix the ID with this, useful to namespace the results.
  *
  * @returns {AnalysisReportResult} The analysis report result.
  */
-const transformAnalysisResult = ( result, idPrefix = "" ) => {
+const transformAnalysisResult = ( assessmentResult, idPrefix = "" ) => {
+	const result = isObject( assessmentResult ) ? AssessmentResult.parse( assessmentResult ) : assessmentResult;
 	const score = result.getScore();
 	const rating = interpreters.scoreToRating( score );
 	let id = result.getIdentifier();
@@ -62,14 +63,14 @@ const transformAnalysisResult = ( result, idPrefix = "" ) => {
  * Transforms the analysis results, while grouping them by rating.
  *
  * @param {AssessmentResult[]} results The assessment results, as returned by the analysis.
- * @param {string} idPrefix Prefix the ID with this, useful to namespace the results.
+ * @param {string} [idPrefix] Prefix the ID with this, useful to namespace the results.
  *
  * @returns {Object.<string, AnalysisReportResults[]>} The assessment results, grouped by rating.
  */
 export const transformAnalysisResults = ( results = [], idPrefix = "" ) => reduce(
 	results,
 	( grouped, result ) => {
-		const transformed = transformAnalysisResult( result );
+		const transformed = transformAnalysisResult( result, idPrefix );
 
 		switch ( transformed.rating ) {
 			case "error":

--- a/packages/seo-integration/src/analysis-result-containers/transformers.js
+++ b/packages/seo-integration/src/analysis-result-containers/transformers.js
@@ -1,0 +1,102 @@
+/**
+ * @typedef {Object} AnalysisReportResult
+ *
+ * @property {number} score The score as a number.
+ * @property {string} rating The rating, which is the interpreted score.
+ * @property {string} text The feedback string.
+ * @property {string} id Unique ID. Used in the mark button as ID and passed to the callback.
+ * @property {Mark[]} marker The marks. Used as argument in the mark callback.
+ * @property {string} markerId Should be the same as the ID, used to check if a mark button is pressed.
+ * @property {bool} hasMarks Whether the result has something to mark.
+ */
+
+/**
+ * @typedef {Object} AnalysisReportResults
+ *
+ * @property {AnalysisReportResult[]} errorsResults The error results.
+ * @property {AnalysisReportResult[]} problemsResults The problem results.
+ * @property {AnalysisReportResult[]} improvementsResults The improvement results.
+ * @property {AnalysisReportResult[]} goodResults The good results.
+ * @property {AnalysisReportResult[]} considerationsResults The consideration results.
+ */
+
+import { reduce } from "lodash";
+import { interpreters } from "yoastseo";
+
+/**
+ * Maps an AssessmentResult to an analysis report result.
+ *
+ * So that it can be used by @yoast/analysis-report's ContentAnalysis.
+ *
+ * @param {AssessmentResult} result Result provided by the analysis worker.
+ * @param {string} idPrefix Prefix the ID with this, useful to namespace the results.
+ *
+ * @returns {AnalysisReportResult} The analysis report result.
+ */
+const transformAnalysisResult = ( result, idPrefix = "" ) => {
+	const score = result.getScore();
+	const rating = interpreters.scoreToRating( score );
+	let id = result.getIdentifier();
+
+	if ( idPrefix.length > 0 ) {
+		id = `${ idPrefix }:${ id }`;
+	}
+
+	return {
+		id,
+		markerId: id,
+		text: result.getText(),
+		score,
+		// Because of inconsistency between `yoastseo` and `@yoast/analysis-report`.
+		rating: rating === "ok" ? "OK" : rating,
+		hasMarks: result.hasMarks(),
+		/*
+		 * Returning the marks instead of the marker to decouple the marker from the results. Leaving the marking to the UI.
+		 * This is done here to be able to leave the AnalysisList package alone, where the `marker` is the attribute passed to the button callback.
+		 */
+		marker: result.getMarks(),
+	};
+};
+
+/**
+ * Transforms the analysis results, while grouping them by rating.
+ *
+ * @param {AssessmentResult[]} results The assessment results, as returned by the analysis.
+ * @param {string} idPrefix Prefix the ID with this, useful to namespace the results.
+ *
+ * @returns {Object.<string, AnalysisReportResults[]>} The assessment results, grouped by rating.
+ */
+export const transformAnalysisResults = ( results = [], idPrefix = "" ) => reduce(
+	results,
+	( grouped, result ) => {
+		const transformed = transformAnalysisResult( result );
+
+		switch ( transformed.rating ) {
+			case "error":
+				grouped.errorsResults.push( transformed );
+				break;
+			case "feedback":
+				grouped.considerationsResults.push( transformed );
+				break;
+			case "bad":
+				grouped.problemsResults.push( transformed );
+				break;
+			case "ok":
+			case "OK":
+				grouped.improvementsResults.push( transformed );
+				break;
+			case "good":
+				grouped.goodResults.push( transformed );
+				break;
+		}
+
+		return grouped;
+	},
+	{
+		errorsResults: [],
+		problemsResults: [],
+		improvementsResults: [],
+		goodResults: [],
+		considerationsResults: [],
+	},
+);

--- a/packages/seo-integration/src/index.js
+++ b/packages/seo-integration/src/index.js
@@ -29,6 +29,7 @@ export { SEO_STORE_NAME, useAnalyze } from "@yoast/seo-store";
 export { createDefaultReplacementVariableConfigurations } from "./replacement-variables";
 
 export { default as GooglePreviewContainer } from "./google-preview-container";
+export { ReadabilityResultsContainer, SeoResultsContainer } from "./analysis-result-containers";
 
 export { useSeoContext } from "./seo-context";
 

--- a/packages/seo-integration/src/index.js
+++ b/packages/seo-integration/src/index.js
@@ -17,20 +17,13 @@
 import registerSeoStore from "@yoast/seo-store";
 import { mapValues } from "lodash";
 import createAnalysisWorker from "./analysis";
-import { createSeoProvider } from "./seo-context";
 import createAnalysisTypeReplacementVariables from "./replacement-variables";
+import { createSeoProvider } from "./seo-context";
 
 export { SEO_STORE_NAME, useAnalyze } from "@yoast/seo-store";
-
-/*
- * The implementation is responsible for the replacement variable configurations per analysis type.
- * This provides a way to get the default configurations to pick from.
- */
-export { createDefaultReplacementVariableConfigurations } from "./replacement-variables";
-
-export { default as GooglePreviewContainer } from "./google-preview-container";
 export { ReadabilityResultsContainer, SeoResultsContainer } from "./analysis-result-containers";
-
+export { default as GooglePreviewContainer } from "./google-preview-container";
+export { createDefaultReplacementVariableConfigurations } from "./replacement-variables";
 export { useSeoContext } from "./seo-context";
 
 /**
@@ -68,7 +61,10 @@ const createSeoIntegration = async ( {
 
 	registerSeoStore( { initialState, analyze: analysisWorker.analyze } );
 
-	const { analysisTypeReplacementVariables, unregisterReplacementVariables } = createAnalysisTypeReplacementVariables( mapValues( analysisTypes, "replacementVariableConfigurations" ) );
+	const {
+		analysisTypeReplacementVariables,
+		unregisterReplacementVariables,
+	} = createAnalysisTypeReplacementVariables( mapValues( analysisTypes, "replacementVariableConfigurations" ) );
 
 	return {
 		analysisWorker,

--- a/packages/seo-store/src/analysis/slice/config.js
+++ b/packages/seo-store/src/analysis/slice/config.js
@@ -33,8 +33,8 @@ const configSlice = createSlice( {
 export const configSelectors = {
 	selectAnalysisConfig: state => get( state, "analysis.config" ),
 	selectAnalysisType: state => get( state, "analysis.config.analysisType" ),
-	isSeoAnalysisActive: state => get( state, "analysis.config.isSeoActive" ),
-	isReadabilityAnalysisActive: state => get( state, "analysis.config.isReadabilityActive" ),
+	selectIsSeoAnalysisActive: state => get( state, "analysis.config.isSeoActive" ),
+	selectIsReadabilityAnalysisActive: state => get( state, "analysis.config.isReadabilityActive" ),
 	selectResearches: state => get( state, "analysis.config.researches" ),
 };
 

--- a/packages/seo-store/src/analysis/tests.js
+++ b/packages/seo-store/src/analysis/tests.js
@@ -183,19 +183,19 @@ describe( "Config slice", () => {
 		} );
 
 		test( "should select the is SEO active", () => {
-			const { isSeoAnalysisActive } = configSelectors;
+			const { selectIsSeoAnalysisActive } = configSelectors;
 
 			const state = { ...initialState, isSeoActive: false };
-			const result = isSeoAnalysisActive( createStoreState( state ) );
+			const result = selectIsSeoAnalysisActive( createStoreState( state ) );
 
 			expect( result ).toBe( false );
 		} );
 
 		test( "should select the is readability active", () => {
-			const { isReadabilityAnalysisActive } = configSelectors;
+			const { selectIsReadabilityAnalysisActive } = configSelectors;
 
 			const state = { ...initialState, isReadabilityActive: false };
-			const result = isReadabilityAnalysisActive( createStoreState( state ) );
+			const result = selectIsReadabilityAnalysisActive( createStoreState( state ) );
 
 			expect( result ).toBe( false );
 		} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a `ReadabilityResultsContainer`.
* Adds a `SeoResultsContainer`.

## Relevant technical choices:

* Renamed the configuration selectors to start with `select` too.
* Added a transform for the analysis results, this is temporary (the grouping is there to stay though). As discussed, this will be removed in favor of doing this in the `yoastseo` in between layer directly. Resulting in the Redux store having the results as objects already.
* Not sure about:
  * the folder name
  * the non-hook-ness of the transform
  * the double action of the transformer. I.e. grouping and transforming
  * the secret different defaults for the `headingLevel` and `marksButtonClassName`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Install / build steps
* Install dependencies in the monorepo
* Link dependencies inside `@yoast/seo-integration`:
  * `@yoast/replacement-variables`
  * `@yoast/seo-store`
* Build the packages:
  * `@yoast/replacement-variables`
  * `@yoast/seo-store`
  * `@yoast/seo-integration`
* Install dependencies in the `@yoast/seo-integration-app` (note the app part here)
* Link `@yoast/seo-integration` inside the app
* Start the app

#### Test
* Verify you see the SEO & readability results in the app (added fake results, one for each group)
* Note: they are rendered inside the related keyphrases too, but there is currently no way to know the custom IDs (the keyphrases are not passed through the worker right now)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/P1-1042
