### PR TITLE
DUPP-104 Prevent SEO managers to change the site tagline

### DIFF
--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -166,10 +166,12 @@ async function updateSiteRepresentation( state ) {
 		person_logo: state.personLogo,
 		person_logo_id: state.personLogoId ? state.personLogoId : 0,
 		company_or_person_user_id: state.personId,
-		description: state.siteTagline,
 		/* eslint-enable camelcase */
 	};
 
+	if ( window.wpseoWorkoutsData.canEditWordPressOptions ) {
+		siteRepresentation.description = state.siteTagline;
+	}
 	const response = await apiFetch( {
 		path: "yoast/v1/workouts/site_representation",
 		method: "POST",
@@ -661,14 +663,14 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							personId={ state.personId }
 						/>
 					</Fragment> }
-					<TextInput
+					{ window.wpseoWorkoutsData.canEditWordPressOptions && <TextInput
 						id="site-tagline-input"
 						name="site-tagline"
 						label={ __( "Site tagline", "wordpress-seo" ) }
 						description={ sprintf( __( "Add a catchy tagline that describes your site in the best light. Use the keywords you want people to find your site with. Example: %1$s’s tagline is ‘SEO for everyone.’", "wordpress-seo" ), "Yoast" ) }
 						value={ state.siteTagline }
 						onChange={ onSiteTaglineChange }
-					/>
+					/> }
 					{ siteRepresentationEmpty && <Alert type="warning">
 						{ __(
 							// eslint-disable-next-line max-len

--- a/src/actions/configuration/configuration-workout-action.php
+++ b/src/actions/configuration/configuration-workout-action.php
@@ -65,7 +65,7 @@ class Configuration_Workout_Action {
 
 		foreach ( self::SITE_REPRESENTATION_FIELDS as $field_name ) {
 			if ( isset( $params[ $field_name ] ) ) {
-				if ( $field_name === 'description' ) {
+				if ( $field_name === 'description' && \current_user_can( 'manage_options' ) ) {
 					$result = \update_option( 'blogdescription', $params['description'] );
 					if ( ! $result && $params['description'] === \get_option( 'blogdescription' ) ) {
 						$result = true;

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -170,6 +170,7 @@ class Workouts_Integration implements Integration_Interface {
 				'upsellText'                => $this->get_upsell_text(),
 				'upsellLink'                => $this->get_upsell_link(),
 				'canDoConfigurationWorkout' => $this->user_can_do_configuration_workout(),
+				'canEditWordPressOptions'   => $this->user_can_edit_wordpress_options(),
 			]
 		);
 	}
@@ -424,6 +425,15 @@ class Workouts_Integration implements Integration_Interface {
 	 */
 	private function user_can_do_configuration_workout() {
 		return \current_user_can( 'wpseo_manage_options' );
+	}
+
+	/**
+	 * Whether the user can edit WordPress options.
+	 *
+	 * @return bool Whether the current user can edit WordPress options.
+	 */
+	private function user_can_edit_wordpress_options() {
+		return \current_user_can( 'manage_options' );
 	}
 
 	/**

--- a/tests/unit/actions/configuration/configuration-workout-action-test.php
+++ b/tests/unit/actions/configuration/configuration-workout-action-test.php
@@ -73,6 +73,10 @@ class Configuration_Workout_Action_Test extends TestCase {
 			->times( $times )
 			->andReturn( ...$yoast_options_results );
 
+		Monkey\Functions\expect( 'current_user_can' )
+			->with( 'manage_options' )
+			->andReturnTrue();
+
 		Monkey\Functions\expect( 'update_option' )
 			->with( 'blogdescription' )
 			->andReturn( $wp_option_result );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to prevent the SEO managers to change the site tagline in the conf. workout

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents SEO managers from changing the site description in the configuration workout.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* log in as a SEO Manager
* open the configuration workout
* see that you can't see the "tagline" input field in the second step
  * when saving the step, inspect the payload of the AJAX call to the `/site_representation` endpoint and see that it doesn't contain a `description` field.
* now login as admin
* open the configuration workout
* see that now you can see the "tagline" input field in the second step
* change the value and save the step
* reload or visit `Settings` > `General` to check that the site tagline has actually changed.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [X] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-104]


[DUPP-104]: https://yoast.atlassian.net/browse/DUPP-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ