### PR TITLE
Only show First-time configuration notice to first-install users

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -173,6 +173,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'enable_metabox_insights',
 		'enable_link_suggestions',
 		'workouts',
+		'first_time_install',
 	];
 
 	/**

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -83,6 +83,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'workouts_data'                            => [ 'configuration' => [ 'finishedSteps' => [] ] ],
 		'dismiss_configuration_workout_notice'     => false,
 		'importing_completed'                      => [],
+		'first_time_install'                       => false,
 	];
 
 	/**
@@ -382,6 +383,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				 *  'yoast_tracking'
 				 *  'dynamic_permalinks'
 				 *  'indexing_first_time'
+				 *  'first_time_install'
 				 *  and most of the feature variables.
 				 */
 				default:

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -208,6 +208,10 @@ class Workouts_Integration implements Integration_Interface {
 			return false;
 		}
 
+		if ( $this->options_helper->get( 'first_time_install', false ) === false ) {
+			return false;
+		}
+
 		return ! $this->are_site_representation_name_and_logo_set() || $this->indexing_helper->get_unindexed_count() > 0;
 	}
 

--- a/src/routes/workouts-route.php
+++ b/src/routes/workouts-route.php
@@ -102,7 +102,7 @@ class Workouts_Route implements Route_Interface {
 
 		$result = $this->options_helper->set( 'workouts_data', $free_workouts_data );
 
-		if ( $free_workouts_data['configuration']['finishedSteps'] === 5 ) {
+		if ( count( $free_workouts_data['configuration']['finishedSteps'] ) === 5 ) {
 			$this->options_helper->set( 'first_time_install', false );
 		}
 

--- a/src/routes/workouts-route.php
+++ b/src/routes/workouts-route.php
@@ -102,6 +102,10 @@ class Workouts_Route implements Route_Interface {
 
 		$result = $this->options_helper->set( 'workouts_data', $free_workouts_data );
 
+		if ( $free_workouts_data['configuration']['finishedSteps'] === 5 ) {
+			$this->options_helper->set( 'first_time_install', false );
+		}
+
 		/**
 		 * Filter: 'Yoast\WP\SEO\workouts_route_save' - Allows the add-ons to save the options data in their own options.
 		 *

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -218,6 +218,7 @@ function _wpseo_activate() {
 	}
 
 	WPSEO_Options::set( 'indexing_reason', 'first_install' );
+	WPSEO_Options::set( 'first_time_install', true );
 
 	do_action( 'wpseo_register_roles' );
 	WPSEO_Role_Manager_Factory::get()->add();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Slack thread for reference: https://yoast.slack.com/archives/C027BFR5L/p1638353248381200

The desired behaviour should be: when a user activates the plugin the `first_time_install` option is set to `true`, which means we are assuming we are looking at a first-time user. When the configuration workout is finished, then this value is set to `false`. 

The notification should only be shown to users when they have this `first_time_install` value set to `true` in combination with the existing requirements. So as soon as the configuration workout has been finished once, the notice should never be shown again (unless the free plugin is deactivated and activated again - and the value is set back to `true`). 


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the notification to start configuring Yoast SEO would also been shown on existing installations.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you restart / have NOT completed the configuration workout.
* In the configuration workout or the search appearance settings, make sure you set a name and logo (either for organization or person), and save.
* Using the Yoast Test Helper, reset the indexables using the `Reset indexables tables & migrations` button.
* Deactivate & activate Yoast SEO.
* Navigate to SEO > General.
* You should see the first-time SEO configuration notice.
* Navigate to SEO > Tools and `Start data optimization`.
* Navigate to SEO > General.
* You should NOT see the first-time SEO configuration notice.
* Using the Yoast Test Helper, reset the indexables using the `Reset indexables tables & migrations` button.
* Navigate to SEO > General.
* You should see the first-time SEO configuration notice again.
* Navigate to SEO > Workouts and start/continue the configuration workout.
* Finish step 1 by clicking `Start SEO data optimization`.
* Then click `Finish this workout`.
* Navigate to SEO > General.
* You should NOT see the first-time SEO configuration notice.
* Using the Yoast Test Helper, reset the indexables using the `Reset indexables tables & migrations` button.
* Navigate to SEO > General.
* You should NOT see the first-time SEO configuration notice.
* Deactivate & activate Yoast SEO.
* Navigate to SEO > General.
* You should NOT see the first-time SEO configuration notice.
* Navigate to SEO > Workouts and click `Do workout again` for the configuration workout.
* Navigate to SEO > General.
* You should see the first-time SEO configuration notice again (as since you've activated you have not finished the workout since then).


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
