### PR TITLE
Sketch initial classic editor setup

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -223,35 +223,40 @@ class WPSEO_Admin_Asset_Manager {
 			'block-editor',
 			'classic-editor',
 			'post-edit',
+			'classic-editor-integration',
 			'help-scout-beacon',
 		];
 		$additional_dependencies = [
-			'analysis-worker'    => [ self::PREFIX . 'analysis-package' ],
-			'api-client'         => [ 'wp-api' ],
-			'dashboard-widget'   => [ self::PREFIX . 'api-client' ],
-			'elementor'          => [ self::PREFIX . 'api-client' ],
-			'indexation'         => [
+			'analysis-worker'  => [ self::PREFIX . 'analysis-package' ],
+			'api-client'       => [ 'wp-api' ],
+			'dashboard-widget' => [ self::PREFIX . 'api-client' ],
+			'elementor'        => [ self::PREFIX . 'api-client' ],
+			'indexation'       => [
 				'jquery-ui-core',
 				'jquery-ui-progressbar',
 			],
-			'post-edit'          => [
+			'post-edit'        => [
 				self::PREFIX . 'api-client',
 				self::PREFIX . 'block-editor',
 				self::PREFIX . 'select2',
 			],
-			'reindex-links'      => [
+			'reindex-links'    => [
 				'jquery-ui-core',
 				'jquery-ui-progressbar',
 			],
-			'settings'           => [
+			'settings'         => [
 				'jquery-ui-core',
 				'jquery-ui-progressbar',
 				self::PREFIX . 'api-client',
 				self::PREFIX . 'select2',
 			],
-			'term-edit'          => [
+			'term-edit'        => [
 				self::PREFIX . 'api-client',
 				self::PREFIX . 'classic-editor',
+				self::PREFIX . 'select2',
+			],
+			'classic-editor'   => [
+				self::PREFIX . 'api-client',
 				self::PREFIX . 'select2',
 			],
 		];
@@ -294,21 +299,6 @@ class WPSEO_Admin_Asset_Manager {
 			$select2_scripts,
 			$renamed_scripts
 		);
-
-		$scripts['post-edit-classic'] = [
-			'name'      => 'post-edit-classic',
-			'src'       => $scripts['post-edit']['src'],
-			'deps'      => array_map(
-				static function( $dep ) {
-					if ( $dep === self::PREFIX . 'block-editor' ) {
-						return self::PREFIX . 'classic-editor';
-					}
-					return $dep;
-				},
-				$scripts['post-edit']['deps']
-			),
-			'in_footer' => ! in_array( 'post-edit-classic', $header_scripts, true ),
-		];
 
 		// Add the current language to every script that requires the analysis package.
 		foreach ( $scripts as $name => $script ) {

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -851,7 +851,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$is_block_editor  = WP_Screen::get()->is_block_editor();
 		$post_edit_handle = 'post-edit';
 		if ( ! $is_block_editor ) {
-			$post_edit_handle = 'post-edit-classic';
+			$post_edit_handle = 'classic-editor';
 		}
 		$asset_manager->enqueue_script( $post_edit_handle );
 		$asset_manager->enqueue_style( 'admin-css' );

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -132,12 +132,14 @@ class WPSEO_Taxonomy {
 		) {
 			wp_enqueue_media(); // Enqueue files needed for upload functionality.
 
+			$term_edit_handle = 'classic-editor';
+
 			$asset_manager->enqueue_style( 'metabox-css' );
 			$asset_manager->enqueue_style( 'scoring' );
-			$asset_manager->enqueue_script( 'term-edit' );
+			$asset_manager->enqueue_script( $term_edit_handle );
 
 			$yoast_components_l10n = new WPSEO_Admin_Asset_Yoast_Components_L10n();
-			$yoast_components_l10n->localize_script( 'term-edit' );
+			$yoast_components_l10n->localize_script( $term_edit_handle );
 
 			/**
 			 * Remove the emoji script as it is incompatible with both React and any
@@ -145,7 +147,7 @@ class WPSEO_Taxonomy {
 			 */
 			remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 
-			$asset_manager->localize_script( 'term-edit', 'wpseoAdminL10n', WPSEO_Utils::get_admin_l10n() );
+			$asset_manager->localize_script( $term_edit_handle, 'wpseoAdminL10n', WPSEO_Utils::get_admin_l10n() );
 
 			$script_data = [
 				'analysis'         => [
@@ -172,7 +174,7 @@ class WPSEO_Taxonomy {
 				'userLanguageCode' => WPSEO_Language_Utils::get_language( \get_user_locale() ),
 				'isTerm'           => true,
 			];
-			$asset_manager->localize_script( 'term-edit', 'wpseoScriptData', $script_data );
+			$asset_manager->localize_script( $term_edit_handle, 'wpseoScriptData', $script_data );
 			$asset_manager->enqueue_user_language_script();
 		}
 

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -41,6 +41,7 @@
     "@yoast/replacement-variable-editor": "^1.17.0",
     "@yoast/schema-blocks": "^1.7.0",
     "@yoast/search-metadata-previews": "^2.24.0",
+    "@yoast/seo-integration": "file:../seo-integration",
     "@yoast/social-metadata-forms": "^1.16.0",
     "@yoast/style-guide": "^0.13.0",
     "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#master",

--- a/packages/js/src/classic-editor.js
+++ b/packages/js/src/classic-editor.js
@@ -1,8 +1,61 @@
-/* eslint-disable no-unused-vars */
+import domReady from "@wordpress/dom-ready";
+import createSeoIntegration, { createDefaultReplacementVariableConfigurations, SEO_STORE_NAME } from "@yoast/seo-integration";
+import { mapValues } from "lodash";
+import initAdmin from "./initializers/admin";
+import initAdminMedia from "./initializers/admin-media";
 import initClassicEditorIntegration from "./initializers/classic-editor-integration";
-import ClassicEditorData from "./analysis/classicEditorData";
+import initTabs from "./initializers/metabox-tabs";
+import initPrimaryCategory from "./initializers/primary-category";
+import createClassicEditorWatcher, { getEditorData } from "./watchers/classicEditorWatcher";
 
-window.yoast = window.yoast || {};
-window.yoast.initEditorIntegration = initClassicEditorIntegration;
-window.yoast.EditorData = ClassicEditorData;
-/* eslint-enable no-unused-vars */
+domReady( async () => {
+	// Initialize the tab behavior of the metabox.
+	initTabs( jQuery );
+
+	// Initialize global admin scripts.
+	initAdmin( jQuery );
+
+	// Initialize the media library for our social settings.
+	initAdminMedia( jQuery );
+
+	// Initialize the primary category integration.
+	if ( typeof wpseoPrimaryCategoryL10n !== "undefined" ) {
+		initPrimaryCategory( jQuery );
+	}
+
+
+	const watcher = createClassicEditorWatcher( { storeName: SEO_STORE_NAME } );
+
+	const {} = await createSeoIntegration( {
+		analysisWorkerUrl: wpseoScriptData.analysis.worker.url,
+		analysisResearcherUrl: wpseoScriptData.analysis.worker.dependencies[ "yoast-seo-en-language" ],
+		analysisTypes: {
+			post: {
+				name: "post",
+				replacementVariableConfigurations: mapValues( createDefaultReplacementVariableConfigurations() ),
+			},
+			term: {
+				name: "term",
+				replacementVariableConfigurations: mapValues( createDefaultReplacementVariableConfigurations() ),
+			},
+		},
+		initialState: {
+			editor: getEditorData(),
+		},
+	} );
+
+
+	// TODO:
+	// - expose global API (pluggable/see scrapers).
+	// - create a SEO data watcher that updates our hidden fields so that the changed data is saved along with the WP save.
+	// - traffic light & admin bar: update analysis scores?
+
+	// Start watching the editor data.
+	watcher.watch();
+
+	// We have to do this differently: all the components are coupled to the store, which we are changing :)
+	// Responsibility:
+	// - render metabox
+	// - provide slot/fill mechanism
+	initClassicEditorIntegration( {} );
+} );

--- a/packages/js/src/watchers/classicEditorWatcher.js
+++ b/packages/js/src/watchers/classicEditorWatcher.js
@@ -1,0 +1,23 @@
+import { subscribe } from "@wordpress/data";
+
+/**
+ * Gets the title from the document.
+ *
+ * @returns {string} The title or an empty string.
+ */
+const getTitle = () => {
+	const titleElement = document.getElementById( "title" );
+	return titleElement && titleElement.value || "";
+};
+
+export const getEditorData = () => ( {
+	title: getTitle(),
+} );
+
+const createClassicEditorWatcher = ( { storeName } ) => {
+	return {
+		watch: () => {},
+	};
+};
+
+export default createClassicEditorWatcher;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5425,6 +5425,13 @@
   dependencies:
     lodash "^4.17.21"
 
+"@yoast/seo-integration@file:packages/seo-integration":
+  version "1.0.0"
+  dependencies:
+    "@yoast/replacement-variables" "file:../../../../Library/Caches/Yarn/v6/npm-@yoast-seo-integration-1.0.0-d41b037c-1789-4494-b71a-106beb9f584c-1638280144928/node_modules/@yoast/replacement-variables"
+    "@yoast/seo-store" "file:../../../../Library/Caches/Yarn/v6/npm-@yoast-seo-integration-1.0.0-d41b037c-1789-4494-b71a-106beb9f584c-1638280144928/node_modules/@yoast/seo-store"
+    lodash "^4.17.21"
+
 "@yoast/seo-store@file:packages/seo-store":
   version "1.0.0"
   dependencies:


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Implement our SEO integration within the classic editor as a first target. This PR is giving a JS entry point to start the SEO integration from, it is not yet functional (and actually produces errors).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Replaces the classic editor integration with a sketch of our SEO integration setup.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

The classic editor should now load in our integration. Both for posts and for taxonomies.
But it does not function and produces errors in this PR. The Main thing to see is that the old metabox is gone

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A for this specific PR

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Other editor should be unaffected. Main one to check is the block editor. Both posts and taxonomies.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
