### PR TITLE
DUPP-124 small styling fixes workouts

### DIFF
--- a/css/src/workouts.css
+++ b/css/src/workouts.css
@@ -214,6 +214,11 @@
 	background-position: center center;
 }
 
+.workflow li.step.finished p,
+.workflow li.step.finished table {
+	opacity: 0.5;
+}
+
 .workflow li.step img {
 	max-width: 100%;
 }

--- a/css/src/workouts.css
+++ b/css/src/workouts.css
@@ -218,8 +218,8 @@
 	background-position: center center;
 }
 
-.workflow li.step.finished p,
-.workflow li.step.finished table {
+.workflow li.step.finished.grey p,
+.workflow li.step.finished.grey table {
 	opacity: 0.5;
 }
 

--- a/css/src/workouts.css
+++ b/css/src/workouts.css
@@ -7,6 +7,9 @@
 #wpseo-workouts-container-free h3 {
 	font-size: 18px;
 	line-height: 24px;
+}
+
+.card.card-small h3 {
 	min-height: 48px;
 }
 
@@ -206,6 +209,7 @@
 	top:-8px;
 	left: -48px;
 }
+
 .workflow li.step.finished::after {
 	content: "";
 	background: url("data:image/svg+xml,<svg width='24' fill='none' stroke='%23FFFFFF' height='24' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg' role='img' aria-hidden='true' focusable='false'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M5 13l4 4L19 7'></path></svg>") #a4286a;

--- a/css/src/workouts.css
+++ b/css/src/workouts.css
@@ -218,8 +218,8 @@
 	background-position: center center;
 }
 
-.workflow li.step.finished.grey p,
-.workflow li.step.finished.grey table {
+.workflow li.step.finished.faded p,
+.workflow li.step.finished.faded table {
 	opacity: 0.5;
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Fixes an unreleased bug where the steps in the premium workouts would not be greyed out on finishing a step.
* Fixes an unreleased bug where there was too much whitespace between the title and the workflow within the workouts.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Free and Premium.
* Open the configuration workout. See the spacing between the title and the subtitle is correct (see screenshots below).
* Finish all steps for the configuration workout. Make sure none of the steps are greyed out when finished.
* Open the cornerstone workout. See the spacing between the title and the subtitle is correct (see screenshots below).
* Finish all the steps for the cornerstone workout. Make sure all of the steps are greyed out when finished.
* Open the cornerstone workout. See the spacing between the title and the subtitle is correct (see screenshots below).
* Finish all the steps for the orphaned workout. Make sure all of the steps are greyed out when finished.



<img width="601" alt="Screenshot 2021-12-02 at 11 24 48" src="https://user-images.githubusercontent.com/43582255/144404079-f885688d-5a20-4def-8602-895ad56bc6e7.png">
<img width="597" alt="Screenshot 2021-12-02 at 11 24 18" src="https://user-images.githubusercontent.com/43582255/144404084-cac76bc4-2079-4446-a80b-e2f554c32917.png">
<img width="596" alt="Screenshot 2021-12-02 at 11 24 25" src="https://user-images.githubusercontent.com/43582255/144404090-c28055ec-402a-40b2-aed2-de17d881b5a9.png">

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
