### PR TITLE
Adapt sentence length assessment for Japanese

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/languages/ja/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ja/ResearcherSpec.js
@@ -1,6 +1,7 @@
 import Researcher from "../../../../src/languageProcessing/languages/ja/Researcher.js";
 import Paper from "../../../../src/values/Paper.js";
 import functionWords from "../../../../src/languageProcessing/languages/ja/config/functionWords";
+import sentenceLength from "../../../../src/languageProcessing/languages/ja/config/sentenceLength";
 
 import getMorphologyData from "../../../specHelpers/getMorphologyData";
 import { isFeatureEnabled } from "@yoast/feature-flag";
@@ -22,11 +23,11 @@ describe( "a test for Japanese Researcher", function() {
 		expect( researcher.getHelper( "fleschReadingScore" ) ).toBe( false );
 	} );
 
-	it( "returns false if the Japanese Researcher doesn't have a certain config", function() {
-		expect( researcher.getConfig( "sentenceLength" ) ).toBe( false );
+	it( "returns the Japanese sentence length configuration", function() {
+		expect( researcher.getConfig( "sentenceLength" ) ).toEqual( sentenceLength );
 	} );
 
-	it( "returns false if the Japanese Researcher doesn't have a certain config", function() {
+	it( "returns the Japanese function words", function() {
 		expect( researcher.getConfig( "functionWords" ) ).toEqual( functionWords );
 	} );
 

--- a/packages/yoastseo/spec/scoring/assessments/readability/SentenceLengthInTextAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SentenceLengthInTextAssessmentSpec.js
@@ -465,7 +465,7 @@ describe( "An assessment for sentence length", function() {
 describe( "A test for getting the right config", function() {
 	it( "uses the default config if no language-specific config is available", function() {
 		const defaultConfig = {
-			recommendedWordCount: 20,
+			recommendedLength: 20,
 			slightlyTooMany: 25,
 			farTooMany: 30,
 			urlCallToAction: "<a href='https://yoa.st/34w' target='_blank'>",
@@ -476,7 +476,7 @@ describe( "A test for getting the right config", function() {
 	} );
 	it( "uses the default config if no language-specific config is available in cornerstone", function() {
 		const defaultConfigCornerstrone = {
-			recommendedWordCount: 20,
+			recommendedLength: 20,
 			slightlyTooMany: 20,
 			farTooMany: 25,
 			urlCallToAction: "<a href='https://yoa.st/34w' target='_blank'>",
@@ -505,7 +505,7 @@ describe( "A test for getting the right config", function() {
 			farTooMany: 25,
 		}, true ).getLanguageSpecificConfig( new PolishResearcher( mockPaper ) ) ).toEqual( {
 			farTooMany: 20,
-			recommendedWordCount: 20,
+			recommendedLength: 20,
 			slightlyTooMany: 15,
 			urlCallToAction: "<a href='https://yoa.st/34w' target='_blank'>",
 			urlTitle: "<a href='https://yoa.st/34v' target='_blank'>",
@@ -514,7 +514,7 @@ describe( "A test for getting the right config", function() {
 	it( "uses a combination of language-specific and default config in cornerstone if there is regular but not cornerstone config" +
 		" available", function() {
 		const expectedConfig = {
-			recommendedWordCount: 25,
+			recommendedLength: 25,
 			slightlyTooMany: 20,
 			farTooMany: 25,
 			urlCallToAction: "<a href='https://yoa.st/34w' target='_blank'>",

--- a/packages/yoastseo/spec/scoring/assessments/readability/SentenceLengthInTextAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SentenceLengthInTextAssessmentSpec.js
@@ -1,45 +1,25 @@
 import { merge } from "lodash-es";
-import addMark from "../../../../src/markers/addMark";
+
 import SentenceLengthInTextAssessment from "../../../../src/scoring/assessments/readability/SentenceLengthInTextAssessment";
+
 import Paper from "../../../../src/values/Paper.js";
-import Factory from "../../../specHelpers/factory.js";
 import Mark from "../../../../src/values/Mark.js";
+import addMark from "../../../../src/markers/addMark";
+import Factory from "../../../specHelpers/factory.js";
+
 import DefaultResearcher from "../../../../src/languageProcessing/languages/_default/Researcher";
 import PolishResearcher from "../../../../src/languageProcessing/languages/pl/Researcher";
 import ItalianResearcher from "../../../../src/languageProcessing/languages/it/Researcher";
-import polishConfig from "../../../../src/languageProcessing/languages/pl/config/sentenceLength";
-import turkishConfig from "../../../../src/languageProcessing/languages/tr/config/sentenceLength";
 
-const spanishConfig = {
-	recommendedWordCount: 25,
-	slightlyTooMany: 25,
-	farTooMany: 30,
-};
-const hebrewConfig = {
-	recommendedWordCount: 15,
-	slightlyTooMany: 25,
-	farTooMany: 30,
-};
-const russianConfig = {
-	recommendedWordCount: 15,
-	slightlyTooMany: 25,
-	farTooMany: 30,
-};
-const italianConfig = {
-	recommendedWordCount: 25,
-	slightlyTooMany: 25,
-	farTooMany: 30,
-};
-const portugueseConfig = {
-	recommendedWordCount: 25,
-	slightlyTooMany: 25,
-	farTooMany: 30,
-};
-const catalanConfig = {
-	recommendedWordCount: 25,
-	slightlyTooMany: 25,
-	farTooMany: 30,
-};
+import catalanConfig from "../../../../src/languageProcessing/languages/ca/config/sentenceLength";
+import spanishConfig from "../../../../src/languageProcessing/languages/es/config/sentenceLength";
+import hebrewConfig from "../../../../src/languageProcessing/languages/he/config/sentenceLength";
+import italianConfig from "../../../../src/languageProcessing/languages/it/config/sentenceLength";
+import japaneseConfig from "../../../../src/languageProcessing/languages/ja/config/sentenceLength";
+import russianConfig from "../../../../src/languageProcessing/languages/ru/config/sentenceLength";
+import polishConfig from "../../../../src/languageProcessing/languages/pl/config/sentenceLength";
+import portugueseConfig from "../../../../src/languageProcessing/languages/pt/config/sentenceLength";
+import turkishConfig from "../../../../src/languageProcessing/languages/tr/config/sentenceLength";
 
 // eslint-disable-next-line max-statements
 describe( "An assessment for sentence length", function() {
@@ -432,17 +412,48 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "returns the score for 100% short sentences in Turkish", function() {
-		const mockPaper = new Paper();
+	it( "returns the score for 100% long sentences in Japanese", function() {
+		const mockPaper = new Paper( "" );
 		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
-			{ sentence: "", sentenceLength: 14 },
-		], false, false, turkishConfig ) );
+			{ sentence: "", sentenceLength: 41 },
+		], false, false, japaneseConfig ) );
+
+		expect( assessment.hasScore() ).toBe( true );
+		expect( assessment.getScore() ).toEqual( 3 );
+		// Update words to characters in LINGO-1109
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
+			"100% of the sentences contain more than 40 words, which is more than the recommended maximum of 25%." +
+			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
+		expect( assessment.hasMarks() ).toBe( true );
+	} );
+
+	it( "returns the score for 100% short sentences in Japanese", function() {
+		const mockPaper = new Paper( "" );
+		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
+			{ sentence: "", sentenceLength: 39 },
+		], false, false, japaneseConfig ) );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
+
+	it( "returns the score for 25% long sentences in Japanese", function() {
+		const mockPaper = new Paper( "" );
+		const assessment = new SentenceLengthInTextAssessment().getResult( mockPaper, Factory.buildMockResearcher( [
+			{ sentence: "", sentenceLength: 39 },
+			{ sentence: "", sentenceLength: 30 },
+			{ sentence: "", sentenceLength: 42 },
+			{ sentence: "", sentenceLength: 38 },
+		], false, false, japaneseConfig ) );
+
+		expect( assessment.hasScore() ).toBe( true );
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
+		expect( assessment.hasMarks() ).toBe( true );
+	} );
+
 
 	it( "is not applicable for empty papers", function() {
 		const mockPaper = new Paper();
@@ -480,7 +491,10 @@ describe( "A test for getting the right config", function() {
 	it( "uses language-specific config if available", function() {
 		const mockPaper = new Paper( "" );
 		const researcher = new ItalianResearcher( mockPaper );
-		const config = merge( italianConfig, { 	urlCallToAction: "<a href='https://yoa.st/34w' target='_blank'>",
+		const config = merge( italianConfig, {
+			slightlyTooMany: 25,
+			farTooMany: 30,
+			urlCallToAction: "<a href='https://yoa.st/34w' target='_blank'>",
 			urlTitle: "<a href='https://yoa.st/34v' target='_blank'>" } );
 		expect( new SentenceLengthInTextAssessment().getLanguageSpecificConfig( researcher ) ).toEqual( config );
 	} );

--- a/packages/yoastseo/src/languageProcessing/languages/ca/config/sentenceLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ca/config/sentenceLength.js
@@ -1,3 +1,3 @@
 export default {
-	recommendedWordCount: 25,
+	recommendedLength: 25,
 };

--- a/packages/yoastseo/src/languageProcessing/languages/es/config/sentenceLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/es/config/sentenceLength.js
@@ -1,3 +1,3 @@
 export default {
-	recommendedWordCount: 25,
+	recommendedLength: 25,
 };

--- a/packages/yoastseo/src/languageProcessing/languages/fa/config/sentenceLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/fa/config/sentenceLength.js
@@ -1,3 +1,3 @@
 export default {
-	recommendedWordCount: 25,
+	recommendedLength: 25,
 };

--- a/packages/yoastseo/src/languageProcessing/languages/he/config/sentenceLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/he/config/sentenceLength.js
@@ -1,3 +1,3 @@
 export default {
-	recommendedWordCount: 15,
+	recommendedLength: 15,
 };

--- a/packages/yoastseo/src/languageProcessing/languages/it/config/sentenceLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/it/config/sentenceLength.js
@@ -1,3 +1,3 @@
 export default {
-	recommendedWordCount: 25,
+	recommendedLength: 25,
 };

--- a/packages/yoastseo/src/languageProcessing/languages/ja/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/Researcher.js
@@ -16,6 +16,7 @@ import firstWordExceptions from "./config/firstWordExceptions";
 import functionWords from "./config/functionWords";
 import transitionWords from "./config/transitionWords";
 import topicLength from "./config/topicLength";
+import sentenceLength from "./config/sentenceLength";
 
 // All custom researches
 import morphology from "./customResearches/getWordForms";
@@ -46,6 +47,7 @@ export default class Researcher extends AbstractResearcher {
 			functionWords,
 			transitionWords,
 			topicLength,
+			sentenceLength,
 		} );
 
 		Object.assign( this.helpers, {

--- a/packages/yoastseo/src/languageProcessing/languages/ja/config/sentenceLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/config/sentenceLength.js
@@ -1,4 +1,4 @@
-// The sentence length for Japanese is measured in characters rather than words
+// The sentence length for Japanese is measured in characters rather than words.
 export default {
 	recommendedLength: 40,
 };

--- a/packages/yoastseo/src/languageProcessing/languages/ja/config/sentenceLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/config/sentenceLength.js
@@ -1,3 +1,4 @@
+// The sentence length for Japanese is measured in characters rather than words
 export default {
-	recommendedWordCount: 40,
+	recommendedLength: 40,
 };

--- a/packages/yoastseo/src/languageProcessing/languages/ja/config/sentenceLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/config/sentenceLength.js
@@ -1,0 +1,3 @@
+export default {
+	recommendedWordCount: 40,
+};

--- a/packages/yoastseo/src/languageProcessing/languages/pt/config/sentenceLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/pt/config/sentenceLength.js
@@ -1,3 +1,3 @@
 export default {
-	recommendedWordCount: 25,
+	recommendedLength: 25,
 };

--- a/packages/yoastseo/src/languageProcessing/languages/ru/config/sentenceLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ru/config/sentenceLength.js
@@ -1,3 +1,3 @@
 export default {
-	recommendedWordCount: 15,
+	recommendedLength: 15,
 };

--- a/packages/yoastseo/src/languageProcessing/languages/tr/config/sentenceLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/tr/config/sentenceLength.js
@@ -1,5 +1,5 @@
 export default {
-	recommendedWordCount: 15,
+	recommendedLength: 15,
 	percentages: {
 		slightlyTooMany: 20,
 		farTooMany: 25,

--- a/packages/yoastseo/src/scoring/assessments/readability/SentenceLengthInTextAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/SentenceLengthInTextAssessment.js
@@ -18,7 +18,7 @@ class SentenceLengthInTextAssessment extends Assessment {
 	/**
 	 * Sets the identifier and the config.
 	 *
-	 * @param {boolean} config			The scoring configuration that should be used.
+	 * @param {object} config			The scoring configuration that should be used.
 	 * @param {boolean} isCornerstone	Whether cornerstone configuration should be used.
 	 * @param {boolean} isProduct		Whether product configuration should be used.
 

--- a/packages/yoastseo/src/scoring/assessments/readability/SentenceLengthInTextAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/SentenceLengthInTextAssessment.js
@@ -28,7 +28,7 @@ class SentenceLengthInTextAssessment extends Assessment {
 		super();
 
 		const defaultConfig = {
-			recommendedWordCount: 20,
+			recommendedLength: 20,
 			slightlyTooMany: 25,
 			farTooMany: 30,
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/34v" ),
@@ -115,8 +115,8 @@ class SentenceLengthInTextAssessment extends Assessment {
 		const currentConfig = this._config;
 		const languageSpecificConfig = researcher.getConfig( "sentenceLength" );
 
-		if ( languageSpecificConfig.hasOwnProperty( "recommendedWordCount" ) ) {
-			currentConfig.recommendedWordCount = languageSpecificConfig.recommendedWordCount;
+		if ( languageSpecificConfig.hasOwnProperty( "recommendedLength" ) ) {
+			currentConfig.recommendedLength = languageSpecificConfig.recommendedLength;
 		}
 
 		// Check if a language has specific cornerstone configuration for non-product pages.
@@ -164,7 +164,7 @@ class SentenceLengthInTextAssessment extends Assessment {
 			this._config.urlTitle,
 			"</a>",
 			percentage + "%",
-			this._config.recommendedWordCount,
+			this._config.recommendedLength,
 			this._config.slightlyTooMany + "%",
 			this._config.urlCallToAction
 		);
@@ -222,7 +222,7 @@ class SentenceLengthInTextAssessment extends Assessment {
 	 * @returns {array} Array with all the sentences considered to be too long.
 	 */
 	getTooLongSentences( sentences ) {
-		return getTooLongSentences( sentences, this._config.recommendedWordCount );
+		return getTooLongSentences( sentences, this._config.recommendedLength );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adapts the sentence length assessment for Japanese: the recommended sentence length is set to 40 characters (rather than 20 words in the default assessor)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adapts the sentence length assessment for Japanese.

## Relevant technical choices:

* Changed the config item `recommendedWordCount` to `recommendedLength` to reflect that the length of a sentence need not necessarily be measured in number of words.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Note: you can use a [Japanese lorem ipsum generator](https://generator.lorem-ipsum.info/_japanese) in combination with a [character counter](https://wordcounter.net/character-count) to create texts for testing.

This PR can be acceptance tested by following these steps:

* Enable the JAPANESE_SUPPORT feature by adding `define( 'YOAST_SEO_JAPANESE_SUPPORT', true );` in `basic-wordpress-config.php`.
* Change the site language to Japanese (`日本語`).
* Create a new post and paste this sentence: `ジャガーは、哺乳綱食肉目ネコ科ヒョウ属に分類される食肉類。`.
* The sentence length assessment should return a green bullet and the following feedback: `文の長さ: いい感じです !`
* Remove the sentence and paste the sentence: `アメリカ合衆国でも繁殖個体群は絶滅しているが、アリゾナ州ではメキシコ（ソノラ州）から国境を越えた個体が確認されることもある。`.
* The sentence length assessment should return a red bullet and the following feedback: `Sentence length: 100% of the sentences contain more than 40 words, which is more than the recommended maximum of 25%. Try to shorten the sentences.`. Or, in Japanese: `文章の長さ: 文章の 100% は 40 以上の語を含みます。これは推奨する最大値 25% を上回ります。文章を短くしてください。`.
* Remove the sentence and add the following text:
``
ジャガーは、哺乳綱食肉目ネコ科ヒョウ属に分類される食肉類。北アメリカ大陸南部、南アメリカ大陸に分布している。アメリカ合衆国でも繁殖個体群は絶滅しているが、アリゾナ州ではメキシコ（ソノラ州）から国境を越えた個体が確認されることもある。
``
* The sentence length assessment should return a red bullet and the following feedback: `Sentence length: 33.3% of the sentences contain more than 40 words, which is more than the recommended maximum of 25%. Try to shorten the sentences.`. Or, in Japanese: `文章の長さ: 文章の 33.3% は 40 以上の語を含みます。これは推奨する最大値 25% を上回ります。文章を短くしてください。`.

* Disable the JAPANESE_SUPPORT feature by adding `define( 'YOAST_SEO_JAPANESE_SUPPORT', false );` in `basic-wordpress-config.php`.
* Save your changes and reload the post
* The sentence length assessment should return a green bullet and the following feedback: `文の長さ: いい感じです !`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [x] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-356
