### PR TITLE
QA-2591 Wincher: do not include already tracked keyphrases in track_all

### DIFF
--- a/packages/js/src/initializers/admin.js
+++ b/packages/js/src/initializers/admin.js
@@ -316,7 +316,7 @@ export default function initAdmin( jQuery ) {
 
 		const data = await trackAllKeyphrases();
 
-		if ( data.status === 201 ) {
+		if ( data.status === 200 || data.status === 201 ) {
 			jQuery( "#wincher-track-all-keyphrases-success" ).show();
 		}
 

--- a/src/actions/wincher/wincher-keyphrases-action.php
+++ b/src/actions/wincher/wincher-keyphrases-action.php
@@ -344,8 +344,9 @@ class Wincher_Keyphrases_Action {
 			}
 		}
 
-		// Filter out empty entries.
-		return \array_filter( $keyphrases );
+		// Filter out empty entries and convert the rest to lowercase.
+		$strtolower_fn = \function_exists( 'mb_strtolower' ) ? 'mb_strtolower' : 'strtolower';
+		return \array_map( $strtolower_fn, \array_filter( $keyphrases ) );
 	}
 
 	/**

--- a/src/actions/wincher/wincher-keyphrases-action.php
+++ b/src/actions/wincher/wincher-keyphrases-action.php
@@ -245,6 +245,18 @@ class Wincher_Keyphrases_Action {
 	 */
 	public function track_all( $limits ) {
 		$keyphrases = $this->collect_all_keyphrases();
+		$tracked    = $this->get_tracked_keyphrases( $keyphrases );
+
+		if ( isset( $tracked->error ) ) {
+			return $tracked;
+		}
+
+		$keyphrases = array_filter(
+			$keyphrases,
+			function( $keyphrase ) use ( $tracked ) {
+				return ! isset( $tracked->results[ $keyphrase ] );
+			}
+		);
 
 		if ( empty( $keyphrases ) ) {
 			return $this->to_result_object(

--- a/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
+++ b/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
@@ -674,7 +674,7 @@ class Wincher_Keyphrases_Action_Test extends TestCase {
 			->expects( 'query->select->where_not_null->where->distinct->find_array' )
 			->andReturns(
 				[
-					[ 'primary_focus_keyword' => 'yoast seo' ],
+					[ 'primary_focus_keyword' => 'Yoast SEO' ],
 					[ 'primary_focus_keyword' => 'blog seo' ],
 					[ 'primary_focus_keyword' => '' ],
 				]

--- a/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
+++ b/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
@@ -671,7 +671,7 @@ class Wincher_Keyphrases_Action_Test extends TestCase {
 		);
 
 		$this->indexable_repository
-			->expects( 'query->select->where_not_null->where->distinct->find_array' )
+			->expects( 'query->select->where_not_null->where->where_not_equal->distinct->find_array' )
 			->andReturns(
 				[
 					[ 'primary_focus_keyword' => 'Yoast SEO' ],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When using the "Add existing keyphrases" button, existing keyphrases should not be included when counting the limits and whatnot.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* No longer count already tracked keyphrases when using the "Add existing keyphrases" button of the Wincher integration.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
