### PR TITLE
Allow passing of id to card and add more ids to its contents

### DIFF
--- a/packages/js/src/workouts/components/ConfigurationWorkoutCard.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkoutCard.js
@@ -20,6 +20,7 @@ export default function ConfigurationWorkoutCard( {
 } ) {
 	const finishedSteps = useSelect( select => select( "yoast-seo/workouts" ).getFinishedSteps( "configuration" ) );
 	return <WorkoutCard
+		id={ "configuration-workout-card" }
 		name={ "configuration" }
 		title={ __( "Configuration", "wordpress-seo" ) }
 		// translators: %s translates to Yoast SEO.

--- a/packages/js/src/workouts/components/CornerstoneWorkoutCard.js
+++ b/packages/js/src/workouts/components/CornerstoneWorkoutCard.js
@@ -26,6 +26,7 @@ export default function CornerstoneWorkoutCard( {
 	const actualUpsellLink = upsellLink ? upsellLink :  "https://yoa.st/workout-cornerstone-upsell";
 
 	return <WorkoutCard
+		id={ "cornerstone-workout-card" }
 		name={ WORKOUTS.cornerstone }
 		title={ __( "The cornerstone approach", "wordpress-seo" ) }
 		subtitle={ __( "Rank with articles you want to rank with", "wordpress-seo" ) }

--- a/packages/js/src/workouts/components/OrphanedWorkoutCard.js
+++ b/packages/js/src/workouts/components/OrphanedWorkoutCard.js
@@ -26,6 +26,7 @@ export default function OrphanedWorkoutCard( {
 	const actualUpsellLink = upsellLink ? upsellLink :  "https://yoa.st/workout-orphaned-content-upsell";
 
 	return <WorkoutCard
+		id={ "orphaned-workout-card" }
 		name={ WORKOUTS.orphaned }
 		title={ __( "Orphaned content", "wordpress-seo" ) }
 		subtitle={ __( "Clean up your unlinked content to make sure people can find it", "wordpress-seo" ) }

--- a/packages/js/src/workouts/components/WorkoutCard.js
+++ b/packages/js/src/workouts/components/WorkoutCard.js
@@ -20,6 +20,7 @@ export default function WorkoutCard( {
 	title,
 	subtitle,
 	usps,
+	id,
 	image,
 	finishableSteps,
 	finishedSteps,
@@ -77,22 +78,22 @@ export default function WorkoutCard( {
 	const disabled = workout && ! blocked ? "" : " card-disabled";
 
 	return ( <Fragment>
-		{ ! activeWorkout && <div className={ `card card-small${ disabled }` }>
+		{ ! activeWorkout && <div id={ id } className={ `card card-small${ disabled }` }>
 			<h2>{ title } { badges }</h2>
 			<h3>{ subtitle }</h3>
 			<div className="workout-card-content-flex">
-				<ul className="yoast-list--usp">
+				<ul id={ `${ id }-usp-list` } className="yoast-list--usp">
 					{
-						usps.map( ( usp, index ) => <li key={ `${ title }-${ index }` }>{ usp }</li> )
+						usps.map( ( usp, index ) => <li id={ `${ id }-usp-${ index }` } key={ `${ id }-${ index }` }>{ usp }</li> )
 					}
 				</ul>
 				{ image && <ImageComponent /> }
 			</div>
 			<span>
 				{ /* eslint-disable-next-line max-len */ }
-				{ ! blocked && workout && <Button className={ `yoast-button yoast-button--${ isToggle ? "secondary" : "primary" }` } onClick={ onClick }>{ buttonText }</Button> }
+				{ ! blocked && workout && <Button id={ `${ id }-action-button` } className={ `yoast-button yoast-button--${ isToggle ? "secondary" : "primary" }` } onClick={ onClick }>{ buttonText }</Button> }
 				{ ! workout &&
-					<UpsellButton href={ upsellLink } className="yoast-button yoast-button-upsell">
+					<UpsellButton id={ `${ id }-upsell-button` } href={ upsellLink } className="yoast-button yoast-button-upsell">
 						{ actualUpsellText }
 						<span aria-hidden="true" className="yoast-button-upsell__caret" />
 					</UpsellButton>
@@ -100,11 +101,11 @@ export default function WorkoutCard( {
 				{ finishableSteps && finishedSteps &&
 				<div className="workout-card-progress">
 					<ProgressBar
-						id={ `${title}-workout-progress` }
+						id={ `${ id }-progress` }
 						max={ finishableSteps.length }
 						value={ finishedSteps.length }
 					/>
-					<label htmlFor={ `${title}-workout-progress` }><i>
+					<label htmlFor={ `${ id }-progress` }><i>
 						{
 							sprintf(
 								// translators: %1$s: number of finished steps, %2$s: number of finishable steps
@@ -119,9 +120,9 @@ export default function WorkoutCard( {
 					</i></label>
 				</div> }
 			</span>
-			{ blocked && workout && <div className="workout-card-blocked">
-				<p className="workout-card-blocked-title">{ __( "Configuration required", "wordpress-seo" ) }</p>
-				<p id="workout-card-blocked-description">{
+			{ blocked && workout && <div id={ `${ id }-blocked-section` }className="workout-card-blocked">
+				<p id={ `${ id }-blocked-title` } className="workout-card-blocked-title">{ __( "Configuration required", "wordpress-seo" ) }</p>
+				<p id={ `${ id }-blocked-description` }>{
 					__( "Please finish the Configuration workout first in order for this workout to be effective.", "wordpress-seo" )
 				}</p>
 			</div> }
@@ -135,6 +136,7 @@ WorkoutCard.propTypes = {
 	title: PropTypes.string.isRequired,
 	subtitle: PropTypes.string.isRequired,
 	usps: PropTypes.arrayOf( PropTypes.string ).isRequired,
+	id: PropTypes.string,
 	finishableSteps: PropTypes.arrayOf( PropTypes.string ),
 	finishedSteps: PropTypes.arrayOf( PropTypes.string ),
 	image: PropTypes.func,
@@ -146,6 +148,7 @@ WorkoutCard.propTypes = {
 };
 
 WorkoutCard.defaultProps = {
+	id: "",
 	finishableSteps: null,
 	finishedSteps: null,
 	image: null,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Dario requested more defined and specific ids per workout card to help with automated testing.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds specific id's to several elements on the workout cards.

## Relevant technical choices:



## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify that the workout cards, usps (green checkmark thingies), buttons (also check with and without premium active), and locked sections (when you have not done the configuration workout yet) have specific ID's.
	* You can do so by opening the element inspector, clicking the "highlighting arrow" and hover over the elements. Id's are recognisable by looking like so: `div#my-specific-id` when you hover, or as `id="my-specific-id"`


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-140
