### PR TITLE
Adapt keyphrase length research for Japanese

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/languages/ja/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ja/ResearcherSpec.js
@@ -9,7 +9,7 @@ import { isFeatureEnabled } from "@yoast/feature-flag";
 const morphologyDataJA = getMorphologyData( "ja" );
 
 describe( "a test for Japanese Researcher", function() {
-	const researcher = new Researcher( new Paper( "" ) );
+	const researcher = new Researcher( ( new Paper( "", { keyword: "小さい花の刺繍" } ) ) );
 
 	it( "returns true if the Japanese Researcher has a specific research", function() {
 		expect( researcher.hasResearch( "getParagraphLength" ) ).toBe( true );
@@ -38,6 +38,10 @@ describe( "a test for Japanese Researcher", function() {
 			allWordsFound: true,
 			position: 0,
 		} );
+	} );
+
+	it( "returns the keyphrase length", function() {
+		expect( researcher.getResearch( "keyphraseLength" ).keyphraseLength ).toEqual( 7 );
 	} );
 
 	if ( isFeatureEnabled( "JAPANESE_SUPPORT" ) ) {

--- a/packages/yoastseo/spec/languageProcessing/languages/ja/customResearches/getKeyphraseLengthSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ja/customResearches/getKeyphraseLengthSpec.js
@@ -1,0 +1,42 @@
+import { enableFeatures } from "@yoast/feature-flag";
+import getKeyphraseLength from "../../../../../src/languageProcessing/languages/ja/customResearches/getKeyphraseLength";
+import Paper from "../../../../../src/values/Paper";
+
+// The Japanese support is enabled in this spec file so that the Japanese punctuation(s) are available.
+enableFeatures( [ "JAPANESE_SUPPORT" ] );
+
+describe( "test for calculating the Japanese keyphrase length research", function() {
+	it( "returns the length of the keyphrase without function word(s)", function() {
+		const mockPaper = new Paper( "私の猫はかわいいです。", { keyword: "猫用フード" } );
+
+		expect( getKeyphraseLength( mockPaper ).keyphraseLength ).toBe( 5 );
+	} );
+
+	it( "returns the length of the keyphrase with function word(s): the function word(s) is also included in the calculation", function() {
+		const mockPaper = new Paper( "私の猫はかわいいです。", { keyword: "猫用のフード" } );
+
+		expect( getKeyphraseLength( mockPaper ).keyphraseLength ).toBe( 6 );
+	} );
+
+	it( "returns the length of the keyphrase that contains space(s): the space(s) " +
+		"should not be included in the calculation", function() {
+		const mockPaper = new Paper( "", { keyword: "小さい花 の 刺繍" } );
+
+		expect( getKeyphraseLength( mockPaper ).keyphraseLength ).toBe( 7 );
+	} );
+
+	it( "returns the length of the keyphrase that contains punctuation: the punctuation " +
+		"should not be included in the calculation", function() {
+		const mockPaper = new Paper( "", { keyword: "小さい花の刺繍。" } );
+
+		expect( getKeyphraseLength( mockPaper ).keyphraseLength ).toBe( 7 );
+	} );
+
+	it( "returns 0 if the keyword is empty or not set", function() {
+		let mockPaper = new Paper( "", { keyword: "" } );
+		expect( getKeyphraseLength( mockPaper ).keyphraseLength ).toBe( 0 );
+
+		mockPaper = new Paper( "" );
+		expect( getKeyphraseLength( mockPaper ).keyphraseLength ).toBe( 0 );
+	} );
+} );

--- a/packages/yoastseo/src/languageProcessing/languages/ja/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/Researcher.js
@@ -21,6 +21,7 @@ import sentenceLength from "./config/sentenceLength";
 // All custom researches
 import morphology from "./customResearches/getWordForms";
 import getKeywordDensity from "./customResearches/getKeywordDensity";
+import getKeyphraseLength from "./customResearches/getKeyphraseLength";
 
 /**
  * The researches contains all the researches
@@ -63,6 +64,7 @@ export default class Researcher extends AbstractResearcher {
 
 		Object.assign( this.defaultResearches, {
 			morphology,
+			keyphraseLength: getKeyphraseLength,
 		} );
 	}
 }

--- a/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/getKeyphraseLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/getKeyphraseLength.js
@@ -1,0 +1,18 @@
+import getWords from "../helpers/getWords";
+import characterCountHelper from "../helpers/wordsCharacterCount";
+
+/**
+ * Calculates the character length of the keyphrase.
+ *
+ * @param {Paper} paper The paper to research
+ *
+ * @returns {Object} The length of the keyphrase and an empty array of function words.
+ */
+export default function( paper ) {
+	const keyphrase = getWords( paper.getKeyword() );
+
+	return {
+		keyphraseLength: characterCountHelper( keyphrase ),
+		functionWords: [],
+	};
+}

--- a/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/getKeyphraseLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/getKeyphraseLength.js
@@ -13,6 +13,7 @@ export default function( paper ) {
 
 	return {
 		keyphraseLength: characterCountHelper( keyphrase ),
+		// Returns empty array because we don't take function words into account for Japanese keyphrase length calculations.
 		functionWords: [],
 	};
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds custom `keyphraseLength` research for Japanese.

## Relevant technical choices:

* I named the custom research inside Japanese folder `getKeyphraseLength` instead of just `keyphraseLength`. This is to avoid confusion later when the `keyphraseLength` config is also added in the researcher.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Note**: This PR cannot be tested on Docker yet since the Keyphrase length assessment is not yet adjusted.
* Run `yarn test` and make sure there is no failing tests.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1099
