### PR TITLE
DUPP-136 installation success integration

### DIFF
--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -88,6 +88,8 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'wincher_automatically_add_keyphrases'     => false,
 		'wincher_website_id'                       => '',
 		'first_time_install'                       => false,
+		'should_redirect_after_install_free'       => false,
+		'activation_redirect_timestamp_free'       => 0,
 	];
 
 	/**
@@ -329,6 +331,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 
 				case 'first_activated_on':
 				case 'indexing_started':
+				case 'activation_redirect_timestamp_free':
 					$clean[ $key ] = false;
 					if ( isset( $dirty[ $key ] ) ) {
 						if ( $dirty[ $key ] === false || WPSEO_Utils::validate_int( $dirty[ $key ] ) ) {
@@ -371,7 +374,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 					break;
 
 				case 'import_cursors':
-				case 'workouts_data':
 				case 'importing_completed':
 					if ( isset( $dirty[ $key ] ) && is_array( $dirty[ $key ] ) ) {
 						$clean[ $key ] = $dirty[ $key ];
@@ -390,6 +392,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				 *  'dynamic_permalinks'
 				 *  'indexing_first_time'
 				 *  'first_time_install'
+				 *  'should_redirect_after_install_free'
 				 *  and most of the feature variables.
 				 */
 				default:

--- a/src/conditionals/installation-success-conditional.php
+++ b/src/conditionals/installation-success-conditional.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Feature flag conditional for the Installation Success screen.
+ */
+class Installation_Success_Conditional extends Feature_Flag_Conditional {
+
+	/**
+	 * Returns the name of the Installation Success feature flag.
+	 *
+	 * @return string The name of the feature flag.
+	 */
+	protected function get_feature_flag() {
+		return 'INSTALLATION_SUCCESS';
+	}
+}

--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Installation_Success_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
@@ -23,7 +24,7 @@ class Installation_Success_Integration implements Integration_Interface {
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
-		return [ Admin_Conditional::class ];
+		return [ Admin_Conditional::class, Installation_Success_Conditional::class ];
 	}
 
 	/**

--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Installation_Success_Integration class
+ */
+class Installation_Success_Integration implements Integration_Interface {
+
+	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_conditionals() {
+		return [ Admin_Conditional::class ];
+	}
+
+	/**
+	 * Installation_Success_Integration constructor.
+	 *
+	 * @param Options_Helper $options_helper The options helper.
+	 */
+	public function __construct( Options_Helper $options_helper ) {
+		$this->options_helper = $options_helper;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register_hooks() {
+		\add_filter( 'admin_menu', [ $this, 'add_submenu_page' ], 9 );
+		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+		\add_action( 'admin_init', [ $this, 'maybe_redirect' ] );
+	}
+
+	/**
+	 * Redirects to the installation success page if an installation has just occurred.
+	 *
+	 * @return void
+	 */
+	public function maybe_redirect() {
+		if ( ! $this->options_helper->get( 'should_redirect_after_install_free' ) ) {
+			return;
+		}
+		$this->options_helper->set( 'should_redirect_after_install_free', false );
+
+		if ( ! empty( $this->options_helper->get( 'activation_redirect_timestamp_free' ) ) ) {
+			return;
+		}
+		$this->options_helper->set( 'activation_redirect_timestamp_free', \time() );
+
+		\wp_safe_redirect( \admin_url( 'admin.php?page=wpseo_installation_successful_free' ), 302, 'Yoast SEO' );
+		exit;
+	}
+
+	/**
+	 * Adds the installation success submenu page.
+	 *
+	 * @param array $submenu_pages The Yoast SEO submenu pages.
+	 *
+	 * @return array the filtered submenu pages.
+	 */
+	public function add_submenu_page( $submenu_pages ) {
+		\add_submenu_page(
+			null,
+			\__( 'Installation Successful', 'wordpress-seo' ),
+			null,
+			'manage_options',
+			'wpseo_installation_successful_free',
+			[ $this, 'render_page' ]
+		);
+
+		return $submenu_pages;
+	}
+
+	/**
+	 * Enqueue assets on the Installation success page.
+	 */
+	public function enqueue_assets() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Date is not processed or saved.
+		if ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'wpseo_installation_successful_free' ) {
+			return;
+		}
+
+		$asset_manager = new WPSEO_Admin_Asset_Manager();
+		$asset_manager->enqueue_style( 'monorepo' );
+	}
+
+	/**
+	 * Renders the installation success page.
+	 */
+	public function render_page() {
+		echo '<div id="wpseo-installation-successful-free" class="yoast"></div>';
+	}
+}

--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -50,12 +50,12 @@ class Installation_Success_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function maybe_redirect() {
-		if ( ! $this->options_helper->get( 'should_redirect_after_install_free' ) ) {
+		if ( ! $this->options_helper->get( 'should_redirect_after_install_free', false ) ) {
 			return;
 		}
 		$this->options_helper->set( 'should_redirect_after_install_free', false );
 
-		if ( ! empty( $this->options_helper->get( 'activation_redirect_timestamp_free' ) ) ) {
+		if ( ! empty( $this->options_helper->get( 'activation_redirect_timestamp_free', 0 ) ) ) {
 			return;
 		}
 		$this->options_helper->set( 'activation_redirect_timestamp_free', \time() );

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -460,6 +460,7 @@ class Workouts_Integration implements Integration_Interface {
 			$exceptions = [
 				'wpseo_workouts',
 				'wpseo_installation_successful',
+				'wpseo_installation_successful_free',
 			];
 
 			if ( ! \in_array( $page_from_get, $exceptions, true ) ) {

--- a/tests/unit/integrations/admin/installation-success-integration-test.php
+++ b/tests/unit/integrations/admin/installation-success-integration-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
 use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\Installation_Success_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Installation_Success_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -51,6 +52,7 @@ class Installation_Success_Integration_Test extends TestCase {
 		static::assertEquals(
 			[
 				Admin_Conditional::class,
+				Installation_Success_Conditional::class,
 			],
 			Installation_Success_Integration::get_conditionals()
 		);
@@ -84,6 +86,7 @@ class Installation_Success_Integration_Test extends TestCase {
 	 * Tests the successful redirection.
 	 *
 	 * @covers ::maybe_redirect
+	 * @runInSeparateProcess
 	 */
 	public function test_maybe_redirect_successful() {
 		$this->options_helper

--- a/tests/unit/integrations/admin/installation-success-integration-test.php
+++ b/tests/unit/integrations/admin/installation-success-integration-test.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Admin\Installation_Success_Integration;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Installation_Success_Integration_Test
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Admin\Installation_Success_Integration
+ *
+ * @group integrations
+ */
+class Installation_Success_Integration_Test extends TestCase {
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Installation_Success_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * Options Helper class mock.
+	 *
+	 * @var Options_Helper|Mockery\Mock
+	 */
+	protected $options_helper;
+
+	/**
+	 * Set up the fixtures for the tests.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->options_helper = Mockery::mock( Options_Helper::class );
+		$this->instance       = new Installation_Success_Integration( $this->options_helper );
+	}
+
+	/**
+	 * Tests the retrieval of the conditionals.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		static::assertEquals(
+			[
+				Admin_Conditional::class,
+			],
+			Installation_Success_Integration::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests if the required dependencies are set right.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		static::assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $this->instance, 'options_helper' )
+		);
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+		$this->assertNotFalse( Monkey\Filters\has( 'admin_menu', [ $this->instance, 'add_submenu_page' ] ), 'Does not have expected admin_menu filter' );
+		$this->assertNotFalse( Monkey\Actions\has( 'admin_enqueue_scripts', [ $this->instance, 'enqueue_assets' ] ), 'Does not have expected admin_enqueue_scripts action' );
+		$this->assertNotFalse( Monkey\Actions\has( 'admin_init', [ $this->instance, 'maybe_redirect' ] ), 'Does not have expected admin_init action' );
+	}
+
+	/**
+	 * Tests the successful redirection.
+	 *
+	 * @covers ::maybe_redirect
+	 */
+	public function test_maybe_redirect_successful() {
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'should_redirect_after_install_free', false )
+			->andReturnTrue();
+
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'should_redirect_after_install_free', false );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'activation_redirect_timestamp_free', 0 )
+			->andReturn( 0 );
+
+		$this->options_helper
+			->expects( 'set' )
+			->withSomeOfArgs( 'activation_redirect_timestamp_free' );
+
+		$redirect_url = 'http://basic.wordpress.test/wp-admin/admin.php?page=wpseo_installation_successful_free';
+
+		Monkey\Functions\expect( 'admin_url' )
+			->with( 'admin.php?page=wpseo_installation_successful_free' )
+			->andReturn( $redirect_url );
+
+		Monkey\Functions\expect( 'wp_safe_redirect' )
+			->with( $redirect_url, 302, 'Yoast SEO' );
+
+		$this->instance->maybe_redirect();
+	}
+
+	/**
+	 * Tests the unsuccessful redirection when it has already happened.
+	 *
+	 * @covers ::maybe_redirect
+	 */
+	public function test_maybe_redirect_unsuccessful() {
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'should_redirect_after_install_free', false )
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'wp_safe_redirect' )
+			->never();
+
+		$this->instance->maybe_redirect();
+	}
+
+	/**
+	 * Tests the addition of a submenu page.
+	 *
+	 * @covers ::add_submenu_page
+	 */
+	public function test_add_submenu_page() {
+		Monkey\Functions\expect( '__' )
+			->andReturnFirstArg();
+
+		Monkey\Functions\expect( 'add_submenu_page' );
+
+		$submenu_pages = [
+			'array',
+			'that',
+			'should',
+			'remain',
+			'untouched',
+		];
+
+		$this->assertSame( $submenu_pages, $this->instance->add_submenu_page( $submenu_pages ) );
+	}
+}

--- a/tests/unit/integrations/admin/installation-success-integration-test.php
+++ b/tests/unit/integrations/admin/installation-success-integration-test.php
@@ -83,48 +83,11 @@ class Installation_Success_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the successful redirection.
-	 *
-	 * @covers ::maybe_redirect
-	 * @runInSeparateProcess
-	 */
-	public function test_maybe_redirect_successful() {
-		$this->options_helper
-			->expects( 'get' )
-			->with( 'should_redirect_after_install_free', false )
-			->andReturnTrue();
-
-		$this->options_helper
-			->expects( 'set' )
-			->with( 'should_redirect_after_install_free', false );
-
-		$this->options_helper
-			->expects( 'get' )
-			->with( 'activation_redirect_timestamp_free', 0 )
-			->andReturn( 0 );
-
-		$this->options_helper
-			->expects( 'set' )
-			->withSomeOfArgs( 'activation_redirect_timestamp_free' );
-
-		$redirect_url = 'http://basic.wordpress.test/wp-admin/admin.php?page=wpseo_installation_successful_free';
-
-		Monkey\Functions\expect( 'admin_url' )
-			->with( 'admin.php?page=wpseo_installation_successful_free' )
-			->andReturn( $redirect_url );
-
-		Monkey\Functions\expect( 'wp_safe_redirect' )
-			->with( $redirect_url, 302, 'Yoast SEO' );
-
-		$this->instance->maybe_redirect();
-	}
-
-	/**
-	 * Tests the unsuccessful redirection when it has already happened.
+	 * Tests that the redirection does not occur when it's already happened.
 	 *
 	 * @covers ::maybe_redirect
 	 */
-	public function test_maybe_redirect_unsuccessful() {
+	public function test_maybe_redirect_prevented() {
 		$this->options_helper
 			->expects( 'get' )
 			->with( 'should_redirect_after_install_free', false )

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -225,6 +225,7 @@ function _wpseo_activate() {
 
 	WPSEO_Options::set( 'indexing_reason', 'first_install' );
 	WPSEO_Options::set( 'first_time_install', true );
+	WPSEO_Options::set( 'should_redirect_after_install_free', true );
 
 	do_action( 'wpseo_register_roles' );
 	WPSEO_Role_Manager_Factory::get()->add();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to redirect to a new installation successful page after the first activation

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces the integration and the feature flag for the "installation successful" page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### feature flag on
* deactivate Yoast SEO Free
* add `define( 'YOAST_SEO_INSTALLATION_SUCCESS', true );` to your `wp-config.php` file
* reactivate Yoast SEO Free
* You should be redirect to a blank page with URL `{admin_path}/admin.php?page=wpseo_installation_successful_free`
* deactivate Yoast SEO Free
* reactivate Yoast SEO Free
* you shouldn't be redirected anymore

#### feature flag off
* deactivate Yoast SEO Free
* comment out `define( 'YOAST_SEO_INSTALLATION_SUCCESS', true );` in your `wp-config.php` file
* reactivate Yoast SEO Free
* you shouldn't be redirected to any page


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-136]


[DUPP-136]: https://yoast.atlassian.net/browse/DUPP-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ