### PR TITLE
QA-2596 Fix loading of slugs for drafts in Elementor

### DIFF
--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -502,6 +502,11 @@ class Elementor implements Integration_Interface {
 	protected function get_post_slug() {
 		$post = $this->get_metabox_post();
 
+		// In case get_metabox_post returns null for whatever reason.
+		if ( ! $post instanceof WP_Post ) {
+			return '';
+		}
+
 		// Drafts might not have a post_name unless the slug has been manually changed.
 		// In this case we get it using get_sample_permalink.
 		if ( ! $post->post_name ) {

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -510,7 +510,12 @@ class Elementor implements Integration_Interface {
 		// Drafts might not have a post_name unless the slug has been manually changed.
 		// In this case we get it using get_sample_permalink.
 		if ( ! $post->post_name ) {
-			return \get_sample_permalink( $post->id )[1];
+			$sample = \get_sample_permalink( $post->id );
+
+			// Since get_sample_permalink runs through filters, ensure that it has the expected return value.
+			if ( is_array( $sample ) && count( $sample ) === 2 && is_string( $sample[1] ) ) {
+				return $sample[1];
+			}
 		}
 
 		return $post->post_name;

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -485,13 +485,30 @@ class Elementor implements Integration_Interface {
 		\printf(
 			'<input type="hidden" id="%1$s" name="%1$s" value="%2$s" />',
 			\esc_attr( WPSEO_Meta::$form_prefix . 'slug' ),
-			\esc_attr( $this->get_metabox_post()->post_name )
+			\esc_attr( $this->get_post_slug() )
 		);
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output should be escaped in the filter.
 		echo \apply_filters( 'wpseo_elementor_hidden_fields', '' );
 
 		echo '</form>';
+	}
+
+	/**
+	 * Returns the slug for the post being edited.
+	 *
+	 * @return string
+	 */
+	protected function get_post_slug() {
+		$post = $this->get_metabox_post();
+
+		// Drafts might not have a post_name unless the slug has been manually changed.
+		// In this case we get it using get_sample_permalink.
+		if ( ! $post->post_name ) {
+			return \get_sample_permalink( $post->id )[1];
+		}
+
+		return $post->post_name;
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Slugs were not initialized for draft posts in elementor because they generally don't have a saved `post_name`, leading to unexpected behavior such as the Wincher modal not working and the permalink field of the Google Preview modal being empty.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where slugs were not loaded for draft posts in Elementor. 

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add a new draft post and edit it with Elementor.
* Ensure that the permalink field of the "Google preview" modal is set correctly.
* Ensure that the "Track SEO Performance" modal does not display an error message like this: "Before you can track your SEO performance make sure to set either the post’s title and save it as a draft or manually set the post’s slug" 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
