### PR TITLE
Fixed wrong wordCount for JSON-LD schema in Article (Russian/Ukrainia…

### DIFF
--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -200,9 +200,35 @@ class Article extends Abstract_Schema_Piece {
 		// Strip pre/code blocks and their content.
 		$post_content = \preg_replace( '@<(pre|code)[^>]*?>.*?</\\1>@si', '', $post_content );
 
+		// Add space between tags that don't have it.
+		$post_content = \preg_replace( '@>\s{0}<@', '> <', $post_content );
+
 		// Strips all other tags.
 		$post_content = \wp_strip_all_tags( $post_content );
 
-		return \str_word_count( $post_content, 0 );
+		// Remove Emoji.
+		$pattern      = \join( '|', \_wp_emoji_list( 'partials' ) );
+		$post_content = \wp_encode_emoji( $post_content );
+		$post_content = \preg_replace( "@$pattern/@i", ' ', $post_content );
+
+		$characters = '';
+
+		if ( \preg_match( '@[а-я]@ui', $post_content ) ) {
+			// Correct counting of the number of words in the Russian and Ukrainian languages.
+			$alphabet = [
+				'ru' => 'абвгдеёжзийклмнопрстуфхцчшщъыьэюя',
+				'ua' => 'абвгґдеєжзиіїйклмнопрстуфхцчшщьюя',
+			];
+
+			$characters = \implode( '', $alphabet );
+			$characters = \array_unique( \mb_str_split( $characters ) );
+			$characters = \implode( '', $characters );
+			$characters .= \mb_strtoupper( $characters );
+		}
+
+		// Remove characters from HTML entities
+		$post_content = \preg_replace( '@&[a-z0-9]+;@i', ' ', \htmlentities( $post_content ) );
+
+		return \str_word_count( $post_content, 0, $characters );
 	}
 }


### PR DESCRIPTION
## Context
* An issue was created #17756. I made changes to the code so that everything worked out correctly, including the Cyrillic alphabet.

## Summary
This PR can be summarized in the following changelog entry:

* Fixed a bug with incorrect counting of the number of words in the text when using Cyrillic (Russian and Ukrainian).

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a page or post with text containing Cyrillic (Russian, Ukrainian words)
* Open developer tools and find the value for wordCount in the JSON-LD schema code
* Prior to this fix, emoji and all possible characters (HTML entities) were considered
* When debugging the code, you can change the second argument of the function to 1 ( `str_word_count ( $post_content, 1 )` ) and see the list of words that got there.
* Before that, it was not correct. After the correction, it counts the Cyrillic characters


### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

*

## Impact check

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #17756
