### PR TITLE
Disable keyword in slug assessment for Japanese

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/runFullTextTests.js
+++ b/packages/yoastseo/spec/fullTextTests/runFullTextTests.js
@@ -209,7 +209,7 @@ testPapers.forEach( function( testPaper ) {
 		} );
 
 		it( "returns a score and the associated feedback text for the urlKeyword assessment", function() {
-			const isApplicable = urlKeywordAssessment.isApplicable( paper );
+			const isApplicable = urlKeywordAssessment.isApplicable( paper, researcher );
 			expect( isApplicable ).toBe( expectedResults.urlKeyword.isApplicable );
 
 			if ( isApplicable ) {

--- a/packages/yoastseo/spec/languageProcessing/languages/ja/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ja/ResearcherSpec.js
@@ -17,6 +17,8 @@ describe( "a test for Japanese Researcher", function() {
 
 	it( "returns false if the default research is deleted in the Japanese Researcher", function() {
 		expect( researcher.getResearch( "getFleschReadingScore" ) ).toBe( false );
+		expect( researcher.getResearch( "getPassiveVoiceResult" ) ).toBe( false );
+		expect( researcher.getResearch( "keywordCountInUrl" ) ).toBe( false );
 	} );
 
 	it( "returns false if the Japanese Researcher doesn't have a certain helper", function() {

--- a/packages/yoastseo/spec/scoring/assessments/seo/UrlKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/UrlKeywordAssessmentSpec.js
@@ -1,5 +1,7 @@
 import UrlKeywordAssessment from "../../../../src/scoring/assessments/seo/UrlKeywordAssessment";
 import Paper from "../../../../src/values/Paper.js";
+import JapaneseResearcher from "../../../../src/languageProcessing/languages/ja/Researcher";
+import DefaultResearcher from "../../../../src/languageProcessing/languages/_default/Researcher";
 import Factory from "../../../specHelpers/factory.js";
 
 const keywordInUrl = new UrlKeywordAssessment();
@@ -98,6 +100,30 @@ describe( "tests for the assessment applicability.", function() {
 			keyword: "kéyword",
 		} );
 		expect( keywordInUrl.isApplicable( paper ) ).toBe( true );
+	} );
+
+	it( "returns false when the researcher doesn't have the keywordCountInUrl research.", function() {
+		const paper = new Paper( "sample keyword", {
+			url: "sample-with-keyword",
+			keyword: "keyword",
+		} );
+
+		// The Japanese researcher doesn't have the keywordCountInUrl research.
+		const researcher = new JapaneseResearcher( paper );
+
+		expect( keywordInUrl.isApplicable( paper, researcher ) ).toBe( false );
+	} );
+
+	it( "returns true when the researcher has the keywordCountInUrl research.", function() {
+		const paper = new Paper( "sample keyword", {
+			url: "sample-with-keyword",
+			keyword: "keyword",
+		} );
+
+		// The Japanese researcher doesn't have the keywordCountInUrl research.
+		const researcher = new DefaultResearcher( paper );
+
+		expect( keywordInUrl.isApplicable( paper, researcher ) ).toBe( true );
 	} );
 } );
 

--- a/packages/yoastseo/spec/scoring/assessments/seo/UrlKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/UrlKeywordAssessmentSpec.js
@@ -91,7 +91,9 @@ describe( "A keyword in url count assessment", function() {
 describe( "tests for the assessment applicability.", function() {
 	it( "returns false when there is no keyword and url found.", function() {
 		const paper = new Paper( "sample keyword" );
-		expect( keywordInUrl.isApplicable( paper ) ).toBe( false );
+		const researcher = new DefaultResearcher( paper );
+
+		expect( keywordInUrl.isApplicable( paper, researcher ) ).toBe( false );
 	} );
 
 	it( "returns true when the paper has keyword and url.", function() {
@@ -99,7 +101,9 @@ describe( "tests for the assessment applicability.", function() {
 			url: "sample-with-keyword",
 			keyword: "kéyword",
 		} );
-		expect( keywordInUrl.isApplicable( paper ) ).toBe( true );
+		const researcher = new DefaultResearcher( paper );
+
+		expect( keywordInUrl.isApplicable( paper, researcher ) ).toBe( true );
 	} );
 
 	it( "returns false when the researcher doesn't have the keywordCountInUrl research.", function() {
@@ -120,7 +124,7 @@ describe( "tests for the assessment applicability.", function() {
 			keyword: "keyword",
 		} );
 
-		// The Japanese researcher doesn't have the keywordCountInUrl research.
+		// The default researcher has the keywordCountInUrl research.
 		const researcher = new DefaultResearcher( paper );
 
 		expect( keywordInUrl.isApplicable( paper, researcher ) ).toBe( true );

--- a/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/runFullTextTests.js
+++ b/packages/yoastseo/spec/scoring/collectionPages/fullTextTests/runFullTextTests.js
@@ -218,7 +218,7 @@ testPapers.forEach( function( testPaper ) {
 		} );
 
 		it( "returns a score and the associated feedback text for the urlKeyword assessment", function() {
-			const isApplicable = urlKeywordAssessment.isApplicable( paper );
+			const isApplicable = urlKeywordAssessment.isApplicable( paper, researcher );
 			expect( isApplicable ).toBe( expectedResults.urlKeyword.isApplicable );
 
 			if ( isApplicable ) {

--- a/packages/yoastseo/spec/scoring/productPages/fullTextTests/runFullTextTests.js
+++ b/packages/yoastseo/spec/scoring/productPages/fullTextTests/runFullTextTests.js
@@ -285,7 +285,7 @@ testPapers.forEach( function( testPaper ) {
 		} );
 
 		it( "returns a score and the associated feedback text for the urlKeyword assessment", function() {
-			const isApplicable = urlKeywordAssessment.isApplicable( paper );
+			const isApplicable = urlKeywordAssessment.isApplicable( paper, researcher );
 			expect( isApplicable ).toBe( expectedResults.urlKeyword.isApplicable );
 
 			if ( isApplicable ) {

--- a/packages/yoastseo/src/languageProcessing/languages/ja/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/Researcher.js
@@ -39,6 +39,7 @@ export default class Researcher extends AbstractResearcher {
 		// Deletes researches that are not available for languages that we haven't supported yet.
 		delete this.defaultResearches.getFleschReadingScore;
 		delete this.defaultResearches.getPassiveVoiceResult;
+		delete this.defaultResearches.keywordCountInUrl;
 
 		// Adds the Japanese custom research to calculate the keyword density.
 		this.addResearch( "getKeywordDensity", getKeywordDensity );

--- a/packages/yoastseo/src/scoring/assessments/seo/UrlKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/UrlKeywordAssessment.js
@@ -59,11 +59,12 @@ class UrlKeywordAssessment extends Assessment {
 	 * Checks whether the paper has a keyword and a url.
 	 *
 	 * @param {Paper}       paper       The paper to use for the assessment.
+	 * @param {Researcher}  researcher  The researcher object.
 	 *
-	 * @returns {boolean} True when there is a keyword and an url.
+	 * @returns {boolean} True if the paper contains a keyword and a URL, and if the keywordCountInUrl research is available on the researcher.
 	 */
-	isApplicable( paper ) {
-		return paper.hasKeyword() && paper.hasUrl();
+	isApplicable( paper, researcher ) {
+		return paper.hasKeyword() && paper.hasUrl() && researcher.hasResearch( "keywordCountInUrl" );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In Japanese, URLs are often written in Latin characters. Due to potential encoding errors, this is actually the preferential way of writing them. Therefore it doesn't make sense to ask for the Japanese keyphrase to be included in the slug.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Disables the keyphrase in slug assessment for Japanese.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Testing the Japanese functionality:
* Enable the JAPANESE_SUPPORT feature by adding `define( 'YOAST_SEO_JAPANESE_SUPPORT', true );` in `basic-wordpress-config.php`.
* Change the site language to Japanese (`日本語`).
* Open a new post.
* Set a keyphrase.
* Make sure the slug is filled in and doesn't contain your keyphrase.
* You **should not** see the assessment feedback with an orange bullet and the feedback text `Keyphrase in slug: (Part of) your keyphrase does not appear in the slug. Change that!`/`スラッグ中のキーフレーズ: キーフレーズ (の一部) がスラッグ中にありません。変更しましょう !`.

#### Regression Japanese with the feature flag switched off:
* Disable the JAPANESE_SUPPORT feature by adding `define( 'YOAST_SEO_JAPANESE_SUPPORT', false );` in `basic-wordpress-config.php`.
* Change the site language to English.
* Open a new post.
* Set a keyphrase.
* Make sure the slug is filled in and doesn't contain your keyphrase.
* You **should** see the assessment feedback with an orange bullet and the feedback text `Keyphrase in slug: (Part of) your keyphrase does not appear in the slug. Change that!`/`スラッグ中のキーフレーズ: キーフレーズ (の一部) がスラッグ中にありません。変更しましょう !`.

#### Regression testing in English:
* Enable the JAPANESE_SUPPORT feature by adding `define( 'YOAST_SEO_JAPANESE_SUPPORT', true );` in `basic-wordpress-config.php`.
* Change the site language to English.
* Open a new post.
* Set a keyphrase.
* Make sure the slug is filled in and doesn't contain your keyphrase.
* You **should** see the assessment feedback with an orange bullet and the feedback text `Keyphrase in slug: (Part of) your keyphrase does not appear in the slug. Change that!`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.
Note: once the feature is in the RC, the steps in `Regression Japanese with the feature flag switched off` become obsolete.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1101
