### PR TITLE
QA-2605 Wincher: hide "Add existing keyphrases" button when there are no keyphrases to track

### DIFF
--- a/packages/js/src/components/WincherPerformanceReport.js
+++ b/packages/js/src/components/WincherPerformanceReport.js
@@ -107,7 +107,7 @@ NotConnectedMessage.defaultProps = {
  * @returns {wp.Element} The message.
  */
 const NoTrackedKeyphrasesMessage = ( props ) => {
-	const { className, onTrackAllAction, limits } = props;
+	const { className, onTrackAllAction, limits, data } = props;
 
 	return (
 		<WincherSEOPerformanceReportText
@@ -116,19 +116,21 @@ const NoTrackedKeyphrasesMessage = ( props ) => {
 			{ ! isEmpty( limits ) && <WincherLimitReached limit={ limits.limit } /> }
 			{ isEmpty( limits )  && <WincherNoTrackedKeyphrasesAlert /> }
 
-			<div className={ "yoast" }>
-				<NewButton
-					variant={ "secondary" }
-					id="yoast-wincher-dashboard-widget-track-all"
-					onClick={ onTrackAllAction }
-				>
-					{ sprintf(
-						/* translators: %s expands to Wincher */
-						__( "Add your existing keyphrases to %s", "wordpress-seo" ),
-						"Wincher"
-					) }
-				</NewButton>
-			</div>
+			{ data && ! data.noKeyphrases && (
+				<div className={ "yoast" }>
+					<NewButton
+						variant={ "secondary" }
+						id="yoast-wincher-dashboard-widget-track-all"
+						onClick={ onTrackAllAction }
+					>
+						{ sprintf(
+							/* translators: %s expands to Wincher */
+							__( "Add your existing keyphrases to %s", "wordpress-seo" ),
+							"Wincher"
+						) }
+					</NewButton>
+				</div>
+			) }
 		</WincherSEOPerformanceReportText>
 	);
 };
@@ -137,11 +139,13 @@ NoTrackedKeyphrasesMessage.propTypes = {
 	className: PropTypes.string,
 	onTrackAllAction: PropTypes.func.isRequired,
 	limits: PropTypes.object,
+	data: PropTypes.object,
 };
 
 NoTrackedKeyphrasesMessage.defaultProps = {
 	className: "",
 	limits: {},
+	data: null,
 };
 
 /**

--- a/packages/js/src/dashboard-widget.js
+++ b/packages/js/src/dashboard-widget.js
@@ -165,6 +165,7 @@ class DashboardWidget extends Component {
 			this.setState( {
 				wincherData: {
 					results,
+					noKeyphrases: !! keyphraseChartData.no_keyphrases,
 					status: keyphraseChartData.status,
 				},
 			} );

--- a/src/actions/wincher/wincher-keyphrases-action.php
+++ b/src/actions/wincher/wincher-keyphrases-action.php
@@ -195,6 +195,17 @@ class Wincher_Keyphrases_Action {
 				$used_keyphrases = $this->collect_all_keyphrases();
 			}
 
+			// Don't bother proceeding if we don't have any keyphrases to fetch data for as API will 400 anyway.
+			if ( empty( $used_keyphrases ) ) {
+				return $this->to_result_object(
+					[
+						'status'        => 200,
+						'no_keyphrases' => true,  // to differentiate between 0 in Wincher and 0 in DB
+						'results'       => [],
+					]
+				);
+			}
+
 			$endpoint = \sprintf(
 				self::KEYPHRASES_URL,
 				$this->options_helper->get( 'wincher_website_id' )
@@ -217,9 +228,7 @@ class Wincher_Keyphrases_Action {
 				return $this->to_result_object( $results );
 			}
 
-			if ( ! empty( $used_keyphrases ) ) {
-				$results['data'] = $this->filter_results_by_used_keyphrases( $results['data'], $used_keyphrases );
-			}
+			$results['data'] = $this->filter_results_by_used_keyphrases( $results['data'], $used_keyphrases );
 
 			// Extract the positional data and assign it to the keyphrase.
 			$results['data'] = \array_combine(

--- a/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
+++ b/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
@@ -478,6 +478,31 @@ class Wincher_Keyphrases_Action_Test extends TestCase {
 	}
 
 	/**
+	 * Tests retrieval of keyphrases when used_keyphrases is empty.
+	 *
+	 * @covers ::get_tracked_keyphrases
+	 */
+	public function test_get_tracked_keyphrases_without_used_keyphrases() {
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'wincher_website_id' )
+			->never();
+
+		$this->client_instance
+			->expects( 'post' )
+			->never();
+
+		$this->assertEquals(
+			(object) [
+				'status'        => 200,
+				'no_keyphrases' => true,
+				'results'       => [],
+			],
+			$this->instance->get_tracked_keyphrases( [] )
+		);
+	}
+
+	/**
 	 * Tests tracking of all keyphrases.
 	 *
 	 * @covers ::track_all


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The "Add existing keyphrases" button in the dashboard was visible even though there were no focus/related keyphrases in the DB. Clicking on it had seemingly no effect since no keyphrase would be added for tracking.

**NOTE:** not 100% sure that this is the QA-2605 bug but I could not replicate it using the steps described so my best guess is that this is what caused it.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a display bug where clicking on the "Add existing keyphrases" button would seemingly have no effect.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
