### PR TITLE
PHP 8.1 | WPSEO_Image_Utils::get_image(): fix autovivification from false to array

### DIFF
--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -186,13 +186,14 @@ class WPSEO_Image_Utils {
 		}
 
 		if ( ! $image ) {
-			$image         = image_get_intermediate_size( $attachment_id, $size );
-			$image['size'] = $size;
+			$image = image_get_intermediate_size( $attachment_id, $size );
 		}
 
 		if ( ! $image ) {
 			return false;
 		}
+
+		$image['size'] = $size;
 
 		return self::get_data( $image, $attachment_id );
 	}

--- a/tests/integration/frontend/test-class-wpseo-image-utils.php
+++ b/tests/integration/frontend/test-class-wpseo-image-utils.php
@@ -62,6 +62,15 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Tests getting a non-existent medium image.
+	 *
+	 * @covers \WPSEO_Image_Utils::get_image
+	 */
+	public function test_get_image_for_non_existent_medium_image() {
+		$this->assertFalse( WPSEO_Image_Utils::get_image( 0, 'medium' ) );
+	}
+
+	/**
 	 * Returns getting the image for an existing attachment.
 	 *
 	 * @covers \WPSEO_Image_Utils::get_image


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.1

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.1

## Relevant technical choices:

The WP native `image_get_intermediate_size()` function has a return type of `array|false`, which meant that for a non-existent medium size image, `false` would be converted to an empty array by the `$image['size'] = $size;` assignment.

This type of conversion ("autovivification") was only allowed for `false`, not for any other scalar value. For other scalars (`true`, integers, floats, strings), PHP throws a fatal "Cannot use a scalar value as an array" error.

As of PHP 8.1, autovivification from `false` to array is deprecated and this will become a fatal error, same as for the other scalars, as of PHP 9.0.

To fix this, I'm proposing to move the `$image['size'] = $size;` assignment to _after_ the last `if ( ! $image )` check.

Doing so, _does_ change the behaviour of the function.
* Previously when `image_get_intermediate_size()` would return `false`, `$image` would be turned into an array anyway by the assignment, would then pass the `if ( ! $image )` check and be passed off to the `WPSEO_Image_Utils::get_data()` function.
* With the proposed change, the `WPSEO_Image_Utils::get_image()` function will effectively bow out early by returning `false` on the `if ( ! $image )` check.

In effect, though, this code flow change makes no difference as the second condition in the `WPSEO_Image_Utils::get_data()` function checks for the `'width'`  and `'height'` array indexes being set and returns `false` if they are not.
As these wouldn't be set after the autovivification from `false`, which only sets the `'size'`, the net result is the same, i.e. the function returning `false` (just quicker now).

To confirm and proof there is no behavioural change, I've added an extra unit test specifically targetting a non-existent medium image.
This test passed on PHP < 8.1 both without and with the fix and with the fix, also passes on PHP 8.1.

As a side-note, I'd recommend changing the `if ( ! $image )` conditions to a more precise check, i.e. `if ( ! is_array( $image ) )`.

Refs:
* https://wiki.php.net/rfc/autovivification_false
* https://developer.wordpress.org/reference/functions/image_get_intermediate_size/

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This change should have no effect on existing functionality and this is verified via the existing tests and the newly added test.