### PR TITLE
PHP 8.1 | WPSEO_Sitemap_Cache_Data: implement magic serialization methods

### DIFF
--- a/inc/sitemaps/class-sitemap-cache-data.php
+++ b/inc/sitemaps/class-sitemap-cache-data.php
@@ -106,37 +106,93 @@ class WPSEO_Sitemap_Cache_Data implements Serializable, WPSEO_Sitemap_Cache_Data
 	/**
 	 * String representation of object.
 	 *
-	 * @link http://php.net/manual/en/serializable.serialize.php
+	 * {@internal This magic method is only "magic" as of PHP 7.4 in which the magic method was introduced.}
 	 *
-	 * @since 5.1.0
+	 * @link https://www.php.net/language.oop5.magic#object.serialize
+	 * @link https://wiki.php.net/rfc/custom_object_serialization
 	 *
-	 * @return string The string representation of the object or null.
+	 * @since 17.8.0
+	 *
+	 * @return array The data to be serialized.
 	 */
-	public function serialize() {
+	public function __serialize() { // phpcs:ignore PHPCompatibility.FunctionNameRestrictions.NewMagicMethods.__serializeFound
 
 		$data = [
 			'status' => $this->status,
 			'xml'    => $this->sitemap,
 		];
 
-		return serialize( $data );
+		return $data;
 	}
 
 	/**
 	 * Constructs the object.
 	 *
-	 * @link http://php.net/manual/en/serializable.unserialize.php
+	 * {@internal This magic method is only "magic" as of PHP 7.4 in which the magic method was introduced.}
 	 *
-	 * @since 5.1.0
+	 * @link https://www.php.net/language.oop5.magic#object.serialize
+	 * @link https://wiki.php.net/rfc/custom_object_serialization
 	 *
-	 * @param string $serialized The string representation of the object.
+	 * @since 17.8.0
+	 *
+	 * @param array $data The unserialized data to use to (re)construct the object.
 	 *
 	 * @return void
 	 */
-	public function unserialize( $serialized ) {
+	public function __unserialize( $data ) { // phpcs:ignore PHPCompatibility.FunctionNameRestrictions.NewMagicMethods.__unserializeFound
 
-		$data = unserialize( $serialized );
 		$this->set_sitemap( $data['xml'] );
 		$this->set_status( $data['status'] );
+	}
+
+	/**
+	 * String representation of object.
+	 *
+	 * {@internal The magic methods take precedence over the Serializable interface.
+	 * This means that in practice, this method will now only be called on PHP < 7.4.
+	 * For PHP 7.4 and higher, the magic methods will be used instead.}
+	 *
+	 * {@internal The Serializable interface is being phased out, in favour of the magic methods.
+	 * This method should be deprecated and removed and the class should no longer
+	 * implement the `Serializable` interface.
+	 * This change, however, can't be made until the minimum PHP version goes up to PHP 7.4 or higher.}
+	 *
+	 * @link http://php.net/manual/en/serializable.serialize.php
+	 * @link https://wiki.php.net/rfc/phase_out_serializable
+	 *
+	 * @since 5.1.0
+	 *
+	 * @return string The string representation of the object or null in C-format.
+	 */
+	public function serialize() {
+
+		return serialize( $this->__serialize() );
+	}
+
+	/**
+	 * Constructs the object.
+	 *
+	 * {@internal The magic methods take precedence over the Serializable interface.
+	 * This means that in practice, this method will now only be called on PHP < 7.4.
+	 * For PHP 7.4 and higher, the magic methods will be used instead.}
+	 *
+	 * {@internal The Serializable interface is being phased out, in favour of the magic methods.
+	 * This method should be deprecated and removed and the class should no longer
+	 * implement the `Serializable` interface.
+	 * This change, however, can't be made until the minimum PHP version goes up to PHP 7.4 or higher.}
+	 *
+	 * @link http://php.net/manual/en/serializable.unserialize.php
+	 * @link https://wiki.php.net/rfc/phase_out_serializable
+	 *
+	 * @since 5.1.0
+	 *
+	 * @param string $data The string representation of the object in C or O-format.
+	 *
+	 * @return void
+	 */
+	public function unserialize( $data ) {
+
+		$data = unserialize( $data );
+		$this->__unserialize( $data );
 	}
 }

--- a/inc/sitemaps/class-sitemaps-cache.php
+++ b/inc/sitemaps/class-sitemaps-cache.php
@@ -122,9 +122,15 @@ class WPSEO_Sitemaps_Cache {
 			return null;
 		}
 
-		// Unserialize Cache Data object (is_serialized doesn't recognize classes).
+		/*
+		 * Unserialize Cache Data object as is_serialized() doesn't recognize classes in C format.
+		 * This work-around should no longer be needed once the minimum PHP version has gone up to PHP 7.4,
+		 * as the `WPSEO_Sitemap_Cache_Data` class uses O format serialization in PHP 7.4 and higher.
+		 *
+		 * @link https://wiki.php.net/rfc/custom_object_serialization
+		 */
 		if ( is_string( $sitemap ) && strpos( $sitemap, 'C:24:"WPSEO_Sitemap_Cache_Data"' ) === 0 ) {
-
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- Can't be avoided due to how WP stores options.
 			$sitemap = unserialize( $sitemap );
 		}
 

--- a/tests/integration/sitemaps/test-class-wpseo-sitemaps-cache-data.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemaps-cache-data.php
@@ -147,7 +147,10 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 	 *
 	 * Tests if the class is serializable.
 	 *
-	 * @covers WPSEO_Sitemap_Cache_Data::set_sitemap
+	 * @covers WPSEO_Sitemap_Cache_Data::__serialize
+	 * @covers WPSEO_Sitemap_Cache_Data::__unserialize
+	 * @covers WPSEO_Sitemap_Cache_Data::serialize
+	 * @covers WPSEO_Sitemap_Cache_Data::unserialize
 	 */
 	public function test_serialize_unserialize() {
 		$sitemap = 'this is a sitemap';

--- a/tests/integration/sitemaps/test-class-wpseo-sitemaps-cache.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemaps-cache.php
@@ -55,8 +55,19 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 
 		$result = $cache->get_sitemap( $type, $page );
 
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- Reason: There's no security risk, because users don't interact with tests.
-		$this->assertEquals( $test, unserialize( $result ) );
+		/*
+		 * In PHP < 7.4 the "old" serialization mechanism via the Serializable interface is used,
+		 * which combined with the WP logic doesn't automatically unserialize, which is why we need
+		 * to do so ourselves.
+		 * As of PHP 7.4, the new serialization using magic methods is used.
+		 */
+		if ( PHP_VERSION_ID < 70400 ) {
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- Reason: There's no security risk, because users don't interact with tests.
+			$result = unserialize( $result );
+		}
+
+		$this->assertEquals( $test, $result );
+
 		$this->assertEquals( $test, $cache->get_sitemap_data( $type, $page ) );
 	}
 

--- a/tests/integration/sitemaps/test-class-wpseo-sitemaps-cache.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemaps-cache.php
@@ -96,6 +96,99 @@ class WPSEO_Sitemaps_Cache_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
+	 * Test that a sitemap cache originally stored when WP was running on PHP < 7.4 can be retrieved and used in all PHP versions.
+	 *
+	 * @covers WPSEO_Sitemaps_Cache::get_sitemap_data
+	 * @covers WPSEO_Sitemap_Cache_Data::__serialize
+	 * @covers WPSEO_Sitemap_Cache_Data::__unserialize
+	 * @covers WPSEO_Sitemap_Cache_Data::serialize
+	 * @covers WPSEO_Sitemap_Cache_Data::unserialize
+	 */
+	public function test_retrieving_transient_stored_in_php_lt_74() {
+
+		$sitemap = 'this is a wpseo_sitemap_cache_data object stored in PHP < 7.4';
+		$type    = 'post';
+		$page    = 1;
+
+		$transient_key = WPSEO_Sitemaps_Cache_Validator::get_storage_key( $type, $page );
+
+		/*
+		 * Using this filter, we effectively mock the get_transient() and
+		 * the get_option() WP functions, including the call to maybe_unserialize() in get_option().
+		 * These functions are used in the get_sitemap[_data]() method to retrieve the transient.
+		 * This filter short-circuits those function calls to return the specific value we need for this test.
+		 */
+		add_filter(
+			"pre_transient_{$transient_key}",
+			static function ( $pre_transient ) {
+				$pre_transient = 'C:24:"WPSEO_Sitemap_Cache_Data":107:{a:2:{s:6:"status";s:2:"ok";s:3:"xml";s:61:"this is a wpseo_sitemap_cache_data object stored in PHP < 7.4";}}';
+				return maybe_unserialize( $pre_transient );
+			}
+		);
+
+		$cache  = new WPSEO_Sitemaps_Cache();
+		$result = $cache->get_sitemap_data( $type, $page );
+
+		$this->assertInstanceOf( 'WPSEO_Sitemap_Cache_Data', $result );
+		$this->assertSame( $sitemap, $result->get_sitemap() );
+		$this->assertSame( 'ok', $result->get_status() );
+	}
+
+	/**
+	 * Test that a sitemap cache originally stored when WP was running on PHP >= 7.4 can be retrieved and used
+	 * without problems on PHP >= 7.4.
+	 *
+	 * This test also documents that when the cache was stored in PHP >= 7.4, but the PHP version on which WP
+	 * is being run was subsequently downgraded to PHP < 7.4, the cache will be disregarded and the sitemap will
+	 * need to be rebuild.
+	 *
+	 * For that particular scenario, this test also safeguards that the code under test doesn't yield any PHP
+	 * errors when the unusable sitemap cache data is encountered.
+	 *
+	 * @covers WPSEO_Sitemaps_Cache::get_sitemap_data
+	 * @covers WPSEO_Sitemap_Cache_Data::__serialize
+	 * @covers WPSEO_Sitemap_Cache_Data::__unserialize
+	 * @covers WPSEO_Sitemap_Cache_Data::serialize
+	 * @covers WPSEO_Sitemap_Cache_Data::unserialize
+	 */
+	public function test_retrieving_transient_stored_in_php_gte_74() {
+
+		$sitemap = 'this is a wpseo_sitemap_cache_data object stored in PHP >= 7.4';
+		$type    = 'post';
+		$page    = 1;
+
+		$transient_key = WPSEO_Sitemaps_Cache_Validator::get_storage_key( $type, $page );
+
+		/*
+		 * Using this filter, we effectively mock the get_transient() and
+		 * the get_option() WP functions, including the call to maybe_unserialize() in get_option().
+		 * These functions are used in the get_sitemap[_data]() method to retrieve the transient.
+		 * This filter short-circuits those function calls to return the specific value we need for this test.
+		 */
+		add_filter(
+			"pre_transient_{$transient_key}",
+			static function ( $pre_transient ) {
+				$pre_transient = 'O:24:"WPSEO_Sitemap_Cache_Data":2:{s:6:"status";s:2:"ok";s:3:"xml";s:62:"this is a wpseo_sitemap_cache_data object stored in PHP >= 7.4";}';
+				return maybe_unserialize( $pre_transient );
+			}
+		);
+
+		$cache  = new WPSEO_Sitemaps_Cache();
+		$result = $cache->get_sitemap_data( $type, $page );
+
+		if ( PHP_VERSION_ID >= 70400 ) {
+			// PHP 7.4+.
+			$this->assertInstanceOf( 'WPSEO_Sitemap_Cache_Data', $result );
+			$this->assertSame( $sitemap, $result->get_sitemap() );
+			$this->assertSame( 'ok', $result->get_status() );
+		}
+		else {
+			// PHP 7.3 and lower.
+			$this->assertNull( $result );
+		}
+	}
+
+	/**
 	 * Clearing all cache.
 	 *
 	 * @covers WPSEO_Sitemaps_Cache::clear


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.1

## Summary

This PR can be summarized in the following changelog entry:

* Prepares for compatibility with PHP 8.1 by implementing magic methods used by PHP7.4 and up.

## Relevant technical choices:

### PHP 8.1 | WPSEO_Sitemap_Cache_Data: implement magic serialization methods

PHP 7.4 introduced the magic `__serialize()` and `__unserialize()` methods as an improved way to handle object serialization compared to the `Serializable` interface and/or the magic `__sleep()` and __wakeup()` methods.

As of PHP 8.1, implementing the `Serializable` interface is deprecated, unless the class also implements the new magic methods.

The `WPSEO_Sitemap_Cache_Data` class implements the `Serializable` interface and would throw the following deprecation notice on PHP 8.1:
```
Deprecated: WPSEO_Sitemap_Cache_Data implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)
```

As the minimum supported PHP version is below 7.4, this means that - for the time being - both the `Serializable` interface as well as the magic methods need to be implemented.

For PHP 7.4 and higher, the magic methods will take precedence over the `Serializable` implementation and the `serialize()` and `unserialize()` methods will no longer be used.

Once PHP 7.4 becomes the minimum supported PHP version, these unused methods should be removed.

Note: the `Serializable` interface will be removed from PHP in PHP 9.0 and, while the interface can be polyfilled, such a polyfill will have **no effect** on the serialization of the object.

The existing `WPSEO_Sitemaps_Cache_Data_Test::test_serialize_unserialize()` integration test covers this change.

Includes a small adjustment to the `WPSEO_Sitemaps_Cache_Test::test_transient_cache_data_object()` to allow for WP handling the two types of serialization differently.

Includes fixing up the parameter name for the existing `unserialize()` method to be in line with the documented parameter name in PHP (for named parameter support in PHP 8.0).

Includes fixing the `@covers` tags for the `WPSEO_Sitemaps_Cache_Data_Test::test_serialize_unserialize()` test.

Refs:
* https://wiki.php.net/rfc/custom_object_serialization
* https://wiki.php.net/rfc/phase_out_serializable
* https://www.php.net/language.oop5.magic#object.serialize
* https://www.php.net/manual/en/class.serializable.php
* https://www.phpinternalsbook.com/php5/classes_objects/serialization.html

### WPSEO_Sitemaps_Cache_Test: add two extra tests

These tests document and safeguard the behaviour for the serialized class when the serialization of the sitemap was done on a different PHP version than the PHP version on which the sitemap is being unserialized.

For sitemaps cached on PHP < 7.4 (and on PHP 7.4+ prior to this change) and unserialized on any PHP version, everything will work fine.

For sitemaps cached on PHP 7.4+ (after this change) and unserialized on PHP < 7.4, the unserialization will fail because of the O-format being used in PHP 7.4+, which cannot be unserialized with PHP < 7.4.

As a site being downgraded from PHP 7.4+ to PHP < 7.4 should be regarded as an edge-case, I'm deeming it unnecessary to create a custom unserialization function for this. Instead the cache will be empty and the sitemap will need to be rebuild. This rebuilding is a one-time only action (for this particular problem).

Note: I've added these tests to the `WPSEO_Sitemaps_Cache_Test` class rather than the `WPSEO_Sitemaps_Cache_Data_Test`.
While the serialization is handled in the `WPSEO_Sitemaps_Cache_Data_Test`, it is the combination with the WP native `get_transient()` and `get_option()` functions as used in the `WPSEO_Sitemaps_Cache::get_sitemap()` and the `WPSEO_Sitemaps_Cache::get_sitemap_data()` functions which leads to the behaviour we're seeing and to the fact that this behaviour is not causing new PHP errors.


👉🏻 Note: I've milestoned this PR to `17.9` as the PR introduces two new methods. If the PR would move to a later YoastSEO version, the `@since` tags for the new methods will needs to be updated.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

This is a technical change to the serialization methodology used. There should be no behavioural changes in the sitemap component and the technical aspects of it is covered in detail by the pre-existing and newly added unit tests.

The only "user-facing" test which could be done is to test both against `trunk` and this branch that for an install which has posts and a sitemap already generated, the sitemap gets displayed correctly when called up again (from the cache).

The value of such manual testing however is low in this case, so I'd advise to critically review the unit tests instead and then trust the CI build.


### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.


## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* Sitemaps
