### PR TITLE
DUPP-145 Revert conf. workout prerequisite

### DIFF
--- a/packages/js/src/workouts/components/CornerstoneWorkoutCard.js
+++ b/packages/js/src/workouts/components/CornerstoneWorkoutCard.js
@@ -21,8 +21,6 @@ export default function CornerstoneWorkoutCard( {
 	upsellText,
 } ) {
 	const finishedSteps = useSelect( select => select( "yoast-seo/workouts" ).getFinishedSteps( WORKOUTS.cornerstone ) );
-	const finishedWorkouts = useSelect( select => select( "yoast-seo/workouts" ).getFinishedWorkouts() );
-	const isConfigurationWorkoutFinished = finishedWorkouts.includes( WORKOUTS.configuration );
 	const actualUpsellLink = upsellLink ? upsellLink :  "https://yoa.st/workout-cornerstone-upsell";
 
 	return <WorkoutCard
@@ -40,7 +38,6 @@ export default function CornerstoneWorkoutCard( {
 		upsellText={ upsellText }
 		workout={ workout }
 		badges={ badges }
-		blocked={ ! isConfigurationWorkoutFinished && ( window.wpseoWorkoutsData.canDoConfigurationWorkout === "1" ) }
 	/>;
 }
 

--- a/packages/js/src/workouts/components/OrphanedWorkoutCard.js
+++ b/packages/js/src/workouts/components/OrphanedWorkoutCard.js
@@ -21,8 +21,6 @@ export default function OrphanedWorkoutCard( {
 	upsellText,
 } ) {
 	const finishedSteps = useSelect( select => select( "yoast-seo/workouts" ).getFinishedSteps( WORKOUTS.orphaned ) );
-	const finishedWorkouts = useSelect( select => select( "yoast-seo/workouts" ).getFinishedWorkouts() );
-	const isConfigurationWorkoutFinished = finishedWorkouts.includes( WORKOUTS.configuration );
 	const actualUpsellLink = upsellLink ? upsellLink :  "https://yoa.st/workout-orphaned-content-upsell";
 
 	return <WorkoutCard
@@ -40,7 +38,6 @@ export default function OrphanedWorkoutCard( {
 		upsellText={ upsellText }
 		workout={ workout }
 		badges={ badges }
-		blocked={ ! isConfigurationWorkoutFinished && ( window.wpseoWorkoutsData.canDoConfigurationWorkout === "1" ) }
 	/>;
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Reverts #17729

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the configuration workout as a prerequisite for the Premium workouts.

## Relevant technical choices:

* We just remove the variables on which the condition is triggered, but the overaly is still there for future use if needed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Premium > 17.7
* visit SEO > Workouts
* if the Configuration workout is already completed, restart it and then navigate back to the workouts overview
* check that the premium workouts are still accessible even with the conf. workout not completed, and you don't see the "required" overlay hiding the buttons
* disable premium and check that you can see the upsell buttons for the premium workouts



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-145]


[DUPP-145]: https://yoast.atlassian.net/browse/DUPP-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ