### PR TITLE
Add skip link to free installation success page

### DIFF
--- a/css/src/installation-success.css
+++ b/css/src/installation-success.css
@@ -87,3 +87,13 @@
 #installation-success-card-configuration-workout .yoast-button {
 	box-shadow: inset 0 -3px rgba(0, 0, 0, 0.3);
 }
+
+#installation-success-skip-link {
+	align-self: end;
+	bottom: 0;
+	margin-bottom: 9px;
+	position: absolute;
+	margin-right: 20px;
+	letter-spacing: -0.08px;
+	line-height: 19px;
+}

--- a/packages/js/src/installation-success.js
+++ b/packages/js/src/installation-success.js
@@ -68,8 +68,8 @@ function InstallationSuccessPage() {
 			</div>
 			<a id="installation-success-skip-link" href={ "/wp-admin/admin.php?page=wpseo_dashboard" }>
 				{
-					/* translators: %s expands to '»'. */
-					sprintf( __( "Skip %s", "wordpress-seo" ), "»" )
+					/* translators: %s expands to ' »'. */
+					sprintf( __( "Skip%s", "wordpress-seo" ), " »" )
 				}
 			</a>
 		</div>

--- a/packages/js/src/installation-success.js
+++ b/packages/js/src/installation-success.js
@@ -66,6 +66,12 @@ function InstallationSuccessPage() {
 					</div>
 				</div>
 			</div>
+			<a id="installation-success-skip-link" href={ "/wp-admin/admin.php?page=wpseo_dashboard" }>
+				{
+					/* translators: %s expands to '»'. */
+					sprintf( __( "Skip %s", "wordpress-seo" ), "»" )
+				}
+			</a>
 		</div>
 	);
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the skip link to free the installation success page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Feature flag enabled
* Enable the feature flag: add `define( 'YOAST_SEO_INSTALLATION_SUCCESS', true );` to your `wp-config.php` file
* Navigate to `{admin-url}/admin.php?page=wpseo_installation_successful_free`.
* See the Skip link matches the [design](https://www.sketch.com/s/d8601833-a14f-4dff-bee0-426acfa4a2c8/a/098oodO/play).
* See the skip link navigates you to the SEO Dashboard.

#### Feature flag disabled
* N/A



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-132](https://yoast.atlassian.net/browse/DUPP-132)
