### PR TITLE
Change font size alerts from 14px to 13px

### DIFF
--- a/css/src/alerts.css
+++ b/css/src/alerts.css
@@ -31,7 +31,7 @@
 /* Needs higher specificity than a Gutenberg ruleset selector. */
 .yoast-alert__icon.yoast-alert__icon {
 	display: block;
-	margin-top: 0.125rem;
+	margin-top: 0.1rem;
 	margin-right: 8px;
 	height: 16px;
 	width: 16px;

--- a/css/src/alerts.css
+++ b/css/src/alerts.css
@@ -3,7 +3,7 @@
 	align-items: flex-start;
 	padding: 16px;
 	border: 1px solid rgba(0, 0, 0, 0.2);
-	font-size: 14px;
+	font-size: 13px;
 	line-height: 1.5;
 	margin: 16px 0;
 }

--- a/packages/components/src/Alert.js
+++ b/packages/components/src/Alert.js
@@ -15,7 +15,7 @@ import SvgIcon from "./SvgIcon";
 const AlertContainer = styled.div`
 	display: flex;
 	align-items: flex-start;
-	font-size: 14px;
+	font-size: 13px;
 	line-height: 1.5;
 	border: 1px solid rgba(0, 0, 0, 0.2);
 	padding: 16px;
@@ -30,7 +30,7 @@ const AlertContent = styled.div`
 	a {
 		color: ${ colors.$color_alert_link_text };
 	}
-	
+
 	p {
 		margin-top: 0;
 	}

--- a/packages/components/src/Alert.js
+++ b/packages/components/src/Alert.js
@@ -37,7 +37,7 @@ const AlertContent = styled.div`
 `;
 
 const AlertIcon = styled( SvgIcon )`
-	margin-top: 0.125rem;
+	margin-top: 0.1rem;
 	${ getDirectionalStyle( "margin-right: 8px", "margin-left: 8px" ) };
 `;
 

--- a/packages/components/tests/__snapshots__/AlertTest.js.snap
+++ b/packages/components/tests/__snapshots__/AlertTest.js.snap
@@ -86,7 +86,7 @@ exports[`Alert passing onDismissed makes the alert dismissable 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.5;
   border: 1px solid rgba(0,0,0,0.2);
   padding: 16px;
@@ -111,7 +111,7 @@ exports[`Alert passing onDismissed makes the alert dismissable 1`] = `
 }
 
 .c2 {
-  margin-top: 0.125rem;
+  margin-top: 0.1rem;
   margin-right: 8px;
 }
 
@@ -215,7 +215,7 @@ exports[`Alert the Alert types match the snapshot 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.5;
   border: 1px solid rgba(0,0,0,0.2);
   padding: 16px;
@@ -240,7 +240,7 @@ exports[`Alert the Alert types match the snapshot 1`] = `
 }
 
 .c2 {
-  margin-top: 0.125rem;
+  margin-top: 0.1rem;
   margin-right: 8px;
 }
 
@@ -287,7 +287,7 @@ exports[`Alert the Alert types match the snapshot 2`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.5;
   border: 1px solid rgba(0,0,0,0.2);
   padding: 16px;
@@ -312,7 +312,7 @@ exports[`Alert the Alert types match the snapshot 2`] = `
 }
 
 .c2 {
-  margin-top: 0.125rem;
+  margin-top: 0.1rem;
   margin-right: 8px;
 }
 
@@ -359,7 +359,7 @@ exports[`Alert the Alert types match the snapshot 3`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.5;
   border: 1px solid rgba(0,0,0,0.2);
   padding: 16px;
@@ -384,7 +384,7 @@ exports[`Alert the Alert types match the snapshot 3`] = `
 }
 
 .c2 {
-  margin-top: 0.125rem;
+  margin-top: 0.1rem;
   margin-right: 8px;
 }
 
@@ -431,7 +431,7 @@ exports[`Alert the Alert types match the snapshot 4`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.5;
   border: 1px solid rgba(0,0,0,0.2);
   padding: 16px;
@@ -456,7 +456,7 @@ exports[`Alert the Alert types match the snapshot 4`] = `
 }
 
 .c2 {
-  margin-top: 0.125rem;
+  margin-top: 0.1rem;
   margin-right: 8px;
 }
 

--- a/packages/social-metadata-forms/tests/__snapshots__/ImageSelectTest.js.snap
+++ b/packages/social-metadata-forms/tests/__snapshots__/ImageSelectTest.js.snap
@@ -86,7 +86,7 @@ exports[`The ImageSelect component displays warnings 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.5;
   border: 1px solid rgba(0,0,0,0.2);
   padding: 16px;
@@ -111,7 +111,7 @@ exports[`The ImageSelect component displays warnings 1`] = `
 }
 
 .c4 {
-  margin-top: 0.125rem;
+  margin-top: 0.1rem;
   margin-right: 8px;
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the font size of the alerts from 14px to 13px.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### PHP Alerts
* Navigate to SEO > Social > Facebook.
* Set `Add Open Graph meta data` to `Enabled`.
* Check the font-size of the alert is 13px.
  <img width="500" alt="Screenshot 2021-12-08 at 11 04 20" src="https://user-images.githubusercontent.com/43582255/145189118-707dc05c-22c5-436b-a095-b252669a615d.png">

#### JS Alerts
* Navigate to SEO > Search Appearance.
* Remove your Organization / Person name or logo.
* Check the font-size of the alert is 13px. 
  <img width="500" alt="Screenshot 2021-12-08 at 11 05 40" src="https://user-images.githubusercontent.com/43582255/145189303-64cb2035-a942-4179-a5bd-8f2bc6bc387e.png">

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-119](https://yoast.atlassian.net/browse/DUPP-119)
