### PR TITLE
Fixes highlights for sentence length assessment

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/sentence/sentencesLengthSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/sentence/sentencesLengthSpec.js
@@ -1,29 +1,41 @@
 import sentencesLength from "../../../../src/languageProcessing/helpers/sentence/sentencesLength";
 import JapaneseResearcher from "../../../../src/languageProcessing/languages/ja/Researcher";
 import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
+import Paper from "../../../../src/values/Paper";
 
-describe( "A test to count the sentence length.", function() {
-	it( "doesn't return a length for an empty sentence", function() {
+describe( "A test to count sentence lengths.", function() {
+	it( "should not return a length for an empty sentence", function() {
 		const sentences = [ "", "A sentence" ];
+		const mockResearcher = new EnglishResearcher( new Paper( "" ) );
 
-		const lengths = sentencesLength( sentences, new EnglishResearcher() );
+		const lengths = sentencesLength( sentences, mockResearcher );
 
-		expect( lengths ).toEqual( [ { sentence: "A sentence", sentenceLength: 2 } ] );
+		expect( lengths ).toEqual( [
+			{ sentence: "A sentence", sentenceLength: 2 },
+		] );
 	} );
 
-	it( "returns the string and the length of each sentence (the HTML tags should be stripped if present)", function() {
-		const sentences = [ "A good text", "this is a <span>textstring</span>" ];
+	it( "should return the sentences and their length (the HTML tags should not be counted if present)", function() {
+		const sentences = [ "A <strong>good</strong> text", "this is a <span style='color: blue;'> textstring </span>" ];
+		const mockResearcher = new EnglishResearcher( new Paper( "" ) );
 
-		const lengths = sentencesLength( sentences, new EnglishResearcher() );
+		const lengths = sentencesLength( sentences, mockResearcher );
 
-		expect( lengths ).toEqual( [ { sentence: "A good text", sentenceLength: 3 }, { sentence: "this is a textstring", sentenceLength: 4 } ] );
+		expect( lengths ).toEqual( [
+			{ sentence: "A <strong>good</strong> text", sentenceLength: 3 },
+			{ sentence: "this is a <span style='color: blue;'> textstring </span>", sentenceLength: 4 },
+		] );
 	} );
 
-	it( "returns the string and the length of each sentence (the HTML tags should be stripped if present) in Japanese", function() {
-		const sentences = [ "自然おのずから存在しているもの", "歩くさわやかな森 <span>自然</span>" ];
+	it( "should return the sentences and their length for Japanese (so counting characters)", function() {
+		const sentences = [ "自然おのずから存在しているもの", "歩くさわやかな森 <span style='color: red;'> 自然 </span>" ];
+		const mockJapaneseResearcher = new JapaneseResearcher( new Paper( "" ) );
 
-		const lengths = sentencesLength( sentences, new JapaneseResearcher() );
+		const lengths = sentencesLength( sentences, mockJapaneseResearcher );
 
-		expect( lengths ).toEqual( [ { sentence: "自然おのずから存在しているもの", sentenceLength: 15 }, { sentence: "歩くさわやかな森 自然", sentenceLength: 11 } ] );
+		expect( lengths ).toEqual( [
+			{ sentence: "自然おのずから存在しているもの", sentenceLength: 15 },
+			{ sentence: "歩くさわやかな森 <span style='color: red;'> 自然 </span>", sentenceLength: 11 },
+		] );
 	} );
 } );

--- a/packages/yoastseo/src/languageProcessing/helpers/sentence/sentencesLength.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/sentence/sentencesLength.js
@@ -3,12 +3,12 @@ import { forEach } from "lodash-es";
 import { stripFullTags as stripHTMLTags } from "../sanitize/stripHTMLTags.js";
 
 /**
- * Returns an array with the number of words in a sentence.
+ * Returns an array with the length of each sentence.
  *
  * @param {Array} sentences Array with sentences from text.
  * @param {Researcher} 	researcher 	The researcher to use for analysis.
  *
- * @returns {Array} Array with amount of words in each sentence.
+ * @returns {Array} Array with the length of each sentence.
  */
 export default function( sentences, researcher ) {
 	const sentencesWordCount = [];
@@ -23,7 +23,7 @@ export default function( sentences, researcher ) {
 		}
 
 		sentencesWordCount.push( {
-			sentence: strippedSentence,
+			sentence: sentence,
 			sentenceLength: length,
 		} );
 	} );


### PR DESCRIPTION

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The highlight for sentence length assessment did not work outside the WordPress environment. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Fixes highlights for sentence length assessment for other environments

## Relevant technical choices:

* While we used to output the sentence stripped from HTML, we now output the sentence with its HTML, so that it can be matched with the sentence in the editor. This functionality already worked in WordPress, but not outside this environment. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See the final steps in https://github.com/Yoast/shopify-seo/pull/485 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Highlighting of the results of the readability and SEO analysis. 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1148
