### PR TITLE
WPSEO_Admin_Gutenberg_Compatibility_Notification_Test: minor fixes/simplification

### DIFF
--- a/tests/unit/admin/admin-gutenberg-compatibility-notification-test.php
+++ b/tests/unit/admin/admin-gutenberg-compatibility-notification-test.php
@@ -58,14 +58,6 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification_Test extends TestCase {
 	}
 
 	/**
-	 * Tear down the test mocks.
-	 */
-	public function tear_down() {
-		parent::tear_down();
-		Mockery::close();
-	}
-
-	/**
 	 * Tests the conditions that remove the Gutenberg notification.
 	 *
 	 * @dataProvider data_provider_manage_notification_remove_notification
@@ -84,9 +76,12 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification_Test extends TestCase {
 				->andReturn( false );
 		}
 
-		$this->gutenberg_compatibility_mock->allows()->is_installed()->andReturns( $installed );
-
-		$this->gutenberg_compatibility_mock->allows()->is_fully_compatible()->andReturns( $fully_compatible );
+		$this->gutenberg_compatibility_mock->allows(
+			[
+				'is_installed'        => $installed,
+				'is_fully_compatible' => $fully_compatible,
+			]
+		);
 
 		$this->notification_center_mock->expects( 'remove_notification_by_id' )->once()->with( 'wpseo-outdated-gutenberg-plugin' );
 
@@ -135,17 +130,17 @@ class WPSEO_Admin_Gutenberg_Compatibility_Notification_Test extends TestCase {
 			]
 		);
 
-		$this->gutenberg_compatibility_mock->allows()->is_installed()->andReturns( true );
-
-		$this->gutenberg_compatibility_mock->allows()->is_fully_compatible()->andReturns( false );
+		$this->gutenberg_compatibility_mock->allows(
+			[
+				'is_installed'        => true,
+				'is_fully_compatible' => false,
+			]
+		);
 
 		$this->notification_center_mock->expects( 'add_notification' )->once()->withArgs(
 			static function ( $arg ) {
 				// Verify that the added notification is a Yoast_Notification object and has the correct id.
-				if ( \is_a( $arg, 'Yoast_Notification' ) && $arg->get_id() === 'wpseo-outdated-gutenberg-plugin' ) {
-					return true;
-				}
-				return false;
+				return ( \is_a( $arg, 'Yoast_Notification' ) && $arg->get_id() === 'wpseo-outdated-gutenberg-plugin' );
 			}
 		);
 


### PR DESCRIPTION
## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

1. The `Mockery::close()` is already handled by the parent `tear_down()`, or rather, the `Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration` trait used by the parent class handles this, so the `tear_down()` method is redundant.
2. The Mockery `allows()` method allows for passing an array of functions with their return value, so let's use that instead of calling the method multiple times.
    Ref: http://docs.mockery.io/en/latest/reference/alternative_should_receive_syntax.html?highlight=allows#allows
3. The if/else to return a boolean value is unnecessary. Returning the result of the condition does the same.



## Test instructions

This PR can be tested by following these steps:
* _N/A_ This change only involves the tests. If the build passes, we're good.

