### PR TITLE
HTML_Helper_Test: improve tests

### DIFF
--- a/tests/unit/helpers/schema/html-helper-test.php
+++ b/tests/unit/helpers/schema/html-helper-test.php
@@ -35,53 +35,80 @@ class HTML_Helper_Test extends TestCase {
 	 * Test whether sanitize sanitizes properly.
 	 *
 	 * @covers ::sanitize
+	 *
+	 * @dataProvider data_sanitize
+	 *
+	 * @param mixed  $input    The input to sanitize.
+	 * @param string $expected The expected return value.
 	 */
-	public function test_sanitize() {
-		// Test whether sanitize properly removes script tags.
-		$input    = 'Test <script>alert(0)</script> bla';
-		$expected = 'Test alert(0) bla';
-		$this->assertEquals( $expected, $this->instance->sanitize( $input ) );
+	public function test_sanitize( $input, $expected ) {
+		$this->assertSame( $expected, $this->instance->sanitize( $input ) );
+	}
 
-		// Test whether sanitize leaves allowed <p> tags intact.
-		$input    = 'Test <p>Paragraph</p> bla';
-		$expected = 'Test <p>Paragraph</p> bla';
-		$this->assertEquals( $expected, $this->instance->sanitize( $input ) );
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_sanitize() {
+		return [
+			'Text containing script tags should have the script tags stripped' => [
+				'input'    => 'Test <script>alert(0)</script> bla',
+				'expected' => 'Test alert(0) bla',
+			],
+			'Text containing allowed tag should be returned unchanged' => [
+				'input'    => 'Test <p>Paragraph</p> bla',
+				'expected' => 'Test <p>Paragraph</p> bla',
+			],
+		];
 	}
 
 	/**
 	 * Test whether smart strips tags strips tags in a smart way.
 	 *
 	 * @covers ::smart_strip_tags
+	 *
+	 * @dataProvider data_smart_strip_tags
+	 *
+	 * @param mixed  $input    The input to sanitize.
+	 * @param string $expected The expected return value.
 	 */
-	public function test_smart_strip_tags() {
-		// Test removing script tags.
-		$input    = 'Test </script>bla';
-		$expected = 'Test bla';
-		$this->assertEquals( $expected, $this->instance->smart_strip_tags( $input ) );
+	public function test_smart_strip_tags( $input, $expected ) {
+		$this->assertSame( $expected, $this->instance->smart_strip_tags( $input ) );
+	}
 
-		// Test removing script tags.
-		$input    = 'Test </script ><script>alert(0)</script><script>';
-		$expected = 'Test';
-		$this->assertEquals( $expected, $this->instance->smart_strip_tags( $input ) );
-
-		// Test replacing `<br>` tags with spaces.
-		$input    = 'Test<br>word';
-		$expected = 'Test word';
-		$this->assertEquals( $expected, $this->instance->smart_strip_tags( $input ) );
-
-		// Test replacing closing heading tags with spaces.
-		$input    = '<h1>Heading</h1>
-First words';
-		$expected = 'Heading First words';
-		$this->assertEquals( $expected, $this->instance->smart_strip_tags( $input ) );
-
-		// Test replacing tags li with • and new lines with spaces.
-		$input    = 'I am:
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_smart_strip_tags() {
+		return [
+			'Test replacing `<br>` tag with space' => [
+				'input'    => 'Test<br>word',
+				'expected' => 'Test word',
+			],
+			'Test adding a space when replacing heading close tags' => [
+				'input'    => '<h1>Heading</h1>
+First words',
+				'expected' => 'Heading First words',
+			],
+			'Test replacing tags li with • and new lines with spaces' => [
+				'input'    => 'I am:
 <ul>
 <li>smart</li>
 <li>beautiful</li>
-</ul>';
-		$expected = 'I am: • smart • beautiful';
-		$this->assertEquals( $expected, $this->instance->smart_strip_tags( $input ) );
+</ul>',
+				'expected' => 'I am: • smart • beautiful',
+			],
+			'Test removing incomplete set of script tags' => [
+				'input'    => 'Test </script>bla',
+				'expected' => 'Test bla',
+			],
+			'Test removing incomplete + complete set of script tags' => [
+				'input'    => 'Test </script ><script>alert(0)</script><script>',
+				'expected' => 'Test',
+			],
+		];
 	}
 }

--- a/tests/unit/helpers/schema/html-helper-test.php
+++ b/tests/unit/helpers/schema/html-helper-test.php
@@ -96,19 +96,50 @@ class HTML_Helper_Test extends TestCase {
 	 */
 	public function data_smart_strip_tags() {
 		return [
+			'Empty text string' => [
+				'input'    => '',
+				'expected' => '',
+			],
+			'Text without HTML' => [
+				'input'    => 'This is just a simple text string',
+				'expected' => 'This is just a simple text string',
+			],
+			'Multi-line text without HTML' => [
+				'input'    => 'This is
+just a simple
+text string',
+				'expected' => 'This is just a simple text string',
+			],
+			'String containing only whitespace' => [
+				'input'    => '
+
+
+
+
+   				 ',
+				'expected' => '',
+			],
 			'Test replacing `<br>` tag with space' => [
 				'input'    => 'Test<br>word',
+				'expected' => 'Test word',
+			],
+			'Test replacing `<BR />` tag (uppercase and with self-closing slash) with space' => [
+				'input'    => 'Test<BR />word',
 				'expected' => 'Test word',
 			],
 			'Test adding a space when replacing heading close tags' => [
 				'input'    => '<h1>Heading</h1>First words',
 				'expected' => 'Heading First words',
 			],
+			'Test adding a space when replacing select close tags' => [
+				'input'    => 'End of previous</Div>This safeguards the case insensitivity',
+				'expected' => 'End of previous This safeguards the case insensitivity',
+			],
 			'Test replacing tags li with • and new lines with spaces' => [
 				'input'    => 'I am:
 <ul>
 <li>smart</li>
-<li>beautiful</li>
+<LI>beautiful</LI>
 </ul>',
 				'expected' => 'I am: • smart • beautiful',
 			],
@@ -119,6 +150,10 @@ class HTML_Helper_Test extends TestCase {
 			'Test removing incomplete + complete set of script tags' => [
 				'input'    => 'Test </script ><script>alert(0)</script><script>',
 				'expected' => 'Test',
+			],
+			'Test trimming surrounding whitespace and extraneous whitespace within string' => [
+				'input'    => '   This is 	just a     simple text string   ',
+				'expected' => 'This is just a simple text string',
 			],
 		];
 	}

--- a/tests/unit/helpers/schema/html-helper-test.php
+++ b/tests/unit/helpers/schema/html-helper-test.php
@@ -52,13 +52,25 @@ class HTML_Helper_Test extends TestCase {
 	 */
 	public function data_sanitize() {
 		return [
-			'Text containing script tags should have the script tags stripped' => [
+			'Empty text string' => [
+				'input'    => '',
+				'expected' => '',
+			],
+			'Text without any HTML' => [
+				'input'    => 'This is just a simple text string',
+				'expected' => 'This is just a simple text string',
+			],
+			'Text containing tags not on the allowed list should have those tags stripped' => [
 				'input'    => 'Test <script>alert(0)</script> bla',
 				'expected' => 'Test alert(0) bla',
 			],
 			'Text containing allowed tag should be returned unchanged' => [
 				'input'    => 'Test <p>Paragraph</p> bla',
 				'expected' => 'Test <p>Paragraph</p> bla',
+			],
+			'Text containing both allowed tag and disallowed tag should have the disallowed tag stripped' => [
+				'input'    => 'Test <p>Paragraph</p> bla <marque>stuck in the 80s</marque>',
+				'expected' => 'Test <p>Paragraph</p> bla stuck in the 80s',
 			],
 		];
 	}

--- a/tests/unit/helpers/schema/html-helper-test.php
+++ b/tests/unit/helpers/schema/html-helper-test.php
@@ -101,8 +101,7 @@ class HTML_Helper_Test extends TestCase {
 				'expected' => 'Test word',
 			],
 			'Test adding a space when replacing heading close tags' => [
-				'input'    => '<h1>Heading</h1>
-First words',
+				'input'    => '<h1>Heading</h1>First words',
 				'expected' => 'Heading First words',
 			],
 			'Test replacing tags li with • and new lines with spaces' => [


### PR DESCRIPTION
## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

### HTML_Helper_Test: refactor the tests to use data providers

This refactors both the `test_sanitize()` and `test_smart_strip_tags()`  tests to use data providers.

This:
1. Makes it easier to debug the test as the data provider will show a descriptive name for the failing test case and the test method itself now only contains one assertion instead of multiple.
2. Auto-documents the test cases by using named data providers.
3. Allows for more easily adding additional test cases.

Note: The actual test cases themselves have not been changed by this refactor, though the order in which they are run has (to more closely match the logic order in the method under test).

Includes changing the used assertion from `assertEquals()` (loose type check) to `assertSame()` (strict type check).

### HTML_Helper_Test::test_sanitize(): add additional test cases

... which should be handled without problems by the function.

This documents the expected behaviour and safeguards the function against future regressions.

### HTML_Helper_Test::test_smart_strip_tags(): fix incorrect test

The `Test adding a space when replacing heading close tags` test case was intended to test/cover the regex which adds an extra space to select close tags to prevent two words being joined together when the close tag is removed.

However, due to the new line in the test input, this case was never actually tested and the test would not fail if the regex mentioned above would be removed.

Fixed now by improving the input data passed to the test.

### HTML_Helper_Test::test_smart_strip_tags(): add additional test cases

... which should be handled without problems by the function.

This documents the expected behaviour and safeguards the function against future regressions.

Includes adjusting one pre-existing test case to ensure that the case-insensitivity of the regex is safeguarded.


## Test instructions

This PR can be tested by following these steps:
* _N/A_ This change only involves the tests. If the build passes, we're good.