### PR TITLE
Date_Helper_Test: improve tests

### DIFF
--- a/tests/unit/helpers/date-helper-test.php
+++ b/tests/unit/helpers/date-helper-test.php
@@ -40,10 +40,9 @@ class Date_Helper_Test extends TestCase {
 	 * @param string $date     The date to format.
 	 * @param string $format   The format.
 	 * @param string $expected The expected value.
-	 * @param string $message  Message to show when test fails.
 	 */
-	public function test_format( $date, $format, $expected, $message ) {
-		static::assertEquals( $expected, $this->instance->format( $date, $format ), $message );
+	public function test_format( $date, $format, $expected ) {
+		static::assertSame( $expected, $this->instance->format( $date, $format ) );
 	}
 
 	/**
@@ -53,53 +52,45 @@ class Date_Helper_Test extends TestCase {
 	 */
 	public function format_provider() {
 		return [
-			[
+			'Test formatting the date, the default way' => [
 				'date'     => '2020-12-31 13:37:00',
 				'format'   => \DATE_W3C,
 				'expected' => '2020-12-31T13:37:00+00:00',
-				'message'  => 'Test formatting the date, the default way',
 			],
-			[
+			'Test formatting the date to a timestamp' => [
 				'date'     => '1973-11-29 21:33:09',
 				'format'   => 'U',
-				'expected' => 123456789,
-				'message'  => 'Test formatting the date to a timestamp',
+				'expected' => '123456789',
 			],
-			[
+			'Test formatting the date with no given date' => [
 				'date'     => '',
 				'format'   => \DATE_W3C,
 				'expected' => '',
-				'message'  => 'Test formatting the date with no given date',
 			],
-			[
+			'Test formatting the date with null as date' => [
 				'date'     => null,
 				'format'   => \DATE_W3C,
 				'expected' => null,
-				'message'  => 'Test formatting the date with null as date',
 			],
-			[
+			'Test formatting the date with false as date' => [
 				'date'     => false,
 				'format'   => \DATE_W3C,
 				'expected' => false,
-				'message'  => 'Test formatting the date with false as date',
 			],
-			[
+			'Test formatting the date with true as date' => [
 				'date'     => true,
 				'format'   => \DATE_W3C,
 				'expected' => true,
-				'message'  => 'Test formatting the date with true as date',
 			],
-			[
+			'Test formatting the date with a string as date' => [
 				'date'     => 'this is a date',
 				'format'   => \DATE_W3C,
 				'expected' => 'this is a date',
-				'message'  => 'Test formatting the date with a string as date',
 			],
-			[
+			'Test formatting the date with date in wrong format being given' => [
 				'date'     => '2020-12-31',
 				'format'   => \DATE_W3C,
 				'expected' => '2020-12-31',
-				'message'  => 'Test formatting the date with date in wrong format being given',
 			],
 		];
 	}
@@ -113,10 +104,9 @@ class Date_Helper_Test extends TestCase {
 	 * @param string $timestamp The timestamp to format.
 	 * @param string $format    The format.
 	 * @param string $expected  The expected value.
-	 * @param string $message   Message to show when test fails.
 	 */
-	public function test_format_timestamp( $timestamp, $format, $expected, $message ) {
-		static::assertEquals( $expected, $this->instance->format_timestamp( $timestamp, $format ), $message );
+	public function test_format_timestamp( $timestamp, $format, $expected ) {
+		static::assertSame( $expected, $this->instance->format_timestamp( $timestamp, $format ) );
 	}
 
 	/**
@@ -126,23 +116,20 @@ class Date_Helper_Test extends TestCase {
 	 */
 	public function format_timestamp_provider() {
 		return [
-			[
+			'Test formatting a date given as timestamp' => [
 				'timestamp' => '1973-11-29 21:33:09',
 				'format'    => \DATE_W3C,
 				'expected'  => '1973-11-29 21:33:09',
-				'message'   => 'Test formatting a date given as timestamp',
 			],
-			[
+			'Test formatting an integer timestamp to a date' => [
 				'timestamp' => 123456789,
 				'format'    => \DATE_W3C,
 				'expected'  => '1973-11-29T21:33:09+00:00',
-				'message'   => 'Test formatting the timestamp to a date',
 			],
-			[
+			'Test formatting the date with null as timestamp' => [
 				'date'     => null,
 				'format'   => \DATE_W3C,
 				'expected' => null,
-				'message'  => 'Test formatting the date with null as timestamp',
 			],
 		];
 	}
@@ -158,7 +145,7 @@ class Date_Helper_Test extends TestCase {
 			->with( \DATE_W3C, '1609421820' )
 			->andReturn( '2020-12-31' );
 
-		static::assertEquals(
+		static::assertSame(
 			'2020-12-31',
 			$this->instance->format_translated( '2020-12-31 13:37:00' )
 		);

--- a/tests/unit/helpers/date-helper-test.php
+++ b/tests/unit/helpers/date-helper-test.php
@@ -164,18 +164,31 @@ class Date_Helper_Test extends TestCase {
 	/**
 	 * Test the datetime with a valid date string.
 	 *
-	 * @covers ::is_valid_datetime
+	 * @dataProvider data_is_valid_datetime
+	 * @covers       ::is_valid_datetime
+	 *
+	 * @param mixed $input    The date to validate.
+	 * @param bool  $expected The expected function return value.
 	 */
-	public function test_is_valid_datetime_WITH_valid_datetime() {
-		static::assertTrue( $this->instance->is_valid_datetime( '2015-02-25T04:44:44+00:00' ) );
+	public function test_is_valid_datetime( $input, $expected ) {
+		static::assertSame( $expected, $this->instance->is_valid_datetime( $input ) );
 	}
 
 	/**
-	 * Test the datetime with an invalid date string.
+	 * Data Provider.
 	 *
-	 * @covers ::is_valid_datetime
+	 * @return array
 	 */
-	public function test_is_valid_datetime_WITH_invalid_datetime() {
-		static::assertFalse( $this->instance->is_valid_datetime( '-0001-11-30T00:00:00+00:00' ) );
+	public function data_is_valid_datetime() {
+		return [
+			'Valid datetime string' => [
+				'input'    => '2015-02-25T04:44:44+00:00',
+				'expected' => true,
+			],
+			'Invalid datetime string' => [
+				'input'    => '-0001-11-30T00:00:00+00:00',
+				'expected' => false,
+			],
+		];
 	}
 }

--- a/tests/unit/helpers/date-helper-test.php
+++ b/tests/unit/helpers/date-helper-test.php
@@ -82,6 +82,11 @@ class Date_Helper_Test extends TestCase {
 				'format'   => \DATE_W3C,
 				'expected' => true,
 			],
+			'Test formatting the date with an integer as date' => [
+				'date'     => 123456789,
+				'format'   => \DATE_W3C,
+				'expected' => 123456789,
+			],
 			'Test formatting the date with a string as date' => [
 				'date'     => 'this is a date',
 				'format'   => \DATE_W3C,

--- a/tests/unit/helpers/date-helper-test.php
+++ b/tests/unit/helpers/date-helper-test.php
@@ -131,6 +131,11 @@ class Date_Helper_Test extends TestCase {
 				'format'    => \DATE_W3C,
 				'expected'  => '1973-11-29T21:33:09+00:00',
 			],
+			'Test formatting a string timestamp to a date' => [
+				'timestamp' => '123456789',
+				'format'    => \DATE_W3C,
+				'expected'  => '1973-11-29T21:33:09+00:00',
+			],
 			'Test formatting the date with null as timestamp' => [
 				'date'     => null,
 				'format'   => \DATE_W3C,


### PR DESCRIPTION
## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

### Date_Helper_Test: improve tests

1. Use type strict assertions in the tests (`assertSame()` instead of `assertEquals()`.
2. Use named data sets and remove the redundant `$message` parameter.
    The `$message` parameter for assertions is (mostly) intended to be used when there are multiple assertions within one test.
    When there is just one assertion and the test uses a data provider, naming the data sets is the better way to allow for identifying which test case failed.

Includes fixing one test case "Test formatting the date to a timestamp" in the `format_provider()` method where the "expected" value was set as an integer, while the function returns a string.

### Date_Helper_Test::test_format(): add additional test

... to document the behaviour when an integer is passed.

### Date_Helper_Test::test_format_timestamp(): add additional test

... to document the behaviour when a numeric (integer) string is passed.

### Date_Helper_Test: refactor is_valid_datetime() tests to use a data provider

These tests basically did the same thing and were just using different assertions.

By refactoring to a data provider, it becomes easier to add additional tests for this method.


## Test instructions

This PR can be tested by following these steps:
* _N/A_ This change only involves the tests. If the build passes, we're good.