### PR TITLE
WPSEO_Sitemap_Provider_Overlap_Test: stabilize the tests

### DIFF
--- a/tests/integration/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemap-provider-overlap.php
@@ -32,7 +32,7 @@ class WPSEO_Sitemap_Provider_Overlap_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Set up our double class.
+	 * Set up our double class and register the taxonomy.
 	 */
 	public function set_up() {
 		parent::set_up();
@@ -41,15 +41,23 @@ class WPSEO_Sitemap_Provider_Overlap_Test extends WPSEO_UnitTestCase {
 
 		// Reset the instance.
 		self::$class_instance->reset();
+
+		// Create private taxonomy "author", overlapping the "author" sitemap.
+		register_taxonomy( 'author', [ 'post' ], [ 'public' => false ] );
+	}
+
+	/**
+	 * Clean up the taxonomy.
+	 */
+	public function tear_down() {
+		unregister_taxonomy( 'author' );
+		parent::tear_down();
 	}
 
 	/**
 	 * Makes sure the private taxonomy "author" does not override the "Author" sitemap.
 	 */
 	public function test_private_taxonomy_author_overlap() {
-		// Create private taxonomy "author", overlapping the "author" sitemap.
-		register_taxonomy( 'author', [ 'post' ], [ 'public' => false ] );
-
 		// Create a user with a post.
 		$user_id = $this->factory->user->create( [ 'role' => 'author' ] );
 		$this->factory->post->create_many( 1, [ 'post_author' => $user_id ] );
@@ -66,17 +74,12 @@ class WPSEO_Sitemap_Provider_Overlap_Test extends WPSEO_UnitTestCase {
 		$this->expectOutputContains(
 			'<loc>' . $url . '</loc>'
 		);
-
-		unregister_taxonomy( 'author' );
 	}
 
 	/**
 	 * Makes sure the private taxonomy "author" does not override the "Author" sitemap.
 	 */
 	public function test_private_taxonomy_author_overlap_author_in_sitemap() {
-		// Create private taxonomy "author", overlapping the "author" sitemap.
-		register_taxonomy( 'author', [ 'post' ], [ 'public' => false ] );
-
 		// Create a user with a post.
 		$user_id = $this->factory->user->create( [ 'role' => 'author' ] );
 		$this->factory->post->create_many( 1, [ 'post_author' => $user_id ] );
@@ -91,7 +94,5 @@ class WPSEO_Sitemap_Provider_Overlap_Test extends WPSEO_UnitTestCase {
 		$this->expectOutputContains(
 			'<loc>' . get_author_posts_url( $user_id ) . '</loc>'
 		);
-
-		unregister_taxonomy( 'author' );
 	}
 }


### PR DESCRIPTION
## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

The `unregister_taxonomy()` function call may not be executed when the tests fails before reaching that point. In this case, that's unlikely as the tests don't contain assertions, but only expectations.
Still, as a matter of best practice and example, I'm moving the `register_taxonomy()` and `unregister_taxonomy()` function calls to the `set_up()` and `tear_down()` fixture methods.


## Test instructions

This PR can be tested by following these steps:
* _N/A_ This change only involves the tests. If the build passes, we're good.