### PR TITLE
Don't redirect to free success page when also activating Premium

### DIFF
--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -26,7 +26,7 @@ class Installation_Success_Integration implements Integration_Interface {
 	 *
 	 * @var Product_Helper
 	 */
-	private $product_helper;
+	protected $product_helper;
 
 	/**
 	 * {@inheritDoc}

--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -6,6 +6,7 @@ use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\Installation_Success_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
@@ -21,6 +22,13 @@ class Installation_Success_Integration implements Integration_Interface {
 	protected $options_helper;
 
 	/**
+	 * The product helper.
+	 *
+	 * @var Product_Helper
+	 */
+	private $product_helper;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
@@ -31,9 +39,11 @@ class Installation_Success_Integration implements Integration_Interface {
 	 * Installation_Success_Integration constructor.
 	 *
 	 * @param Options_Helper $options_helper The options helper.
+	 * @param Product_Helper $product_helper The product helper.
 	 */
-	public function __construct( Options_Helper $options_helper ) {
+	public function __construct( Options_Helper $options_helper, Product_Helper $product_helper ) {
 		$this->options_helper = $options_helper;
+		$this->product_helper = $product_helper;
 	}
 
 	/**
@@ -63,6 +73,10 @@ class Installation_Success_Integration implements Integration_Interface {
 
 		// phpcs:ignore WordPress.Security.NonceVerification -- This is not a form.
 		if ( isset( $_REQUEST['activate-multi'] ) && $_REQUEST['activate-multi'] === 'true' ) {
+			return;
+		}
+
+		if ( $this->product_helper->is_premium() ) {
 			return;
 		}
 

--- a/tests/unit/integrations/admin/installation-success-integration-test.php
+++ b/tests/unit/integrations/admin/installation-success-integration-test.php
@@ -154,29 +154,6 @@ class Installation_Success_Integration_Test extends TestCase {
 			->with( 'should_redirect_after_install_free', false )
 			->andReturnFalse();
 
-		$this->options_helper
-			->expects( 'set' )
-			->with( 'should_redirect_after_install_free', false )
-			->never();
-
-		$this->options_helper
-			->expects( 'get' )
-			->with( 'activation_redirect_timestamp_free', 0 )
-			->never();
-
-		$this->options_helper
-			->expects( 'set' )
-			->with( 'activation_redirect_timestamp_free', \time() )
-			->never();
-
-		$this->product_helper
-			->expects( 'is_premium' )
-			->never();
-
-		Monkey\Functions\expect( 'admin_url' )
-			->with( 'admin.php?page=wpseo_installation_successful_free', 302, 'Yoast SEO' )
-			->never();
-
 		Monkey\Functions\expect( 'wp_safe_redirect' )
 			->never();
 
@@ -202,19 +179,6 @@ class Installation_Success_Integration_Test extends TestCase {
 			->expects( 'get' )
 			->with( 'activation_redirect_timestamp_free', 0 )
 			->andReturn( '1638969347' );
-
-		$this->options_helper
-			->expects( 'set' )
-			->with( 'activation_redirect_timestamp_free', \time() )
-			->never();
-
-		$this->product_helper
-			->expects( 'is_premium' )
-			->never();
-
-		Monkey\Functions\expect( 'admin_url' )
-			->with( 'admin.php?page=wpseo_installation_successful_free', 302, 'Yoast SEO' )
-			->never();
 
 		Monkey\Functions\expect( 'wp_safe_redirect' )
 			->never();
@@ -249,10 +213,6 @@ class Installation_Success_Integration_Test extends TestCase {
 		$this->product_helper
 			->expects( 'is_premium' )
 			->andReturnTrue();
-
-		Monkey\Functions\expect( 'admin_url' )
-			->with( 'admin.php?page=wpseo_installation_successful_free', 302, 'Yoast SEO' )
-			->never();
 
 		Monkey\Functions\expect( 'wp_safe_redirect' )
 			->never();

--- a/tests/unit/integrations/admin/installation-success-integration-test.php
+++ b/tests/unit/integrations/admin/installation-success-integration-test.php
@@ -7,6 +7,7 @@ use Mockery;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\Installation_Success_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Installation_Success_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -34,13 +35,24 @@ class Installation_Success_Integration_Test extends TestCase {
 	protected $options_helper;
 
 	/**
+	 * Product Helper class mock.
+	 *
+	 * @var Product_Helper|Mockery\Mock
+	 */
+	protected $product_helper;
+
+	/**
 	 * Set up the fixtures for the tests.
 	 */
 	protected function set_up() {
 		parent::set_up();
 
 		$this->options_helper = Mockery::mock( Options_Helper::class );
-		$this->instance       = Mockery::mock( Installation_Success_Integration::class, [ $this->options_helper ] )->makePartial();
+		$this->product_helper = Mockery::mock( Product_Helper::class );
+		$this->instance       = Mockery::mock(
+			Installation_Success_Integration::class,
+			[ $this->options_helper, $this->product_helper ]
+		)->makePartial();
 	}
 
 	/**
@@ -67,6 +79,11 @@ class Installation_Success_Integration_Test extends TestCase {
 		static::assertInstanceOf(
 			Options_Helper::class,
 			$this->getPropertyValue( $this->instance, 'options_helper' )
+		);
+
+		static::assertInstanceOf(
+			Product_Helper::class,
+			$this->getPropertyValue( $this->instance, 'product_helper' )
 		);
 	}
 
@@ -106,6 +123,10 @@ class Installation_Success_Integration_Test extends TestCase {
 			->expects( 'set' )
 			->withSomeOfArgs( 'activation_redirect_timestamp_free' );
 
+		$this->product_helper
+			->expects( 'is_premium' )
+			->andReturnFalse();
+
 		$redirect_url = 'http://basic.wordpress.test/wp-admin/admin.php?page=wpseo_installation_successful_free';
 
 		Monkey\Functions\expect( 'admin_url' )
@@ -132,6 +153,106 @@ class Installation_Success_Integration_Test extends TestCase {
 			->expects( 'get' )
 			->with( 'should_redirect_after_install_free', false )
 			->andReturnFalse();
+
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'should_redirect_after_install_free', false )
+			->never();
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'activation_redirect_timestamp_free', 0 )
+			->never();
+
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'activation_redirect_timestamp_free', \time() )
+			->never();
+
+		$this->product_helper
+			->expects( 'is_premium' )
+			->never();
+
+		Monkey\Functions\expect( 'admin_url' )
+			->with( 'admin.php?page=wpseo_installation_successful_free', 302, 'Yoast SEO' )
+			->never();
+
+		Monkey\Functions\expect( 'wp_safe_redirect' )
+			->never();
+
+		$this->instance->maybe_redirect();
+	}
+
+	/**
+	 * Tests that the redirection does not occur when it is not a first time install.
+	 *
+	 * @covers ::maybe_redirect
+	 */
+	public function test_maybe_redirect_not_first_time_install() {
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'should_redirect_after_install_free', false )
+			->andReturnTrue();
+
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'should_redirect_after_install_free', false );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'activation_redirect_timestamp_free', 0 )
+			->andReturn( '1638969347' );
+
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'activation_redirect_timestamp_free', \time() )
+			->never();
+
+		$this->product_helper
+			->expects( 'is_premium' )
+			->never();
+
+		Monkey\Functions\expect( 'admin_url' )
+			->with( 'admin.php?page=wpseo_installation_successful_free', 302, 'Yoast SEO' )
+			->never();
+
+		Monkey\Functions\expect( 'wp_safe_redirect' )
+			->never();
+
+		$this->instance->maybe_redirect();
+	}
+
+	/**
+	 * Tests that the redirection does not occur when free it is activated through premium.
+	 *
+	 * @covers ::maybe_redirect
+	 */
+	public function test_maybe_redirect_premium_active() {
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'should_redirect_after_install_free', false )
+			->andReturnTrue();
+
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'should_redirect_after_install_free', false );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'activation_redirect_timestamp_free', 0 )
+			->andReturn( '0' );
+
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'activation_redirect_timestamp_free', \time() );
+
+		$this->product_helper
+			->expects( 'is_premium' )
+			->andReturnTrue();
+
+		Monkey\Functions\expect( 'admin_url' )
+			->with( 'admin.php?page=wpseo_installation_successful_free', 302, 'Yoast SEO' )
+			->never();
 
 		Monkey\Functions\expect( 'wp_safe_redirect' )
 			->never();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Only shows the Premium installation success screen when Free and Premium are activated simultaneously. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Feature flag enabled
* Enable the feature flag: add `define( 'YOAST_SEO_INSTALLATION_SUCCESS', true );` to your `wp-config.php` file
* Clean and restart your docker.
* Activate Premium (this should automatically activate Free as well).
* You should be redirected to the Premium installation success screen (and not the free one).
* In the database check `activation_redirect_timestamp` in `wpseo_premium` has a value (other than 0), and check `activation_redirect_timestamp_free` in `wpseo` has a value (other than 0).

#### Feature flag disabled
* It should behave the same way.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Use a fresh install of Free and Premium. 
* Install Free and Premium but don't activate them yet!
* Activate Premium (this should automatically activate Free as well).
* You should be redirected to the Premium installation success screen (and not the free one).

#### Feature flag disabled
* N/A

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
