### PR TITLE
WPSEO_Sitemaps_Cache_Data_Test: improve tests

### DIFF
--- a/tests/integration/sitemaps/test-class-wpseo-sitemaps-cache-data.php
+++ b/tests/integration/sitemaps/test-class-wpseo-sitemaps-cache-data.php
@@ -37,7 +37,7 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 		$sitemap = 'this is a sitemap';
 
 		$this->subject->set_sitemap( $sitemap );
-		$this->assertEquals( $sitemap, $this->subject->get_sitemap() );
+		$this->assertSame( $sitemap, $this->subject->get_sitemap() );
 	}
 
 	/**
@@ -51,7 +51,7 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 		$sitemap->doesnt = 'matter';
 
 		$this->subject->set_sitemap( $sitemap );
-		$this->assertEquals( '', $this->subject->get_sitemap() );
+		$this->assertSame( '', $this->subject->get_sitemap() );
 		$this->assertFalse( $this->subject->is_usable() );
 	}
 
@@ -64,7 +64,7 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 		$status = 'invalid';
 
 		$this->subject->set_status( $status );
-		$this->assertEquals( WPSEO_Sitemap_Cache_Data_Interface::UNKNOWN, $this->subject->get_status() );
+		$this->assertSame( WPSEO_Sitemap_Cache_Data_Interface::UNKNOWN, $this->subject->get_status() );
 		$this->assertFalse( $this->subject->is_usable() );
 	}
 
@@ -74,7 +74,7 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Sitemap_Cache_Data::get_status
 	 */
 	public function test_sitemap_status_unset() {
-		$this->assertEquals( WPSEO_Sitemap_Cache_Data::UNKNOWN, $this->subject->get_status() );
+		$this->assertSame( WPSEO_Sitemap_Cache_Data::UNKNOWN, $this->subject->get_status() );
 	}
 
 	/**
@@ -87,7 +87,7 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 		$sitemap = '';
 
 		$this->subject->set_sitemap( $sitemap );
-		$this->assertEquals( WPSEO_Sitemap_Cache_Data::ERROR, $this->subject->get_status() );
+		$this->assertSame( WPSEO_Sitemap_Cache_Data::ERROR, $this->subject->get_status() );
 	}
 
 	/**
@@ -109,16 +109,37 @@ class WPSEO_Sitemaps_Cache_Data_Test extends WPSEO_UnitTestCase {
 	 *
 	 * @covers WPSEO_Sitemap_Cache_Data::set_status
 	 * @covers WPSEO_Sitemap_Cache_Data::get_status
+	 *
+	 * @dataProvider data_set_status_string
+	 *
+	 * @param string $input    Input to pass to set_status().
+	 * @param string $expected Expected get_status() function output.
 	 */
-	public function test_set_status_string() {
-		$this->subject->set_status( WPSEO_Sitemap_Cache_Data::OK );
-		$this->assertEquals( WPSEO_Sitemap_Cache_Data::OK, $this->subject->get_status() );
+	public function test_set_status_string( $input, $expected ) {
+		$this->subject->set_status( $input );
+		$this->assertSame( $expected, $this->subject->get_status() );
+	}
 
-		$this->subject->set_status( 'ok' );
-		$this->assertEquals( WPSEO_Sitemap_Cache_Data::OK, $this->subject->get_status() );
-
-		$this->subject->set_status( 'error' );
-		$this->assertEquals( WPSEO_Sitemap_Cache_Data::ERROR, $this->subject->get_status() );
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_set_status_string() {
+		return [
+			'Ok using interface constant' => [
+				'input'    => WPSEO_Sitemap_Cache_Data::OK,
+				'expected' => WPSEO_Sitemap_Cache_Data::OK,
+			],
+			'Ok using hard coded string' => [
+				'input'    => 'ok',
+				'expected' => WPSEO_Sitemap_Cache_Data::OK,
+			],
+			'Error using hard coded string' => [
+				'input'    => 'error',
+				'expected' => WPSEO_Sitemap_Cache_Data::ERROR,
+			],
+		];
 	}
 
 	/**


### PR DESCRIPTION

## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

* Use `assertSame()` instead of `assertEquals()` where applicable
* Change one test to use a data provider instead of having multiple test cases within the test method.



## Test instructions

This PR can be tested by following these steps:
* _N/A_ This change only involves the tests. If the build passes, we're good.