### PR TITLE
QA-2610 Wincher: Use horizontal scroll for table on mobile

### DIFF
--- a/packages/components/src/Toggle.js
+++ b/packages/components/src/Toggle.js
@@ -13,6 +13,7 @@ const ToggleDiv = styled.div`
 	width: 100%;
 	justify-content: space-between;
 	align-items: center;
+	position: relative;
 `;
 
 const ToggleLabel = styled.span`

--- a/packages/js/src/components/WincherKeyphrasesTable.js
+++ b/packages/js/src/components/WincherKeyphrasesTable.js
@@ -23,13 +23,23 @@ import {
 const GetMoreInsightsLink = makeOutboundLink();
 
 const FocusKeyphraseFootnote = styled.span`
-	position: absolute;
-	${ getDirectionalStyle( "right", "left" ) }: 8px;
+	display: block;
 	font-style: italic;
+
+	@media (min-width: 782px) {
+		display: inline;
+		position: absolute;
+		${ getDirectionalStyle( "right", "left" ) }: 8px;
+	}
 `;
 
 const ViewColumn = styled.th`
 	min-width: 60px;
+`;
+
+const TableWrapper = styled.div`
+	width: 100%;
+	overflow-y: auto;
 `;
 
 /**
@@ -337,54 +347,56 @@ class WincherKeyphrasesTable extends Component {
 
 		return (
 			keyphrases && ! isEmpty( keyphrases ) && <Fragment>
-				<table className="yoast yoast-table">
-					<thead>
-						<tr>
-							<th
-								scope="col"
-								abbr={ __( "Tracking", "wordpress-seo" ) }
-							>
-								{ __( "Tracking", "wordpress-seo" ) }
-							</th>
-							<th
-								scope="col"
-								abbr={ __( "Keyphrase", "wordpress-seo" ) }
-							>
-								{ __( "Keyphrase", "wordpress-seo" ) }
-							</th>
-							<th
-								scope="col"
-								abbr={ __( "Position", "wordpress-seo" ) }
-							>
-								{ __( "Position", "wordpress-seo" ) }
-							</th>
-							<th
-								scope="col"
-								abbr={ __( "Position over time", "wordpress-seo" ) }
-							>
-								{ __( "Position over time", "wordpress-seo" ) }
-							</th>
-							<ViewColumn className="yoast-table--nobreak" />
-						</tr>
-					</thead>
-					<tbody>
-						{
-							keyphrases.map( ( keyphrase, index ) => {
-								return ( <WincherTableRow
-									key={ `trackable-keyphrase-${index}` }
-									keyphrase={ keyphrase }
-									onTrackKeyphrase={ this.onTrackKeyphrase }
-									onUntrackKeyphrase={ this.onUntrackKeyphrase }
-									rowData={ this.getKeyphraseData( keyphrase ) }
-									isFocusKeyphrase={ keyphrase === focusKeyphrase.trim() }
-									websiteId={ websiteId }
-									isDisabled={ isDisabled }
-									isLoading={ isLoading }
-								/> );
-							} )
-						}
-					</tbody>
-				</table>
+				<TableWrapper>
+					<table className="yoast yoast-table">
+						<thead>
+							<tr>
+								<th
+									scope="col"
+									abbr={ __( "Tracking", "wordpress-seo" ) }
+								>
+									{ __( "Tracking", "wordpress-seo" ) }
+								</th>
+								<th
+									scope="col"
+									abbr={ __( "Keyphrase", "wordpress-seo" ) }
+								>
+									{ __( "Keyphrase", "wordpress-seo" ) }
+								</th>
+								<th
+									scope="col"
+									abbr={ __( "Position", "wordpress-seo" ) }
+								>
+									{ __( "Position", "wordpress-seo" ) }
+								</th>
+								<th
+									scope="col"
+									abbr={ __( "Position over time", "wordpress-seo" ) }
+								>
+									{ __( "Position over time", "wordpress-seo" ) }
+								</th>
+								<ViewColumn className="yoast-table--nobreak" />
+							</tr>
+						</thead>
+						<tbody>
+							{
+								keyphrases.map( ( keyphrase, index ) => {
+									return ( <WincherTableRow
+										key={ `trackable-keyphrase-${index}` }
+										keyphrase={ keyphrase }
+										onTrackKeyphrase={ this.onTrackKeyphrase }
+										onUntrackKeyphrase={ this.onUntrackKeyphrase }
+										rowData={ this.getKeyphraseData( keyphrase ) }
+										isFocusKeyphrase={ keyphrase === focusKeyphrase.trim() }
+										websiteId={ websiteId }
+										isDisabled={ isDisabled }
+										isLoading={ isLoading }
+									/> );
+								} )
+							}
+						</tbody>
+					</table>
+				</TableWrapper>
 				<p style={ { marginBottom: 0, position: "relative" } }>
 					<GetMoreInsightsLink
 						href={ wpseoAdminGlobalL10n[ "links.wincher.login" ] }

--- a/packages/js/src/components/WincherPerformanceReport.js
+++ b/packages/js/src/components/WincherPerformanceReport.js
@@ -38,6 +38,11 @@ const WincherSEOPerformanceReportHeader = styled.h3`
 	font-size: 1em;
 `;
 
+const WincherSEOPerformanceTableWrapper = styled.div`
+	width: 100%;
+	overflow-y: auto;
+`;
+
 
 /**
  * Creates a view link URL based on the passed props.
@@ -185,42 +190,44 @@ const WincherPerformanceReport = ( props ) => {
 			<GetUserMessage { ...props } />
 
 			{ isLoggedIn && data && ! isEmpty( data ) && ! isEmpty( data.results ) && <Fragment>
-				<table className="yoast yoast-table">
-					<thead>
-						<tr>
-							<th
-								scope="col"
-								abbr={ __( "Keyphrase", "wordpress-seo" ) }
-							>
-								{ __( "Keyphrase", "wordpress-seo" ) }
-							</th>
-							<th
-								scope="col"
-								abbr={ __( "Position", "wordpress-seo" ) }
-							>
-								{ __( "Position", "wordpress-seo" ) }
-							</th>
-							<th
-								scope="col"
-								abbr={ __( "Position over time", "wordpress-seo" ) }
-							>
-								{ __( "Position over time", "wordpress-seo" ) }
-							</th>
-							<td className="yoast-table--nobreak" />
-						</tr>
-					</thead>
-					<tbody>
-						{
-							map( data.results, ( entry, index ) => {
-								return <Row
-									key={ `keyphrase-${index}` }
-									keyphrase={ entry }
-									websiteId={ websiteId }
-								/>;
-							} )
-						}
-					</tbody>
-				</table>
+				<WincherSEOPerformanceTableWrapper>
+					<table className="yoast yoast-table">
+						<thead>
+							<tr>
+								<th
+									scope="col"
+									abbr={ __( "Keyphrase", "wordpress-seo" ) }
+								>
+									{ __( "Keyphrase", "wordpress-seo" ) }
+								</th>
+								<th
+									scope="col"
+									abbr={ __( "Position", "wordpress-seo" ) }
+								>
+									{ __( "Position", "wordpress-seo" ) }
+								</th>
+								<th
+									scope="col"
+									abbr={ __( "Position over time", "wordpress-seo" ) }
+								>
+									{ __( "Position over time", "wordpress-seo" ) }
+								</th>
+								<td className="yoast-table--nobreak" />
+							</tr>
+						</thead>
+						<tbody>
+							{
+								map( data.results, ( entry, index ) => {
+									return <Row
+										key={ `keyphrase-${index}` }
+										keyphrase={ entry }
+										websiteId={ websiteId }
+									/>;
+								} )
+							}
+						</tbody>
+					</table>
+				</WincherSEOPerformanceTableWrapper>
 				<p style={ { marginBottom: 0, position: "relative" } }>
 					<GetMoreInsightsLink
 						href={ wpseoAdminGlobalL10n[ "links.wincher.login" ] }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes a bug where the metabox UI was broken on mobile when the Track SEO Performance dialog was open.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the metabox UI was broken on mobile when the Track SEO Performance dialog was open.

## Relevant technical choices:

* Had to add `position: relative;` to the Toggle container. I don't think this should impact anything else.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Load post editor with a mobile viewport
* Ensure that layout is not broken when opening the "Track SEO Performance" box.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
