### PR TITLE
QA-2601 Wincher: Fatal error on routes if no token is present

### DIFF
--- a/src/actions/wincher/wincher-account-action.php
+++ b/src/actions/wincher/wincher-account-action.php
@@ -57,8 +57,11 @@ class Wincher_Account_Action {
 				'usage'     => $usage,
 				'status'    => 200,
 			];
-		} catch ( Authentication_Failed_Exception $e ) {
-			return $e->get_response();
+		} catch ( \Exception $e ) {
+			return (object) [
+				'status' => $e->getCode(),
+				'error'  => $e->getMessage(),
+			];
 		}
 	}
 }

--- a/src/routes/wincher-route.php
+++ b/src/routes/wincher-route.php
@@ -238,7 +238,6 @@ class Wincher_Route implements Route_Interface {
 	 */
 	public function check_limit( WP_REST_Request $request ) {
 		$data = $this->account_action->check_limit();
-
 		return new WP_REST_Response( $data, $data->status );
 	}
 
@@ -251,7 +250,12 @@ class Wincher_Route implements Route_Interface {
 	 */
 	public function track_keyphrases( WP_REST_Request $request ) {
 		$limits = $this->account_action->check_limit();
-		$data   = $this->keyphrases_action->track_keyphrases( $request['keyphrases'], $limits );
+
+		if ( $limits->status !== 200 ) {
+			return new WP_REST_Response( $limits, $limits->status );
+		}
+
+		$data = $this->keyphrases_action->track_keyphrases( $request['keyphrases'], $limits );
 
 		return new WP_REST_Response( $data, $data->status );
 	}
@@ -292,7 +296,12 @@ class Wincher_Route implements Route_Interface {
 	 */
 	public function track_all( WP_REST_Request $request ) {
 		$limits = $this->account_action->check_limit();
-		$data   = $this->keyphrases_action->track_all( $limits );
+
+		if ( $limits->status !== 200 ) {
+			return new WP_REST_Response( $limits, $limits->status );
+		}
+
+		$data = $this->keyphrases_action->track_all( $limits );
 
 		return new WP_REST_Response( $data, $data->status );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Sending requests to the Wincher endpoints without having connected first caused some endpoints to throw exceptions. This fixes that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improve error handling for certain Wincher routes. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable Wincher integration but do not actually Connect
* Send authenticated requests to Wincher endpoints and make sure that they do not throw an exception:
   - `GET` request to `http://basic.wordpress.test/wp-json/yoast/v1/wincher/limits`
   - `POST` request to `http://basic.wordpress.test/wp-json/yoast/v1/wincher/keyphrases/track` with body `{ "keyphrases": []  }`
   - `POST` request to `http://basic.wordpress.test/wp-json/yoast/v1/wincher/keyphrases/track/all` with no body

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Enable Wincher integration but do not actually Connect
* Send authenticated requests to Wincher endpoints and make sure that they do not throw an exception:
   - `POST` request to `http://basic.wordpress.test/wp-json/yoast/v1/wincher/keyphrases/track` with body `{ "keyphrases": []  }`

**note:** 
-  `http://basic.wordpress.test/wp-json/yoast/v1/wincher/limits` endpoint has been removed by https://github.com/Yoast/wordpress-seo/pull/17834
- `http://basic.wordpress.test/wp-json/yoast/v1/wincher/keyphrases/track/all` endpoint has been removed by https://github.com/Yoast/wordpress-seo/pull/17804


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
