### PR TITLE
QA-2606 Disable Wincher integration for multisite environments

### DIFF
--- a/src/conditionals/wincher-conditional.php
+++ b/src/conditionals/wincher-conditional.php
@@ -15,4 +15,13 @@ class Wincher_Conditional extends Feature_Flag_Conditional {
 	protected function get_feature_flag() {
 		return 'WINCHER_INTEGRATION';
 	}
+
+	/**
+	 * Override is_met to also make sure this isn't a multisite installation.
+	 *
+	 * @return bool
+	 */
+	public function is_met() {
+		return parent::is_met() && ! \is_multisite();
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Disable Wincher for multisite environments.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the Wincher integration for multisite environments.

## Relevant technical choices:

* Decided to add this to the same conditional to not duplicate logic since the integration should be completely and fully hidden for multisite installs.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Setup a multisite environment
* Add `define('YOAST_SEO_WINCHER_INTEGRATION', true);` to your wp-config.php
* Navigate to SEO > General > Integrations and see that there is no Wincher integration toggle.
* Edit a post, and see there is no Wincher item to Track SEO performance in (1) the sidebar and (2) the metabox.
* Navigate to the WordPress Dashboard and make sure you don't see any Wincher information in the Yoast SEO widget.



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-179]


[DUPP-179]: https://yoast.atlassian.net/browse/DUPP-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ