### PR TITLE
Fix wincher feature flag

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -58,7 +58,7 @@ class WPSEO_Metabox_Formatter {
 
 		$is_wincher_active = WPSEO_Options::get( 'wincher_integration_active', true );
 
-		// If feature flag is disabled, set wincher should not be active.
+		// If feature flag is disabled, Wincher should not be active.
 		$conditional = new Wincher_Conditional();
 		if ( ! $conditional->is_met() ) {
 			$is_wincher_active = false;

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -5,6 +5,7 @@
  * @package WPSEO\Admin\Formatter
  */
 
+use Yoast\WP\SEO\Conditionals\Wincher_Conditional;
 use Yoast\WP\SEO\Config\Schema_Types;
 use Yoast\WP\SEO\Config\SEMrush_Client;
 use Yoast\WP\SEO\Config\Wincher_Client;
@@ -54,6 +55,14 @@ class WPSEO_Metabox_Formatter {
 		$analysis_seo         = new WPSEO_Metabox_Analysis_SEO();
 		$analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 		$schema_types         = new Schema_Types();
+
+		$is_wincher_active = WPSEO_Options::get( 'wincher_integration_active', true );
+
+		// If feature flag is disabled, set wincher should not be active.
+		$conditional = new Wincher_Conditional();
+		if ( ! $conditional->is_met() ) {
+			$is_wincher_active = false;
+		}
 
 		return [
 			'author_name'                 => get_the_author_meta( 'display_name' ),
@@ -167,8 +176,8 @@ class WPSEO_Metabox_Formatter {
 			'analysisHeadingTitle'        => __( 'Analysis', 'wordpress-seo' ),
 			'zapierIntegrationActive'     => WPSEO_Options::get( 'zapier_integration_active', false ) ? 1 : 0,
 			'zapierConnectedStatus'       => ! empty( WPSEO_Options::get( 'zapier_subscription', [] ) ) ? 1 : 0,
-			'wincherIntegrationActive'    => WPSEO_Options::get( 'wincher_integration_active', true ) ? 1 : 0,
-			'wincherLoginStatus'          => WPSEO_Options::get( 'wincher_integration_active', true ) ? YoastSEO()->helpers->wincher->login_status() : false,
+			'wincherIntegrationActive'    => $is_wincher_active ? 1 : 0,
+			'wincherLoginStatus'          => $is_wincher_active ? YoastSEO()->helpers->wincher->login_status() : false,
 			'wincherWebsiteId'            => WPSEO_Options::get( 'wincher_website_id', '' ),
 			'wincherAutoAddKeyphrases'    => WPSEO_Options::get( 'wincher_automatically_add_keyphrases', false ),
 

--- a/packages/js/src/initializers/block-editor-integration.js
+++ b/packages/js/src/initializers/block-editor-integration.js
@@ -97,6 +97,7 @@ function registerFills( store ) {
 	const preferences = store.getState().preferences;
 	const analysesEnabled = preferences.isKeywordAnalysisActive || preferences.isContentAnalysisActive;
 	const showZapierPanel = preferences.isZapierIntegrationActive && ! preferences.isZapierConnected;
+	const showWincherPanel = preferences.isKeywordAnalysisActive && preferences.isWincherIntegrationActive;
 	initiallyOpenDocumentSettings();
 
 	/**
@@ -145,7 +146,7 @@ function registerFills( store ) {
 				icon={ <Fragment /> }
 			>
 				<PostPublish />
-				{ preferences.isKeywordAnalysisActive && <WincherPostPublish /> }
+				{ showWincherPanel && <WincherPostPublish /> }
 			</PluginPostPublishPanel>
 			{ analysesEnabled && <PluginDocumentSettingPanel
 				name="document-panel"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix the Wincher's integration feature flag

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the Wincher integration's feature flag

## Relevant technical choices:

* We also put the post-publish panel under the right condition since it was displayed even with the Wincher integration non active

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* set the wincher feature flag **ON**
* make sure Wincher is enabled
* set the wincher feature flag **OFF**
* edit a new post (in Block editor, Classic Editor and Elementor) and check that the "Track SEO performance" section is not there in the metabox
* add a keyphrase
* in the block editor, publish the post
  * see that in the sidebar there is no "SEO Performance" section mentioning Wincher.
* set the wincher feature flag **ON**
* edit a new post (in Block editor, Classic Editor and Elementor) and check that the "Track SEO performance" section is in the metabox
* add a keyphrase
* in the block editor, publish the post
  * see that in the sidebar there is a "SEO Performance" section mentioning Wincher.




### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
