### PR TITLE
PHP 8.1 | Tests: fix two incomplete mocks

### DIFF
--- a/tests/unit/actions/addon-installation/addon-activate-action-test.php
+++ b/tests/unit/actions/addon-installation/addon-activate-action-test.php
@@ -68,7 +68,7 @@ class Addon_Activate_Action_Test extends TestCase {
 	/**
 	 * Tests if an activated addon can be activated "again".
 	 */
-	public function test_activate_addon_is_already_installed() {
+	public function test_activate_addon_is_already_activated() {
 
 		Monkey\Functions\expect( 'current_user_can' )
 			->once()
@@ -89,7 +89,7 @@ class Addon_Activate_Action_Test extends TestCase {
 	/**
 	 * Tests if an exception is thrown on activation error.
 	 */
-	public function test_activate_addon_activation_result_is_null() {
+	public function test_activate_addon_activation_when_activation_fails() {
 
 		Monkey\Functions\expect( 'current_user_can' )
 			->once()
@@ -117,7 +117,8 @@ class Addon_Activate_Action_Test extends TestCase {
 
 		$wp_error
 			->expects( 'get_error_message' )
-			->once();
+			->once()
+			->andReturn( '' );
 
 		Monkey\Functions\expect( 'activate_plugin' )
 			->once()

--- a/tests/unit/actions/addon-installation/addon-install-action-test.php
+++ b/tests/unit/actions/addon-installation/addon-install-action-test.php
@@ -135,7 +135,8 @@ class Addon_Install_Action_Test extends TestCase {
 
 		$wp_error
 			->expects( 'get_error_message' )
-			->once();
+			->once()
+			->andReturn( '' );
 
 		$plugin_upgrader = Mockery::mock( 'overload:' . Plugin_Upgrader::class );
 


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.1

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.1

## Relevant technical choices:

Both the `Addon_Activate_Action_Test::test_activate_addon_activation_result_is_null()`, as well as the `Addon_Install_Action_Test::test_install_addon_thows_when_install_fails()` test would throw a `"Exception::__construct(): Passing null to parameter #1 ($message) of type string is deprecated"` deprecation notice on PHP 8.1 due to the mock for WP_Error not being complete (not returning a value for `WP_Error::get_error_message()`).

Fixed now.

Includes renaming two tests in the `Addon_Activate_Action_Test` class to be more descriptive.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is a test-only change. This change should have no effect on existing functionality and this is verified via the existing tests.
