### PR TITLE
PHP 8.1 | WPSEO_Admin_Gutenberg_Compatibility_Notification: fix null to non-nullable notice

### DIFF
--- a/admin/class-gutenberg-compatibility.php
+++ b/admin/class-gutenberg-compatibility.php
@@ -29,7 +29,7 @@ class WPSEO_Gutenberg_Compatibility {
 	 *
 	 * @var string
 	 */
-	protected $current_version;
+	protected $current_version = '';
 
 	/**
 	 * WPSEO_Gutenberg_Compatibility constructor.


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.1

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.1

## Relevant technical choices:

In PHP 8.1, the `test_manage_notification_gutenberg_show_notification()` test throws a `version_compare(): Passing null to parameter #1 ($version1) of type string is deprecated` notification causing the test to error out.

Let's unpack this one:

The `version_compare()` function is called from the `WPSEO_Admin_Gutenberg_Compatibility_Notification::is_below_minimum()` method and expects the `$current_version` property to be set.

The default state of the `$current_version` property is "uninitialized", however, in "real" life, the property will always have a value as the constructor of the `WPSEO_Admin_Gutenberg_Compatibility_Notification()` will always set the `$current_version` property via a call to the `detect_installed_gutenberg_version()` method and the class cannot be used without instantiation.

So why is the test erroring out ?

This is caused by the following chain of events:
1. The test uses a partial Mock.
2. This in turn causes the constructor of the class not to be called.
3. As the class constructor is not run, the `$current_version` property remains uninitialized.
4. Causing the error when the `WPSEO_Admin_Gutenberg_Compatibility_Notification::is_below_minimum()` method is called.

There are two ways in which the failing test could be fixed:
1. Mocking the `is_below_minimum()` method call to return `true` in the `WPSEO_Admin_Gutenberg_Compatibility_Notification_Test::test_manage_notification_gutenberg_show_notification()` method.
2. Setting a default value for the `WPSEO_Admin_Gutenberg_Compatibility_Notification::$current_version` property.

After discussion with Diede and JoostB, we have decided to implement the second fix as it improves the stability and default state of the object.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is a code-technical change only and should have no effect on existing functionality. This can be verified via the existing tests.