### PR TITLE
Tests: fix some incorrect `@covers` tags

### DIFF
--- a/tests/unit/actions/importing/deactivate-conflicting-plugins-action-test.php
+++ b/tests/unit/actions/importing/deactivate-conflicting-plugins-action-test.php
@@ -151,7 +151,6 @@ class Deactivate_Conflicting_Plugins_Action_Test extends TestCase {
 	/**
 	 * Test the get_total_unindexed method
 	 *
-	 * @covers ::query
 	 * @covers ::get_total_unindexed
 	 */
 	public function test_get_total_unindexed() {
@@ -172,7 +171,6 @@ class Deactivate_Conflicting_Plugins_Action_Test extends TestCase {
 	/**
 	 * Test the index method
 	 *
-	 * @covers ::query
 	 * @covers ::index
 	 */
 	public function test_index() {
@@ -217,7 +215,6 @@ class Deactivate_Conflicting_Plugins_Action_Test extends TestCase {
 	 * @param int $expected The expected result.
 	 *
 	 * @covers ::get_limited_unindexed_count
-	 * @covers ::query
 	 */
 	public function test_get_limited_unindexed_count( $limit, $expected ) {
 		// Arrange.

--- a/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
+++ b/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
@@ -417,7 +417,7 @@ class Wincher_Keyphrases_Action_Test extends TestCase {
 	/**
 	 * Tests retrieval of tracked keyphrases chart data filtered by the passed permalink.
 	 *
-	 * @covers ::get_keyphrase_chart_data
+	 * @covers ::get_tracked_keyphrases
 	 */
 	public function test_get_tracked_keyphrases_with_permalink() {
 		$this->options_helper


### PR DESCRIPTION
## Context

* Improves test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improves test suite

## Relevant technical choices:




## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a test-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.
