### PR TITLE
QA-2612 Disallow contributors from using the Wincher integration

### DIFF
--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -124,13 +124,7 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 	 * @return array The translated strings.
 	 */
 	public function localize_dashboard_script() {
-		$is_wincher_active = WPSEO_Options::get( 'wincher_integration_active', true );
-
-		// If feature flag is disabled, Wincher should not be active.
-		$conditional = new Wincher_Conditional();
-		if ( ! $conditional->is_met() ) {
-			$is_wincher_active = false;
-		}
+		$is_wincher_active = YoastSEO()->helpers->wincher->is_active();
 
 		return [
 			'feed_header'          => sprintf(
@@ -141,8 +135,8 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 			'feed_footer'          => __( 'Read more like this on our SEO blog', 'wordpress-seo' ),
 			'wp_version'           => substr( $GLOBALS['wp_version'], 0, 3 ) . '-' . ( is_plugin_active( 'classic-editor/classic-editor.php' ) ? '1' : '0' ),
 			'php_version'          => PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
-			'is_wincher_active'    => $is_wincher_active ? 1 : 0,
-			'wincher_is_logged_in' => $is_wincher_active ? YoastSEO()->helpers->wincher->login_status() : false,
+			'is_wincher_active'    => ( $is_wincher_active ) ? 1 : 0,
+			'wincher_is_logged_in' => ( $is_wincher_active ) ? YoastSEO()->helpers->wincher->login_status() : false,
 			'wincher_website_id'   => WPSEO_Options::get( 'wincher_website_id', '' ),
 		];
 	}

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -55,14 +55,7 @@ class WPSEO_Metabox_Formatter {
 		$analysis_seo         = new WPSEO_Metabox_Analysis_SEO();
 		$analysis_readability = new WPSEO_Metabox_Analysis_Readability();
 		$schema_types         = new Schema_Types();
-
-		$is_wincher_active = WPSEO_Options::get( 'wincher_integration_active', true );
-
-		// If feature flag is disabled, Wincher should not be active.
-		$conditional = new Wincher_Conditional();
-		if ( ! $conditional->is_met() ) {
-			$is_wincher_active = false;
-		}
+		$is_wincher_active    = YoastSEO()->helpers->wincher->is_active();
 
 		return [
 			'author_name'                 => get_the_author_meta( 'display_name' ),
@@ -176,8 +169,8 @@ class WPSEO_Metabox_Formatter {
 			'analysisHeadingTitle'        => __( 'Analysis', 'wordpress-seo' ),
 			'zapierIntegrationActive'     => WPSEO_Options::get( 'zapier_integration_active', false ) ? 1 : 0,
 			'zapierConnectedStatus'       => ! empty( WPSEO_Options::get( 'zapier_subscription', [] ) ) ? 1 : 0,
-			'wincherIntegrationActive'    => $is_wincher_active ? 1 : 0,
-			'wincherLoginStatus'          => $is_wincher_active ? YoastSEO()->helpers->wincher->login_status() : false,
+			'wincherIntegrationActive'    => ( $is_wincher_active ) ? 1 : 0,
+			'wincherLoginStatus'          => ( $is_wincher_active ) ? YoastSEO()->helpers->wincher->login_status() : false,
 			'wincherWebsiteId'            => WPSEO_Options::get( 'wincher_website_id', '' ),
 			'wincherAutoAddKeyphrases'    => WPSEO_Options::get( 'wincher_automatically_add_keyphrases', false ),
 

--- a/src/helpers/wincher-helper.php
+++ b/src/helpers/wincher-helper.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Helpers;
 
+use WPSEO_Options;
+use Yoast\WP\SEO\Conditionals\Wincher_Conditional;
 use Yoast\WP\SEO\Config\Wincher_Client;
 use Yoast\WP\SEO\Exceptions\OAuth\Authentication_Failed_Exception;
 use Yoast\WP\SEO\Exceptions\OAuth\Tokens\Empty_Property_Exception;
@@ -11,6 +13,25 @@ use Yoast\WP\SEO\Exceptions\OAuth\Tokens\Empty_Token_Exception;
  * A helper object for Wincher matters.
  */
 class Wincher_Helper {
+
+	/**
+	 * Checks if the integration is active for the current user.
+	 *
+	 * @return bool Whether or not the integration is active.
+	 */
+	public function is_active() {
+		// If feature flag is disabled, Wincher should not be active.
+		$conditional = new Wincher_Conditional();
+		if ( ! $conditional->is_met() ) {
+			return false;
+		}
+
+		if ( ! \current_user_can( 'publish_posts' ) && ! \current_user_can( 'publish_pages' ) ) {
+			return false;
+		}
+
+		return ! ! WPSEO_Options::get( 'wincher_integration_active', true );
+	}
 
 	/**
 	 * Checks if the user is logged in to Wincher.

--- a/src/routes/wincher-route.php
+++ b/src/routes/wincher-route.php
@@ -320,11 +320,11 @@ class Wincher_Route implements Route_Interface {
 	}
 
 	/**
-	 * Whether the current user is allowed to edit post/pages and thus use the Wincher integration.
+	 * Whether the current user is allowed to publish post/pages and thus use the Wincher integration.
 	 *
 	 * @return bool Whether the current user is allowed to use Wincher.
 	 */
 	public function can_use_wincher() {
-		return \current_user_can( 'edit_posts' ) || \current_user_can( 'edit_pages' );
+		return \current_user_can( 'publish_posts' ) || \current_user_can( 'publish_pages' );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Disallow contributors from using the Wincher integration.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where contributors still had access to the Wincher integration.

## Relevant technical choices:

* Moved wincher active check to a shared helper function in Wincher_Helper.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable the Wincher integration and Connect to Wincher
* Log in as Contributor
* Go to Dashboard, verify that there is no trace of Wincher in the Dashboard widget
* Edit a post
* Verify that there is no "Track SEO Performance" in the metabox or side bar.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
