### PR TITLE
P1-1115 Setup cornerstone component

### DIFF
--- a/packages/js/src/classic-editor/components/advanced-settings.js
+++ b/packages/js/src/classic-editor/components/advanced-settings.js
@@ -6,7 +6,7 @@ import AdvancedSettingsContainer from "../../containers/AdvancedSettings";
 /**
  * The Advanced settings component.
  *
- * @returns {wp.Element} The Advanced settings component.
+ * @returns {JSX.Element} The Advanced settings component.
  */
 const AdvancedSettings = () => {
 	return (

--- a/packages/js/src/classic-editor/components/advanced-settings.js
+++ b/packages/js/src/classic-editor/components/advanced-settings.js
@@ -1,0 +1,19 @@
+
+import { __ } from "@wordpress/i18n";
+import MetaboxCollapsible from "../../components/MetaboxCollapsible";
+import AdvancedSettingsContainer from "../../containers/AdvancedSettings";
+
+/**
+ * The Advanced settings component.
+ *
+ * @returns {wp.Element} The Advanced settings component.
+ */
+const AdvancedSettings = () => {
+	return (
+		<MetaboxCollapsible id={ "collapsible-advanced-settings" } title={ __( "Advanced", "wordpress-seo" ) }>
+			<AdvancedSettingsContainer />
+		</MetaboxCollapsible>
+	);
+};
+
+export default AdvancedSettings;

--- a/packages/js/src/classic-editor/components/cornerstone-content.js
+++ b/packages/js/src/classic-editor/components/cornerstone-content.js
@@ -14,6 +14,8 @@ const LearnMoreLink = makeOutboundLink();
 /**
  * Renders the 'Cornerstone content' collapsible.
  *
+ * @param {string} cornerstoneContentInfoLink A URL to a page to read more about cornerstone content.
+ *
  * @returns {JSX.Element} The collapsible cornerstone toggle component.
  */
 const CornerstoneContent = ( { cornerstoneContentInfoLink } ) => {

--- a/packages/js/src/classic-editor/components/cornerstone-content.js
+++ b/packages/js/src/classic-editor/components/cornerstone-content.js
@@ -1,0 +1,48 @@
+import PropTypes from "prop-types";
+import { useDispatch, useSelect } from "@wordpress/data";
+import { Slot } from "@wordpress/components";
+import { __ } from "@wordpress/i18n";
+import { HelpText } from "@yoast/components";
+import { makeOutboundLink } from "@yoast/helpers";
+import { SEO_STORE_NAME } from "@yoast/seo-store";
+
+import MetaboxCollapsible from "../../components/MetaboxCollapsible";
+import CornerstoneToggle from "../../components/CornerstoneToggle";
+
+const LearnMoreLink = makeOutboundLink();
+
+/**
+ * Renders the 'Cornerstone content' collapsible.
+ *
+ * @returns {JSX.Element} The collapsible cornerstone toggle component.
+ */
+const CornerstoneContent = ( { cornerstoneContentInfoLink } ) => {
+	const isCornerstone  = useSelect( select => select( SEO_STORE_NAME ).selectIsCornerstone() );
+	const { updateIsCornerstone } = useDispatch( SEO_STORE_NAME );
+
+	return (
+		<MetaboxCollapsible
+			id="yoast-cornerstone-collapsible-metabox"
+			title={ __( "Cornerstone content", "wordpress-seo" ) }
+		>
+			<HelpText>
+				{ __( "Cornerstone content should be the most important and extensive articles on your site.", "wordpress-seo" ) + " " }
+				<LearnMoreLink href={ cornerstoneContentInfoLink }>
+					{ __( "Learn more about Cornerstone Content.", "wordpress-seo" ) }
+				</LearnMoreLink>
+			</HelpText>
+			<CornerstoneToggle
+				id="yoast-cornerstone-metabox"
+				isEnabled={ isCornerstone }
+				onToggle={ updateIsCornerstone }
+			/>
+			<Slot name="YoastAfterCornerstoneToggle" />
+		</MetaboxCollapsible>
+	);
+};
+
+CornerstoneContent.propTypes = {
+	cornerstoneContentInfoLink: PropTypes.string.isRequired,
+};
+
+export default CornerstoneContent;

--- a/packages/js/src/classic-editor/components/google-preview.js
+++ b/packages/js/src/classic-editor/components/google-preview.js
@@ -1,0 +1,37 @@
+import { SnippetEditor } from "@yoast/search-metadata-previews";
+import { GooglePreviewContainer } from "@yoast/seo-integration";
+import { SEO_STORE_NAME } from "@yoast/seo-store";
+import { __ } from "@wordpress/i18n";
+import { useSelect } from "@wordpress/data";
+
+import { EDITOR_STORE_NAME } from "../editor-store";
+import MetaboxCollapsible from "../../components/MetaboxCollapsible";
+
+/**
+ * The Google preview component.
+ *
+ * @returns {wp.Element} The Google preview component.
+ */
+const GooglePreview = () => {
+	const shoppingData = useSelect( select => select( EDITOR_STORE_NAME ).getShoppingData() );
+	const siteIconUrl = useSelect( select => select( EDITOR_STORE_NAME ).getSiteIconUrlFromSettings() );
+	const previewImageUrl = useSelect( select => select( EDITOR_STORE_NAME ).getSnippetEditorPreviewImageUrl() );
+	const analysisType = useSelect( select => select( SEO_STORE_NAME ).selectAnalysisType() );
+
+	return (
+		<MetaboxCollapsible
+			id={ "yoast-snippet-editor-metabox" }
+			title={ __( "Google preview", "wordpress-seo" ) } initialIsOpen={ true }
+		>
+			<GooglePreviewContainer
+				as={ SnippetEditor }
+				shoppingData={ shoppingData }
+				faviconSrc={ siteIconUrl }
+				mobileImageSrc={ previewImageUrl }
+				isTaxonomy={ analysisType === "term" }
+			/>
+		</MetaboxCollapsible>
+	);
+};
+
+export default GooglePreview;

--- a/packages/js/src/classic-editor/components/google-preview.js
+++ b/packages/js/src/classic-editor/components/google-preview.js
@@ -10,7 +10,7 @@ import MetaboxCollapsible from "../../components/MetaboxCollapsible";
 /**
  * The Google preview component.
  *
- * @returns {wp.Element} The Google preview component.
+ * @returns {JSX.Element} The Google preview component.
  */
 const GooglePreview = () => {
 	const shoppingData = useSelect( select => select( EDITOR_STORE_NAME ).getShoppingData() );

--- a/packages/js/src/classic-editor/components/metabox/index.js
+++ b/packages/js/src/classic-editor/components/metabox/index.js
@@ -48,7 +48,8 @@ const Metabox = () => {
 			{ isReadabilityAnalysisActive &&
 				<SidebarItem key="readability-analysis" renderPriority={ 10 }>
 					<ReadabilityAnalysis />
-				</SidebarItem> }
+				</SidebarItem>
+			}
 			{ isSeoAnalysisActive &&
 				<SidebarItem key="seo-analysis" renderPriority={ 20 }>
 					<SeoAnalysis

--- a/packages/js/src/classic-editor/components/metabox/index.js
+++ b/packages/js/src/classic-editor/components/metabox/index.js
@@ -29,43 +29,50 @@ const Metabox = () => {
 
 	return (
 		<Fragment>
-			<SidebarItem
-				key="warning"
-				renderPriority={ 1 }
-			>
+			<SidebarItem key="warning" renderPriority={ 1 }>
 				<Warning />
 			</SidebarItem>
-			{ isSeoAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>
-				<FocusKeyphraseInput focusKeyphraseInfoLink={ wpseoAdminL10n[ "shortlinks.focus_keyword_info" ] } />
-				{ ! wpseoScriptData.metabox.isPremium && <Fill name="YoastRelatedKeyphrases">
-					<SEMrushRelatedKeyphrases />
-				</Fill> }
-			</SidebarItem> }
+			{ isSeoAnalysisActive &&
+				<SidebarItem key="keyword-input" renderPriority={ 8 }>
+					<FocusKeyphraseInput focusKeyphraseInfoLink={ wpseoAdminL10n[ "shortlinks.focus_keyword_info" ] } />
+					{ ! wpseoScriptData.metabox.isPremium &&
+						<Fill name="YoastRelatedKeyphrases">
+							<SEMrushRelatedKeyphrases />
+						</Fill>
+					}
+				</SidebarItem>
+			}
 			<SidebarItem key="google-preview" renderPriority={ 9 }>
 				<GooglePreview />
 			</SidebarItem>
-			{ isReadabilityAnalysisActive && <SidebarItem key="readability-analysis" renderPriority={ 10 }>
-				<ReadabilityAnalysis />
-			</SidebarItem> }
-			{ isSeoAnalysisActive && <SidebarItem key="seo-analysis" renderPriority={ 20 }>
-				<SeoAnalysis
-					shouldUpsell={ settings.shouldUpsell }
-					shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
-				/>
-			</SidebarItem> }
-			{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
-				<CornerstoneContent cornerstoneContentInfoLink={ wpseoAdminL10n[ "shortlinks.cornerstone_content_info" ] } />
-			</SidebarItem> }
-			{ settings.displayAdvancedTab && <SidebarItem key="advanced" renderPriority={ 40 }>
-				<AdvancedSettings />
-			</SidebarItem> }
-			{ settings.displaySchemaSettings && <SidebarItem key="schema" renderPriority={ 50 }>
-				<SchemaTabContainer />
-			</SidebarItem> }
-			<SidebarItem
-				key="social"
-				renderPriority={ -1 }
-			>
+			{ isReadabilityAnalysisActive &&
+				<SidebarItem key="readability-analysis" renderPriority={ 10 }>
+					<ReadabilityAnalysis />
+				</SidebarItem> }
+			{ isSeoAnalysisActive &&
+				<SidebarItem key="seo-analysis" renderPriority={ 20 }>
+					<SeoAnalysis
+						shouldUpsell={ settings.shouldUpsell }
+						shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
+					/>
+				</SidebarItem>
+			}
+			{ settings.isCornerstoneActive &&
+				<SidebarItem key="cornerstone" renderPriority={ 30 }>
+					<CornerstoneContent cornerstoneContentInfoLink={ wpseoAdminL10n[ "shortlinks.cornerstone_content_info" ] } />
+				</SidebarItem>
+			}
+			{ settings.displayAdvancedTab &&
+				<SidebarItem key="advanced" renderPriority={ 40 }>
+					<AdvancedSettings />
+				</SidebarItem>
+			}
+			{ settings.displaySchemaSettings &&
+				<SidebarItem key="schema" renderPriority={ 50 }>
+					<SchemaTabContainer />
+				</SidebarItem>
+			}
+			<SidebarItem key="social" renderPriority={ -1 }>
 				<SocialMetadataPortal target="wpseo-section-social" />
 			</SidebarItem>
 		</Fragment>

--- a/packages/js/src/classic-editor/components/metabox/index.js
+++ b/packages/js/src/classic-editor/components/metabox/index.js
@@ -13,7 +13,7 @@ import MetaboxCollapsible from "../../../components/MetaboxCollapsible";
 import SocialMetadataPortal from "../../../components/portals/SocialMetadataPortal";
 import SidebarItem from "../../../components/SidebarItem";
 import AdvancedSettings from "../../../containers/AdvancedSettings";
-import CollapsibleCornerstone from "../../../containers/CollapsibleCornerstone";
+import CornerstoneContent from "../cornerstone-content";
 import SchemaTabContainer from "../../../containers/SchemaTab";
 import SEMrushRelatedKeyphrases from "../../../containers/SEMrushRelatedKeyphrases";
 import Warning from "../../../containers/Warning";
@@ -72,7 +72,7 @@ const Metabox = () => {
 				/>
 			</SidebarItem> }
 			{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
-				<CollapsibleCornerstone />
+				<CornerstoneContent cornerstoneContentInfoLink={ wpseoAdminL10n[ "shortlinks.cornerstone_content_info" ] } />
 			</SidebarItem> }
 			{ settings.displayAdvancedTab && <SidebarItem key="advanced" renderPriority={ 40 }>
 				<MetaboxCollapsible id={ "collapsible-advanced-settings" } title={ __( "Advanced", "wordpress-seo" ) }>

--- a/packages/js/src/classic-editor/components/metabox/index.js
+++ b/packages/js/src/classic-editor/components/metabox/index.js
@@ -3,15 +3,13 @@
 import { Fill } from "@wordpress/components";
 import { useSelect } from "@wordpress/data";
 import { Fragment } from "@wordpress/element";
-import { __ } from "@wordpress/i18n";
 import { SEO_STORE_NAME } from "@yoast/seo-store";
 import GooglePreview from "../google-preview";
 import SeoAnalysis from "../seo-analysis";
 import ReadabilityAnalysis from "../readability-analysis";
-import MetaboxCollapsible from "../../../components/MetaboxCollapsible";
 import SocialMetadataPortal from "../../../components/portals/SocialMetadataPortal";
 import SidebarItem from "../../../components/SidebarItem";
-import AdvancedSettings from "../../../containers/AdvancedSettings";
+import AdvancedSettings from "../advanced-settings";
 import CornerstoneContent from "../cornerstone-content";
 import SchemaTabContainer from "../../../containers/SchemaTab";
 import SEMrushRelatedKeyphrases from "../../../containers/SEMrushRelatedKeyphrases";
@@ -59,9 +57,7 @@ const Metabox = () => {
 				<CornerstoneContent cornerstoneContentInfoLink={ wpseoAdminL10n[ "shortlinks.cornerstone_content_info" ] } />
 			</SidebarItem> }
 			{ settings.displayAdvancedTab && <SidebarItem key="advanced" renderPriority={ 40 }>
-				<MetaboxCollapsible id={ "collapsible-advanced-settings" } title={ __( "Advanced", "wordpress-seo" ) }>
-					<AdvancedSettings />
-				</MetaboxCollapsible>
+				<AdvancedSettings />
 			</SidebarItem> }
 			{ settings.displaySchemaSettings && <SidebarItem key="schema" renderPriority={ 50 }>
 				<SchemaTabContainer />

--- a/packages/js/src/classic-editor/components/metabox/index.js
+++ b/packages/js/src/classic-editor/components/metabox/index.js
@@ -4,9 +4,8 @@ import { Fill } from "@wordpress/components";
 import { useSelect } from "@wordpress/data";
 import { Fragment } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
-import { SnippetEditor } from "@yoast/search-metadata-previews";
-import { GooglePreviewContainer } from "@yoast/seo-integration";
 import { SEO_STORE_NAME } from "@yoast/seo-store";
+import GooglePreview from "../google-preview";
 import SeoAnalysis from "../seo-analysis";
 import ReadabilityAnalysis from "../readability-analysis";
 import MetaboxCollapsible from "../../../components/MetaboxCollapsible";
@@ -29,10 +28,6 @@ const Metabox = () => {
 	const settings = useSelect( select => select( EDITOR_STORE_NAME ).getPreferences() );
 	const isSeoAnalysisActive = useSelect( select => select( SEO_STORE_NAME ).selectIsSeoAnalysisActive() );
 	const isReadabilityAnalysisActive = useSelect( select => select( SEO_STORE_NAME ).selectIsReadabilityAnalysisActive() );
-	const shoppingData = useSelect( select => select( EDITOR_STORE_NAME ).getShoppingData() );
-	const siteIconUrl = useSelect( select => select( EDITOR_STORE_NAME ).getSiteIconUrlFromSettings() );
-	const previewImageUrl = useSelect( select => select( EDITOR_STORE_NAME ).getSnippetEditorPreviewImageUrl() );
-	const analysisType = useSelect( select => select( SEO_STORE_NAME ).selectAnalysisType() );
 
 	return (
 		<Fragment>
@@ -49,18 +44,7 @@ const Metabox = () => {
 				</Fill> }
 			</SidebarItem> }
 			<SidebarItem key="google-preview" renderPriority={ 9 }>
-				<MetaboxCollapsible
-					id={ "yoast-snippet-editor-metabox" }
-					title={ __( "Google preview", "wordpress-seo" ) } initialIsOpen={ true }
-				>
-					<GooglePreviewContainer
-						as={ SnippetEditor }
-						shoppingData={ shoppingData }
-						faviconSrc={ siteIconUrl }
-						mobileImageSrc={ previewImageUrl }
-						isTaxonomy={ analysisType === "term" }
-					/>
-				</MetaboxCollapsible>
+				<GooglePreview />
 			</SidebarItem>
 			{ isReadabilityAnalysisActive && <SidebarItem key="readability-analysis" renderPriority={ 10 }>
 				<ReadabilityAnalysis />


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Setup the 'Cornerstone content' component
* Made components for `AdvancedSettings` and `GooglePreview` to be consistent and increase the readability of the `metabox` component

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Setup the 'Cornerstone content' component

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Verify the cornerstone content toggle toggles the `isCornerstone` value in our Seo store


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes P1-1115
