### PR TITLE
Fix readability analysis for terms

### DIFF
--- a/packages/js/src/analysis/refreshAnalysis.js
+++ b/packages/js/src/analysis/refreshAnalysis.js
@@ -1,6 +1,16 @@
 import { actions } from "@yoast/externals/redux";
 import handleWorkerError from "./handleWorkerError";
 
+/**
+ * These actions NEED to be imported from yoast-components here.
+ * The actions from @yoast/externals/redux contain a synching mechanism to our hidden DOM elements
+ * that doesn't handle the difference between these elements on post and term pages correctly.
+ */
+import {
+	setOverallReadabilityScore,
+	setOverallSeoScore,
+} from "yoast-components";
+
 let isInitialized = false;
 
 /**
@@ -46,9 +56,8 @@ export default function refreshAnalysis( worker, collectData, applyMarks, store,
 				seoResults.results = sortResultsByIdentifier( seoResults.results );
 
 				store.dispatch( actions.setSeoResultsForKeyword( paper.getKeyword(), seoResults.results ) );
-				store.dispatch( actions.setOverallSeoScore( seoResults.score, paper.getKeyword() ) );
+				store.dispatch( setOverallSeoScore( seoResults.score, paper.getKeyword() ) );
 				store.dispatch( actions.refreshSnippetEditor() );
-
 				dataCollector.saveScores( seoResults.score, paper.getKeyword() );
 			}
 
@@ -59,9 +68,8 @@ export default function refreshAnalysis( worker, collectData, applyMarks, store,
 				} );
 
 				readability.results = sortResultsByIdentifier( readability.results );
-
 				store.dispatch( actions.setReadabilityResults( readability.results ) );
-				store.dispatch( actions.setOverallReadabilityScore( readability.score ) );
+				store.dispatch( setOverallReadabilityScore( readability.score ) );
 				store.dispatch( actions.refreshSnippetEditor() );
 
 				dataCollector.saveContentScore( readability.score );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* One of the artifact size optimisations accidentally broke the readability analysis for terms pages. This PR fixes that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the readability analysis was broken on terms pages only.

## Relevant technical choices:

* Directly import `setOverallReadabilityScore` and `setOverallSeoScore` from `yoast-components`, because the **wrapped version** from `packages/js/src/redux/actions/index.js` breaks for terms pages due to a bad DOM element sync in `packages/js/src/helpers/fields/AnalysisFields.js`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to a terms page, ie. categories or tags.
* Check if the readability analysis works as expected.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
