### PR TITLE
Only allow admins to use the deactivating plugins endpoint

### DIFF
--- a/src/routes/importing-route.php
+++ b/src/routes/importing-route.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Routes;
 use WP_Error;
 use WP_REST_Response;
 use Yoast\WP\SEO\Actions\Importing\Importing_Action_Interface;
-use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Conditionals\AIOSEO_V4_Importer_Conditional;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\Services\Importing\Importer_Action_Filter_Trait;
 
@@ -15,8 +15,6 @@ use Yoast\WP\SEO\Services\Importing\Importer_Action_Filter_Trait;
  * Importing route for importing from other SEO plugins.
  */
 class Importing_Route extends Abstract_Action_Route {
-
-	use No_Conditionals;
 
 	use Importer_Action_Filter_Trait;
 
@@ -41,6 +39,15 @@ class Importing_Route extends Abstract_Action_Route {
 	 */
 	public function __construct( Importing_Action_Interface ...$importers ) {
 		$this->importers = $importers;
+	}
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * @return array
+	 */
+	public static function get_conditionals() {
+		return [ AIOSEO_V4_Importer_Conditional::class ];
 	}
 
 	/**
@@ -145,6 +152,6 @@ class Importing_Route extends Abstract_Action_Route {
 	 * @return bool Whether or not the current user is allowed to import.
 	 */
 	public function is_user_permitted_to_import() {
-		return \current_user_can( 'edit_posts' );
+		return \current_user_can( 'activate_plugins' );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to prevent editors from being able to use the new `import/conflicting-plugins/deactivation` endpoint to deactivate plugins
* We also want to stop adding the new endpoints unless the feature flag is enabled.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an editor would be able to deactivate plugins using a newly introduced endpoint

## Relevant technical choices:

* Use the `AIOSEO_V4_Importer_Conditional` conditional before registering the new importing route, so that the new endpoints won't be available without the feature flag.
* Have the `activate_plugins` capability as `permission_callback` for the new importing endpoints (instead of `edit_posts` that used to be there)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

Notes:
* You should have the AIOSEO plugin activated for each step below.
* If the request passes (code 200) AIOSEO will be deactivated, so you have to reactivate again.

With the `YOAST_SEO_AIOSEO_V4_IMPORTER` not enabled:
* Users used to be able to POST the `/wp-json/yoast/v1/import/conflicting-plugins/deactivation` endpoint
* POST example (you can use the console in any Yoast SEO  page to run that):
```
( async function() {
    const a = await fetch( "/wp-json/yoast/v1/import/conflicting-plugins/deactivation" ,
        {
            method: "POST",
            headers: { "X-WP-Nonce": wpApiSettings.nonce }
        }
    );
    console.log( await a.json() );
} )();
```
* With this PR, POSTing that endpoint gives a 404

Also, with the `YOAST_SEO_AIOSEO_V4_IMPORTER` enabled:
* Editors used to be able to POST the `/wp-json/yoast/v1/import/conflicting-plugins/deactivation` endpoint and have plugins deactivated, for example the AIOSEO plugin
* POST example (you can use the console in any Yoast SEO  page to run that):
```
( async function() {
    const a = await fetch( "/wp-json/yoast/v1/import/conflicting-plugins/deactivation" ,
        {
            method: "POST",
            headers: { "X-WP-Nonce": wpApiSettings.nonce }
        }
    );
    console.log( await a.json() );
} )();
```
* With this PR, POSTing that endpoint while being an editor gives a 403


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Minimal impact since we're just tweaking the import route which is not actively used anywhere, aside from the new importer.
* No time should be spent checking new importer, since any issues can be identified while testing the importer's tasks.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
