### PR TITLE
DUPP-135 Prevent installation success to be displayed when activating with WP CLI

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -219,7 +219,9 @@ function _wpseo_activate() {
 
 	WPSEO_Options::set( 'indexing_reason', 'first_install' );
 	WPSEO_Options::set( 'first_time_install', true );
-	WPSEO_Options::set( 'should_redirect_after_install_free', true );
+	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+		WPSEO_Options::set( 'should_redirect_after_install_free', true );
+	}
 
 	do_action( 'wpseo_register_roles' );
 	WPSEO_Role_Manager_Factory::get()->add();

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -222,6 +222,9 @@ function _wpseo_activate() {
 	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 		WPSEO_Options::set( 'should_redirect_after_install_free', true );
 	}
+	else {
+		WPSEO_Options::set( 'activation_redirect_timestamp_free', \time() );
+	}
 
 	do_action( 'wpseo_register_roles' );
 	WPSEO_Role_Manager_Factory::get()->add();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid displaying the installation success screen when the plugin is activated using WP CLI

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents the installation success page to be displayed when the plugin is activated using WP CLI

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* add `define( 'YOAST_SEO_INSTALLATION_SUCCESS', true );` to your `wp-config.php` file
* deactivate Yoast SEO Free
* make sure that `activation_redirect_timestamp_free` in `wpseo` is set to 0;
* use WP CLI to activate the plugin: open a terminal, cd to the WP folder and `wp plugin activate wordpress-seo`
   * if you are using our docker env, you can use `./wp.sh plugin activate wordpress-seo` from the docker env folder
* visit any page in the backend
* You **should NOT** be redirected to the installation success page.

#### With feature flag disabled
* you should never see the installation success page regardless of how you activated the plugin.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-135]


[DUPP-135]: https://yoast.atlassian.net/browse/DUPP-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ