### PR TITLE
Jrf/fix sitemaps rendered url escaping encoding

### DIFF
--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -130,7 +130,7 @@ class WPSEO_Sitemaps_Renderer {
 	/**
 	 * Produce final XML output with debug information.
 	 *
-	 * @param string $sitemap   Sitemap XML.
+	 * @param string $sitemap Sitemap XML.
 	 *
 	 * @return string
 	 */
@@ -208,7 +208,6 @@ class WPSEO_Sitemaps_Renderer {
 	public function sitemap_url( $url ) {
 
 		$date = null;
-
 
 		if ( ! empty( $url['mod'] ) ) {
 			// Create a DateTime object date in the correct timezone.


### PR DESCRIPTION
## Context

* Fixes potentially mangled URLs in the XML sitemaps in certain edge cases, most notably when schema-relative URLs are used.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes potentially mangled URLs in the XML sitemaps in certain edge cases, most notably when schema-relative URLs are used.

## Relevant technical choices:

### WPSEO_Sitemaps_Renderer::encode_url_rfc3986(): add tests

This method, so far, did not have any dedicated tests.

As it is a `protected` method, it cannot be tested directly, but it can be tested via the `get_sitemap()` method.

Note: the tests will not pass as things are at the moment. Basically, adding these tests put a highlight on a pre-existing bug. This bug will be fixed in a subsequent commit.

### WPSEO_Sitemaps_Renderer: fix escaping of URLs in the sitemap

As things were, the URLs which were being added to the sitemap would be incorrectly escaped.

* The `loc` URL would be escaped before the encoding was checked, which could lead to `&amp&amp;` type of artifacts in the URL in the sitemap.
* The image `src` URLs would be escaped with `esc_html()` instead of `esc_url()`.
* In both cases, the schema (protocol) for schema-relative URLs would not be added, which the sitemap specs explicitly state a protocol is required.

This introduces a new `WPSEO_Sitemaps_Renderer::encode_and_escape()` method which handles the encoding and escaping in the right order and is subsequently used in the `WPSEO_Sitemaps_Renderer::get_sitemap()` method.

The previously added tests for the URL "encoding" already largely cover this change.

For the additional changes to the `get_sitemap()` method, the `loc` URL in that test has been adjusted and a few additional image URLs have been added. Together these changes  will safeguard that the encoding and escaping is done correctly.

### WPSEO_Sitemaps_Renderer: minor CS fixes

... as I was touching the class now anyway.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Simple unit test-based check:
* Check out the first commit of this PR and run the newly added tests, like so:
   `phpunit -c phpunit-integration.xml.dist --testdox --filter WPSEO_Sitemaps_Renderer_Test`
* The test will fail and show you the difference between how the URLs _should_ be encoded and how they actually are encoded.
* Check out the HEAD of this PR and run the tests again to see them pass with the fix in place.

Manual check:
* On `trunk`, create a post with a couple of schema-relative image URLs in the post.
* Possibly: edit the URL of the post to be schema-relative as well and have spaces or other special characters in the "path" part of the URL.
* Even better, make sure that the URL rewriting to "pretty permalinks" is turned OFF or only partially turned on, and the URL (in part) will be a query string.
* Check the sitemap and find the relevant URLs and see them being mangled.
* Switch to this branch.
* Clear the sitemap cache.
* Check the sitemap again and see the URLs being correctly encoded and escaped.


### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.  **_(second part, manual check)_**


## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* XML sitemaps
