### PR TITLE
Schema sameAs URLs should be unique

### DIFF
--- a/src/generators/schema/organization.php
+++ b/src/generators/schema/organization.php
@@ -38,7 +38,7 @@ class Organization extends Abstract_Schema_Piece {
 			'@id'    => $this->context->site_url . Schema_IDs::ORGANIZATION_HASH,
 			'name'   => $this->helpers->schema->html->smart_strip_tags( $this->context->company_name ),
 			'url'    => $this->context->site_url,
-			'sameAs' => array_unique( $this->fetch_social_profiles() ),
+			'sameAs' => \array_values( \array_unique( $this->fetch_social_profiles() ) ),
 			'logo'   => $logo,
 			'image'  => [ '@id' => $logo_schema_id ],
 		];

--- a/src/generators/schema/organization.php
+++ b/src/generators/schema/organization.php
@@ -38,7 +38,7 @@ class Organization extends Abstract_Schema_Piece {
 			'@id'    => $this->context->site_url . Schema_IDs::ORGANIZATION_HASH,
 			'name'   => $this->helpers->schema->html->smart_strip_tags( $this->context->company_name ),
 			'url'    => $this->context->site_url,
-			'sameAs' => $this->fetch_social_profiles(),
+			'sameAs' => array_unique( $this->fetch_social_profiles() ),
 			'logo'   => $logo,
 			'image'  => [ '@id' => $logo_schema_id ],
 		];

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -293,6 +293,7 @@ class Person extends Abstract_Schema_Piece {
 		$same_as_urls = $this->get_social_profiles( $same_as_urls, $user_id );
 
 		if ( ! empty( $same_as_urls ) ) {
+			$same_as_urls   = array_unique( $same_as_urls );
 			$data['sameAs'] = $same_as_urls;
 		}
 

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -293,7 +293,7 @@ class Person extends Abstract_Schema_Piece {
 		$same_as_urls = $this->get_social_profiles( $same_as_urls, $user_id );
 
 		if ( ! empty( $same_as_urls ) ) {
-			$same_as_urls   = array_unique( $same_as_urls );
+			$same_as_urls   = \array_values( \array_unique( $same_as_urls ) );
 			$data['sameAs'] = $same_as_urls;
 		}
 

--- a/tests/unit/generators/schema/organization-test.php
+++ b/tests/unit/generators/schema/organization-test.php
@@ -133,6 +133,7 @@ class Organization_Test extends TestCase {
 				->andReturn( $profile_value );
 		}
 		Filters\expectApplied( 'wpseo_schema_organization_social_profiles' )
+			->atMost()
 			->once()
 			->with( $profiles_expected )
 			->andReturn( $profiles_expected );
@@ -192,6 +193,7 @@ class Organization_Test extends TestCase {
 				->andReturn( $profile_value );
 		}
 		Filters\expectApplied( 'wpseo_schema_organization_social_profiles' )
+			->atMost()
 			->once()
 			->with( $profiles_expected )
 			->andReturn( $profiles_expected );
@@ -246,8 +248,7 @@ class Organization_Test extends TestCase {
 	 */
 	public function generate_provider() {
 		return [
-			// Every possible social profile filled.
-			[
+			'Every possible social profile filled' => [
 				'profiles_input'    => [
 					'facebook_site' => 'https://www.facebook.com/yoast/',
 					'instagram_url' => 'https://www.instagram.com/yoast/',
@@ -269,8 +270,7 @@ class Organization_Test extends TestCase {
 					'https://twitter.com/yoast',
 				],
 			],
-			// Without Twitter.
-			[
+			'Without Twitter' => [
 				'profiles_input'    => [
 					'facebook_site' => 'https://www.facebook.com/yoast/',
 					'instagram_url' => 'https://www.instagram.com/yoast/',
@@ -291,8 +291,7 @@ class Organization_Test extends TestCase {
 					'https://en.wikipedia.org/wiki/Yoast_SEO',
 				],
 			],
-			// Only Twitter.
-			[
+			'Only Twitter' => [
 				'profiles_input'    => [
 					'facebook_site' => '',
 					'instagram_url' => '',
@@ -304,6 +303,27 @@ class Organization_Test extends TestCase {
 					'twitter_site'  => 'yoast',
 				],
 				'profiles_expected' => [
+					'https://twitter.com/yoast',
+				],
+			],
+			'Duplicated URLs' => [
+				'profiles_input'    => [
+					'facebook_site' => 'https://www.facebook.com/yoast/',
+					'instagram_url' => 'https://www.facebook.com/yoast/',
+					'linkedin_url'  => 'https://www.linkedin.com/company/yoast-com',
+					'myspace_url'   => 'https://myspace.com/yoast/',
+					'youtube_url'   => 'https://www.youtube.com/yoast',
+					'pinterest_url' => 'https://www.pinterest.com/yoast/',
+					'wikipedia_url' => 'https://en.wikipedia.org/wiki/Yoast_SEO',
+					'twitter_site'  => 'yoast',
+				],
+				'profiles_expected' => [
+					'https://www.facebook.com/yoast/',
+					'https://www.linkedin.com/company/yoast-com',
+					'https://myspace.com/yoast/',
+					'https://www.youtube.com/yoast',
+					'https://www.pinterest.com/yoast/',
+					'https://en.wikipedia.org/wiki/Yoast_SEO',
 					'https://twitter.com/yoast',
 				],
 			],

--- a/tests/unit/generators/schema/person-test.php
+++ b/tests/unit/generators/schema/person-test.php
@@ -97,7 +97,6 @@ class Person_Test extends TestCase {
 			'display_name' => 'John',
 			'description'  => 'Description',
 		];
-		$person_logo_id        = 42;
 		$person_schema_logo_id = $this->instance->context->site_url . Schema_IDs::PERSON_LOGO_HASH;
 		$image_schema          = [
 			'@type'      => 'ImageObject',
@@ -440,6 +439,90 @@ class Person_Test extends TestCase {
 			->andReturn( true );
 
 		$this->assertFalse( $this->instance->is_needed() );
+	}
+
+	/**
+	 * Tests whether generate returns the expected schema when duplicated URLs are provded.
+	 *
+	 * @covers ::generate
+	 * @covers ::determine_user_id
+	 * @covers ::build_person_data
+	 * @covers ::add_image
+	 * @covers ::set_image_from_options
+	 * @covers ::set_image_from_avatar
+	 * @covers ::get_social_profiles
+	 * @covers ::url_social_site
+	 */
+	public function test_generate_duplicated_URLs() {
+		$this->instance->context->site_user_id     = 1337;
+		$this->instance->context->site_url         = 'https://example.com/';
+		$this->instance->context->site_represents  = 'person';
+		$this->instance->context->person_logo_meta = [
+			'height' => 100,
+			'width'  => 100,
+			'url'    => 'http://example.com/image.png',
+		];
+
+		$user_data             = (object) [
+			'display_name' => 'John',
+			'description'  => 'Description',
+		];
+		$person_schema_logo_id = $this->instance->context->site_url . Schema_IDs::PERSON_LOGO_HASH;
+		$image_schema          = [
+			'@type'      => 'ImageObject',
+			'@id'        => $person_schema_logo_id,
+			'inLanguage' => 'en-US',
+			'url'        => 'https://example.com/image.png',
+			'width'      => 64,
+			'height'     => 128,
+			'caption'    => 'Person image',
+		];
+
+		$duplicated_social_profiles = [
+			'facebook',
+			'facebook',
+			'linkedin',
+			'pinterest',
+			'twitter',
+			'myspace',
+			'youtube',
+			'soundcloud',
+			'tumblr',
+			'wikipedia',
+		];
+
+
+		$expected = [
+			'@type'       => [ 'Person', 'Organization' ],
+			'@id'         => 'person_id',
+			'name'        => 'John',
+			'logo'        => [ '@id' => 'https://example.com/#personlogo' ],
+			'description' => 'Description',
+			'sameAs'      => [
+				'https://example.com/social/facebook',
+				'https://example.com/social/linkedin',
+				'https://example.com/social/pinterest',
+				'https://twitter.com/https://example.com/social/twitter',
+				'https://example.com/social/myspace',
+				'https://example.com/social/youtube',
+				'https://example.com/social/soundcloud',
+				'https://example.com/social/tumblr',
+				'https://example.com/social/wikipedia',
+			],
+			'image'       => $image_schema,
+		];
+
+		$this->expects_for_determine_user_id();
+		$this->expects_for_get_userdata( $user_data );
+
+		$this->instance->helpers->schema->image->expects( 'generate_from_attachment_meta' )
+			->once()
+			->with( $person_schema_logo_id, $this->instance->context->person_logo_meta, $user_data->display_name )
+			->andReturn( $image_schema );
+
+		$this->expects_for_social_profiles( $duplicated_social_profiles );
+
+		$this->assertEquals( $expected, $this->instance->generate( $this->instance->context ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes sure we don't output the same `sameAs` URL twice on `Person` and `Organization`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Organization
- in SEO > Search Appearance, set "Organization" and add name and logo
- in SEO > Social, add a Twitter nickname and some social URLs, making sure that some of them are duplicated
- visit the home page in the front end and inspect the Schema
  - check that the `Organization` piece doesn't display duplicated URLs in `sameAs`

#### Person
- pick a user which is the author of some posts
- add a Twitter nickname and some social URLs, making sure that some of them are duplicated
- visit in the front end one of the user's posts and inspect the Schema
  - check that the `Persone` piece doesn't display duplicated URLs in `sameAs`


* Can be also tested on Yoast.com, for example currently https://yoast.com/how-to-use-headings-on-your-site/ shows `jonoalderson.com` twice.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.
## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

