### PR TITLE
DUPP-144 Improve style of the installation success page on mobile screens

### DIFF
--- a/css/src/installation-success.css
+++ b/css/src/installation-success.css
@@ -2,7 +2,9 @@
 	display: flex;
 	flex-direction: column;
 	height: 88vh;
-	justify-content: center;
+	justify-content: start;
+	padding-top: 7%;
+	box-sizing: border-box;
 }
 
 .installation-success-page .step-list {
@@ -173,6 +175,7 @@
 @media screen and (max-width: 768px) {
 	.installation-success-page {
 		height: unset;
+		padding-top: unset;
 		padding-right: 10px;
 	}
 

--- a/css/src/installation-success.css
+++ b/css/src/installation-success.css
@@ -1,9 +1,8 @@
 .installation-success-page {
 	display: flex;
 	flex-direction: column;
-	height: 90vh;
-	margin-top: 16vh;
-	flex-wrap: wrap;
+	height: 88vh;
+	justify-content: center;
 }
 
 .installation-success-page .step-list {
@@ -163,10 +162,45 @@
 
 #installation-success-skip-link {
 	align-self: end;
-	bottom: 0;
+	bottom: 20px;
+	right: 0;
 	margin-bottom: 9px;
 	position: absolute;
 	margin-right: 20px;
 	letter-spacing: -0.08px;
 	line-height: 19px;
+}
+
+@media screen and (max-width: 768px) {
+	.installation-success-page {
+		height: unset;
+		padding-right: 10px;
+	}
+
+	.installation-success-content {
+		display: flex;
+		flex-direction: row;
+		justify-content: center;
+		align-items: center;
+	}
+
+	.installation-success-cards {
+		flex-direction: column;
+	}
+
+	.installation-success-page .step-list {
+		flex-direction: column;
+		margin: auto 24px auto 0;
+	}
+
+	.installation-success-page .step-first-div {
+		width: unset;
+		height: 376px;
+		flex-direction: column;
+	}
+
+	.installation-success-page .step-second-div {
+		width: 2px;
+		height: 100%;
+	}
 }

--- a/css/src/installation-success.css
+++ b/css/src/installation-success.css
@@ -100,7 +100,7 @@
 	border: 1px solid rgba(0,0,0,.2);
 	border-radius: 8px;
 	box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
-	width: 320px;
+	max-width: 320px;
 	height: 315px;
 	padding: 24px;
 	display: flex;
@@ -110,7 +110,6 @@
 .installation-success-card.active {
 	border-color: var( --yoast-color-primary );
 	box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.1), 0 6px 6px 0 rgba(0, 0, 0, 0.06);
-	width: 320px;
 	height: 327px;
 }
 
@@ -175,6 +174,10 @@
 	.installation-success-page {
 		height: unset;
 		padding-right: 10px;
+	}
+
+	.installation-success-page .installation-success-title {
+		font-size: 32px;
 	}
 
 	.installation-success-content {

--- a/packages/js/src/installation-success.js
+++ b/packages/js/src/installation-success.js
@@ -47,55 +47,57 @@ function InstallationSuccessPage() {
 					"Yoast SEO" )
 				}
 			</h1>
-			<div className="installation-success-steps">
-				<Steppers />
-			</div>
-			<div className="installation-success-cards">
-				<div id="installation-success-card-optimized-site" className="installation-success-card">
-					<h2>{ __( "Your site is now easy to find for search engines!", "wordpress-seo" ) }</h2>
-					<p>
-						{ sprintf(
-							/* translators: %s expands to Yoast SEO. */
-							__( "%s rolls out the red carpet for the search bots, which helps your site perform better in search engines.",
-								"wordpress-seo" ),
-							"Yoast SEO"
-						) }
-					</p>
-					<div className="card-button-section">
-						<img
-							className="man-with-tablet"
-							src={ window.wpseoInstallationSuccess.pluginUrl + "/images/man_with_tablet.png" }
-							alt={ __( "Man holding a tablet.", "wordpress-seo" ) }
-						/>
-					</div>
+			<div className="installation-success-content">
+				<div className="installation-success-steps">
+					<Steppers />
 				</div>
-				<div id="installation-success-card-configuration-workout" className="installation-success-card active">
-					<h2>
-						{ sprintf(
-							/* translators: %s expands to Yoast SEO. */
-							__( "Configure %s!", "wordpress-seo" ),
-							"Yoast SEO"
-						) }
-					</h2>
-					<p>
-						{ sprintf(
-							/* translators: %s expands to Yoast SEO. */
-							__( "Set the essential %s settings in a few steps.", "wordpress-seo" ),
-							"Yoast SEO"
-						) }
-					</p>
-					<img
-						src={ window.wpseoInstallationSuccess.pluginUrl + "/images/mirrored_fit_bubble_woman_1_optim.svg" }
-						alt={ "" }
-					/>
-					<div className="card-button-section">
-						<ButtonStyledLink
-							id="installation-successful-configuration-workout-link"
-							href={ window.wpseoInstallationSuccess.configurationWorkoutUrl }
-							variant="primary"
-						>
-							{ __( "Start configuration workout!", "wordpress-seo" ) }
-						</ButtonStyledLink>
+				<div className="installation-success-cards">
+					<div id="installation-success-card-optimized-site" className="installation-success-card">
+						<h2>{ __( "Your site is now easy to find for search engines!", "wordpress-seo" ) }</h2>
+						<p>
+							{ sprintf(
+								/* translators: %s expands to Yoast SEO. */
+								__( "%s rolls out the red carpet for the search bots, which helps your site perform better in search engines.",
+									"wordpress-seo" ),
+								"Yoast SEO"
+							) }
+						</p>
+						<div className="card-button-section">
+							<img
+								className="man-with-tablet"
+								src={ window.wpseoInstallationSuccess.pluginUrl + "/images/man_with_tablet.png" }
+								alt={ __( "Man holding a tablet.", "wordpress-seo" ) }
+							/>
+						</div>
+					</div>
+					<div id="installation-success-card-configuration-workout" className="installation-success-card active">
+						<h2>
+							{ sprintf(
+								/* translators: %s expands to Yoast SEO. */
+								__( "Configure %s!", "wordpress-seo" ),
+								"Yoast SEO"
+							) }
+						</h2>
+						<p>
+							{ sprintf(
+								/* translators: %s expands to Yoast SEO. */
+								__( "Set the essential %s settings in a few steps.", "wordpress-seo" ),
+								"Yoast SEO"
+							) }
+						</p>
+						<img
+							src={ window.wpseoInstallationSuccess.pluginUrl + "/images/mirrored_fit_bubble_woman_1_optim.svg" }
+							alt={ "" }
+						/>
+						<div className="card-button-section">
+							<ButtonStyledLink
+								id="installation-successful-configuration-workout-link"
+								href={ window.wpseoInstallationSuccess.configurationWorkoutUrl }
+								variant="primary"
+							>
+								{ __( "Start configuration workout!", "wordpress-seo" ) }
+							</ButtonStyledLink>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/packages/js/src/installation-success.js
+++ b/packages/js/src/installation-success.js
@@ -44,6 +44,7 @@ function InstallationSuccessPage() {
 				{ sprintf(
 					/* translators: %s expands to Yoast SEO. */
 					__( "You've successfully installed %s!", "wordpress-seo" ),
+					// The space between 'Yoast' and 'SEO' is a non-breaking space (Unicode 160).
 					"Yoast SEO" )
 				}
 			</h1>

--- a/packages/js/src/installation-success.js
+++ b/packages/js/src/installation-success.js
@@ -44,7 +44,7 @@ function InstallationSuccessPage() {
 				{ sprintf(
 					/* translators: %s expands to Yoast SEO. */
 					__( "You've successfully installed %s!", "wordpress-seo" ),
-					"Yoast SEO" )
+					"Yoast SEO" )
 				}
 			</h1>
 			<div className="installation-success-content">


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to improve the looke of the installation success page on mobile screens

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the look of the installation success page on mobile screens.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

##### feature flag on
* add `define( 'YOAST_SEO_INSTALLATION_SUCCESS', true );` to your `wp-config.php` file
* visit the installation success page (URL: `{domain}/wp-admin/admin.php?page=wpseo_installation_successful_free`)
* check that the look hasn't changed from the expected design
* switch to mobile view and shrink the width of the screen until it becomes less than 768px
* you should now see the mobile version of the screen:
  * the stepped is to the left side and it's vertical
  * the cards are on the right side and they are in a column
  * you'll probably need to scroll the page to find the "Skip" link
* please check in different browsers: Chrome, Firefox, Edge, Safari

##### feature flag off
* NA: the installation success page shouldn't be accessible in this case.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-144]


[DUPP-144]: https://yoast.atlassian.net/browse/DUPP-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ