### PR TITLE
DUPP-167 Deal with showing installation success for network activation of the plugin

### DIFF
--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -80,7 +80,7 @@ class Installation_Success_Integration implements Integration_Interface {
 			return;
 		}
 
-		if ( \is_network_admin() ) {
+		if ( \is_network_admin() || \is_plugin_active_for_network( WPSEO_BASENAME ) ) {
 			return;
 		}
 

--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -80,6 +80,10 @@ class Installation_Success_Integration implements Integration_Interface {
 			return;
 		}
 
+		if ( \is_network_admin() ) {
+			return;
+		}
+
 		\wp_safe_redirect( \admin_url( 'admin.php?page=wpseo_installation_successful_free' ), 302, 'Yoast SEO' );
 		$this->terminate_execution();
 	}

--- a/tests/unit/integrations/admin/installation-success-integration-test.php
+++ b/tests/unit/integrations/admin/installation-success-integration-test.php
@@ -127,6 +127,9 @@ class Installation_Success_Integration_Test extends TestCase {
 			->expects( 'is_premium' )
 			->andReturnFalse();
 
+		Monkey\Functions\expect( 'is_network_admin' )
+			->andReturn( false );
+
 		$redirect_url = 'http://basic.wordpress.test/wp-admin/admin.php?page=wpseo_installation_successful_free';
 
 		Monkey\Functions\expect( 'admin_url' )
@@ -245,6 +248,45 @@ class Installation_Success_Integration_Test extends TestCase {
 			->withSomeOfArgs( 'activation_redirect_timestamp_free' );
 
 		$_REQUEST['activate-multi'] = 'true';
+
+		Monkey\Functions\expect( 'wp_safe_redirect' )
+			->never();
+
+		$this->instance->maybe_redirect();
+	}
+
+	/**
+	 * Tests that the redirection does not occur when free is Network Activated.
+	 *
+	 * @covers ::maybe_redirect
+	 */
+	public function test_maybe_redirect_network_admin() {
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'should_redirect_after_install_free', false )
+			->andReturnTrue();
+
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'should_redirect_after_install_free', false );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'activation_redirect_timestamp_free', 0 )
+			->andReturn( '0' );
+
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'activation_redirect_timestamp_free', \time() );
+
+		$_REQUEST['activate-multi'] = null;
+
+		$this->product_helper
+			->expects( 'is_premium' )
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'is_network_admin' )
+			->andReturn( true );
 
 		Monkey\Functions\expect( 'wp_safe_redirect' )
 			->never();

--- a/tests/unit/integrations/admin/installation-success-integration-test.php
+++ b/tests/unit/integrations/admin/installation-success-integration-test.php
@@ -130,6 +130,9 @@ class Installation_Success_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'is_network_admin' )
 			->andReturn( false );
 
+		Monkey\Functions\expect( 'is_plugin_active_for_network' )
+			->andReturn( false );
+
 		$redirect_url = 'http://basic.wordpress.test/wp-admin/admin.php?page=wpseo_installation_successful_free';
 
 		Monkey\Functions\expect( 'admin_url' )
@@ -256,7 +259,7 @@ class Installation_Success_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that the redirection does not occur when free is Network Activated.
+	 * Tests that the redirection does not occur when in the Network admin.
 	 *
 	 * @covers ::maybe_redirect
 	 */
@@ -286,6 +289,48 @@ class Installation_Success_Integration_Test extends TestCase {
 			->andReturnFalse();
 
 		Monkey\Functions\expect( 'is_network_admin' )
+			->andReturn( true );
+
+		Monkey\Functions\expect( 'wp_safe_redirect' )
+			->never();
+
+		$this->instance->maybe_redirect();
+	}
+
+	/**
+	 * Tests that the redirection does not occur when free is Network Activated.
+	 *
+	 * @covers ::maybe_redirect
+	 */
+	public function test_maybe_redirect_network_active() {
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'should_redirect_after_install_free', false )
+			->andReturnTrue();
+
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'should_redirect_after_install_free', false );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'activation_redirect_timestamp_free', 0 )
+			->andReturn( '0' );
+
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'activation_redirect_timestamp_free', \time() );
+
+		$_REQUEST['activate-multi'] = null;
+
+		$this->product_helper
+			->expects( 'is_premium' )
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'is_network_admin' )
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_plugin_active_for_network' )
 			->andReturn( true );
 
 		Monkey\Functions\expect( 'wp_safe_redirect' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Avoids redirecting to the installation succes page when  Yoast SEO is activated in the network admin. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Feature flag enabled
_Network activation_
* Make sure you have the `YOAST_SEO_INSTALLATION_SUCCESS` feature flag enabled.
* Use a fresh environment, or make sure Yoast SEO is not activated for any of the subsites and the `activation_redirect_timestamp_free` timestamp is set to `0` for all subsites.
* Visit the Network admin of a multisite.
* Network activate Yoast SEO and see you are not redirected to the installation success page.
* Visit the admin of one of the subsites (make sure you check one of the other subsites than the main one!) and see you are not redirected to the installation success page. 

_Individual activation_
* Make sure you have the `YOAST_SEO_INSTALLATION_SUCCESS` feature flag enabled.
* Use a fresh environment, or make sure Yoast SEO is not activated in the Network admin, or for any of the subsites, and the `activation_redirect_timestamp_free` timestamp is set to `0` for all subsites.
* Visit the admin of one of the subsites.
* Activate Yoast SEO and see you are redirected to the corresponding installation success page. 
* Visit the admin of a second subsite.
* Activate Yoast SEO there as well and see you are redirected to the corresponding installation success page again. 

#### Feature flag disabled
* You should never be redirected to the installation success page regardless of how or where you activate the plugin. 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-167]


[DUPP-167]: https://yoast.atlassian.net/browse/DUPP-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ