### PR TITLE
DUPP-164 Use `capability` instead of deprecated `who` param in WP 5.9

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -308,7 +308,8 @@ class WPSEO_Admin {
 		// Capability queries were only introduced in WP 5.9.
 		if ( version_compare( $wordpress_version, '5.9-alpha', '<' ) ) {
 			$users = get_users( [ 'who' => 'authors' ] );
-		} else {
+		}
+		else {
 			$users = get_users( [ 'capability' => 'edit_posts' ] );
 		}
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -5,7 +5,7 @@
  * @package WPSEO\Admin
  */
 
-use Yoast\WP\SEO\Config\Wincher_Links;
+use Yoast\WP\SEO\Helpers\Wordpress_Helper;
 
 /**
  * Class that holds most of the admin functionality for Yoast SEO.
@@ -302,7 +302,16 @@ class WPSEO_Admin {
 	 * Log the updated timestamp for user profiles when theme is changed.
 	 */
 	public function switch_theme() {
-		$users = get_users( [ 'who' => 'authors' ] );
+		$wordpress_helper  = new Wordpress_Helper();
+		$wordpress_version = $wordpress_helper->get_wordpress_version();
+
+		// Capability queries were only introduced in WP 5.9.
+		if ( version_compare( $wordpress_version, '5.9-alpha', '<' ) ) {
+			$users = get_users( [ 'who' => 'authors' ] );
+		} else {
+			$users = get_users( [ 'capability' => 'edit_posts' ] );
+		}
+
 		if ( is_array( $users ) && $users !== [] ) {
 			foreach ( $users as $user ) {
 				update_user_meta( $user->ID, '_yoast_wpseo_profile_updated', time() );

--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -240,8 +240,8 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 
 		// Capability queries were only introduced in WP 5.9.
 		if ( version_compare( $wordpress_version, '5.9-alpha', '<' ) ) {
-			$defaults['who'] = 'authors';
-			unset( $defaults['capability'] );
+			$user_criteria['who'] = 'authors';
+			unset( $user_criteria['capability'] );
 		}
 
 		$users = get_users( $user_criteria );

--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -131,8 +131,8 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		// Capability queries were only introduced in WP 5.9.
 		if ( version_compare( $wordpress_version, '5.9-alpha', '<' ) ) {
 			$defaults['who'] = 'authors';
- 	        unset( $defaults['capability'] );
- 	    }
+			unset( $defaults['capability'] );
+		}
 
 		if ( WPSEO_Options::get( 'noindex-author-noposts-wpseo', true ) ) {
 			unset( $defaults['capability'] );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* WP 5.9 [deprecates](https://core.trac.wordpress.org/ticket/16841#comment:80) the `'who'` parameter in `get_users()`. We want to avoid a warning to be displayed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a deprecation notice would be displayed when using WordPress 5.9.

## Relevant technical choices:

* Also removes an outdated `use` statement for a non-existing `Wincher_Links` class.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Preparation
* make sure you have `WP_DEBUG` set to `true`
* disable Debug Bar and Query Monitor to make sure you can see the warning
* install and activate the WordPress Beta Tester plugin
* make sure you have at least:
   * a user with role `Contributor` or higher who *doesn't* have any published post (call it A)
   * a user with role `Subscriber` who *does* have at least a published post (call it B)
* visit SEO > Search Appearance, tab `Archives`, `Authors` section, and make sure  `Show archives for authors without posts in search results?` is set to OFF

#### Check that there are no regressions with WP < 5.9
* checkout, build and activate this branch
* visit the sitemap (e.g. http://basic.wordpress.test/sitemap_index.xml) and see that you don't get any warning/error
* navigate to the authors sitemap and check that:
  * you can't see an entry for the user A nor user B
* visit SEO > Search Appearance, tab `Archives`, `Authors` section, and make sure  `Show archives for authors without posts in search results?` is set to ON
* navigate to the authors sitemap and check that:
  * you **can** see an entry for the user A
  * you still can't see an entry for the user B
* inspect the DB and launch this query:
```
SELECT *
FROM `wp_usermeta`
WHERE `meta_key` = '_yoast_wpseo_profile_updated'
```
(change `wp_` prefix with the one you actually have)
   * take note of the values you see
* switch to a different theme
* re-launch the query and see that all the values have been updated, except the one related to the `Subscriber` user (if present - it will happen if you downgraded an existing user)
* delete all the `_yoast_wpseo_profile_updated` user meta fields
* visit the main sitemap
* re-launch the query and see that all the values have been re-created, except the one related to the `Subscriber` user.

#### Reproduce the bug
* checkout, build and activate latest `trunk` 
* visit Tools > Beta tester, switch to `Bleeding edge` and save
* on reload, set `Beta/RC only` and save.
* go to `Dashboard` > `Updates` and install WP 5.9-beta2
* visit the main sitemap and see that it fails with a message
```
Deprecated: WP_User_Query was called with an argument that is deprecated since version 5.9.0! 
who is deprecated. Use capability instead.
```

#### Test on WP 5.9
* checkout, build and activate latest `trunk` and verify on the sitemap (e.g. http://basic.wordpress.test/sitemap_index.xml)  that you get an error.
* checkout and build the current branch, visit the sitemap again and see that you don't get any warning/error
* visit SEO > Search Appearance, tab `Archives`, `Authors` section, and make sure  `Show archives for authors without posts in search results?` is set to OFF
* navigate to the authors sitemap and check that:
  * you can't see an entry for the user A nor user B
* visit SEO > Search Appearance, tab `Archives`, `Authors` section, and make sure  `Show archives for authors without posts in search results?` is set to ON
* navigate to the authors sitemap and check that:
  * you **can** see an entry for the user A
  * you still can't see an entry for the user B
* inspect the DB and launch this query:
```
SELECT *
FROM `wp_usermeta`
WHERE `meta_key` = '_yoast_wpseo_profile_updated'
```
(change `wp_` prefix with the one you actually have)
   * take note of the values you see
* switch to a different theme
* re-launch the query and see that all the values have been updated, except the one related to the `Subscriber` user (if present - it will happen if you downgraded an existing user, but if you deleted that while testing the regressions you won't find it anymore - not a big deal)
* delete all the `_yoast_wpseo_profile_updated` user meta fields
* visit the main sitemap
* re-launch the query and see that all the values have been re-created, except the one related to the `Subscriber` user.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-164]


[DUPP-164]: https://yoast.atlassian.net/browse/DUPP-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ