### PR TITLE
QA-2616 Wincher: add explanation to table on the Dashboard

### DIFF
--- a/packages/js/src/components/WincherPerformanceReport.js
+++ b/packages/js/src/components/WincherPerformanceReport.js
@@ -16,9 +16,11 @@ import WincherConnectExplanation from "./modals/WincherConnectExplanation";
 import WincherNoTrackedKeyphrasesAlert from "./modals/WincherNoTrackedKeyphrasesAlert";
 import { getKeyphrasePosition, PositionOverTimeChart } from "./WincherTableRow";
 import WincherReconnectAlert from "./modals/WincherReconnectAlert";
+import interpolateComponents from "interpolate-components";
 
 const ViewLink = makeOutboundLink();
 const GetMoreInsightsLink = makeOutboundLink();
+const WincherAccountLink = makeOutboundLink();
 
 /**
  * Wincher SEO Performance container.
@@ -168,6 +170,39 @@ GetUserMessage.propTypes = {
 };
 
 /**
+ * TableFootnote component.
+ *
+ * @returns {wp.Element} The footnote.
+ */
+const TableExplanation = () => {
+	const message = sprintf(
+		/* translators: %s expands to a link to Wincher login */
+		// eslint-disable-next-line max-len
+		__( "This overview only shows you keyphrases added to Yoast SEO. There may be other keyphrases added to your %s.", "wordpress-seo" ),
+		"{{wincherAccountLink/}}"
+	);
+
+	return <p>
+		{
+			interpolateComponents( {
+				mixedString: message,
+				components: {
+					wincherAccountLink: <WincherAccountLink href={ wpseoAdminGlobalL10n[ "links.wincher.login" ] }>
+						{
+							sprintf(
+								/* translators: %s : Expands to "Wincher". */
+								__( "%s account", "wordpress-seo" ),
+								"Wincher"
+							)
+						}
+					</WincherAccountLink>,
+				},
+			} )
+		}
+	</p>;
+};
+
+/**
  * The Dashboard Wincer SEO Performance component.
  *
  * @param {Object} props The component props.
@@ -190,6 +225,8 @@ const WincherPerformanceReport = ( props ) => {
 			<GetUserMessage { ...props } />
 
 			{ isLoggedIn && data && ! isEmpty( data ) && ! isEmpty( data.results ) && <Fragment>
+				<TableExplanation />
+
 				<WincherSEOPerformanceTableWrapper>
 					<table className="yoast yoast-table">
 						<thead>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add more context about the keyphrases listed in the overview on the dashboard.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add explanation to the Wincher keyphrases table on the dashboard. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable Wincher integration and connect
* Track one or more keyphrases
* Visit the WordPress Dashboard
* Ensure that there's a text at the keyphrases table like this "This overview only shows you keyphrases added to Yoast SEO. There may be other keyphrases added to your <link>Wincher account</link>."


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
