### PR TITLE
Fix 8.1 compatibility: Table yoast_wp_seo_models_indexable doesn't exist

### DIFF
--- a/lib/model.php
+++ b/lib/model.php
@@ -172,9 +172,11 @@ class Model implements JsonSerializable {
 			return $default_value;
 		}
 
-		$properties = \get_class_vars( $class_name );
+		if ( ! isset( $class_name::${$property} ) ) {
+			return $default_value;
+		}
 
-		return $properties[ $property ];
+		return $class_name::${$property};
 	}
 
 	/**

--- a/lib/model.php
+++ b/lib/model.php
@@ -163,7 +163,7 @@ class Model implements JsonSerializable {
 	 *
 	 * @param string      $class_name    The target class name.
 	 * @param string      $property      The property to get the value for.
-	 * @param mixed|null $default_value Default value when property does not exist.
+	 * @param mixed|null  $default_value Default value when property does not exist.
 	 *
 	 * @return mixed|null The value of the property.
 	 */

--- a/lib/model.php
+++ b/lib/model.php
@@ -161,9 +161,9 @@ class Model implements JsonSerializable {
 	 * class or the property does not exist, returns the default
 	 * value supplied as the third argument (which defaults to null).
 	 *
-	 * @param string      $class_name    The target class name.
-	 * @param string      $property      The property to get the value for.
-	 * @param mixed|null  $default_value Default value when property does not exist.
+	 * @param string     $class_name    The target class name.
+	 * @param string     $property      The property to get the value for.
+	 * @param mixed|null $default_value Default value when property does not exist.
 	 *
 	 * @return mixed|null The value of the property.
 	 */

--- a/lib/model.php
+++ b/lib/model.php
@@ -163,9 +163,9 @@ class Model implements JsonSerializable {
 	 *
 	 * @param string      $class_name    The target class name.
 	 * @param string      $property      The property to get the value for.
-	 * @param string|null $default_value Default value when property does not exist.
+	 * @param mixed|null $default_value Default value when property does not exist.
 	 *
-	 * @return string The value of the property.
+	 * @return mixed|null The value of the property.
 	 */
 	protected static function get_static_property( $class_name, $property, $default_value = null ) {
 		if ( ! \class_exists( $class_name ) || ! \property_exists( $class_name, $property ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
As of PHP 8.1 get_class_vars doesn't return the _current_
value of any static property anymore. The function was never intended
to do so. Instead, it returns the initial value of the property,
which is `null` in the case of our models.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where using the plugin would throw a fatal error ("Table yoast_wp_seo_models_indexable doesn't exist") when using PHP 8.1.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Use PHP 8.1
* Update any post
* See that you don't get an error
* See that your changes were saved

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

