### PR TITLE
Import showMetaBox setting when importing posttype settings

### DIFF
--- a/src/actions/importing/abstract-aioseo-settings-importing-action.php
+++ b/src/actions/importing/abstract-aioseo-settings-importing-action.php
@@ -309,4 +309,15 @@ abstract class Abstract_Aioseo_Settings_Importing_Action extends Abstract_Import
 	public function simple_import( $meta_data ) {
 		return $meta_data;
 	}
+
+	/**
+	 * Minimally transforms boolean data to be imported.
+	 *
+	 * @param bool $meta_data The boolean meta data to be imported.
+	 *
+	 * @return bool The transformed boolean meta data.
+	 */
+	public function simple_boolean_import( $meta_data ) {
+		return $meta_data;
+	}
 }

--- a/src/actions/importing/aioseo-posttype-defaults-settings-importing-action.php
+++ b/src/actions/importing/aioseo-posttype-defaults-settings-importing-action.php
@@ -48,13 +48,17 @@ class Aioseo_Posttype_Defaults_Settings_Importing_Action extends Abstract_Aioseo
 
 		foreach ( $post_type_objects as $pt ) {
 			// Use all the custom post types that are public.
-			$this->aioseo_options_to_yoast_map[ '/' . $pt->name . '/title' ]           = [
+			$this->aioseo_options_to_yoast_map[ '/' . $pt->name . '/title' ]                = [
 				'yoast_name'       => 'title-' . $pt->name,
 				'transform_method' => 'simple_import',
 			];
-			$this->aioseo_options_to_yoast_map[ '/' . $pt->name . '/metaDescription' ] = [
+			$this->aioseo_options_to_yoast_map[ '/' . $pt->name . '/metaDescription' ]      = [
 				'yoast_name'       => 'metadesc-' . $pt->name,
 				'transform_method' => 'simple_import',
+			];
+			$this->aioseo_options_to_yoast_map[ '/' . $pt->name . '/advanced/showMetaBox' ] = [
+				'yoast_name'       => 'display-metabox-pt-' . $pt->name,
+				'transform_method' => 'simple_boolean_import',
 			];
 
 			if ( $pt->name === 'attachment' ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to import the `Show Meta Box` setting when importing AIOSEO settings

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Enhances the importing of settings from AIOSEO by importing wether or not we should show meta boxes for each post type.

## Relevant technical choices:

* Added a new key/value pair in the aioseo_to_yoast map array to cover this setting

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have Books and Movies custom post types enabled
* Have AIOSEO and Yoast activated
* Have the `YOAST_SEO_AIOSEO_V4_IMPORTER` feature flag enabled (defined to `true`). If it's disabled, the POST call mentioned below will return 404.
* Go to the AIOSEO->Search Appearance page in the Content Types tab
* In the Advanced tab of every post type there, set the `Show AIOSEO Meta Box` setting
* Do the same for attachments in the Image SEO tab
* In the Yoast->Tools page, open the developer console. in the console, repeatedly run this snippet
```
( async function() {
    const a = await fetch( "/wp-json/yoast/v1/import/aioseo/posttype_default_settings" ,
        {
            method: "POST",
            headers: { "X-WP-Nonce": wpApiSettings.nonce }
        }
    );
    console.log( await a.json() );
```
until you get a `{objects: Array(0), next_url: false}` response. This indicates there's nothing left to import.
* Check the Yoast->Search Appearance settings in the Content Types tab
* For each post type you set the `Show AIOSEO Meta Box` setting, check Yoast's `Show SEO settings for Media?` setting. They should be the same as AIOSEO's setting for each type.
* Check the same in the Media tab
* For each post type you are working with, go to add a new post,page, etc. 
* Confirm that Yoast's Meta box is showing there or not showing there, depending on the value you imported.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Quickly check if other setting for Post Types have been imported successfully, like Post Title, Page Description, etc.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
