### PR TITLE
DUPP-175 Revert the removal of WPSEO_Frontend

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=251",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=252",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=220",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/config/dependency-injection/services.php
+++ b/config/dependency-injection/services.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use WPSEO_Addon_Manager;
 use WPSEO_Admin_Asset_Manager;
 use WPSEO_Breadcrumbs;
+use WPSEO_Frontend;
 use WPSEO_Replace_Vars;
 use WPSEO_Shortlinker;
 use Yoast\WP\Lib\Migrations\Adapter;
@@ -32,6 +33,7 @@ $container->register( WPSEO_Shortlinker::class, WPSEO_Shortlinker::class )->setF
 
 // Backwards-compatibility classes in the global namespace.
 $container->register( WPSEO_Breadcrumbs::class, WPSEO_Breadcrumbs::class )->setAutowired( true )->setPublic( true );
+$container->register( WPSEO_Frontend::class, WPSEO_Frontend::class )->setAutowired( true )->setPublic( true );
 
 // The container itself.
 $container->setAlias( ContainerInterface::class, 'service_container' );

--- a/src/deprecated/frontend/frontend.php
+++ b/src/deprecated/frontend/frontend.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Backwards compatibility class for WPSEO_Frontend.
+ *
+ * @package Yoast\YoastSEO\Backwards_Compatibility
+ */
+
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Presenters\Canonical_Presenter;
+use Yoast\WP\SEO\Presenters\Meta_Description_Presenter;
+use Yoast\WP\SEO\Presenters\Rel_Next_Presenter;
+use Yoast\WP\SEO\Presenters\Rel_Prev_Presenter;
+use Yoast\WP\SEO\Presenters\Robots_Presenter;
+use Yoast\WP\SEO\Surfaces\Helpers_Surface;
+
+/**
+ * Class WPSEO_Frontend
+ *
+ * @codeCoverageIgnore Because of deprecation.
+ */
+class WPSEO_Frontend {
+
+	/**
+	 * Instance of this class.
+	 *
+	 * @var WPSEO_Frontend
+	 */
+	public static $instance;
+
+	/**
+	 * The memoizer for the meta tags context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $context_memoizer;
+
+	/**
+	 * The WPSEO Replace Vars object.
+	 *
+	 * @var WPSEO_Replace_Vars
+	 */
+	private $replace_vars;
+
+	/**
+	 * The helpers surface.
+	 *
+	 * @var Helpers_Surface
+	 */
+	private $helpers;
+
+	/**
+	 * WPSEO_Frontend constructor.
+	 */
+	public function __construct() {
+		$this->context_memoizer = YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->replace_vars     = YoastSEO()->classes->get( WPSEO_Replace_Vars::class );
+		$this->helpers          = YoastSEO()->classes->get( Helpers_Surface::class );
+	}
+
+	/**
+	 * Catches call to methods that don't exist and might deprecated.
+	 *
+	 * @param string $method    The called method.
+	 * @param array  $arguments The given arguments.
+	 *
+	 * @return mixed
+	 */
+	public function __call( $method, $arguments ) {
+		_deprecated_function( $method, 'WPSEO 14.0' );
+
+		$title_methods = [
+			'title',
+			'fix_woo_title',
+			'get_content_title',
+			'get_seo_title',
+			'get_taxonomy_title',
+			'get_author_title',
+			'get_title_from_options',
+			'get_default_title',
+			'force_wp_title',
+		];
+		if ( in_array( $method, $title_methods, true ) ) {
+			return $this->get_title();
+		}
+
+		return null;
+	}
+
+	/**
+	 * Retrieves an instance of the class.
+	 *
+	 * @return static The instance.
+	 */
+	public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Outputs the canonical value.
+	 *
+	 * @param bool $echo        Whether or not to output the canonical element.
+	 * @param bool $un_paged    Whether or not to return the canonical with or without pagination added to the URL.
+	 * @param bool $no_override Whether or not to return a manually overridden canonical.
+	 *
+	 * @return string|void
+	 */
+	public function canonical( $echo = true, $un_paged = false, $no_override = false ) {
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+
+		$presentation = $this->get_current_page_presentation();
+		$presenter    = new Canonical_Presenter();
+		/** This filter is documented in src/integrations/front-end-integration.php */
+		$presenter->presentation = $presentation;
+		$presenter->helpers      = $this->helpers;
+		$presenter->replace_vars = $this->replace_vars;
+
+		if ( ! $echo ) {
+			return $presenter->get();
+		}
+
+		echo $presenter->present();
+	}
+
+	/**
+	 * Retrieves the meta robots value.
+	 *
+	 * @return string
+	 */
+	public function get_robots() {
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+
+		$presentation = $this->get_current_page_presentation();
+		return $presentation->robots;
+	}
+
+	/**
+	 * Outputs the meta robots value.
+	 */
+	public function robots() {
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+
+		$presentation            = $this->get_current_page_presentation();
+		$presenter               = new Robots_Presenter();
+		$presenter->presentation = $presentation;
+		$presenter->helpers      = $this->helpers;
+		$presenter->replace_vars = $this->replace_vars;
+		echo $presenter->present();
+	}
+
+	/**
+	 * Determine $robots values for a single post.
+	 *
+	 * @param array $robots  Robots data array.
+	 * @param int   $post_id The post ID for which to determine the $robots values, defaults to current post.
+	 *
+	 * @return array
+	 */
+	public function robots_for_single_post( $robots, $post_id = 0 ) {
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+
+		$presentation = $this->get_current_page_presentation();
+
+		return $presentation->robots;
+	}
+
+	/**
+	 * Used for static home and posts pages as well as singular titles.
+	 *
+	 * @param object|null $object If filled, object to get the title for.
+	 *
+	 * @return string The content title.
+	 */
+	private function get_title( $object = null ) {
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+
+		$presentation = $this->get_current_page_presentation();
+		$title        = $presentation->title;
+
+		return $this->replace_vars->replace( $title, $presentation->source );
+	}
+
+	/**
+	 * This function adds paging details to the title.
+	 *
+	 * @param string $sep         Separator used in the title.
+	 * @param string $seplocation Whether the separator should be left or right.
+	 * @param string $title       The title to append the paging info to.
+	 *
+	 * @return string
+	 */
+	public function add_paging_to_title( $sep, $seplocation, $title ) {
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+
+		return $title;
+	}
+
+	/**
+	 * Add part to title, while ensuring that the $seplocation variable is respected.
+	 *
+	 * @param string $sep         Separator used in the title.
+	 * @param string $seplocation Whether the separator should be left or right.
+	 * @param string $title       The title to append the title_part to.
+	 * @param string $title_part  The part to append to the title.
+	 *
+	 * @return string
+	 */
+	public function add_to_title( $sep, $seplocation, $title, $title_part ) {
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+
+		if ( $seplocation === 'right' ) {
+			return $title . $sep . $title_part;
+		}
+
+		return $title_part . $sep . $title;
+	}
+
+	/**
+	 * Adds 'prev' and 'next' links to archives.
+	 *
+	 * @link http://googlewebmastercentral.blogspot.com/2011/09/pagination-with-relnext-and-relprev.html
+	 */
+	public function adjacent_rel_links() {
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+
+		$presentation = $this->get_current_page_presentation();
+
+		$rel_prev_presenter               = new Rel_Prev_Presenter();
+		$rel_prev_presenter->presentation = $presentation;
+		$rel_prev_presenter->helpers      = $this->helpers;
+		$rel_prev_presenter->replace_vars = $this->replace_vars;
+		echo $rel_prev_presenter->present();
+
+		$rel_next_presenter               = new Rel_Next_Presenter();
+		$rel_next_presenter->presentation = $presentation;
+		$rel_next_presenter->helpers      = $this->helpers;
+		$rel_next_presenter->replace_vars = $this->replace_vars;
+		echo $rel_next_presenter->present();
+	}
+
+	/**
+	 * Outputs the meta description element or returns the description text.
+	 *
+	 * @param bool $echo Echo or return output flag.
+	 *
+	 * @return string
+	 */
+	public function metadesc( $echo = true ) {
+		_deprecated_function( __METHOD__, 'WPSEO 14.0' );
+
+		$presentation            = $this->get_current_page_presentation();
+		$presenter               = new Meta_Description_Presenter();
+		$presenter->presentation = $presentation;
+		$presenter->helpers      = $this->helpers;
+		$presenter->replace_vars = $this->replace_vars;
+
+		if ( ! $echo ) {
+			return $presenter->get();
+		}
+		$presenter->present();
+	}
+
+	/**
+	 * Returns the current page presentation.
+	 *
+	 * @return Indexable_Presentation The current page presentation.
+	 */
+	private function get_current_page_presentation() {
+		$context = $this->context_memoizer->for_current_page();
+		/** This filter is documented in src/integrations/front-end-integration.php */
+		return apply_filters( 'wpseo_frontend_presentation', $context->presentation, $context );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Reverts https://github.com/Yoast/wordpress-seo/pull/17671

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reverts the removal of the deprecated `WPSEO_Frontend` class.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* NA the class is not used anymore so it shouldn't have any effect. Just do a smoke test to check the plugin is working (open a post, and one of the admin pages).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-175]


[DUPP-175]: https://yoast.atlassian.net/browse/DUPP-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ