### PR TITLE
PHP 8.1 | HTML_Helper: add input validation

### DIFF
--- a/src/helpers/schema/html-helper.php
+++ b/src/helpers/schema/html-helper.php
@@ -15,6 +15,14 @@ class HTML_Helper {
 	 * @return string The sanitized HTML.
 	 */
 	public function sanitize( $html ) {
+		if ( ! $this->is_non_empty_string_or_stringable( $html ) ) {
+			if ( \is_int( $html ) || \is_float( $html ) ) {
+				return (string) $html;
+			}
+
+			return '';
+		}
+
 		return \strip_tags( $html, '<h1><h2><h3><h4><h5><h6><br><ol><ul><li><a><p><b><strong><i><em>' );
 	}
 
@@ -26,6 +34,14 @@ class HTML_Helper {
 	 * @return string The sanitized HTML.
 	 */
 	public function smart_strip_tags( $html ) {
+		if ( ! $this->is_non_empty_string_or_stringable( $html ) ) {
+			if ( \is_int( $html ) || \is_float( $html ) ) {
+				return (string) $html;
+			}
+
+			return '';
+		}
+
 		// Replace all new lines with spaces.
 		$html = \preg_replace( '/(\r|\n)/', ' ', $html );
 
@@ -45,5 +61,16 @@ class HTML_Helper {
 		$html = \preg_replace( '!\s+!', ' ', $html );
 
 		return \trim( $html );
+	}
+
+	/**
+	 * Verifies that the received input is either a string or stringable object.
+	 *
+	 * @param string $html The original HTML.
+	 *
+	 * @return bool
+	 */
+	private function is_non_empty_string_or_stringable( $html ) {
+		return ( \is_string( $html ) || \is_object( $html ) && \method_exists( $html, '__toString' ) ) && ! empty( $html );
 	}
 }

--- a/tests/unit/doubles/stringable-object-mock.php
+++ b/tests/unit/doubles/stringable-object-mock.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Doubles;
+
+/**
+ * Stringable object for use in type handling checking data providers.
+ *
+ * This is not really a "mock", but a test fixture instead.
+ */
+final class Stringable_Object_Mock {
+
+	/**
+	 * Dummy property.
+	 *
+	 * @var mixed
+	 */
+	private $value;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param mixed $value Value which should be stringable.
+	 */
+	public function __construct( $value ) {
+		$this->value = $value;
+	}
+
+	/**
+	 * Retrieves a string representation of the object.
+	 *
+	 * @return string
+	 */
+	public function __toString() {
+		return (string) $this->value;
+	}
+}

--- a/tests/unit/helpers/schema/html-helper-test.php
+++ b/tests/unit/helpers/schema/html-helper-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Helpers\Schema;
 
 use stdClass;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Stringable_Object_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -36,6 +37,7 @@ class HTML_Helper_Test extends TestCase {
 	 * Test whether sanitize sanitizes properly.
 	 *
 	 * @covers ::sanitize
+	 * @covers ::is_non_empty_string_or_stringable
 	 *
 	 * @dataProvider data_incorrect_input_types
 	 * @dataProvider data_sanitize
@@ -74,6 +76,10 @@ class HTML_Helper_Test extends TestCase {
 				'input'    => 'Test <p>Paragraph</p> bla <marque>stuck in the 80s</marque>',
 				'expected' => 'Test <p>Paragraph</p> bla stuck in the 80s',
 			],
+			'Test passing the parameter as a stringable object (plain string)' => [
+				'input'    => new Stringable_Object_Mock( 'This is just a simple text string' ),
+				'expected' => 'This is just a simple text string',
+			],
 		];
 	}
 
@@ -81,6 +87,7 @@ class HTML_Helper_Test extends TestCase {
 	 * Test whether smart strips tags strips tags in a smart way.
 	 *
 	 * @covers ::smart_strip_tags
+	 * @covers ::is_non_empty_string_or_stringable
 	 *
 	 * @dataProvider data_incorrect_input_types
 	 * @dataProvider data_smart_strip_tags
@@ -156,6 +163,10 @@ text string',
 			],
 			'Test trimming surrounding whitespace and extraneous whitespace within string' => [
 				'input'    => '   This is 	just a     simple text string   ',
+				'expected' => 'This is just a simple text string',
+			],
+			'Test passing the parameter as a stringable object (plain string)' => [
+				'input'    => new Stringable_Object_Mock( 'This is just a simple text string' ),
 				'expected' => 'This is just a simple text string',
 			],
 		];

--- a/tests/unit/helpers/schema/html-helper-test.php
+++ b/tests/unit/helpers/schema/html-helper-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Helpers\Schema;
 
+use stdClass;
 use Yoast\WP\SEO\Helpers\Schema\HTML_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -36,6 +37,7 @@ class HTML_Helper_Test extends TestCase {
 	 *
 	 * @covers ::sanitize
 	 *
+	 * @dataProvider data_incorrect_input_types
 	 * @dataProvider data_sanitize
 	 *
 	 * @param mixed  $input    The input to sanitize.
@@ -80,6 +82,7 @@ class HTML_Helper_Test extends TestCase {
 	 *
 	 * @covers ::smart_strip_tags
 	 *
+	 * @dataProvider data_incorrect_input_types
 	 * @dataProvider data_smart_strip_tags
 	 *
 	 * @param mixed  $input    The input to sanitize.
@@ -154,6 +157,44 @@ text string',
 			'Test trimming surrounding whitespace and extraneous whitespace within string' => [
 				'input'    => '   This is 	just a     simple text string   ',
 				'expected' => 'This is just a simple text string',
+			],
+		];
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_incorrect_input_types() {
+		return [
+			'null' => [
+				'input'    => null,
+				'expected' => '',
+			],
+			'boolean false' => [
+				'input'    => false,
+				'expected' => '',
+			],
+			'boolean true' => [
+				'input'    => true,
+				'expected' => '',
+			],
+			'integer' => [
+				'input'    => -25,
+				'expected' => '-25',
+			],
+			'float' => [
+				'input'    => -2.5,
+				'expected' => '-2.5',
+			],
+			'array' => [
+				'input'    => [],
+				'expected' => '',
+			],
+			'plain object' => [
+				'input'    => new stdClass(),
+				'expected' => '',
 			],
 		];
 	}


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.1

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.1 by validating input types



## Relevant technical choices:

### HTML_Helper_Test: add secondary data provider to both test methods

This adds a data provider to both test methods which sets the tests up with unexpected data types and sets expectations on how those should be handled.

As things are, a select number of these tests will fail/error out:
* `true` would currently return `1` instead of an empty string.
* Both array and object would currently throw a warning in PHP 7.4 and a type error on PHP 8.0+.
* `null` would throw a deprecation on PHP 8.1.

### PHP 8.1 | HTML_Helper: add input validation

As of PHP 8.1, passing `null` to not explicitly nullable scalar parameters for PHP native functions is deprecated.

In the tests, a number of errors could be seen along the lines of:
```
preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated

path/to/src/helpers/schema/html-helper.php:30
path/to/src/generators/schema/website.php:31
path/to/src/generators/schema-generator.php:128
path/to/src/generators/schema-generator.php:76
path/to/tests/unit/generators/schema-generator-test.php:283
```

In this case, both methods in the `HTML_Helper` class expect a `string` as input, but it is not verified that they actually receive a `string` and the received parameter is blindly passed on to PHP native functions.
As running `strip_tags()` or the various regexes used with `preg_replace()` is useless, when the input is not a text string, as it wouldn't make a difference to the output, we can short circuit both functions by doing a type check at the start and bowing out early if the received parameter is not a string.

To maintain the "old" behaviour as much as possible:
* Integers and floats will be cast to string and returned (same as before as running these through the PHP native functions would also result in the parameter being cast to string).
* Stringable objects will be allowed through.
* In all other cases, an empty string is returned.
    This is a minor change in behaviour in case `true` would have been passed, which would previously return `1`, but IMO, that behaviour was incorrect anyway.
    This is also a change for when an array or (non-stringable) object would have been passed:
        - Previously an array or non-stringable object would lead to a PHP warning/error, now it will just return an empty string.

Includes:
* Adding tests safeguarding the support for stringable objects.
* Adding a test fixture for a stringable object.
    👉🏻 For now, this test fixture is added into this code base. At a later point in time, I'd like to propose to add typical "type test" fixture classes to WP Test Utils so these test utility classes are available to all projects.

Refs:
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg
* https://www.php.net/manual/en/function.preg-replace.php


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is a code-technical change only and should have no effect on existing functionality. This can be verified via the existing tests.
