### PR TITLE
PHP 8.1 | Date_Helper: add input validation (x2)

### DIFF
--- a/src/helpers/date-helper.php
+++ b/src/helpers/date-helper.php
@@ -35,6 +35,10 @@ class Date_Helper {
 	 * @return string The formatted date.
 	 */
 	public function format( $date, $format = \DATE_W3C ) {
+		if ( ! \is_string( $date ) ) {
+			return $date;
+		}
+
 		$immutable_date = \date_create_immutable_from_format( 'Y-m-d H:i:s', $date, new DateTimeZone( 'UTC' ) );
 
 		if ( ! $immutable_date ) {
@@ -53,6 +57,10 @@ class Date_Helper {
 	 * @return string The formatted date.
 	 */
 	public function format_timestamp( $timestamp, $format = \DATE_W3C ) {
+		if ( ! \is_string( $timestamp ) && ! \is_int( $timestamp ) ) {
+			return $timestamp;
+		}
+
 		$immutable_date = \date_create_immutable_from_format( 'U', $timestamp, new DateTimeZone( 'UTC' ) );
 
 		if ( ! $immutable_date ) {

--- a/src/helpers/date-helper.php
+++ b/src/helpers/date-helper.php
@@ -96,10 +96,18 @@ class Date_Helper {
 	 *
 	 * @param string $datetime String input to check as valid input for DateTime class.
 	 *
-	 * @return bool True when datatime is valid.
+	 * @return bool True when datetime is valid.
 	 */
 	public function is_valid_datetime( $datetime ) {
-		if ( \substr( $datetime, 0, 1 ) === '-' ) {
+		if ( $datetime === null ) {
+			/*
+			 * While not "officially" supported, `null` will be handled as `"now"` until PHP 9.0.
+			 * @link https://3v4l.org/tYp2k
+			 */
+			return true;
+		}
+
+		if ( \is_string( $datetime ) && \substr( $datetime, 0, 1 ) === '-' ) {
 			return false;
 		}
 

--- a/tests/unit/helpers/date-helper-test.php
+++ b/tests/unit/helpers/date-helper-test.php
@@ -189,6 +189,18 @@ class Date_Helper_Test extends TestCase {
 				'input'    => '-0001-11-30T00:00:00+00:00',
 				'expected' => false,
 			],
+			'Empty string' => [
+				'input'    => '',
+				'expected' => true,
+			],
+			'null' => [
+				'input'    => null,
+				'expected' => true,
+			],
+			'Other non-string' => [
+				'input'    => 123456789,
+				'expected' => false,
+			],
 		];
 	}
 }


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.1

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.1

## Relevant technical choices:

### PHP 8.1 | Date_Helper: add input validation [1]

As of PHP 8.1, passing `null` to not explicitly nullable scalar parameters for PHP native functions is deprecated.

In the tests, a number of errors could be seen along the lines of:
```
date_create_immutable_from_format(): Passing null to parameter #2 ($datetime) of type string is deprecated
```

In this case, both methods in the `Date_Helper` class expect a `string` as input, but it is not verified that they actually receive a `string` and the received parameter is blindly passed on to PHP native functions.
As running `date_create_immutable_from_format()` is useless when no valid date/timestamp is passed, we can short circuit both functions by doing a type check at the start and bowing out early if the received parameter is not a string, or in the case of `format_timestamp()`, not a string nor an integer.

Refs:
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg
* https://www.php.net/manual/en/datetimeimmutable.createfromformat.php
* https://www.php.net/manual/en/datetime.createfromformat.php


### Date_Helper_Test::test_is_valid_datetime(): add additional tests

... to document and safeguard the behaviour with various other types of input.

### PHP 8.1 | Date_Helper: add input validation [2]

As of PHP 8.1, passing `null` to not explicitly nullable scalar parameters for PHP native functions is deprecated.

In the newly added tests, this could be seen via the following notice:
```
substr(): Passing null to parameter #1 ($string) of type string is deprecated
```

The above can be guarded against by adding an additional `is_string()` check to the condition containing the `substr()` call, however, that then leads us to the next issue:
```
Deprecated: DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated
```

Here we have a more complex problem:
* For the time being, `null` is still handled the same as before by PHP, i.e. `null` will be treated as the default value `"now"`.
* However, as of PHP 9.0, passing `null` to the `DateTime` constructor will become a Fatal Error.
* And in the mean time for PHP 8.1 < 9.0, we have an issue in the tests:
    As PHPUnit (intentionally) converts deprecation notices to Exceptions, the PHP 8.1+ deprecation notice means that during the test run an Exception is thrown and subsequently caught, leading to a `false` return value, while in production (without the deprecation to Exception conversion), the function will still return `true` when passed `null`.

So, now we have a choice to make:
1. Add stricter input validation only allowing the officially supported `string` type and returning `false` in all other cases, even when `DateTime` does actually support the input for the time being.
    This would constitute a BC-break, but then again, this BC-break would otherwise happen in PHP 9.0 anyway.
2. Special case a `null` input for the time being, by bowing out early and returning `true` as we know it is supported for now.
3. Add special handling for a `null` input, but changing it to `"now"`. This would provide optimal PHP cross-version support and will maintain the current behaviour of the function in PHP 9.0 as well, but may hide other errors, as the `null` value should maybe have been caught at an earlier point in the code logic and `"now"` may not have been the intended behaviour.
4. Make the running of the `null` test conditional on the PHP version. I.e. skip the test for PHP 8.1 < 9.0.

For now, I've elected to implement option 2, but option 1 or 3 are also prefectly valid choices to make, so should also be considered.

Refs:
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg
* https://www.php.net/manual/en/datetime.construct.php
* https://3v4l.org/tYp2k

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is a code-technical change only and should have no effect on existing functionality. This can be verified via the existing tests.
