### PR TITLE
PHP 8.1 | Meta_Surface::is_date_archive_url(): prevent null to non-nullable deprecation notice

### DIFF
--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -345,8 +345,11 @@ class Meta_Surface {
 	 */
 	protected function is_date_archive_url( $url ) {
 		$path = \wp_parse_url( $url, \PHP_URL_PATH );
-		$path = \ltrim( $path, '/' );
+		if ( $path === null ) {
+			return false;
+		}
 
+		$path         = \ltrim( $path, '/' );
 		$wp_rewrite   = $this->wp_rewrite_wrapper->get();
 		$date_rewrite = $wp_rewrite->generate_rewrite_rules( $wp_rewrite->get_date_permastruct(), \EP_DATE );
 		$date_rewrite = \apply_filters( 'date_rewrite_rules', $date_rewrite );

--- a/tests/unit/surfaces/meta-surface-test.php
+++ b/tests/unit/surfaces/meta-surface-test.php
@@ -493,21 +493,22 @@ class Meta_Surface_Test extends TestCase {
 				->andReturn( $this->indexable );
 		}
 
+		$times = ( \strpos( $page_type, 'Home_Page' ) === false ) ? 1 : 0;
 		$this->wp_rewrite_wrapper->expects( 'get' )
-			->once()
+			->times( $times )
 			->andReturn( $wp_rewrite );
 
 		$wp_rewrite->expects( 'get_date_permastruct' )
-			->once()
+			->times( $times )
 			->andReturn( 'date_permastruct' );
 
 		$wp_rewrite->expects( 'generate_rewrite_rules' )
-			->once()
+			->times( $times )
 			->with( 'date_permastruct', \EP_DATE )
 			->andReturn( [] );
 
 		Filters\expectApplied( 'date_rewrite_rules' )
-			->once()
+			->times( $times )
 			->andReturn(
 				[
 					'([0-9]{4})/page/?([0-9]{1,})/?$' => 'index.php?year=$matches[1]&paged=$matches[2]',


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.1

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.1 by preventing the use of null values.

## Relevant technical choices:

### Meta_Surface::for_url(): add extra test for date archive page and improve tests for home page

As the `Meta_Surface::for_url()` method contains a diverging path specifically for date archives, a test needs to be added covering that path.

As the expectation setting in the test function needs changing to accommodate for data archives, we may as well also adjust the "Home page" test cases to be more realistic, i.e. set these to use a `$url` without path component.

This way, the changes being made to accommodate the date archive test, will not hide a PHP 8.1 deprecation notice which is triggered on a `$url` without path component being passed to the `Meta_Surface::is_date_archive_url()` method.

Previously, all test cases would hit the deprecation notice as the third call to `wp_parse_url()` (the call made from within `Meta_Surface::is_date_archive_url()` did not have an expectation nor mocked return, which resulted in that call always returning `null`.

With the changed test logic, the deprecation notice will now only be thrown for the "Home Page" test cases, but that does mean there are tests which cover that particular situation.

### PHP 8.1 | Meta_Surface::is_date_archive_url(): prevent null to non-nullable deprecation notice

As per the PHP manual:
> If the component parameter is omitted, an associative array is returned.
> If the component parameter is specified, `parse_url()` returns a string (or an int, in the case of `PHP_URL_PORT`) instead of an array. If the requested component doesn't exist within the given URL, `null` will be returned.

Ref: https://www.php.net/manual/en/function.parse-url.php#refsect1-function.parse-url-returnvalues

The same applies to the WP native `wp_parse_url()` function which emulates the PHP function minus some bugs.

Ref: https://developer.wordpress.org/reference/functions/wp_parse_url/

In this case, `parse_url()` is called with the `PHP_URL_PATH` as `$component` from within the `Meta_Surface::is_date_archive_url()` method.
This will return `null` when the passed `$url` does not contain a path component, such as when `$url` is a URL without trailing slash, like `http://example.org`.

The return value of `parse_url()` was subsequently passed to `ltrim()` leading to a `ltrim(): Passing null to parameter #1 ($string) of type string is deprecated` deprecation notice on PHP 8.1.

Fixed by bowing out early if the `$path` is `null`, as in that case the page can never be a date archive page anyway.

Includes adjusting the expectations in the tests, as the "bowing out early" means that certain methods will now only be called when there is a `$path` component to the `$url`.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is a code-technical change only and should have no effect on existing functionality. This can be verified via the existing tests.