### PR TITLE
PHP 8.1 | Indexable_Test: fix null to non-nullable notice

### DIFF
--- a/tests/unit/models/indexable-test.php
+++ b/tests/unit/models/indexable-test.php
@@ -43,6 +43,11 @@ class Indexable_Test extends TestCase {
 	public function test_save() {
 		$permalink = 'https://example.com/';
 
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'permalink_structure' )
+			->andReturn( '' );
+
 		Functions\expect( 'wp_parse_url' )
 			->once()
 			->with( 'https://example.com/' )


### PR DESCRIPTION
## Context

* Improves test for compatibility with PHP 8.1

## Summary

This PR can be summarized in the following changelog entry:

* Improves test for compatibility with PHP 8.1

## Relevant technical choices:

In PHP 8.1, the `test_save()` test throws a ` substr(): Passing null to parameter #1 ($string) of type string is deprecated` notification causing the test to error out.

This highlighted two separate issues:
1. The call to `get_option()` not being mocked in the `test_save()` method resulting in the function call returning `null`.
2. The call to `get_option()` in the `Indexable::sanitize_permalink()` method not passing a default value, which mean that it could potentially return `false` if the option does not (yet) exist for a virgin website.

The first issue has now been fixed by setting an expectation for the function call to `get_option()`.

The second issue is out of scope and - at this time - does not lead to any PHP errors as `false` being passed to `substr()` will result in `substr()` getting an empty string.
If so desired, the second issue could be fixed by adding the second argument - `$default` - to the `get_option()` call in the `Indexable::sanitize_permalink()` method and setting this to an empty string.
In that case, the expectations in the tests need to be adjusted to expect the function call with both arguments.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is a test-only change only. If the builds pass, we're good.