### PR TITLE
PHP 8.1 | Indexable::save() prevent null to non-nullable deprecation notice + multi-byte language fix

### DIFF
--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -167,7 +167,7 @@ class Indexable extends Model {
 			$this->sanitize_permalink();
 			$this->permalink_hash = \strlen( $this->permalink ) . ':' . \md5( $this->permalink );
 		}
-		if ( \strlen( $this->primary_focus_keyword ) > 191 ) {
+		if ( is_string( $this->primary_focus_keyword ) && \strlen( $this->primary_focus_keyword ) > 191 ) {
 			$this->primary_focus_keyword = \mb_substr( $this->primary_focus_keyword, 0, 191, 'UTF-8' );
 		}
 

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -167,7 +167,7 @@ class Indexable extends Model {
 			$this->sanitize_permalink();
 			$this->permalink_hash = \strlen( $this->permalink ) . ':' . \md5( $this->permalink );
 		}
-		if ( is_string( $this->primary_focus_keyword ) && \strlen( $this->primary_focus_keyword ) > 191 ) {
+		if ( is_string( $this->primary_focus_keyword ) && \mb_strlen( $this->primary_focus_keyword ) > 191 ) {
 			$this->primary_focus_keyword = \mb_substr( $this->primary_focus_keyword, 0, 191, 'UTF-8' );
 		}
 

--- a/tests/unit/models/indexable-test.php
+++ b/tests/unit/models/indexable-test.php
@@ -61,7 +61,7 @@ class Indexable_Test extends TestCase {
 			->with( 'permalink_hash', \strlen( $permalink ) . ':' . \md5( $permalink ) );
 		// Once for going into the if-statement, then twice for the permalink_hash.
 		$this->instance->orm->expects( 'get' )->times( 5 )->with( 'permalink' )->andReturn( $permalink );
-		$this->instance->orm->expects( 'get' )->once()->with( 'primary_focus_keyword' )->andReturn( 'keyword' );
+		$this->instance->orm->expects( 'get' )->twice()->with( 'primary_focus_keyword' )->andReturn( 'keyword' );
 		$this->instance->orm->expects( 'save' )->once();
 
 		$this->instance->save();
@@ -97,7 +97,7 @@ class Indexable_Test extends TestCase {
 			->with( 'permalink_hash', \strlen( $permalink_no_slash ) . ':' . \md5( $permalink_no_slash ) );
 		// Once for going into the if-statement, then once more for trailingslashit, then twice for the permalink_hash.
 		$this->instance->orm->expects( 'get' )->times( 5 )->with( 'permalink' )->andReturn( $permalink_no_slash );
-		$this->instance->orm->expects( 'get' )->once()->with( 'primary_focus_keyword' )->andReturn( 'keyword' );
+		$this->instance->orm->expects( 'get' )->twice()->with( 'primary_focus_keyword' )->andReturn( 'keyword' );
 		$this->instance->orm->expects( 'save' )->once();
 
 		$this->instance->save();
@@ -113,7 +113,7 @@ class Indexable_Test extends TestCase {
 		$keyword           = $keyword_truncated . 'l primary focus keyword. Because it does not fit in the database field, we truncate the value.';
 
 		$this->instance->orm->expects( 'get' )->once()->with( 'permalink' )->andReturnFalse();
-		$this->instance->orm->expects( 'get' )->twice()->with( 'primary_focus_keyword' )->andReturn( $keyword );
+		$this->instance->orm->expects( 'get' )->times( 3 )->with( 'primary_focus_keyword' )->andReturn( $keyword );
 		$this->instance->orm->expects( 'set' )->once()->with( 'primary_focus_keyword', $keyword_truncated );
 		$this->instance->orm->expects( 'save' )->once();
 
@@ -173,7 +173,7 @@ class Indexable_Test extends TestCase {
 		$this->instance->orm->expects( 'set' )
 			->once()
 			->with( 'permalink_hash', \strlen( $permalink ) . ':' . \md5( $permalink ) );
-		$this->instance->orm->expects( 'get' )->once()->with( 'primary_focus_keyword' )->andReturn( 'keyword' );
+		$this->instance->orm->expects( 'get' )->twice()->with( 'primary_focus_keyword' )->andReturn( 'keyword' );
 		$this->instance->orm->expects( 'save' )->once();
 
 		$this->instance->set( 'permalink', $permalink );

--- a/tests/unit/models/indexable-test.php
+++ b/tests/unit/models/indexable-test.php
@@ -121,6 +121,19 @@ class Indexable_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that no "passing null to non-nullable" deprecation notice is thrown on PHP 8.1.
+	 *
+	 * @covers ::save
+	 */
+	public function test_save_without_changes() {
+		$this->instance->orm->expects( 'get' )->once()->with( 'permalink' );
+		$this->instance->orm->expects( 'get' )->once()->with( 'primary_focus_keyword' );
+		$this->instance->orm->expects( 'save' )->once();
+
+		$this->instance->save();
+	}
+
+	/**
 	 * Tests get_extension.
 	 *
 	 * @covers ::get_extension


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.1
* Improves handling of multi-byte languages

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.1
* Improves handling of multi-byte languages

## Relevant technical choices:

### Indexable_Test: add a test which will fail on PHP 8.1 due to a deprecation notice

### PHP 8.1 | Indexable::save() prevent null to non-nullable deprecation notice

The `$primary_focus_keyword` property is a (dynamic/managed via magic methods) property on the `ORM` class. This property may or may not be set at the time of a save.

As of PHP 8.1, passing `null` to a non-nullable PHP native function will generate a deprecation notice, which is what will happen when the `$primary_focus_keyword` property has not been set (yet) and is subsequently passed to the PHP native `strlen()` function.

Verifying that the property is a string before passing it to `strlen()` prevents the notice without BC-break.

Note: I've elected to verify the usability of the property using the relatively strict `is_string()` as the property is _documented_ as expecting to be a string.
This does mean that the `$primary_focus_keyword` can now no longer be passed a `Stringable` object, nor be a non-string scalar.

IMO, for non-string scalars, checking the string length and using `mb_substr()` on the value doesn't really make much sense anyway.
And as these classes are only intended for "internal" use and the Yoast plugins do not use `Stringable` objects for the primary focus keyword, supporting those was deemed unnecessary.
If this would at a later point in time become something which should be supported, the condition can then be updated to also check for `Stringable` objects.

Includes updating existing unit tests to expect the extra call to the `get()` method to retrieve the property.

Refs:
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg

### Indexable::save(): use mb_strlen()

The `Indexable::save()` method uses the `mb_substr()` method to create a substring for the primary keyword, but determines whether or not that substring should be created using the non-binary safe `strlen()` function.

In practice, this means that for primary keywords set in a multi-byte character script, the `mb_substr()` may be called when it is unnecessary as the _byte_ length is more than 191, but the _character_ length is less than 191.

As WP Core polyfills the PHP native `mb_strlen()` function anyway (same as the `mb_substr()` function), it seems more prudent to make sure that these function calls are aligned with each other.

👉🏻 Note: it would be prudent to add an additional test for this, along the same lines as the existing `Indexable_Test::test_save_primary_focus_keyword_truncated()`, but with a text string in a multi-byte character set.
Would love to do so, but I would need some sample text for that. Maybe team Lingo could provide that ?

Refs:
* https://www.php.net/manual/en/function.mb-strlen.php
* https://core.trac.wordpress.org/browser/trunk/src/wp-includes/compat.php#L137

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is (mostly) a code-technical change only and should have no effect on existing functionality. This can be verified via the existing tests.

For the multi-byte language fix, this can be tested by passing a (long) multi-byte language text string as the primary focus keyword and verifying that the truncation of the text is now at 191 characters instead of 191 bytes.
