### PR TITLE
PHP 8.1 | Current_Page_Helper::is_yoast_seo_page() prevent null to non-nullable deprecation notice

### DIFF
--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -416,7 +416,7 @@ class Current_Page_Helper {
 
 		if ( $is_yoast_seo === null ) {
 			$current_page = \filter_input( \INPUT_GET, 'page' );
-			$is_yoast_seo = ( \strpos( $current_page, 'wpseo_' ) === 0 );
+			$is_yoast_seo = ( is_string( $current_page ) && \strpos( $current_page, 'wpseo_' ) === 0 );
 		}
 
 		return $is_yoast_seo;


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.1

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.1

## Relevant technical choices:

As per the documentation, the PHP native `filter_input()` function will return the value of a variable, `false` if the filter fails or `null` if the variable is not set.

While it will be rare for the `page` variable to not be set for an active request to WP, it is common in test situations (and I believe also possible in non-test situations), which would result in `filter_input()` returning `null`.

As of PHP 8.1, passing `null` to a non-nullable PHP native function will generate a deprecation notice, which is what will happen when the `$_GET['page']` is not set and is subsequently passed to the PHP native `strpos()` function.

Verifying that the returned value is a string before passing it to `strpos()` prevents the notice without BC-break and prevents a useless call to `strpos()` for non-strings as those will never contain the `wpseo_` prefix which the `strpos()` call is looking for.

Note: this function does not have any tests directly covering the functionality, however as the function works based on a `static` variable, adding tests is not really an option as it could adversely influence other tests.

Refs:
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg
* https://www.php.net/manual/en/function.filter-input.php

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is a code-technical change only and should have no effect on existing functionality. 