### PR TITLE
PHP 8.1 | Schema_Generator::get_type_from_piece(): prevent null to non-nullable deprecation notice

### DIFF
--- a/src/generators/schema-generator.php
+++ b/src/generators/schema-generator.php
@@ -309,7 +309,8 @@ class Schema_Generator implements Generator_Interface {
 	private function get_type_from_piece( $piece ) {
 		if ( isset( $piece['@type'] ) ) {
 			if ( \is_array( $piece['@type'] ) ) {
-				return $piece['@type'];
+				// Return as-is, but remove unusable values, like sub-arrays, objects, null.
+				return \array_filter( $piece['@type'], 'is_string' );
 			}
 
 			return [ $piece['@type'] ];


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.1

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.1 by filtering invalid values.

## Relevant technical choices:

The `Schema_Generator::get_type_from_piece()` method _does_ check that the `$piece['@type']` is set, but doesn't check if every value within an array set as `$piece['@type']` is actually set.

This is exposed by the existing test case for the FAQPage in the `Schema_Generator_Test::get_expected_schema()` method, where the `@type` is deliberately set as `[ null, 'FAQPage' ]`.

This in turn on PHP 8.1, leads to "passing null to non-nullable" deprecation notices for the `strtolower()` function call in the `Schema_Generator::type_filter()` method.

As `null` as a type is not useful anyway and is (was) ignored/discarded in the `type_filter()` method when creating the `$graph_piece`, we may as well make sure it would never reach that method anyway.

To that end, I'm proposing to filter the `$piece['@type']` when set as an array, for all non-string values, as the "type" to use should always be a string.

Refs:
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg
* https://www.php.net/manual/en/function.array-filter.php

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is a code-technical change only and should have no effect on existing functionality. This can be verified via the existing tests.