### PR TITLE
Pass tracking params to shortlinks configuration workout

### DIFF
--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -506,7 +506,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 								"Yoast SEO",
 								"</a>"
 							),
-							"https://yoa.st/config-workout-guide",
+							window.wpseoWorkoutsData.configuration.shortlinks.workoutGuide,
 							"yoast-configuration-workout-guide-link"
 						)
 					}
@@ -546,7 +546,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							"<a>",
 							"</a>"
 						),
-						"https://yoa.st/config-workout-index-data",
+						window.wpseoWorkoutsData.configuration.shortlinks.indexData,
 						"yoast-configuration-workout-index-data-link"
 					) }
 					subtitleClass={ window.wpseoWorkoutsData.shouldUpdatePremium ? "disabled" : "" }
@@ -787,7 +787,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 					isFinished={ isStep5Finished }
 				>
 					<br />
-					<NewsletterSignup />
+					<NewsletterSignup gdprLink={ window.wpseoWorkoutsData.configuration.shortlinks.gdpr } />
 				</Step>
 				<FinishButtonSection
 					buttonId="yoast-configuration-workout-finish-workout-button"

--- a/packages/js/src/workouts/components/NewsletterSignup.js
+++ b/packages/js/src/workouts/components/NewsletterSignup.js
@@ -5,7 +5,6 @@ import { isEmail } from "@wordpress/url";
 import { NewButton as Button } from "@yoast/components";
 import { addLinkToString } from "../../helpers/stringHelpers";
 import ValidatedTextInput from "../components/ValidatedTextInput";
-import { ConfigurationWorkout } from "./ConfigurationWorkout";
 import PropTypes from "prop-types";
 
 /**

--- a/packages/js/src/workouts/components/NewsletterSignup.js
+++ b/packages/js/src/workouts/components/NewsletterSignup.js
@@ -48,9 +48,11 @@ const subscribedFeedback = __(
 /**
  * The newsletter signup section.
  *
+ * @param {string} gdprLink Shortlink to the Yoast Privacy policy.
+ *
  * @returns {WPElement} A newslettersignup element.
  */
-export function NewsletterSignup() {
+export function NewsletterSignup( gdprLink ) {
 	const [ newsletterEmail, setNewsletterEmail ] = useState( "" );
 	const [ signUpState, setSignUpState ] = useState( "waiting" );
 	const [ emailFeedback, setEmailFeedback ] = useState( "" );
@@ -105,8 +107,8 @@ export function NewsletterSignup() {
 								"<a>",
 								"</a>"
 							),
-							"https://yoa.st/gdpr-config-workout",
-							"yoast-configuration-workout-gdpr-link"
+							gdprLink,
+							"yoast-configuration-workout-gdpr-gdprLink"
 						)
 					}
 				/>

--- a/packages/js/src/workouts/components/NewsletterSignup.js
+++ b/packages/js/src/workouts/components/NewsletterSignup.js
@@ -108,7 +108,7 @@ export function NewsletterSignup( gdprLink ) {
 								"</a>"
 							),
 							gdprLink,
-							"yoast-configuration-workout-gdpr-gdprLink"
+							"yoast-configuration-workout-gdpr-link"
 						)
 					}
 				/>

--- a/packages/js/src/workouts/components/NewsletterSignup.js
+++ b/packages/js/src/workouts/components/NewsletterSignup.js
@@ -5,6 +5,8 @@ import { isEmail } from "@wordpress/url";
 import { NewButton as Button } from "@yoast/components";
 import { addLinkToString } from "../../helpers/stringHelpers";
 import ValidatedTextInput from "../components/ValidatedTextInput";
+import { ConfigurationWorkout } from "./ConfigurationWorkout";
+import PropTypes from "prop-types";
 
 /**
  * A function to request a sign up to the newsletter.
@@ -48,11 +50,11 @@ const subscribedFeedback = __(
 /**
  * The newsletter signup section.
  *
- * @param {string} gdprLink Shortlink to the Yoast Privacy policy.
+ * @param {string} gdprLink Shortlink to the Yoast privacy policy.
  *
  * @returns {WPElement} A newslettersignup element.
  */
-export function NewsletterSignup( gdprLink ) {
+export function NewsletterSignup( { gdprLink } ) {
 	const [ newsletterEmail, setNewsletterEmail ] = useState( "" );
 	const [ signUpState, setSignUpState ] = useState( "waiting" );
 	const [ emailFeedback, setEmailFeedback ] = useState( "" );
@@ -124,3 +126,11 @@ export function NewsletterSignup( gdprLink ) {
 		</Fragment>
 	);
 }
+
+NewsletterSignup.propTypes = {
+	gdprLink: PropTypes.string,
+};
+
+NewsletterSignup.defaultProps = {
+	gdprLink: "",
+};

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 
 use WPSEO_Addon_Manager;
 use WPSEO_Admin_Asset_Manager;
+use WPSEO_Shortlinker;
 use WPSEO_Utils;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
@@ -31,6 +32,13 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	private $addon_manager;
 
 	/**
+	 * The shortlinker.
+	 *
+	 * @var WPSEO_Shortlinker
+	 */
+	private $shortlinker;
+
+	/**
 	 * The options' helper.
 	 *
 	 * @var Options_Helper
@@ -56,17 +64,20 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	 *
 	 * @param WPSEO_Admin_Asset_Manager $admin_asset_manager The admin asset manager.
 	 * @param WPSEO_Addon_Manager       $addon_manager       The addon manager.
+	 * @param WPSEO_Shortlinker         $shortlinker         The shortlinker.
 	 * @param Options_Helper            $options_helper      The options helper.
 	 * @param Product_Helper            $product_helper      The product helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $admin_asset_manager,
 		WPSEO_Addon_Manager $addon_manager,
+		WPSEO_Shortlinker $shortlinker,
 		Options_Helper $options_helper,
 		Product_Helper $product_helper
 	) {
 		$this->admin_asset_manager = $admin_asset_manager;
 		$this->addon_manager       = $addon_manager;
+		$this->shortlinker         = $shortlinker;
 		$this->options_helper      = $options_helper;
 		$this->product_helper      = $product_helper;
 	}
@@ -157,6 +168,11 @@ class Configuration_Workout_Integration implements Integration_Interface {
 					"companyOrPersonOptions": %s,
 					"shouldForceCompany": %d,
 					"knowledgeGraphMessage": "%s",
+					"shortlinks": {
+						"workoutGuide": "%s",
+						"indexData": "%s",
+						"gdpr": "%s",
+					},
 				};',
 				$this->is_company_or_person(),
 				$selected_option_label,
@@ -178,7 +194,10 @@ class Configuration_Workout_Integration implements Integration_Interface {
 				$this->has_tracking_enabled(),
 				WPSEO_Utils::format_json_encode( $options ),
 				$this->should_force_company(),
-				$knowledge_graph_message
+				$knowledge_graph_message,
+				$this->shortlinker->build_shortlink( 'https://yoa.st/config-workout-guide' ),
+				$this->shortlinker->build_shortlink( 'https://yoa.st/config-workout-index-data' ),
+				$this->shortlinker->build_shortlink( 'https://yoa.st/gdpr-config-workout' )
 			),
 			'before'
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds system tracking parameters to the shortlinks in the configuration workout. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Navigate to the configuration workout.
* Check that all links contain (at least) the PHP version.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
