### PR TITLE
Change the Wincher feature flag into a regular conditional based on a new Non_Multisite conditional

### DIFF
--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -5,12 +5,6 @@
  * @package WPSEO\Admin
  */
 
-use Yoast\WP\SEO\Conditionals\Wincher_Conditional;
-use Yoast\WP\SEO\Config\Wincher_Client;
-use Yoast\WP\SEO\Exceptions\OAuth\Authentication_Failed_Exception;
-use Yoast\WP\SEO\Exceptions\OAuth\Tokens\Empty_Property_Exception;
-use Yoast\WP\SEO\Exceptions\OAuth\Tokens\Empty_Token_Exception;
-
 /**
  * Class to change or add WordPress dashboard widgets.
  */

--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -5,10 +5,8 @@
  * @package WPSEO\Admin\Formatter
  */
 
-use Yoast\WP\SEO\Conditionals\Wincher_Conditional;
 use Yoast\WP\SEO\Config\Schema_Types;
 use Yoast\WP\SEO\Config\SEMrush_Client;
-use Yoast\WP\SEO\Config\Wincher_Client;
 use Yoast\WP\SEO\Exceptions\OAuth\Authentication_Failed_Exception;
 use Yoast\WP\SEO\Exceptions\OAuth\Tokens\Empty_Property_Exception;
 use Yoast\WP\SEO\Exceptions\OAuth\Tokens\Empty_Token_Exception;

--- a/admin/views/class-yoast-integration-toggles.php
+++ b/admin/views/class-yoast-integration-toggles.php
@@ -5,8 +5,6 @@
  * @package WPSEO\Admin
  */
 
-use Yoast\WP\SEO\Conditionals\Wincher_Conditional;
-
 /**
  * Class for managing integration toggles.
  */
@@ -121,22 +119,6 @@ class Yoast_Integration_Toggles {
 			],
 		];
 
-		// Don't render when feature flag is not enabled.
-		$conditional = new Wincher_Conditional();
-		if ( $conditional->is_met() ) {
-			$integration_toggles[] = (object) [
-				/* translators: %s: 'Wincher' */
-				'name'            => sprintf( __( '%s integration', 'wordpress-seo' ), 'Wincher' ),
-				'setting'         => 'wincher_integration_active',
-				'label'           => sprintf(
-				/* translators: %s: 'Wincher' */
-					__( 'The %s integration offers the option to track specific keyphrases and gain insights in their positions.', 'wordpress-seo' ),
-					'Wincher'
-				),
-				'order'           => 11,
-			];
-		}
-
 		/**
 		 * Filter to add integration toggles from add-ons.
 		 *
@@ -147,8 +129,6 @@ class Yoast_Integration_Toggles {
 
 		$integration_toggles = array_map( [ $this, 'ensure_toggle' ], $integration_toggles );
 		usort( $integration_toggles, [ $this, 'sort_toggles_callback' ] );
-
-		add_action( 'Yoast\WP\SEO\admin_integration_after', [ $this, 'load_toggle_additional_content' ] );
 
 		return $integration_toggles;
 	}
@@ -186,22 +166,5 @@ class Yoast_Integration_Toggles {
 	 */
 	protected function sort_toggles_callback( Yoast_Feature_Toggle $feature_a, Yoast_Feature_Toggle $feature_b ) {
 		return ( $feature_a->order - $feature_b->order );
-	}
-
-	/**
-	 * Loads additional content for the passed integration.
-	 *
-	 * @param Object $integration The integration object.
-	 *
-	 * @return void
-	 */
-	public function load_toggle_additional_content( $integration ) {
-		switch ( $integration->setting ) {
-			case 'wincher_integration_active':
-				require __DIR__ . '/tabs/metas/paper-content/integrations/wincher.php';
-				break;
-			default:
-				break;
-		}
 	}
 }

--- a/admin/views/tabs/metas/paper-content/integrations/wincher.php
+++ b/admin/views/tabs/metas/paper-content/integrations/wincher.php
@@ -7,14 +7,6 @@
  * @uses    Yoast_Form $yform Form object.
  */
 
-use Yoast\WP\SEO\Conditionals\Wincher_Conditional;
-
-// Don't render when feature flag is not enabled.
-$conditional = new Wincher_Conditional();
-if ( ! $conditional->is_met() ) {
-	return;
-}
-
 $yform = Yoast_Form::get_instance();
 
 // Ensure we don't accidentally reset the website ID.

--- a/packages/js/src/components/WincherSEOPerformanceModal.js
+++ b/packages/js/src/components/WincherSEOPerformanceModal.js
@@ -13,7 +13,6 @@ import { ReactComponent as YoastIcon } from "../../images/Yoast_icon_kader.svg";
 import { isCloseEvent } from "./modals/editorModals/EditorModal.js";
 import SidebarButton from "./SidebarButton";
 import WincherSEOPerformance from "../containers/WincherSEOPerformance";
-import { isFeatureEnabled } from "@yoast/feature-flag";
 
 /**
  * Handles the click event on the "Track SEO performance" button.
@@ -58,10 +57,6 @@ export function closeModal( props, event ) {
  * @returns {wp.Element} The WincherSEOPerformanceModal.
  */
 export default function WincherSEOPerformanceModal( props ) {
-	if ( ! isFeatureEnabled( "WINCHER_INTEGRATION" ) ) {
-		return null;
-	}
-
 	const { location, whichModalOpen } = props;
 
 	const onModalOpen = useCallback( () => {

--- a/src/actions/wincher/wincher-account-action.php
+++ b/src/actions/wincher/wincher-account-action.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Actions\Wincher;
 
 use Yoast\WP\SEO\Config\Wincher_Client;
-use Yoast\WP\SEO\Exceptions\OAuth\Authentication_Failed_Exception;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 
 /**

--- a/src/conditionals/non-multisite-conditional.php
+++ b/src/conditionals/non-multisite-conditional.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Conditional that is only met when we aren't in a multisite setup.
+ */
+class Non_Multisite_Conditional implements Conditional {
+
+	/**
+	 * Returns `true` when we aren't in a multisite setup.
+	 *
+	 * @return bool `true` when we aren't in a multisite setup.
+	 */
+	public function is_met() {
+		return ! \is_multisite();
+	}
+}

--- a/src/conditionals/wincher-conditional.php
+++ b/src/conditionals/wincher-conditional.php
@@ -5,14 +5,4 @@ namespace Yoast\WP\SEO\Conditionals;
 /**
  * Conditional for the Wincher integration.
  */
-class Wincher_Conditional extends Non_Multisite_Conditional {
-
-	/**
-	 * Override is_met to also make sure this isn't a multisite installation.
-	 *
-	 * @return bool
-	 */
-	public function is_met() {
-		return parent::is_met();
-	}
-}
+class Wincher_Conditional extends Non_Multisite_Conditional {}

--- a/src/conditionals/wincher-conditional.php
+++ b/src/conditionals/wincher-conditional.php
@@ -3,18 +3,9 @@
 namespace Yoast\WP\SEO\Conditionals;
 
 /**
- * Feature flag conditional for the Wincher integration.
+ * Conditional for the Wincher integration.
  */
-class Wincher_Conditional extends Feature_Flag_Conditional {
-
-	/**
-	 * Returns the name of the Wincher integration feature flag.
-	 *
-	 * @return string The name of the feature flag.
-	 */
-	protected function get_feature_flag() {
-		return 'WINCHER_INTEGRATION';
-	}
+class Wincher_Conditional extends Non_Multisite_Conditional {
 
 	/**
 	 * Override is_met to also make sure this isn't a multisite installation.
@@ -22,6 +13,6 @@ class Wincher_Conditional extends Feature_Flag_Conditional {
 	 * @return bool
 	 */
 	public function is_met() {
-		return parent::is_met() && ! \is_multisite();
+		return parent::is_met();
 	}
 }

--- a/src/helpers/wincher-helper.php
+++ b/src/helpers/wincher-helper.php
@@ -20,7 +20,7 @@ class Wincher_Helper {
 	 * @return bool Whether or not the integration is active.
 	 */
 	public function is_active() {
-		// If feature flag is disabled, Wincher should not be active.
+		// If the integration is disabled, Wincher should not be active.
 		$conditional = new Wincher_Conditional();
 		if ( ! $conditional->is_met() ) {
 			return false;

--- a/src/integrations/third-party/wincher.php
+++ b/src/integrations/third-party/wincher.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Third_Party;
+
+use Yoast\WP\SEO\Conditionals\Wincher_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Adds the Wincher integration.
+ */
+class Wincher implements Integration_Interface {
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		/**
+		 * Called by Yoast_Integration_Toggles to add extra toggles to the ones defined there.
+		 */
+		\add_filter( 'wpseo_integration_toggles', [ $this, 'add_integration_toggle' ] );
+		/**
+		 * Called in dashboard/integrations.php to put additional content after the toggle.
+		 */
+		\add_action( 'Yoast\WP\SEO\admin_integration_after', [ $this, 'load_toggle_additional_content' ] );
+	}
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * @return array The conditionals.
+	 */
+	public static function get_conditionals() {
+		return [ Wincher_Conditional::class ];
+	}
+
+	/**
+	 * Adds the Wincher integration toggle to the array.
+	 *
+	 * @param array $integration_toggles The integration toggles array.
+	 *
+	 * @return array The updated integration toggles array.
+	 */
+	public function add_integration_toggle( $integration_toggles ) {
+		if ( \is_array( $integration_toggles ) ) {
+			$integration_toggles[] = (object) [
+				/* translators: %s: 'Wincher' */
+				'name'    => \sprintf( \__( '%s integration', 'wordpress-seo' ), 'Wincher' ),
+				'setting' => 'wincher_integration_active',
+				'label'   => \sprintf(
+				/* translators: %s: 'Wincher' */
+					\__( 'The %s integration offers the option to track specific keyphrases and gain insights in their positions.', 'wordpress-seo' ),
+					'Wincher'
+				),
+				'order'   => 11,
+			];
+		}
+
+		return $integration_toggles;
+	}
+
+	/**
+	 * Loads additional content for the passed integration.
+	 *
+	 * @param Object $integration The integration object.
+	 *
+	 * @return void
+	 */
+	public function load_toggle_additional_content( $integration ) {
+		switch ( $integration->setting ) {
+			case 'wincher_integration_active':
+				require WPSEO_PATH . 'admin/views/tabs/metas/paper-content/integrations/wincher.php';
+				break;
+			default:
+				break;
+		}
+	}
+}

--- a/tests/unit/admin/views/integration-toggles-test.php
+++ b/tests/unit/admin/views/integration-toggles-test.php
@@ -13,16 +13,6 @@ use Yoast_Integration_Toggles;
  * @covers \Yoast_Integration_Toggles
  */
 class Yoast_Integration_Toggles_Test extends TestCase {
-	/**
-	 * Sets up the test fixtures.
-	 */
-	protected function set_up() {
-		parent::set_up();
-
-		if ( ! defined( 'YOAST_SEO_WINCHER_INTEGRATION' ) ) {
-			define( 'YOAST_SEO_WINCHER_INTEGRATION', true );
-		}
-	}
 
 	/**
 	 * Test the basic functionality of the Yoast_Integration_Toggles class.
@@ -32,10 +22,9 @@ class Yoast_Integration_Toggles_Test extends TestCase {
 	public function test_integration_toggles() {
 		$expected_names = [
 			0 => 'Semrush integration',
-			1 => 'Wincher integration',
-			2 => 'Ryte integration',
-			3 => 'Zapier integration',
-			4 => 'Algolia integration',
+			1 => 'Ryte integration',
+			2 => 'Zapier integration',
+			3 => 'Algolia integration',
 		];
 
 		$this->stubTranslationFunctions();
@@ -64,11 +53,10 @@ class Yoast_Integration_Toggles_Test extends TestCase {
 		$expected_names = [
 			0 => 'Dummy prio 5',
 			1 => 'Semrush integration',
-			2 => 'Wincher integration',
-			3 => 'Ryte integration',
-			4 => 'Zapier integration',
-			5 => 'Algolia integration',
-			6 => 'Dummy prio 50',
+			2 => 'Ryte integration',
+			3 => 'Zapier integration',
+			4 => 'Algolia integration',
+			5 => 'Dummy prio 50',
 		];
 
 		$this->stubTranslationFunctions();
@@ -92,7 +80,7 @@ class Yoast_Integration_Toggles_Test extends TestCase {
 	 * @param array $toggles Current array with integration toggle objects where each object
 	 *                       should have a `name`, `setting` and `label` property.
 	 *
-	 * @return Adjusted array with integration toggle objects.
+	 * @return array Adjusted array with integration toggle objects.
 	 */
 	public function toggle_filter_callback( $toggles ) {
 		$toggles[] = (object) [

--- a/tests/unit/conditionals/non-multisite-conditional-test.php
+++ b/tests/unit/conditionals/non-multisite-conditional-test.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Conditionals;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Conditionals\Non_Multisite_Conditional;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Non_Multisite_Conditional test.
+ *
+ * @group conditionals
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Conditionals\Non_Multisite_Conditional
+ */
+class Non_Multisite_Conditional_Test extends TestCase {
+
+	/**
+	 * The schema blocks feature flag conditional.
+	 *
+	 * @var Non_Multisite_Conditional
+	 */
+	protected $instance;
+
+	/**
+	 * Does the setup for testing.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->instance = new Non_Multisite_Conditional();
+	}
+
+	/**
+	 * Tests whether the conditional is not met when we are in a multisite setup.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_not_met() {
+		Monkey\Functions\stubs(
+			[
+				'is_multisite'   => true,
+			]
+		);
+		self::assertFalse( $this->instance->is_met() );
+	}
+
+	/**
+	 * Tests whether the conditional is met when we are not in a multisite setup.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_met() {
+		Monkey\Functions\stubs(
+			[
+				'is_multisite'   => false,
+			]
+		);
+
+		self::assertTrue( $this->instance->is_met() );
+	}
+}

--- a/tests/unit/conditionals/wincher-conditional-test.php
+++ b/tests/unit/conditionals/wincher-conditional-test.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Conditionals;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Conditionals\Wincher_Conditional;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Wincher_Conditional test.
+ *
+ * @group conditionals
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Conditionals\Wincher_Conditional
+ */
+class Wincher_Conditional_Test extends TestCase {
+
+	/**
+	 * The schema blocks feature flag conditional.
+	 *
+	 * @var Wincher_Conditional
+	 */
+	protected $instance;
+
+	/**
+	 * Does the setup for testing.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->instance = new Wincher_Conditional();
+	}
+
+	/**
+	 * Tests whether the conditional is not met when we are in a multisite setup.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_not_met() {
+		Monkey\Functions\stubs(
+			[
+				'is_multisite'   => true,
+			]
+		);
+		self::assertFalse( $this->instance->is_met() );
+	}
+
+	/**
+	 * Tests whether the conditional is met when we are not in a multisite setup.
+	 *
+	 * @covers ::is_met
+	 */
+	public function test_is_met() {
+		Monkey\Functions\stubs(
+			[
+				'is_multisite'   => false,
+			]
+		);
+
+		self::assertTrue( $this->instance->is_met() );
+	}
+}

--- a/tests/unit/integrations/third-party/wincher-publish-test.php
+++ b/tests/unit/integrations/third-party/wincher-publish-test.php
@@ -29,7 +29,7 @@ class Wincher_Publish_Test extends TestCase {
 	/**
 	 * The test instance.
 	 *
-	 * @var Wincher_Publish
+	 * @var Wincher_Publish|Mockery\LegacyMockInterface|Mockery\MockInterface
 	 */
 	private $instance;
 
@@ -66,10 +66,6 @@ class Wincher_Publish_Test extends TestCase {
 	 */
 	protected function set_up() {
 		parent::set_up();
-
-		if ( ! defined( 'YOAST_SEO_WINCHER_INTEGRATION' ) ) {
-			define( 'YOAST_SEO_WINCHER_INTEGRATION', true );
-		}
 
 		$this->options_helper    = Mockery::mock( Options_Helper::class );
 		$this->wincher_enabled   = Mockery::mock( Wincher_Enabled_Conditional::class );

--- a/tests/unit/integrations/third-party/wincher-test.php
+++ b/tests/unit/integrations/third-party/wincher-test.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party;
+
+use Brain\Monkey;
+use Mockery;
+use WP_Post;
+use Yoast\WP\SEO\Conditionals\Wincher_Conditional;
+use Yoast\WP\SEO\Integrations\Third_Party\Wincher;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Wincher.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Third_Party\Wincher
+ *
+ * @group integrations
+ */
+class Wincher_Test extends TestCase {
+
+	/**
+	 * The test instance.
+	 *
+	 * @var Wincher
+	 */
+	private $instance;
+
+	/**
+	 * Sets an instance for test purposes.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Wincher();
+	}
+
+	/**
+	 * Tests if the expected conditionals are in place.
+	 *
+	 * @covers ::get_conditionals
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals(
+			[
+				Wincher_Conditional::class,
+			],
+			Wincher::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @covers ::register_hooks
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertNotFalse( Monkey\Filters\has( 'wpseo_integration_toggles', [ $this->instance, 'add_integration_toggle' ] ) );
+		$this->assertNotFalse( Monkey\Actions\has( 'Yoast\WP\SEO\admin_integration_after', [ $this->instance, 'load_toggle_additional_content' ] ) );
+	}
+
+	/**
+	 * Tests the add_integration_toggle request function.
+	 *
+	 * @covers ::add_integration_toggle
+	 */
+	public function test_add_integration_toggle() {
+		$integration_toggles = [
+			(object) [
+				'name'            => 'Semrush integration',
+				'setting'         => 'semrush_integration_active',
+				'label'           => 'The Semrush integration offers suggestions and insights for keywords related to the entered focus keyphrase.',
+				'order'           => 10,
+			],
+			(object) [
+				'name'            => 'Ryte integration',
+				'setting'         => 'ryte_indexability',
+				'label'           => 'Ryte will check weekly if your site is still indexable by search engines and Yoast SEO will notify you when this is not the case.',
+				'read_more_label' => 'Read more about how Ryte works.',
+				'read_more_url'   => 'https://yoa.st/2an',
+				'order'           => 15,
+			],
+		];
+
+		Monkey\Functions\stubTranslationFunctions();
+
+		$result = $this->instance->add_integration_toggle( $integration_toggles );
+		$this->assertEquals(
+			(object) [
+				'name'    => 'Wincher integration',
+				'setting' => 'wincher_integration_active',
+				'label'   => 'The Wincher integration offers the option to track specific keyphrases and gain insights in their positions.',
+				'order'   => 11,
+			],
+			$result[2]
+		);
+	}
+}

--- a/tests/unit/integrations/third-party/wincher-test.php
+++ b/tests/unit/integrations/third-party/wincher-test.php
@@ -3,8 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Unit\Integrations\Third_Party;
 
 use Brain\Monkey;
-use Mockery;
-use WP_Post;
 use Yoast\WP\SEO\Conditionals\Wincher_Conditional;
 use Yoast\WP\SEO\Integrations\Third_Party\Wincher;
 use Yoast\WP\SEO\Tests\Unit\TestCase;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to enable the Wincher integration, currently behind a feature flag.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces a keyphrase position tracking tool that gives insight into how your content ranks in the search results. Powered by Wincher. 

## Relevant technical choices:

* The `Wincher_Conditional` implementing the feature flag has been re-worked into a "standard" conditional extending a new `Non_Multisite_Conditional`. This makes it easier to refactor the `Wincher_Conditional` to add/change conditions.
* A new Wincher integration has been added to nicely use conditionals to add the integration toggle in SEO > Integrations.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* remove `define( 'YOAST_SEO_WINCHER_INTEGRATION', true );` from `wp-config.php`
* check that the feature integration works as expected (Integration toggle, Post editor, Dashboard widget).
  * in SEO > General, in the Integrations tab, check that there is a `wincher_website_id` hidden form input.
* test on a multisite environment: the feature should not be available at all.
  * this means that you shouldn't see the things mentioned above in the subsites
  * in SEO > General, in the Integrations tab, check that there is **not** a `wincher_website_id` hidden form input anywhere

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-173]

[DUPP-173]: https://yoast.atlassian.net/browse/DUPP-173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ