### PR TITLE
PHP 8.1: fix deprecation warning / http_build_query()

### DIFF
--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -307,7 +307,7 @@ class WPSEO_Sitemaps_Renderer {
 
 			parse_str( $query, $parsed_query );
 
-			$parsed_query = http_build_query( $parsed_query, null, '&amp;', PHP_QUERY_RFC3986 );
+			$parsed_query = http_build_query( $parsed_query, '', '&amp;', PHP_QUERY_RFC3986 );
 
 			$url = str_replace( $query, $parsed_query, $url );
 		}


### PR DESCRIPTION
## Context

* Improves compatibility with PHP 8.1

## Summary

This PR can be summarized in the following changelog entry:

* Improves compatibility with PHP 8.1 by filtering invalid values.


## Relevant technical choices:

This fixes an issue with a call to the PHP native `http_build_query()` function, the second parameter of which is the _optional_ `$numeric_prefix` parameter which expects a `string`.

A parameter being optional, however, does not automatically make it nullable.

As of PHP 8.1, passing `null` to a non-nullable PHP native function will generate a deprecation notice.
In this case, this function call yielded a `http_build_query(): Passing null to parameter composer#2 ($numeric_prefix) of type string is deprecated` notice.

Changing the `null` to an empty string fixes this without BC-break.

Note: the tests which are being added in #17825 safeguard this fix as well, so no additional tests are needed (provided #17825 will be merged).

Refs:
* https://www.php.net/manual/en/function.http-build-query.php
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is a code-technical change only and should have no effect on existing functionality. This can be verified via the tests added in #17825.