### PR TITLE
Prevent WP-CLI indexing on non-production environments

### DIFF
--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -15,6 +15,7 @@ use Yoast\WP\SEO\Actions\Indexing\Indexing_Prepare_Action;
 use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Main;
+use Yoast\WP\SEO\Helpers\Environment_Helper;
 
 /**
  * Command to generate indexables for all posts and terms.
@@ -78,6 +79,13 @@ class Index_Command implements Command_Interface {
 	private $prepare_indexing_action;
 
 	/**
+	 * Represents the environment helper.
+	 *
+	 * @var Environment_Helper
+	 */
+	protected $environment_helper;
+
+	/**
 	 * Generate_Indexables_Command constructor.
 	 *
 	 * @param Indexable_Post_Indexation_Action              $post_indexation_action              The post indexation
@@ -96,6 +104,7 @@ class Index_Command implements Command_Interface {
 	 *                                                                                           action.
 	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action           The term link indexation
 	 *                                                                                           action.
+	 * @param Environment_Helper                            $environment_helper                  The Environment helper.
 	 */
 	public function __construct(
 		Indexable_Post_Indexation_Action $post_indexation_action,
@@ -105,7 +114,8 @@ class Index_Command implements Command_Interface {
 		Indexable_Indexing_Complete_Action $complete_indexation_action,
 		Indexing_Prepare_Action $prepare_indexing_action,
 		Post_Link_Indexing_Action $post_link_indexing_action,
-		Term_Link_Indexing_Action $term_link_indexing_action
+		Term_Link_Indexing_Action $term_link_indexing_action,
+		Environment_Helper $environment_helper
 	) {
 		$this->post_indexation_action              = $post_indexation_action;
 		$this->term_indexation_action              = $term_indexation_action;
@@ -115,6 +125,7 @@ class Index_Command implements Command_Interface {
 		$this->prepare_indexing_action             = $prepare_indexing_action;
 		$this->post_link_indexing_action           = $post_link_indexing_action;
 		$this->term_link_indexing_action           = $term_link_indexing_action;
+		$this->environment_helper                  = $environment_helper;
 	}
 
 	/**
@@ -158,6 +169,11 @@ class Index_Command implements Command_Interface {
 	 * @return void
 	 */
 	public function index( $args = null, $assoc_args = null ) {
+		if ( ! $this->environment_helper->is_production_mode() ) {
+			WP_CLI::log( 'Your WordPress environment is running on a non-production site. Indexables can only be created on production environments. Please check your `WP_ENVIRONMENT_TYPE` settings.' );
+			return;
+		}
+
 		if ( ! isset( $assoc_args['network'] ) ) {
 			$this->run_indexation_actions( $assoc_args );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Prevent WP-CLI indexing commands on non-production environments, as they will be unable to run.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces a check that will prevent indexing via WP-CLI when the site environment is non-production. 

## Relevant technical choices:

* Completely short-circuits the indexing command early in the stack to prevent any type of indexing or reindexing.
* In a later stadium, we may want to build the WP-CLI utility so that it can index on a non-production environment. As it is a poweruser utility, it should allow for a bit more powerful / risky options.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have a site with some posts, pages, categories, etc. I had about 50 of each.
* Have your WP environment set to staging with `define( 'WP_ENVIRONMENT_TYPE', 'staging' );` in your `wp-config.php`.
* Without this PR: try to run `wp yoast index --reindex`. It will clear the indexables table and then show a progressbar for posts indexing. However, it will not finish.
* With this PR, the indexing will not run at all. Instead, you will see a message and the script will stop.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://github.com/Yoast/wordpress-seo/issues/17859