### PR TITLE
Add JSON_UNESCAPED_UNICODE flag for schema output

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -947,7 +947,7 @@ class WPSEO_Utils {
 	 * @return false|string The prepared JSON string.
 	 */
 	public static function format_json_encode( $data ) {
-		$flags = JSON_UNESCAPED_SLASHES;
+		$flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
 
 		if ( self::is_development_mode() ) {
 			$flags = ( $flags | JSON_PRETTY_PRINT );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Make the schema output more friendly to non-alphanumeric languages.
* There have been comments that the unicode escaping was hurting SEO performance. I could not find any evidence for this.
* Not escaping the unicode characters may reduce the overall character count / size of the schema by quite a bit, which is preferable.
* It makes debugging in other languages more user-friendly.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enhances schema presentation for languages that are not alphanumeric. Props to [sous-studio](https://github.com/sous-studio)

## Relevant technical choices:

* Did some additional investigation into the security-side of enabling this flag. I was unable to find anything that could seriously go wrong with this flag enabled.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a post with a non-alphanumeric SEO title and description in our metabox (or use the following):
Title: `Это русское название` (`this is a title in Russian`)
Description: `А теперь я хотел бы рассказать небольшую историю на русском языке. Не так я стал новым принцем бел-эйр.` (`Now here is a little story in Russian I'd like to tell. This is not how I became the fresh prince of bel-air.`)
* Without this PR, the schema of the page would show the title and description as a load of `\u0410 \u0442\u0435\u043f\u0435\u0440\u044c` sequences.
* With this PR, the schema should just reflect the contents of the metabox


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above, as well as

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Test as much of the values that can be manually set for schema presentation. Think of author fields when a site is set to "person" and. 
* Experiment with strange and weird characters to make sure schema never breaks.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Schema

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://github.com/Yoast/wordpress-seo/issues/17862
