### PR TITLE
DUPP-185 fix translations in the installation success page

### DIFF
--- a/css/src/installation-success.css
+++ b/css/src/installation-success.css
@@ -2,7 +2,7 @@
 	display: flex;
 	flex-direction: column;
 	height: 88vh;
-	justify-content: start;
+	justify-content: flex-start;
 	padding-top: 7%;
 	box-sizing: border-box;
 }

--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Integrations\Admin;
 
 use WPSEO_Admin_Asset_Manager;
+use WPSEO_Admin_Asset_Yoast_Components_L10n;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\Installation_Success_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
@@ -121,6 +122,9 @@ class Installation_Success_Integration implements Integration_Interface {
 		$asset_manager->enqueue_script( 'installation-success' );
 		$asset_manager->enqueue_style( 'installation-success' );
 		$asset_manager->enqueue_style( 'monorepo' );
+
+		$yoast_components_l10n = new WPSEO_Admin_Asset_Yoast_Components_L10n();
+		$yoast_components_l10n->localize_script( 'installation-success' );
 
 		$asset_manager->localize_script(
 			'installation-success',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the installation success page to display translations

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the installation success page would not display the translations.

## Relevant technical choices:

* Also fixes a small issue in CSS building step where `flex-start` was suggested to be used instead of `start`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* make sure you have the feature flag `YOAST_SEO_INSTALLATION_SUCCESS` set to `true`
* build the branch
  * check that on `grunt build` you don't see this:
```
Running "postcss:build" (postcss) task
>> autoprefixer: /home/lopo/src/Yoast/plugin-development-docker/plugins/wordpress-seo/css/dist/installation-success-1780.css:5:2: start value has mixed support, consider using flex-start instead
>> 27 processed stylesheets created.
>> 27 sourcemaps created.
>> 1 issue found.
```
* Install and activate
* visit the WP settings and switch language to Italian
* visit Dashboard > Updates to make sure you have the latest translations, otherwise click on the button to pull them
* visit the installation success page (e.g. http://basic.wordpress.test/wp-admin/admin.php?page=wpseo_installation_successful_free) and check it's translated in Italian, except for the `Start configuration workout` string that doesn't have a translation yet.
* check that the position of the content hasn't changed


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* make sure you have the feature flag `YOAST_SEO_INSTALLATION_SUCCESS` set to `true`
* Install and activate
* visit the WP settings and switch language to Italian
* visit Dashboard > Updates to make sure you have the latest translations, otherwise click on the button to pull them
* visit the installation success page (e.g. http://basic.wordpress.test/wp-admin/admin.php?page=wpseo_installation_successful_free) and check it's translated in Italian, except for the `Start configuration workout` string that doesn't have a translation yet.
* check that the position of the content hasn't changed

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-185][DUPP-183]


[DUPP-185]: https://yoast.atlassian.net/browse/DUPP-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ