### PR TITLE
Allow all blur events except media library clicks to close editormodals

### DIFF
--- a/packages/js/src/components/modals/editorModals/EditorModal.js
+++ b/packages/js/src/components/modals/editorModals/EditorModal.js
@@ -2,6 +2,7 @@ import { __, sprintf } from "@wordpress/i18n";
 import { useCallback, Fragment } from "@wordpress/element";
 import Modal from "../Modal";
 import PropTypes from "prop-types";
+import { intersection } from "lodash";
 import SidebarButton from "../../SidebarButton";
 import { LocationProvider } from "@yoast/externals/contexts";
 
@@ -14,22 +15,20 @@ import { LocationProvider } from "@yoast/externals/contexts";
  * @returns {boolean} False when this event should not lead to closing to modal. True otherwise.
  */
 export const isCloseEvent = ( event ) => {
+	let shouldClose = true;
 	if ( event.type === "blur" ) {
 		// Catch any blur events that are not supposed to blur to modal, by identifying the clicked item.
-		let relatedTargetClasses = [];
+		const { relatedTarget } = event;
 
 		// Blur events to a non-focusable HTML element do not have a relatedTarget.
-		if ( event.relatedTarget && event.relatedTarget.classList ) {
-			relatedTargetClasses = Array.from( event.relatedTarget.classList );
-		}
-
-		// If the modal was blurred because the media library opened don't close the modal
-		if ( relatedTargetClasses.includes( "media-modal" ) && relatedTargetClasses.includes( "wp-core-ui" ) ) {
-			return false;
+		if ( relatedTarget ) {
+			// Modal should not close if the modal blurs because the media modal is clicked
+			const mediaModalClasses = [ "media-modal", "wp-core-ui" ];
+			shouldClose = intersection( mediaModalClasses, Array.from( relatedTarget.classList ) ).length !== mediaModalClasses.length;
 		}
 	}
 
-	return true;
+	return shouldClose;
 };
 
 /**

--- a/packages/js/src/components/modals/editorModals/EditorModal.js
+++ b/packages/js/src/components/modals/editorModals/EditorModal.js
@@ -15,11 +15,18 @@ import { LocationProvider } from "@yoast/externals/contexts";
  */
 export const isCloseEvent = ( event ) => {
 	if ( event.type === "blur" ) {
-		// The blur event type should only close the modal when the screen overlay is clicked.
-		if ( event.relatedTarget && event.relatedTarget.querySelector( ".components-modal__screen-overlay" ) ) {
-			return true;
+		// Catch any blur events that are not supposed to blur to modal, by identifying the clicked item.
+		let relatedTargetClasses = [];
+
+		// Blur events to a non-focusable HTML element do not have a relatedTarget.
+		if ( event.relatedTarget && event.relatedTarget.classList ) {
+			relatedTargetClasses = Array.from( event.relatedTarget.classList );
 		}
-		return false;
+
+		// If the modal was blurred because the media library opened don't close the modal
+		if ( relatedTargetClasses.includes( "media-modal" ) && relatedTargetClasses.includes( "wp-core-ui" ) ) {
+			return false;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where clicking outside of a Yoast modal in the block editor would not close the modal.

## Relevant technical choices:

It is likely something has changed in WordPress, where presumably a `tabindex=-1` was added to the Modal Screen Overlay (the background that covers the rest of the page while the modal content is displayed). 

Why did that change break our modals?In the past we had a PostSettingsModal where there were some dropdown selects. Because a click on such a dropdown caused the modal to close (as the modal was "blurred), we made a check to see whether at least the background overlay was clicked by checking the `event.relatedTarget`. However, if an item has no tabindex, there is no relatedTarget. Therefore this check has started to always return false. 

Removing that check fixes the blurring issue, but reintroduces an old bug (see https://yoast.atlassian.net/browse/P1-134 and https://github.com/Yoast/wordpress-seo/pull/15889 ) where the media library modal would cause the modal to close.

I've changed the blurEvent check back to only catch that specific bug, but kept it "future proof" to accept other checks too.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Without this branch, verify that you cannot close our Block Editor modals (Google Preview, Facebook Preview, Twitter Preview) when clicking outside of the modal. Escape and clicking the submit / `x` button still work.
* With this branch verify that you _can_ close the Block Editor modals in all of those ways AND by clicking outside of the modal.
* Verify that opening and clicking on the media library (e.g. by selecting a facebook/twitter image) does not close the modal.
* Try to break by blurring (focussing and then clicking away from) other items in all of our editor modals.
	* NOTE: I am aware the removing an image and then clicking outside of the modal does NOT close the modal. This is an issue with the focus being lost, so it's a different issue that predates the current bug. Workaround: click the modal once to focus it and then click outside.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-193
