### PR TITLE
Remove version from JS file names and add it as a file hash in the ve…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -193,7 +193,7 @@ before_script:
       mysql -e "CREATE DATABASE wordpress_tests;" -uroot
       cd "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
       mkdir src/generated/assets
-      echo "<?php return [ 'post-edit.min.js' => [ 'dependencies' => [], 'version' => 'test' ] ];" >> src/generated/assets/plugin.php
+      echo "<?php return [ 'installation-success.min.js' => [ 'dependencies' => [], 'version' => 'test' ], 'workouts.min.js' => [ 'dependencies' => [], 'version' => 'test' ] ];" >> src/generated/assets/plugin.php
       echo "<?php return [];" >> src/generated/assets/externals.php
       echo "<?php return [];" >> src/generated/assets/languages.php
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -193,7 +193,7 @@ before_script:
       mysql -e "CREATE DATABASE wordpress_tests;" -uroot
       cd "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
       mkdir src/generated/assets
-      echo "<?php return [ 'post-edit-' . ( new WPSEO_Admin_Asset_Manager() )->flatten_version( WPSEO_VERSION ) . '.js' => [ 'dependencies' => [] ] ];" >> src/generated/assets/plugin.php
+      echo "<?php return [ 'post-edit.min.js' => [ 'dependencies' => [], 'version' => 'test' ] ];" >> src/generated/assets/plugin.php
       echo "<?php return [];" >> src/generated/assets/externals.php
       echo "<?php return [];" >> src/generated/assets/languages.php
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -193,7 +193,7 @@ before_script:
       mysql -e "CREATE DATABASE wordpress_tests;" -uroot
       cd "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
       mkdir src/generated/assets
-      echo "<?php return [ 'installation-success.min.js' => [ 'dependencies' => [], 'version' => 'test' ], 'workouts.min.js' => [ 'dependencies' => [], 'version' => 'test' ] ];" >> src/generated/assets/plugin.php
+      echo "<?php return [ 'post-edit.min.js' => [ 'dependencies' => [], 'version' => 'test' ], 'installation-success.min.js' => [ 'dependencies' => [], 'version' => 'test' ], 'workouts.min.js' => [ 'dependencies' => [], 'version' => 'test' ] ];" >> src/generated/assets/plugin.php
       echo "<?php return [];" >> src/generated/assets/externals.php
       echo "<?php return [];" >> src/generated/assets/languages.php
     fi

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -226,9 +226,6 @@ class WPSEO_Admin_Asset_Manager {
 	 * @return array The scripts that need to be registered.
 	 */
 	protected function scripts_to_be_registered() {
-		$flat_version = $this->flatten_version( WPSEO_VERSION );
-		$ext_length   = ( strlen( $flat_version ) + 4 );
-
 		$header_scripts          = [
 			'admin-global',
 			'block-editor',
@@ -281,7 +278,7 @@ class WPSEO_Admin_Asset_Manager {
 		$plugin_scripts   = $this->load_generated_asset_file(
 			[
 				'asset_file'      => __DIR__ . '/../src/generated/assets/plugin.php',
-				'ext_length'      => $ext_length,
+				'ext_length'      => 3,
 				'additional_deps' => $additional_dependencies,
 				'header_scripts'  => $header_scripts,
 			]
@@ -289,7 +286,7 @@ class WPSEO_Admin_Asset_Manager {
 		$external_scripts = $this->load_generated_asset_file(
 			[
 				'asset_file'      => __DIR__ . '/../src/generated/assets/externals.php',
-				'ext_length'      => $ext_length,
+				'ext_length'      => 3,
 				'suffix'          => '-package',
 				'base_dir'        => 'externals/',
 				'additional_deps' => $additional_dependencies,
@@ -299,7 +296,7 @@ class WPSEO_Admin_Asset_Manager {
 		$language_scripts = $this->load_generated_asset_file(
 			[
 				'asset_file'      => __DIR__ . '/../src/generated/assets/languages.php',
-				'ext_length'      => $ext_length,
+				'ext_length'      => 3,
 				'suffix'          => '-language',
 				'base_dir'        => 'languages/',
 				'additional_deps' => $additional_dependencies,
@@ -318,9 +315,9 @@ class WPSEO_Admin_Asset_Manager {
 		);
 
 		$scripts['installation-success'] = [
-			'name' => 'installation-success',
-			'src'  => 'installation-success-' . $flat_version . '.js',
-			'deps' => [
+			'name'    => 'installation-success',
+			'src'     => 'installation-success.js',
+			'deps'    => [
 				'wp-a11y',
 				'wp-dom-ready',
 				'wp-components',
@@ -329,6 +326,7 @@ class WPSEO_Admin_Asset_Manager {
 				self::PREFIX . 'yoast-components',
 				self::PREFIX . 'externals-components',
 			],
+			'version' => $scripts['installation-success']['version'],
 		];
 
 		$scripts['post-edit-classic'] = [
@@ -344,12 +342,13 @@ class WPSEO_Admin_Asset_Manager {
 				$scripts['post-edit']['deps']
 			),
 			'in_footer' => ! in_array( 'post-edit-classic', $header_scripts, true ),
+			'version'   => $scripts['post-edit']['version'],
 		];
 
 		$scripts['workouts'] = [
-			'name' => 'workouts',
-			'src'  => 'workouts-' . $flat_version . '.js',
-			'deps' => [
+			'name'    => 'workouts',
+			'src'     => 'workouts.js',
+			'deps'    => [
 				'clipboard',
 				'lodash',
 				'wp-api-fetch',
@@ -367,6 +366,7 @@ class WPSEO_Admin_Asset_Manager {
 				self::PREFIX . 'react-select',
 				self::PREFIX . 'yoast-components',
 			],
+			'version' => $scripts['workouts']['version'],
 		];
 
 		// Add the current language to every script that requires the analysis package.
@@ -432,6 +432,7 @@ class WPSEO_Admin_Asset_Manager {
 				'src'       => $args['base_dir'] . $file,
 				'deps'      => $deps,
 				'in_footer' => ! in_array( $name, $args['header_scripts'], true ),
+				'version'   => $data['version'],
 			];
 		}
 

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -278,7 +278,7 @@ class WPSEO_Admin_Asset_Manager {
 		$plugin_scripts   = $this->load_generated_asset_file(
 			[
 				'asset_file'      => __DIR__ . '/../src/generated/assets/plugin.php',
-				'ext_length'      => 3,
+				'ext_length'      => 7,
 				'additional_deps' => $additional_dependencies,
 				'header_scripts'  => $header_scripts,
 			]
@@ -286,7 +286,7 @@ class WPSEO_Admin_Asset_Manager {
 		$external_scripts = $this->load_generated_asset_file(
 			[
 				'asset_file'      => __DIR__ . '/../src/generated/assets/externals.php',
-				'ext_length'      => 3,
+				'ext_length'      => 7,
 				'suffix'          => '-package',
 				'base_dir'        => 'externals/',
 				'additional_deps' => $additional_dependencies,
@@ -296,7 +296,7 @@ class WPSEO_Admin_Asset_Manager {
 		$language_scripts = $this->load_generated_asset_file(
 			[
 				'asset_file'      => __DIR__ . '/../src/generated/assets/languages.php',
-				'ext_length'      => 3,
+				'ext_length'      => 7,
 				'suffix'          => '-language',
 				'base_dir'        => 'languages/',
 				'additional_deps' => $additional_dependencies,

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -17,7 +17,7 @@ const {
 const languages = readdirSync( root + "node_modules/yoastseo/src/languageProcessing/languages" );
 const pluginVersion = packageJson.yoast.pluginVersion;
 const pluginVersionSlug = paths.flattenVersionForFile( pluginVersion );
-const outputFilename = "[name]-" + pluginVersionSlug + ".js";
+const outputFilename = "[name].js";
 
 module.exports = [
 	baseConfig(

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -17,7 +17,7 @@ const {
 const languages = readdirSync( root + "node_modules/yoastseo/src/languageProcessing/languages" );
 const pluginVersion = packageJson.yoast.pluginVersion;
 const pluginVersionSlug = paths.flattenVersionForFile( pluginVersion );
-const outputFilename = "[name].js";
+const outputFilename = "[name].min.js";
 
 module.exports = [
 	baseConfig(


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Renames our JS files so their file names are consistent across versions to facilitate wordpress.org script translations. File hashes in the params are used instead to ensure cache busting.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Renames our JavaScript files to no longer include the version number, file hashes in the params are used instead for cache busting.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Build the JavaScript.
* All JavaScript files should load as normal.


### Test instructions for QA when the code is in the RC
<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* There should be no console errors on any of our pages in the admin.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Loading all JavaScript files.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
