### PR TITLE
Try: fixing Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -256,8 +256,8 @@ script:
   - |
     if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.integration-tests" && travis_time_start
-      composer remove phpunit/phpunit --ignore-platform-reqs --no-interaction
-      travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
+      composer remove --dev yoast/wp-test-utils phpunit/phpunit --ignore-platform-reqs --no-interaction
+      travis_retry composer require --dev yoast/wp-test-utils:"^1.0.0" phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction
       vendor/bin/phpunit -c phpunit-integration.xml.dist
       travis_time_finish && travis_fold end "PHP.integration-tests"
     fi;
@@ -270,9 +270,8 @@ script:
   - |
     if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.tests" && travis_time_start
-      composer remove phpunit/phpunit --ignore-platform-reqs --no-interaction
-      composer require --dev phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
-      composer update yoast/wp-test-utils --with-all-dependencies --ignore-platform-reqs --no-interaction &&
+      composer remove --dev yoast/wp-test-utils phpunit/phpunit --ignore-platform-reqs --no-interaction
+      composer require --dev yoast/wp-test-utils phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs --no-interaction
       vendor/bin/phpunit
       travis_time_finish && travis_fold end "PHP.tests"
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -256,7 +256,7 @@ script:
   - |
     if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.integration-tests" && travis_time_start
-      composer remove phpunit/phpunit
+      composer remove phpunit/phpunit --ignore-platform-reqs --no-interaction
       travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
       vendor/bin/phpunit -c phpunit-integration.xml.dist
       travis_time_finish && travis_fold end "PHP.integration-tests"
@@ -270,7 +270,7 @@ script:
   - |
     if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.tests" && travis_time_start
-      composer remove phpunit/phpunit
+      composer remove phpunit/phpunit --ignore-platform-reqs --no-interaction
       composer require --dev phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
       composer update yoast/wp-test-utils --with-all-dependencies --ignore-platform-reqs --no-interaction &&
       vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -256,7 +256,7 @@ script:
   - |
     if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.integration-tests" && travis_time_start
-      travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
+      travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-all-dependencies --ignore-platform-reqs --no-interaction &&
       vendor/bin/phpunit -c phpunit-integration.xml.dist
       travis_time_finish && travis_fold end "PHP.integration-tests"
     fi;
@@ -269,7 +269,7 @@ script:
   - |
     if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.tests" && travis_time_start
-      composer require --dev phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
+      composer require --dev phpunit/phpunit:"^9.0" --update-with-all-dependencies --ignore-platform-reqs --no-interaction &&
       composer update yoast/wp-test-utils --with-all-dependencies --ignore-platform-reqs --no-interaction &&
       vendor/bin/phpunit
       travis_time_finish && travis_fold end "PHP.tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -256,7 +256,8 @@ script:
   - |
     if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.integration-tests" && travis_time_start
-      travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-all-dependencies --ignore-platform-reqs --no-interaction &&
+      composer remove phpunit/phpunit
+      travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
       vendor/bin/phpunit -c phpunit-integration.xml.dist
       travis_time_finish && travis_fold end "PHP.integration-tests"
     fi;
@@ -269,7 +270,8 @@ script:
   - |
     if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.tests" && travis_time_start
-      composer require --dev phpunit/phpunit:"^9.0" --update-with-all-dependencies --ignore-platform-reqs --no-interaction &&
+      composer remove phpunit/phpunit
+      composer require --dev phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
       composer update yoast/wp-test-utils --with-all-dependencies --ignore-platform-reqs --no-interaction &&
       vendor/bin/phpunit
       travis_time_finish && travis_fold end "PHP.tests"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
