### PR TITLE
Remove spaces before processing keyphrase in Japanese

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/languages/ja/customResearches/getWordFormsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ja/customResearches/getWordFormsSpec.js
@@ -6,6 +6,27 @@ import getMorphologyData from "../../../../specHelpers/getMorphologyData";
 const morphologyData = getMorphologyData( "ja" );
 
 describe( "The getWordForms function", () => {
+	it( "creates word forms for a Japanese keyphrase that contains spaces", () => {
+		const paper = new Paper(
+			"休ま",
+			{
+				keyword: "かしら かい を ばっかり",
+			}
+		);
+
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		const forms = getWordForms( paper, researcher );
+		expect( forms ).toEqual( {
+			keyphraseForms: [ [ "かしらかう", "かしらかい", "かしらかわ", "かしらかえ", "かしらかお", "かしらかっ", "かしらかえる", "かしらかわせ",
+				"かしらかわせる", "かしらかわれ", "かしらかわれる", "かしらかおう", "かしらかく", "かしらかき", "かしらかか", "かしらかけ",
+				"かしらかこ", "かしらかける", "かしらかかせ", "かしらかかせる", "かしらかかれ", "かしらかかれる", "かしらかこう", "かしらかかっ",
+				"かしらかぐ", "かしらかぎ", "かしらかが", "かしらかげ", "かしらかご", "かしらかげる", "かしらかがせ", "かしらかがせる", "かしらかがれ",
+				"かしらかがれる", "かしらかごう" ] ],
+			synonymsForms: [],
+		} );
+	} );
 	it( "creates word forms for a Japanese keyphrase.", () => {
 		const paper = new Paper(
 			"休ま",

--- a/packages/yoastseo/spec/languageProcessing/researches/functionWordsInKeyphraseSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/functionWordsInKeyphraseSpec.js
@@ -81,4 +81,9 @@ describe( "Test for checking if the keyphrase contains only Japanese function wo
 		const mockPaper = new Paper( "私の猫は愛らしいです。", { keyword: "からかいをばっかり", locale: "ja" } );
 		expect( functionWordsInKeyphrase( mockPaper, new JapaneseResearcher( mockPaper ) ) ).toBe( true );
 	} );
+
+	it( "returns true if all the words in the keyphrase are function words (separated by spaces)", () => {
+		const mockPaper = new Paper( "私の猫は愛らしいです。", { keyword: "かしら かい を ばっかり", locale: "ja" } );
+		expect( functionWordsInKeyphrase( mockPaper, new JapaneseResearcher( mockPaper ) ) ).toBe( true );
+	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
@@ -147,6 +147,15 @@ describe( "the meta description keyword match research for languages that have c
 			const result = metaDescriptionKeyword( paper, researcher );
 			expect( result ).toEqual( 0 );
 		} );
+
+		it( "shouldn't give NaN/infinity times of keyphrase occurrence when the keyphrase contains tabs and " +
+			"there is no match in the text", function() {
+			const paper = new Paper( "", { keyword: "かしら	かい	を	ばっかり", description: "この記事は小さい花の刺繍をどうやってすてればいいのか、" +
+					"基本的な情報を紹介します。私は美しい猫を飼っています。 野生のハーブの刺繡。" } );
+			const researcher = new JapaneseResearcher( paper );
+			const result = metaDescriptionKeyword( paper, researcher );
+			expect( result ).toEqual( 0 );
+		} );
 	} );
 	describe( "test the research when the morphology data is available", () => {
 		it( "returns 1 when the keyword is found once in the meta description (exact match)", function() {

--- a/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
@@ -138,6 +138,15 @@ describe( "the meta description keyword match research for languages that have c
 			const result = metaDescriptionKeyword( paper, researcher );
 			expect( result ).toEqual( 2 );
 		} );
+
+		it( "shouldn't give NaN/infinity times of keyphrase occurrence when the keyphrase contains spaces and " +
+			"there is no match in the text", function() {
+			const paper = new Paper( "", { keyword: "かしら かい を ばっかり", description: "この記事は小さい花の刺繍をどうやってすてればいいのか、" +
+					"基本的な情報を紹介します。私は美しい猫を飼っています。 野生のハーブの刺繡。" } );
+			const researcher = new JapaneseResearcher( paper );
+			const result = metaDescriptionKeyword( paper, researcher );
+			expect( result ).toEqual( 0 );
+		} );
 	} );
 	describe( "test the research when the morphology data is available", () => {
 		it( "returns 1 when the keyword is found once in the meta description (exact match)", function() {

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
@@ -209,6 +209,20 @@ describe( "A test for marking the keyword", function() {
 } );
 
 describe( "A test for keyword density in Japanese", function() {
+	it( "shouldn't give NaN/infinity times of keyphrase occurrence when the keyphrase contains spaces and there is no match in the text", function() {
+		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 32 ), {
+			keyword: "かしら かい を ばっかり",
+			locale: "ja",
+		} );
+		const researcher = new JapaneseResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyDataJA );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
+		expect( result.getScore() ).toBe( 4 );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 6 times for a text of this length. " +
+			"<a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
+	} );
+
 	it( "gives a very BAD result when keyword density is above 4% when the text contains way too many instances" +
 		" of the keyphrase forms", function() {
 		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 32 ), {

--- a/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/getWordForms.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/getWordForms.js
@@ -38,7 +38,7 @@ function getKeyphraseForms( keyphrase, researcher ) {
 export default function( paper, researcher ) {
 	let keyphrase = paper.getKeyword().toLocaleLowerCase( "ja" ).trim();
 	// Remove spaces from the keyphrase.
-	keyphrase = keyphrase.replace( / /g, "" );
+	keyphrase = keyphrase.replace( /\s/g, "" );
 	const synonyms = parseSynonyms( paper.getSynonyms().toLocaleLowerCase( "ja" ).trim() );
 	const keyphraseForms = getKeyphraseForms( keyphrase, researcher );
 	const synonymsForms = synonyms.map( synonym => getKeyphraseForms( synonym, researcher ) );

--- a/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/getWordForms.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/getWordForms.js
@@ -36,7 +36,9 @@ function getKeyphraseForms( keyphrase, researcher ) {
  * found in the text or created forms.
  */
 export default function( paper, researcher ) {
-	const keyphrase = paper.getKeyword().toLocaleLowerCase( "ja" ).trim();
+	let keyphrase = paper.getKeyword().toLocaleLowerCase( "ja" ).trim();
+	// Remove spaces from the keyphrase.
+	keyphrase = keyphrase.replace( / /g, "" );
 	const synonyms = parseSynonyms( paper.getSynonyms().toLocaleLowerCase( "ja" ).trim() );
 	const keyphraseForms = getKeyphraseForms( keyphrase, researcher );
 	const synonymsForms = synonyms.map( synonym => getKeyphraseForms( synonym, researcher ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adding a related keyphrase that contains only function words triggered 'NaN' and 'Infinity' in feedback strings.
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Fixes a bug where Japanese keyphrase that contains spaces would give `NaN` or `Infinity` result when matching the keyphrase in the text.

## Relevant technical choices:

* Removing spaces before processing Japanese keyphrase prevent `NaN`/`Infinity` result when matching the keyphrase in the text.
* This approach also makes more sense, otherwise no forms are outputted at all in `ja/getWordsForms` when the keyphrase contains spaces.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Build and activate Free and Premium (run `composer require yoast/wordpress-seo:dev-LINGO-1207-fix-counting-related-keyphrase@dev` on the Premium branch before building)
* Set your site to Japanese (日本語)

**Test related keyphrase**
* Set `かしら かい を ばっかり` as the related keyphrase (under `関連するキーフレーズ` tab in the metabox)
* Add a text of 600 characters ( you can use [this generator](https://generator.lorem-ipsum.info/_japanese) and [this character counter](https://wordcounter.net/character-count) for this purpose)
* Don't add the keyphrase in the text or in the meta description
* Under the related keyphrase analysis, confirm that there is no `NaN`/`Infinity` result in the feedback strings:
   * The Keyphrase density assessment should return with:
      * bullet: red
      * feedback: `キーフレーズ密度: フォーカスキーフレーズが0回見つかりました。文字数に対するおすすめの最低数2回に足りません。キーフレーズにフォーカスしましょう !`
   * The Keyphrase in meta description assessment should return with:
      * bullet: red
      * feedback: `メタディスクリプション中のキーフレーズ: メタディスクリプションが設定されていますが、キーフレーズがありません。修正しましょう !`

**Test focus keyphrase**
* Add `小さい花の刺繍` as the focus keyphrase
* Add this sentence `小さくて可愛い花の刺繍に関する一般一般の記事です。` to your text and to your met description
* Under the focus keyphrase analysis, confirm that:
   * The Keyphrase density assessment should return with:
      * bullet: red
      * feedback: `キーフレーズ密度: フォーカスキーフレーズが1回見つかりました。文字数に対するおすすめの最低数2回に足りません。キーフレーズにフォーカスしましょう !` (there is one occurrence detected)
   * Click on the eye icon and make sure that the keyphrase is highlighted in the text
   * The Keyphrase in meta description assessment should return with:
      * bullet: green
      * feedback: `メタディスクリプション中のキーフレーズ: メタディスクリプション中にキーフレーズまたは同義語が含まれています。いいですね !`
* Change the focus keyphrase to `小さい 花 の 刺繍`
* Confirm that you still get the same results for both Keyphrase density and Keyphrase in meta description assessment 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* None

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1207
