### PR TITLE
QA-2712 Wincher: fix keyphrase limit message not being shown

### DIFF
--- a/packages/js/src/components/WincherKeyphrasesTable.js
+++ b/packages/js/src/components/WincherKeyphrasesTable.js
@@ -158,8 +158,8 @@ const WincherKeyphrasesTable = ( props ) => {
 				getTrackedKeyphrases();
 			},
 			( response ) => {
-				if ( response.status === 400 && response.results && response.results.canTrack === false ) {
-					setKeyphraseLimitReached( response.results.limit );
+				if ( response.status === 400 && response.limit ) {
+					setKeyphraseLimitReached( response.limit );
 				}
 				setRequestFailed( response );
 			},

--- a/src/actions/wincher/wincher-keyphrases-action.php
+++ b/src/actions/wincher/wincher-keyphrases-action.php
@@ -97,11 +97,7 @@ class Wincher_Keyphrases_Action {
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- To ensure JS code style, this can be ignored.
 			if ( ! $limits->canTrack || $this->would_exceed_limits( $keyphrases, $limits ) ) {
 				$response = [
-					'data'   => [
-						'limit'    => $limits->limit,
-						// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- To ensure JS code style, this can be ignored.
-						'canTrack' => $limits->canTrack,
-					],
+					'limit'  => $limits->limit,
 					'error'  => 'Account limit exceeded',
 					'status' => 400,
 				];

--- a/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
+++ b/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
@@ -164,10 +164,7 @@ class Wincher_Keyphrases_Action_Test extends TestCase {
 
 		$this->assertEquals(
 			(object) [
-				'results' => [
-					'limit'    => 1000,
-					'canTrack' => false,
-				],
+				'limit'   => 1000,
 				'error'   => 'Account limit exceeded',
 				'status'  => 400,
 			],
@@ -196,10 +193,7 @@ class Wincher_Keyphrases_Action_Test extends TestCase {
 
 		$this->assertEquals(
 			(object) [
-				'results' => [
-					'limit'    => 1000,
-					'canTrack' => true,
-				],
+				'limit'   => 1000,
 				'error'   => 'Account limit exceeded',
 				'status'  => 400,
 			],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Keyphrase limit message was not being shown correctly when trying to add multiple keyphrases at once.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes bug causing keyphrase limit message not to be shown correctly. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Connect Wincher free account with several keyphrases (for instance, 2 keyphrases)
2. Create a post and add 5 keyphrases to it (1 focus keyphrase and 4 related) that aren't already tracked
3. Publish the post
4. On the post publish screen click "Track all keyphrases on this page"
5. Ensure limit reached message is shown


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes QA-2712
