### PR TITLE
Fixes the assessment of short cornerstone content

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/readability/SubheadingDistributionTooLongAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SubheadingDistributionTooLongAssessmentSpec.js
@@ -273,11 +273,11 @@ describe( "Language-specific configuration for specific types of content is used
 	const longCornerstoneTextJapanese = "熱".repeat( 550 );
 
 	it( "should use a language-specific default configuration", function() {
-		const assessor = new SubheadingDistributionTooLong();
-		assessor.getLanguageSpecificConfig( japaneseResearcher );
-		expect( assessor._config.recommendedMaximumLength ).toEqual( japaneseConfig.defaultParameters.recommendedMaximumLength );
-		expect( assessor._config.slightlyTooMany ).toEqual( japaneseConfig.defaultParameters.slightlyTooMany );
-		expect( assessor._config.farTooMany ).toEqual( japaneseConfig.defaultParameters.farTooMany );
+		const assessment = new SubheadingDistributionTooLong();
+		assessment.getLanguageSpecificConfig( japaneseResearcher );
+		expect( assessment._config.recommendedMaximumLength ).toEqual( japaneseConfig.defaultParameters.recommendedMaximumLength );
+		expect( assessment._config.slightlyTooMany ).toEqual( japaneseConfig.defaultParameters.slightlyTooMany );
+		expect( assessment._config.farTooMany ).toEqual( japaneseConfig.defaultParameters.farTooMany );
 	} );
 
 	let cornerStoneContentAssessor = new CornerStoneContentAssessor( englishResearcher );

--- a/packages/yoastseo/src/languageProcessing/languages/ja/config/assessmentApplicabilityCharacterCount.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/config/assessmentApplicabilityCharacterCount.js
@@ -1,5 +1,4 @@
 export default {
-	subheadingDistribution: 600,
 	transitionWords: 400,
 	keyphraseDensity: 200,
 };

--- a/packages/yoastseo/src/languageProcessing/languages/ja/config/subheadingsTooLong.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/config/subheadingsTooLong.js
@@ -13,5 +13,6 @@ export default {
 			slightlyTooMany: 500,
 			farTooMany: 600,
 		},
+		applicableIfTextLongerThan: 500,
 	},
 };

--- a/packages/yoastseo/src/scoring/assessments/readability/SubheadingDistributionTooLongAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/SubheadingDistributionTooLongAssessment.js
@@ -57,7 +57,7 @@ class SubheadingsDistributionTooLong extends Assessment {
 	 */
 	getResult( paper, researcher ) {
 		this._subheadingTextsLength = researcher.getResearch( "getSubheadingTextLengths" );
-		if	( researcher.getConfig( "subheadingsTooLong" ) ) {
+		if ( researcher.getConfig( "subheadingsTooLong" ) ) {
 			this._config = this.getLanguageSpecificConfig( researcher );
 		}
 		const countTextInCharacters = researcher.getConfig( "countCharacters" );
@@ -121,12 +121,11 @@ class SubheadingsDistributionTooLong extends Assessment {
 		 * characters instead of words, which also makes the minimum required length higher).
 		**/
 		if ( this._config.shouldNotAppearInShortText ) {
-			const customCountLength = researcher.getHelper( "customCountLength" );
-			const customApplicabilityConfig = researcher.getConfig( "assessmentApplicability" ).subheadingDistribution;
-			if ( customApplicabilityConfig ) {
-				this._config.applicableIfTextLongerThan = customApplicabilityConfig;
+			if ( researcher.getConfig( "subheadingsTooLong" ) ) {
+				this._config = this.getLanguageSpecificConfig( researcher );
 			}
 
+			const customCountLength = researcher.getHelper( "customCountLength" );
 			const textLength = customCountLength ? customCountLength( paper.getText() ) : researcher.getResearch( "wordCountInText" );
 
 			return paper.hasText() && textLength > this._config.applicableIfTextLongerThan;

--- a/packages/yoastseo/src/scoring/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/cornerstone/contentAssessor.js
@@ -38,6 +38,7 @@ const CornerStoneContentAssessor = function( researcher, options = {} ) {
 				farTooMany: 300,
 				recommendedMaximumLength: 250,
 			},
+			applicableIfTextLongerThan: 250,
 			cornerstoneContent: true,
 		} ),
 		new ParagraphTooLong(),

--- a/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
+++ b/packages/yoastseo/src/scoring/productPages/cornerstone/contentAssessor.js
@@ -28,6 +28,7 @@ const ProductCornerstoneContentAssessor = function( researcher, options ) {
 				farTooMany: 300,
 				recommendedMaximumLength: 250,
 			},
+			applicableIfTextLongerThan: 250,
 			shouldNotAppearInShortText: true,
 			urlTitle: createAnchorOpeningTag( options.subheadingUrlTitle ),
 			urlCallToAction: createAnchorOpeningTag( options.subheadingCTAUrl ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Short cornerstone content was erroneously given a red bullet, because the parameter `applicableIfTextLongerThan` was not set. This parameter was introduced during development for Japanese support, but was only set for regular Japanese content. This PR sets the parameter `applicableIfTextLongerThan` for default cornerstone content, product cornerstone content, and Japanese cornerstone content. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Fixes the assessment of short cornerstone content.

## Relevant technical choices:

* We have removed the parameter`subheadingDistribution` from `packages/yoastseo/src/languageProcessing/languages/ja/config/assessmentApplicabilityCharacterCount.js`, as that had the same function as the parameter `applicableIfTextLongerThan`. By doing so, we create a single point of definition.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Note: use https://generator.lorem-ipsum.info/ for the generation of texts, in combination with https://wordcounter.net/character-count

### Cornerstone content

* Set the site language to English.
* Create a new post with 225 words.
* Set the post to be cornerstone content. 
* Confirm that the bullet for the subheading distribution assessment is green.
* Increase the length of the post to 275 words.
* Confirm that the bullet for the subheading distribution assessment is now red.
* Set the post to be non-cornerstone content.
* Confirm that the bullet for the subheading distribution assessment is now green again.
* Increase the length of the post to 325 words.
* Confirm that the bullet for the subheading distribution assessment is now red again.

### Product cornerstone content

* Open one of the other editors.
* Set the site language to English.
* Create a new product with 225 words.
* Set the post to be cornerstone content. 
* Confirm that the bullet for the subheading distribution assessment does not appear.
* Increase the length of the post to 275 words.
* Confirm that the bullet for the subheading distribution assessment is now red.
* Set the post to be non-cornerstone content.
* Confirm that the bullet for the subheading distribution assessment does not appear.
* Increase the length of the post to 325 words.
* Confirm that the bullet for the subheading distribution assessment is now red again.

### Japanese cornerstone content

* Set the site language to Japanese.
* Create a new post with 450 characters.
* Set the post to be cornerstone content. 
* Confirm that the bullet for the subheading distribution assessment is green.
* Increase the length of the post to 550 characters.
* Confirm that the bullet for the subheading distribution assessment is now red.
* Set the post to be non-cornerstone content.
* Confirm that the bullet for the subheading distribution assessment is now green again.
* Increase the length of the post to 650 characters.
* Confirm that the bullet for the subheading distribution assessment is now red again.

### Japanese product cornerstone content

* Set the site language to Japanese.
* Create a new post with 450 characters.
* Set the post to be cornerstone content. 
* Confirm that the bullet for the subheading distribution assessment does not appear.
* Increase the length of the post to 550 characters.
* Confirm that the bullet for the subheading distribution assessment is now red.
* Set the post to be non-cornerstone content.
* Confirm that the bullet for the subheading distribution assessment does not appear.
* Increase the length of the post to 650 characters.
* Confirm that the bullet for the subheading distribution assessment is now red again.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* None

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1206
