### PR TITLE
[QA-2716] Keep tracked keyphrases in Wincher table until untrack/reload

### DIFF
--- a/packages/js/src/redux/selectors/WincherSEOPerformance.js
+++ b/packages/js/src/redux/selectors/WincherSEOPerformance.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import { isEmpty, filter } from "lodash-es";
+import { isEmpty, filter, uniq } from "lodash-es";
 
 /* Internal dependencies */
 import getL10nObject from "../../analysis/getL10nObject";
@@ -48,13 +48,14 @@ export function hasWincherTrackedKeyphrases( state ) {
 export function getWincherTrackableKeyphrases( state ) {
 	const isPremium = getL10nObject().isPremium;
 	const premiumStore = window.wp.data.select( "yoast-seo-premium/editor" );
-	const keyphrases = [ state.focusKeyword.trim() ];
+	const tracked = Object.keys( getWincherTrackedKeyphrases( state ) || {} ).map( k => k.trim() );
+	const keyphrases = [ state.focusKeyword.trim(), ...tracked ];
 
 	if ( isPremium && premiumStore ) {
 		keyphrases.push( ...premiumStore.getKeywords().map( k => k.keyword.trim() ) );
 	}
 
-	return keyphrases.filter( k => !! k );
+	return uniq( keyphrases.filter( k => !! k ) ).sort();
 }
 
 /**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Keep tracked keyphrases in the Wincher table even if they are removed as focus or related keyphrase from Yoast. They should be visible until page reload or that they are untracked from Wincher via the table. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improve handling of keyphrases in Wincher so that removed keyphrases are kept in the Table until reload.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Connect Wincher
* Create post and add a focus keyphrase and a related keyphrase
* Open Wincher modal and track both keyphrase
* Close modal and remove the related keyphrase
* Open modal again and ensure that the related keyphrase is still visible in the Table and marked as tracked (green toggle)
* Untrack keyphrase
* Ensure that keyphrase is removed from Table


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
