### PR TITLE
Handle focus loss by disappearing button in ImageSelect

### DIFF
--- a/packages/components/src/image-select/ImageSelectButtons.js
+++ b/packages/components/src/image-select/ImageSelectButtons.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { NewButton as Button } from "../button";
 import { __ } from "@wordpress/i18n";
+import { useCallback } from "@wordpress/element";
 import PropTypes from "prop-types";
 
 /**
@@ -21,6 +22,11 @@ const ImageSelectButtons = ( props ) => {
 		isDisabled,
 	 } = props;
 
+	const removeImage = useCallback( () => {
+		document.getElementById( replaceImageButtonId ).focus();
+		onRemoveImageClick();
+	}, [ document, removeImageButtonId, onRemoveImageClick ] );
+
 	return (
 		<div className="yoast-image-select-buttons">
 			<Button
@@ -39,7 +45,7 @@ const ImageSelectButtons = ( props ) => {
 				imageSelected && <Button
 					variant="remove"
 					id={ removeImageButtonId }
-					onClick={ onRemoveImageClick }
+					onClick={ removeImage }
 					disabled={ isDisabled }
 				>
 					{ __( "Remove image", "wordpress-seo" ) }

--- a/packages/components/src/image-select/ImageSelectButtons.js
+++ b/packages/components/src/image-select/ImageSelectButtons.js
@@ -22,12 +22,10 @@ const ImageSelectButtons = ( props ) => {
 		isDisabled,
 	 } = props;
 
-	const removeImage = useCallback( () => {
-		if ( document.getElementById( replaceImageButtonId ) ) {
-			document.getElementById( replaceImageButtonId ).focus();
-		}
+	const removeImage = useCallback( ( event ) => {
+		event.target.previousElementSibling.focus();
 		onRemoveImageClick();
-	}, [ document, replaceImageButtonId, onRemoveImageClick ] );
+	}, [ onRemoveImageClick ] );
 
 	return (
 		<div className="yoast-image-select-buttons">

--- a/packages/components/src/image-select/ImageSelectButtons.js
+++ b/packages/components/src/image-select/ImageSelectButtons.js
@@ -23,9 +23,11 @@ const ImageSelectButtons = ( props ) => {
 	 } = props;
 
 	const removeImage = useCallback( () => {
-		document.getElementById( replaceImageButtonId ).focus();
+		if ( document.getElementById( replaceImageButtonId ) ) {
+			document.getElementById( replaceImageButtonId ).focus();
+		}
 		onRemoveImageClick();
-	}, [ document, removeImageButtonId, onRemoveImageClick ] );
+	}, [ document, replaceImageButtonId, onRemoveImageClick ] );
 
 	return (
 		<div className="yoast-image-select-buttons">


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Focus loss is confusing to visually impaired users.
* Clicking outside of one of our EditorModals after removing an image will not close the modal (you have to click the modal first and then click outside of it) because focus is elsewhere and the blur event does not get handled by the modal.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where removing an image from our Facebook Preview and Twitter Preview modals could lead to a confusing accessibility experience due to focus loss.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Before this change, (so on `trunk`) in our editor modals clicking the "remove image" button would cause a loss of focus.
* This was for example evident when removing an image, and clicking outside of the modal: it would not close.
* With this branch checked out and built, add an image to one of our Social Preview modals in the block editor).
* Remove the image. Click outside of the modal. The modal should close.
* Find other places where the image select is used (e.g. the admin, the configuration workout etc). and verify that it does not cause errors there.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* add an image to one of our Social Preview modals in the block editor).
* Remove the image. Click outside of the modal. The modal should close.
* Find other places where the image select is used (e.g. the admin, the configuration workout etc). and verify that it does not cause errors there.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-204
