### PR TITLE
QA-2722 Wincher: fix debounce not working in WincherKeyphrasesTable

### DIFF
--- a/packages/js/src/components/WincherKeyphrasesTable.js
+++ b/packages/js/src/components/WincherKeyphrasesTable.js
@@ -56,6 +56,10 @@ const usePrevious = ( value ) => {
 	return ref.current;
 };
 
+const debouncedGetKeyphrases = debounce( getKeyphrases, 500, {
+	leading: true,
+} );
+
 /**
  * The WincherKeyphrasesTable component.
  *
@@ -111,7 +115,7 @@ const WincherKeyphrasesTable = ( props ) => {
 	 *
 	 * @returns {void}
 	 */
-	const getTrackedKeyphrases = useMemo( () => debounce( async() => {
+	const getTrackedKeyphrases = useMemo( () => async() => {
 		await handleAPIResponse(
 			() => {
 				// Ensure that we're not waiting for multiple of these requests at once.
@@ -119,7 +123,7 @@ const WincherKeyphrasesTable = ( props ) => {
 					abortController.current.abort();
 				}
 				abortController.current = typeof AbortController === "undefined" ? null : new AbortController();
-				return getKeyphrases( keyphrases, permalink, abortController.current.signal );
+				return debouncedGetKeyphrases( keyphrases, permalink, abortController.current.signal );
 			},
 			( response ) => {
 				setRequestSucceeded( response );
@@ -129,7 +133,7 @@ const WincherKeyphrasesTable = ( props ) => {
 				setRequestFailed( response );
 			}
 		);
-	}, 300, { leading: true } ), [
+	}, [
 		setRequestSucceeded,
 		setRequestFailed,
 		setTrackedKeyphrases,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Bug causing request spam to Wincher endpoints.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes bug that caused spamming to Wincher API endpoints.

## Relevant technical choices:

* Kept "leading: true" - this will lead to one additional request when typing, but also faster loading when opening the metabox/modal. Think this is preferable for now.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Connect to Wincher
2. Open a post and open the Wincher tab in the metabox
3. Open the network tab of the development tools of your browser.
4. Start typing in the keyphrase field of the metabox.
5. Ensure that there is not a spam of POST requests as you're typing. There should be one request initially and then one when you're finished typing.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
