### PR TITLE
make a hard split between post and term logic

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -82,6 +82,7 @@ class WPSEO_Admin_Pages {
 
 		$script_data = [
 			'userLanguageCode' => WPSEO_Language_Utils::get_language( \get_user_locale() ),
+			'siteTimezone'     => \wp_timezone_string(),
 			'dismissedAlerts'  => $dismissed_alerts,
 		];
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -901,6 +901,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'media'            => [ 'choose_image' => __( 'Use Image', 'wordpress-seo' ) ],
 			'metabox'          => $this->get_metabox_script_data(),
 			'userLanguageCode' => WPSEO_Language_Utils::get_language( \get_user_locale() ),
+			'siteTimezone'     => \wp_timezone_string(),
 			'isPost'           => true,
 			'isBlockEditor'    => $is_block_editor,
 			'postStatus'       => get_post_status( $post_id ),

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -172,6 +172,7 @@ class WPSEO_Taxonomy {
 				],
 				'metabox'          => $this->localize_term_scraper_script(),
 				'userLanguageCode' => WPSEO_Language_Utils::get_language( \get_user_locale() ),
+				'siteTimezone'     => \wp_timezone_string(),
 				'isTerm'           => true,
 			];
 			$asset_manager->localize_script( $term_edit_handle, 'wpseoScriptData', $script_data );

--- a/packages/js/src/classic-editor.js
+++ b/packages/js/src/classic-editor.js
@@ -21,7 +21,7 @@ import { getAnalysisConfiguration } from "./classic-editor/analysis";
 import { refreshDelay } from "./analysis/constants";
 import { initTermDescriptionTinyMce } from "./initializers/tiny-mce";
 
-// These are either "1" or undefined
+// These are either "1" or undefined.
 const isPost = Boolean( get( window, "wpseoScriptData.isPost" ) );
 const isTerm = Boolean( get( window, "wpseoScriptData.isTerm" ) );
 
@@ -73,12 +73,12 @@ const registerYoastApis = ( { analysisWorker } ) => registerGlobalApis(
 const initPost = async () => {
 	// Register shortcodes to work on paper data.
 	registerShortcodes();
-	// Initialize the publish box
+	// Initialize the publish box.
 	initPublishBox();
 	// Create SEO integration with post state.
 	const { SeoProvider, analysisWorker } = await createSeoIntegration( {
 		analysis: getAnalysisConfiguration(),
-		initialState: getInitialPostState( { isPost, isTerm } ),
+		initialState: getInitialPostState(),
 	} );
 	// Register global Yoast APIs
 	registerYoastApis( { analysisWorker } );
@@ -94,7 +94,7 @@ const initPost = async () => {
  * @returns {void}
  */
 const initTerm = async () => {
-	// Initialize TinyMCE description editor for terms
+	// Initialize TinyMCE description editor for terms.
 	initTermDescriptionTinyMce( jQuery );
 	// Create SEO integration with term state.
 	const { SeoProvider, analysisWorker } = await createSeoIntegration( {

--- a/packages/js/src/classic-editor.js
+++ b/packages/js/src/classic-editor.js
@@ -80,7 +80,7 @@ const initPost = async () => {
 		analysis: getAnalysisConfiguration(),
 		initialState: getInitialPostState(),
 	} );
-	// Register global Yoast APIs
+	// Register global Yoast APIs.
 	registerYoastApis( { analysisWorker } );
 	// Start watching for DOM/store changes.
 	initPostWatcher();
@@ -101,7 +101,7 @@ const initTerm = async () => {
 		analysis: getAnalysisConfiguration(),
 		initialState: getInitialTermState(),
 	} );
-	// Register global Yoast APIs
+	// Register global Yoast APIs.
 	registerYoastApis( { analysisWorker } );
 	// Start watching for DOM/store changes.
 	initTermWatcher();

--- a/packages/js/src/classic-editor.js
+++ b/packages/js/src/classic-editor.js
@@ -1,5 +1,6 @@
-/* global wpseoScriptData wpseoPrimaryCategoryL10n */
+/* global wpseoPrimaryCategoryL10n */
 
+import { get, debounce } from "lodash";
 import domReady from "@wordpress/dom-ready";
 import { dispatch } from "@wordpress/data";
 import createSeoIntegration, { SEO_STORE_NAME } from "@yoast/seo-integration";
@@ -10,84 +11,125 @@ import initAdmin from "./initializers/admin";
 import initAdminMedia from "./initializers/admin-media";
 import initTabs from "./initializers/metabox-tabs";
 import initPrimaryCategory from "./initializers/primary-category";
+import { initialize as initPublishBox } from "./ui/publishBox";
 import initEditorStore from "./classic-editor/editor-store";
 import Metabox from "./classic-editor/components/metabox";
 import { MetaboxFill, MetaboxSlot } from "./classic-editor/components/metabox/slot-fill";
-import createClassicEditorWatcher from "./classic-editor/watcher";
-import { getInitialState } from "./classic-editor/initial-state";
+import { initPostWatcher, initTermWatcher } from "./classic-editor/watcher";
+import { getInitialPostState, getInitialTermState } from "./classic-editor/initial-state";
 import { getAnalysisConfiguration } from "./classic-editor/analysis";
 import { refreshDelay } from "./analysis/constants";
-import { debounce } from "lodash";
+import { initTermDescriptionTinyMce } from "./initializers/tiny-mce";
 
-const registerApis = registerGlobalApis( "YoastSEO" );
+// These are either "1" or undefined
+const isPost = Boolean( get( window, "wpseoScriptData.isPost" ) );
+const isTerm = Boolean( get( window, "wpseoScriptData.isTerm" ) );
+
+/**
+ * Renders the metabox React components.
+ *
+ * @param {Object} options Options object.
+ * @param {JSX.Element} options.SeoProvider SeoProvider component.
+ * @returns {void}
+ */
+const renderMetabox = ( { SeoProvider } ) => renderReactRoot( {
+	target: "wpseo-metabox-root",
+	children: (
+		<SeoProvider>
+			<MetaboxSlot />
+			<MetaboxFill>
+				<Metabox />
+			</MetaboxFill>
+		</SeoProvider>
+	),
+	theme: { isRtl: Boolean( get( window, "wpseoScriptData.metabox.isRtl", false ) ) },
+	location: "metabox",
+} );
+
+/**
+ * Registers Yoast API's on the global for backwards compatibility.
+ *
+ * @param {Object} options Options object.
+ * @param {JSX.Element} options.analysisWorker The ananlysis worker interface.
+ * @returns {void}
+ */
+const registerYoastApis = ( { analysisWorker } ) => registerGlobalApis(
+	"YoastSEO",
+	[
+		// YoastSEO._registerReactComponent: Render new components inside the React tree.
+		{ _registerReactComponent: registerReactComponent },
+		// YoastSEO.analysis.worker: access the analysis worker directly.
+		{ analysis: { worker: analysisWorker } },
+		// YoastSEO.app.refresh: refresh the analysis by dispatching the analyze action.
+		{ app: { refresh: debounce( dispatch( SEO_STORE_NAME ).analyze, refreshDelay ) } },
+	]
+);
+
+/**
+ * Initialize the post specific logic.
+ *
+ * @returns {void}
+ */
+const initPost = async () => {
+	// Register shortcodes to work on paper data.
+	registerShortcodes();
+	// Initialize the publish box
+	initPublishBox();
+	// Create SEO integration with post state.
+	const { SeoProvider, analysisWorker } = await createSeoIntegration( {
+		analysis: getAnalysisConfiguration(),
+		initialState: getInitialPostState( { isPost, isTerm } ),
+	} );
+	// Register global Yoast APIs
+	registerYoastApis( { analysisWorker } );
+	// Start watching for DOM/store changes.
+	initPostWatcher();
+	// Render metabox with provider.
+	renderMetabox( { SeoProvider } );
+};
+
+/**
+ * Initialize the term specific logic.
+ *
+ * @returns {void}
+ */
+const initTerm = async () => {
+	// Initialize TinyMCE description editor for terms
+	initTermDescriptionTinyMce( jQuery );
+	// Create SEO integration with term state.
+	const { SeoProvider, analysisWorker } = await createSeoIntegration( {
+		analysis: getAnalysisConfiguration(),
+		initialState: getInitialTermState(),
+	} );
+	// Register global Yoast APIs
+	registerYoastApis( { analysisWorker } );
+	// Start watching for DOM/store changes.
+	initTermWatcher();
+	// Render metabox with provider.
+	renderMetabox( { SeoProvider } );
+};
 
 domReady( async () => {
 	// Initialize the tab behavior of the metabox.
 	initTabs( jQuery );
-
 	// Initialize global admin scripts.
 	initAdmin( jQuery );
-
 	// Initialize the media library for our social settings.
 	initAdminMedia( jQuery );
-
+	// Until ALL the components are carried over, the `@yoast-seo/editor` store is still needed.
+	initEditorStore();
 	// Initialize the primary category integration.
 	if ( typeof wpseoPrimaryCategoryL10n !== "undefined" ) {
 		initPrimaryCategory( jQuery );
 	}
-
-	const { SeoProvider, analysisWorker } = await createSeoIntegration( {
-		analysis: getAnalysisConfiguration(),
-		initialState: getInitialState(),
-	} );
-
-	/*
-	 * Register the analysis worker on `window.YoastSEO.analysis.worker`
-	 * and refreshing the analysis on `window.YoastSEO.app.refresh`
-	 * for backwards compatibility with the add-ons.
-	 */
-	registerApis( [
-		{ analysis: { worker: analysisWorker } },
-		{
-			app: {
-				refresh: debounce( dispatch( SEO_STORE_NAME ).analyze, refreshDelay ),
-			},
-		},
-	] );
-
-	// Until ALL the components are carried over, the `@yoast-seo/editor` store is still needed.
-	initEditorStore();
-
-	// - expose global API (pluggable/see scrapers).
-	registerShortcodes();
-
-	// - create a SEO data watcher that updates our hidden fields so that the changed data is saved along with the WP save.
-	// - traffic light & admin bar: update analysis scores?
-
-	// Start watching and syncing between store and editor data.
-	const watcher = createClassicEditorWatcher();
-	watcher.watch();
-
-	// We have to do this differently: all the components are coupled to the store, which we are changing :)
-	// Responsibility:
-	// - render metabox
-	// - provide slot/fill mechanism
-	// Expose registerReactComponent as an alternative to registerPlugin.
-	registerApis( [ { _registerReactComponent: registerReactComponent } ] );
-
-	renderReactRoot( {
-		target: "wpseo-metabox-root",
-		children: (
-			<SeoProvider>
-				<MetaboxSlot />
-				<MetaboxFill>
-					<Metabox />
-				</MetaboxFill>
-			</SeoProvider>
-		),
-		theme: { isRtl: Boolean( wpseoScriptData.metabox.isRtl ) },
-		location: "metabox",
-	} );
-
+	// Initialize post logic if post page.
+	if ( isPost ) {
+		await initPost();
+	}
+	// Initialize term logic if term page.
+	if ( isTerm ) {
+		await initTerm();
+	}
+	// All systems go!
 	jQuery( window ).trigger( "YoastSEO:ready" );
 } );

--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -199,18 +199,18 @@ export const getPostMetaDescription = createGetDomElementProp( DOM_YOAST_IDS.POS
 export const getTermMetaDescription = createGetDomElementProp( DOM_YOAST_IDS.TERM_META_DESCRIPTION );
 
 /**
- * Gets the term focus keyphrase from the document.
+ * Gets whether the post is cornerstone content from the document.
  *
- * @returns {string} The term focus keyphrase or an empty string.
+ * @returns {boolean} Whether the post is cornerstone content.
  */
-export const getPostIsCornerstone = () => isEqual( "1", get( document.getElementById( DOM_YOAST_IDS.POST_IS_CORNERSTONE ), "value", "0" ) );
+export const getPostIsCornerstone = () => isEqual( get( document.getElementById( DOM_YOAST_IDS.POST_IS_CORNERSTONE ), "value", "0" ), "1" );
 
 /**
- * Gets the term focus keyphrase from the document.
+ * Gets whether the term is cornerstone content from the document.
  *
- * @returns {string} The term focus keyphrase or an empty string.
+ * @returns {boolean} Whether the term is cornerstone content.
  */
-export const getTermIsCornerstone = () => isEqual( "1", get( document.getElementById( DOM_YOAST_IDS.TERM_IS_CORNERSTONE ), "value", "0" ) );
+export const getTermIsCornerstone = () => isEqual( get( document.getElementById( DOM_YOAST_IDS.TERM_IS_CORNERSTONE ), "value", "0" ), "1" );
 
 /**
  * Gets the post slug from the document.

--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -5,7 +5,7 @@ import { excerptFromContent } from "../../helpers/replacementVariableHelpers";
 import firstImageUrlInContent from "../../helpers/firstImageUrlInContent";
 
 export const DOM_IDS = {
-	// Post editor
+	// Post editor.
 	POST_TITLE: "title",
 	POST_CONTENT: "content",
 	POST_EXCERPT: "excerpt",
@@ -18,7 +18,7 @@ export const DOM_IDS = {
 	POST_DATE_YEAR: "aa",
 	POST_DATE_HOUR: "hh",
 	POST_DATE_MINUTE: "mn",
-	// Term editor
+	// Term editor.
 	TERM_NAME: "name",
 	TERM_DESCRIPTION: "description",
 	TERM_SLUG: "slug",
@@ -32,14 +32,14 @@ export const DOM_QUERIES = {
 };
 
 export const DOM_YOAST_IDS = {
-	// Post
+	// Post.
 	POST_SEO_TITLE: "yoast_wpseo_title",
 	POST_META_DESCRIPTION: "yoast_wpseo_metadesc",
 	POST_FOCUS_KEYPHRASE: "yoast_wpseo_focuskw",
 	POST_IS_CORNERSTONE: "yoast_wpseo_is_cornerstone",
 	POST_SEO_SCORE: "yoast_wpseo_linkdex",
 	POST_READABILITY_SCORE: "yoast_wpseo_content_score",
-	// Term
+	// Term.
 	TERM_SEO_TITLE: "hidden_wpseo_title",
 	TERM_META_DESCRIPTION: "hidden_wpseo_desc",
 	TERM_FOCUS_KEYPHRASE: "hidden_wpseo_focuskw",
@@ -260,7 +260,7 @@ export const getPostReadabilityScore = createGetDomElementProp( DOM_YOAST_IDS.PO
 export const getTermReadabilityScore = createGetDomElementProp( DOM_YOAST_IDS.TERM_READABILITY_SCORE );
 
 /**
- * Set the post SEO title value prop on its DOM element.
+ * Sets the post SEO title value prop on its DOM element.
  *
  * @param {*} value The value to set.
  * @returns {HTMLElement} The DOM element.
@@ -268,7 +268,7 @@ export const getTermReadabilityScore = createGetDomElementProp( DOM_YOAST_IDS.TE
 export const setPostSeoTitle = createSetDomElementProp( DOM_YOAST_IDS.POST_SEO_TITLE );
 
 /**
- * Set the term SEO title value prop on its DOM element.
+ * Sets the term SEO title value prop on its DOM element.
  *
  * @param {*} value The value to set.
  * @returns {HTMLElement} The DOM element.
@@ -276,7 +276,7 @@ export const setPostSeoTitle = createSetDomElementProp( DOM_YOAST_IDS.POST_SEO_T
 export const setTermSeoTitle = createSetDomElementProp( DOM_YOAST_IDS.TERM_SEO_TITLE );
 
 /**
-  * Set the post meta description value prop on its DOM element.
+  * Sets the post meta description value prop on its DOM element.
   *
   * @param {*} value The value to set.
   * @returns {HTMLElement} The DOM element.
@@ -284,7 +284,7 @@ export const setTermSeoTitle = createSetDomElementProp( DOM_YOAST_IDS.TERM_SEO_T
 export const setPostMetaDescription = createSetDomElementProp( DOM_YOAST_IDS.POST_META_DESCRIPTION );
 
 /**
-  * Set the term meta description value prop on its DOM element.
+  * Sets the term meta description value prop on its DOM element.
   *
   * @param {*} value The value to set.
   * @returns {HTMLElement} The DOM element.
@@ -292,7 +292,7 @@ export const setPostMetaDescription = createSetDomElementProp( DOM_YOAST_IDS.POS
 export const setTermMetaDescription = createSetDomElementProp( DOM_YOAST_IDS.TERM_META_DESCRIPTION );
 
 /**
-  * Set the post is cornerstone value prop on its DOM element.
+  * Sets the post is cornerstone value prop on its DOM element.
   *
   * @param {boolean} value The value to set.
   * @returns {HTMLElement} The DOM element.
@@ -300,7 +300,7 @@ export const setTermMetaDescription = createSetDomElementProp( DOM_YOAST_IDS.TER
 export const setPostIsCornerstone = ( value ) => set( document.getElementById( DOM_YOAST_IDS.POST_IS_CORNERSTONE ), "value", value ? 1 : 0 );
 
 /**
-  * Set the term is cornerstone value prop on its DOM element.
+  * Sets the term is cornerstone value prop on its DOM element.
   *
   * @param {boolean} value The value to set.
   * @returns {HTMLElement} The DOM element.
@@ -308,7 +308,7 @@ export const setPostIsCornerstone = ( value ) => set( document.getElementById( D
 export const setTermIsCornerstone = ( value ) => set( document.getElementById( DOM_YOAST_IDS.TERM_IS_CORNERSTONE ), "value", value ? 1 : 0 );
 
 /**
-  * Set the post focus keyphrase value prop on its DOM element.
+  * Sets the post focus keyphrase value prop on its DOM element.
   *
   * @param {boolean} value The value to set.
   * @returns {HTMLElement} The DOM element.
@@ -316,7 +316,7 @@ export const setTermIsCornerstone = ( value ) => set( document.getElementById( D
 export const setPostFocusKeyphrase = createSetDomElementProp( DOM_YOAST_IDS.POST_FOCUS_KEYPHRASE );
 
 /**
-  * Set the term focus keyphrase value prop on its DOM element.
+  * Sets the term focus keyphrase value prop on its DOM element.
   *
   * @param {boolean} value The value to set.
   * @returns {HTMLElement} The DOM element.
@@ -324,7 +324,7 @@ export const setPostFocusKeyphrase = createSetDomElementProp( DOM_YOAST_IDS.POST
 export const setTermFocusKeyphrase = createSetDomElementProp( DOM_YOAST_IDS.TERM_FOCUS_KEYPHRASE );
 
 /**
-  * Set the post SEO score value prop on its DOM element.
+  * Sets the post SEO score value prop on its DOM element.
   *
   * @param {boolean} value The value to set.
   * @returns {HTMLElement} The DOM element.
@@ -332,7 +332,7 @@ export const setTermFocusKeyphrase = createSetDomElementProp( DOM_YOAST_IDS.TERM
 export const setPostSeoScore = createSetDomElementProp( DOM_YOAST_IDS.POST_SEO_SCORE );
 
 /**
-  * Set the term SEO score value prop on its DOM element.
+  * Sets the term SEO score value prop on its DOM element.
   *
   * @param {boolean} value The value to set.
   * @returns {HTMLElement} The DOM element.
@@ -340,7 +340,7 @@ export const setPostSeoScore = createSetDomElementProp( DOM_YOAST_IDS.POST_SEO_S
 export const setTermSeoScore = createSetDomElementProp( DOM_YOAST_IDS.TERM_SEO_SCORE );
 
 /**
-  * Set the post readability score value prop on its DOM element.
+  * Sets the post readability score value prop on its DOM element.
   *
   * @param {boolean} value The value to set.
   * @returns {HTMLElement} The DOM element.
@@ -348,7 +348,7 @@ export const setTermSeoScore = createSetDomElementProp( DOM_YOAST_IDS.TERM_SEO_S
 export const setPostReadabilityScore = createSetDomElementProp( DOM_YOAST_IDS.POST_READABILITY_SCORE );
 
 /**
-  * Set the term readability score value prop on its DOM element.
+  * Sets the term readability score value prop on its DOM element.
   *
   * @param {boolean} value The value to set.
   * @returns {HTMLElement} The DOM element.

--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -5,173 +5,352 @@ import { excerptFromContent } from "../../helpers/replacementVariableHelpers";
 import firstImageUrlInContent from "../../helpers/firstImageUrlInContent";
 
 export const DOM_IDS = {
-	TITLE: "title",
-	CONTENT: "content",
-	CONTENT_TERM: "description",
-	EXCERPT: "excerpt",
-	PERMALINK: "sample-permalink",
-	FEATURED_IMAGE_ID: "_thumbnail_id",
-	SLUG: "slug",
-	SLUG_NEW_POST: "new-post-slug",
-	SLUG_EDIT_POST: "editable-post-name-full",
-	DATE_MONTH: "mm",
-	DATE_DAY: "jj",
-	DATE_YEAR: "aa",
-	DATE_HOUR: "hh",
-	DATE_MINUTE: "mn",
+	// Post editor
+	POST_TITLE: "title",
+	POST_CONTENT: "content",
+	POST_EXCERPT: "excerpt",
+	POST_PERMALINK: "sample-permalink",
+	POST_FEATURED_IMAGE_ID: "_thumbnail_id",
+	POST_SLUG_NEW: "new-post-slug",
+	POST_SLUG_EDIT: "editable-post-name-full",
+	POST_DATE_MONTH: "mm",
+	POST_DATE_DAY: "jj",
+	POST_DATE_YEAR: "aa",
+	POST_DATE_HOUR: "hh",
+	POST_DATE_MINUTE: "mn",
+	// Term editor
+	TERM_NAME: "name",
+	TERM_DESCRIPTION: "description",
+	TERM_SLUG: "slug",
 };
 
 export const DOM_QUERIES = {
-	EDIT_SLUG_BUTTON: "#edit-slug-buttons .edit-slug",
-	SAVE_SLUG_BUTTON: "#edit-slug-buttons .save",
-	CANCEL_SLUG_BUTTON: "#edit-slug-buttons .cancel",
+	POST_EDIT_SLUG_BUTTON: "#edit-slug-buttons .edit-slug",
+	POST_SAVE_SLUG_BUTTON: "#edit-slug-buttons .save",
+	POST_CANCEL_SLUG_BUTTON: "#edit-slug-buttons .cancel",
+	POST_FEATURED_IMAGE: "#set-post-thumbnail img",
 };
 
 export const DOM_YOAST_IDS = {
-	SEO_TITLE: "yoast_wpseo_title",
-	META_DESCRIPTION: "yoast_wpseo_metadesc",
-	FOCUS_KEYPHRASE: "yoast_wpseo_focuskw",
-	IS_CORNERSTONE: "yoast_wpseo_is_cornerstone",
+	// Post
+	POST_SEO_TITLE: "yoast_wpseo_title",
+	POST_META_DESCRIPTION: "yoast_wpseo_metadesc",
+	POST_FOCUS_KEYPHRASE: "yoast_wpseo_focuskw",
+	POST_IS_CORNERSTONE: "yoast_wpseo_is_cornerstone",
+	POST_SEO_SCORE: "yoast_wpseo_linkdex",
+	POST_READABILITY_SCORE: "yoast_wpseo_content_score",
+	// Term
+	TERM_SEO_TITLE: "hidden_wpseo_title",
+	TERM_META_DESCRIPTION: "hidden_wpseo_desc",
+	TERM_FOCUS_KEYPHRASE: "hidden_wpseo_focuskw",
+	TERM_IS_CORNERSTONE: "hidden_wpseo_is_cornerstone",
+	TERM_SEO_SCORE: "hidden_wpseo_linkdex",
+	TERM_READABILITY_SCORE: "hidden_wpseo_content_score",
 };
 
 /**
- * Gets the title from the document.
+ * Create a function that gets a prop from a DOM element.
  *
- * @returns {string} The 	title or an empty string.
+ * @param {string} domId Id of DOM element.
+ * @param {string} [prop] Name of the prop to get. Defaults to value prop.
+ * @param {*} [defaultValue] Default to return if prop is not found. Default to empty string.
+ * @returns {Function} Function that gets prop from DOM element.
  */
-export const getTitle = () => get( document.getElementById( DOM_IDS.TITLE ), "value", "" );
+const createGetDomElementProp = ( domId, prop = "value", defaultValue = "" ) => () => get( document.getElementById( domId ), prop, defaultValue );
 
 /**
- * Gets the content from the document.
+ * Create a function that gets a prop from a DOM element.
  *
- * @returns {string} The content or an empty string.
+ * @param {string} domId Id of DOM element.
+ * @param {string} [prop] Name of the prop to set. Defaults to value prop.
+ * @returns {Function} Function that sets value on DOM element prop.
  */
-export const getContent = () => getContentTinyMce( DOM_IDS.CONTENT ) || getContentTinyMce( DOM_IDS.CONTENT_TERM ) || "";
+const createSetDomElementProp = ( domId, prop = "value" ) => ( value ) => set( document.getElementById( domId ), prop, value );
 
 /**
- * Gets the date month from the document.
+ * Gets the post title from the document.
  *
- * @returns {string} The date month or an empty string.
+ * @returns {string} The post title or an empty string.
  */
-export const getDateMonth = () => get( document.getElementById( DOM_IDS.DATE_MONTH ), "value", "" );
+export const getPostTitle = createGetDomElementProp( DOM_IDS.POST_TITLE );
 
 /**
- * Gets the date day from the document.
+ * Gets the term name from the document.
  *
- * @returns {string} The date day or an empty string.
+ * @returns {string} The term name or an empty string.
  */
-export const getDateDay = () => get( document.getElementById( DOM_IDS.DATE_DAY ), "value", "" );
+export const getTermName = createGetDomElementProp( DOM_IDS.TERM_NAME );
 
 /**
- * Gets the date year from the document.
+ * Gets the post content from the document.
  *
- * @returns {string} The date year or an empty string.
+ * @returns {string} The post content or an empty string.
  */
-export const getDateYear = () => get( document.getElementById( DOM_IDS.DATE_YEAR ), "value", "" );
+export const getPostContent = () => getContentTinyMce( DOM_IDS.POST_CONTENT ) || "";
 
 /**
- * Gets the date from the document.
+ * Gets the term description from the document.
  *
- * @returns {string} The date or an empty string.
+ * @returns {string} The term description or an empty string.
  */
-export const getDate = () => `${ getDateYear() }-${ getDateMonth() }-${ getDateDay() }`;
+export const getTermDescription = () => getContentTinyMce( DOM_IDS.TERM_DESCRIPTION ) || "";
 
 /**
- * Gets the meta description from the document.
+ * Gets the post date month from the document.
  *
- * @returns {string} The meta description or an empty string.
+ * @returns {string} The post date month or an empty string.
  */
-export const getMetaDescription = () => get( document.getElementById( DOM_YOAST_IDS.META_DESCRIPTION ), "value", "" );
+export const getPostDateMonth = createGetDomElementProp( DOM_IDS.POST_DATE_MONTH );
 
 /**
- * Gets the SEO title from the document.
+ * Gets the post date day from the document.
  *
- * @returns {string} The SEO title or an empty string.
+ * @returns {string} The post date day or an empty string.
  */
-export const getSeoTitle = () => get( document.getElementById( DOM_YOAST_IDS.SEO_TITLE ), "value", "" );
-
-
-/**
- * Gets the focus keyphrase from the document.
- *
- * @returns {string} The focus keyphrase or an empty string.
- */
-export const getIsCornerstone = () => isEqual( "1", get( document.getElementById( DOM_YOAST_IDS.IS_CORNERSTONE ), "value", "0" ) );
+export const getPostDateDay = createGetDomElementProp( DOM_IDS.POST_DATE_DAY );
 
 /**
- * Gets the slug from the document.
+ * Gets the post date year from the document.
  *
- * @returns {string} The slug or an empty string.
+ * @returns {string} The post date year or an empty string.
  */
-export const getSlug = () => (
-	get( document.getElementById( DOM_IDS.SLUG_NEW_POST ), "value" ) ||
-	get( document.getElementById( DOM_IDS.SLUG_EDIT_POST ), "textContent" ) ||
-	get( document.getElementById( DOM_IDS.SLUG ), "value", "" )
+export const getPostDateYear = createGetDomElementProp( DOM_IDS.POST_DATE_YEAR );
+
+/**
+ * Gets the post date from the document.
+ *
+ * @returns {string} The post date or an empty string.
+ */
+export const getPostDate = () => `${ getPostDateYear() }-${ getPostDateMonth() }-${ getPostDateDay() }`;
+
+/**
+ * Gets the post SEO title from the document.
+ *
+ * @returns {string} The post SEO title or an empty string.
+ */
+export const getPostSeoTitle = createGetDomElementProp( DOM_YOAST_IDS.POST_SEO_TITLE );
+
+/**
+ * Gets the term SEO title from the document.
+ *
+ * @returns {string} The term SEO title or an empty string.
+ */
+export const getTermSeoTitle = createGetDomElementProp( DOM_YOAST_IDS.TERM_SEO_TITLE );
+
+/**
+ * Gets the post meta description from the document.
+ *
+ * @returns {string} The post meta description or an empty string.
+ */
+export const getPostMetaDescription = createGetDomElementProp( DOM_YOAST_IDS.POST_META_DESCRIPTION );
+
+/**
+ * Gets the term meta description from the document.
+ *
+ * @returns {string} The term meta description or an empty string.
+ */
+export const getTermMetaDescription = createGetDomElementProp( DOM_YOAST_IDS.TERM_META_DESCRIPTION );
+
+/**
+ * Gets the term focus keyphrase from the document.
+ *
+ * @returns {string} The term focus keyphrase or an empty string.
+ */
+export const getPostIsCornerstone = () => isEqual( "1", get( document.getElementById( DOM_YOAST_IDS.POST_IS_CORNERSTONE ), "value", "0" ) );
+
+/**
+ * Gets the term focus keyphrase from the document.
+ *
+ * @returns {string} The term focus keyphrase or an empty string.
+ */
+export const getTermIsCornerstone = () => isEqual( "1", get( document.getElementById( DOM_YOAST_IDS.TERM_IS_CORNERSTONE ), "value", "0" ) );
+
+/**
+ * Gets the post slug from the document.
+ *
+ * @returns {string} The post slug or an empty string.
+ */
+export const getPostSlug = () => (
+	get( document.getElementById( DOM_IDS.POST_SLUG_NEW ), "value" ) ||
+	get( document.getElementById( DOM_IDS.POST_SLUG_EDIT ), "textContent" )
 );
 
 /**
- * Gets the permalink from the document.
+ * Gets the term slug from the document.
  *
- * @returns {string} The permalink or an empty string.
+ * @returns {string} The term slug or an empty string.
  */
-export const getPermalink = () => get( window, "wpseoScriptData.metabox.base_url", "" ) + getSlug();
+export const getTermSlug = createGetDomElementProp( DOM_IDS.TERM_SLUG );
 
 /**
- * Gets the excerpt from the document.
+ * Gets the post permalink from the document.
  *
- * @returns {string} The excerpt or an empty string.
+ * @returns {string} The post permalink or an empty string.
  */
-export const getExcerpt = () => get( document.getElementById( DOM_IDS.EXCERPT ), "value", "" ) || excerptFromContent( getContent() );
+export const getPostPermalink = () => get( window, "wpseoScriptData.metabox.base_url", "" ) + getPostSlug();
 
 /**
- * Returns the featured image source if one is set.
+ * Gets the term permalink from the document.
  *
- * @returns {string} The source of the featured image.
+ * @returns {string} The term permalink or an empty string.
  */
-const getFeaturedImageSetInEditor = () => document.querySelector( DOM_QUERIES.FEATURED_IMAGE )?.getAttribute( "src" ) || "";
+export const getTermPermalink = () => get( window, "wpseoScriptData.metabox.base_url", "" ) + getTermSlug();
+
+/**
+ * Gets the post excerpt from the document.
+ *
+ * @returns {string} The post excerpt or an empty string.
+ */
+export const getPostExcerpt = () => get( document.getElementById( DOM_IDS.POST_EXCERPT ), "value", "" ) || excerptFromContent( getPostContent() );
+
+/**
+ * Returns the post featured image source if one is set.
+ *
+ * @returns {string} The source of the post featured image.
+ */
+const getPostFeaturedImageSetInEditor = () => document.querySelector( DOM_QUERIES.POST_FEATURED_IMAGE )?.getAttribute( "src" );
 
 /**
  * Gets the featured image if one is set. Falls back to the first image from the content.
  *
  * @returns {string} The featured image URL.
  */
-export const getFeaturedImageUrl = () => getFeaturedImageSetInEditor() || firstImageUrlInContent( getContent() ) || "";
+export const getPostFeaturedImageUrl = () => getPostFeaturedImageSetInEditor() || firstImageUrlInContent( getPostContent() ) || "";
 
 /**
- * Gets the focus keyphrase from the document.
+ * Gets the post focus keyphrase from the document.
  *
- * @returns {string} The focus keyphrase or an empty string.
+ * @returns {string} The post focus keyphrase or an empty string.
  */
-export const getFocusKeyphrase = () => get( document.getElementById( DOM_YOAST_IDS.FOCUS_KEYPHRASE ), "value", "" );
+export const getPostFocusKeyphrase = createGetDomElementProp( DOM_YOAST_IDS.POST_FOCUS_KEYPHRASE );
 
 /**
- * Set the SEO title value prop on its DOM element.
+ * Gets the term focus keyphrase from the document.
+ *
+ * @returns {string} The term focus keyphrase or an empty string.
+ */
+export const getTermFocusKeyphrase = createGetDomElementProp( DOM_YOAST_IDS.TERM_FOCUS_KEYPHRASE );
+
+/**
+ * Gets the post SEO score from the document.
+ *
+ * @returns {string} The post SEO score or an empty string.
+ */
+export const getPostSeoScore = createGetDomElementProp( DOM_YOAST_IDS.POST_SEO_SCORE );
+
+/**
+ * Gets the term SEO score from the document.
+ *
+ * @returns {string} The term SEO score or an empty string.
+ */
+export const getTermSeoScore = createGetDomElementProp( DOM_YOAST_IDS.TERM_SEO_SCORE );
+
+/**
+ * Gets the post readability score from the document.
+ *
+ * @returns {string} The post readability score or an empty string.
+ */
+export const getPostReadabilityScore = createGetDomElementProp( DOM_YOAST_IDS.POST_READABILITY_SCORE );
+
+/**
+ * Gets the term readability score from the document.
+ *
+ * @returns {string} The term readability score or an empty string.
+ */
+export const getTermReadabilityScore = createGetDomElementProp( DOM_YOAST_IDS.TERM_READABILITY_SCORE );
+
+/**
+ * Set the post SEO title value prop on its DOM element.
  *
  * @param {*} value The value to set.
  * @returns {HTMLElement} The DOM element.
  */
-export const setSeoTitle = ( value ) => set( document.getElementById( DOM_YOAST_IDS.SEO_TITLE ), "value", value );
+export const setPostSeoTitle = createSetDomElementProp( DOM_YOAST_IDS.POST_SEO_TITLE );
 
 /**
-  * Set the meta description value prop on its DOM element.
+ * Set the term SEO title value prop on its DOM element.
+ *
+ * @param {*} value The value to set.
+ * @returns {HTMLElement} The DOM element.
+ */
+export const setTermSeoTitle = createSetDomElementProp( DOM_YOAST_IDS.TERM_SEO_TITLE );
+
+/**
+  * Set the post meta description value prop on its DOM element.
   *
   * @param {*} value The value to set.
   * @returns {HTMLElement} The DOM element.
   */
-export const setMetaDescription = ( value ) => set( document.getElementById( DOM_YOAST_IDS.META_DESCRIPTION ), "value", value );
+export const setPostMetaDescription = createSetDomElementProp( DOM_YOAST_IDS.POST_META_DESCRIPTION );
 
 /**
-  * Set the is cornerstone value prop on its DOM element.
+  * Set the term meta description value prop on its DOM element.
+  *
+  * @param {*} value The value to set.
+  * @returns {HTMLElement} The DOM element.
+  */
+export const setTermMetaDescription = createSetDomElementProp( DOM_YOAST_IDS.TERM_META_DESCRIPTION );
+
+/**
+  * Set the post is cornerstone value prop on its DOM element.
   *
   * @param {boolean} value The value to set.
   * @returns {HTMLElement} The DOM element.
   */
-export const setIsCornerstone = ( value ) => set( document.getElementById( DOM_YOAST_IDS.IS_CORNERSTONE ), "value", value ? 1 : 0 );
+export const setPostIsCornerstone = ( value ) => set( document.getElementById( DOM_YOAST_IDS.POST_IS_CORNERSTONE ), "value", value ? 1 : 0 );
 
 /**
-  * Set the focus keyphrase value prop on its DOM element.
+  * Set the term is cornerstone value prop on its DOM element.
   *
   * @param {boolean} value The value to set.
   * @returns {HTMLElement} The DOM element.
   */
-export const setFocusKeyphrase = ( value ) => set( document.getElementById( DOM_YOAST_IDS.FOCUS_KEYPHRASE ), "value", value );
+export const setTermIsCornerstone = ( value ) => set( document.getElementById( DOM_YOAST_IDS.TERM_IS_CORNERSTONE ), "value", value ? 1 : 0 );
+
+/**
+  * Set the post focus keyphrase value prop on its DOM element.
+  *
+  * @param {boolean} value The value to set.
+  * @returns {HTMLElement} The DOM element.
+  */
+export const setPostFocusKeyphrase = createSetDomElementProp( DOM_YOAST_IDS.POST_FOCUS_KEYPHRASE );
+
+/**
+  * Set the term focus keyphrase value prop on its DOM element.
+  *
+  * @param {boolean} value The value to set.
+  * @returns {HTMLElement} The DOM element.
+  */
+export const setTermFocusKeyphrase = createSetDomElementProp( DOM_YOAST_IDS.TERM_FOCUS_KEYPHRASE );
+
+/**
+  * Set the post SEO score value prop on its DOM element.
+  *
+  * @param {boolean} value The value to set.
+  * @returns {HTMLElement} The DOM element.
+  */
+export const setPostSeoScore = createSetDomElementProp( DOM_YOAST_IDS.POST_SEO_SCORE );
+
+/**
+  * Set the term SEO score value prop on its DOM element.
+  *
+  * @param {boolean} value The value to set.
+  * @returns {HTMLElement} The DOM element.
+  */
+export const setTermSeoScore = createSetDomElementProp( DOM_YOAST_IDS.TERM_SEO_SCORE );
+
+/**
+  * Set the post readability score value prop on its DOM element.
+  *
+  * @param {boolean} value The value to set.
+  * @returns {HTMLElement} The DOM element.
+  */
+export const setPostReadabilityScore = createSetDomElementProp( DOM_YOAST_IDS.POST_READABILITY_SCORE );
+
+/**
+  * Set the term readability score value prop on its DOM element.
+  *
+  * @param {boolean} value The value to set.
+  * @returns {HTMLElement} The DOM element.
+  */
+export const setTermReadabilityScore = createSetDomElementProp( DOM_YOAST_IDS.TERM_READABILITY_SCORE );

--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -77,7 +77,7 @@ const createSetDomElementProp = ( domId, prop = "value" ) => ( value ) => set( d
  * @param {Function} fn The function that should return a value.
  * @returns {Function} Function that wraps the fn and parses the return value to an integer.
  */
-const createAsInteger = fn => flow( [ fn, parseInt ] );
+const createAsInteger = ( fn ) => flow( [ fn, parseInt ] );
 
 /**
  * Gets the post title from the document.
@@ -213,14 +213,25 @@ export const getPostIsCornerstone = () => isEqual( get( document.getElementById(
 export const getTermIsCornerstone = () => isEqual( get( document.getElementById( DOM_YOAST_IDS.TERM_IS_CORNERSTONE ), "value", "0" ), "1" );
 
 /**
+ * Gets the post edit slug from the document.
+ *
+ * @returns {string} The post edit slug or an empty string.
+ */
+export const getPostNewSlug = () => get( document.getElementById( DOM_IDS.POST_SLUG_NEW ), "value" );
+
+/**
+ * Gets the post edit slug from the document.
+ *
+ * @returns {string} The post edit slug or an empty string.
+ */
+export const getPostEditSlug = () => get( document.getElementById( DOM_IDS.POST_SLUG_EDIT ), "textContent" );
+
+/**
  * Gets the post slug from the document.
  *
  * @returns {string} The post slug or an empty string.
  */
-export const getPostSlug = () => (
-	get( document.getElementById( DOM_IDS.POST_SLUG_NEW ), "value" ) ||
-	get( document.getElementById( DOM_IDS.POST_SLUG_EDIT ), "textContent" )
-);
+export const getPostSlug = () => getPostNewSlug() || getPostEditSlug();
 
 /**
  * Gets the term slug from the document.

--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -69,6 +69,14 @@ const createGetDomElementProp = ( domId, prop = "value", defaultValue = "" ) => 
 const createSetDomElementProp = ( domId, prop = "value" ) => ( value ) => set( document.getElementById( domId ), prop, value );
 
 /**
+ * Create a function that parses the return value of function to an integer.
+ *
+ * @param {Function} fn The function that should return a value.
+ * @returns {Function} Function that wraps the fn and parses the return value to an integer.
+ */
+const createAsInteger = fn => flow( [ fn, parseInt ] );
+
+/**
  * Gets the post title from the document.
  *
  * @returns {string} The post title or an empty string.
@@ -216,27 +224,25 @@ const getPostFeaturedImageUrl = () => document.querySelector( DOM_QUERIES.POST_F
  *
  * @returns {number} The featured image ID or -1, or NaN if parsing to a number went wrong.
  */
-const getPostFeaturedImageId = flow( [ createGetDomElementProp( DOM_IDS.POST_FEATURED_IMAGE_ID ), parseInt ] );
+const getPostFeaturedImageId = createAsInteger( createGetDomElementProp( DOM_IDS.POST_FEATURED_IMAGE_ID ) );
 
 /**
  * Gets the post featured image width if one is set.
  *
  * @returns {number} The featured image width or -1, or NaN if parsing to a number went wrong.
  */
-const getPostFeaturedImageWidth = flow( [
-	() => document.querySelector( DOM_QUERIES.POST_FEATURED_IMAGE )?.getAttribute( "width" ) || "-1",
-	parseInt,
-] );
+const getPostFeaturedImageWidth = createAsInteger(
+	() => document.querySelector( DOM_QUERIES.POST_FEATURED_IMAGE )?.getAttribute( "width" ) || "-1"
+);
 
 /**
  * Gets the post featured image height if one is set.
  *
  * @returns {number} The featured image height or -1, or NaN if parsing to a number went wrong.
  */
-const getPostFeaturedImageHeight = flow( [
-	() => document.querySelector( DOM_QUERIES.POST_FEATURED_IMAGE )?.getAttribute( "height" ) || "-1",
-	parseInt,
-] );
+const getPostFeaturedImageHeight = createAsInteger(
+	() => document.querySelector( DOM_QUERIES.POST_FEATURED_IMAGE )?.getAttribute( "height" ) || "-1"
+);
 
 /**
  * Gets the post featured image alt if one is set.

--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -13,6 +13,7 @@ export const DOM_IDS = {
 	POST_FEATURED_IMAGE_REMOVE: "remove-post-thumbnail",
 	POST_SLUG_NEW: "new-post-slug",
 	POST_SLUG_EDIT: "editable-post-name-full",
+	POST_SLUG_EDIT_PARENT: "edit-slug-box",
 	POST_DATE_MONTH: "mm",
 	POST_DATE_DAY: "jj",
 	POST_DATE_YEAR: "aa",
@@ -25,12 +26,13 @@ export const DOM_IDS = {
 	TERM_SLUG: "slug",
 };
 
+export const DOM_CLASSES = {
+	POST_SLUG_SAVE_BUTTON: "save",
+};
+
 export const DOM_QUERIES = {
-	POST_EDIT_SLUG_BUTTON: "#edit-slug-buttons .edit-slug",
-	POST_SAVE_SLUG_BUTTON: "#edit-slug-buttons .save",
-	POST_CANCEL_SLUG_BUTTON: "#edit-slug-buttons .cancel",
 	POST_FEATURED_IMAGE: "#set-post-thumbnail img",
-	POST_SAVE_DATE_BUTTON: "#timestampdiv .save-timestamp",
+	POST_DATE_SAVE_BUTTON: "#timestampdiv .save-timestamp",
 };
 
 export const DOM_YOAST_IDS = {

--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -29,6 +29,7 @@ export const DOM_QUERIES = {
 	POST_SAVE_SLUG_BUTTON: "#edit-slug-buttons .save",
 	POST_CANCEL_SLUG_BUTTON: "#edit-slug-buttons .cancel",
 	POST_FEATURED_IMAGE: "#set-post-thumbnail img",
+	POST_SAVE_DATE_BUTTON: "#timestampdiv .save-timestamp",
 };
 
 export const DOM_YOAST_IDS = {

--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -1,8 +1,6 @@
-import { get, set, isEqual } from "lodash";
-
-import { getContentTinyMce } from "../../lib/tinymce";
+import { get, isEqual, set, flow } from "lodash";
 import { excerptFromContent } from "../../helpers/replacementVariableHelpers";
-import firstImageUrlInContent from "../../helpers/firstImageUrlInContent";
+import { getContentTinyMce } from "../../lib/tinymce";
 
 export const DOM_IDS = {
 	// Post editor.
@@ -11,6 +9,8 @@ export const DOM_IDS = {
 	POST_EXCERPT: "excerpt",
 	POST_PERMALINK: "sample-permalink",
 	POST_FEATURED_IMAGE_ID: "_thumbnail_id",
+	POST_FEATURED_IMAGE_PARENT: "postimagediv",
+	POST_FEATURED_IMAGE_REMOVE: "remove-post-thumbnail",
 	POST_SLUG_NEW: "new-post-slug",
 	POST_SLUG_EDIT: "editable-post-name-full",
 	POST_DATE_MONTH: "mm",
@@ -204,18 +204,58 @@ export const getTermPermalink = () => get( window, "wpseoScriptData.metabox.base
 export const getPostExcerpt = () => get( document.getElementById( DOM_IDS.POST_EXCERPT ), "value", "" ) || excerptFromContent( getPostContent() );
 
 /**
- * Returns the post featured image source if one is set.
+ * Gets the post featured image source if one is set.
  *
- * @returns {string} The source of the post featured image.
+ * @returns {string} The featured image source or an empty string.
  */
-const getPostFeaturedImageSetInEditor = () => document.querySelector( DOM_QUERIES.POST_FEATURED_IMAGE )?.getAttribute( "src" );
+const getPostFeaturedImageUrl = () => document.querySelector( DOM_QUERIES.POST_FEATURED_IMAGE )?.getAttribute( "src" ) || "";
 
 /**
- * Gets the featured image if one is set. Falls back to the first image from the content.
+ * Gets the post featured image ID if one is set.
  *
- * @returns {string} The featured image URL.
+ * @returns {number} The featured image ID or -1, or NaN if parsing to a number went wrong.
  */
-export const getPostFeaturedImageUrl = () => getPostFeaturedImageSetInEditor() || firstImageUrlInContent( getPostContent() ) || "";
+const getPostFeaturedImageId = flow( [ createGetDomElementProp( DOM_IDS.POST_FEATURED_IMAGE_ID ), parseInt ] );
+
+/**
+ * Gets the post featured image width if one is set.
+ *
+ * @returns {number} The featured image width or -1, or NaN if parsing to a number went wrong.
+ */
+const getPostFeaturedImageWidth = flow( [
+	() => document.querySelector( DOM_QUERIES.POST_FEATURED_IMAGE )?.getAttribute( "width" ) || "-1",
+	parseInt,
+] );
+
+/**
+ * Gets the post featured image height if one is set.
+ *
+ * @returns {number} The featured image height or -1, or NaN if parsing to a number went wrong.
+ */
+const getPostFeaturedImageHeight = flow( [
+	() => document.querySelector( DOM_QUERIES.POST_FEATURED_IMAGE )?.getAttribute( "height" ) || "-1",
+	parseInt,
+] );
+
+/**
+ * Gets the post featured image alt if one is set.
+ *
+ * @returns {string} The featured image alt or an empty string.
+ */
+const getPostFeaturedImageAlt = () => document.querySelector( DOM_QUERIES.POST_FEATURED_IMAGE )?.getAttribute( "alt" ) || "";
+
+/**
+ * Gets the featured image from the document.
+ *
+ * @returns {{ id: number, url: string, width: number, height: number, alt: string }} The featured image.
+ */
+export const getPostFeaturedImage = () => ( {
+	id: getPostFeaturedImageId(),
+	url: getPostFeaturedImageUrl(),
+	width: getPostFeaturedImageWidth(),
+	height: getPostFeaturedImageHeight(),
+	alt: getPostFeaturedImageAlt(),
+} );
 
 /**
  * Gets the post focus keyphrase from the document.
@@ -276,81 +316,81 @@ export const setPostSeoTitle = createSetDomElementProp( DOM_YOAST_IDS.POST_SEO_T
 export const setTermSeoTitle = createSetDomElementProp( DOM_YOAST_IDS.TERM_SEO_TITLE );
 
 /**
-  * Sets the post meta description value prop on its DOM element.
-  *
-  * @param {*} value The value to set.
-  * @returns {HTMLElement} The DOM element.
-  */
+ * Sets the post meta description value prop on its DOM element.
+ *
+ * @param {*} value The value to set.
+ * @returns {HTMLElement} The DOM element.
+ */
 export const setPostMetaDescription = createSetDomElementProp( DOM_YOAST_IDS.POST_META_DESCRIPTION );
 
 /**
-  * Sets the term meta description value prop on its DOM element.
-  *
-  * @param {*} value The value to set.
-  * @returns {HTMLElement} The DOM element.
-  */
+ * Sets the term meta description value prop on its DOM element.
+ *
+ * @param {*} value The value to set.
+ * @returns {HTMLElement} The DOM element.
+ */
 export const setTermMetaDescription = createSetDomElementProp( DOM_YOAST_IDS.TERM_META_DESCRIPTION );
 
 /**
-  * Sets the post is cornerstone value prop on its DOM element.
-  *
-  * @param {boolean} value The value to set.
-  * @returns {HTMLElement} The DOM element.
-  */
+ * Sets the post is cornerstone value prop on its DOM element.
+ *
+ * @param {boolean} value The value to set.
+ * @returns {HTMLElement} The DOM element.
+ */
 export const setPostIsCornerstone = ( value ) => set( document.getElementById( DOM_YOAST_IDS.POST_IS_CORNERSTONE ), "value", value ? 1 : 0 );
 
 /**
-  * Sets the term is cornerstone value prop on its DOM element.
-  *
-  * @param {boolean} value The value to set.
-  * @returns {HTMLElement} The DOM element.
-  */
+ * Sets the term is cornerstone value prop on its DOM element.
+ *
+ * @param {boolean} value The value to set.
+ * @returns {HTMLElement} The DOM element.
+ */
 export const setTermIsCornerstone = ( value ) => set( document.getElementById( DOM_YOAST_IDS.TERM_IS_CORNERSTONE ), "value", value ? 1 : 0 );
 
 /**
-  * Sets the post focus keyphrase value prop on its DOM element.
-  *
-  * @param {boolean} value The value to set.
-  * @returns {HTMLElement} The DOM element.
-  */
+ * Sets the post focus keyphrase value prop on its DOM element.
+ *
+ * @param {boolean} value The value to set.
+ * @returns {HTMLElement} The DOM element.
+ */
 export const setPostFocusKeyphrase = createSetDomElementProp( DOM_YOAST_IDS.POST_FOCUS_KEYPHRASE );
 
 /**
-  * Sets the term focus keyphrase value prop on its DOM element.
-  *
-  * @param {boolean} value The value to set.
-  * @returns {HTMLElement} The DOM element.
-  */
+ * Sets the term focus keyphrase value prop on its DOM element.
+ *
+ * @param {boolean} value The value to set.
+ * @returns {HTMLElement} The DOM element.
+ */
 export const setTermFocusKeyphrase = createSetDomElementProp( DOM_YOAST_IDS.TERM_FOCUS_KEYPHRASE );
 
 /**
-  * Sets the post SEO score value prop on its DOM element.
-  *
-  * @param {boolean} value The value to set.
-  * @returns {HTMLElement} The DOM element.
-  */
+ * Sets the post SEO score value prop on its DOM element.
+ *
+ * @param {boolean} value The value to set.
+ * @returns {HTMLElement} The DOM element.
+ */
 export const setPostSeoScore = createSetDomElementProp( DOM_YOAST_IDS.POST_SEO_SCORE );
 
 /**
-  * Sets the term SEO score value prop on its DOM element.
-  *
-  * @param {boolean} value The value to set.
-  * @returns {HTMLElement} The DOM element.
-  */
+ * Sets the term SEO score value prop on its DOM element.
+ *
+ * @param {boolean} value The value to set.
+ * @returns {HTMLElement} The DOM element.
+ */
 export const setTermSeoScore = createSetDomElementProp( DOM_YOAST_IDS.TERM_SEO_SCORE );
 
 /**
-  * Sets the post readability score value prop on its DOM element.
-  *
-  * @param {boolean} value The value to set.
-  * @returns {HTMLElement} The DOM element.
-  */
+ * Sets the post readability score value prop on its DOM element.
+ *
+ * @param {boolean} value The value to set.
+ * @returns {HTMLElement} The DOM element.
+ */
 export const setPostReadabilityScore = createSetDomElementProp( DOM_YOAST_IDS.POST_READABILITY_SCORE );
 
 /**
-  * Sets the term readability score value prop on its DOM element.
-  *
-  * @param {boolean} value The value to set.
-  * @returns {HTMLElement} The DOM element.
-  */
+ * Sets the term readability score value prop on its DOM element.
+ *
+ * @param {boolean} value The value to set.
+ * @returns {HTMLElement} The DOM element.
+ */
 export const setTermReadabilityScore = createSetDomElementProp( DOM_YOAST_IDS.TERM_READABILITY_SCORE );

--- a/packages/js/src/classic-editor/initial-state.js
+++ b/packages/js/src/classic-editor/initial-state.js
@@ -1,60 +1,77 @@
-import {
-	getContent,
-	getDate,
-	getExcerpt,
-	getFeaturedImageUrl,
-	getFocusKeyphrase,
-	getMetaDescription,
-	getPermalink,
-	getSeoTitle,
-	getSlug,
-	getTitle,
-	getIsCornerstone,
-} from "./helpers/dom";
+import * as dom from "./helpers/dom";
 import { FOCUS_KEYPHRASE_ID } from "@yoast/seo-integration";
+import isSeoAnalysisActive from "../analysis/isKeywordAnalysisActive";
+import isReadabilityAnalysisActive from "../analysis/isContentAnalysisActive";
 
 /**
- * Gather the initial state of the classic editor.
+ * Gets the initial state for SEO store from post DOM.
  *
- * @returns {Object} The initial state of the classic editor.
+ * @returns {Object} The initial state.
  */
-const getEditorInitialState = () => ( {
-	title: getTitle(),
-	date: getDate(),
-	permalink: getPermalink(),
-	excerpt: getExcerpt(),
-	content: getContent(),
-	featuredImage: {
-		url: getFeaturedImageUrl(),
+export const getInitialPostState = () => ( {
+	analysis: {
+		config: {
+			analysisType: "post",
+			isSeoActive: isSeoAnalysisActive(),
+			isReadabilityActive: isReadabilityAnalysisActive(),
+		},
 	},
-} );
-
-/**
- * Gathers the initial state of the metabox of the classic editor.
- *
- * @returns {Object} The initial state of the metabox of the classic editor.
- */
-const getFormInitialState = () => ( {
-	seo: {
-		title: getSeoTitle(),
-		description: getMetaDescription(),
-		slug: getSlug(),
-		isCornerstone: getIsCornerstone(),
+	editor: {
+		title: dom.getPostTitle(),
+		date: dom.getPostDate(),
+		permalink: dom.getPostPermalink(),
+		excerpt: dom.getPostExcerpt(),
+		content: dom.getPostContent(),
+		featuredImage: {
+			url: dom.getPostFeaturedImageUrl(),
+		},
 	},
-	keyphrases: {
-		[ FOCUS_KEYPHRASE_ID ]: {
-			id: FOCUS_KEYPHRASE_ID,
-			keyphrase: getFocusKeyphrase(),
+	form: {
+		seo: {
+			title: dom.getPostSeoTitle(),
+			description: dom.getPostMetaDescription(),
+			slug: dom.getPostSlug(),
+			isCornerstone: dom.getPostIsCornerstone(),
+		},
+		keyphrases: {
+			[ FOCUS_KEYPHRASE_ID ]: {
+				id: FOCUS_KEYPHRASE_ID,
+				keyphrase: dom.getPostFocusKeyphrase(),
+			},
 		},
 	},
 } );
 
 /**
- * Gathers the initial state of the SEO store.
+ * Gets the initial state for SEO store from term DOM.
  *
  * @returns {Object} The initial state.
  */
-export const getInitialState = () => ( {
-	editor: getEditorInitialState(),
-	form: getFormInitialState(),
+export const getInitialTermState = () => ( {
+	analysis: {
+		config: {
+			analysisType: "term",
+			isSeoActive: isSeoAnalysisActive(),
+			isReadabilityActive: isReadabilityAnalysisActive(),
+		},
+	},
+	editor: {
+		title: dom.getTermName(),
+		permalink: dom.getTermPermalink(),
+		content: dom.getTermDescription(),
+	},
+	form: {
+		seo: {
+			title: dom.getTermSeoTitle(),
+			description: dom.getTermMetaDescription(),
+			slug: dom.getTermSlug(),
+			isCornerstone: dom.getTermIsCornerstone(),
+		},
+		keyphrases: {
+			[ FOCUS_KEYPHRASE_ID ]: {
+				id: FOCUS_KEYPHRASE_ID,
+				keyphrase: dom.getTermFocusKeyphrase(),
+			},
+		},
+	},
 } );

--- a/packages/js/src/classic-editor/initial-state.js
+++ b/packages/js/src/classic-editor/initial-state.js
@@ -22,9 +22,7 @@ export const getInitialPostState = () => ( {
 		permalink: dom.getPostPermalink(),
 		excerpt: dom.getPostExcerpt(),
 		content: dom.getPostContent(),
-		featuredImage: {
-			url: dom.getPostFeaturedImageUrl(),
-		},
+		featuredImage: dom.getPostFeaturedImage(),
 	},
 	form: {
 		seo: {

--- a/packages/js/src/classic-editor/shortcodes.js
+++ b/packages/js/src/classic-editor/shortcodes.js
@@ -154,11 +154,6 @@ const parseShortcodes = text => {
  * @returns {function} Unregister function.
  */
 const registerShortcodes = () => {
-	const isPost = get( window, "wpseoScriptData.isPost", "" ) === "1";
-	if ( ! isPost ) {
-		return;
-	}
-
 	// Priority of 11 to run it after the replacement variables (priority 10). As a shortcode is not expected to have replacement variables.
 	addFilter(
 		"yoast.seoStore.analysis.preparePaper",

--- a/packages/js/src/classic-editor/watcher.js
+++ b/packages/js/src/classic-editor/watcher.js
@@ -143,9 +143,9 @@ const syncPostToStore = () => {
 		 * The save button is only there in edit mode, but even the button container seems to be removed and re-added.
 		 */
 		// eslint-disable-next-line no-unused-expressions
-		document.getElementById( DOM_IDS.POST_SLUG_EDIT_PARENT )?.addEventListener( "click", e => {
-			if ( e.target.classList.contains( DOM_CLASSES.POST_SLUG_SAVE_BUTTON ) ) {
-				const slug = document.getElementById( DOM_IDS.POST_SLUG_NEW )?.value;
+		document.getElementById( DOM_IDS.POST_SLUG_EDIT_PARENT )?.addEventListener( "click", ( event ) => {
+			if ( event.target.classList.contains( DOM_CLASSES.POST_SLUG_SAVE_BUTTON ) ) {
+				const slug = dom.getPostNewSlug();
 				if ( slug ) {
 					actions.updateSlug( slug );
 					actions.updatePermalink( get( window, "wpseoScriptData.metabox.base_url", "" ) + slug );
@@ -201,8 +201,8 @@ const syncPostToStore = () => {
 		// eslint-disable-next-line no-unused-expressions
 		document.getElementById( DOM_IDS.POST_FEATURED_IMAGE_PARENT )?.addEventListener(
 			"click",
-			e => {
-				if ( e.target.id === DOM_IDS.POST_FEATURED_IMAGE_REMOVE ) {
+			( event ) => {
+				if ( event.target.id === DOM_IDS.POST_FEATURED_IMAGE_REMOVE ) {
 					actions.updateFeaturedImage( {} );
 				}
 			}

--- a/packages/js/src/classic-editor/watcher.js
+++ b/packages/js/src/classic-editor/watcher.js
@@ -8,7 +8,7 @@ import * as publishBox from "../ui/publishBox";
 import { update as updateTrafficLight } from "../ui/trafficLight";
 import * as dom from "./helpers/dom";
 
-const SYNC_DEBOUNCE_TIME = 200;
+const SYNC_DEBOUNCE_TIME = 500;
 const { DOM_IDS, DOM_CLASSES, DOM_QUERIES } = dom;
 
 /**

--- a/packages/js/src/classic-editor/watcher.js
+++ b/packages/js/src/classic-editor/watcher.js
@@ -21,7 +21,7 @@ const { DOM_IDS, DOM_QUERIES } = dom;
 const createHandleValueChange = ( action ) => debounce( ( event ) => action( get( event, "target.value", "" ) ), SYNC_DEBOUNCE_TIME );
 
 /**
- * Creates a store sync that subscribes to DOM changes and maybe dispatches an store action.
+ * Creates a store sync that subscribes to DOM changes and maybe dispatches a store action.
  *
  * @param {string} domId Id of DOM element to listen to.
  * @param {Function} action Store action to dispatch.
@@ -54,6 +54,7 @@ const createTinyMceContentSync = ( domId, action ) => {
 
 // Store cache for performance.
 let storeCache = {};
+
 /**
  * Creates a debounced DOM sync that subscribes to store changes and maybe updates a DOM element.
  *
@@ -71,7 +72,7 @@ const createDomSync = ( selector, { domGet, domSet }, storeCacheKey = "" ) => su
 		return false;
 	}
 	if ( isEqual( domGet(), storeValue ) ) {
-		// Store change is alreday in DOM.
+		// Store change is already in DOM.
 		return false;
 	}
 	if ( storeCacheKey ) {
@@ -103,7 +104,7 @@ const createUpdateSeoScore = ( selectIsActive, domSet ) => ( score ) => {
 };
 
 /**
- * Create an readability score updating function for DOM and legacy UI.
+ * Create a readability score updating function for DOM and legacy UI.
  *
  * @param {Function} selectIsActive Selector that checks if analysis is active.
  * @param {Function} domSet Function that sets DOM elements prop.
@@ -122,7 +123,7 @@ const createUpdateReadabilityScore = ( selectIsActive, domSet ) => ( score ) => 
 };
 
 /**
- * Watches and syncs post DOM change to the store.
+ * Watches and syncs post DOM changes to the store.
  *
  * @returns {void}
  */
@@ -171,7 +172,7 @@ const syncPostToStore = () => {
 };
 
 /**
- * Watches and syncs store change to the post DOM.
+ * Watches and syncs store changes to the post DOM.
  *
  * @returns {void}
  */
@@ -201,7 +202,7 @@ const syncStoreToPost = () => {
 };
 
 /**
- * Watches and syncs term DOM change to the store.
+ * Watches and syncs term DOM changes to the store.
  *
  * @returns {void}
  */
@@ -223,7 +224,7 @@ const syncTermToStore = () => {
 };
 
 /**
- * Watches and syncs store change to the term DOM.
+ * Watches and syncs store changes to the term DOM.
  *
  * @returns {void}
  */
@@ -263,7 +264,7 @@ export const initPostWatcher = () => {
 };
 
 /**
- * Wachtes term changes.
+ * Watches term changes.
  *
  * @returns {void}
  */

--- a/packages/js/src/classic-editor/watcher.js
+++ b/packages/js/src/classic-editor/watcher.js
@@ -153,7 +153,7 @@ const syncPostToStore = () => {
 			}
 		} );
 	};
-	// Sync post slug changes to store.
+	// Sync post slug changes to the store.
 	createSlugSync();
 
 	/**
@@ -167,7 +167,7 @@ const syncPostToStore = () => {
 			actions.updateDate( dom.getPostDate() );
 		} );
 	};
-	// Sync date changes to store.
+	// Sync date changes to the store.
 	createDateSync();
 
 	/**
@@ -208,11 +208,13 @@ const syncPostToStore = () => {
 			}
 		);
 	};
-	// Sync post featured image fields changes to store.
+	// Sync post featured image fields changes to the store.
 	createFeaturedImageSync();
 
-	// Sync TinyMCE editor changes to store.
+	// Sync TinyMCE editor changes to the store.
 	createTinyMceContentSync( DOM_IDS.POST_CONTENT, actions.updateContent );
+	// Sync editor changes to the store when in text mode.
+	createStoreSync( DOM_IDS.POST_CONTENT, actions.updateContent, "input" );
 };
 
 /**
@@ -252,7 +254,7 @@ const syncStoreToPost = () => {
  */
 const syncTermToStore = () => {
 	const actions = dispatch( SEO_STORE_NAME );
-	// Sync term field changes to store.
+	// Sync term field changes to the store.
 	createStoreSync( DOM_IDS.TERM_NAME, actions.updateTitle, "input" );
 	createStoreSync(
 		DOM_IDS.TERM_SLUG,
@@ -263,8 +265,10 @@ const syncTermToStore = () => {
 		"input"
 	);
 
-	// Sync TinyMCE editor changes to store.
+	// Sync TinyMCE editor changes to the store.
 	createTinyMceContentSync( DOM_IDS.TERM_DESCRIPTION, actions.updateContent );
+	// Sync editor changes to the store when in text mode.
+	createStoreSync( DOM_IDS.TERM_DESCRIPTION, actions.updateContent, "input" );
 };
 
 /**

--- a/packages/js/src/classic-editor/watcher.js
+++ b/packages/js/src/classic-editor/watcher.js
@@ -3,167 +3,271 @@ import { get, set, debounce, forEach, isEqual } from "lodash";
 import { subscribe, dispatch, select } from "@wordpress/data";
 import { SEO_STORE_NAME } from "@yoast/seo-integration";
 import { addEventHandler as addTinyMceEventListener, getContentTinyMce } from "../lib/tinymce";
+import getIndicatorForScore from "../analysis/getIndicatorForScore";
+import * as publishBox from "../ui/publishBox";
+import { update as updateTrafficLight } from "../ui/trafficLight";
+import { update as updateAdminBar } from "../ui/adminBar";
 import * as dom from "./helpers/dom";
 
 const SYNC_DEBOUNCE_TIME = 200;
 const { DOM_IDS, DOM_QUERIES } = dom;
 
 /**
- * Watches and syncs DOM change to the store.
+ * Creates a debounced function that handles value change events on DOM elements.
+ *
+ * @param {Function} action Store action to dispatch.
+ * @returns {Function} Value change event handler.
+ */
+const createHandleValueChange = ( action ) => debounce( ( event ) => action( get( event, "target.value", "" ) ), SYNC_DEBOUNCE_TIME );
+
+/**
+ * Creates a store sync that subscribes to DOM changes and maybe dispatches an store action.
+ *
+ * @param {string} domId Id of DOM element to listen to.
+ * @param {Function} action Store action to dispatch.
+ * @param {string} [eventName] Event name to add listener to.
+ * @returns {void}
+ */
+const createStoreSync = ( domId, action, eventName = "change" ) => document.getElementById( domId )?.addEventListener(
+	eventName,
+	createHandleValueChange( action )
+);
+
+/**
+ * Creates a debounced function that handles value change events on Tiny MCE editors.
+ *
+ * @param {string} domId Id of DOM element.
+ * @param {Function} action Store action.
+ * @returns {Function} Value change event handler.
+ */
+const createTinyMceContentSync = ( domId, action ) => {
+	const tinyMceEventNames = [ "input", "change", "cut", "paste" ];
+	const editor = window?.tinymce?.editors?.[ domId ];
+	const handleEvent = debounce( () => action( getContentTinyMce( domId ) ), SYNC_DEBOUNCE_TIME );
+	if ( editor ) {
+		// If editor already initialized, go ahead and listen for events.
+		return forEach( tinyMceEventNames, ( eventName ) => editor?.on( eventName, handleEvent ) );
+	}
+	// Fallback to adding event listeners when editor with id is initialized.
+	addTinyMceEventListener( domId, tinyMceEventNames, handleEvent );
+};
+
+// Store cache for performance.
+let storeCache = {};
+/**
+ * Creates a debounced DOM sync that subscribes to store changes and maybe updates a DOM element.
+ *
+ * @param {Function} selector Store selector to listen to.
+ * @param {{ domGet: Function, domSet: Function }} domLens Lens for getting and setting DOM element values.
+ * @param {string} [storeCacheKey] Optional key to use in the cache.
+ * @returns {Function} Unsubscribe from store function.
+ */
+const createDomSync = ( selector, { domGet, domSet }, storeCacheKey = "" ) => subscribe( debounce( () => {
+	const cacheValue = get( storeCache, storeCacheKey );
+	const storeValue = selector();
+
+	if ( isEqual( cacheValue, storeValue ) ) {
+		// No store change.
+		return false;
+	}
+	if ( isEqual( domGet(), storeValue ) ) {
+		// Store change is alreday in DOM.
+		return false;
+	}
+	if ( storeCacheKey ) {
+		// Update cache if cache key exists.
+		storeCache = set( storeCache, storeCacheKey, storeValue );
+	}
+	// Update DOM if store value changed.
+	domSet( storeValue );
+}, SYNC_DEBOUNCE_TIME ) );
+
+/**
+ * Create an SEO score updating function for DOM and legacy UI.
+ *
+ * @param {Function} selectIsActive Selector that checks if analysis is active.
+ * @param {Function} domSet Function that sets DOM elements prop.
+ * @returns {Function} Function that updates DOM and legacy UI with SEO score.
+ */
+const createUpdateSeoScore = ( selectIsActive, domSet ) => ( score ) => {
+	if ( ! selectIsActive() ) {
+		return;
+	}
+	// Update DOM.
+	domSet( score );
+	// Also update legacy UI.
+	const indicator = getIndicatorForScore( score );
+	updateTrafficLight( indicator );
+	updateAdminBar( indicator );
+	publishBox.updateScore( "keyword", indicator.className );
+};
+
+/**
+ * Create an readability score updating function for DOM and legacy UI.
+ *
+ * @param {Function} selectIsActive Selector that checks if analysis is active.
+ * @param {Function} domSet Function that sets DOM elements prop.
+ * @returns {Function} Function that updates DOM and legacy UI with SEO score.
+ */
+const createUpdateReadabilityScore = ( selectIsActive, domSet ) => ( score ) => {
+	if ( ! selectIsActive() ) {
+		return;
+	}
+	// Update DOM.
+	domSet( score );
+	// Also update legacy UI.
+	const indicator = getIndicatorForScore( score );
+	updateAdminBar( indicator );
+	publishBox.updateScore( "content", indicator.className );
+};
+
+/**
+ * Watches and syncs post DOM change to the store.
  *
  * @returns {void}
  */
-const watchDomChanges = () => {
+const syncPostToStore = () => {
 	const actions = dispatch( SEO_STORE_NAME );
-	/**
-	 * Creates a debounced function that handles value change events on DOM elements.
-	 *
-	 * @param {Function} action Store action to dispatch.
-	 * @returns {Function} Value change event handler.
-	 */
-	const createHandleValueChange = ( action ) => debounce( ( event ) => action( get( event, "target.value", "" ) ), SYNC_DEBOUNCE_TIME );
-
-	/**
-	 * Creates a store sync that subscribes to DOM changes and maybe dispatches an store action.
-	 *
-	 * @param {string} domId Id of DOM element to listen to.
-	 * @param {Function} action Store action to dispatch.
-	 * @param {string} [eventName] Event name to add listener to.
-	 * @returns {void}
-	 */
-	const createStoreSync = ( domId, action, eventName = "change" ) => document.getElementById( domId )?.addEventListener(
-		eventName,
-		createHandleValueChange( action )
-	);
-
 	// Sync simple editor changes to store.
-	createStoreSync( DOM_IDS.TITLE, actions.updateTitle, "input" );
-	createStoreSync( DOM_IDS.EXCERPT, actions.updateExcerpt, "input" );
-
-	/**
-	 * Updates slug changes in store by dispatching actions for updating both slug and permalink.
-	 *
-	 * @param {string} slug New slug.
-	 * @returns {void}
-	 */
-	const updateSlugAndPermalink = ( slug ) => {
-		actions.updateSlug( slug );
-		actions.updatePermalink( get( window, "wpseoScriptData.metabox.base_url", "" ) + slug );
-	};
-
-	// Sync term slug field changes to store.
-	createStoreSync( DOM_IDS.SLUG, updateSlugAndPermalink, "input" );
+	createStoreSync( DOM_IDS.POST_TITLE, actions.updateTitle, "input" );
+	createStoreSync( DOM_IDS.POST_EXCERPT, actions.updateExcerpt, "input" );
 
 	/**
 	 * Handles attaching listeners to opening and closing of edit post slug field.
 	 *
 	 * @returns {void}
 	 */
-	const addSlugChangeListener = () => {
-		document.querySelector( DOM_QUERIES.EDIT_SLUG_BUTTON )?.addEventListener( "click", () => {
+	const createSlugSync = () => {
+		document.querySelector( DOM_QUERIES.POST_EDIT_SLUG_BUTTON )?.addEventListener( "click", () => {
 			// Hack to back of queue
 			setTimeout( () => {
-				createStoreSync( DOM_IDS.SLUG_NEW_POST, updateSlugAndPermalink, "input" );
+				createStoreSync(
+					DOM_IDS.POST_SLUG_NEW,
+					( slug ) => {
+						actions.updateSlug( slug );
+						actions.updatePermalink( get( window, "wpseoScriptData.metabox.base_url", "" ) + slug );
+					},
+					"input"
+				);
 				// Reattach edit slug button listener if field is closed.
 				forEach(
-					[ DOM_QUERIES.SAVE_SLUG_BUTTON, DOM_QUERIES.CANCEL_SLUG_BUTTON ],
-					( domQuery ) => document.querySelector( domQuery )?.addEventListener( "click", addSlugChangeListener )
+					[ DOM_QUERIES.POST_SAVE_SLUG_BUTTON, DOM_QUERIES.POST_CANCEL_SLUG_BUTTON ],
+					( domQuery ) => document.querySelector( domQuery )?.addEventListener( "click", createSlugSync )
 				);
 			}, 0 );
 		} );
 	};
 	// Sync post slug field changes to store
-	addSlugChangeListener();
+	createSlugSync();
 
 	// Sync multiple date fields changes to store.
 	forEach(
-		[ DOM_IDS.DATE_MONTH, DOM_IDS.DATE_DAY, DOM_IDS.DATE_YEAR ],
-		( domId ) => createStoreSync( domId, () => actions.updateDate( dom.getDate() ) )
+		[ DOM_IDS.POST_DATE_MONTH, DOM_IDS.POST_DATE_DAY, DOM_IDS.POST_DATE_YEAR ],
+		( domId ) => createStoreSync( domId, () => actions.updateDate( dom.getPostDate() ) )
 	);
-
-	/**
-	 * Creates a debounced function that handles value change events on Tiny MCE editors.
-	 *
-	 * @param {string} domId Id of DOM element.
-	 * @param {Function} action Store action.
-	 * @returns {Function} Value change event handler.
-	 */
-	const createHandleTinyMceValueChange = ( domId, action ) => debounce( () => action( getContentTinyMce( domId ) ), SYNC_DEBOUNCE_TIME );
-	const tinyMceEventNames = [ "input", "change", "cut", "paste" ];
 
 	// Sync TinyMCE editor changes to store.
-	forEach(
-		[ DOM_IDS.CONTENT, DOM_IDS.CONTENT_TERM ],
-		( domId ) => {
-			const editor = window?.tinymce?.editors?.[ domId ];
-			const handleEvent = createHandleTinyMceValueChange( domId, actions.updateContent );
-			if ( editor ) {
-				// If editor already initialized, go ahead and listen for events.
-				return forEach( tinyMceEventNames, ( eventName ) => editor?.on( eventName, handleEvent ) );
-			}
-			// Fallback to adding event listeners when editor with id is initialized.
-			addTinyMceEventListener( domId, tinyMceEventNames, handleEvent );
-		}
-	);
+	createTinyMceContentSync( DOM_IDS.POST_CONTENT, actions.updateContent );
 };
 
 /**
- * Watches and syncs store change to the DOM.
+ * Watches and syncs store change to the post DOM.
  *
  * @returns {void}
  */
-const watchStoreChanges = () => {
+const syncStoreToPost = () => {
 	const selectors = select( SEO_STORE_NAME );
-	let cache = {};
-
-	/**
-	 * Creates a debounced DOM sync that subscribes to store changes and maybe updates a DOM element.
-	 *
-	 * @param {Function} selector Store selector to listen to.
-	 * @param {{ domGet: Function, domSet: Function }} domLens Lens for getting and setting DOM element values.
-	 * @param {string} [cacheKey] Optional key to use in the cache.
-	 * @returns {Function} Unsubscribe from store function.
-	 */
-	const createDomSync = ( selector, { domGet, domSet }, cacheKey = "" ) => subscribe( debounce( () => {
-		const cacheValue = get( cache, cacheKey );
-		const storeValue = selector();
-
-		if ( isEqual( cacheValue, storeValue ) ) {
-			// No store change.
-			return false;
-		}
-
-		if ( isEqual( domGet(), storeValue ) ) {
-			// Store change is alreday in DOM.
-			return false;
-		}
-
-		if ( cacheKey ) {
-			// Update cache if cache key exists.
-			cache = set( cache, cacheKey, storeValue );
-		}
-
-		// Update DOM if store value changed.
-		domSet( storeValue );
-	}, SYNC_DEBOUNCE_TIME ) );
-
 	// Sync simple store changes to hidden inputs.
-	createDomSync( selectors.selectSeoTitle, { domGet: dom.getSeoTitle, domSet: dom.setSeoTitle }, "seoTitle" );
-	createDomSync( selectors.selectMetaDescription, { domGet: dom.getMetaDescription, domSet: dom.setMetaDescription }, "metaDescription" );
-	createDomSync( selectors.selectKeyphrase, { domGet: dom.getFocusKeyphrase, domSet: dom.setFocusKeyphrase }, "focusKeyphrase" );
-	createDomSync( selectors.selectIsCornerstone, { domGet: dom.getIsCornerstone, domSet: dom.setIsCornerstone }, "isCornerstone" );
+	createDomSync( selectors.selectSeoTitle, { domGet: dom.getPostSeoTitle, domSet: dom.setPostSeoTitle }, "seoTitle" );
+	createDomSync( selectors.selectMetaDescription, { domGet: dom.getPostMetaDescription, domSet: dom.setPostMetaDescription }, "metaDescription" );
+	createDomSync( selectors.selectKeyphrase, { domGet: dom.getPostFocusKeyphrase, domSet: dom.setPostFocusKeyphrase }, "focusKeyphrase" );
+	createDomSync( selectors.selectIsCornerstone, { domGet: dom.getPostIsCornerstone, domSet: dom.setPostIsCornerstone }, "isCornerstone" );
+	createDomSync(
+		selectors.selectSeoScore,
+		{
+			domGet: dom.getPostSeoScore,
+			domSet: createUpdateSeoScore( selectors.selectIsSeoAnalysisActive, dom.setPostSeoScore ),
+		},
+		"seoScore"
+	);
+	createDomSync(
+		selectors.selectReadabilityScore,
+		{
+			domGet: dom.getPostReadabilityScore,
+			domSet: createUpdateReadabilityScore( selectors.selectIsReadabilityAnalysisActive, dom.setPostReadabilityScore ),
+		},
+		"readabilityScore"
+	);
 };
 
 /**
- * Creates a Classic Editor watcher.
+ * Watches and syncs term DOM change to the store.
  *
- * @returns {{ watch: Function }} Watcher interface with a watch method that watches
+ * @returns {void}
  */
-const createClassicEditorWatcher = () => ( {
-	watch: () => {
-		watchDomChanges();
-		watchStoreChanges();
-	},
-} );
+const syncTermToStore = () => {
+	const actions = dispatch( SEO_STORE_NAME );
+	// Sync term field changes to store.
+	createStoreSync( DOM_IDS.TERM_NAME, actions.updateTitle, "input" );
+	createStoreSync(
+		DOM_IDS.TERM_SLUG,
+		( slug ) => {
+			actions.updateSlug( slug );
+			actions.updatePermalink( get( window, "wpseoScriptData.metabox.base_url", "" ) + slug );
+		},
+		"input"
+	);
 
-export default createClassicEditorWatcher;
+	// Sync TinyMCE editor changes to store.
+	createTinyMceContentSync( DOM_IDS.TERM_DESCRIPTION, actions.updateContent );
+};
+
+/**
+ * Watches and syncs store change to the term DOM.
+ *
+ * @returns {void}
+ */
+const syncStoreToTerm = () => {
+	const selectors = select( SEO_STORE_NAME );
+	// Sync simple store changes to hidden inputs.
+	createDomSync( selectors.selectSeoTitle, { domGet: dom.getTermSeoTitle, domSet: dom.setTermSeoTitle }, "seoTitle" );
+	createDomSync( selectors.selectMetaDescription, { domGet: dom.getTermMetaDescription, domSet: dom.setTermMetaDescription }, "metaDescription" );
+	createDomSync( selectors.selectKeyphrase, { domGet: dom.getTermFocusKeyphrase, domSet: dom.setTermFocusKeyphrase }, "focusKeyphrase" );
+	createDomSync( selectors.selectIsCornerstone, { domGet: dom.getTermIsCornerstone, domSet: dom.setTermIsCornerstone }, "isCornerstone" );
+	createDomSync(
+		selectors.selectSeoScore,
+		{
+			domGet: dom.getTermSeoScore,
+			domSet: createUpdateSeoScore( selectors.selectIsSeoAnalysisActive, dom.setTermSeoScore ),
+		},
+		"seoScore"
+	);
+	createDomSync(
+		selectors.selectReadabilityScore,
+		{
+			domGet: dom.getTermReadabilityScore,
+			domSet: createUpdateReadabilityScore( selectors.selectIsReadabilityAnalysisActive, dom.setTermReadabilityScore ),
+		},
+		"readabilityScore"
+	);
+};
+
+/**
+ * Watches post changes.
+ *
+ * @returns {void}
+ */
+export const initPostWatcher = () => {
+	syncPostToStore();
+	syncStoreToPost();
+};
+
+/**
+ * Wachtes term changes.
+ *
+ * @returns {void}
+ */
+export const initTermWatcher = () => {
+	syncTermToStore();
+	syncStoreToTerm();
+};

--- a/packages/js/src/classic-editor/watcher.js
+++ b/packages/js/src/classic-editor/watcher.js
@@ -161,11 +161,18 @@ const syncPostToStore = () => {
 	// Sync post slug field changes to store.
 	createSlugSync();
 
-	// Sync multiple date fields changes to store.
-	forEach(
-		[ DOM_IDS.POST_DATE_MONTH, DOM_IDS.POST_DATE_DAY, DOM_IDS.POST_DATE_YEAR ],
-		( domId ) => createStoreSync( domId, () => actions.updateDate( dom.getPostDate() ) )
-	);
+	/**
+	 * Handles attaching listeners to saving the date (published or publish on).
+	 *
+	 * @returns {void}
+	 */
+	const createDateSync = () => {
+		document.querySelector( DOM_QUERIES.POST_SAVE_DATE_BUTTON )?.addEventListener( "click", () => {
+			actions.updateDate( dom.getPostDate() );
+		} );
+	};
+	// Sync date changes to store.
+	createDateSync();
 
 	/**
 	 * Handles attaching listeners to the set and remove of the featured image.

--- a/packages/js/src/initializers/tiny-mce.js
+++ b/packages/js/src/initializers/tiny-mce.js
@@ -3,34 +3,29 @@
  * table cell. This way we can use the wp tinyMCE editor on the description field.
  *
  * @param {Object} jQuery The jQuery object.
- * @param {{ isTerm: boolean }} options Options object specifying if current page is a term.
  * @returns {void}
  */
 export const initTermDescriptionTinyMce = function( jQuery ) {
 	// Get the table cell that contains the description textarea.
-	var descriptionTd = jQuery( ".term-description-wrap" ).find( "td" );
-
+	const descriptionTd = jQuery( ".term-description-wrap" ).find( "td" );
 	// Get the description textarea label.
-	var descriptionLabel = jQuery( ".term-description-wrap" ).find( "label" );
-
+	const descriptionLabel = jQuery( ".term-description-wrap" ).find( "label" );
 	// Get the textNode from the original textarea.
-	var textNode = descriptionTd.find( "textarea" ).val();
-
+	const textNode = descriptionTd.find( "textarea" ).val();
 	// Get the editor container.
-	var newEditor = document.getElementById( "wp-description-wrap" );
-
+	const newEditor = document.getElementById( "wp-description-wrap" );
 	// Get the description help text below the textarea.
-	var text = descriptionTd.find( "p" );
+	const text = descriptionTd.find( "p" );
 
 	// Empty the TD with the old description textarea.
 	descriptionTd.html( "" );
 
 	/*
-     * The editor is printed out via PHP as child of the form and initially
-     * hidden with a child `>` CSS selector. We now move the editor and the
-     * help text in a new position so the previous CSS rule won't apply any
-     * longer and the editor will be visible.
-     */
+	 * The editor is printed out via PHP as child of the form and initially
+	 * hidden with a child `>` CSS selector. We now move the editor and the
+	 * help text in a new position so the previous CSS rule won't apply any
+	 * longer and the editor will be visible.
+	 */
 	descriptionTd.append( newEditor ).append( text );
 
 	// Populate the editor textarea with the original content.

--- a/packages/js/src/initializers/tiny-mce.js
+++ b/packages/js/src/initializers/tiny-mce.js
@@ -1,0 +1,41 @@
+/**
+ * Get the editor created via wp_editor() and append it to the term-description-wrap
+ * table cell. This way we can use the wp tinyMCE editor on the description field.
+ *
+ * @param {Object} jQuery The jQuery object.
+ * @param {{ isTerm: boolean }} options Options object specifying if current page is a term.
+ * @returns {void}
+ */
+export const initTermDescriptionTinyMce = function( jQuery ) {
+	// Get the table cell that contains the description textarea.
+	var descriptionTd = jQuery( ".term-description-wrap" ).find( "td" );
+
+	// Get the description textarea label.
+	var descriptionLabel = jQuery( ".term-description-wrap" ).find( "label" );
+
+	// Get the textNode from the original textarea.
+	var textNode = descriptionTd.find( "textarea" ).val();
+
+	// Get the editor container.
+	var newEditor = document.getElementById( "wp-description-wrap" );
+
+	// Get the description help text below the textarea.
+	var text = descriptionTd.find( "p" );
+
+	// Empty the TD with the old description textarea.
+	descriptionTd.html( "" );
+
+	/*
+     * The editor is printed out via PHP as child of the form and initially
+     * hidden with a child `>` CSS selector. We now move the editor and the
+     * help text in a new position so the previous CSS rule won't apply any
+     * longer and the editor will be visible.
+     */
+	descriptionTd.append( newEditor ).append( text );
+
+	// Populate the editor textarea with the original content.
+	document.getElementById( "description" ).value = textNode;
+
+	// Make the description textarea label plain text removing the label tag.
+	descriptionLabel.replaceWith( descriptionLabel.html() );
+};

--- a/packages/js/src/ui/publishBox.js
+++ b/packages/js/src/ui/publishBox.js
@@ -134,6 +134,9 @@ export function initialize() {
 	$( "#keyword-score" ).on( "click", "[href='#yoast-seo-analysis-collapsible-metabox']", function( event ) {
 		event.preventDefault();
 
+		// Pretend to click on the SEO tab to make it focused.
+		document.querySelector( "#wpseo-meta-tab-content" ).click();
+
 		scrollToCollapsible( "#yoast-seo-analysis-collapsible-metabox" );
 	} );
 }

--- a/packages/js/src/ui/publishBox.js
+++ b/packages/js/src/ui/publishBox.js
@@ -125,7 +125,8 @@ export function initialize() {
 		event.preventDefault();
 
 		// Pretend to click on the readability tab to make it focused.
-		document.querySelector( "#wpseo-meta-tab-readability" ).click();
+		// eslint-disable-next-line no-unused-expressions
+		document.querySelector( "#wpseo-meta-tab-readability" )?.click();
 
 		scrollToCollapsible( "#wpseo-meta-section-readability" );
 	} );

--- a/packages/seo-integration/src/replacement-variables/configurations.js
+++ b/packages/seo-integration/src/replacement-variables/configurations.js
@@ -1,7 +1,7 @@
 import { select } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
-import { SEO_STORE_NAME } from "@yoast/seo-store";
 import { strings as stringHelpers } from "@yoast/helpers";
+import { SEO_STORE_NAME } from "@yoast/seo-store";
 
 /**
  * Holds the replacement variable configurations, for use within the SEO store context.
@@ -19,7 +19,15 @@ export const content = {
 export const date = {
 	name: "date",
 	getLabel: () => __( "Date", "wordpress-seo" ),
-	getReplacement: () => select( SEO_STORE_NAME ).selectDate(),
+	getReplacement: () => new Date( select( SEO_STORE_NAME ).selectDate() ).toLocaleDateString(
+		// eslint-disable-next-line no-undefined
+		undefined,
+		{
+			day: "numeric",
+			month: "long",
+			year: "numeric",
+		},
+	),
 };
 
 export const excerpt = {

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -428,6 +428,7 @@ class Elementor implements Integration_Interface {
 			'media'             => [ 'choose_image' => \__( 'Use Image', 'wordpress-seo' ) ],
 			'metabox'           => $this->get_metabox_script_data(),
 			'userLanguageCode'  => WPSEO_Language_Utils::get_language( \get_user_locale() ),
+			'siteTimezone'     => \wp_timezone_string(),
 			'isPost'            => true,
 			'isBlockEditor'     => WP_Screen::get()->is_block_editor(),
 			'isElementorEditor' => true,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Split logic between post and term and handle branching at the root level.
* This split is needed because post and terms are too different to try to handle with the same logic. Primarily the differences in DOM elements used by WordPress and our own hidden inputs between post and term pages. By trying to support both post and term DOM, a lot of functions got messy and responsible for multiple things (branching between post/term in a lot of places) and I didn't like that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Splits post and term logic in favour of structuring.

## Relevant technical choices:

* Split logic between post and term at the highest level in `classic-editor.js` entrypoint. Removed this split from some other places, like the `shortcodes` plugin.
* Added support for legacy UI functions: `updateTrafficLight`(never used?), `updateAdminBar` and `pulbishBox`.
* Added support for Tiny MCE on term pages description field.
* Did some refactoring of the DOM helpers.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Do a smoke test on a post and a term page and check if analysis integration and watcher are still working properly.
* On a post page, check if legacy UI is updated: publish box and admin bar. Traffic light is not being used anywhere?
* On a term page, check if Tiny MCE works for the description field.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
