### PR TITLE
Travis: remove "Fix PHP 8.0 build after composer update"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -256,8 +256,7 @@ script:
   - |
     if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.integration-tests" && travis_time_start
-      composer remove --dev yoast/wp-test-utils phpunit/phpunit --ignore-platform-reqs --no-interaction &&
-      travis_retry composer require --dev yoast/wp-test-utils:"^1.0.0" phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
+      travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
       vendor/bin/phpunit -c phpunit-integration.xml.dist
       travis_time_finish && travis_fold end "PHP.integration-tests"
     fi;
@@ -270,8 +269,8 @@ script:
   - |
     if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
       travis_fold start "PHP.tests" && travis_time_start
-      composer remove --dev yoast/wp-test-utils phpunit/phpunit --ignore-platform-reqs --no-interaction &&
-      composer require --dev yoast/wp-test-utils phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
+      travis_retry composer require --dev phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
+      travis_retry composer update yoast/wp-test-utils --with-all-dependencies --ignore-platform-reqs --no-interaction &&
       vendor/bin/phpunit
       travis_time_finish && travis_fold end "PHP.tests"
     fi


### PR DESCRIPTION


## Context

* Simplify CI

## Summary

This PR can be summarized in the following changelog entry:

* Simplify CI

## Relevant technical choices:

This reverts commit b3999428193d5cdcdd0758dcb7dc060e6992c507.

Composer 2.2.3 has been released which contains a fix for the overly greedy optimization pass which was introduced in Composer 2.2.0.

With this fix in place, the previously introduced work-around for Composer 2.2 is no longer needed.

Refs:
* https://github.com/composer/composer/releases/tag/2.2.3
* https://github.com/composer/composer/issues/10394

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.