### PR TITLE
Adapt the recommended meta description length for Japanese

### DIFF
--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -394,6 +394,8 @@ class WPSEO_Replace_Vars {
 	 */
 	private function retrieve_excerpt() {
 		$replacement = null;
+		$locale = \get_locale();
+		$limit = ( $locale === 'ja' ) ? 80 : 156;
 
 		// The check `post_password_required` is because excerpt must be hidden for a post with a password.
 		if ( ! empty( $this->args->ID ) && ! post_password_required( $this->args->ID ) ) {
@@ -404,11 +406,11 @@ class WPSEO_Replace_Vars {
 				$content = strip_shortcodes( $this->args->post_content );
 				$content = wp_strip_all_tags( $content );
 
-				if ( strlen( utf8_decode( $content ) ) <= 156 ) {
+				if ( strlen( utf8_decode( $content ) ) <= $limit ) {
 					return $content;
 				}
 
-				$replacement = wp_html_excerpt( $content, 156 );
+				$replacement = wp_html_excerpt( $content, $limit );
 
 				// Check if the description has space and trim the auto-generated string to a word boundary.
 				if ( strrpos( $replacement, ' ' ) ) {

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -394,8 +394,8 @@ class WPSEO_Replace_Vars {
 	 */
 	private function retrieve_excerpt() {
 		$replacement = null;
-		$locale = \get_locale();
-		$limit = ( $locale === 'ja' ) ? 80 : 156;
+		$locale      = \get_locale();
+		$limit       = ( $locale === 'ja' ) ? 80 : 156;
 
 		// The check `post_password_required` is because excerpt must be hidden for a post with a password.
 		if ( ! empty( $this->args->ID ) && ! post_password_required( $this->args->ID ) ) {

--- a/packages/js/src/analysis/blockEditorData.js
+++ b/packages/js/src/analysis/blockEditorData.js
@@ -4,6 +4,7 @@ import { debounce } from "lodash-es";
 import { languageProcessing } from "yoastseo";
 import { reapplyAnnotationsForSelectedBlock } from "../decorator/gutenberg";
 import { excerptFromContent, fillReplacementVariables, mapCustomFields, mapCustomTaxonomies } from "../helpers/replacementVariableHelpers";
+import getContentLocale from "./getContentLocale";
 
 const {
 	updateReplacementVariable,
@@ -175,12 +176,13 @@ export default class BlockEditorData {
 		const content = this.getPostAttribute( "content" );
 		const contentImage = this.calculateContentImage( content );
 		const excerpt = this.getPostAttribute( "excerpt" ) || "";
+		const limit = ( getContentLocale() === "ja" ) ? 80 : 156;
 
 		return {
 			content,
 			title: this.getPostAttribute( "title" ) || "",
 			slug: this.getSlug(),
-			excerpt: excerpt || excerptFromContent( content ),
+			excerpt: excerpt || excerptFromContent( content, limit ),
 			// eslint-disable-next-line camelcase
 			excerpt_only: excerpt,
 			snippetPreviewImageURL: this.getFeaturedImage() || contentImage,

--- a/packages/js/src/analysis/classicEditorData.js
+++ b/packages/js/src/analysis/classicEditorData.js
@@ -4,6 +4,7 @@ import { debounce, isUndefined } from "lodash-es";
 import analysis from "yoastseo";
 import { excerptFromContent, fillReplacementVariables, mapCustomFields, mapCustomTaxonomies } from "../helpers/replacementVariableHelpers";
 import * as tmceHelper from "../lib/tinymce";
+import getContentLocale from "./getContentLocale";
 
 const { removeMarks } = analysis.markers;
 const { updateReplacementVariable, updateData, hideReplacementVariables, setContentImage } = actions;
@@ -185,12 +186,13 @@ export default class ClassicEditorData {
 	getExcerpt( useFallBack = true ) {
 		const excerptElement = document.getElementById( "excerpt" );
 		const excerptValue = excerptElement && excerptElement.value || "";
+		const limit = ( getContentLocale() === "ja" ) ? 80 : 156;
 
 		if ( excerptValue !== "" || useFallBack === false ) {
 			return excerptValue;
 		}
 
-		return excerptFromContent( this.getContent() );
+		return excerptFromContent( this.getContent(), limit );
 	}
 
 	/**

--- a/packages/js/src/containers/SnippetEditor.js
+++ b/packages/js/src/containers/SnippetEditor.js
@@ -87,6 +87,7 @@ export function mapSelectToProps( select ) {
 		getSnippetEditorWordsToHighlight,
 		isCornerstoneContent,
 		getIsTerm,
+		getContentLocale,
 	} = select( "yoast-seo/editor" );
 
 	const replacementVariables = getReplaceVars();
@@ -112,6 +113,7 @@ export function mapSelectToProps( select ) {
 		wordsToHighlight: getSnippetEditorWordsToHighlight(),
 		isCornerstone: isCornerstoneContent(),
 		isTaxonomy: getIsTerm(),
+		locale: getContentLocale(),
 	};
 }
 

--- a/packages/js/src/elementor/containers/SnippetEditor.js
+++ b/packages/js/src/elementor/containers/SnippetEditor.js
@@ -117,6 +117,7 @@ export default compose( [
 			getSnippetEditorMode,
 			getSnippetEditorWordsToHighlight,
 			isCornerstoneContent,
+			getContentLocale,
 		} = select( "yoast-seo/editor" );
 
 		return {
@@ -132,6 +133,7 @@ export default compose( [
 			replacementVariables: getCurrentReplacementVariablesForEditor(),
 			wordsToHighlight: getSnippetEditorWordsToHighlight(),
 			isCornerstone: isCornerstoneContent(),
+			locale: getContentLocale(),
 		};
 	} ),
 	withDispatch( dispatch => {

--- a/packages/js/src/redux/selectors/editorData.js
+++ b/packages/js/src/redux/selectors/editorData.js
@@ -1,5 +1,6 @@
 import { get } from "lodash";
 import { applyFilters } from "@wordpress/hooks";
+import getContentLocale from "../../analysis/getContentLocale";
 import { excerptFromContent } from "../../helpers/replacementVariableHelpers";
 
 /**
@@ -41,7 +42,9 @@ export const getEditorDataExcerptWithFallback = ( state ) => {
 
 	// Fallback to the first piece of the content.
 	if ( excerpt === "" ) {
-		excerpt = excerptFromContent( get( state, "editorData.content", "" ) );
+		const limit = ( getContentLocale() === "ja" ) ? 80 : 156;
+
+		excerpt = excerptFromContent( get( state, "editorData.content", "" ), limit );
 	}
 
 	return excerpt;

--- a/packages/js/tests/containers/SnippetEditor.test.js
+++ b/packages/js/tests/containers/SnippetEditor.test.js
@@ -37,6 +37,7 @@ describe( "SnippetEditor container", () => {
 					getSnippetEditorWordsToHighlight: jest.fn().mockReturnValue( [ "active" ] ),
 					isCornerstoneContent: jest.fn().mockReturnValue( true ),
 					getIsTerm: jest.fn().mockReturnValue( true ),
+					getContentLocale: jest.fn().mockReturnValue( "en" ),
 				};
 			}
 		} );
@@ -74,6 +75,7 @@ describe( "SnippetEditor container", () => {
 			wordsToHighlight: [ "active" ],
 			isCornerstone: true,
 			isTaxonomy: true,
+			locale: "en",
 		};
 
 		const result = mapSelectToProps( select );

--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
@@ -77,10 +77,11 @@ function getTitleProgress( title ) {
  * @param {string}  date            The meta description date.
  * @param {bool}    isCornerstone   Whether the cornerstone content toggle is on or off.
  * @param {bool}    isTaxonomy      Whether the page is a taxonomy page.
+ * @param {string}  locale          The locale.
  *
  * @returns {Object} The description progress.
  */
-function getDescriptionProgress( description, date, isCornerstone, isTaxonomy ) {
+function getDescriptionProgress( description, date, isCornerstone, isTaxonomy, locale ) {
 	const descriptionLength = languageProcessing.countMetaDescriptionLength( date, description );
 
 	// Override the default config if the cornerstone content toggle is on and it is not a taxonomy page.
@@ -91,8 +92,8 @@ function getDescriptionProgress( description, date, isCornerstone, isTaxonomy ) 
 		},
 	} ) : new MetaDescriptionLengthAssessment();
 
-	const score = metaDescriptionLengthAssessment.calculateScore( descriptionLength );
-	const maximumLength = metaDescriptionLengthAssessment.getMaximumLength();
+	const score = metaDescriptionLengthAssessment.calculateScore( descriptionLength, locale  );
+	const maximumLength = metaDescriptionLengthAssessment.getMaximumLength( locale );
 
 	return {
 		max: maximumLength,
@@ -148,7 +149,8 @@ class SnippetEditor extends React.Component {
 				measurementData.description,
 				this.props.date,
 				this.props.isCornerstone,
-				this.props.isTaxonomy
+				this.props.isTaxonomy,
+				this.props.locale
 			),
 		};
 
@@ -177,7 +179,8 @@ class SnippetEditor extends React.Component {
 			prevProps.data.slug !== nextProps.data.slug ||
 			prevProps.data.title !== nextProps.data.title ||
 			prevProps.isCornerstone !== nextProps.isCornerstone ||
-			prevProps.isTaxonomy !== nextProps.isTaxonomy
+			prevProps.isTaxonomy !== nextProps.isTaxonomy ||
+			prevProps.locale !== nextProps.locale
 		) {
 			isDirty = true;
 		}
@@ -210,7 +213,8 @@ class SnippetEditor extends React.Component {
 						data.description,
 						nextProps.date,
 						nextProps.isCornerstone,
-						nextProps.isTaxonomy ),
+						nextProps.isTaxonomy,
+						nextProps.locale ),
 				}
 			);
 		}

--- a/packages/yoastseo/spec/languageProcessing/languages/ja/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ja/ResearcherSpec.js
@@ -3,7 +3,7 @@ import Paper from "../../../../src/values/Paper.js";
 import functionWords from "../../../../src/languageProcessing/languages/ja/config/functionWords";
 import subheadingsTooLong from "../../../../src/languageProcessing/languages/ja/config/subheadingsTooLong";
 import sentenceLength from "../../../../src/languageProcessing/languages/ja/config/sentenceLength";
-
+import metaDescriptionLength from "../../../../src/languageProcessing/languages/ja/config/metaDescriptionLength";
 import getMorphologyData from "../../../specHelpers/getMorphologyData";
 
 const morphologyDataJA = getMorphologyData( "ja" );
@@ -27,6 +27,10 @@ describe( "a test for Japanese Researcher", function() {
 
 	it( "returns the Japanese sentence length configuration", function() {
 		expect( researcher.getConfig( "sentenceLength" ) ).toEqual( sentenceLength );
+	} );
+
+	it( "returns the Japanese meta description length configuration", function() {
+		expect( researcher.getConfig( "metaDescriptionLength" ) ).toEqual( metaDescriptionLength );
 	} );
 
 	it( "returns the Japanese function words", function() {

--- a/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionLengthAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionLengthAssessmentSpec.js
@@ -99,16 +99,18 @@ describe( "a test for assessing the meta description length in Japanese", functi
 		} );
 	} );
 	describe( "a test in a cornerstone content", () => {
+		const cornerstoneDescriptionLengthAssessment = new MetaDescriptionLengthAssessment( {
+			scores:	{
+				tooLong: 3,
+				tooShort: 3,
+			},
+		} );
+
 		it( "assesses an empty description", function() {
 			const mockPaper = new Paper( "" );
 			const researcher = new JapaneseResearcher( mockPaper );
 
-			const metaDescriptionLengthResult = new MetaDescriptionLengthAssessment( {
-				scores:	{
-					tooLong: 3,
-					tooShort: 3,
-				},
-			} ).getResult( mockPaper, researcher );
+			const metaDescriptionLengthResult = cornerstoneDescriptionLengthAssessment.getResult( mockPaper, researcher );
 
 			expect( metaDescriptionLengthResult.getScore() ).toEqual( 1 );
 			expect( metaDescriptionLengthResult.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length" +
@@ -120,12 +122,7 @@ describe( "a test for assessing the meta description length in Japanese", functi
 			const mockPaper = new Paper( "", { description: "塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネ綸乾んみ。" } );
 			const researcher = new JapaneseResearcher( mockPaper );
 
-			const metaDescriptionLengthResult = new MetaDescriptionLengthAssessment( {
-				scores:	{
-					tooLong: 3,
-					tooShort: 3,
-				},
-			} ).getResult( mockPaper, researcher );
+			const metaDescriptionLengthResult = cornerstoneDescriptionLengthAssessment.getResult( mockPaper, researcher );
 
 			expect( metaDescriptionLengthResult.getScore() ).toEqual( 3 );
 			expect( metaDescriptionLengthResult.getText() ).toEqual(   "<a href='https://yoa.st/34d' target='_blank'>" +
@@ -140,12 +137,7 @@ describe( "a test for assessing the meta description length in Japanese", functi
 					"よ並道ネホル長英ツヤ第野ヒソア問適チホレ番参び給財がをざイ同綸乾んみ。" } );
 			const researcher = new JapaneseResearcher( mockPaper );
 
-			const metaDescriptionLengthResult = new MetaDescriptionLengthAssessment( {
-				scores:	{
-					tooLong: 3,
-					tooShort: 3,
-				},
-			} ).getResult( mockPaper, researcher );
+			const metaDescriptionLengthResult = cornerstoneDescriptionLengthAssessment.getResult( mockPaper, researcher );
 
 			expect( metaDescriptionLengthResult.getScore() ).toEqual( 3 );
 			expect( metaDescriptionLengthResult.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>" +
@@ -158,12 +150,7 @@ describe( "a test for assessing the meta description length in Japanese", functi
 					"れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。" } );
 			const researcher = new JapaneseResearcher( mockPaper );
 
-			const metaDescriptionLengthResult = new MetaDescriptionLengthAssessment( {
-				scores:	{
-					tooLong: 3,
-					tooShort: 3,
-				},
-			} ).getResult( mockPaper, researcher );
+			const metaDescriptionLengthResult = cornerstoneDescriptionLengthAssessment.getResult( mockPaper, researcher );
 
 			expect( metaDescriptionLengthResult.getScore() ).toEqual( 9 );
 			expect( metaDescriptionLengthResult.getText() ).toEqual(  "<a href='https://yoa.st/34d' target='_blank'>" +

--- a/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionLengthAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionLengthAssessmentSpec.js
@@ -1,10 +1,11 @@
 import MetaDescriptionLengthAssessment from "../../../../src/scoring/assessments/seo/MetaDescriptionLengthAssessment.js";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../specHelpers/factory.js";
+import JapaneseResearcher from "../../../../src/languageProcessing/languages/ja/Researcher";
 
 const descriptionLengthAssessment = new MetaDescriptionLengthAssessment();
 
-describe( "the meta description length assessment", function() {
+describe( "a test for assessing the meta description length", function() {
 	it( "assesses an empty description", function() {
 		const mockPaper = new Paper();
 		const assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 0 ) );
@@ -42,5 +43,131 @@ describe( "the meta description length assessment", function() {
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: Well done!" );
+	} );
+} );
+
+describe( "a test for assessing the meta description length in Japanese", function() {
+	describe( "a test in a regular content", () => {
+		it( "assesses an empty description", function() {
+			const mockPaper = new Paper( "" );
+			const researcher = new JapaneseResearcher( mockPaper );
+
+			const assessment = descriptionLengthAssessment.getResult( mockPaper, researcher );
+
+			expect( assessment.getScore() ).toEqual( 1 );
+			expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length" +
+				"</a>:  No meta description has been specified. Search engines will display copy from the page instead. " +
+				"<a href='https://yoa.st/34e' target='_blank'>Make sure to write one</a>!" );
+		} );
+
+		it( "assesses a short description where the text is less than 60 characters", function() {
+			const mockPaper = new Paper( "", { description: "塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネ綸乾んみ。" } );
+			const researcher = new JapaneseResearcher( mockPaper );
+
+			const assessment = descriptionLengthAssessment.getResult( mockPaper, researcher );
+
+			expect( assessment.getScore() ).toEqual( 6 );
+			expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: " +
+				"The meta description is too short (under 60 characters). Up to 80 characters are available. " +
+				"<a href='https://yoa.st/34e' target='_blank'>Use the space</a>!" );
+		} );
+
+		it( "assesses a too long description where the text contains more than 80 characters", function() {
+			const mockPaper = new Paper( "", { description: "治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地" +
+					"部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネキロフ殺佐ず持容フ" +
+					"よ並道ネホル長英ツヤ第野ヒソア問適チホレ番参び給財がをざイ同綸乾んみ。" } );
+			const researcher = new JapaneseResearcher( mockPaper );
+
+			const assessment = descriptionLengthAssessment.getResult( mockPaper, researcher );
+
+			expect( assessment.getScore() ).toEqual( 6 );
+			expect( descriptionLengthAssessment.getMaximumLength() ).toEqual( 80 );
+			expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: " +
+				"The meta description is over 80 characters. To ensure the entire description will be visible, " +
+				"<a href='https://yoa.st/34e' target='_blank'>you should reduce the length</a>!" );
+		} );
+
+		it( "assesses a good description where the text is between 60-80 characters", function() {
+			const mockPaper = new Paper( "", { description: "治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地部" +
+					"れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。" } );
+			const researcher = new JapaneseResearcher( mockPaper );
+
+			const assessment = descriptionLengthAssessment.getResult( mockPaper, researcher );
+
+			expect( assessment.getScore() ).toEqual( 9 );
+			expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: Well done!" );
+		} );
+	} );
+	describe( "a test in a cornerstone content", () => {
+		it( "assesses an empty description", function() {
+			const mockPaper = new Paper( "" );
+			const researcher = new JapaneseResearcher( mockPaper );
+
+			const metaDescriptionLengthResult = new MetaDescriptionLengthAssessment( {
+				scores:	{
+					tooLong: 3,
+					tooShort: 3,
+				},
+			} ).getResult( mockPaper, researcher );
+
+			expect( metaDescriptionLengthResult.getScore() ).toEqual( 1 );
+			expect( metaDescriptionLengthResult.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length" +
+				"</a>:  No meta description has been specified. Search engines will display copy from the page instead. " +
+				"<a href='https://yoa.st/34e' target='_blank'>Make sure to write one</a>!" );
+		} );
+
+		it( "assesses a short description where the text is less than 60 characters", function() {
+			const mockPaper = new Paper( "", { description: "塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネ綸乾んみ。" } );
+			const researcher = new JapaneseResearcher( mockPaper );
+
+			const metaDescriptionLengthResult = new MetaDescriptionLengthAssessment( {
+				scores:	{
+					tooLong: 3,
+					tooShort: 3,
+				},
+			} ).getResult( mockPaper, researcher );
+
+			expect( metaDescriptionLengthResult.getScore() ).toEqual( 3 );
+			expect( metaDescriptionLengthResult.getText() ).toEqual(   "<a href='https://yoa.st/34d' target='_blank'>" +
+				"Meta description length</a>: The meta description is too short (under 60 characters). Up to 80 characters are available." +
+				" <a href='https://yoa.st/34e' target='_blank'>Use the space</a>!"
+			);
+		} );
+
+		it( "assesses a too long description where the text contains more than 80 characters", function() {
+			const mockPaper = new Paper( "", { description: "治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地" +
+					"部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネキロフ殺佐ず持容フ" +
+					"よ並道ネホル長英ツヤ第野ヒソア問適チホレ番参び給財がをざイ同綸乾んみ。" } );
+			const researcher = new JapaneseResearcher( mockPaper );
+
+			const metaDescriptionLengthResult = new MetaDescriptionLengthAssessment( {
+				scores:	{
+					tooLong: 3,
+					tooShort: 3,
+				},
+			} ).getResult( mockPaper, researcher );
+
+			expect( metaDescriptionLengthResult.getScore() ).toEqual( 3 );
+			expect( metaDescriptionLengthResult.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>" +
+				"Meta description length</a>: The meta description is over 80 characters. To ensure the entire description will be visible," +
+				" <a href='https://yoa.st/34e' target='_blank'>you should reduce the length</a>!" );
+		} );
+
+		it( "assesses a good description where the text is between 60-80 characters", function() {
+			const mockPaper = new Paper( "", { description: "治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地部" +
+					"れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。" } );
+			const researcher = new JapaneseResearcher( mockPaper );
+
+			const metaDescriptionLengthResult = new MetaDescriptionLengthAssessment( {
+				scores:	{
+					tooLong: 3,
+					tooShort: 3,
+				},
+			} ).getResult( mockPaper, researcher );
+
+			expect( metaDescriptionLengthResult.getScore() ).toEqual( 9 );
+			expect( metaDescriptionLengthResult.getText() ).toEqual(  "<a href='https://yoa.st/34d' target='_blank'>" +
+				"Meta description length</a>: Well done!" );
+		} );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionLengthAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionLengthAssessmentSpec.js
@@ -31,7 +31,7 @@ describe( "a test for assessing the meta description length", function() {
 		const assessment = descriptionLengthAssessment.getResult( mockPaper, Factory.buildMockResearcher( 400 ) );
 
 		expect( assessment.getScore() ).toEqual( 6 );
-		expect( descriptionLengthAssessment.getMaximumLength() ).toEqual( 156 );
+		expect( descriptionLengthAssessment.getMaximumLength( "en" ) ).toEqual( 156 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: " +
 			"The meta description is over 156 characters. To ensure the entire description will be visible, " +
 			"<a href='https://yoa.st/34e' target='_blank'>you should reduce the length</a>!" );
@@ -81,7 +81,7 @@ describe( "a test for assessing the meta description length in Japanese", functi
 			const assessment = descriptionLengthAssessment.getResult( mockPaper, researcher );
 
 			expect( assessment.getScore() ).toEqual( 6 );
-			expect( descriptionLengthAssessment.getMaximumLength() ).toEqual( 80 );
+			expect( descriptionLengthAssessment.getMaximumLength( "ja" ) ).toEqual( 80 );
 			expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34d' target='_blank'>Meta description length</a>: " +
 				"The meta description is over 80 characters. To ensure the entire description will be visible, " +
 				"<a href='https://yoa.st/34e' target='_blank'>you should reduce the length</a>!" );

--- a/packages/yoastseo/src/languageProcessing/languages/ja/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/Researcher.js
@@ -21,6 +21,7 @@ import assessmentApplicability from "./config/assessmentApplicabilityCharacterCo
 import sentenceLength from "./config/sentenceLength";
 import subheadingsTooLong from "./config/subheadingsTooLong";
 import keyphraseLength from "./config/keyphraseLength";
+import metaDescriptionLength from "./config/metaDescriptionLength";
 
 // All custom researches
 import morphology from "./customResearches/getWordForms";
@@ -58,6 +59,7 @@ export default class Researcher extends AbstractResearcher {
 			keyphraseLength,
 			subheadingsTooLong,
 			countCharacters: true,
+			metaDescriptionLength,
 		} );
 
 		Object.assign( this.helpers, {

--- a/packages/yoastseo/src/languageProcessing/languages/ja/config/metaDescriptionLength.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/config/metaDescriptionLength.js
@@ -1,0 +1,4 @@
+export default {
+	recommendedMaximumLength: 60,
+	maximumLength: 80,
+};

--- a/packages/yoastseo/src/scoring/assessments/seo/MetaDescriptionLengthAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/MetaDescriptionLengthAssessment.js
@@ -55,6 +55,10 @@ export default class MetaDescriptionLengthAssessment extends Assessment {
 	getResult( paper, researcher ) {
 		const descriptionLength = researcher.getResearch( "metaDescriptionLength" );
 		const assessmentResult = new AssessmentResult();
+		const languageSpecificConfig = researcher.getConfig( "metaDescriptionLength" );
+		if ( languageSpecificConfig ) {
+			this._config = merge( this._config, languageSpecificConfig );
+		}
 
 		assessmentResult.setScore( this.calculateScore( descriptionLength ) );
 		assessmentResult.setText( this.translateScore( descriptionLength ) );

--- a/packages/yoastseo/src/scoring/assessments/seo/MetaDescriptionLengthAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/MetaDescriptionLengthAssessment.js
@@ -4,6 +4,7 @@ import Assessment from "../assessment";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import AssessmentResult from "../../../values/AssessmentResult";
 import japaneseConfig from "../../../languageProcessing/languages/ja/config/metaDescriptionLength";
+
 /**
  * Assessment for calculating the length of the meta description.
  */

--- a/packages/yoastseo/src/scoring/assessments/seo/MetaDescriptionLengthAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/MetaDescriptionLengthAssessment.js
@@ -3,7 +3,7 @@ import { merge } from "lodash-es";
 import Assessment from "../assessment";
 import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
 import AssessmentResult from "../../../values/AssessmentResult";
-
+import japaneseConfig from "../../../languageProcessing/languages/ja/config/metaDescriptionLength";
 /**
  * Assessment for calculating the length of the meta description.
  */
@@ -38,10 +38,30 @@ export default class MetaDescriptionLengthAssessment extends Assessment {
 	/**
 	 * Returns the maximum length.
 	 *
+	 * @param {string}  locale  The locale.
+	 *
 	 * @returns {number} The maximum length.
 	 */
-	getMaximumLength() {
-		return this._config.maximumLength;
+	getMaximumLength( locale ) {
+		return this.getConfig( locale ).maximumLength;
+	}
+
+	/**
+	 * Checks if language specific config is available, and overwrite the default config if it is.
+	 *
+	 * This method of returning the configuration by checking the locale is necessary since this assessment is also
+	 * initialized for calculations outside content analysis where we don't have access to the Researcher.
+	 *
+	 * @param {string}  locale  The locale.
+	 *
+	 * @returns {object}    The configuration to use.
+	 */
+	getConfig( locale ) {
+		let config = this._config;
+		if ( locale === "ja" ) {
+			config = merge( config, japaneseConfig );
+		}
+		return config;
 	}
 
 	/**
@@ -55,16 +75,14 @@ export default class MetaDescriptionLengthAssessment extends Assessment {
 	getResult( paper, researcher ) {
 		const descriptionLength = researcher.getResearch( "metaDescriptionLength" );
 		const assessmentResult = new AssessmentResult();
-		const languageSpecificConfig = researcher.getConfig( "metaDescriptionLength" );
-		if ( languageSpecificConfig ) {
-			this._config = merge( this._config, languageSpecificConfig );
-		}
+		const locale = researcher.getConfig( "language" );
+		const config = this.getConfig( locale );
 
-		assessmentResult.setScore( this.calculateScore( descriptionLength ) );
-		assessmentResult.setText( this.translateScore( descriptionLength ) );
+		assessmentResult.setScore( this.calculateScore( descriptionLength, locale ) );
+		assessmentResult.setText( this.translateScore( descriptionLength, config ) );
 
 		// Max and actual are used in the snippet editor progress bar.
-		assessmentResult.max = this._config.maximumLength;
+		assessmentResult.max = config.maximumLength;
 		assessmentResult.actual = descriptionLength;
 
 		return assessmentResult;
@@ -73,34 +91,37 @@ export default class MetaDescriptionLengthAssessment extends Assessment {
 	/**
 	 * Returns the score for the descriptionLength.
 	 *
-	 * @param {number} descriptionLength The length of the metadescription.
+	 * @param {number}  descriptionLength The length of the meta description.
+	 * @param {string}  locale            The locale.
 	 *
 	 * @returns {number} The calculated score.
 	 */
-	calculateScore( descriptionLength ) {
+	calculateScore( descriptionLength, locale ) {
+		const config = this.getConfig( locale );
 		if ( descriptionLength === 0 ) {
-			return this._config.scores.noMetaDescription;
+			return config.scores.noMetaDescription;
 		}
 
 		if ( descriptionLength <= this._config.recommendedMaximumLength ) {
-			return this._config.scores.tooShort;
+			return config.scores.tooShort;
 		}
 
 		if ( descriptionLength > this._config.maximumLength ) {
-			return this._config.scores.tooLong;
+			return config.scores.tooLong;
 		}
 
-		return this._config.scores.correctLength;
+		return config.scores.correctLength;
 	}
 
 	/**
 	 * Translates the descriptionLength to a message the user can understand.
 	 *
-	 * @param {number} descriptionLength    The length of the metadescription.
+	 * @param {number}  descriptionLength   The length of the meta description.
+	 * @param {object}  config              The configuration to use.
 	 *
 	 * @returns {string} The translated string.
 	 */
-	translateScore( descriptionLength ) {
+	translateScore( descriptionLength, config ) {
 		if ( descriptionLength === 0 ) {
 			return sprintf(
 				/* Translators:  %1$s and %2$s expand to a links on yoast.com, %3$s expands to the anchor end tag */
@@ -109,13 +130,13 @@ export default class MetaDescriptionLengthAssessment extends Assessment {
 					"%1$sMeta description length%3$s:  No meta description has been specified. Search engines will display copy from the page instead. %2$sMake sure to write one%3$s!",
 					"wordpress-seo"
 				),
-				this._config.urlTitle,
-				this._config.urlCallToAction,
+				config.urlTitle,
+				config.urlCallToAction,
 				"</a>"
 			);
 		}
 
-		if ( descriptionLength <= this._config.recommendedMaximumLength ) {
+		if ( descriptionLength <= config.recommendedMaximumLength ) {
 			return sprintf(
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag,
 				%4$d expands to the number of characters in the meta description, %5$d expands to
@@ -125,15 +146,15 @@ export default class MetaDescriptionLengthAssessment extends Assessment {
 					"%1$sMeta description length%3$s: The meta description is too short (under %4$d characters). Up to %5$d characters are available. %2$sUse the space%3$s!",
 					"wordpress-seo"
 				),
-				this._config.urlTitle,
-				this._config.urlCallToAction,
+				config.urlTitle,
+				config.urlCallToAction,
 				"</a>",
-				this._config.recommendedMaximumLength,
-				this._config.maximumLength
+				config.recommendedMaximumLength,
+				config.maximumLength
 			);
 		}
 
-		if ( descriptionLength > this._config.maximumLength ) {
+		if ( descriptionLength > config.maximumLength ) {
 			return sprintf(
 				/* Translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag,
 				%4$d expands to	the total available number of characters in the meta description */
@@ -142,17 +163,17 @@ export default class MetaDescriptionLengthAssessment extends Assessment {
 					"%1$sMeta description length%3$s: The meta description is over %4$d characters. To ensure the entire description will be visible, %2$syou should reduce the length%3$s!",
 					"wordpress-seo"
 				),
-				this._config.urlTitle,
-				this._config.urlCallToAction,
+				config.urlTitle,
+				config.urlCallToAction,
 				"</a>",
-				this._config.maximumLength
+				config.maximumLength
 			);
 		}
 
 		return sprintf(
 			/* Translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 			__( "%1$sMeta description length%2$s: Well done!", "wordpress-seo" ),
-			this._config.urlTitle,
+			config.urlTitle,
 			"</a>"
 		);
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adapts the recommended meta description length and meta description preview limit for Japanese.
* [search-metadata-preview] Adds locale as one of the props in `SnippetEditor.js` to be used to determine which configuration to use in meta description length progress bar.
* [yoastseo] Adds Japanese configuration for meta description length.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
Requirements:
* Build the Free plugin
* Install and activate Elementor
* Set the site language to Japanese

Note that the meta description length is calculated *including* the date and the separator. The length of the date is language-specific. The date and separator count for 12 characters in Japanese. 

### Proceed with the testing steps below both in Default editor and in Elementor editor:
**Test in regular content**
* Create a post (don't add meta description yet)
* Confirm that the Meta description length assessment returns with:
   * Bullet: red
   * Feedback: `meta description の長さ: meta description が指定されていません。検索エンジンは代替としてページのコピーを表示します。meta description を書いてください !`
* Add a meta description with less than 60 characters:
> 塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネ綸乾んみ。 
* Confirm that the Meta description length assessment returns with:
   * Progress bar: orange
   * Bullet: orange
   * Feedback: `meta description の長さ: meta description が 60 文字以下と短すぎます。80 文字まで可能です。スペースを使用してください !`
* Add a meta description with more than 80 characters:
> 治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネキロフ殺佐ず持容フよ並道ネホル長英ツヤ第野ヒソア問適チホレ番参び給財がをざイ同綸乾んみ。 
* Confirm that the Meta description length assessment returns with:
   * Progress bar: orange
   * Bullet: orange
   * Feedback: `meta description の長さ: meta description が 80 文字を超えています。すべての description が読めるように、長さを縮めてください !`
* Add a meta description with between 60-80 characters:
> 治クツワ警集クカナユ設者本い児化76促縮成ゅりとあ親別るぎく公来こさみふ地部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。 
* Confirm that the Meta description length assessment returns with:
   * Progress bar: green 
   * Bullet: green
   * Feedback: `メタディスクリプションの長さ: いいですね !`

**Test in cornerstone content**
* Toggle the cornerstone content on
* Add a meta description with less than 60 characters:
> 塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネ綸乾んみ。 
* Confirm that the Meta description length assessment returns with:
   * Progress bar: red 
   * Bullet: red
   * Feedback: `meta description の長さ: meta description が 60 文字以下と短すぎます。80 文字まで可能です。スペースを使用してください !`
* Add a meta description with more than 80 characters:
> 治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネキロフ殺佐ず持容フよ並道ネホル長英ツヤ第野ヒソア問適チホレ番参び給財がをざイ同綸乾んみ。 
* Confirm that the Meta description length assessment returns with:
   * Progress bar: red 
   * Bullet: red
   * Feedback: `meta description の長さ: meta description が 80 文字を超えています。すべての description が読めるように、長さを縮めてください !`
* Add a meta description with between 60-80 characters:
> 治クツワ警集クカナユ設者本い児化76促縮成ゅりとあ親別るぎく公来こさみふ地部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。
* Confirm that the Meta description length assessment returns with:
   * Progress bar: green 
   * Bullet: green
   * Feedback: `メタディスクリプションの長さ: いいですね !`

### **Testing steps for Meta Description preview**
* Go to "SEO > Search Appearance".
* Set any post / page / CPTS' "Meta description" to excerpt by using %%excerpt%%. Save changes.
* Set your site to Japanese` 日本語`
* Make a new post / page / CPTS
* Confirm that the Meta Description is set to `抜粋`
<img width="575" alt="Schermafbeelding 2021-09-17 om 12 42 49" src="https://user-images.githubusercontent.com/48715883/133771522-5f1f9229-0bb0-4fd1-8a97-fd77badcf912.png">

* Copy and paste the Japanese text below. Don't add anything else to the Meta Description box. Publish.
> 治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。塾ちッり暮検ラヌコリ信字花キ口昇動フス季紅ネキロフ殺佐ず持容フよ並道ネホル長英ツヤ第野ヒソア問適チホレ番参び給財がをざイ同綸乾んみ。29社ユ試雪転ぱッは遺編ヒネヤノ増93東めフ志邪ム害表コシロ英旬2斜公せにどれ上名ほぼく庫権フぐ身削響川リじびみ。

* Check in Yoast metabox in the editor
* Confirm that the Google Preview returns this result:
<img width="598" alt="Screenshot 2022-01-04 at 12 04 35" src="https://user-images.githubusercontent.com/48715883/148050097-ec7cf65d-000b-4159-a53b-2313f0ffe71c.png">

* Open the post / page / CPTS in the front page
* Open the source code
* Confirm that the content of meta description tag `<meta name="description" content="">` is `治クツワ警集クカナユ設者本い児化76促縮繰壌7成ゅりとあ親別るぎく公来こさみふ地部れみゅ政週ゆら図現よぜフを田報ロユ速年文みーがま郎在ぎフ。塾ちッり暮検ラヌコリ` which is 80 characters.

* Install and activate Classic editor
* Open the post previously published
* Confirm that you still get the same result for Google preview and the content of the meta tag in front end

### Regression test in English
* Set the site language to English
**Test in regular content**
* Create a post (don't add meta description yet)
* Confirm that the Meta description length assessment returns with:
   * Bullet: red
   * Feedback: `Meta description length: No meta description has been specified. Search engines will display copy from the page instead. Make sure to write one!`
* Add a meta description with less than 120 characters
* Confirm that the Meta description length assessment returns with:
   * Progress bar: orange
   * Bullet: orange
   * Feedback: `Meta description length: The meta description is too short (under 120 characters). Up to 156 characters are available. Use the space!`
* Add a meta description with more than 156 characters
* Confirm that the Meta description length assessment returns with:
   * Progress bar: orange
   * Bullet: orange
   * Feedback: `Meta description length: The meta description is over 156 characters. To ensure the entire description will be visible, you should reduce the length!`
* Add a meta description with between 120-156 characters:
* Confirm that the Meta description length assessment returns with:
   * Progress bar: green 
   * Bullet: green
   * Feedback: `Meta description length: Well done!`

**Test Meta Description Preview**
* Create a post with text without spaces with around 200 characters
* Set the meta description to %%excerpt%%
* Confirm that both in Google Preview and the content of the meta tag in front end return with a text that is truncated to the last space before 156 characters. 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1215
