### PR TITLE
Avoid core bug by not asking for non-existent key on WP_Post

### DIFF
--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -510,7 +510,7 @@ class Elementor implements Integration_Interface {
 		// Drafts might not have a post_name unless the slug has been manually changed.
 		// In this case we get it using get_sample_permalink.
 		if ( ! $post->post_name ) {
-			$sample = \get_sample_permalink( $post->id );
+			$sample = \get_sample_permalink( $post );
 
 			// Since get_sample_permalink runs through filters, ensure that it has the expected return value.
 			if ( is_array( $sample ) && count( $sample ) === 2 && is_string( $sample[1] ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* There's a visible PHP Notice on new Elementor posts that is due to a core bug (see: https://core.trac.wordpress.org/ticket/54736 ). We can avoid it by not asking `$post->id`, which does not exist and leads to some bad paths to eventually cause the notice. That call was introduced here https://github.com/Yoast/wordpress-seo/pull/17771

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where a PHP Notice would be shown when creating a new post in the Elementor editor.

## Relevant technical choices:

* Passing a `WP_Post` object to `get_sample_permalink` rather than just an id, because that is more efficient. Also, the bug was exposed by asking for `$post->id`, rather than the actual property, which is capitalised ( `$post->ID` ).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure https://github.com/Yoast/wordpress-seo/pull/17771 still works, here are the test instructions from that PR:
	* Add a new draft post and edit it with Elementor.
	* Ensure that the permalink field of the "Google preview" modal is set correctly.
	* Ensure that the "Track SEO Performance" modal does not display an error message like this: "Before you can track your SEO performance make sure to set either the post’s title and save it as a draft or manually set the post’s slug"
* Also make sure that when adding a new Elementor post you don't get the Notice: `Notice: Undefined property: WP_Post::$filter in /var/www/html/wp-includes/class-wp-post.php on line 342`


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-207
