### PR TITLE
P1-1128 - Fix featured image with first image in content fallback in Google Preview container

### DIFF
--- a/packages/js/src/classic-editor/components/google-preview.js
+++ b/packages/js/src/classic-editor/components/google-preview.js
@@ -6,6 +6,7 @@ import { useSelect } from "@wordpress/data";
 
 import { EDITOR_STORE_NAME } from "../editor-store";
 import MetaboxCollapsible from "../../components/MetaboxCollapsible";
+import firstImageUrlInContent from "../../helpers/firstImageUrlInContent";
 
 /**
  * The Google preview component.
@@ -15,8 +16,11 @@ import MetaboxCollapsible from "../../components/MetaboxCollapsible";
 const GooglePreview = () => {
 	const shoppingData = useSelect( select => select( EDITOR_STORE_NAME ).getShoppingData() );
 	const siteIconUrl = useSelect( select => select( EDITOR_STORE_NAME ).getSiteIconUrlFromSettings() );
-	const previewImageUrl = useSelect( select => select( EDITOR_STORE_NAME ).getSnippetEditorPreviewImageUrl() );
 	const analysisType = useSelect( select => select( SEO_STORE_NAME ).selectAnalysisType() );
+	const featuredImage = useSelect( select => select( SEO_STORE_NAME ).selectFeaturedImage() );
+	const content = useSelect( select => select( SEO_STORE_NAME ).selectContent() );
+
+	const featuredImageUrl = featuredImage.url || firstImageUrlInContent( content );
 
 	return (
 		<MetaboxCollapsible
@@ -27,7 +31,7 @@ const GooglePreview = () => {
 				as={ SnippetEditor }
 				shoppingData={ shoppingData }
 				faviconSrc={ siteIconUrl }
-				mobileImageSrc={ previewImageUrl }
+				mobileImageSrc={ featuredImageUrl }
 				isTaxonomy={ analysisType === "term" }
 			/>
 		</MetaboxCollapsible>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Let the 'Google preview container' determine which image it should use as featured image.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Let the 'Google preview container' determine which image it should use as featured image.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create and edit a new post using the Classic Editor
* Add a featured image and verify the image will be set in the google preview
* Remove the featured image
* Add multiple images in the `content`
* Verify the google preview will pick the first image


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes P1-1128
