### PR TITLE
Added support for global YoastSEO api's in the classic editor for compatibility with add-ons.

### DIFF
--- a/packages/js/src/classic-editor.js
+++ b/packages/js/src/classic-editor.js
@@ -50,7 +50,7 @@ domReady( async () => {
 		{ analysis: { worker: analysisWorker } },
 		{
 			app: {
-				refresh: debounce( () => dispatch( SEO_STORE_NAME ).analyze(), refreshDelay ),
+				refresh: debounce( dispatch( SEO_STORE_NAME ).analyze, refreshDelay ),
 			},
 		},
 	] );

--- a/packages/seo-integration/src/analyze.js
+++ b/packages/seo-integration/src/analyze.js
@@ -22,7 +22,8 @@ const createPaper = ( data, keyphrase, configuration ) => {
 			description: data.metaDescription,
 			title: data.seoTitle,
 			titleWidth: data.seoTitleWidth,
-			permalink: data.slug,
+			permalink: data.permalink,
+			url: data.slug,
 			date: data.date,
 			// Configuration data.
 			locale: configuration.locale,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want our add-ons to still work with the new classic editor integration.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds back support for `window.YoastSEO.analysis` and `window.YoastSEO.app.refresh` within the new classic editor integration for compatibility with add-ons.
* Fixes a bug where the permalink and slug would not be passed to the analysis correctly.

## Relevant technical choices:

* Wrapped the call to `analyze` in a `debounce`, as was the case in the original implementation of `window.YoastSEO.app.refresh`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
* Install the latest version of Local SEO.
* Install the latest version of WooCommerce SEO.

#### Local SEO
* Activate Local SEO.
* Set Local SEO to use multiple locations within the Local SEO settings.
* Create a new Location.
* In the SEO analysis, you should see these assessment results with red bullets:
    * > Your h1 and/or h2 headings do not contain your location's city, you should really add that.
    * > Your URL does not contain your location's city, you should really add that.
    * > Your content does not contain an address shortcode which is important for search engines to validate your business address. You should really add that.
* Make the three assessments become green by following their advice.
    * Make sure everything works as expected (e.g. you do not get any grey bullets indicating that an assessment has gone wrong).   

#### WooCommerce SEO
* Activate WooCommerce SEO.
* Create a new product.
* In the SEO analysis, you should see this assessment result with a red bullet:
   * > You should write a short description for this product.
* Make the assessment green by adding a short description.
   * You can also try descriptions of differing lengths to trigger the different states (too short, too long).  

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The SEO analysis within the classic editor should work as expected when using other add ons (News SEO, Video SEO).

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
