### PR TITLE
Indexable sitemaps improvements

### DIFF
--- a/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
+++ b/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
@@ -57,21 +57,24 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
 		}
 
 		$table_name = Model::get_table_name( 'Indexable' );
-        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared by our ORM.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared by our ORM.
 		$raw_query = $wpdb->prepare( $query->get_sql(), $query->get_values() );
 
-        // phpcs:ignore WordPress.DB.DirectDatabaseQuery -- Complex query is not possible without a direct query.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- Complex query is not possible without a direct query.
 		$last_object_per_page = $wpdb->get_results(
-            // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Variables are secure.
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Variables are secure.
 			$wpdb->prepare(
-				// This query pulls only every Nth last_modified from the database, resetting row counts when the sub type changes.
+			// This query pulls only every Nth last_modified from the database, resetting row counts when the sub type changes.
 				"
 					SELECT i.object_sub_type, i.object_last_modified
 					FROM $table_name AS i
 					INNER JOIN (
 						SELECT id
 						FROM (
-							SELECT IF( @previous_sub_type = object_sub_type, @row:=@row+1, @row:=0) AS rownum, @previous_sub_type:=object_sub_type AS previous_sub_type, id
+							SELECT 
+								IF( @previous_sub_type = object_sub_type, @row:=@row+1, @row:=0) AS rownum, 
+								@previous_sub_type:=object_sub_type AS previous_sub_type,
+								id
 							FROM ( $raw_query ) AS sorted, ( SELECT @row:=-1, @previous_sub_type:=null ) AS init
 						) AS ranked
 						WHERE rownum MOD %d = 0
@@ -80,7 +83,7 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
 				",
 				$max_entries
 			)
-            // phpcs:enable
+		// phpcs:enable
 		);
 
 		$links      = [];

--- a/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
+++ b/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
@@ -83,12 +83,15 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
             // phpcs:enable
 		);
 
-		$links = [];
-		$page  = 1;
+		$links      = [];
+		$page       = 1;
+		$page_types = [];
 		foreach ( $last_object_per_page as $index => $object ) {
 			if ( $this->should_exclude_object_sub_type( $object->object_sub_type ) ) {
 				continue;
 			}
+
+			$page_types[ $object->object_sub_type ] = true;
 
 			$next_object_is_not_same_sub_type = ! isset( $last_object_per_page[ ( $index + 1 ) ] ) || $last_object_per_page[ ( $index + 1 ) ]->object_sub_type !== $object->object_sub_type;
 			if ( $page === 1 && $next_object_is_not_same_sub_type ) {
@@ -105,7 +108,27 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
 			}
 		}
 
+		foreach ( $this->get_non_empty_types() as $object_sub_type ) {
+			if ( ! isset( $page_types[ $object_sub_type ] ) || $page_types[ $object_sub_type ] !== true ) {
+				$links[] = [
+					'loc'     => WPSEO_Sitemaps_Router::get_base_url( $object_sub_type . '-sitemap.xml' ),
+					'lastmod' => null,
+				];
+			}
+		}
+
 		return $links;
+	}
+
+	/**
+	 * Gets a list of object subtypes that should have at least one link on the sitemap index.
+	 * This is needed for sitemaps that add links to the first page of the sitemap. If there are no posts,
+	 * there would not be a link on the sitemap index, unless if the object subtype is defined here.
+	 *
+	 * @return string[] A list of indexable subtypes that should get at least one link on the sitemap index.
+	 */
+	protected function get_non_empty_types() {
+		return [];
 	}
 
 	/**

--- a/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
+++ b/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
@@ -48,8 +48,6 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
 		$query = $this->repository
 			->query_where_noindex( false, $this->get_object_type() )
 			->select_many( 'id', 'object_sub_type' )
-			->where( 'is_publicly_viewable', true )
-			->where( 'is_protected', false )
 			->order_by_asc( 'object_sub_type' )
 			->order_by_asc( 'object_last_modified' );
 

--- a/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
+++ b/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
@@ -86,15 +86,15 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
 		// phpcs:enable
 		);
 
-		$links      = [];
-		$page       = 1;
-		$page_types = [];
+		$links              = [];
+		$page               = 1;
+		$present_page_types = [];
 		foreach ( $last_object_per_page as $index => $object ) {
 			if ( $this->should_exclude_object_sub_type( $object->object_sub_type ) ) {
 				continue;
 			}
 
-			$page_types[ $object->object_sub_type ] = true;
+			$present_page_types[] = $object->object_sub_type;
 
 			$next_object_is_not_same_sub_type = ! isset( $last_object_per_page[ ( $index + 1 ) ] ) || $last_object_per_page[ ( $index + 1 ) ]->object_sub_type !== $object->object_sub_type;
 			if ( $page === 1 && $next_object_is_not_same_sub_type ) {
@@ -112,7 +112,7 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
 		}
 
 		foreach ( $this->get_non_empty_types() as $object_sub_type ) {
-			if ( ! isset( $page_types[ $object_sub_type ] ) || $page_types[ $object_sub_type ] !== true ) {
+			if ( ! in_array( $object_sub_type, $present_page_types, true ) ) {
 				$links[] = [
 					'loc'     => WPSEO_Sitemaps_Router::get_base_url( $object_sub_type . '-sitemap.xml' ),
 					'lastmod' => null,

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -47,7 +47,6 @@ class WPSEO_Post_Type_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider 
 		return array_merge( $indexed_archives, [ 'post', 'page' ] );
 	}
 
-
 	/**
 	 * Whether or not a specific object sub type should be excluded.
 	 *

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -31,6 +31,24 @@ class WPSEO_Post_Type_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider 
 	}
 
 	/**
+	 * Gets a list of sitemap types that will always have at least one archive entry in the sitemap,
+	 * even if there are no posts of that type.
+	 *
+	 * @return string[] A list of indexable subtypes that should get at least one link on the sitemap index.
+	 */
+	protected function get_non_empty_types() {
+		$indexed_archives = $this->repository
+			->query_where_noindex( false, 'post-type-archive' )
+			->select_many( 'object_sub_type' )
+			->find_array();
+		$indexed_archives = wp_list_pluck( $indexed_archives, 'object_sub_type' );
+
+		// Post and page sitemaps always get a link to the homepage or posts page.
+		return array_merge( $indexed_archives, [ 'post', 'page' ] );
+	}
+
+
+	/**
 	 * Whether or not a specific object sub type should be excluded.
 	 *
 	 * @param string $object_sub_type The object sub type.

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -76,8 +76,6 @@ class WPSEO_Post_Type_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider 
 		$query = $this->repository
 			->query_where_noindex( false, 'post', $type )
 			->select_many( 'id', 'object_id', 'permalink', 'object_last_modified' )
-			->where( 'is_publicly_viewable', true )
-			->where( 'is_protected', false )
 			->order_by_asc( 'object_last_modified' )
 			->offset( $offset )
 			->limit( $max_entries );
@@ -95,7 +93,6 @@ class WPSEO_Post_Type_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider 
 				$home_page = $this->repository
 					->query_where_noindex( false, 'home-page' )
 					->select_many( 'id', 'object_id', 'permalink', 'object_last_modified' )
-					->where( 'is_publicly_viewable', true )
 					->find_one();
 				if ( $home_page ) {
 					// Prepend homepage.
@@ -110,7 +107,6 @@ class WPSEO_Post_Type_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider 
 					$posts_page = $this->repository
 						->query_where_noindex( false, 'post', 'page' )
 						->select_many( 'id', 'object_id', 'permalink', 'object_last_modified' )
-						->where( 'is_publicly_viewable', true )
 						->where( 'object_id', $page_for_posts )
 						->find_one();
 				}
@@ -118,7 +114,6 @@ class WPSEO_Post_Type_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider 
 					$posts_page = $this->repository
 						->query_where_noindex( false, 'home-page' )
 						->select_many( 'id', 'object_id', 'permalink', 'object_last_modified' )
-						->where( 'is_publicly_viewable', true )
 						->find_one();
 				}
 				if ( $posts_page ) {
@@ -130,7 +125,6 @@ class WPSEO_Post_Type_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider 
 				$archive_page = $this->repository
 					->query_where_noindex( false, 'post-type-archive', $type )
 					->select_many( 'id', 'object_id', 'permalink', 'object_last_modified' )
-					->where( 'is_publicly_viewable', true )
 					->find_one();
 				if ( $archive_page ) {
 					// Prepend archive.

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -192,6 +192,18 @@ class WPSEO_Post_Type_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider 
 	protected function get_excluded_object_ids() {
 		$excluded_posts_ids = [];
 
+		// The homepage is covered by the home-page indexable.
+		$homepage_post_id = (int) get_option( 'page_on_front' );
+		if ( ! empty( $homepage_post_id ) ) {
+			$excluded_posts_ids[] = $homepage_post_id;
+		}
+
+		// The posts page is added to the posts sitemap after filtering. Prevent it from being duplicated in the page sitemap.
+		$posts_page_id = (int) get_option( 'page_for_posts' );
+		if ( ! empty( $posts_page_id ) ) {
+			$excluded_posts_ids[] = $posts_page_id;
+		}
+
 		/**
 		 * Filter: 'wpseo_exclude_from_sitemap_by_post_ids' - Allow extending and modifying the posts to exclude.
 		 *

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -57,11 +57,11 @@ class WPSEO_Post_Type_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider 
 	 */
 	protected function should_exclude_object_sub_type( $object_sub_type ) {
 		/**
-			 * Filter decision if post type is excluded from the XML sitemap.
-			 *
-			 * @param bool   $exclude   Default false.
-			 * @param string $post_type Post type name.
-			 */
+		 * Filter decision if post type is excluded from the XML sitemap.
+		 *
+		 * @param bool   $exclude   Default false.
+		 * @param string $post_type Post type name.
+		 */
 		if ( apply_filters( 'wpseo_sitemap_exclude_post_type', false, $object_sub_type ) ) {
 			return true;
 		}

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -102,7 +102,6 @@ class WPSEO_Taxonomy_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider i
 		$query = $this->repository
 			->query_where_noindex( false, 'term', $type )
 			->select_many( 'id', 'object_id', 'permalink', 'object_last_modified' )
-			->where( 'is_publicly_viewable', true )
 			->order_by_asc( 'object_last_modified' )
 			->offset( $offset )
 			->limit( $steps );

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -88,14 +88,13 @@ class Indexable_Author_Builder {
 		$indexable->is_robots_noimageindex = null;
 		$indexable->is_robots_nosnippet    = null;
 		$indexable->blog_id                = \get_current_blog_id();
+		$indexable->is_publicly_viewable   = true;
 		$indexable->set_deprecated_property( 'is_public', ( $indexable->is_robots_noindex ) ? false : null );
 
 		$this->reset_social_images( $indexable );
 		$this->handle_social_images( $indexable );
 
 		$indexable = $this->set_aggregate_values( $indexable );
-
-		$indexable->is_publicly_viewable = $indexable->number_of_publicly_viewable_posts > 0;
 
 		$indexable->version = $this->version;
 

--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -95,6 +95,8 @@ class Indexable_Author_Builder {
 
 		$indexable = $this->set_aggregate_values( $indexable );
 
+		$indexable->is_publicly_viewable = $indexable->number_of_publicly_viewable_posts > 0;
+
 		$indexable->version = $this->version;
 
 		return $indexable;

--- a/src/config/migrations/20211108133106_AddIsPubliclyViewableToIndexables.php
+++ b/src/config/migrations/20211108133106_AddIsPubliclyViewableToIndexables.php
@@ -35,7 +35,7 @@ class AddIsPubliclyViewableToIndexables extends Migration {
 			]
 		);
 
-		$this->query( "UPDATE $table_name SET is_publicly_viewable = is_public" );
+		$this->query( "UPDATE $table_name SET is_publicly_viewable = is_public IS NULL OR is_public != false" );
 	}
 
 	/**

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -189,7 +189,8 @@ class Indexable_Repository {
 		$default_noindex = $this->robots_helper->get_default_noindex_for_object( $object_type, $object_sub_type );
 
 		$conditions = '`is_robots_noindex` = %d ';
-		$values     = [ (int) $noindex ];
+		$values     = [ $noindex ];
+
 		// If the requested noindex value matches the default, include NULL values in the result.
 		if ( $default_noindex === $noindex ) {
 			$conditions = '(' . $conditions . 'OR `is_robots_noindex` IS NULL )';
@@ -202,7 +203,7 @@ class Indexable_Repository {
 		}
 		else {
 			$conditions = '(' . $conditions . ') OR `is_protected` = %d OR `is_publicly_viewable` != %d';
-			$values     = array_merge( $values, [ (int) $noindex, (int) $noindex ] );
+			$values     = array_merge( $values, [ $noindex, $noindex ] );
 		}
 
 		// Let the number of posts in an archive determine the noindex value.
@@ -216,7 +217,7 @@ class Indexable_Repository {
 			}
 		}
 
-		return $query->where_raw( $conditions, (int) $values );
+		return $query->where_raw( $conditions, $values );
 	}
 
 	/**

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -186,6 +186,11 @@ class Indexable_Repository {
 			$query->where( 'object_sub_type', $object_sub_type );
 		}
 
+		if ( $noindex === false ) {
+			// Consider password protected posts as noindex.
+			$query->where( 'is_protected', false );
+		}
+
 		$default_noindex = $this->robots_helper->get_default_noindex_for_object( $object_type, $object_sub_type );
 
 		$condition = 'is_robots_noindex = %d ';

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -187,8 +187,9 @@ class Indexable_Repository {
 		}
 
 		if ( $noindex === false ) {
-			// Consider password protected posts as noindex.
+			// Consider hidden and password protected posts as noindex.
 			$query->where( 'is_protected', false );
+			$query->where( 'is_publicly_viewable', true );
 		}
 
 		$default_noindex = $this->robots_helper->get_default_noindex_for_object( $object_type, $object_sub_type );

--- a/tests/integration/sitemaps/test-class-wpseo-author-sitemap-provider.php
+++ b/tests/integration/sitemaps/test-class-wpseo-author-sitemap-provider.php
@@ -128,15 +128,7 @@ class WPSEO_Author_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 		$this->factory->post->create_many( 3, [ 'post_author' => $user_id ] );
 
 		// Excludes the user from the sitemaps.
-		/**
-		 * The indexable repository.
-		 *
-		 * @var Indexable_Repository $repository
-		 */
-		$repository                   = YoastSEO()->classes->get( Indexable_Repository::class );
-		$indexable                    = $repository->find_by_id_and_type( $user_id, 'user' );
-		$indexable->is_robots_noindex = true;
-		$indexable->save();
+		update_user_meta( $user_id, 'wpseo_noindex_author', 'on' );
 
 		// Checks which authors are in the sitemap, there should be none.
 		self::$class_instance->get_sitemap_links( 'author', 10, 1 );

--- a/tests/integration/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
+++ b/tests/integration/sitemaps/test-class-wpseo-post-type-sitemap-provider.php
@@ -43,8 +43,6 @@ class WPSEO_Post_Type_Sitemap_Provider_Test extends WPSEO_UnitTestCase {
 	 * @covers WPSEO_Post_Type_Sitemap_Provider::get_index_links
 	 */
 	public function test_get_index_links_no_entries() {
-		$this->factory->post->create();
-		$this->factory->post->create( [ 'post_type' => 'page' ] );
 		$index_links = self::$class_instance->get_index_links( 1 );
 		$this->assertNotEmpty( $index_links );
 		$this->assertContains( 'http://example.org/post-sitemap.xml', $index_links[0] );

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -166,6 +166,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->indexable_mock->orm->expects( 'get' )->twice()->with( 'twitter_image' );
 		$this->indexable_mock->orm->expects( 'get' )->times( 3 )->with( 'twitter_image_id' );
 		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'object_last_modified' );
+		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'number_of_publicly_viewable_posts' )->andReturn( '7' );
 
 		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image', 'avatar_image.jpg' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_source', 'gravatar-image' );
@@ -175,6 +176,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->indexable_mock->orm->expects( 'set' )->with( 'object_published_at', '1234-12-12 00:00:00' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'object_last_modified', '1234-12-12 23:59:59' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'number_of_publicly_viewable_posts', '7' );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'is_publicly_viewable', true );
 
 		Monkey\Functions\expect( 'get_avatar_url' )
 			->once()
@@ -205,10 +207,12 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'twitter_image' );
 		$this->indexable_mock->orm->expects( 'get' )->twice()->with( 'twitter_image_id' );
 		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'object_last_modified' );
+		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'number_of_publicly_viewable_posts' )->andReturn( '7' );
 
 		$this->indexable_mock->orm->expects( 'set' )->with( 'object_published_at', '1234-12-12 00:00:00' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'object_last_modified', '1234-12-12 23:59:59' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'number_of_publicly_viewable_posts', '7' );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'is_publicly_viewable', true );
 
 		Monkey\Functions\expect( 'get_avatar_url' )
 			->once()
@@ -247,6 +251,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->indexable_mock->orm->expects( 'get' )->twice()->with( 'twitter_image' );
 		$this->indexable_mock->orm->expects( 'get' )->times( 3 )->with( 'twitter_image_id' );
 		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'object_last_modified' );
+		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'number_of_publicly_viewable_posts' )->andReturn( '7' );
 
 		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image', 'avatar_image.jpg' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_source', 'gravatar-image' );
@@ -256,6 +261,7 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->indexable_mock->orm->expects( 'set' )->with( 'object_published_at', '1234-12-12 00:00:00' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'object_last_modified', '1234-12-12 23:59:59' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'number_of_publicly_viewable_posts', '7' );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'is_publicly_viewable', true );
 
 		Monkey\Functions\expect( 'get_avatar_url' )
 			->once()

--- a/tests/unit/builders/indexable-author-builder-test.php
+++ b/tests/unit/builders/indexable-author-builder-test.php
@@ -166,8 +166,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->indexable_mock->orm->expects( 'get' )->twice()->with( 'twitter_image' );
 		$this->indexable_mock->orm->expects( 'get' )->times( 3 )->with( 'twitter_image_id' );
 		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'object_last_modified' );
-		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'number_of_publicly_viewable_posts' )->andReturn( '7' );
-
 		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image', 'avatar_image.jpg' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_source', 'gravatar-image' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'twitter_image', 'avatar_image.jpg' );
@@ -207,8 +205,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'twitter_image' );
 		$this->indexable_mock->orm->expects( 'get' )->twice()->with( 'twitter_image_id' );
 		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'object_last_modified' );
-		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'number_of_publicly_viewable_posts' )->andReturn( '7' );
-
 		$this->indexable_mock->orm->expects( 'set' )->with( 'object_published_at', '1234-12-12 00:00:00' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'object_last_modified', '1234-12-12 23:59:59' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'number_of_publicly_viewable_posts', '7' );
@@ -251,8 +247,6 @@ class Indexable_Author_Builder_Test extends TestCase {
 		$this->indexable_mock->orm->expects( 'get' )->twice()->with( 'twitter_image' );
 		$this->indexable_mock->orm->expects( 'get' )->times( 3 )->with( 'twitter_image_id' );
 		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'object_last_modified' );
-		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'number_of_publicly_viewable_posts' )->andReturn( '7' );
-
 		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image', 'avatar_image.jpg' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_source', 'gravatar-image' );
 		$this->indexable_mock->orm->expects( 'set' )->with( 'twitter_image', 'avatar_image.jpg' );

--- a/tests/unit/integrations/watchers/indexable-static-home-page-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-static-home-page-watcher-test.php
@@ -52,7 +52,7 @@ class Indexable_Static_Home_Page_Watcher_Test extends TestCase {
 	 */
 	public function test_get_conditionals() {
 		$this->assertEquals(
-			[ Admin_Conditional::class ],
+			[],
 			Indexable_Static_Home_Page_Watcher::get_conditionals()
 		);
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* Make indexable sitemaps more consistent with the current generation sitemaps
* Don't require existing sites to do a full reindex before getting valid sitemaps.
* Deduplicate code

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Make indexable sitemaps more consistent with the current generation sitemaps
* Don't require existing sites to do a full reindex before getting valid sitemaps.

## Relevant technical choices:

* I've derived the is_publicly_viewable value for authors off of the number of publicly viewable posts. There is another condition that determines if author archives are viewable, but that is a global wpseo setting that would require us to reindex _all_ authors when that setting is changed. This operation will be too heavy for some sites, so it isn't included in the expression.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
#### Preserve sitemap index links for empty sitemaps.
* Remove/trash all pages from your site
* Visit the XML sitemap and see that there is still a page-sitemap.xml entry on the sitemap index.
* Click the entry and see that it only contains a link to the homepage.

#### home- and pages page
* Create a new page
* See that the page is added to the page sitemap
* Go to wp-admin/options-reading.php and under " A static page (select below)", select your new page as the "posts page"
* In the posts sitemap, your page should now be the first entry of the sitemap.
* In the pages sitemap, your page should no longer be visible.
* Create a new page
* See that the page is added to the page sitemap
* Go to the reading settings again and make that page your home page.
* In the pages sitemap, your page should no longer be visible under its full url, but instead you should see the url of the homepage of your site (e.g. yoast.com instead of yoast.com/my-home-page).
 
#### watch for author meta changes
* Open the author sitemap and find an author with posts (depending on your Yoast SEO settings they could all have posts).
* Find the user in wp-admin/users.php and click Edit
* Check the  "Do not allow search engines to show this author's archives in search results." checkbox and save the user.
* Open the author sitemap again and confirm that this author doesn't show up in the sitemaps anymore.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
