### PR TITLE
P1-1140 Fix title width and primary category plugins

### DIFF
--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -129,8 +129,13 @@ class WPSEO_Primary_Term_Admin implements WPSEO_WordPress_Integration {
 			'taxonomies' => $mapped_taxonomies,
 		];
 
-		$asset_manager->localize_script( 'post-edit', 'wpseoPrimaryCategoryL10n', $data );
-		$asset_manager->localize_script( 'post-edit-classic', 'wpseoPrimaryCategoryL10n', $data );
+		$is_block_editor  = WP_Screen::get()->is_block_editor();
+		$post_edit_handle = 'post-edit';
+		if ( ! $is_block_editor ) {
+			$post_edit_handle = 'classic-editor';
+		}
+
+		$asset_manager->localize_script( $post_edit_handle, 'wpseoPrimaryCategoryL10n', $data );
 	}
 
 	/**

--- a/packages/js/src/classic-editor.js
+++ b/packages/js/src/classic-editor.js
@@ -8,6 +8,7 @@ import Metabox from "./classic-editor/components/metabox";
 import { MetaboxFill, MetaboxSlot } from "./classic-editor/components/metabox/slot-fill";
 import initEditorStore from "./classic-editor/editor-store";
 import { getInitialPostState, getInitialTermState } from "./classic-editor/initial-state";
+import registerSeoTitleWidth from "./classic-editor/plugins/seo-title-width";
 import registerShortcodes from "./classic-editor/shortcodes";
 import { initPostWatcher, initTermWatcher } from "./classic-editor/watcher";
 import { registerReactComponent, renderReactRoot } from "./helpers/reactRoot";
@@ -74,6 +75,8 @@ const initPost = async () => {
 	initFeaturedImagePlugin();
 	// Register shortcodes to work on paper data.
 	registerShortcodes();
+	// Register SEO title width plugin.
+	registerSeoTitleWidth();
 	// Initialize the publish box.
 	initPublishBox();
 	// Create SEO integration with post state.
@@ -95,6 +98,8 @@ const initPost = async () => {
  * @returns {void}
  */
 const initTerm = async () => {
+	// Register SEO title width plugin.
+	registerSeoTitleWidth();
 	// Initialize TinyMCE description editor for terms.
 	initTermDescriptionTinyMce( jQuery );
 	// Create SEO integration with term state.

--- a/packages/js/src/classic-editor.js
+++ b/packages/js/src/classic-editor.js
@@ -9,7 +9,7 @@ import { MetaboxFill, MetaboxSlot } from "./classic-editor/components/metabox/sl
 import initEditorStore from "./classic-editor/editor-store";
 import { getInitialPostState, getInitialTermState } from "./classic-editor/initial-state";
 import registerSeoTitleWidth from "./classic-editor/plugins/seo-title-width";
-import registerShortcodes from "./classic-editor/shortcodes";
+import registerShortcodes from "./classic-editor/plugins/shortcodes";
 import { initPostWatcher, initTermWatcher } from "./classic-editor/watcher";
 import { registerReactComponent, renderReactRoot } from "./helpers/reactRoot";
 import registerGlobalApis from "./helpers/register-global-apis";

--- a/packages/js/src/classic-editor.js
+++ b/packages/js/src/classic-editor.js
@@ -75,8 +75,6 @@ const initPost = async () => {
 	initFeaturedImagePlugin();
 	// Register shortcodes to work on paper data.
 	registerShortcodes();
-	// Register SEO title width plugin.
-	registerSeoTitleWidth();
 	// Initialize the publish box.
 	initPublishBox();
 	// Create SEO integration with post state.
@@ -98,8 +96,6 @@ const initPost = async () => {
  * @returns {void}
  */
 const initTerm = async () => {
-	// Register SEO title width plugin.
-	registerSeoTitleWidth();
 	// Initialize TinyMCE description editor for terms.
 	initTermDescriptionTinyMce( jQuery );
 	// Create SEO integration with term state.
@@ -124,6 +120,8 @@ domReady( async () => {
 	initAdminMedia( jQuery );
 	// Until ALL the components are carried over, the `@yoast-seo/editor` store is still needed.
 	initEditorStore();
+	// Register SEO title width plugin.
+	registerSeoTitleWidth();
 	// Initialize the primary category integration.
 	if ( get( window, "wpseoPrimaryCategoryL10n", false ) ) {
 		initPrimaryCategory( jQuery );

--- a/packages/js/src/classic-editor.js
+++ b/packages/js/src/classic-editor.js
@@ -1,25 +1,23 @@
-/* global wpseoPrimaryCategoryL10n */
-
-import { get, debounce } from "lodash";
-import domReady from "@wordpress/dom-ready";
 import { dispatch } from "@wordpress/data";
+import domReady from "@wordpress/dom-ready";
 import createSeoIntegration, { SEO_STORE_NAME } from "@yoast/seo-integration";
-import registerShortcodes from "./classic-editor/plugins/shortcodes";
+import { debounce, get } from "lodash";
+import { refreshDelay } from "./analysis/constants";
+import { getAnalysisConfiguration } from "./classic-editor/analysis";
+import Metabox from "./classic-editor/components/metabox";
+import { MetaboxFill, MetaboxSlot } from "./classic-editor/components/metabox/slot-fill";
+import initEditorStore from "./classic-editor/editor-store";
+import { getInitialPostState, getInitialTermState } from "./classic-editor/initial-state";
+import registerShortcodes from "./classic-editor/shortcodes";
+import { initPostWatcher, initTermWatcher } from "./classic-editor/watcher";
 import { registerReactComponent, renderReactRoot } from "./helpers/reactRoot";
 import registerGlobalApis from "./helpers/register-global-apis";
 import initAdmin from "./initializers/admin";
 import initAdminMedia from "./initializers/admin-media";
 import initTabs from "./initializers/metabox-tabs";
 import initPrimaryCategory from "./initializers/primary-category";
-import { initialize as initPublishBox } from "./ui/publishBox";
-import initEditorStore from "./classic-editor/editor-store";
-import Metabox from "./classic-editor/components/metabox";
-import { MetaboxFill, MetaboxSlot } from "./classic-editor/components/metabox/slot-fill";
-import { initPostWatcher, initTermWatcher } from "./classic-editor/watcher";
-import { getInitialPostState, getInitialTermState } from "./classic-editor/initial-state";
-import { getAnalysisConfiguration } from "./classic-editor/analysis";
-import { refreshDelay } from "./analysis/constants";
 import { initTermDescriptionTinyMce } from "./initializers/tiny-mce";
+import { initialize as initPublishBox } from "./ui/publishBox";
 import initFeaturedImagePlugin from "./classic-editor/plugins/featured-image";
 
 // These are either "1" or undefined.
@@ -48,11 +46,11 @@ const renderMetabox = ( { SeoProvider } ) => renderReactRoot( {
 } );
 
 /**
- * Registers Yoast API's on the global for backwards compatibility.
+ * Registers Yoast APIs on the global for backwards compatibility.
  *
  * @param {Object} options Options object.
- * @param {JSX.Element} options.analysisWorker The ananlysis worker interface.
- * @returns {void}
+ * @param {Object} options.analysisWorker The analysis worker interface.
+ * @returns {function} Function to register YoastSEO APIs.
  */
 const registerYoastApis = ( { analysisWorker } ) => registerGlobalApis(
 	"YoastSEO",
@@ -122,7 +120,7 @@ domReady( async () => {
 	// Until ALL the components are carried over, the `@yoast-seo/editor` store is still needed.
 	initEditorStore();
 	// Initialize the primary category integration.
-	if ( typeof wpseoPrimaryCategoryL10n !== "undefined" ) {
+	if ( get( window, "wpseoPrimaryCategoryL10n", false ) ) {
 		initPrimaryCategory( jQuery );
 	}
 	// Initialize post logic if post page.

--- a/packages/js/src/classic-editor/plugins/seo-title-width.js
+++ b/packages/js/src/classic-editor/plugins/seo-title-width.js
@@ -10,7 +10,7 @@ import { helpers } from "yoastseo";
  */
 const registerSeoTitleWidth = () => {
 	const hookName = "yoast.seoStore.analysis.preparePaper";
-	const namespace = "yoast/seo-integration-app/measureSeoTitleWidth";
+	const namespace = "yoast/free/measureSeoTitleWidth";
 
 	addFilter(
 		hookName,
@@ -20,7 +20,7 @@ const registerSeoTitleWidth = () => {
 			seoTitleWidth: helpers.measureTextWidth( paper.seoTitle ),
 		} ),
 		// Priority of 11, because no replacevars are used in the SEO title width.
-		11,
+		11
 	);
 
 	return () => removeFilter( hookName, namespace );

--- a/packages/js/src/classic-editor/plugins/seo-title-width.js
+++ b/packages/js/src/classic-editor/plugins/seo-title-width.js
@@ -1,0 +1,29 @@
+import { addFilter, removeFilter } from "@wordpress/hooks";
+import { helpers } from "yoastseo";
+
+/**
+ * Registers the SEO title width plugin.
+ *
+ * This "plugin" measures the SEO title width and adds it to the analysis data.
+ *
+ * @returns {function} Function to unregister the SEO title width plugin.
+ */
+const registerSeoTitleWidth = () => {
+	const hookName = "yoast.seoStore.analysis.preparePaper";
+	const namespace = "yoast/seo-integration-app/measureSeoTitleWidth";
+
+	addFilter(
+		hookName,
+		namespace,
+		paper => ( {
+			...paper,
+			seoTitleWidth: helpers.measureTextWidth( paper.seoTitle ),
+		} ),
+		// Priority of 11, because no replacevars are used in the SEO title width.
+		11,
+	);
+
+	return () => removeFilter( hookName, namespace );
+};
+
+export default registerSeoTitleWidth;

--- a/src/integrations/admin/fix-news-dependencies-integration.php
+++ b/src/integrations/admin/fix-news-dependencies-integration.php
@@ -52,7 +52,7 @@ class Fix_News_Dependencies_Integration implements Integration_Interface {
 		$is_block_editor  = WP_Screen::get()->is_block_editor();
 		$post_edit_handle = 'post-edit';
 		if ( ! $is_block_editor ) {
-			$post_edit_handle = 'post-edit-classic';
+			$post_edit_handle = 'classic-editor';
 		}
 
 		$scripts->registered['wpseo-news-editor']->deps[] = WPSEO_Admin_Asset_Manager::PREFIX . $post_edit_handle;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds SEO title width plugin.
* Fixes a bug where the primary category plugin would not be loaded due to the L10n not being available.
* Fixes a bug where the news add-on would not have the free scripts loaded due to the script handle being wrong.

## Relevant technical choices:

* Searched for the `post-edit-classic` script handle and changed the implementations to use `classic-editor` when not on the block editor.
* Added the SEO title width as preparePaper filter. Using the `measureTextWidth` from our `yoastseo` package.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### News SEO
* Check out the `analysis-integration` branch before this PR
* Activate News SEO
* Open the classic editor
* Verify the news tab in the metabox does not have any content and there is a PHP warning about missing dependencies (Query monitor)
* Switch to this branch
* Verify the news tab works again and the missing dependencies warning is gone

#### Primary category plugin
* Open the classic editor
* Add at least two categories
* Verify you can now change the primary category
* Note: the replacement variable is not coupled to this yet, that is another issue

#### SEO title width plugin
* Open the classic editor
* Type an SEO title
* Verify you can influence the SEO analysis's `SEO title width` assessment. I.e. empty it, make it silly long etc.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/P1-1140
