### PR TITLE
Add upgrade 17.9 routine to set wincher active to true

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -75,6 +75,7 @@ class WPSEO_Upgrade {
 			'16.5-RC0'   => 'upgrade_165',
 			'17.2-RC0'   => 'upgrade_172',
 			'17.7.1-RC0' => 'upgrade_1771',
+			'17.9-RC0'   => 'upgrade_179',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -852,6 +853,13 @@ class WPSEO_Upgrade {
 		$enabled_auto_updates = \get_site_option( 'auto_update_plugins' );
 		$addon_update_watcher = YoastSEO()->classes->get( \Yoast\WP\SEO\Integrations\Watchers\Addon_Update_Watcher::class );
 		$addon_update_watcher->toggle_auto_updates_for_add_ons( 'auto_update_plugins', $enabled_auto_updates, [] );
+	}
+
+	/**
+	 * Performs the 17.9 upgrade routine.
+	 */
+	private function upgrade_179() {
+		WPSEO_Options::set( 'wincher_integration_active', true );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Wincher options already existed behind a feature flag in 17.8. This can cause issues when users save the deactivated value, and then upgrade to 17.9. An upgrade routine was created to set the Wincher integration to active in 17.9, as it emerges from behind the feature flag.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where saving the integrations form in 17.8 and upgrading to 17.9 would set the Wincher integration to "off".

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

 * If you have it enabled, disable the `YOAST_SEO_WINCHER_INTEGRATION` feature flag in your wp-config.
 * Go to Yoast>general>integrations, change something (i.e. turn ryte off) and press save.
 * Get the yoast-test-helper plugin.
 * Go to tools>yoast-test-helper
 * Set the DB version to 17.8.
 * See that an upgrade routine is called.
 * Go to Yoast>general>integrations and verify that Wincher integration is active.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Have 17.8 without the wincher feature flag active.
* Go to Yoast>general>integrations, make sure there is nothing about the wincher integration, and save the form (you could also change some values if you want).
* Upgrade to 17.9.
* Verify that, in Yoast>general>integrations, Wincher is now visible and active.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-209
