### PR TITLE
Fix wordpress.org translation parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -193,7 +193,7 @@ before_script:
       mysql -e "CREATE DATABASE wordpress_tests;" -uroot
       cd "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
       mkdir src/generated/assets
-      echo "<?php return [ 'post-edit.min.js' => [ 'dependencies' => [], 'version' => 'test' ], 'installation-success.min.js' => [ 'dependencies' => [], 'version' => 'test' ], 'workouts.min.js' => [ 'dependencies' => [], 'version' => 'test' ] ];" >> src/generated/assets/plugin.php
+      echo "<?php return [ 'post-edit.js' => [ 'dependencies' => [], 'version' => 'test' ], 'installation-success.js' => [ 'dependencies' => [], 'version' => 'test' ], 'workouts.js' => [ 'dependencies' => [], 'version' => 'test' ] ];" >> src/generated/assets/plugin.php
       echo "<?php return [];" >> src/generated/assets/externals.php
       echo "<?php return [];" >> src/generated/assets/languages.php
     fi

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -278,7 +278,7 @@ class WPSEO_Admin_Asset_Manager {
 		$plugin_scripts   = $this->load_generated_asset_file(
 			[
 				'asset_file'      => __DIR__ . '/../src/generated/assets/plugin.php',
-				'ext_length'      => 7,
+				'ext_length'      => 3,
 				'additional_deps' => $additional_dependencies,
 				'header_scripts'  => $header_scripts,
 			]
@@ -286,7 +286,7 @@ class WPSEO_Admin_Asset_Manager {
 		$external_scripts = $this->load_generated_asset_file(
 			[
 				'asset_file'      => __DIR__ . '/../src/generated/assets/externals.php',
-				'ext_length'      => 7,
+				'ext_length'      => 3,
 				'suffix'          => '-package',
 				'base_dir'        => 'externals/',
 				'additional_deps' => $additional_dependencies,
@@ -296,7 +296,7 @@ class WPSEO_Admin_Asset_Manager {
 		$language_scripts = $this->load_generated_asset_file(
 			[
 				'asset_file'      => __DIR__ . '/../src/generated/assets/languages.php',
-				'ext_length'      => 7,
+				'ext_length'      => 3,
 				'suffix'          => '-language',
 				'base_dir'        => 'languages/',
 				'additional_deps' => $additional_dependencies,
@@ -316,7 +316,7 @@ class WPSEO_Admin_Asset_Manager {
 
 		$scripts['installation-success'] = [
 			'name'    => 'installation-success',
-			'src'     => 'installation-success.min.js',
+			'src'     => 'installation-success.js',
 			'deps'    => [
 				'wp-a11y',
 				'wp-dom-ready',
@@ -347,7 +347,7 @@ class WPSEO_Admin_Asset_Manager {
 
 		$scripts['workouts'] = [
 			'name'    => 'workouts',
-			'src'     => 'workouts.min.js',
+			'src'     => 'workouts.js',
 			'deps'    => [
 				'clipboard',
 				'lodash',

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -17,7 +17,7 @@ const {
 const languages = readdirSync( root + "node_modules/yoastseo/src/languageProcessing/languages" );
 const pluginVersion = packageJson.yoast.pluginVersion;
 const pluginVersionSlug = paths.flattenVersionForFile( pluginVersion );
-const outputFilename = "[name].min.js";
+const outputFilename = "[name].js";
 
 module.exports = [
 	baseConfig(

--- a/yarn.lock
+++ b/yarn.lock
@@ -23250,9 +23250,9 @@ typescript@^4.2.4:
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 u3@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/u3/-/u3-0.1.0.tgz#0060927663b68353c539cda99e9511d6687edd9d"
-  integrity sha1-AGCSdmO2g1PFOc2pnpUR1mh+3Z0=
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/u3/-/u3-0.1.1.tgz#5f52044f42ee76cd8de33148829e14528494b73b"
+  integrity sha512-+J5D5ir763y+Am/QY6hXNRlwljIeRMZMGs0cT6qqZVVzzT3X3nFPXVyPOFRMOR4kupB0T8JnCdpWdp6Q/iXn3w==
 
 ua-parser-js@^0.7.18:
   version "0.7.25"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes issues that caused our JS files to not be fully parsed by translate.wordpress.org.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reverts the change renaming our `.js` files to `.min.js`, `.min.js` files are not parsed by translate.wordpress.org.
* Updates a sub-dependency causing our analysis library to not be fully parsed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* There should be no JS errors in the metabox/sidebar, the workouts and our settings pages.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Script loading errors in our metabox/sidebar, workouts and our settings pages.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
