### PR TITLE
Fix untranslated string for the Keyphrase in title assessment

### DIFF
--- a/packages/yoastseo/src/scoring/assessments/seo/TitleKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/TitleKeywordAssessment.js
@@ -92,8 +92,8 @@ class TitleKeywordAssessment extends Assessment {
 	calculateResult( keyword, language ) {
 		const feedbackStrings = this._config.feedbackStrings;
 		if ( language === "ja" ) {
-			feedbackStrings.bad = "For the best SEO results include all words of your keyphrase in the SEO title, " +
-					"and put the keyphrase at the beginning of the title";
+			feedbackStrings.bad = __( "For the best SEO results include all words of your keyphrase in the SEO title, " +
+					"and put the keyphrase at the beginning of the title", "wordpress-seo" );
 		}
 		const exactMatchFound = this._keywordMatches.exactMatchFound;
 		const position = this._keywordMatches.position;

--- a/packages/yoastseo/src/scoring/assessments/seo/TitleKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/TitleKeywordAssessment.js
@@ -37,8 +37,8 @@ class TitleKeywordAssessment extends Assessment {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/33g" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/33h" ),
 			feedbackStrings: {
-				bad: "For the best SEO results write the exact match of your keyphrase in the SEO title, " +
-					"and put the keyphrase at the beginning of the title",
+				bad: __( "For the best SEO results write the exact match of your keyphrase in the SEO title, " +
+					"and put the keyphrase at the beginning of the title", "wordpress-seo" )
 			},
 		};
 
@@ -206,7 +206,7 @@ class TitleKeywordAssessment extends Assessment {
 			score: this._config.scores.bad,
 			resultText: sprintf(
 				/* Translators: %1$s and %2$s expand to a link on yoast.com,
-				%3$s expands to the anchor end tag, %4$s expands to the keyword of the article. */
+				%3$s expands to the anchor end tag, %4$s expands to the keyword of the article, %5$s expands to the call to action text. */
 				__(
 					// eslint-disable-next-line max-len
 					"%1$sKeyphrase in title%3$s: Not all the words from your keyphrase \"%4$s\" appear in the SEO title. %2$s%5$s%3$s.",

--- a/packages/yoastseo/src/scoring/assessments/seo/TitleKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/TitleKeywordAssessment.js
@@ -38,7 +38,7 @@ class TitleKeywordAssessment extends Assessment {
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/33h" ),
 			feedbackStrings: {
 				bad: __( "For the best SEO results write the exact match of your keyphrase in the SEO title, " +
-					"and put the keyphrase at the beginning of the title", "wordpress-seo" )
+					"and put the keyphrase at the beginning of the title", "wordpress-seo" ),
 			},
 		};
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Encloses a feedback string for the Keyphrase in title assessment in the WordPress translation function so that it can be translated to other languages.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new post and add a keyphrase, e.g. `cats and dogs`
* Add a title that doesn't contain all words from the keyphrase, e.g. `cats`
* Confirm that the Keyphrase in title assessment returns the following feedback: `Keyphrase in title: Not all the words from your keyphrase X appear in the SEO title. For the best SEO results write the exact match of your keyphrase in the SEO title, and put the keyphrase at the beginning of the title.`
* Switch site language to Japanese
* Go back to the post and confirm that the Keyphrase in title assessment returns the following feedback: `タイトル内のキーフレーズ: SEOタイトルにキーフレーズ「猫」のいくつかの語が入っていません。For the best SEO results include all words of your keyphrase in the SEO title, and put the keyphrase at the beginning of the title。`
* Switch to another language than English or Japanese
* Go back to the post and confirm that the last sentence of the Keyphrase in title feedback string is the same as for English.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Follow the same steps as above
* In addition, confirm that the string `For the best SEO results include all words of your keyphrase in the SEO title, and put the keyphrase at the beginning of the title` shows up under the [following link](https://translate.wordpress.org/projects/wp-plugins/wordpress-seo/dev/ja/default/?filters%5Bterm%5D=For+the+best+SEO+results+include+all+words+of+your+keyphrase+in+the+SEO+title%2C+%22+%2B+%09%09%09%09%09%22and+put+the+keyphrase+at+the+beginning+of+the+title&filters%5Bterm_scope%5D=scope_any&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filters%5Buser_login%5D=&filter=Apply+Filters&sort%5Bby%5D=priority&sort%5Bhow%5D=desc).
* Confirm that the string `For the best SEO results write the exact match of your keyphrase in the SEO title, and put the keyphrase at the beginning of the title` shows up under the [following link](https://translate.wordpress.org/projects/wp-plugins/wordpress-seo/dev/nl/default/?filters%5Bterm%5D=For+the+best+SEO+results+write+the+exact+match+of+your+keyphrase+in+the+SEO+title%2C+and+put+the+keyphrase+at+the+beginning+of+the+title&filters%5Bterm_scope%5D=scope_any&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filters%5Buser_login%5D=&filter=Apply+Filters&sort%5Bby%5D=priority&sort%5Bhow%5D=desc).

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
