### PR TITLE
P1-1139 - Create build script in wordpress-seo

### DIFF
--- a/config/grunt/task-config/aliases.yaml
+++ b/config/grunt/task-config/aliases.yaml
@@ -28,7 +28,18 @@
 'build:js':
   - 'clean:build-assets-js'
   - 'copy:js-dependencies'
+  - 'build:seo-integration'
   - 'shell:webpack'
+
+'build:seo-integration':
+  - 'shell:build-seo-store'
+  - 'shell:build-replacement-variables'
+  - 'shell:build-seo-integration'
+
+'build:seo-integration-prod':
+  - 'shell:build-seo-store-prod'
+  - 'shell:build-replacement-variables-prod'
+  - 'shell:build-seo-integration-prod'
 
 # Build CSS for development
 'build:css':
@@ -156,6 +167,7 @@ release:
   - 'shell:install-schema-blocks'
 'release:js':
   - 'copy:js-dependencies'
+  - 'build:seo-integration-prod'
   - 'shell:webpack-prod'
 
 # Build CSS for production

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -24,6 +24,30 @@ module.exports = function( grunt ) {
 	// Temporarily disable require-jsdoc due to the structure of the code below.
 	/* eslint-disable require-jsdoc */
 	return {
+		"build-seo-store": {
+			command: "cd packages/seo-store && yarn build",
+		},
+
+		"build-replacement-variables": {
+			command: "cd packages/replacement-variables && yarn build",
+		},
+
+		"build-seo-integration": {
+			command: "cd packages/seo-integration && yarn build",
+		},
+
+		"build-seo-store-prod": {
+			command: "cd packages/seo-store && yarn build:prod",
+		},
+
+		"build-replacement-variables-prod": {
+			command: "cd packages/replacement-variables && yarn build:prod",
+		},
+
+		"build-seo-integration-prod": {
+			command: "cd packages/seo-integration && yarn build:prod",
+		},
+
 		"combine-pot-files": {
 			fromFiles: [
 				"languages/<%= pkg.plugin.textdomain %>-temp.pot",

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -193,10 +193,6 @@ module.exports = function( grunt ) {
 			command: "composer check-branch-cs",
 		},
 
-		"unlink-monorepo": {
-			command: "yarn unlink-monorepo",
-		},
-
 		"get-monorepo-versions": {
 			command: "yarn list --pattern 'yoastseo|yoast-components' --depth=0",
 		},

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -154,15 +154,15 @@ module.exports = function( grunt ) {
 		},
 
 		webpack: {
-			command: "cross-env NODE_ENV=development yarn run wp-scripts build --config config/webpack/webpack.config.js",
+			command: "cross-env NODE_ENV=development yarn build",
 		},
 
 		"webpack-prod": {
-			command: "yarn run wp-scripts build --config config/webpack/webpack.config.js",
+			command: "yarn build",
 		},
 
 		"webpack-watch": {
-			command: "yarn run wp-scripts start --config config/webpack/webpack.config.js",
+			command: "yarn start",
 		},
 
 		"composer-install-production": {

--- a/packages/replacement-variables/package.json
+++ b/packages/replacement-variables/package.json
@@ -10,8 +10,9 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "build": "yarn clean && babel src --out-dir build",
-    "watch": "yarn clean && babel src --watch --out-dir build",
+    "build": "yarn clean && babel src --out-dir build --source-maps",
+    "build:prod": "yarn clean && babel src --out-dir build",
+    "watch": "yarn clean && babel src --watch --out-dir build --source-maps",
     "clean": "rimraf build",
     "lint": "eslint src --max-warnings=0",
     "lint:watch": "esw src --max-warnings=0 --watch",

--- a/packages/seo-integration/package.json
+++ b/packages/seo-integration/package.json
@@ -17,8 +17,9 @@
   "author": "Team Yoast",
   "license": "GPL-3.0",
   "scripts": {
-    "build": "yarn clean && babel src --out-dir build",
-    "watch": "yarn clean && babel src --watch --out-dir build",
+    "build": "yarn clean && babel src --out-dir build --source-maps",
+    "build:prod": "yarn clean && babel src --out-dir build",
+    "watch": "yarn clean && babel src --watch --out-dir build --source-maps",
     "clean": "rimraf build",
     "lint": "eslint src --max-warnings=0",
     "lint:watch": "esw src --max-warnings=0 --watch",

--- a/packages/seo-store/package.json
+++ b/packages/seo-store/package.json
@@ -17,8 +17,9 @@
   "author": "Team Yoast",
   "license": "GPL-3.0",
   "scripts": {
-    "build": "yarn clean && babel src --out-dir build",
-    "watch": "yarn clean && babel src --watch --out-dir build",
+    "build": "yarn clean && babel src --out-dir build --source-maps",
+    "build:prod": "yarn clean && babel src --out-dir build",
+    "watch": "yarn clean && babel src --watch --out-dir build --source-maps",
     "clean": "rimraf build",
     "lint": "eslint src --max-warnings=0",
     "lint:watch": "esw src --max-warnings=0 --watch",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Running yarn build in wordpress-seo should also build the new SEO integration packages. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Build the seo-integration packages alongside free 

## Relevant technical choices:

- Codescout:
  - Removed unused grunt shell command
  - Refactored shell commands to use our yarn script commands 
- Added sourcemaps to our packages `build` command

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- Run `grunt build`
  - Verify the three seo-integration packages are built.
    - verify that these packages have sourcemaps 
- Run `grunt release`
  - Verify the three seo-integration packages are built.
    - verify that these packages **do not** have sourcemaps 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* This is tooling so this does not have to be tested by QA.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes P1-1139
