### PR TITLE
P1-1148 - The build of our internationalisation features fails

### DIFF
--- a/config/.babelrc
+++ b/config/.babelrc
@@ -1,0 +1,7 @@
+{
+    "presets": [ "react" ],
+	"plugins": [
+        "transform-object-rest-spread",
+		"@babel/plugin-proposal-optional-chaining"
+    ]
+}

--- a/config/grunt/task-config/aliases.yaml
+++ b/config/grunt/task-config/aliases.yaml
@@ -28,18 +28,8 @@
 'build:js':
   - 'clean:build-assets-js'
   - 'copy:js-dependencies'
-  - 'build:seo-integration'
-  - 'shell:webpack'
-
-'build:seo-integration':
-  - 'shell:build-seo-store'
-  - 'shell:build-replacement-variables'
   - 'shell:build-seo-integration'
-
-'build:seo-integration-prod':
-  - 'shell:build-seo-store-prod'
-  - 'shell:build-replacement-variables-prod'
-  - 'shell:build-seo-integration-prod'
+  - 'shell:webpack'
 
 # Build CSS for development
 'build:css':
@@ -167,7 +157,7 @@ release:
   - 'shell:install-schema-blocks'
 'release:js':
   - 'copy:js-dependencies'
-  - 'build:seo-integration-prod'
+  - 'shell:build-seo-integration-prod'
   - 'shell:webpack-prod'
 
 # Build CSS for production

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -24,28 +24,12 @@ module.exports = function( grunt ) {
 	// Temporarily disable require-jsdoc due to the structure of the code below.
 	/* eslint-disable require-jsdoc */
 	return {
-		"build-seo-store": {
-			command: "cd packages/seo-store && yarn build",
-		},
-
-		"build-replacement-variables": {
-			command: "cd packages/replacement-variables && yarn build",
-		},
-
 		"build-seo-integration": {
-			command: "cd packages/seo-integration && yarn build",
-		},
-
-		"build-seo-store-prod": {
-			command: "cd packages/seo-store && yarn build:prod",
-		},
-
-		"build-replacement-variables-prod": {
-			command: "cd packages/replacement-variables && yarn build:prod",
+			command: "yarn lerna run build --scope={'@yoast/seo-integration','@yoast/seo-store','@yoast/replacement-variables'}",
 		},
 
 		"build-seo-integration-prod": {
-			command: "cd packages/seo-integration && yarn build:prod",
+			command: "yarn lerna run build:prod --scope={'@yoast/seo-integration','@yoast/seo-store','@yoast/replacement-variables'}",
 		},
 
 		"combine-pot-files": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@babel/cli": "^7.16.7",
     "@babel/plugin-transform-runtime": "^7.13.10",
     "@slack/webhook": "^5.0.2",
     "@typescript-eslint/eslint-plugin": "^4.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,22 @@
     "@nicolo-ribaudo/chokidar-2" "2.1.8-no-fsevents.3"
     chokidar "^3.4.0"
 
+"@babel/cli@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.16.7.tgz#4184b5ec6a22106e9dd64bbcaa2eb22675ff595d"
+  integrity sha512-0iBF+G2Qml0y3mY5dirolyToLSR88a/KB6F2Gm8J/lOnyL8wbEOHak0DHF8gjc9XZGgTDGv/jYXNiapvsYyHTA==
+  dependencies:
+    commander "^4.0.1"
+    convert-source-map "^1.1.0"
+    fs-readdir-recursive "^1.1.0"
+    glob "^7.0.0"
+    make-dir "^2.1.0"
+    slash "^2.0.0"
+    source-map "^0.5.0"
+  optionalDependencies:
+    "@nicolo-ribaudo/chokidar-2" "2.1.8-no-fsevents.3"
+    chokidar "^3.4.0"
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The i118 build step was failing because babel configuration was missing(no jsx support)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the build step of our internationalisation features would fail (when no .babelrc file was present).

## Relevant technical choices:

* Added @babel/cli to use the "@babel/plugin-proposal-optional-chaining" (min version required: 7.0.0 was 6.26.0)
* Codescout to use lerna to build our agnostic integration packages
  * improves build time 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Execute `grunt build:i18n` and verify all our internationalisation features compile succesfully


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes P1-1148
