### PR TITLE
P1-1149 seo integration translations pipeline

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,6 +38,7 @@ module.exports = function( grunt ) {
 			jsDist: "js/dist/",
 			languages: "languages/",
 			logs: "logs/",
+			packages: "packages/",
 			svnCheckoutDir: ".wordpress-svn",
 			assets: "svn-assets",
 			vendor: "vendor/",
@@ -83,6 +84,7 @@ module.exports = function( grunt ) {
 				yoastJsSearchMetadataPreviews: "<%= paths.languages %>yoast-js-search-metadata-previews.pot",
 				yoastJsSocialMetadataForms: "<%= paths.languages %>yoast-js-social-metadata-forms.pot",
 				yoastJsReplacementVariableEditor: "<%= paths.languages %>yoast-js-replacement-variable-editor.pot",
+				yoastJsSeoIntegration: "<%= paths.languages %>yoast-js-seo-integration.pot",
 
 				yoastseojs: "<%= paths.languages %>yoast-seo-js.pot",
 				yoastComponents: "<%= paths.languages %>yoast-components.pot",

--- a/config/grunt/task-config/aliases.yaml
+++ b/config/grunt/task-config/aliases.yaml
@@ -64,6 +64,8 @@
   - 'copy:makepot-yoast-js-social-metadata-forms'
   - 'shell:makepot-yoast-js-replacement-variable-editor'
   - 'copy:makepot-yoast-js-replacement-variable-editor'
+  - 'shell:makepot-yoast-js-seo-integration'
+  - 'copy:makepot-yoast-js-seo-integration'
   - 'shell:makepot-yoast-components-remaining'
   - 'shell:combine-pots-yoast-components'
   - 'shell:makepot-yoastseojs'

--- a/config/grunt/task-config/copy.js
+++ b/config/grunt/task-config/copy.js
@@ -87,6 +87,10 @@ module.exports = {
 		src: "gettext.pot",
 		dest: "<%= files.pot.yoastJsReplacementVariableEditor %>",
 	},
+	"makepot-yoast-js-seo-integration": {
+		src: "gettext.pot",
+		dest: "<%= files.pot.yoastJsSeoIntegration %>",
+	},
 	"makepot-yoastseojs": {
 		src: "gettext.pot",
 		dest: "<%= files.pot.yoastseojs %>",

--- a/config/grunt/task-config/shell.js
+++ b/config/grunt/task-config/shell.js
@@ -62,6 +62,7 @@ module.exports = function( grunt ) {
 				"<%= files.pot.yoastJsSearchMetadataPreviews %>",
 				"<%= files.pot.yoastJsSocialMetadataForms %>",
 				"<%= files.pot.yoastJsReplacementVariableEditor %>",
+				"<%= files.pot.yoastJsSeoIntegration %>",
 				"<%= files.pot.yoastComponentsConfigurationWizard %>",
 				"<%= files.pot.yoastComponentsRemaining %>",
 			],
@@ -100,6 +101,9 @@ module.exports = function( grunt ) {
 		},
 		"makepot-yoast-js-replacement-variable-editor": {
 			command: "yarn i18n-yoast-js-replacement-variable-editor",
+		},
+		"makepot-yoast-js-seo-integration": {
+			command: "yarn i18n-yoast-js-seo-integration",
 		},
 
 		"makepot-yoast-components-configuration-wizard": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@slack/webhook": "^5.0.2",
     "@typescript-eslint/eslint-plugin": "^4.24.0",
     "@typescript-eslint/parser": "^4.24.0",
-    "@wordpress/babel-plugin-makepot": "^4.1.2",
+    "@wordpress/babel-plugin-makepot": "^4.2.0",
     "@wordpress/dependency-extraction-webpack-plugin": "^3.1.0",
     "@wordpress/scripts": "^14.1.1",
     "@yoast/browserslist-config": "file:packages/browserslist-config",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "i18n-yoast-js-search-metadata-previews": "cross-env NODE_ENV=production babel packages/search-metadata-previews --ignore packages/search-metadata-previews/node_modules,__mocks__/*.js --plugins=@wordpress/babel-plugin-makepot | shusher",
     "i18n-yoast-js-social-metadata-forms": "cross-env NODE_ENV=production babel packages/social-metadata-forms --ignore packages/social-metadata-forms/node_modules,__mocks__/*.js --plugins=@wordpress/babel-plugin-makepot | shusher",
     "i18n-yoast-js-replacement-variable-editor": "cross-env NODE_ENV=production babel packages/replacement-variable-editor --ignore packages/replacement-variable-editor/node_modules,__mocks__/*.js --plugins=@wordpress/babel-plugin-makepot | shusher",
+    "i18n-yoast-js-seo-integration": "cross-env NODE_ENV=production babel packages/seo-integration/src --plugins=@wordpress/babel-plugin-makepot | shusher",
     "prestart": "grunt build:css && grunt copy:js-dependencies",
     "start": "wp-scripts start --config config/webpack/webpack.config.js"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4423,13 +4423,13 @@
   resolved "https://registry.yarnpkg.com/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.1.0.tgz#0a1be89a64bb938f91b733c31bfebd89519c2548"
   integrity sha512-518mL3goaSeXtJCQcPK9OYHUUiA0sjXuoGWHBwRalkyTIQZZy5ZZzlwrlSc9ESZcOw9BZ+Uo8CJRjV2OWnx+Zw==
 
-"@wordpress/babel-plugin-makepot@^4.1.2":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@wordpress/babel-plugin-makepot/-/babel-plugin-makepot-4.1.2.tgz#5b8911c4f0310bc1a9f96f0be4732a0e36919831"
-  integrity sha512-A4u9Y+08gBsvIcSzfuAKMP8lDY2tOSVWxQg5nw5pzXAhG2usx4ORIgV+hwjjNkxiEoRQ79loBXpZNeFzuJnlyg==
+"@wordpress/babel-plugin-makepot@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/babel-plugin-makepot/-/babel-plugin-makepot-4.2.0.tgz#5936099fd56962677eab24dad38e97807bf8f7ff"
+  integrity sha512-AkB5I+OGfvCarKTwTIkK8ZjdIqvmYEnsLQAa6USUosdraFGbgKMSZBDhL1VuyC7LqQ2eIu7RyClLukoAN1L0GA==
   dependencies:
     gettext-parser "^1.3.1"
-    lodash "^4.17.19"
+    lodash "^4.17.21"
 
 "@wordpress/babel-preset-default@^5.2.1":
   version "5.2.2"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Have translations for the new JS package

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the `seo-integration` package to the translations pipeline.

## Relevant technical choices:

* Tried to put the i18n command in the package itself (since we also build there), but then the translator comments are relative to that package, which is confusing I think. So I put it along the other ones, inside the root.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run `grunt build:i18n`
* Ensure you have the translations from `seo-integration` in the pot file:
  * Search for `Something went wrong with loading the analysis, please refresh the page to try again.` in the `languages` folder. You should get a hit in the `yoast-components.php` file (the packages get merged into that one).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/P1-1149
