### PR TITLE
Account for a failed query and return early.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
 		],
 		"check-cs-thresholds": [
 			"@putenv YOASTCS_THRESHOLD_ERRORS=252",
-			"@putenv YOASTCS_THRESHOLD_WARNINGS=220",
+			"@putenv YOASTCS_THRESHOLD_WARNINGS=219",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],
 		"check-cs": [

--- a/src/repositories/seo-links-repository.php
+++ b/src/repositories/seo-links-repository.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Repositories;
 
 use Yoast\WP\Lib\Model;
 use Yoast\WP\Lib\ORM;
+use Yoast\WP\SEO\Models\SEO_Links;
 
 /**
  * Class SEO_Links_Repository.
@@ -118,17 +119,17 @@ class SEO_Links_Repository {
 			->find_array();
 
 		// If the above query fails, do not update anything.
-		if ( ! is_array( $indexable_counts ) ) {
+		if ( ! \is_array( $indexable_counts ) ) {
 			return [];
 		}
 
 		// Get all ID's returned from the query and set them as keys for easy access.
-		$returned_ids = array_flip( array_column( $indexable_counts, 'target_indexable_id' ) );
+		$returned_ids = \array_flip( \array_column( $indexable_counts, 'target_indexable_id' ) );
 
 		// Loop over the original ID's and search them in the returned ID's. If they don't exist, add them with an incoming count of 0.
 		foreach ( $indexable_ids as $id ) {
 			// Cast the ID to string, as the arrays only contain stringified versions of the ID.
-			$id = strval( $id );
+			$id = \strval( $id );
 			if ( isset( $returned_ids[ $id ] ) === false ) {
 				$indexable_counts[] = [
 					'incoming'            => '0',

--- a/src/repositories/seo-links-repository.php
+++ b/src/repositories/seo-links-repository.php
@@ -117,6 +117,11 @@ class SEO_Links_Repository {
 			->group_by( 'target_indexable_id' )
 			->find_array();
 
+		// If the above query fails, do not update anything.
+		if ( ! is_array( $indexable_counts ) ) {
+			return [];
+		}
+
 		// Get all ID's returned from the query and set them as keys for easy access.
 		$returned_ids = array_flip( array_column( $indexable_counts, 'target_indexable_id' ) );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* A database query may fail and return a false boolean which would be used as an array and cause a fatal. This PR fixes that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the internal link update might cause a fatal error.

## Relevant technical choices:

* It should be noted that if the query fails, the related indexables are not retrieved and therefore not updated. This would not happen regardless of if we would throw a fatal error. So this PR just fixes the fatal, but the underlying problem still persists (whatever that may be).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In `get_incoming_link_counts_for_indexable_ids()` set `$indexable_counts` to `false` immediately after the query.
  * Without this PR, any post update where links in the post are changed will cause a fatal error.
  * With this PR, no fatal error will be thrown.
    * It should be noted that the incoming link count on the linked post will not be updated.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.
* This is because it is unclear what would cause the query to return `false`. So that situation is not easily testable.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
