### PR TITLE
LINGO-1253 Fixes incorrect assessments for keyphrases only consisting of function words

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/languages/ja/customResearches/getWordFormsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ja/customResearches/getWordFormsSpec.js
@@ -319,6 +319,7 @@ describe( "The getWordForms function", () => {
 			synonymsForms: [],
 		} );
 	} );
+
 	it( "should not create forms for a keyword containing only function words", () => {
 		const paper = new Paper(
 			"犬です。",
@@ -337,6 +338,26 @@ describe( "The getWordForms function", () => {
 		expect( forms ).toEqual( {
 			keyphraseForms: [ [] ],
 			synonymsForms: [],
+		} );
+	} );
+
+	it( "should not create forms for a synonym containing only function words", () => {
+		const paper = new Paper(
+			"犬です。",
+			{
+				/*
+				 * ばっかり - function word, is deleted
+				 */
+				keyword: "猫",
+				synonyms: "からより",
+			}
+		);
+
+		const researcher = new Researcher( paper );
+		const forms = getWordForms( paper, researcher );
+		expect( forms ).toEqual( {
+			keyphraseForms: [ [ "猫" ] ],
+			synonymsForms: [ [ [] ] ],
 		} );
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/languages/ja/customResearches/getWordFormsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ja/customResearches/getWordFormsSpec.js
@@ -58,7 +58,7 @@ describe( "The getWordForms function", () => {
 
 		const forms = getWordForms( paper, researcher );
 		expect( forms ).toEqual( {
-			keyphraseForms: [],
+			keyphraseForms: [ [] ],
 			synonymsForms: [],
 		} );
 	} );
@@ -76,7 +76,7 @@ describe( "The getWordForms function", () => {
 
 		const forms = getWordForms( paper, researcher );
 		expect( forms ).toEqual( {
-			keyphraseForms: [],
+			keyphraseForms: [ [] ],
 			synonymsForms: [ [ [ "休む", "休み", "休ま", "休め", "休も", "休ん", "休める", "休ませ", "休ませる", "休まれ", "休まれる", "休もう" ] ] ],
 		} );
 	} );
@@ -294,6 +294,46 @@ describe( "The getWordForms function", () => {
 			keyphraseForms:
 				[ [ "猫" ],
 					[ "及ぼ" ] ],
+			synonymsForms: [],
+		} );
+	} );
+
+	it( "should not create forms for a keyword containing a single function word", () => {
+		const paper = new Paper(
+			"犬です。",
+			{
+				/*
+				 * ばっかり - function word, is deleted
+				 */
+				keyword: "ばっかり",
+				synonyms: "",
+			}
+		);
+
+		const researcher = new Researcher( paper );
+		const forms = getWordForms( paper, researcher );
+		expect( forms ).toEqual( {
+			keyphraseForms: [ [] ],
+			synonymsForms: [],
+		} );
+	} );
+	it( "should not create forms for a keyword containing only function words", () => {
+		const paper = new Paper(
+			"犬です。",
+			{
+				/*
+				 * から - function word, is deleted
+				 * より - function word, is deleted
+				 */
+				keyword: "からより",
+				synonyms: "",
+			}
+		);
+
+		const researcher = new Researcher( paper );
+		const forms = getWordForms( paper, researcher );
+		expect( forms ).toEqual( {
+			keyphraseForms: [ [] ],
 			synonymsForms: [],
 		} );
 	} );

--- a/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
@@ -139,7 +139,16 @@ describe( "the meta description keyword match research for languages that have c
 			expect( result ).toEqual( 2 );
 		} );
 
-		it( "shouldn't give NaN/infinity times of keyphrase occurrence when the keyphrase contains spaces and " +
+		it( "shouldn't return NaN/infinity times of keyphrase occurrence when the keyphrase contains only function words and " +
+			"there is no match in the text", function() {
+			const paper = new Paper( "", { keyword: "ばっかり", description: "この記事は小さい花の刺繍をどうやってすてればいいのか、" +
+					"基本的な情報を紹介します。私は美しい猫を飼っています。 野生のハーブの刺繡。" } );
+			const researcher = new JapaneseResearcher( paper );
+			const result = metaDescriptionKeyword( paper, researcher );
+			expect( result ).toEqual( 0 );
+		} );
+
+		it( "shouldn't return NaN/infinity times of keyphrase occurrence when the keyphrase contains spaces and " +
 			"there is no match in the text", function() {
 			const paper = new Paper( "", { keyword: "かしら かい を ばっかり", description: "この記事は小さい花の刺繍をどうやってすてればいいのか、" +
 					"基本的な情報を紹介します。私は美しい猫を飼っています。 野生のハーブの刺繡。" } );
@@ -148,7 +157,7 @@ describe( "the meta description keyword match research for languages that have c
 			expect( result ).toEqual( 0 );
 		} );
 
-		it( "shouldn't give NaN/infinity times of keyphrase occurrence when the keyphrase contains tabs and " +
+		it( "shouldn't return NaN/infinity times of keyphrase occurrence when the keyphrase contains tabs and " +
 			"there is no match in the text", function() {
 			const paper = new Paper( "", { keyword: "かしら	かい	を	ばっかり", description: "この記事は小さい花の刺繍をどうやってすてればいいのか、" +
 					"基本的な情報を紹介します。私は美しい猫を飼っています。 野生のハーブの刺繡。" } );

--- a/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/metaDescriptionKeywordSpec.js
@@ -171,6 +171,14 @@ describe( "the meta description keyword match research for languages that have c
 			expect( result ).toEqual( 0 );
 		} );
 
+		it( "shouldn't return NaN/infinity times of the synonym occurrence when the synonym contains only function words and " +
+			"there is no match in the text", function() {
+			const paper = new Paper( "", { keyword: "", synonyms: "ばっかり", description: "私は美しい猫を飼っています。" } );
+			const researcher = new JapaneseResearcher( paper );
+			const result = metaDescriptionKeyword( paper, researcher );
+			expect( result ).toEqual( 0 );
+		} );
+
 		it( "shouldn't return NaN/infinity times of keyphrase occurrence when the keyphrase contains spaces and " +
 			"there is no match in the text", function() {
 			const paper = new Paper( "", { keyword: "かしら かい を ばっかり", description: "この記事は小さい花の刺繍をどうやってすてればいいのか、" +

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
@@ -209,7 +209,23 @@ describe( "A test for marking the keyword", function() {
 } );
 
 describe( "A test for keyword density in Japanese", function() {
-	it( "shouldn't give NaN/infinity times of keyphrase occurrence when the keyphrase contains spaces and there is no match in the text", function() {
+	it( "shouldn't return NaN/infinity times of keyphrase occurrence when the keyphrase contains only function words " +
+		"and there is no match in the text", function() {
+		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 32 ), {
+			keyword: "ばっかり",
+			locale: "ja",
+		} );
+		const researcher = new JapaneseResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyDataJA );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
+		expect( result.getScore() ).toBe( 4 );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 6 times for a text of this length. " +
+			"<a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
+	} );
+
+	it( "shouldn't return NaN/infinity times of keyphrase occurrence when the keyphrase contains spaces " +
+		"and there is no match in the text", function() {
 		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 32 ), {
 			keyword: "かしら かい を ばっかり",
 			locale: "ja",

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
@@ -256,6 +256,22 @@ describe( "A test for keyword density in Japanese", function() {
 			"<a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
 	} );
 
+	it( "shouldn't return NaN/infinity times of synonym occurrence when the synonym contains only function words " +
+		"and there is no match in the text", function() {
+		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 32 ), {
+			keyword: "",
+			synonyms: "ばっかり",
+			locale: "ja",
+		} );
+		const researcher = new JapaneseResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyDataJA );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher );
+		expect( result.getScore() ).toBe( 4 );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 6 times for a text of this length. " +
+			"<a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!" );
+	} );
+
 	it( "shouldn't return NaN/infinity times of keyphrase occurrence when the keyphrase contains spaces " +
 		"and there is no match in the text", function() {
 		const paper = new Paper( japaneseSentence + japaneseSentenceWithKeyphrase.repeat( 32 ), {

--- a/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/getWordForms.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/getWordForms.js
@@ -14,6 +14,11 @@ import createWordForms from "../helpers/internal/createWordForms";
 function getKeyphraseForms( keyphrase, researcher ) {
 	const keyphraseWords = getContentWords( keyphrase );
 
+	// If the keyphrase does not contain content words, return an empty list.
+	if ( keyphraseWords.length === 0 ) {
+		return [ [] ];
+	}
+
 	// The keyphrase is in double quotes: use it as an exact match keyphrase.
 	const doubleQuotes = [ "「", "」", "『", "』", "“", "”", "〝", "〞", "〟", "‟", "„", "\"" ];
 	if ( includes( doubleQuotes, keyphrase[ 0 ] ) && includes( doubleQuotes, keyphrase[ keyphrase.length - 1 ] ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Keyphrases with only function words (= do not contain content words) yielded NaN/Infinity results for the keyword density and keyword in meta description assessments. This PR fixes that by adding a guard, returning an empty list in the same format as when there are content words in the keyphrase.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Fixes incorrect assessments for keyphrases only consisting of function words in Japanese.

## Relevant technical choices:

* Currently Japanese keyphrase/synonym containing only function words is not recognised in the text even if there is a match. This will be addressed in a separate issue.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Build and activate Free.
* Build and activate Premium:
  * Check-out the `trunk` branch.
  * Run `composer require yoast/wordpress-seo:dev-LINGO-1253-fix-japanese-only-function-word-keyphrases@dev` before building (`composer install`, `yarn`, `grunt build`).
* Set your site to Japanese (`日本語`).

**Test focus keyphrase**
* Create a new post.
* Add a text of approximately 600 characters (you can use [this generator](https://generator.lorem-ipsum.info/_japanese) and [this character counter](https://wordcounter.net/character-count) for this purpose)
* Add a meta description of approximately 60 characters.
* Set `ばっかり` as the focus keyphrase. This keyphrase only has function words.
* Make sure not to have this keyphrase in the text or in the meta description.
* Under the SEO analysis, confirm that there is no `NaN`/`Infinity` result in the feedback strings:
   * The _Function words in keyphrase assessment_ should return with:
      * bullet: grey
      * feedback: `キーフレーズの中の機能語: キーフレーズ "ばっかり" には機能語しか含まれていません。良いキーフレーズの作り方を学習してください。`
   * The _Keyphrase density assessment_ should return with:
      * bullet: red
      * feedback: `キーフレーズ密度: フォーカスキーフレーズが0回見つかりました。文字数に対するおすすめの最低数2回に足りません。キーフレーズにフォーカスしましょう !`
   * The _Keyphrase in meta description assessment_ should return with:
      * bullet: red
      * feedback: `メタディスクリプション中のキーフレーズ: メタディスクリプションが設定されていますが、キーフレーズがありません。修正しましょう !`

**Test related keyphrase (regression)**
* Continue with the post created above.
* Add `小さい花の刺繍` as the related keyphrase (under `関連するキーフレーズ` tab in the metabox). This keyphrase consists of mostly content words.
* Make sure not to have this keyphrase in the text or in the meta description.
* Add this sentence `小さくて可愛い花の刺繍に関する一般一般の記事です。` to your text and to your meta description
* Under the related keyphrase analysis, confirm that:
   * The _Function words in keyphrase assessment_ does not appear.
   * The _Keyphrase density assessment_ returns with:
      * bullet: red
      * feedback: `キーフレーズ密度: フォーカスキーフレーズが1回見つかりました。文字数に対するおすすめの最低数2回に足りません。キーフレーズにフォーカスしましょう !` (there is one occurrence detected)
      * Click on the eye icon and make sure that the keyphrase is highlighted in the text
   * The _Keyphrase in meta description assessment_ returns with:
      * bullet: green
      * feedback: `メタディスクリプション中のキーフレーズ: メタディスクリプション中にキーフレーズまたは同義語が含まれています。いいですね !`
* Now, set `ばっかり` as the related keyphrase. This keyphrase is the same as the focus keyphrase and only has function words.
* Confirm that the three assessments now return the same results for the related keyphrase and the focus keyphrase.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Asssessments using the keyphrase, though limited to Japanese.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1253
