### PR TITLE
Change the overall SEO score on the posts/pages/movies/books overview page to red when no keyphrase is set

### DIFF
--- a/admin/class-meta-columns.php
+++ b/admin/class-meta-columns.php
@@ -641,7 +641,7 @@ class WPSEO_Meta_Columns {
 		}
 
 		if ( WPSEO_Meta::get_value( 'focuskw', $post_id ) === '' ) {
-			$rank  = new WPSEO_Rank( WPSEO_Rank::NO_FOCUS );
+			$rank  = new WPSEO_Rank( WPSEO_Rank::BAD );
 			$title = __( 'Focus keyphrase not set.', 'wordpress-seo' );
 
 			return $this->render_score_indicator( $rank, $title );

--- a/css/src/score_icon.css
+++ b/css/src/score_icon.css
@@ -21,7 +21,7 @@
 }
 
 .wpseo-score-icon.na {
-	background-color: #888;
+	background-color: #dc3232;
 }
 
 .wpseo-score-icon.noindex {

--- a/css/src/score_icon.css
+++ b/css/src/score_icon.css
@@ -21,7 +21,7 @@
 }
 
 .wpseo-score-icon.na {
-	background-color: #dc3232;
+	background-color: #888;
 }
 
 .wpseo-score-icon.noindex {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The overall score icon used to be grey when no keyphrase was set. This PR changes the color to red.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the overall SEO score color on the posts/pages/movies/books overview page to red when no keyphrase is set.

## Relevant technical choices:

* The color for when no keyphrase is set is not changed centrally in `score_icon.css` file.
* In `parse_column_score()` in `class-meta-columns.php`, the rank for when no focus keyphrase is set is changed from "No_FOCUS" to "BAD".
* This way, this change only affects the overall SEO score icon and not the readability icon. This means that for old posts that were created before installing the plugin, the readability icon on the overview page should still stay grey.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Requirements:
* Install and activate Yoast test helper plugin
* Enable Post types and taxonomies. Go to Tools > Yoast test > Post types and Taxonomies and check the three checkboxes.
<img width="642" alt="Screenshot 2022-01-12 at 12 43 57" src="https://user-images.githubusercontent.com/48715883/149134504-7f8b7723-b748-42e0-853a-d372aa276f25.png">

**Run the steps below in Posts, Pages, Movies, and Books**
* Create a post/page/movie/book
* Don't add a keyphrase
* Confirm that the overall SEO score icon shows red
<img width="1042" alt="70F53260-F15F-412A-A0CB-BC7931389DF1" src="https://user-images.githubusercontent.com/48715883/149135384-7301425d-bfa5-4439-b3af-6bc35e358c71.png">

* Go to the posts/pages/movies/books overview page
* Confirm that the overall SEO score bullet also shows red
<img width="884" alt="764C016D-13A4-41CC-BC6C-72D601FC965C" src="https://user-images.githubusercontent.com/48715883/149135577-7b818d0e-8a8e-47e6-9dcc-2ff89c16c798.png">

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1074
