### PR TITLE
Fix Integration tests

### DIFF
--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -138,7 +138,7 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	public function get_sitemap_links( $type, $max_entries, $current_page ) {
 
 		if ( ! $this->handles_type( 'author' ) ) {
-			return [];
+			throw new OutOfBoundsException( 'Invalid sitemap page requested' );
 		}
 
 		$offset = ( ( $current_page - 1 ) * $max_entries );

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -93,7 +93,7 @@ class WPSEO_Taxonomy_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider i
 	 */
 	public function get_sitemap_links( $type, $max_entries, $current_page ) {
 		if ( ! $this->handles_type( $type ) ) {
-			return [];
+			throw new OutOfBoundsException( 'Invalid sitemap page requested' );
 		}
 
 		$steps  = $max_entries;

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -156,7 +156,7 @@ class Indexable_Post_Watcher implements Integration_Interface {
 	 */
 	public function updated_indexable( $indexable, $post ) {
 		// Only interested in post indexables.
-		if ( $indexable->object_type !== 'post' ) {
+		if ( $indexable->object_type !== 'post' || $indexable->post_status === 'unindexed' ) {
 			return;
 		}
 

--- a/tests/integration/framework/class-wpseo-unit-test-case.php
+++ b/tests/integration/framework/class-wpseo-unit-test-case.php
@@ -30,19 +30,20 @@ abstract class WPSEO_UnitTestCase extends TestCase {
 	}
 
 	/**
-	 * Make sure to remove the indexables created.
+	 * Cleanup any changes made to our custom tables before setting up individual test cases.
+	 * All database changes that are made in a test-case are automatically rolled back, but changes
+	 * made in set_up_before_class for instance are not.
 	 *
 	 * @return void
 	 */
-	public function tear_down() {
+	public static function tear_down_after_class() {
 		global $wpdb;
-
-		parent::tear_down();
-
 		foreach ( [ 'Indexable', 'Indexable_Hierarchy', 'Primary_Term', 'SEO_Links' ] as $table ) {
 			$full_table_name = Model::get_table_name( $table );
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Only executed during integration tests.
 			$wpdb->query( "DELETE FROM {$full_table_name}" );
 		}
+		// The parent must be called last.
+		parent::tear_down_after_class();
 	}
 }

--- a/tests/integration/frontend/test-class-wpseo-image-utils.php
+++ b/tests/integration/frontend/test-class-wpseo-image-utils.php
@@ -11,6 +11,33 @@
 final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 
 	/**
+	 * The id of the attachment test with.
+	 *
+	 * @var int
+	 */
+	protected static $attachment_id;
+
+	/**
+	 * Sets up an attachment post to use for tests.
+	 *
+	 * @param WP_UnitTest_Factory $factory Unit test factory instance.
+	 *
+	 * @return void
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$attachment_id = $factory->attachment->create();
+	}
+
+	/**
+	 * Deletes the attachment post.
+	 *
+	 * @return void
+	 */
+	public static function wpTearDownAfterClass() {
+		wp_delete_attachment( self::$attachment_id );
+	}
+
+	/**
 	 * Tests getting the full image for an existing attachment.
 	 *
 	 * @covers \WPSEO_Image_Utils::get_image
@@ -212,12 +239,11 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 	 * @return array The test data.
 	 */
 	public function get_data_provider() {
-		$attachment_id = self::factory()->attachment->create();
 		return [
 			[
 				'image'         => 'This is a string',
 				'expected'      => false,
-				'attachment_id' => $attachment_id,
+				'attachment_id' => self::$attachment_id,
 				'message'       => 'With a string given as image data',
 			],
 			[
@@ -226,7 +252,7 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 					'and'  => 'height keys given',
 				],
 				'expected'      => false,
-				'attachment_id' => $attachment_id,
+				'attachment_id' => self::$attachment_id,
 				'message'       => 'An array without the width and height keys',
 			],
 			[
@@ -237,12 +263,12 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 				'expected'      => [
 					'width'  => '10',
 					'height' => '10',
-					'id'     => $attachment_id,
+					'id'     => self::$attachment_id,
 					'alt'    => '',
 					'pixels' => 100,
 					'type'   => false,
 				],
-				'attachment_id' => $attachment_id,
+				'attachment_id' => self::$attachment_id,
 				'message'       => 'With no attachment type given',
 			],
 			[
@@ -254,36 +280,36 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 				'expected'      => [
 					'width'  => '10',
 					'height' => '10',
-					'id'     => $attachment_id,
+					'id'     => self::$attachment_id,
 					'alt'    => '',
 					'pixels' => 100,
 					'type'   => false,
 				],
-				'attachment_id' => $attachment_id,
+				'attachment_id' => self::$attachment_id,
 				'message'       => 'With unwanted keys being stripped',
 			],
 			[
 				'image'         => [
-					'width'       => 100,
-					'height'      => 0,
+					'width'  => 100,
+					'height' => 0,
 				],
 				'expected'      => false,
-				'attachment_id' => $attachment_id,
+				'attachment_id' => self::$attachment_id,
 				'message'       => 'Empty height should not be parsed as valid image',
 			],
 			[
 				'image'         => [
-					'width'       => 0,
-					'height'      => 100,
+					'width'  => 0,
+					'height' => 100,
 				],
 				'expected'      => false,
-				'attachment_id' => $attachment_id,
+				'attachment_id' => self::$attachment_id,
 				'message'       => 'Empty width should not be parsed as valid image',
 			],
 			[
 				'image'         => [
-					'width'       => '10',
-					'height'      => '10',
+					'width'  => '10',
+					'height' => '10',
 				],
 				'expected'      => [
 					'width'  => '10',
@@ -298,8 +324,8 @@ final class WPSEO_Image_Utils_Test extends WPSEO_UnitTestCase {
 			],
 			[
 				'image'         => [
-					'width'       => 'string',
-					'height'      => 'string',
+					'width'  => 'string',
+					'height' => 'string',
 				],
 				'expected'      => [
 					'width'  => 'string',


### PR DESCRIPTION
👉 I've set the base branch to [sitemap-feedback](https://github.com/Yoast/wordpress-seo/pull/17912). Once that branch is merged, the base branch can be updated to feature/indexable-sitemaps.

## Context
* Integration tests were failing, some on every supported version of WP, some just on versions other than trunk.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improve stability in integration tests

## Relevant technical choices:

* Instead of creating an attachment in the WPSEO_Image_Utils_Test dataProvider, it now uses the setupBeforeClass and teardownAfterClass methods. The dataproviders are called _before_ any tests are executed to determine the number of tests to run. Any changes to the DB during that period, are not cleaned up or reverted. That's why we need to use the setup/teardown methods for it instead.
* If sitemaps are disabled, the original exception is restored. This was at some point changed to an empty array but that caused tests to fail.
* There's a difference in order of execution of the teardown functions between trunk and 5.8.2 for instance. This resulted in failing tests on 5.8.2. in Trunk, WP_UnitTestCase_Base does a `ROLLBACK` query _before_ we did our `DELETE FROM ...` queries for our custom tables. in WP 5.8.2, `WP_UnitTestCase_Base` does the `ROLLBACK` query _after_ we delete, rendering the delete completely useless. (the change in order is caused by a rename between tear_down and tearDown. Both are called, but tear_down is called before tearDown (see model below)). Because `ROLLBACK` was called right before our `DELETE` query, it's not in a transaction and will be persisted on trunk.
![image](https://user-images.githubusercontent.com/5352634/149318833-8a92ceb8-8084-4523-b060-ce3dab34cbb9.png)
As the UnitTestCase Base automatically rolls back any changes to the database in the tearDown, we don't need to also remove our custom tables. The goal is to remove all indexable changes made _before_ the setup of a test case, so we must use tearDownAfterClass instead.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See integration tests succeed.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
