### PR TITLE
Wincher: don't send access token in GET parameters

### DIFF
--- a/src/config/oauth-client.php
+++ b/src/config/oauth-client.php
@@ -216,10 +216,7 @@ abstract class OAuth_Client {
 	 */
 	protected function do_request( $method, $url, array $options ) {
 		$defaults = [
-			'headers' => $this->provider->getHeaders(),
-			'params'  => [
-				'access_token' => $this->get_tokens()->access_token,
-			],
+			'headers' => $this->provider->getHeaders( $this->get_tokens()->access_token ),
 		];
 
 		$options = \array_merge_recursive( $defaults, $options );

--- a/src/config/semrush-client.php
+++ b/src/config/semrush-client.php
@@ -2,10 +2,13 @@
 
 namespace Yoast\WP\SEO\Config;
 
+use Yoast\WP\SEO\Exceptions\OAuth\Authentication_Failed_Exception;
 use Yoast\WP\SEO\Exceptions\OAuth\Tokens\Empty_Property_Exception;
+use Yoast\WP\SEO\Exceptions\OAuth\Tokens\Empty_Token_Exception;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Wrappers\WP_Remote_Handler;
 use YoastSEO_Vendor\GuzzleHttp\Client;
+use YoastSEO_Vendor\League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use YoastSEO_Vendor\League\OAuth2\Client\Provider\GenericProvider;
 
 /**
@@ -49,5 +52,35 @@ class SEMrush_Client extends OAuth_Client {
 			$provider,
 			$options_helper
 		);
+	}
+
+	/**
+	 * Performs the specified request.
+	 *
+	 * @param string $method  The HTTP method to use.
+	 * @param string $url     The URL to send the request to.
+	 * @param array  $options The options to pass along to the request.
+	 *
+	 * @return mixed The parsed API response.
+	 *
+	 * @throws IdentityProviderException Exception thrown if there's something wrong with the identifying data.
+	 * @throws Authentication_Failed_Exception Exception thrown if authentication has failed.
+	 * @throws Empty_Token_Exception Exception thrown if the token is empty.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function do_request( $method, $url, array $options ) {
+		// Add the access token to the GET parameters as well since this is what
+		// the SEMRush API expects.
+		$options = array_merge_recursive(
+			$options,
+			[
+				'params' => [
+					'access_token' => $this->get_tokens()->access_token,
+				],
+			]
+		);
+
+		return parent::do_request( $method, $url, $options );
 	}
 }

--- a/src/config/wincher-client.php
+++ b/src/config/wincher-client.php
@@ -127,14 +127,6 @@ class Wincher_Client extends OAuth_Client {
 	 */
 	protected function do_request( $method, $url, array $options ) {
 		$options['headers'] = [ 'Content-Type' => 'application/json' ];
-
-		$options = array_merge_recursive(
-			$options,
-			[
-				'headers' => $this->provider->getHeaders( $this->get_tokens()->access_token ),
-			]
-		);
-
 		return parent::do_request( $method, $url, $options );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The plugin was sending Wincher access tokens in the GET params of requests (unnecessarily, since it's read from the headers by our API). This is a (very minor) security concern and also clogs up our logs. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Avoids sending OAuth access tokens in GET parameters when doing requests against the Wincher API.

## Relevant technical choices:

* Make sending access token in the headers the default, since this is what most APIs would expect.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged

* There are no good steps to verify this behavior, but simply make sure that both the Wincher and SEMRush integrations still work as expected. 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Wincher integration
* SEMRush integration

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
