### PR TITLE
Wincher: don't send API request when no keyphrases

### DIFF
--- a/src/actions/wincher/wincher-keyphrases-action.php
+++ b/src/actions/wincher/wincher-keyphrases-action.php
@@ -191,6 +191,17 @@ class Wincher_Keyphrases_Action {
 				$used_keyphrases = $this->collect_all_keyphrases();
 			}
 
+			// If we still have no keyphrases the API will return an error, so
+			// don't even bother sending a request.
+			if ( empty( $used_keyphrases ) ) {
+				return $this->to_result_object(
+					[
+						'data'   => [],
+						'status' => 200,
+					]
+				);
+			}
+
 			$endpoint = \sprintf(
 				self::KEYPHRASES_URL,
 				$this->options_helper->get( 'wincher_website_id' )
@@ -213,9 +224,7 @@ class Wincher_Keyphrases_Action {
 				return $this->to_result_object( $results );
 			}
 
-			if ( ! empty( $used_keyphrases ) ) {
-				$results['data'] = $this->filter_results_by_used_keyphrases( $results['data'], $used_keyphrases );
-			}
+			$results['data'] = $this->filter_results_by_used_keyphrases( $results['data'], $used_keyphrases );
 
 			// Extract the positional data and assign it to the keyphrase.
 			$results['data'] = \array_combine(

--- a/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
+++ b/tests/unit/actions/wincher/wincher-keyphrases-action-test.php
@@ -353,6 +353,25 @@ class Wincher_Keyphrases_Action_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that the API is not called when there are no keyphrases.
+	 *
+	 * @covers ::get_tracked_keyphrases
+	 */
+	public function test_get_tracked_keyphrases_does_not_call_api_when_no_keyphrases() {
+		$this->client_instance
+			->expects( 'post' )
+			->times( 0 );
+
+		$this->assertEquals(
+			(object) [
+				'results' => [],
+				'status'  => 200,
+			],
+			$this->instance->get_tracked_keyphrases( [] )
+		);
+	}
+
+	/**
 	 * Tests retrieval of tracked keyphrases filtered with the used keyphrases.
 	 *
 	 * @covers ::get_tracked_keyphrases


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The plugin was sending API requests to Wincher with no keyphrases. This always results in an API error, so this is unnecessary. Instead return an empty response immediately.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents sending a request to the Wincher API with no keyphrases.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged

* No good way to verify this behavior, but just make sure that the Wincher integration still works correctly.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Wincher integration, primarily on the Dashboard.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [X] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
