### PR TITLE
Improve import UX

### DIFF
--- a/packages/js/src/import.js
+++ b/packages/js/src/import.js
@@ -48,8 +48,13 @@ function importingSuccess() {
 
 	// Remove the plugin that we just finished import for, from the import dropdown.
 	jQuery( "option:selected", dropdown ).remove();
-	if ( dropdown.has( "option" ).length < 1 ) {
-		importButton.prop( "disabled", true );
+	jQuery( "option[value='']", dropdown ).prop( "selected", true );
+	dropdown.trigger( "change" );
+
+	// Dropdown will always have at least one option aka the placeholder, so let's check if it has any more options before displaying the no_data_msg.
+	if ( dropdown.children( "option" ).length < 2 ) {
+		dropdown.prop( "disabled", true );
+		jQuery( "option[value='']", dropdown ).text( window.yoastImportData.assets.no_data_msg );
 	}
 }
 
@@ -134,6 +139,37 @@ function initElements() {
 }
 
 /**
+ * Watches the import select.
+ *
+ * @returns {void}
+ */
+function watchImportSelect() {
+	dropdown.on( "change", function() {
+		if ( jQuery( this ).find( "option:selected" ).attr( "value" ) === "" ) {
+			importButton.prop( "disabled", true );
+
+			return;
+		}
+		importButton.prop( "disabled", false );
+	} );
+}
+
+/**
+ * Prepares the import select.
+ *
+ * @returns {void}
+ */
+function prepareImportSelect() {
+	if ( dropdown ) {
+		watchImportSelect();
+
+		dropdown.append(
+			"<option value='' disabled='disabled' selected hidden>" + window.yoastImportData.assets.select_placeholder + "</option>"
+		).trigger( "change" );
+	}
+}
+
+/**
  * Watches the `Import` form.
  *
  * @returns {void}
@@ -146,6 +182,7 @@ function watchImportForm() {
 
 jQuery( function() {
 	initElements();
+	prepareImportSelect();
 	watchImportForm();
 	addProgressElements();
 } );

--- a/packages/js/src/import.js
+++ b/packages/js/src/import.js
@@ -54,7 +54,7 @@ function importingSuccess() {
 	// Dropdown will always have at least one option aka the placeholder, so let's check if it has any more options before displaying the no_data_msg.
 	if ( dropdown.children( "option" ).length < 2 ) {
 		dropdown.prop( "disabled", true );
-		jQuery( "option[value='']", dropdown ).text( window.yoastImportData.assets.no_data_msg );
+		importForm.after( jQuery( "<p></p>" ).text( window.yoastImportData.assets.no_data_msg ) );
 	}
 }
 
@@ -164,7 +164,7 @@ function prepareImportSelect() {
 		watchImportSelect();
 
 		dropdown.append(
-			"<option value='' disabled='disabled' selected hidden>" + window.yoastImportData.assets.select_placeholder + "</option>"
+			"<option value='' disabled='disabled' selected hidden>&mdash; " + window.yoastImportData.assets.select_placeholder + " &mdash;</option>"
 		).trigger( "change" );
 	}
 }

--- a/src/integrations/admin/import-integration.php
+++ b/src/integrations/admin/import-integration.php
@@ -101,8 +101,10 @@ class Import_Integration implements Integration_Interface {
 				'nonce'               => \wp_create_nonce( 'wp_rest' ),
 			],
 			'assets'  => [
-				'loading_msg' => \esc_html__( 'The import can take a long time depending on your site\'s size', 'wordpress-seo' ),
-				'spinner'     => \admin_url( 'images/loading.gif' ),
+				'loading_msg'        => \esc_html__( 'The import can take a long time depending on your site\'s size', 'wordpress-seo' ),
+				'select_placeholder' => \esc_html__( 'Select SEO plugin', 'wordpress-seo' ),
+				'no_data_msg'        => \esc_html__( 'No data found from other SEO plugins', 'wordpress-seo' ),
+				'spinner'            => \admin_url( 'images/loading.gif' ),
 			],
 		];
 

--- a/src/integrations/admin/import-integration.php
+++ b/src/integrations/admin/import-integration.php
@@ -101,9 +101,9 @@ class Import_Integration implements Integration_Interface {
 				'nonce'               => \wp_create_nonce( 'wp_rest' ),
 			],
 			'assets'  => [
-				'loading_msg'        => \esc_html__( 'The import can take a long time depending on your site\'s size', 'wordpress-seo' ),
+				'loading_msg'        => \esc_html__( 'The import can take a long time depending on your site\'s size.', 'wordpress-seo' ),
 				'select_placeholder' => \esc_html__( 'Select SEO plugin', 'wordpress-seo' ),
-				'no_data_msg'        => \esc_html__( 'No data found from other SEO plugins', 'wordpress-seo' ),
+				'no_data_msg'        => \esc_html__( 'No data found from other SEO plugins.', 'wordpress-seo' ),
 				'spinner'            => \admin_url( 'images/loading.gif' ),
 			],
 		];

--- a/tests/unit/integrations/admin/import-integration-test.php
+++ b/tests/unit/integrations/admin/import-integration-test.php
@@ -182,8 +182,10 @@ class Import_Integration_Test extends TestCase {
 				'nonce'               => 'nonce_value',
 			],
 			'assets'  => [
-				'loading_msg' => 'The import can take a long time depending on your site\'s size',
-				'spinner'     => 'https://example.org/wp-admin/images/loading.gif',
+				'loading_msg'        => 'The import can take a long time depending on your site\'s size',
+				'select_placeholder' => 'Select SEO plugin',
+				'no_data_msg'        => 'No data found from other SEO plugins',
+				'spinner'            => 'https://example.org/wp-admin/images/loading.gif',
 			],
 		];
 

--- a/tests/unit/integrations/admin/import-integration-test.php
+++ b/tests/unit/integrations/admin/import-integration-test.php
@@ -182,9 +182,9 @@ class Import_Integration_Test extends TestCase {
 				'nonce'               => 'nonce_value',
 			],
 			'assets'  => [
-				'loading_msg'        => 'The import can take a long time depending on your site\'s size',
+				'loading_msg'        => 'The import can take a long time depending on your site\'s size.',
 				'select_placeholder' => 'Select SEO plugin',
-				'no_data_msg'        => 'No data found from other SEO plugins',
+				'no_data_msg'        => 'No data found from other SEO plugins.',
 				'spinner'            => 'https://example.org/wp-admin/images/loading.gif',
 			],
 		];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to improve the UX for the new import, by tweaking it considering that AIOSEO should not be available for import once its import is completed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the old import UX for the new importing actions

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

(Designs are as per meeting with @uxkai )

**With the `YOAST_SEO_AIOSEO_V4_IMPORTER` enabled: **

* **When having no other SEO plugins to import from, only AIOSEO**:
* When entering this Import from other SEO plugins tab for the first time, the input field at step 2 should show a default state: `Select SEO plugin`. The Import button should be disabled until the user selects `All In One SEO Pack` from the dropdown
![image](https://user-images.githubusercontent.com/12400734/149526683-422c6407-94cf-4ea6-86bb-f203530c5b9d.png)
![image](https://user-images.githubusercontent.com/12400734/149526719-c2ce7817-dff6-4364-959e-ee1922d3eb96.png)
![image](https://user-images.githubusercontent.com/12400734/149509756-8af709f0-8fe6-4919-a45f-82c001e1d1f6.png)
* While the import is running:
![image](https://user-images.githubusercontent.com/12400734/149509963-39bc6b87-97e4-41e9-9596-5dfa93939081.png)
* When finishing the import (and there are no other SEO plugins detected), under the input field it should say `No data found from other SEO plugins.`:
![image](https://user-images.githubusercontent.com/12400734/149525535-c6b74806-76fe-460c-a199-918f66b0f134.png)



* **When having other SEO plugins to import from, not only AIOSEO**:
* When entering this Import from other SEO plugins tab for the first time, the input field at step 2 should show a default state: Select SEO plugin. The Import button should be disabled until the user selects `All In One SEO Pack` or any other plugin from the dropdown
![image](https://user-images.githubusercontent.com/12400734/149526683-422c6407-94cf-4ea6-86bb-f203530c5b9d.png)
![image](https://user-images.githubusercontent.com/12400734/149526988-596cd0f2-4035-4902-8530-a078e0f41e85.png)
![image](https://user-images.githubusercontent.com/12400734/149509756-8af709f0-8fe6-4919-a45f-82c001e1d1f6.png)
* While the import is running:
![image](https://user-images.githubusercontent.com/12400734/149509963-39bc6b87-97e4-41e9-9596-5dfa93939081.png)
* When finishing the import (and there are other SEO plugins detected), the input field should revert to the original `Select SEO plugin` state:
![image](https://user-images.githubusercontent.com/12400734/149527162-49f1630e-0c24-4e50-9837-c37dcfe7155a.png)
![image](https://user-images.githubusercontent.com/12400734/149527188-da158b7d-31bd-4d68-80de-2debde2aab23.png)
![image](https://user-images.githubusercontent.com/12400734/149511125-50f64af5-079e-4a79-9ad8-e6eb3d1bb772.png)

**With the `YOAST_SEO_AIOSEO_V4_IMPORTER` disabled: **

* Verify that the old import flow is being triggered. To do so, you'll need a AIOSEO version pre-version 4. With a pre-version 4 of the AIOSEO plugin active, create a post. Go to the "import/export" page and you should be seeing a `All In One SEO Pack` option in the Import dropdown. Clicking import while having that selected should refresh the page and perform the import.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* We should verify that the old import (for other plugins aside from AIOSEO) still works as expected, with the feature flag both enabled and disabled. To do so, activate Rankmath and create post.
* Going to the Export/Import page, you should see a `RankMath` option in the import dropdown.
* Clicking import should refresh the page and have the RankMath data from that post imported to the respective Yoast ones.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
