### PR TITLE
title-tag: compatibility with block-based themes

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -220,6 +220,8 @@ class Front_End_Integration implements Integration_Interface {
 		\add_action( 'wp_head', [ $this, 'call_wpseo_head' ], 1 );
 		// Filter the title for compatibility with other plugins and themes.
 		\add_filter( 'wp_title', [ $this, 'filter_title' ], 15 );
+		// Filter the title for compatibility with block-based themes.
+		\add_filter( 'pre_get_document_title', [ $this, 'filter_title' ], 15 );
 
 		// Removes our robots presenter from the list when wp_robots is handling this.
 		\add_filter( 'wpseo_frontend_presenter_classes', [ $this, 'filter_robots_presenter' ] );


### PR DESCRIPTION
## Context

It was reported that in block-based themes, the Yoast title does not work (https://twitter.com/bgardner/status/1482898902336557056?s=20)

Using the latest build of WP 5.9 and the default 2022 theme I was able to replicate the issue.
FSE (block-based) themes use a different method to add the title, and this PR adds compatibility with that.

## Test instructions

* Use the latest nightly build of WP Core (the easiest method to do that is using the plugin from https://wordpress.org/plugins/wordpress-beta-tester/)
* Make sure you're using the default twentytwentytwo theme
* Create a new post and change the Yoast title tag for that post
* Visit the frontend on that post and make sure that there's only 1 `<title>` tag in the page's source, and it's the one that was manually entered instead of the default one.

### Test instructions for QA when the code is in the RC
* [x] QA should use the same steps as above.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects other environments and needs to be tested there.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
