### PR TITLE
Delay a call to `get_plugins()` until after all plugins are loaded

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -97,7 +97,7 @@ class WPSEO_Addon_Manager {
 		add_action( 'admin_init', [ $this, 'validate_addons' ], 15 );
 		add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_for_updates' ] );
 		add_filter( 'plugins_api', [ $this, 'get_plugin_information' ], 10, 3 );
-		add_action( 'plugins_loaded', [ $this, 'register_expired_messages' ], 10  );
+		add_action( 'plugins_loaded', [ $this, 'register_expired_messages' ], 10 );
 	}
 
 	/**

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -97,7 +97,15 @@ class WPSEO_Addon_Manager {
 		add_action( 'admin_init', [ $this, 'validate_addons' ], 15 );
 		add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_for_updates' ] );
 		add_filter( 'plugins_api', [ $this, 'get_plugin_information' ], 10, 3 );
+		add_action( 'plugins_loaded', [ $this, 'register_expired_messages' ], 10  );
+	}
 
+	/**
+	 * Registers "expired subscription" warnings to the update messages of our addons.
+	 *
+	 * @return void
+	 */
+	public function register_expired_messages() {
 		foreach ( array_keys( $this->get_installed_addons() ) as $plugin_file ) {
 			add_action( 'in_plugin_update_message-' . $plugin_file, [ $this, 'expired_subscription_warning' ], 10, 2 );
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We were calling `get_plugins()` in our own plugin initialization loop, instead of after all plugins were loaded. Because `get_plugins()` gets cached, we would potentially cache plugin information before all plugins were fully initialized.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where plugins that would initialize after our plugin would be unable to register certain plugin information or utilize certain hooks.

## Relevant technical choices:

* Moved the call of `get_plugins()` to the `plugins_loaded` action hook.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure Yoast Free is active.
* Create a php file in the plugins directory and name it `z.php`. Add the following content:
```php
<?php
/*
 * Plugin Name:       Yoast Bug Example
 * Version:           1
 */
add_filter( 'extra_plugin_headers', 'my_extra_plugin_headers' );
function my_extra_plugin_headers( $headers ) {

	if ( !in_array( 'BugTestHeader', $headers ) )
		$headers[] = 'BugTestHeader';

	return $headers;
}

add_action('admin_footer','debug_get_plugins');
function debug_get_plugins(){
    $x = get_plugins();
	echo '<pre>' . var_export($x, true) . '</pre>';
}
```
* enable this plugin in WordPress
* Check the bottom of the page (you may need to collapse the menu to make the output readabale)
  * Without this PR, none of the plugins will have `BugTestHeader` as a registered header in their array.
  * With this PR, all the plugins will have that header, and it will look something like this:
```
'wordpress-seo-git/wp-seo.php' => 
  array (
    'BugTestHeader' => '',      <=== the header we're looking for.
    'Name' => 'Yoast SEO',
    'PluginURI' => 'https://yoa.st/1uj',
    'Version' => '18.0-RC4',
    'Description' => 'The first true all-in-one SEO solution for WordPress, including on-page content analysis, XML sitemaps and much more.',
    'Author' => 'Team Yoast',
    'AuthorURI' => 'https://yoa.st/1uk',
    'TextDomain' => 'wordpress-seo',
    'DomainPath' => '/languages/',
    'Network' => false,
    'RequiresWP' => '5.6',
    'RequiresPHP' => '5.6.20',
    'UpdateURI' => '',
    'Title' => 'Yoast SEO',
    'AuthorName' => 'Team Yoast',
```

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

The steps above will indicate if the plugin loading order was fixed. However, I moved the registration of the `subscription expired` message, and that will need to be tested. I have done this myself on a basic level.
* Have an older version of the premium plugin active alongside this PR / RC
* Make sure that your subscription is *expired* in my-yoast.
* Make sure that your WordPress plugin dashboard shows that an update is available, and the warning about having an expired subscription in the same space.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[Shopify]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://github.com/Yoast/wordpress-seo/issues/17953
