### PR TITLE
Add helper magic isset method

### DIFF
--- a/src/surfaces/helpers-surface.php
+++ b/src/surfaces/helpers-surface.php
@@ -103,8 +103,28 @@ class Helpers_Surface {
 	 * @return mixed The helper class.
 	 */
 	public function __get( $helper ) {
+		return $this->container->get( $this->get_helper_class( $helper ) );
+	}
+
+	/**
+	 * Magic isset for ensuring helper exists.
+	 *
+	 * @param string $helper The helper to get.
+	 *
+	 * @return bool The helper class.
+	 */
+	public function __isset( $helper ) {
+		return $this->container->has( $this->get_helper_class( $helper ) );
+	}
+
+	/**
+	 * Get the class name from a helper slug
+	 *
+	 * @param string $helper
+	 * @return string
+	 */
+	protected function get_helper_class( string $helper ) {
 		$helper = \implode( '_', \array_map( 'ucfirst', \explode( '_', $helper ) ) );
-		$class  = "Yoast\WP\SEO\Helpers\\{$helper}_Helper";
-		return $this->container->get( $class );
+		return "Yoast\WP\SEO\Helpers\\{$helper}_Helper";
 	}
 }

--- a/src/surfaces/helpers-surface.php
+++ b/src/surfaces/helpers-surface.php
@@ -123,7 +123,7 @@ class Helpers_Surface {
 	 * @param string $helper
 	 * @return string
 	 */
-	protected function get_helper_class( string $helper ) {
+	protected function get_helper_class( $helper ) {
 		$helper = \implode( '_', \array_map( 'ucfirst', \explode( '_', $helper ) ) );
 		return "Yoast\WP\SEO\Helpers\\{$helper}_Helper";
 	}

--- a/src/surfaces/open-graph-helpers-surface.php
+++ b/src/surfaces/open-graph-helpers-surface.php
@@ -38,8 +38,28 @@ class Open_Graph_Helpers_Surface {
 	 * @return mixed The helper class.
 	 */
 	public function __get( $helper ) {
+		return $this->container->get( $this->get_helper_class( $helper ) );
+	}
+
+	/**
+	 * Magic isset for ensuring helper exists.
+	 *
+	 * @param string $helper The helper to get.
+	 *
+	 * @return bool The helper class.
+	 */
+	public function __isset( $helper ) {
+		return $this->container->has( $this->get_helper_class( $helper ) );
+	}
+
+	/**
+	 * Get the class name from a helper slug
+	 *
+	 * @param string $helper
+	 * @return string
+	 */
+	protected function get_helper_class( string $helper ) {
 		$helper = \implode( '_', \array_map( 'ucfirst', \explode( '_', $helper ) ) );
-		$class  = "Yoast\WP\SEO\Helpers\Open_Graph\\{$helper}_Helper";
-		return $this->container->get( $class );
+		return "Yoast\WP\SEO\Helpers\Open_Graph\\{$helper}_Helper";
 	}
 }

--- a/src/surfaces/open-graph-helpers-surface.php
+++ b/src/surfaces/open-graph-helpers-surface.php
@@ -58,7 +58,7 @@ class Open_Graph_Helpers_Surface {
 	 * @param string $helper
 	 * @return string
 	 */
-	protected function get_helper_class( string $helper ) {
+	protected function get_helper_class( $helper ) {
 		$helper = \implode( '_', \array_map( 'ucfirst', \explode( '_', $helper ) ) );
 		return "Yoast\WP\SEO\Helpers\Open_Graph\\{$helper}_Helper";
 	}

--- a/src/surfaces/schema-helpers-surface.php
+++ b/src/surfaces/schema-helpers-surface.php
@@ -69,7 +69,7 @@ class Schema_Helpers_Surface {
 	 * @param string $helper
 	 * @return string
 	 */
-	protected function get_helper_class( string $helper ) {
+	protected function get_helper_class( $helper ) {
 		if ( \in_array( $helper, $this->capitalized_helpers, true ) ) {
 			$helper = \strtoupper( $helper );
 		}

--- a/src/surfaces/schema-helpers-surface.php
+++ b/src/surfaces/schema-helpers-surface.php
@@ -49,12 +49,31 @@ class Schema_Helpers_Surface {
 	 * @return mixed The helper class.
 	 */
 	public function __get( $helper ) {
+		return $this->container->get( $this->get_helper_class( $helper ) );
+	}
+
+	/**
+	 * Magic isset for ensuring helper exists.
+	 *
+	 * @param string $helper The helper to get.
+	 *
+	 * @return bool The helper class.
+	 */
+	public function __isset( $helper ) {
+		return $this->container->has( $this->get_helper_class( $helper ) );
+	}
+
+	/**
+	 * Get the class name from a helper slug
+	 *
+	 * @param string $helper
+	 * @return string
+	 */
+	protected function get_helper_class( string $helper ) {
 		if ( \in_array( $helper, $this->capitalized_helpers, true ) ) {
 			$helper = \strtoupper( $helper );
 		}
 		$helper = \implode( '_', \array_map( 'ucfirst', \explode( '_', $helper ) ) );
-		$class  = "Yoast\WP\SEO\Helpers\Schema\\{$helper}_Helper";
-
-		return $this->container->get( $class );
+		return "Yoast\WP\SEO\Helpers\Schema\\{$helper}_Helper";
 	}
 }

--- a/src/surfaces/twitter-helpers-surface.php
+++ b/src/surfaces/twitter-helpers-surface.php
@@ -58,7 +58,7 @@ class Twitter_Helpers_Surface {
 	 * @param string $helper
 	 * @return string
 	 */
-	protected function get_helper_class( string $helper ) {
+	protected function get_helper_class( $helper ) {
 		$helper = \implode( '_', \array_map( 'ucfirst', \explode( '_', $helper ) ) );
 		return "Yoast\WP\SEO\Helpers\Twitter\\{$helper}_Helper";
 	}

--- a/src/surfaces/twitter-helpers-surface.php
+++ b/src/surfaces/twitter-helpers-surface.php
@@ -38,8 +38,28 @@ class Twitter_Helpers_Surface {
 	 * @return mixed The helper class.
 	 */
 	public function __get( $helper ) {
+		return $this->container->get( $this->get_helper_class( $helper ) );
+	}
+
+	/**
+	 * Magic isset for ensuring helper exists.
+	 *
+	 * @param string $helper The helper to get.
+	 *
+	 * @return bool The helper class.
+	 */
+	public function __isset( $helper ) {
+		return $this->container->has( $this->get_helper_class( $helper ) );
+	}
+
+	/**
+	 * Get the class name from a helper slug
+	 *
+	 * @param string $helper
+	 * @return string
+	 */
+	protected function get_helper_class( string $helper ) {
 		$helper = \implode( '_', \array_map( 'ucfirst', \explode( '_', $helper ) ) );
-		$class  = "Yoast\WP\SEO\Helpers\Twitter\\{$helper}_Helper";
-		return $this->container->get( $class );
+		return "Yoast\WP\SEO\Helpers\Twitter\\{$helper}_Helper";
 	}
 }


### PR DESCRIPTION
Magic isset method provides a convenient way to check if a helper exists without the need to use a try catch syntax

## Context

While working with Yoast API and since all surfaces rely on properties access, I found that checking on a helper existence quite tedious:
```php
try {
    $helper = $yoast->helpers->some_helper;
} catch(\Exception $e} {
    // The helper doesn't exists or is incorrectly named
}
```
Because the container will throw if some service isn't found.

Adding a magic isset method provides an easier error handling.
```php
if(!isset($yoast->helpers->some_helper)) {
    return;
}
```

## Summary

This PR can be summarized in the following changelog entry:

* Add an isset magic method to ease working with helper surfaces. Props to @nlemoine.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See example code in the PR summary

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[Shopify]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

I'll add tests if I get some approval for this :)
