### PR TITLE
Import canonical url

### DIFF
--- a/src/actions/importing/abstract-importing-action.php
+++ b/src/actions/importing/abstract-importing-action.php
@@ -229,6 +229,6 @@ abstract class Abstract_Importing_Action implements Importing_Action_Interface {
 	 * @return string The transformed meta data.
 	 */
 	public function url_import( $meta_data ) {
-		return WPSEO_Utils::sanitize_url( $meta_data );
+		return $this->utils->sanitize_url( $meta_data, null );
 	}
 }

--- a/src/actions/importing/abstract-importing-action.php
+++ b/src/actions/importing/abstract-importing-action.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Actions\Importing;
 
 use Exception;
+use WPSEO_Utils;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Services\Importing\Aioseo_Replacevar_Handler;
 use Yoast\WP\SEO\Services\Importing\Aioseo_Robots_Provider_Service;
@@ -204,5 +205,16 @@ abstract class Abstract_Importing_Action implements Importing_Action_Interface {
 	 */
 	public function simple_import( $meta_data ) {
 		return $this->replacevar_handler->transform( $meta_data );
+	}
+
+	/**
+	 * Transforms URL to be imported.
+	 *
+	 * @param string $meta_data The meta data to be imported.
+	 *
+	 * @return string The transformed meta data.
+	 */
+	public function url_import( $meta_data ) {
+		return WPSEO_Utils::sanitize_url( $meta_data );
 	}
 }

--- a/src/actions/importing/abstract-importing-action.php
+++ b/src/actions/importing/abstract-importing-action.php
@@ -228,6 +228,7 @@ abstract class Abstract_Importing_Action implements Importing_Action_Interface {
 	 * @return string The transformed meta data.
 	 */
 	public function url_import( $meta_data ) {
+		// We put null as the allowed protocols here, to have the WP default allowed protocols, see https://developer.wordpress.org/reference/functions/wp_allowed_protocols.
 		return $this->sanitization->sanitize_url( $meta_data, null );
 	}
 }

--- a/src/actions/importing/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo-posts-importing-action.php
@@ -67,6 +67,10 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 			'yoast_name'       => 'canonical',
 			'transform_method' => 'url_import',
 		],
+		'keyphrases'          => [
+			'yoast_name'       => 'primary_focus_keyword',
+			'transform_method' => 'keyphrase_import',
+		],
 		'robots_noindex'      => [
 			'yoast_name'       => 'is_robots_noindex',
 			'transform_method' => 'post_robots_noindex_import',
@@ -376,6 +380,22 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 			$replacements
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/**
+	 * Plucks the keyphrase to be imported from the AIOSEO array of keyphrase meta data.
+	 *
+	 * @param array $meta_data The keyphrase meta data to be imported.
+	 *
+	 * @return string|null The plucked keyphrase.
+	 */
+	public function keyphrase_import( $meta_data ) {
+		$meta_data = \json_decode( $meta_data, true );
+		if ( ! isset( $meta_data['focus']['keyphrase'] ) ) {
+			return null;
+		}
+
+		return $this->utils->sanitize_text_field( $meta_data['focus']['keyphrase'] );
 	}
 
 	/**

--- a/src/actions/importing/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo-posts-importing-action.php
@@ -62,6 +62,10 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 			'yoast_name'       => 'twitter_description',
 			'transform_method' => 'simple_import',
 		],
+		'canonical_url'       => [
+			'yoast_name'       => 'canonical',
+			'transform_method' => 'url_import',
+		],
 		'robots_noindex'      => [
 			'yoast_name'       => 'is_robots_noindex',
 			'transform_method' => 'post_robots_noindex_import',

--- a/src/helpers/indexable-to-postmeta-helper.php
+++ b/src/helpers/indexable-to-postmeta-helper.php
@@ -51,6 +51,10 @@ class Indexable_To_Postmeta_Helper {
 			'post_meta_key' => 'canonical',
 			'map_method'    => 'simple_map',
 		],
+		'primary_focus_keyword'  => [
+			'post_meta_key' => 'focuskw',
+			'map_method'    => 'simple_map',
+		],
 		'is_robots_noindex'      => [
 			'post_meta_key' => 'meta-robots-noindex',
 			'map_method'    => 'noindex_map',

--- a/src/helpers/indexable-to-postmeta-helper.php
+++ b/src/helpers/indexable-to-postmeta-helper.php
@@ -47,7 +47,7 @@ class Indexable_To_Postmeta_Helper {
 			'post_meta_key' => 'twitter-description',
 			'map_method'    => 'simple_map',
 		],
-		'canonical'    => [
+		'canonical'              => [
 			'post_meta_key' => 'canonical',
 			'map_method'    => 'simple_map',
 		],

--- a/src/helpers/indexable-to-postmeta-helper.php
+++ b/src/helpers/indexable-to-postmeta-helper.php
@@ -47,6 +47,10 @@ class Indexable_To_Postmeta_Helper {
 			'post_meta_key' => 'twitter-description',
 			'map_method'    => 'simple_map',
 		],
+		'canonical'    => [
+			'post_meta_key' => 'canonical',
+			'map_method'    => 'simple_map',
+		],
 		'is_robots_noindex'      => [
 			'post_meta_key' => 'meta-robots-noindex',
 			'map_method'    => 'noindex_map',

--- a/src/helpers/utils-helper.php
+++ b/src/helpers/utils-helper.php
@@ -12,11 +12,28 @@ class Utils_Helper {
 	/**
 	 * Emulate the WP native sanitize_text_field function in a %%variable%% safe way.
 	 *
+	 * @codeCoverageIgnore We have to write test when this method contains own code.
+	 *
 	 * @param string $value String value to sanitize.
 	 *
-	 * @return string
+	 * @return string The sanitized string.
 	 */
 	public function sanitize_text_field( $value ) {
 		return WPSEO_Utils::sanitize_text_field( $value );
+	}
+
+	/**
+	 * Sanitize a url for saving to the database.
+	 * Not to be confused with the old native WP function.
+	 *
+	 * @codeCoverageIgnore We have to write test when this method contains own code.
+	 *
+	 * @param string $value             String URL value to sanitize.
+	 * @param array  $allowed_protocols Optional set of allowed protocols.
+	 *
+	 * @return string The sanitized URL.
+	 */
+	public function sanitize_url( $value, $allowed_protocols = [ 'http', 'https' ] ) {
+		return WPSEO_Utils::sanitize_url( $value, $allowed_protocols );
 	}
 }

--- a/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
@@ -218,7 +218,7 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			->once()
 			->andReturn( 1337 );
 
-		$expected_query = 'SELECT title, description, og_title, og_description, twitter_title, twitter_description, canonical_url, robots_noindex, robots_nofollow, robots_noarchive, robots_nosnippet, robots_noimageindex, id, post_id, robots_default FROM wp_aioseo_posts WHERE id > %d ORDER BY id LIMIT %d';
+		$expected_query = 'SELECT title, description, og_title, og_description, twitter_title, twitter_description, canonical_url, keyphrases, robots_noindex, robots_nofollow, robots_noarchive, robots_nosnippet, robots_noimageindex, id, post_id, robots_default FROM wp_aioseo_posts WHERE id > %d ORDER BY id LIMIT %d';
 
 		$this->wpdb->expects( 'prepare' )
 			->once()
@@ -259,6 +259,8 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 	 * Tests the mapping of indexable data when we have an empty Yoast indexable.
 	 *
 	 * @covers ::map
+	 * @covers ::url_import
+	 * @covers ::keyphrase_import
 	 */
 	public function test_map_with_empty_yoast_indexable() {
 		$indexable      = Mockery::mock( Indexable_Mock::class );
@@ -271,6 +273,12 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			'og_description'       => 'og_description1',
 			'twitter_title'        => 'twitter_title1',
 			'twitter_description'  => 'twitter_description1',
+			'canonical_url'        => 'https://example.com/',
+			'keyphrases'           => \json_encode( [
+				'focus' => [
+					'keyphrase' => 'key phrase',
+				],
+			] ),
 			'robots_default'       => true,
 			'robots_nofollow'      => true,
 			'robots_noarchive'     => false,
@@ -337,6 +345,16 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			->once()
 			->with( $aioseio_indexable['twitter_description'] )
 			->andReturn( $aioseio_indexable['twitter_description'] );
+
+		$this->utils->shouldReceive( 'sanitize_url' )
+			->once()
+			->with( $aioseio_indexable['canonical_url'], null )
+			->andReturn( $aioseio_indexable['canonical_url'] );
+
+		$this->utils->shouldReceive( 'sanitize_text_field' )
+			->once()
+			->with( 'key phrase' )
+			->andReturn( 'key phrase' );
 
 		$this->robots_provider->shouldReceive( 'get_subtype_robot_setting' )
 			->andReturn( 'robot_setting' );
@@ -352,6 +370,8 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 		$this->assertSame( 'og_description1', $indexable->open_graph_description );
 		$this->assertSame( 'twitter_title1', $indexable->twitter_title );
 		$this->assertSame( 'twitter_description1', $indexable->twitter_description );
+		$this->assertSame( 'https://example.com/', $indexable->canonical );
+		$this->assertSame( 'key phrase', $indexable->primary_focus_keyword );
 		$this->assertSame( null, $indexable->is_robots_noindex );
 		$this->assertSame( 'robot_value', $indexable->is_robots_nofollow );
 		$this->assertSame( 'robot_value', $indexable->is_robots_noarchive );
@@ -363,6 +383,8 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 	 * Tests the mapping of indexable data when we have existing data in the Yoast indexable.
 	 *
 	 * @covers ::map
+	 * @covers ::url_import
+	 * @covers ::keyphrase_import
 	 */
 	public function test_map_with_existing_yoast_indexable() {
 		$indexable      = Mockery::mock( Indexable_Mock::class );
@@ -378,6 +400,12 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			'og_description'       => 'og_description1',
 			'twitter_title'        => 'twitter_title1',
 			'twitter_description'  => 'twitter_description1',
+			'canonical_url'        => 'https://example.com/',
+			'keyphrases'           => \json_encode( [
+				'focus' => [
+					'not_keyphrase' => 'key phrase',
+				],
+			] ),
 			'robots_default'       => true,
 			'robots_nofollow'      => true,
 			'robots_noarchive'     => false,
@@ -419,6 +447,11 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			->once()
 			->with( $aioseio_indexable['twitter_description'] )
 			->andReturn( $aioseio_indexable['twitter_description'] );
+
+		$this->utils->shouldReceive( 'sanitize_url' )
+			->once()
+			->with( $aioseio_indexable['canonical_url'], null )
+			->andReturn( $aioseio_indexable['canonical_url'] );
 
 		$this->utils->shouldReceive( 'sanitize_text_field' )
 			->once()
@@ -439,6 +472,8 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 		$this->assertSame( 'og_description1', $indexable->open_graph_description );
 		$this->assertSame( 'twitter_title1', $indexable->twitter_title );
 		$this->assertSame( 'twitter_description1', $indexable->twitter_description );
+		$this->assertSame( 'https://example.com/', $indexable->canonical );
+		$this->assertSame( null, $indexable->primary_focus_keyword );
 	}
 
 	/**
@@ -464,6 +499,9 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			->never();
 
 		$this->utils->shouldReceive( 'sanitize_text_field' )
+			->never();
+
+		$this->utils->shouldReceive( 'sanitize_url' )
 			->never();
 
 		$this->robots_provider->shouldReceive( 'get_subtype_robot_setting' )

--- a/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
@@ -25,7 +25,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group importing
  *
  * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo_Posts_Importing_Action
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded,Yoast.Yoast.AlternativeFunctions.json_encode_json_encode
  */
 class Aioseo_Posts_Importing_Action_Test extends TestCase {
 
@@ -274,11 +274,13 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			'twitter_title'        => 'twitter_title1',
 			'twitter_description'  => 'twitter_description1',
 			'canonical_url'        => 'https://example.com/',
-			'keyphrases'           => \json_encode( [
-				'focus' => [
-					'keyphrase' => 'key phrase',
-				],
-			] ),
+			'keyphrases'           => \json_encode(
+				[
+					'focus' => [
+						'keyphrase' => 'key phrase',
+					],
+				]
+			),
 			'robots_default'       => true,
 			'robots_nofollow'      => true,
 			'robots_noarchive'     => false,
@@ -401,11 +403,13 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			'twitter_title'        => 'twitter_title1',
 			'twitter_description'  => 'twitter_description1',
 			'canonical_url'        => 'https://example.com/',
-			'keyphrases'           => \json_encode( [
-				'focus' => [
-					'not_keyphrase' => 'key phrase',
-				],
-			] ),
+			'keyphrases'           => \json_encode(
+				[
+					'focus' => [
+						'not_keyphrase' => 'key phrase',
+					],
+				]
+			),
 			'robots_default'       => true,
 			'robots_nofollow'      => true,
 			'robots_noarchive'     => false,

--- a/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
@@ -218,7 +218,7 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			->once()
 			->andReturn( 1337 );
 
-		$expected_query = 'SELECT title, description, og_title, og_description, twitter_title, twitter_description, robots_noindex, robots_nofollow, robots_noarchive, robots_nosnippet, robots_noimageindex, id, post_id, robots_default FROM wp_aioseo_posts WHERE id > %d ORDER BY id LIMIT %d';
+		$expected_query = 'SELECT title, description, og_title, og_description, twitter_title, twitter_description, canonical_url, robots_noindex, robots_nofollow, robots_noarchive, robots_nosnippet, robots_noimageindex, id, post_id, robots_default FROM wp_aioseo_posts WHERE id > %d ORDER BY id LIMIT %d';
 
 		$this->wpdb->expects( 'prepare' )
 			->once()

--- a/tests/unit/helpers/indexable-to-postmeta-helper-test.php
+++ b/tests/unit/helpers/indexable-to-postmeta-helper-test.php
@@ -59,6 +59,8 @@ class Indexable_To_Postmeta_Helper_Test extends TestCase {
 		$indexable->open_graph_description = 'open_graph_description1';
 		$indexable->twitter_title          = 'twitter_title1';
 		$indexable->twitter_description    = 'twitter_description1';
+		$indexable->canonical              = 'https://example.com/';
+		$indexable->primary_focus_keyword  = 'key phrase';
 		$indexable->is_robots_noindex      = true;
 		$indexable->is_robots_nofollow     = true;
 		$indexable->is_robots_noimageindex = true;
@@ -83,6 +85,12 @@ class Indexable_To_Postmeta_Helper_Test extends TestCase {
 			->andReturn( true );
 		$this->meta->expects( 'set_value' )
 			->with( 'twitter-description', 'twitter_description1', 123 )
+			->andReturn( true );
+		$this->meta->expects( 'set_value' )
+			->with( 'canonical', 'https://example.com/', 123 )
+			->andReturn( true );
+		$this->meta->expects( 'set_value' )
+			->with( 'focuskw', 'key phrase', 123 )
 			->andReturn( true );
 		$this->meta->expects( 'set_value' )
 			->with( 'meta-robots-noindex', true, 123 )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to include the `Focus Keyphrase` and the `Canonical URL` settings in the post import from AIOSEO

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Imports the Canonical URL and the Focus Keyphrase settings for posts from AIOSEO

## Relevant technical choices:

* We do a `sanitize_url` before importing the Canonical URL in our db
* We do a `sanitize_text_field` before importing the Focus Keyphrase in our db

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Note:
* Without the `YOAST_SEO_AIOSEO_V4_IMPORTER` feature flag, you won't be able to see the AIOSEO import as available.

* Create a post while having AIOSEO active
* Add a `Focus Keyphrase` and a `Canonical URL` in the AIOSEO meta box
* Go to the frontend of the post and take a note of the `canonical` link tag.
* Activate Yoast and deactivate AIOSEO
* Go to import/export, select AIOSEO pack and run the import
* Refresh the admin page of that post and confirm that the `Focus Keyphrase` and the `Canonical URL` are the same with what you added in the AIOSEO settings before.
* Go to the frontend of the post and confirm that the `canonical` link tag is the same as before.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[Shopify]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
