### PR TITLE
Prevent filtered links from showing up in the sitemap

### DIFF
--- a/src/helpers/xml-sitemap-helper.php
+++ b/src/helpers/xml-sitemap-helper.php
@@ -158,6 +158,10 @@ class XML_Sitemap_Helper {
 			 */
 			$url = apply_filters( 'wpseo_sitemap_entry', $url, $object_type, $indexable->object_id );
 
+			if ( ! is_array( $url ) || ! isset( $url['loc'] ) ) {
+				continue;
+			}
+
 			$links[] = $url;
 		}
 


### PR DESCRIPTION
## Context
* Yoast SEO Premium, returns `false` in the `wpseo_sitemap_entry` filter to filter out sitemap entries for posts that are redirected. Other plugins can return similar values to prevent sitemap output.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allow for filtering items from the sitemap.

## Relevant technical choices:

* I check if the `loc` key exists, as that's the only required key for the sitemap.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* add the following code block to your functions.php or wp-config.php: it randomly removes around half of your posts from the sitemap.
	```php
	add_filter( 'wpseo_sitemap_entry', function ( $url ) {
		if ( (bool) random_int( 0, 1 ) ) {
			return false;
		}
	
		return $url;
	} );
	```
* Visit your sitemap and see that around half of your content is not in the sitemap. (which posts are gone is randomized and changes with each page load).


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[Shopify]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
