### PR TITLE
Prevent links for no-indexed posttypes/taxonomies on the sitemap index

### DIFF
--- a/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
+++ b/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
@@ -113,7 +113,7 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
 		}
 
 		foreach ( $this->get_non_empty_types() as $object_sub_type ) {
-			if ( ! in_array( $object_sub_type, $present_page_types, true ) ) {
+			if ( ! in_array( $object_sub_type, $present_page_types, true ) && ! $this->should_exclude_object_sub_type( $object_sub_type ) ) {
 				$links[] = [
 					'loc'     => WPSEO_Sitemaps_Router::get_base_url( $object_sub_type . '-sitemap.xml' ),
 					'lastmod' => null,

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -55,21 +55,7 @@ class WPSEO_Post_Type_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider 
 	 * @return boolean Whether or not it should be excluded.
 	 */
 	protected function should_exclude_object_sub_type( $object_sub_type ) {
-		/**
-		 * Filter decision if post type is excluded from the XML sitemap.
-		 *
-		 * @param bool   $exclude   Default false.
-		 * @param string $post_type Post type name.
-		 */
-		if ( apply_filters( 'wpseo_sitemap_exclude_post_type', false, $object_sub_type ) ) {
-			return true;
-		}
-
-		if ( ! WPSEO_Post_Type::is_post_type_accessible( $object_sub_type ) || ! WPSEO_Post_Type::is_post_type_indexable( $object_sub_type ) ) {
-			return true;
-		}
-
-		return false;
+		return ! $this->is_valid_post_type( $object_sub_type );
 	}
 
 	/**

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -49,13 +49,13 @@ class WPSEO_Taxonomy_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider i
 		 * Filter to exclude the taxonomy from the XML sitemap.
 		 *
 		 * @param bool   $exclude       Defaults to false.
-		 * @param string $taxonomy_name Name of the taxonomy to exclude..
+		 * @param string $taxonomy_name Name of the taxonomy to exclude.
 		 */
 		if ( apply_filters( 'wpseo_sitemap_exclude_taxonomy', false, $object_sub_type ) ) {
 			return true;
 		}
 
-		return false;
+		return ! $this->handles_type( $object_sub_type );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Some sitemap links in the index resulted in 404s because the post-type or taxonomy was no-indexed globally.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevent links for no-indexed posttypes/taxonomies on the sitemap index

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In the search appearance settings, set "Show `posttype` in search results?" to "Off" for a posttype and for a taxonomy
* go to the sitemap index: /sitemap_index.xml
* See that there are no links to the no-indexed posttype/taxonomy
* Switch the options back to "On"
* See that there are links to the no-indexed posttype/taxonomy 
* Click the links and see the indexed posts or terms.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[Shopify]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
