### PR TITLE
Expand the first incomplete step on entering the workout

### DIFF
--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -10,7 +10,7 @@ import { ReactComponent as WorkoutDoneImage } from "../../../../../images/mirror
 import { ReactComponent as WorkoutStartImage } from "../../../images/motivated_bubble_woman_1_optim.svg";
 import { addLinkToString } from "../../helpers/stringHelpers.js";
 import { Step, Steps, FinishButtonSection } from "./Steps";
-import Stepper from "./Stepper";
+import Stepper, { getIndexToExpand } from "./Stepper";
 import { STEPS, WORKOUTS } from "../config";
 import { OrganizationSection } from "./OrganizationSection";
 import { PersonSection } from "./PersonSection";
@@ -527,7 +527,15 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 	const siteRepresentsPerson = state.companyOrPerson === "person";
 
 	// PROBABLY DELETE BETWEEN HERE....
-	const [ activeStepIndex, setActiveStepIndex ] = useState( 0 );
+	const savedSteps = [
+		isStepFinished( "configuration", steps.optimizeSeoData ),
+		isStepFinished( "configuration", steps.siteRepresentation ),
+		isStepFinished( "configuration", steps.socialProfiles ),
+		isStepFinished( "configuration", steps.newsletterSignup ),
+		isWorkoutFinished,
+	];
+
+	const [ activeStepIndex, setActiveStepIndex ] = useState( getIndexToExpand( savedSteps ) );
 
 	// AND HERE....
 

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -10,7 +10,7 @@ import { ReactComponent as WorkoutDoneImage } from "../../../../../images/mirror
 import { ReactComponent as WorkoutStartImage } from "../../../images/motivated_bubble_woman_1_optim.svg";
 import { addLinkToString } from "../../helpers/stringHelpers.js";
 import { Step, Steps, FinishButtonSection } from "./Steps";
-import Stepper, { getIndexToExpand } from "./Stepper";
+import Stepper, { getInitialActiveStepIndex } from "./Stepper";
 import { STEPS, WORKOUTS } from "../config";
 import { OrganizationSection } from "./OrganizationSection";
 import { PersonSection } from "./PersonSection";
@@ -542,7 +542,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 		isWorkoutFinished,
 	];
 
-	const [ activeStepIndex, setActiveStepIndex ] = useState( getIndexToExpand( savedSteps ) );
+	const [ activeStepIndex, setActiveStepIndex ] = useState( getInitialActiveStepIndex( savedSteps ) );
 
 	// AND HERE....
 

--- a/packages/js/src/workouts/components/Stepper.js
+++ b/packages/js/src/workouts/components/Stepper.js
@@ -283,7 +283,7 @@ Stepper.defaultProps = {
  *
  * @returns {int} The index to expand.
  */
-export function getIndexToExpand( isSavedSteps ) {
+export function getInitialActiveStepIndex( isSavedSteps ) {
 	// If anything other than an array has been provided, or it is an empty array, return 0.
 	if ( ! Array.isArray( isSavedSteps ) || isSavedSteps.length === 0 ) {
 		return 0;

--- a/packages/js/src/workouts/components/Stepper.js
+++ b/packages/js/src/workouts/components/Stepper.js
@@ -270,3 +270,35 @@ Stepper.defaultProps = {
 	finishStepper: () => { },
 };
 /* eslint-enable complexity, max-len */
+
+// HELPER FUNCTION. Should probably be moved to a separate helper class?
+/**
+ * Gets the index to expand on first render of the stepper.
+ *
+ * If available, the index of the first unsaved step is returned.
+ * If all steps have been finished, the index of the last step is returned.
+ * Otherwise, returns the index of the first step.
+ *
+ * @param {Boolean[]} isSavedSteps Array with the isSaved values for each of the steps.
+ *
+ * @returns {int} The index to expand.
+ */
+export function getIndexToExpand( isSavedSteps ) {
+	// If anything other than an array has been provided, or it is an empty array, return 0.
+	if ( ! Array.isArray( isSavedSteps ) || isSavedSteps.length === 0 ) {
+		return 0;
+	}
+
+	// Get the index of the first element that has not been saved yet.
+	const index = isSavedSteps.findIndex( ( element ) => element === false );
+	if ( index !== -1 ) {
+		return index;
+	}
+
+	// If all steps have been finished, return the index of the last step.
+	if ( isSavedSteps.every( Boolean ) ) {
+		return isSavedSteps.length - 1;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When we open a page that contains a Stepper, we want to expand the first unsaved step. If the stepper has been finished, we want to open the last step.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Expands the first unsaved step when entering a page with the stepper.

## Relevant technical choices:

* Reasoning behind the method: Whether steps are saved or not, should be handled by the parent of the stepper, e.g. the `ConfigurationWorkout`. However, which index should be expanded on first render, given this information, should be handled by the `Stepper`, as this should be the same for all steppers and avoids duplicated code.
* When we have moved the stepper and configuration code (outside of the workouts folder), it might be a good idea to move this method into its own helper class. Also depending on whether we will introduce any other helper functions I suppose.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Navigate to SEO > Workouts and open the Configuration workout. 
* Finish the workout, by clicking the `Finish this workout` button on the bottom of the page (you should see a `Congratulations` message) and then click `Do workout again`.
* Install and activate the Yoast Test Helper plugin.
* Navigate to Tools > Yoast Test and click the `Reset Indexables tables & migrations` button.
* Navigate to SEO > Workouts > Configuration workout. 
* The first step should be expanded when you load/refresh the Configuration workout.
* Run the indexation in the first step and finish some more steps (but not all).
* Refresh the page. 
* The first unsaved step should be opened.
* Click `Go back` and refresh the page. 
* The first unsaved step should again be opened (so not the step you had expanded before refreshing the page).
* Finish all steps of the stepper, and also click `Finish this workout` completely at the bottom of the page (outside of the stepper - you should see a congratulations message).
* Refresh the page. 
* The last step ("Finish Configuration") should be expanded. 
* Click the `Do workout again` button on the bottom of the page and refresh the page.
* The second step ("Knowledge panel") should be expanded (as the first step still depends on the indexation having run).


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[Shopify]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [[DUPP-198](https://yoast.atlassian.net/browse/DUPP-198)]
