### PR TITLE
wp-cron indexing

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -166,6 +166,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'youtube_url',
 		'wikipedia_url',
 		'indexables_indexing_completed',
+		'last_completely_indexed_versions',
 		'semrush_integration_active',
 		'semrush_tokens',
 		'semrush_country_code',

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -34,6 +34,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'indexing_started'                         => null,
 		'indexing_reason'                          => '',
 		'indexables_indexing_completed'            => false,
+		'last_completely_indexed_versions'         => '',
 		// Non-form field, should only be set via validation routine.
 		'version'                                  => '', // Leave default as empty to ensure activation/upgrade works.
 		'previous_version'                         => '',
@@ -275,6 +276,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				case 'home_url':
 				case 'zapier_api_key':
 				case 'wincher_website_id':
+				case 'last_completely_indexed_versions':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = $dirty[ $key ];
 					}

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,0 +1,5 @@
+{
+  "redefinable-internals": [
+	"register_shutdown_function",
+  ]
+}

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,5 +1,6 @@
 {
   "redefinable-internals": [
 	"register_shutdown_function",
+	"time"
   ]
 }

--- a/src/conditionals/wp-cron-conditional.php
+++ b/src/conditionals/wp-cron-conditional.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Class that checks if WP_CRON is enabled.
+ */
+class WP_CRON_Conditional implements Conditional {
+
+	/**
+	 * Checks if WP_CRON is enabled.
+	 *
+	 * @return bool True when WP_CRON is enabled.
+	 */
+	public function is_met() {
+		return ! ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON );
+	}
+}

--- a/src/conditionals/wp-cron-enabled-conditional.php
+++ b/src/conditionals/wp-cron-enabled-conditional.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Conditionals;
 /**
  * Class that checks if WP_CRON is enabled.
  */
-class WP_CRON_Conditional implements Conditional {
+class WP_CRON_Enabled_Conditional implements Conditional {
 
 	/**
 	 * Checks if WP_CRON is enabled.

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -247,7 +247,7 @@ class Indexing_Helper {
 	 * If the indexables are complete, they will always be considered complete until one or more
 	 * indexable builders get a version bump.
 	 *
-	 * @return bool|mixed
+	 * @return bool Whether the index is up to date.
 	 */
 	public function is_index_up_to_date() {
 		$last_completed_index_version = $this->options_helper->get( 'last_completely_indexed_versions' );

--- a/src/helpers/indexing-helper.php
+++ b/src/helpers/indexing-helper.php
@@ -58,9 +58,10 @@ class Indexing_Helper {
 	/**
 	 * Indexing_Helper constructor.
 	 *
-	 * @param Options_Helper            $options_helper      The options helper.
-	 * @param Date_Helper               $date_helper         The date helper.
-	 * @param Yoast_Notification_Center $notification_center The notification center.
+	 * @param Options_Helper             $options_helper             The options helper.
+	 * @param Date_Helper                $date_helper                The date helper.
+	 * @param Yoast_Notification_Center  $notification_center        The notification center.
+	 * @param Indexable_Builder_Versions $indexable_builder_versions Stores the version of each Indexable type.
 	 */
 	public function __construct(
 		Options_Helper $options_helper,

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -115,6 +115,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action             The term indexing action.
 	 * @param Indexing_Helper                               $indexing_helper                       The indexing helper.
 	 * @param Yoast_Admin_And_Dashboard_Conditional         $yoast_admin_and_dashboard_conditional An object that checks if we are on the Yoast admin or on the dashboard page.
+	 * @param Get_Request_Conditional                       $get_request_conditional               An object that checks if we are handling a GET request.
 	 */
 	public function __construct(
 		Indexable_Post_Indexation_Action $post_indexation,
@@ -146,6 +147,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	public function register_hooks() {
 		\add_action( 'admin_init', [ $this, 'register_shutdown_indexing' ] );
 		\add_action( 'Yoast\WP\SEO\index', [ $this, 'index' ] );
+		// phpcs:ignore WordPress.WP.CronInterval -- We use small intervals, so we can use small batches and reduce peak load.
 		\add_filter( 'cron_schedules', [ $this, 'add_cron_schedule' ] );
 		\add_action( 'init', [ $this, 'schedule_cron_indexing' ], 11 );
 		\add_filter( 'wpseo_post_indexation_limit', [ $this, 'throttle_cron_indexing' ] );
@@ -196,7 +198,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 		}
 
 		$schedules['five_minutes'] = [
-			'interval' => 5 * MINUTE_IN_SECONDS,
+			'interval' => ( 5 * MINUTE_IN_SECONDS ),
 			'display'  => esc_html__( 'Every five minutes', 'wordpress-seo' ),
 		];
 
@@ -248,7 +250,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 * @return bool Should background indexation be performed.
 	 */
 	protected function should_index_on_shutdown( $shutdown_limit ) {
-		if ( ! $this->yoast_admin_and_dashboard_conditional->is_met() || !$this->get_request_conditional->is_met() ) {
+		if ( ! $this->yoast_admin_and_dashboard_conditional->is_met() || ! $this->get_request_conditional->is_met() ) {
 			return false;
 		}
 

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -147,7 +147,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	public function register_hooks() {
 		\add_action( 'admin_init', [ $this, 'register_shutdown_indexing' ] );
 		\add_action( 'Yoast\WP\SEO\index', [ $this, 'index' ] );
-		// phpcs:ignore WordPress.WP.CronInterval -- We use small intervals, so we can use small batches and reduce peak load.
+		// phpcs:ignore WordPress.WP.CronInterval -- The sniff doesn't understand values with parentheses. https://github.com/WordPress/WordPress-Coding-Standards/issues/2025
 		\add_filter( 'cron_schedules', [ $this, 'add_cron_schedule' ] );
 		\add_action( 'init', [ $this, 'schedule_cron_indexing' ], 11 );
 		\add_filter( 'wpseo_post_indexation_limit', [ $this, 'throttle_cron_indexing' ] );
@@ -189,20 +189,20 @@ class Background_Indexing_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Adds the 'Every five minutes' cron schedule to WP-Cron.
+	 * Adds the 'Every fifteen minutes' cron schedule to WP-Cron.
 	 *
 	 * @param array $schedules The existing schedules.
 	 *
-	 * @return array The schedules containing the fire_minutes schedule.
+	 * @return array The schedules containing the fifteen_minutes schedule.
 	 */
 	public function add_cron_schedule( $schedules ) {
 		if ( ! is_array( $schedules ) ) {
 			return $schedules;
 		}
 
-		$schedules['five_minutes'] = [
-			'interval' => ( 5 * MINUTE_IN_SECONDS ),
-			'display'  => esc_html__( 'Every five minutes', 'wordpress-seo' ),
+		$schedules['fifteen_minutes'] = [
+			'interval' => ( 15 * MINUTE_IN_SECONDS ),
+			'display'  => esc_html__( 'Every fifteen minutes', 'wordpress-seo' ),
 		];
 
 		return $schedules;
@@ -215,12 +215,12 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 */
 	public function schedule_cron_indexing() {
 		if ( ! wp_next_scheduled( 'Yoast\WP\SEO\index' ) && $this->should_index_on_cron() ) {
-			wp_schedule_event( time(), 'five_minutes', 'Yoast\WP\SEO\index' );
+			wp_schedule_event( time(), 'fifteen_minutes', 'Yoast\WP\SEO\index' );
 		}
 	}
 
 	/**
-	 * Limit cron indexing to 5 indexables per batch instead of 25.
+	 * Limit cron indexing to 15 indexables per batch instead of 25.
 	 *
 	 * @param int $indexation_limit The current limit (filter input).
 	 *
@@ -228,7 +228,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 */
 	public function throttle_cron_indexing( $indexation_limit ) {
 		if ( wp_doing_cron() ) {
-			return 5;
+			return 15;
 		}
 
 		return $indexation_limit;

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -13,6 +13,7 @@ use Yoast\WP\SEO\Conditionals\Get_Request_Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
@@ -79,13 +80,19 @@ class Background_Indexing_Integration implements Integration_Interface {
 	protected $indexing_helper;
 
 	/**
+	 * An object that checks if we are on the Yoast admin or on the dashboard page.
+	 *
+	 * @var Yoast_Admin_And_Dashboard_Conditional
+	 */
+	protected $yoast_admin_and_dashboard_conditional;
+
+	/**
 	 * Returns the conditionals based on which this integration should be active.
 	 *
 	 * @return array The array of conditionals.
 	 */
 	public static function get_conditionals() {
 		return [
-			Yoast_Admin_And_Dashboard_Conditional::class,
 			Migrations_Conditional::class,
 			Get_Request_Conditional::class,
 		];
@@ -94,14 +101,15 @@ class Background_Indexing_Integration implements Integration_Interface {
 	/**
 	 * Shutdown_Indexing_Integration constructor.
 	 *
-	 * @param Indexable_Post_Indexation_Action              $post_indexation              The post indexing action.
-	 * @param Indexable_Term_Indexation_Action              $term_indexation              The term indexing action.
-	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation The post type archive indexing action.
-	 * @param Indexable_General_Indexation_Action           $general_indexation           The general indexing action.
-	 * @param Indexable_Indexing_Complete_Action            $complete_indexation_action   The complete indexing action.
-	 * @param Post_Link_Indexing_Action                     $post_link_indexing_action    The post indexing action.
-	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action    The term indexing action.
-	 * @param Indexing_Helper                               $indexing_helper              The indexing helper.
+	 * @param Indexable_Post_Indexation_Action              $post_indexation                       The post indexing action.
+	 * @param Indexable_Term_Indexation_Action              $term_indexation                       The term indexing action.
+	 * @param Indexable_Post_Type_Archive_Indexation_Action $post_type_archive_indexation          The post type archive indexing action.
+	 * @param Indexable_General_Indexation_Action           $general_indexation                    The general indexing action.
+	 * @param Indexable_Indexing_Complete_Action            $complete_indexation_action            The complete indexing action.
+	 * @param Post_Link_Indexing_Action                     $post_link_indexing_action             The post indexing action.
+	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action             The term indexing action.
+	 * @param Indexing_Helper                               $indexing_helper                       The indexing helper.
+	 * @param Yoast_Admin_And_Dashboard_Conditional         $yoast_admin_and_dashboard_conditional An object that checks if we are on the Yoast admin or on the dashboard page.
 	 */
 	public function __construct(
 		Indexable_Post_Indexation_Action $post_indexation,
@@ -111,23 +119,29 @@ class Background_Indexing_Integration implements Integration_Interface {
 		Indexable_Indexing_Complete_Action $complete_indexation_action,
 		Post_Link_Indexing_Action $post_link_indexing_action,
 		Term_Link_Indexing_Action $term_link_indexing_action,
-		Indexing_Helper $indexing_helper
+		Indexing_Helper $indexing_helper,
+		Yoast_Admin_And_Dashboard_Conditional $yoast_admin_and_dashboard_conditional
 	) {
-		$this->post_indexation              = $post_indexation;
-		$this->term_indexation              = $term_indexation;
-		$this->post_type_archive_indexation = $post_type_archive_indexation;
-		$this->general_indexation           = $general_indexation;
-		$this->complete_indexation_action   = $complete_indexation_action;
-		$this->post_link_indexing_action    = $post_link_indexing_action;
-		$this->term_link_indexing_action    = $term_link_indexing_action;
-		$this->indexing_helper              = $indexing_helper;
+		$this->post_indexation                       = $post_indexation;
+		$this->term_indexation                       = $term_indexation;
+		$this->post_type_archive_indexation          = $post_type_archive_indexation;
+		$this->general_indexation                    = $general_indexation;
+		$this->complete_indexation_action            = $complete_indexation_action;
+		$this->post_link_indexing_action             = $post_link_indexing_action;
+		$this->term_link_indexing_action             = $term_link_indexing_action;
+		$this->indexing_helper                       = $indexing_helper;
+		$this->yoast_admin_and_dashboard_conditional = $yoast_admin_and_dashboard_conditional;
 	}
 
 	/**
 	 * Register hooks.
 	 */
 	public function register_hooks() {
-		\add_action( 'admin_init', [ $this, 'register_shutdown_indexing' ], 10 );
+		\add_action( 'admin_init', [ $this, 'register_shutdown_indexing' ] );
+		\add_action( 'Yoast\WP\SEO\index', [ $this, 'index' ] );
+		\add_filter( 'cron_schedules', [ $this, 'add_cron_schedule' ] );
+		\add_action( 'init', [ $this, 'schedule_cron_indexing' ], 11 );
+		\add_filter( 'wpseo_post_indexation_limit', [ $this, 'throttle_cron_indexing' ] );
 	}
 
 	/**
@@ -147,6 +161,12 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function index() {
+		if ( wp_doing_cron() && ! $this->should_index_on_cron() ) {
+			$this->unschedule_cron_indexing();
+
+			return;
+		}
+
 		$this->post_indexation->index();
 		$this->term_indexation->index();
 		$this->general_indexation->index();
@@ -154,6 +174,80 @@ class Background_Indexing_Integration implements Integration_Interface {
 		$this->post_link_indexing_action->index();
 		$this->term_link_indexing_action->index();
 		$this->complete_indexation_action->complete();
+	}
+
+	/**
+	 * Adds the 'Every five minutes' cron schedule to WP-Cron.
+	 *
+	 * @param array $schedules The existing schedules.
+	 *
+	 * @return array The schedules containing the fire_minutes schedule.
+	 */
+	public function add_cron_schedule( $schedules ) {
+		if ( ! is_array( $schedules ) ) {
+			return $schedules;
+		}
+
+		$schedules['five_minutes'] = [
+			'interval' => 5 * MINUTE_IN_SECONDS,
+			'display'  => esc_html__( 'Every five minutes', 'wordpress-seo' ),
+		];
+
+		return $schedules;
+	}
+
+	/**
+	 * Schedule background indexing every 5 minutes if the index isn't already up to date.
+	 *
+	 * @return void
+	 */
+	public function schedule_cron_indexing() {
+		if ( ! wp_next_scheduled( 'Yoast\WP\SEO\index' ) && $this->should_index_on_cron() ) {
+			wp_schedule_event( time(), 'five_minutes', 'Yoast\WP\SEO\index' );
+		}
+	}
+
+	/**
+	 * Limit cron indexing to 5 indexables per batch instead of 25.
+	 *
+	 * @param int $indexation_limit The current limit (filter input).
+	 *
+	 * @return int The new batch limit.
+	 */
+	public function throttle_cron_indexing( $indexation_limit ) {
+		if ( wp_doing_cron() ) {
+			return 5;
+		}
+
+		return $indexation_limit;
+	}
+
+	/**
+	 * Determine whether cron indexation should be performed.
+	 *
+	 * @return bool Should cron indexation be performed.
+	 */
+	protected function should_index_on_cron() {
+		$enabled = apply_filters( 'Yoast\WP\SEO\enable_cron_indexing', true ) === true;
+
+		return $enabled && ! $this->indexing_helper->is_index_up_to_date();
+	}
+
+	/**
+	 * Determine whether background indexation should be performed.
+	 *
+	 * @param int $shutdown_limit The shutdown limit used to determine whether indexation should be run.
+	 *
+	 * @return bool Should background indexation be performed.
+	 */
+	protected function should_index_on_shutdown( $shutdown_limit ) {
+		if ( ! $this->yoast_admin_and_dashboard_conditional->is_met() ) {
+			return false;
+		}
+
+		$total = $this->indexing_helper->get_limited_filtered_unindexed_count( $shutdown_limit );
+
+		return ( $total > 0 && $total < $shutdown_limit );
 	}
 
 	/**
@@ -171,15 +265,14 @@ class Background_Indexing_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Determine whether background indexation should be performed.
+	 * Removes the cron indexing job from the scheduled event queue.
 	 *
-	 * @param int $shutdown_limit The shutdown limit used to determine whether indexation should be run.
-	 *
-	 * @return bool Should background indexation be performed.
+	 * @return void
 	 */
-	public function should_index_on_shutdown( $shutdown_limit ) {
-		$total = $this->indexing_helper->get_limited_filtered_unindexed_count( $shutdown_limit );
-
-		return ( $total > 0 && $total < $shutdown_limit );
+	protected function unschedule_cron_indexing() {
+		$scheduled = wp_next_scheduled( 'Yoast\WP\SEO\index' );
+		if ( $scheduled ) {
+			wp_unschedule_event( $scheduled, 'Yoast\WP\SEO\index' );
+		}
 	}
 }

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Conditionals\Get_Request_Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
-use Yoast\WP\SEO\Conditionals\WP_CRON_Conditional;
+use Yoast\WP\SEO\Conditionals\WP_CRON_Enabled_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -96,9 +96,9 @@ class Background_Indexing_Integration implements Integration_Interface {
 	/**
 	 * An object that checks if WP_CRON is enabled.
 	 *
-	 * @var WP_CRON_Conditional
+	 * @var WP_CRON_Enabled_Conditional
 	 */
-	private $wp_cron_conditional;
+	private $wp_cron_enabled_conditional;
 
 	/**
 	 * Returns the conditionals based on which this integration should be active.
@@ -124,7 +124,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 * @param Indexing_Helper                               $indexing_helper                       The indexing helper.
 	 * @param Yoast_Admin_And_Dashboard_Conditional         $yoast_admin_and_dashboard_conditional An object that checks if we are on the Yoast admin or on the dashboard page.
 	 * @param Get_Request_Conditional                       $get_request_conditional               An object that checks if we are handling a GET request.
-	 * @param WP_CRON_Conditional                           $wp_cron_conditional                   An object that checks if WP_CRON is enabled.
+	 * @param WP_CRON_Enabled_Conditional                   $wp_cron_enabled_conditional           An object that checks if WP_CRON is enabled.
 	 */
 	public function __construct(
 		Indexable_Post_Indexation_Action $post_indexation,
@@ -137,7 +137,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 		Indexing_Helper $indexing_helper,
 		Yoast_Admin_And_Dashboard_Conditional $yoast_admin_and_dashboard_conditional,
 		Get_Request_Conditional $get_request_conditional,
-		WP_CRON_Conditional $wp_cron_conditional
+		WP_CRON_Enabled_Conditional $wp_cron_enabled_conditional
 	) {
 		$this->post_indexation                       = $post_indexation;
 		$this->term_indexation                       = $term_indexation;
@@ -149,7 +149,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 		$this->indexing_helper                       = $indexing_helper;
 		$this->yoast_admin_and_dashboard_conditional = $yoast_admin_and_dashboard_conditional;
 		$this->get_request_conditional               = $get_request_conditional;
-		$this->wp_cron_conditional                   = $wp_cron_conditional;
+		$this->wp_cron_enabled_conditional           = $wp_cron_enabled_conditional;
 	}
 
 	/**
@@ -273,7 +273,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 			return false;
 		}
 
-		return ! $this->wp_cron_conditional->is_met();
+		return ! $this->wp_cron_enabled_conditional->is_met();
 	}
 
 	/**

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -182,7 +182,10 @@ class Background_Indexing_Integration implements Integration_Interface {
 		$this->post_type_archive_indexation->index();
 		$this->post_link_indexing_action->index();
 		$this->term_link_indexing_action->index();
-		$this->complete_indexation_action->complete();
+
+		if ( $this->indexing_helper->is_index_up_to_date() ) {
+			$this->complete_indexation_action->complete();
+		}
 	}
 
 	/**

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -13,7 +13,6 @@ use Yoast\WP\SEO\Conditionals\Get_Request_Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
-use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
@@ -87,6 +86,13 @@ class Background_Indexing_Integration implements Integration_Interface {
 	protected $yoast_admin_and_dashboard_conditional;
 
 	/**
+	 * An object that checks if we are handling a GET request.
+	 *
+	 * @var Get_Request_Conditional
+	 */
+	private $get_request_conditional;
+
+	/**
 	 * Returns the conditionals based on which this integration should be active.
 	 *
 	 * @return array The array of conditionals.
@@ -94,7 +100,6 @@ class Background_Indexing_Integration implements Integration_Interface {
 	public static function get_conditionals() {
 		return [
 			Migrations_Conditional::class,
-			Get_Request_Conditional::class,
 		];
 	}
 
@@ -120,7 +125,8 @@ class Background_Indexing_Integration implements Integration_Interface {
 		Post_Link_Indexing_Action $post_link_indexing_action,
 		Term_Link_Indexing_Action $term_link_indexing_action,
 		Indexing_Helper $indexing_helper,
-		Yoast_Admin_And_Dashboard_Conditional $yoast_admin_and_dashboard_conditional
+		Yoast_Admin_And_Dashboard_Conditional $yoast_admin_and_dashboard_conditional,
+		Get_Request_Conditional $get_request_conditional
 	) {
 		$this->post_indexation                       = $post_indexation;
 		$this->term_indexation                       = $term_indexation;
@@ -131,6 +137,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 		$this->term_link_indexing_action             = $term_link_indexing_action;
 		$this->indexing_helper                       = $indexing_helper;
 		$this->yoast_admin_and_dashboard_conditional = $yoast_admin_and_dashboard_conditional;
+		$this->get_request_conditional               = $get_request_conditional;
 	}
 
 	/**
@@ -241,7 +248,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 * @return bool Should background indexation be performed.
 	 */
 	protected function should_index_on_shutdown( $shutdown_limit ) {
-		if ( ! $this->yoast_admin_and_dashboard_conditional->is_met() ) {
+		if ( ! $this->yoast_admin_and_dashboard_conditional->is_met() || !$this->get_request_conditional->is_met() ) {
 			return false;
 		}
 

--- a/src/values/indexables/indexable-builder-versions.php
+++ b/src/values/indexables/indexable-builder-versions.php
@@ -41,4 +41,13 @@ class Indexable_Builder_Versions {
 
 		return $this->indexable_builder_versions_by_type[ $object_type ];
 	}
+
+	/**
+	 * Get a unique key for the current state of all combined indexable versions.
+	 *
+	 * @return string a unique key for the current state of all combined indexable versions.
+	 */
+	public function get_combined_version_key() {
+		return implode( '-', array_values( $this->indexable_builder_versions_by_type ) );
+	}
 }

--- a/tests/unit/generators/schema/webpage-test.php
+++ b/tests/unit/generators/schema/webpage-test.php
@@ -85,7 +85,7 @@ class WebPage_Test extends TestCase {
 		$this->meta_tags_context = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->id                = Mockery::mock( ID_Helper::class );
 
-		$this->instance          = new WebPage();
+		$this->instance = new WebPage();
 
 		$this->instance->context = $this->meta_tags_context;
 		$this->instance->helpers = (object) [

--- a/tests/unit/generators/schema/webpage-test.php
+++ b/tests/unit/generators/schema/webpage-test.php
@@ -85,8 +85,8 @@ class WebPage_Test extends TestCase {
 		$this->meta_tags_context = Mockery::mock( Meta_Tags_Context_Mock::class );
 		$this->id                = Mockery::mock( ID_Helper::class );
 
-		$this->instance          = Mockery::mock( WebPage::class )
-			->makePartial();
+		$this->instance          = new WebPage();
+
 		$this->instance->context = $this->meta_tags_context;
 		$this->instance->helpers = (object) [
 			'current_page' => $this->current_page,

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -16,6 +16,7 @@ use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Indexing_Notification_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
 use Yoast_Notification_Center;
 
 /**
@@ -56,6 +57,14 @@ class Indexing_Helper_Test extends TestCase {
 	 * @var Mockery\MockInterface|Yoast_Notification_Center
 	 */
 	protected $notification_center;
+
+
+	/**
+	 * The indexable builder version mock.
+	 *
+	 * @var Mockery\MockInterface|Indexable_Builder_Versions
+	 */
+	protected $indexable_builder_versions;
 
 	/**
 	 * The post indexable indexation action.
@@ -108,10 +117,12 @@ class Indexing_Helper_Test extends TestCase {
 		$this->options_helper      = Mockery::mock( Options_Helper::class );
 		$this->date_helper         = Mockery::mock( Date_Helper::class );
 		$this->notification_center = Mockery::mock( Yoast_Notification_Center::class );
+		$this->indexable_builder_versions = Mockery::mock( Indexable_Builder_Versions::class );
 		$this->instance            = new Indexing_Helper(
 			$this->options_helper,
 			$this->date_helper,
-			$this->notification_center
+			$this->notification_center,
+			$this->indexable_builder_versions
 		);
 
 		$this->post_indexation              = Mockery::mock( Indexable_Post_Indexation_Action::class );

--- a/tests/unit/helpers/indexing-helper-test.php
+++ b/tests/unit/helpers/indexing-helper-test.php
@@ -25,8 +25,8 @@ use Yoast_Notification_Center;
  * @coversDefaultClass \Yoast\WP\SEO\Helpers\Indexing_Helper
  * @covers \Yoast\WP\SEO\Helpers\Indexing_Helper
  *
- * @group helpers
- * @group indexing
+ * @group  helpers
+ * @group  indexing
  */
 class Indexing_Helper_Test extends TestCase {
 
@@ -57,7 +57,6 @@ class Indexing_Helper_Test extends TestCase {
 	 * @var Mockery\MockInterface|Yoast_Notification_Center
 	 */
 	protected $notification_center;
-
 
 	/**
 	 * The indexable builder version mock.
@@ -114,11 +113,11 @@ class Indexing_Helper_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->options_helper      = Mockery::mock( Options_Helper::class );
-		$this->date_helper         = Mockery::mock( Date_Helper::class );
-		$this->notification_center = Mockery::mock( Yoast_Notification_Center::class );
+		$this->options_helper             = Mockery::mock( Options_Helper::class );
+		$this->date_helper                = Mockery::mock( Date_Helper::class );
+		$this->notification_center        = Mockery::mock( Yoast_Notification_Center::class );
 		$this->indexable_builder_versions = Mockery::mock( Indexable_Builder_Versions::class );
-		$this->instance            = new Indexing_Helper(
+		$this->instance                   = new Indexing_Helper(
 			$this->options_helper,
 			$this->date_helper,
 			$this->notification_center,

--- a/tests/unit/integrations/admin/background-indexing-integration-test.php
+++ b/tests/unit/integrations/admin/background-indexing-integration-test.php
@@ -190,12 +190,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 			->once()
 			->andReturn( 10 );
 
-		/**
-		 * We have to register the shutdown function here to prevent a fatal PHP error,
-		 * which would occur because the registered shutdown function is executed
-		 * after the unit test has already completed.
-		 */
-		\register_shutdown_function( [ $this, 'shutdown_indexation_expectations' ] );
+		Monkey\Functions\expect( 'register_shutdown_function' )->with( [ $this->instance, 'index' ] );
 
 		Monkey\Filters\expectApplied( 'wpseo_shutdown_indexation_limit' )
 			->andReturn( 25 );

--- a/tests/unit/integrations/admin/background-indexing-integration-test.php
+++ b/tests/unit/integrations/admin/background-indexing-integration-test.php
@@ -410,7 +410,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 		Monkey\Functions\when( 'time' )->justReturn( 987654321 );
 		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( false );
 		$this->indexing_helper->expects( 'is_index_up_to_date' )->once()->andReturn( false );
-		Monkey\Functions\expect( 'wp_schedule_event' )->once()->with( 987654321, 'five_minutes', 'Yoast\WP\SEO\index' );
+		Monkey\Functions\expect( 'wp_schedule_event' )->once()->with( 987654321, 'fifteen_minutes', 'Yoast\WP\SEO\index' );
 
 		$this->instance->schedule_cron_indexing();
 	}
@@ -469,13 +469,13 @@ class Background_Indexing_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that the background indexing pace is throttled to 5 when doing cron.
+	 * Tests that the background indexing pace is throttled to 15 when doing cron.
 	 *
 	 * @covers ::throttle_cron_indexing
 	 */
 	public function test_throttle_cron_indexing_while_doing_cron() {
 		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( true );
 
-		$this->assertSame( 5, $this->instance->throttle_cron_indexing( 25 ) );
+		$this->assertSame( 15, $this->instance->throttle_cron_indexing( 25 ) );
 	}
 }

--- a/tests/unit/integrations/admin/background-indexing-integration-test.php
+++ b/tests/unit/integrations/admin/background-indexing-integration-test.php
@@ -13,7 +13,7 @@ use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Conditionals\Get_Request_Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
-use Yoast\WP\SEO\Conditionals\WP_CRON_Conditional;
+use Yoast\WP\SEO\Conditionals\WP_CRON_Enabled_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Background_Indexing_Integration;
@@ -109,9 +109,9 @@ class Background_Indexing_Integration_Test extends TestCase {
 	/**
 	 * The WP_CRON_Conditional mock.
 	 *
-	 * @var Mockery\MockInterface|WP_CRON_Conditional
+	 * @var Mockery\MockInterface|WP_CRON_Enabled_Conditional
 	 */
-	private $wp_cron_conditional;
+	private $wp_cron_enabled_conditional;
 
 	/**
 	 * Sets up the tests.
@@ -129,7 +129,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 		$this->indexing_helper                       = Mockery::mock( Indexing_Helper::class );
 		$this->yoast_admin_and_dashboard_conditional = Mockery::mock( Yoast_Admin_And_Dashboard_Conditional::class );
 		$this->get_request_conditional               = Mockery::mock( Get_Request_Conditional::class );
-		$this->wp_cron_conditional                   = Mockery::mock( WP_CRON_Conditional::class );
+		$this->wp_cron_enabled_conditional           = Mockery::mock( WP_CRON_Enabled_Conditional::class );
 		$this->instance                              = new Background_Indexing_Integration(
 			$this->post_indexation,
 			$this->term_indexation,
@@ -141,7 +141,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 			$this->indexing_helper,
 			$this->yoast_admin_and_dashboard_conditional,
 			$this->get_request_conditional,
-			$this->wp_cron_conditional
+			$this->wp_cron_enabled_conditional
 		);
 	}
 
@@ -233,7 +233,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 			->once()
 			->andReturn( true );
 
-		$this->wp_cron_conditional
+		$this->wp_cron_enabled_conditional
 			->expects( 'is_met' )
 			->once()
 			->andReturn( false );
@@ -269,7 +269,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 			->once()
 			->andReturn( true );
 
-		$this->wp_cron_conditional
+		$this->wp_cron_enabled_conditional
 			->expects( 'is_met' )
 			->once()
 			->andReturn( true );

--- a/tests/unit/integrations/admin/background-indexing-integration-test.php
+++ b/tests/unit/integrations/admin/background-indexing-integration-test.php
@@ -131,7 +131,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 			$this->term_link_indexing_action,
 			$this->indexing_helper,
 			$this->yoast_admin_and_dashboard_conditional,
-			$this->get_request_conditional,
+			$this->get_request_conditional
 		);
 	}
 
@@ -276,6 +276,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 	 * Tests the shutdown indexing method.
 	 *
 	 * @covers ::index
+	 * @covers ::should_index_on_cron
 	 */
 	public function test_index() {
 		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( false );
@@ -398,6 +399,11 @@ class Background_Indexing_Integration_Test extends TestCase {
 		$this->instance->index();
 	}
 
+	/**
+	 * Tests that the schedule_cron_indexing function schedules a cron job that performs the Yoast\WP\SEO\index action.
+	 *
+	 * @covers ::schedule_cron_indexing
+	 */
 	public function test_schedule_cron_indexing() {
 		Monkey\Functions\when( 'time' )->justReturn( 987654321 );
 		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( false );
@@ -407,6 +413,11 @@ class Background_Indexing_Integration_Test extends TestCase {
 		$this->instance->schedule_cron_indexing();
 	}
 
+	/**
+	 * Tests that no cron job is scheduled when the cron job is already scheduled.
+	 *
+	 * @covers ::schedule_cron_indexing
+	 */
 	public function test_schedule_cron_indexing_already_scheduled() {
 		Monkey\Functions\when( 'time' )->justReturn( 987654321 );
 		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( 987654321 );
@@ -415,6 +426,11 @@ class Background_Indexing_Integration_Test extends TestCase {
 		$this->instance->schedule_cron_indexing();
 	}
 
+	/**
+	 * Tests that no cron job is scheduled when the cron indexing is disabled through the Yoast\WP\SEO\enable_cron_indexing filter.
+	 *
+	 * @covers ::schedule_cron_indexing
+	 */
 	public function test_schedule_cron_indexing_cron_indexing_disabled() {
 		Monkey\Functions\when( 'time' )->justReturn( 987654321 );
 		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( false );
@@ -424,6 +440,11 @@ class Background_Indexing_Integration_Test extends TestCase {
 		$this->instance->schedule_cron_indexing();
 	}
 
+	/**
+	 * Tests that no cron job is scheduled when the indexing process is already complete.
+	 *
+	 * @covers ::schedule_cron_indexing
+	 */
 	public function test_schedule_cron_indexing_index_complete() {
 		Monkey\Functions\when( 'time' )->justReturn( 987654321 );
 		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( false );
@@ -433,13 +454,23 @@ class Background_Indexing_Integration_Test extends TestCase {
 		$this->instance->schedule_cron_indexing();
 	}
 
-
+	/**
+	 * /**
+	 * Tests that the background indexing pace stays untouched when not doing cron.
+	 *
+	 * @covers ::throttle_cron_indexing
+	 */
 	public function test_throttle_cron_indexing() {
 		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( false );
 
 		$this->assertSame( 25, $this->instance->throttle_cron_indexing( 25 ) );
 	}
 
+	/**
+	 * Tests that the background indexing pace is throttled to 5 when doing cron.
+	 *
+	 * @covers ::throttle_cron_indexing
+	 */
 	public function test_throttle_cron_indexing_while_doing_cron() {
 		Monkey\Functions\when( 'wp_doing_cron' )->justReturn( true );
 

--- a/tests/unit/integrations/admin/background-indexing-integration-test.php
+++ b/tests/unit/integrations/admin/background-indexing-integration-test.php
@@ -288,6 +288,11 @@ class Background_Indexing_Integration_Test extends TestCase {
 		$this->post_link_indexing_action->expects( 'index' )->once();
 		$this->term_link_indexing_action->expects( 'index' )->once();
 
+		$this->indexing_helper
+			->expects( 'is_index_up_to_date' )
+			->once()
+			->andReturn( true );
+
 		$this->complete_indexation_action
 			->expects( 'complete' )
 			->once();
@@ -311,8 +316,9 @@ class Background_Indexing_Integration_Test extends TestCase {
 
 		$this->indexing_helper
 			->expects( 'is_index_up_to_date' )
-			->once()
+			->times( 2 )
 			->andReturn( false );
+
 
 		$this->term_indexation->expects( 'index' )->once();
 		$this->post_indexation->expects( 'index' )->once();
@@ -320,10 +326,6 @@ class Background_Indexing_Integration_Test extends TestCase {
 		$this->post_type_archive_indexation->expects( 'index' )->once();
 		$this->post_link_indexing_action->expects( 'index' )->once();
 		$this->term_link_indexing_action->expects( 'index' )->once();
-
-		$this->complete_indexation_action
-			->expects( 'complete' )
-			->once();
 
 		$this->instance->index();
 	}

--- a/tests/unit/integrations/admin/background-indexing-integration-test.php
+++ b/tests/unit/integrations/admin/background-indexing-integration-test.php
@@ -16,7 +16,6 @@ use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Conditionals\Yoast_Admin_And_Dashboard_Conditional;
 use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Background_Indexing_Integration;
-use Yoast\WP\SEO\Integrations\Admin\Indexing_Tool_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -32,7 +31,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 	/**
 	 * The indexation integration under test.
 	 *
-	 * @var Indexing_Tool_Integration
+	 * @var Background_Indexing_Integration
 	 */
 	protected $instance;
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Users shouldn't have to click the optimize site button every time they install our plugin or every time we release a new version that modifies the indexable model, which needs a full reindex.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Replaces indexing at the end of admin requests with WP-Cron if WP-Cron is not disabled on the site.

## Relevant technical choices:

* In the unittests, [we added our own shutdown hook](https://github.com/Yoast/wordpress-seo/pull/17989/files#diff-cde93b4be417fc1864763094db41de5978a285c6b621790af85a92643b5c714cL193-L198) with assertions to get around testing if the shutdown hook was used as expected. The assertions in that [`shutdown_indexation_expectations` callback](https://github.com/Yoast/wordpress-seo/pull/17989/files#diff-cde93b4be417fc1864763094db41de5978a285c6b621790af85a92643b5c714cL246) never got asserted properly. Instead, I followed the feedback I got in the terminal when trying to spy on `register_shutdown_function`: I used the patchwork.json config to define php internals that are allowed to be overwritten by mocks.
* To ensure consistency with time in some test case assertions, I also allow `time` to be overwritten.
* Once we set a list of `redefinable-internals` in the patchwork.json the WebPage test-cases broke, as patchwork now tries to proxy the `add_image` function call because the instance is a partial mock. This fails because the function expects a reference but patchwork can only provide a value. We didn't use any of the mock features here so I removed the mock and created a real instance instead. Alternatively, I could have also removed the reference, as I don't see why we need to pass `$data` as a reference here. But that'd likely be a BC break and increase test scope, so I didn't.
* I introduced a WP_CRON_Conditional, as that can easily be mocked. Otherwise we'd have to define global constants in tests, which would be nightmarish.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* truncate your indexable table or use a fresh WP install
* Disable Yoast SEO
* Make sure your site has at least 45 posts (`wp post generate --count=45 --post_author=admin` with WP CLI)
* Activate the plugin after you've generated some content.
* Using WP CLI, run `wp cron event run "Yoast\WP\SEO\index"`.
* This should yield output similar to this:
    ``` 
    Executed the cron event 'Yoast\WP\SEO\index' in 0.072s.
    Success: Executed a total of 1 cron event.
    ```
* Check in you database; you should see at least 15 indexables now.
* Repeat the WP CLI step.
* See that there are 15 more indexables.
* Add the following line to your wp-config.php or functions.php: `add_filter( 'Yoast\WP\SEO\enable_cron_indexing', '__return_false' );`
* Repeat the WP CLI step.
* See that there are no added indexables.
* Repeat the v step.
* See that you get a different response in the terminal: `Error: Invalid cron event 'Yoast\WP\SEO\index'`
* Remove the line of code and visit a page on your site.
* Keep repeating the process of calling WP CLI and checking the database until you get a different response: `Error: Invalid cron event 'Yoast\WP\SEO\index'`
* Check that the indexable table is complete and that all your posts/pages/terms/system-pages/homepage are there.
* Disable Yoast SEO again
* Disable WP-Cron by adding the following line to your wp-config.php or functions.php `define( 'DISABLE_WP_CRON', true );`.
* Generate another 10 posts.
* Enable Yoast SEO
* Visit any of the Yoast SEO settings pages.
* Check that the indexable table is complete and that all your posts/pages/terms/system-pages/homepage are there.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

The instructions below are more time consuming than the steps above as it also tests the actual cron timing instead of triggering the cron jobs manually with WP-CLI.

* Have a fresh install of WordPress without Yoast SEO
* Add the following line to your wp-config.php or functions.php: `add_filter( 'Yoast\WP\SEO\enable_cron_indexing', '__return_false' );`
* Make sure your site has at least 45 posts (`wp post generate --count=45 --post_author=admin` with WP CLI)
* Activate the plugin after you've generated some content.
* After a bit over 15 minutes, visit the homepage of your site
* In the database, check that there are fewer than 15 records in the wp_yoast_indexables table. It's likely just the home-page.
* Remove the line from the wp-config that you added in the second step.
* Visit the homepage of you site
* After a bit over 15 minutes, visit the homepage of your site again.
* In the database, check that 15 records are now added to the wp_yoast_indexables table.
* To make sure it doesn't just stop after 1 batch: after a bit over 15 minutes, visit the homepage of your site again.
* In the database, check that another 15 records are added to the wp_yoast_indexables table.
* Disable WP-Cron by adding the following line to your wp-config.php or functions.php `define( 'DISABLE_WP_CRON', true );`.
* Visit any of the Yoast SEO settings pages. (this triggers "shutdown indexing" which is only done if there are fewer than 26 indexables are missing)
* Check that the indexable table is complete and that all your posts/pages/terms/system-pages/homepage are there.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Installing Yoast SEO for the first time on small sites with fewer than 25 posts+authors+terms in total. This used to index the site in one go during the first wp-admin request that hits the plugin's admin pages. This is still the case when `DISABLE_WP_CRON` is set to `true`. If that is not the case, the site should be indexed gradually; 15 posts every 15 minutes (granted the site gets visitors every 15 minutes).

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[Shopify]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.