### PR TITLE
Display the most recent last-modified date for every page in the sitemap

### DIFF
--- a/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
+++ b/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
@@ -62,9 +62,13 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
 			}
 
 			$links[] = [
-				'loc'     => WPSEO_Sitemaps_Router::get_base_url( $object->object_sub_type . '-sitemap' . ( $page++ ) . '.xml' ),
+				'loc'     => WPSEO_Sitemaps_Router::get_base_url( $object->object_sub_type . '-sitemap' . ( $page ) . '.xml' ),
 				'lastmod' => $object->object_last_modified,
 			];
+
+			if ( is_int( $page ) ) {
+				++$page;
+			}
 
 			if ( $next_object_is_not_same_sub_type ) {
 				$page = 1;

--- a/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
+++ b/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
@@ -142,9 +142,9 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
 		$post_type_aggregates = (array) $this->repository
 			->query_where_noindex( false, $this->get_object_type() )
 			->select( 'object_sub_type' )
-			->having_gt( 'number_of_posts', 0 )
 			->select_expr( 'MAX(`object_last_modified`)', 'post_type_last_modified' )
 			->select_expr( 'COUNT(`id`)', 'number_of_posts' )
+			->having_gt( 'number_of_posts', 0 )
 			->find_array();
 
 		foreach ( $post_type_aggregates as $post_type_aggregate ) {

--- a/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
+++ b/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
@@ -133,7 +133,8 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
 					) AS subset
 					ON subset.id = i.id
 				",
-				$max_entries_per_page, $max_entries_per_page
+				$max_entries_per_page,
+				$max_entries_per_page
 			)
 		// phpcs:enable
 		);
@@ -170,7 +171,7 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
 
 				// Insert after the last complete page of the same type.
 				$last_object_per_page = array_merge(
-					array_splice( $last_object_per_page, 0, $last_subtype_index + 1 ),
+					array_splice( $last_object_per_page, 0, ( $last_subtype_index + 1 ) ),
 					[ $half_page_object ],
 					$last_object_per_page
 				);

--- a/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
+++ b/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
@@ -148,6 +148,7 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
 			->select( 'object_sub_type' )
 			->select_expr( 'MAX(`object_last_modified`)', 'post_type_last_modified' )
 			->select_expr( 'COUNT(`id`)', 'number_of_posts' )
+			->where_not_in( 'object_id', $excluded_object_ids )
 			->having_gt( 'number_of_posts', 0 )
 			->find_array();
 

--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -66,54 +66,18 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			return [];
 		}
 
-		$noindex_authors_with_no_posts = WPSEO_Options::get( 'noindex-author-noposts-wpseo' );
-		$query                         = $this->repository
-			->query_where_noindex( false, 'user', null, $noindex_authors_with_no_posts )
-			->select( 'id' )
-			->order_by_asc( 'object_last_modified' );
-
-		$users_to_exclude = $this->exclude_users();
-		if ( is_array( $users_to_exclude ) && count( $users_to_exclude ) > 0 ) {
-			$query->where_not_in( 'object_id', $users_to_exclude );
-		}
-
-		$table_name = Model::get_table_name( 'Indexable' );
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared by our ORM.
-		$raw_query = $wpdb->prepare( $query->get_sql(), $query->get_values() );
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- Complex query is not possible without a direct query.
-		$last_modified_per_page = $wpdb->get_col(
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Variables are secure.
-			$wpdb->prepare(
-				// This query pulls only every Nth last_modified from the database.
-				"
-					SELECT i.object_last_modified
-					FROM $table_name AS i
-					INNER JOIN (
-						SELECT id
-						FROM (
-							SELECT @row:=@row+1 AS rownum, id
-							FROM ( $raw_query ) AS sorted, ( SELECT @row:=-1 ) AS init
-						) AS ranked
-						WHERE rownum MOD %d = 0
-					) AS subset
-					ON subset.id = i.id
-				",
-				$max_entries
-			)
-			// phpcs:enable
-		);
+		$last_object_per_page = $this->get_last_object_per_page( $max_entries );
 
 		$page = 1;
-		if ( count( $last_modified_per_page ) === 1 ) {
+		if ( count( $last_object_per_page ) === 1 ) {
 			$page = '';
 		}
 
 		$index_links = [];
-		foreach ( $last_modified_per_page as $last_modified ) {
+		foreach ( $last_object_per_page as $object ) {
 			$index_links[] = [
 				'loc'     => WPSEO_Sitemaps_Router::get_base_url( 'author-sitemap' . $page . '.xml' ),
-				'lastmod' => $last_modified,
+				'lastmod' => $object->object_last_modified,
 			];
 
 			if ( is_int( $page ) ) {
@@ -164,6 +128,79 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		}
 
 		return $this->xml_sitemap_helper->convert_indexables_to_sitemap_links( $indexables, 'user' );
+	}
+
+	/**
+	 * Gets a list of sitemap objects that represent the last entry on an individual sitemap page.
+	 *
+	 * @param int $max_entries_per_page The maximum allowed number of objects on a single page.
+	 *
+	 * @return array A list of sitemap objects that represent the last entry on an individual sitemap page.
+	 */
+	protected function get_last_object_per_page( $max_entries_per_page ) {
+		global $wpdb;
+
+		$noindex_authors_with_no_posts = WPSEO_Options::get( 'noindex-author-noposts-wpseo' );
+
+		$query = $this->repository
+			->query_where_noindex( false, 'user', null, $noindex_authors_with_no_posts )
+			->select( 'id' )
+			->order_by_asc( 'object_last_modified' );
+
+		$users_to_exclude = $this->exclude_users();
+		if ( is_array( $users_to_exclude ) && count( $users_to_exclude ) > 0 ) {
+			$query->where_not_in( 'object_id', $users_to_exclude );
+		}
+
+		$table_name = Model::get_table_name( 'Indexable' );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared by our ORM.
+		$raw_query = $wpdb->prepare( $query->get_sql(), $query->get_values() );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- Complex query is not possible without a direct query.
+		$last_object_per_page = $wpdb->get_results(
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Variables are secure.
+			$wpdb->prepare(
+			// This query pulls only every Nth last_modified from the database.
+				"
+					SELECT i.object_last_modified
+					FROM $table_name AS i
+					INNER JOIN (
+						SELECT id
+						FROM (
+							SELECT @row:=@row+1 AS rownum, id
+							FROM ( $raw_query ) AS sorted, ( SELECT @row:=-1 ) AS init
+						) AS ranked
+						WHERE rownum MOD %d = (%d-1) -- Get the last entry of all full pages. 
+					) AS subset
+					ON subset.id = i.id
+				",
+				$max_entries_per_page,
+				$max_entries_per_page
+			)
+		// phpcs:enable
+		);
+
+		// Ensure that author pages with fewer objects than the max_entries get a link.
+		$aggregate_query = $this->repository
+			->query_where_noindex( false, 'user', null, $noindex_authors_with_no_posts )
+			->select_expr( 'MAX(`object_last_modified`)', 'most_recently_modified' )
+			->select_expr( 'COUNT(`id`)', 'number_of_authors' )
+			->having_gt( 'number_of_authors', 0 );
+
+		if ( is_array( $users_to_exclude ) && count( $users_to_exclude ) > 0 ) {
+			$aggregate_query->where_not_in( 'object_id', $users_to_exclude );
+		}
+
+		// We must use find_array. Other functions will try to map the aggregates to the Indexable model.
+		$aggregates = (array) $aggregate_query->find_array();
+
+		if ( isset( $aggregates[0]['number_of_authors'] ) && ( $aggregates[0]['number_of_authors'] % $max_entries_per_page !== 0 ) ) {
+			$last_object_per_page[] = (object) [
+				'object_last_modified' => $aggregates[0]['most_recently_modified'],
+			];
+		}
+
+		return $last_object_per_page;
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* There's a bug with indexable sitemaps that shows the _first_ last modified date for every page instead of the most recent.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*  Fixes an unreleased bug where the the sitemap index would show the oldest last modified date of a page instead of the most recent.

## Relevant technical choices:

* Ideally, reversing the sort of the `object_last_modified` column would fix the issue, but that causes a new problem: once a post is updated, _all_ sitemap pages rotate 1 post, which makes them have a new last_modified date.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open the sitemap index of your site
* See that, for every link in the sitemap index, the date that is shown next to it is the most recent date of all dates that are listed in the sitemap that you get when you click that link.
* Check this for every item in the sitemap index
* In your `functions.php` or `wp-config.php`, add the following line: `add_filter('Yoast\WP\SEO\xml_sitemaps_entries_per_sitemap', function($x){return 20;});`
* Refresh the sitemap index. The individual sitemaps should now have multiple pages per type. Each link on the index should _still_ show the most recent date of _that_ page of the sitemap.
* Take a screenshot of the sitemap or duplicate the tab and leave it untouched for later comparison
* Publish a new post
* Refresh the sitemap and compare it to your screenshot or duplicated browser tab: the only link that is changed, should be the _last_ page of the post_sitemap. All other links should keep the same last modified date on the sitemap index.
* Now go back to the line of code in the `wp-config.php` or `functions.php`. Change the number 20 to a number that results in _only_ full pages for the page-sitemap. (for example, if you have 210 posts, leaving the number at 20 will give you 10,5 pages. But setting it to 10 will give you exactly 21 pages. That's what we want).
* Now check the last link of the post-sitemap in the sitemap index, it should still read the most recent last modified date of that last page.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Links on the sitemap index.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[Shopify]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.