### PR TITLE
Restore WPSEO_Sitemaps_Cache to prevent fatal errors

### DIFF
--- a/inc/sitemaps/class-sitemaps-cache.php
+++ b/inc/sitemaps/class-sitemaps-cache.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\XML_Sitemaps
+ */
+
+/**
+ * Handles sitemaps caching and invalidation.
+ *
+ * @since      3.2
+ * @deprecated 18.1 Sitemap caching is removed in favor of indexables. This file now purely exists to prevent fatal errors.
+ */
+class WPSEO_Sitemaps_Cache {
+
+	/**
+	 * Setup context for static calls.
+	 *
+	 * @deprecated 18.1
+	 */
+	public function init() {
+		_deprecated_function( __METHOD__, '18.1' );
+	}
+
+	/**
+	 * If cache is enabled.
+	 *
+	 * @return bool
+	 * @since      3.2
+	 *
+	 * @deprecated 18.1
+	 */
+	public function is_enabled() {
+		_deprecated_function( __METHOD__, "18.1" );
+
+		return false;
+	}
+
+	/**
+	 * Retrieve the sitemap page from cache.
+	 *
+	 * @param string $type Sitemap type.
+	 * @param int    $page Page number to retrieve.
+	 *
+	 * @return string|bool
+	 * @since 3.2
+	 * @deprecated 18.1
+	 */
+	public function get_sitemap( $type, $page ) {
+		_deprecated_function( __METHOD__, '18.1' );
+
+		return false;
+	}
+
+	/**
+	 * Get the sitemap that is cached.
+	 *
+	 * @param string $type Sitemap type.
+	 * @param int    $page Page number to retrieve.
+	 *
+	 * @return WPSEO_Sitemap_Cache_Data|null Null on no cache found otherwise object containing sitemap and meta data.
+	 * @deprecated 18.1
+	 */
+	public function get_sitemap_data( $type, $page ) {
+		_deprecated_function( __METHOD__, '18.1' );
+
+		return null;
+	}
+
+	/**
+	 * Store the sitemap page from cache.
+	 *
+	 * @param string $type    Sitemap type.
+	 * @param int    $page    Page number to store.
+	 * @param string $sitemap Sitemap body to store.
+	 * @param bool   $usable  Is this a valid sitemap or a cache of an invalid sitemap.
+	 *
+	 * @return bool
+	 * @since 3.2
+	 * @deprecated 18.1
+	 */
+	public function store_sitemap( $type, $page, $sitemap, $usable = true ) {
+		_deprecated_function( __METHOD__, '18.1' );
+
+		return false;
+	}
+
+	/**
+	 * Delete cache transients for index and specific type.
+	 *
+	 * Always deletes the main index sitemaps cache, as that's always invalidated by any other change.
+	 *
+	 * @param string $type Sitemap type to invalidate.
+	 *
+	 * @return void
+	 * @since 1.5.4
+	 * @since 3.2   Changed from function wpseo_invalidate_sitemap_cache() to method in this class.
+	 * @deprecated 18.1
+	 */
+	public static function invalidate( $type ) {
+		_deprecated_function( __METHOD__, '18.1' );
+	}
+
+	/**
+	 * Helper to invalidate in hooks where type is passed as second argument.
+	 *
+	 * @param int    $unused Unused term ID value.
+	 * @param string $type   Taxonomy to invalidate.
+	 *
+	 * @return void
+	 * @since 3.2
+	 * @deprecated 18.1
+	 */
+	public static function invalidate_helper( $unused, $type ) {
+		_deprecated_function( __METHOD__, '18.1' );
+	}
+
+	/**
+	 * Invalidate sitemap cache for authors.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return bool True if the sitemap was properly invalidated. False otherwise.
+	 * @deprecated 18.1
+	 */
+	public static function invalidate_author( $user_id ) {
+		_deprecated_function( __METHOD__, '18.1' );
+
+		return false;
+	}
+
+	/**
+	 * Invalidate sitemap cache for the post type of a post.
+	 *
+	 * Don't invalidate for revisions.
+	 *
+	 * @param int $post_id Post ID to invalidate type for.
+	 *
+	 * @return void
+	 * @since 1.5.4
+	 * @since 3.2   Changed from function wpseo_invalidate_sitemap_cache_on_save_post() to method in this class.
+	 * @deprecated 18.1
+	 */
+	public static function invalidate_post( $post_id ) {
+		_deprecated_function( __METHOD__, '18.1' );
+	}
+
+	/**
+	 * Delete cache transients for given sitemaps types or all by default.
+	 *
+	 * @param array $types Set of sitemap types to delete cache transients for.
+	 *
+	 * @return void
+	 * @since 1.8.0
+	 * @since 3.2   Moved from WPSEO_Utils to this class.
+	 * @deprecated 18.1
+	 */
+	public static function clear( $types = [] ) {
+		_deprecated_function( __METHOD__, '18.1' );
+	}
+
+	/**
+	 * Invalidate storage for cache types queued to clear.
+	 *
+	 * @deprecated 18.1
+	 */
+	public static function clear_queued() {
+		_deprecated_function( __METHOD__, '18.1' );
+	}
+
+	/**
+	 * Adds a hook that when given option is updated, the cache is cleared.
+	 *
+	 * @param string $option Option name.
+	 * @param string $type   Sitemap type.
+	 *
+	 * @since 3.2
+	 * @deprecated 18.1
+	 */
+	public static function register_clear_on_option_update( $option, $type = '' ) {
+		_deprecated_function( __METHOD__, '18.1' );
+	}
+
+	/**
+	 * Clears the transient cache when a given option is updated, if that option has been registered before.
+	 *
+	 * @param string $option The option name that's being updated.
+	 *
+	 * @return void
+	 * @since 3.2
+	 * @deprecated 18.1
+	 */
+	public static function clear_on_option_update( $option ) {
+		_deprecated_function( __METHOD__, '18.1' );
+	}
+}

--- a/inc/sitemaps/class-sitemaps-cache.php
+++ b/inc/sitemaps/class-sitemaps-cache.php
@@ -5,6 +5,8 @@
  * @package WPSEO\XML_Sitemaps
  */
 
+// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter
+
 /**
  * Handles sitemaps caching and invalidation.
  *
@@ -17,6 +19,7 @@ class WPSEO_Sitemaps_Cache {
 	 * Setup context for static calls.
 	 *
 	 * @deprecated 18.1
+	 * @codeCoverageIgnore
 	 */
 	public function init() {
 		_deprecated_function( __METHOD__, '18.1' );
@@ -29,9 +32,10 @@ class WPSEO_Sitemaps_Cache {
 	 * @since      3.2
 	 *
 	 * @deprecated 18.1
+	 * @codeCoverageIgnore
 	 */
 	public function is_enabled() {
-		_deprecated_function( __METHOD__, "18.1" );
+		_deprecated_function( __METHOD__, '18.1' );
 
 		return false;
 	}
@@ -45,6 +49,7 @@ class WPSEO_Sitemaps_Cache {
 	 * @return string|bool
 	 * @since 3.2
 	 * @deprecated 18.1
+	 * @codeCoverageIgnore
 	 */
 	public function get_sitemap( $type, $page ) {
 		_deprecated_function( __METHOD__, '18.1' );
@@ -60,6 +65,7 @@ class WPSEO_Sitemaps_Cache {
 	 *
 	 * @return WPSEO_Sitemap_Cache_Data|null Null on no cache found otherwise object containing sitemap and meta data.
 	 * @deprecated 18.1
+	 * @codeCoverageIgnore
 	 */
 	public function get_sitemap_data( $type, $page ) {
 		_deprecated_function( __METHOD__, '18.1' );
@@ -78,6 +84,7 @@ class WPSEO_Sitemaps_Cache {
 	 * @return bool
 	 * @since 3.2
 	 * @deprecated 18.1
+	 * @codeCoverageIgnore
 	 */
 	public function store_sitemap( $type, $page, $sitemap, $usable = true ) {
 		_deprecated_function( __METHOD__, '18.1' );
@@ -96,6 +103,7 @@ class WPSEO_Sitemaps_Cache {
 	 * @since 1.5.4
 	 * @since 3.2   Changed from function wpseo_invalidate_sitemap_cache() to method in this class.
 	 * @deprecated 18.1
+	 * @codeCoverageIgnore
 	 */
 	public static function invalidate( $type ) {
 		_deprecated_function( __METHOD__, '18.1' );
@@ -110,6 +118,7 @@ class WPSEO_Sitemaps_Cache {
 	 * @return void
 	 * @since 3.2
 	 * @deprecated 18.1
+	 * @codeCoverageIgnore
 	 */
 	public static function invalidate_helper( $unused, $type ) {
 		_deprecated_function( __METHOD__, '18.1' );
@@ -122,6 +131,7 @@ class WPSEO_Sitemaps_Cache {
 	 *
 	 * @return bool True if the sitemap was properly invalidated. False otherwise.
 	 * @deprecated 18.1
+	 * @codeCoverageIgnore
 	 */
 	public static function invalidate_author( $user_id ) {
 		_deprecated_function( __METHOD__, '18.1' );
@@ -140,6 +150,7 @@ class WPSEO_Sitemaps_Cache {
 	 * @since 1.5.4
 	 * @since 3.2   Changed from function wpseo_invalidate_sitemap_cache_on_save_post() to method in this class.
 	 * @deprecated 18.1
+	 * @codeCoverageIgnore
 	 */
 	public static function invalidate_post( $post_id ) {
 		_deprecated_function( __METHOD__, '18.1' );
@@ -154,6 +165,7 @@ class WPSEO_Sitemaps_Cache {
 	 * @since 1.8.0
 	 * @since 3.2   Moved from WPSEO_Utils to this class.
 	 * @deprecated 18.1
+	 * @codeCoverageIgnore
 	 */
 	public static function clear( $types = [] ) {
 		_deprecated_function( __METHOD__, '18.1' );
@@ -163,6 +175,7 @@ class WPSEO_Sitemaps_Cache {
 	 * Invalidate storage for cache types queued to clear.
 	 *
 	 * @deprecated 18.1
+	 * @codeCoverageIgnore
 	 */
 	public static function clear_queued() {
 		_deprecated_function( __METHOD__, '18.1' );
@@ -176,6 +189,7 @@ class WPSEO_Sitemaps_Cache {
 	 *
 	 * @since 3.2
 	 * @deprecated 18.1
+	 * @codeCoverageIgnore
 	 */
 	public static function register_clear_on_option_update( $option, $type = '' ) {
 		_deprecated_function( __METHOD__, '18.1' );
@@ -189,8 +203,10 @@ class WPSEO_Sitemaps_Cache {
 	 * @return void
 	 * @since 3.2
 	 * @deprecated 18.1
+	 * @codeCoverageIgnore
 	 */
 	public static function clear_on_option_update( $option ) {
 		_deprecated_function( __METHOD__, '18.1' );
 	}
 }
+// phpcs:enable


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The news SEO plugin (among others) throws fatal errors with the feature/indexable-sitemaps branch because we removed the caching file.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Deprecate the WPSEO_Sitemaps_Cache class.

## Relevant technical choices:

* I kept the return type consistent with the phpdoc return type to prevent potential breakage.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate version 13.1 of News SEO.
* Create and publish a new post
* This should not throw a fatal error. Instead you get deprecation warnings depending on your server config
* the post you updated is now visible in the sitemaps.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* -

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[Shopify]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

