### PR TITLE
Lingo 1250 support primary category pluggable replacement variable

### DIFF
--- a/packages/js/src/classic-editor/replacement-variables/configurations.js
+++ b/packages/js/src/classic-editor/replacement-variables/configurations.js
@@ -46,14 +46,14 @@ export const primaryCategory = {
 	name: "primary_category",
 	getLabel: () => __( "Primary category", "wordpress-seo" ),
 	getReplacement: () => {
-		// Get the ID of the primary category from wpseoPrimaryCategoryL10n.
-		const primaryCategoryID = get( window, "wpseoPrimaryCategoryL10n.taxonomies.category.primary", "" );
-		// Retrieve the list of the categories from the SEO store.
-		const categories = select( SEO_STORE_NAME ).selectCategories();
-		// Use the ID to retrieve the primary category name.
-		const primaryCategoryName = categories.filter( cat => cat.id === primaryCategoryID.toString() )[ 0 ]?.name;
+		const primaryCategoryData = select( "yoast-seo/editor" ).getReplaceVars()
+			.filter( replaceVar => replaceVar.name === "primary_category" );
 
-		return primaryCategoryName || categories[ 0 ].name;
+		const fallbackPrimaryCategory = get( window, "wpseoPrimaryCategoryL10n.taxonomies.category" );
+		const termId = fallbackPrimaryCategory.primary;
+		const termName = fallbackPrimaryCategory.terms.filter( term => term.id === termId )[ 0 ]?.name;
+
+		return primaryCategoryData[ 0 ].value || termName;
 	},
 };
 

--- a/packages/js/src/classic-editor/replacement-variables/configurations.js
+++ b/packages/js/src/classic-editor/replacement-variables/configurations.js
@@ -47,19 +47,14 @@ export const primaryCategory = {
 	getLabel: () => __( "Primary category", "wordpress-seo" ),
 	getReplacement: () => {
 		// Gets the primary category data from `yoast-seo/editor` store.
-		const primaryCategoryData = select( "yoast-seo/editor" ).getReplaceVars()
-			.filter( replaceVar => replaceVar.name === "primary_category" );
+		const primaryTaxonomyIdFromStore = select( "yoast-seo/editor" ).getPrimaryTaxonomyId( "category" );
+		const initialPrimaryTaxonomyId = get( window, "wpseoPrimaryCategoryL10n.taxonomies.category.primary" );
 
-		/*
-		 * The `yoast-seo/editor` store returns an empty primary category upon opening a content
-		 * even when there is already a primary category set to it.
-		 * When this happens, we retrieve the primary content from wpseoPrimaryCategoryL10n object.
-		 */
-		const initialPrimaryCat = get( window, "wpseoPrimaryCategoryL10n.taxonomies.category" );
-		const termId = initialPrimaryCat.primary;
-		const termName = initialPrimaryCat.terms.filter( term => term.id === termId )[ 0 ]?.name;
+		// Uses the id from wpseoPrimaryCategoryL10n global variable if `yoast-seo/editor` store returns an undefined primary category id.
+		const primaryTaxonomyId = primaryTaxonomyIdFromStore || initialPrimaryTaxonomyId;
+		const categories = select( SEO_STORE_NAME ).selectCategories();
 
-		return primaryCategoryData[ 0 ].value || termName;
+		return categories.find( cat => cat.id === primaryTaxonomyId.toString() ).name;
 	},
 };
 

--- a/packages/js/src/classic-editor/replacement-variables/configurations.js
+++ b/packages/js/src/classic-editor/replacement-variables/configurations.js
@@ -1,22 +1,24 @@
+import { select } from "@wordpress/data";
 import { __, sprintf } from "@wordpress/i18n";
 import { replacementVariableConfigurations } from "@yoast/seo-integration";
+import { SEO_STORE_NAME } from "@yoast/seo-store/src";
 import { get, map } from "lodash";
 
 /**
  * Gets the parent title from the select element.
  *
- * @param {HTMLElement} select The select input.
+ * @param {HTMLElement} selectElement The select input.
  *
  * @returns {string} The parent title.
  */
-const getParentTitle = ( select ) => {
-	const selectedValue = get( select, "value", "" );
+const getParentTitle = ( selectElement ) => {
+	const selectedValue = get( selectElement, "value", "" );
 	// The no parent value is an empty string on hierarchical post types, and `-1` (string) on hierarchical taxonomies.
 	if ( selectedValue === "" || selectedValue === "-1" ) {
 		return "";
 	}
 
-	return get( select, `options.${ select?.selectedIndex }.text`, "" );
+	return get( selectElement, `options.${ selectElement?.selectedIndex }.text`, "" );
 };
 
 // Basic variables.
@@ -41,7 +43,14 @@ export const parentTitle = {
 export const primaryCategory = {
 	name: "primary_category",
 	getLabel: () => __( "Primary category", "wordpress-seo" ),
-	getReplacement: () => get( window, "wpseoScriptData.analysis.plugins.replaceVars.replace_vars.primary_category", "" ),
+	getReplacement: () => {
+		// Get the id of the primary category from yoast-seo/editor store.
+		const primaryCategoryID = select( "@yoast-seo/editor" ).getPrimaryTaxonomyId();
+		// Retrieve the list of the categories from the SEO store. [{ id: num, name: string }]
+		const categories = select( SEO_STORE_NAME ).selectCategories();
+		// Use the ID retrieved to retrieve the vale/name of the primary category.
+		return categories.filter( term => term.id === primaryCategoryID ).name;
+	},
 };
 
 export const searchPhrase = {

--- a/packages/js/src/classic-editor/replacement-variables/configurations.js
+++ b/packages/js/src/classic-editor/replacement-variables/configurations.js
@@ -46,12 +46,18 @@ export const primaryCategory = {
 	name: "primary_category",
 	getLabel: () => __( "Primary category", "wordpress-seo" ),
 	getReplacement: () => {
+		// Gets the primary category data from `yoast-seo/editor` store.
 		const primaryCategoryData = select( "yoast-seo/editor" ).getReplaceVars()
 			.filter( replaceVar => replaceVar.name === "primary_category" );
 
-		const fallbackPrimaryCategory = get( window, "wpseoPrimaryCategoryL10n.taxonomies.category" );
-		const termId = fallbackPrimaryCategory.primary;
-		const termName = fallbackPrimaryCategory.terms.filter( term => term.id === termId )[ 0 ]?.name;
+		/*
+		 * The `yoast-seo/editor` store returns an empty primary category upon opening a content
+		 * even when there is already a primary category set to it.
+		 * When this happens, we retrieve the primary content from wpseoPrimaryCategoryL10n object.
+		 */
+		const initialPrimaryCat = get( window, "wpseoPrimaryCategoryL10n.taxonomies.category" );
+		const termId = initialPrimaryCat.primary;
+		const termName = initialPrimaryCat.terms.filter( term => term.id === termId )[ 0 ]?.name;
 
 		return primaryCategoryData[ 0 ].value || termName;
 	},

--- a/packages/js/src/classic-editor/replacement-variables/configurations.js
+++ b/packages/js/src/classic-editor/replacement-variables/configurations.js
@@ -46,12 +46,14 @@ export const primaryCategory = {
 	name: "primary_category",
 	getLabel: () => __( "Primary category", "wordpress-seo" ),
 	getReplacement: () => {
-		// Get the id of the primary category from yoast-seo/editor store.
-		const primaryCategoryID = select( "@yoast-seo/editor" ).getPrimaryTaxonomyId();
-		// Retrieve the list of the categories from the SEO store. [{ id: num, name: string }]
+		// Get the ID of the primary category from wpseoPrimaryCategoryL10n.
+		const primaryCategoryID = get( window, "wpseoPrimaryCategoryL10n.taxonomies.category.primary", "" );
+		// Retrieve the list of the categories from the SEO store.
 		const categories = select( SEO_STORE_NAME ).selectCategories();
-		// Use the ID retrieved to retrieve the vale/name of the primary category.
-		return categories.filter( term => term.id === primaryCategoryID ).name;
+		// Use the ID to retrieve the primary category name.
+		const primaryCategoryName = categories.filter( cat => cat.id === primaryCategoryID.toString() )[ 0 ]?.name;
+
+		return primaryCategoryName || categories[ 0 ].name;
 	},
 };
 

--- a/packages/js/tests/classic-editor/replacement-variables/configurations.test.js
+++ b/packages/js/tests/classic-editor/replacement-variables/configurations.test.js
@@ -1,0 +1,31 @@
+import { primaryCategory } from "../../../src/classic-editor/replacement-variables/configurations";
+
+jest.mock( "@wordpress/data", () => {
+	return {
+		select: () => {
+			return {
+				getReplaceVars: jest.fn().mockReturnValue( [
+					{ label: "Primary category", name: "primary_category", value: "a different primary category" } ] ),
+			};
+		},
+		combineReducers: jest.fn(),
+	};
+} );
+
+self.wpseoPrimaryCategoryL10n = {
+	taxonomies: {
+		category: {
+			primary: 1,
+			terms: [
+				{ id: 1, name: "a primary category" },
+				{ id: 2, name: "a non-primary category" },
+			],
+		},
+	},
+};
+
+describe( "a test for getting the replacement of the variables in classic editor", () => {
+	it( "should return the replacement for primary category variable", () => {
+		expect( primaryCategory.getReplacement() ).toEqual( "a different primary category" );
+	} );
+} );

--- a/packages/js/tests/classic-editor/replacement-variables/configurations.test.js
+++ b/packages/js/tests/classic-editor/replacement-variables/configurations.test.js
@@ -1,25 +1,5 @@
 import { primaryCategory } from "../../../src/classic-editor/replacement-variables/configurations";
-
-jest.mock( "@wordpress/data", () => {
-	return {
-		select: () => {
-			return {
-				getPrimaryTaxonomyId: jest.fn().mockReturnValue( 2 ),
-				selectCategories: jest.fn().mockReturnValue( [
-					{
-						id: "1",
-						name: "category 1",
-					},
-					{
-						id: "2",
-						name: "category 2",
-					},
-				] ),
-			};
-		},
-		combineReducers: jest.fn(),
-	};
-} );
+import * as data from "@wordpress/data";
 
 self.wpseoPrimaryCategoryL10n = {
 	taxonomies: {
@@ -29,8 +9,37 @@ self.wpseoPrimaryCategoryL10n = {
 	},
 };
 
+const categories = jest.fn().mockReturnValue( [
+	{
+		id: "1",
+		name: "category 1",
+	},
+	{
+		id: "2",
+		name: "category 2",
+	},
+] );
+
 describe( "a test for getting the replacement of the variables in classic editor", () => {
-	it( "should return the replacement for primary category variable", () => {
+	it( "should return the replacement for primary category variable when the id from the store is not undefined", () => {
+		jest.spyOn( data, "select" ).mockImplementation( () => {
+			return {
+				getPrimaryTaxonomyId: jest.fn().mockReturnValue( 2 ),
+				selectCategories: categories,
+			};
+		} );
+
 		expect( primaryCategory.getReplacement() ).toEqual( "category 2" );
+	} );
+
+	it( "should return the replacement for primary category variable when the id from the store is undefined", () => {
+		jest.spyOn( data, "select" ).mockImplementation( () => {
+			return {
+				getPrimaryTaxonomyId: jest.fn().mockReturnValue( undefined ),
+				selectCategories: categories,
+			};
+		} );
+
+		expect( primaryCategory.getReplacement() ).toEqual( "category 1" );
 	} );
 } );

--- a/packages/js/tests/classic-editor/replacement-variables/configurations.test.js
+++ b/packages/js/tests/classic-editor/replacement-variables/configurations.test.js
@@ -4,8 +4,17 @@ jest.mock( "@wordpress/data", () => {
 	return {
 		select: () => {
 			return {
-				getReplaceVars: jest.fn().mockReturnValue( [
-					{ label: "Primary category", name: "primary_category", value: "a different primary category" } ] ),
+				getPrimaryTaxonomyId: jest.fn().mockReturnValue( 2 ),
+				selectCategories: jest.fn().mockReturnValue( [
+					{
+						id: "1",
+						name: "category 1",
+					},
+					{
+						id: "2",
+						name: "category 2",
+					},
+				] ),
 			};
 		},
 		combineReducers: jest.fn(),
@@ -16,16 +25,12 @@ self.wpseoPrimaryCategoryL10n = {
 	taxonomies: {
 		category: {
 			primary: 1,
-			terms: [
-				{ id: 1, name: "a primary category" },
-				{ id: 2, name: "a non-primary category" },
-			],
 		},
 	},
 };
 
 describe( "a test for getting the replacement of the variables in classic editor", () => {
 	it( "should return the replacement for primary category variable", () => {
-		expect( primaryCategory.getReplacement() ).toEqual( "a different primary category" );
+		expect( primaryCategory.getReplacement() ).toEqual( "category 2" );
 	} );
 } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Supports primary category replacement variable.

## Relevant technical choices:

* See my comments below.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Requirement:
* Install and activate classic editor
* Create three categories from Posts > Categories > Add new category

**Test with categories created via Posts > Categories > Add new category**
* Create a post
* Use the `Primary category` replacement variable both in SEO title and meta description field
* Check all the categories that you just created for the post
* Make the category that is not on top of the list the primary category
* Confirm that the correct primary category is previewed in Google preview both in SEO title and in meta description
* Uncheck the current primary category
* Confirm that the primary category now is assigned to the first category in the list and this category is previewed immediately in Google preview both in SEO title and in meta description
* Save your changes
* Exit the post and open the post again
* Confirm that the primary category is still displayed in Google preview

**Test with categories created inside the post**
* Create categories from inside the post using `Add new category` button (also create a child and a grandchild category)
* Check the categories that you just created
* Make the category that is not on top of the list the primary category
* Confirm that the correct primary category is previewed in Google preview both in SEO title and in meta description
* Uncheck the current primary category
* Confirm that the primary category now is assigned to the first category in the list and this category is previewed immediately in Google preview both in SEO title and in meta description
* Also make sure that this still works when a child or a grandchild category is selected as the primary category


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[Shopify]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
