### PR TITLE
PHP 8.1 compatibility: build post indexable without advanced robots settings

### DIFF
--- a/src/builders/indexable-post-builder.php
+++ b/src/builders/indexable-post-builder.php
@@ -4,8 +4,8 @@ namespace Yoast\WP\SEO\Builders;
 
 use WP_Error;
 use WP_Post;
-use WPSEO_Meta;
 use Yoast\WP\SEO\Exceptions\Indexable\Post_Not_Found_Exception;
+use Yoast\WP\SEO\Helpers\Meta_Helper;
 use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Models\Indexable;
@@ -50,20 +50,30 @@ class Indexable_Post_Builder {
 	protected $version;
 
 	/**
+	 * The meta helper.
+	 *
+	 * @var Meta_Helper
+	 */
+	protected $meta;
+
+	/**
 	 * Indexable_Post_Builder constructor.
 	 *
 	 * @param Post_Helper                $post_helper      The post helper.
 	 * @param Post_Type_Helper           $post_type_helper The post type helper.
 	 * @param Indexable_Builder_Versions $versions         The indexable builder versions.
+	 * @param Meta_Helper                $meta             The meta helper.
 	 */
 	public function __construct(
 		Post_Helper $post_helper,
 		Post_Type_Helper $post_type_helper,
-		Indexable_Builder_Versions $versions
+		Indexable_Builder_Versions $versions,
+		Meta_Helper $meta
 	) {
 		$this->post_helper      = $post_helper;
 		$this->post_type_helper = $post_type_helper;
 		$this->version          = $versions->get_latest_version_for_type( 'post' );
+		$this->meta             = $meta;
 	}
 
 	/**
@@ -108,21 +118,22 @@ class Indexable_Post_Builder {
 		$indexable->permalink       = $this->get_permalink( $post->post_type, $post_id );
 
 		$indexable->primary_focus_keyword_score = $this->get_keyword_score(
-			$this->get_meta_value( $post_id, 'focuskw' ),
-			(int) $this->get_meta_value( $post_id, 'linkdex' )
+			$this->meta->get_value( 'focuskw', $post_id ),
+			(int) $this->meta->get_value( 'linkdex', $post_id )
 		);
 
-		$indexable->readability_score = (int) $this->get_meta_value( $post_id, 'content_score' );
+		$indexable->readability_score = (int) $this->meta->get_value( 'content_score', $post_id );
 
-		$indexable->is_cornerstone    = ( $this->get_meta_value( $post_id, 'is_cornerstone' ) === '1' );
+		$indexable->is_cornerstone    = ( $this->meta->get_value( 'is_cornerstone', $post_id ) === '1' );
 		$indexable->is_robots_noindex = $this->get_robots_noindex(
-			$this->get_meta_value( $post_id, 'meta-robots-noindex' )
+			(int) $this->meta->get_value( 'meta-robots-noindex', $post_id )
 		);
 
 		// Set additional meta-robots values.
-		$indexable->is_robots_nofollow = ( $this->get_meta_value( $post_id, 'meta-robots-nofollow' ) === '1' );
-		$noindex_advanced              = $this->get_meta_value( $post_id, 'meta-robots-adv' );
+		$indexable->is_robots_nofollow = ( $this->meta->get_value( 'meta-robots-nofollow', $post_id ) === '1' );
+		$noindex_advanced              = $this->meta->get_value( 'meta-robots-adv', $post_id );
 		$meta_robots                   = \explode( ',', $noindex_advanced );
+
 		foreach ( $this->get_robots_options() as $meta_robots_option ) {
 			$indexable->{'is_robots_' . $meta_robots_option} = \in_array( $meta_robots_option, $meta_robots, true ) ? 1 : null;
 		}
@@ -130,7 +141,7 @@ class Indexable_Post_Builder {
 		$this->reset_social_images( $indexable );
 
 		foreach ( $this->get_indexable_lookup() as $meta_key => $indexable_key ) {
-			$indexable->{$indexable_key} = $this->get_meta_value( $post_id, $meta_key );
+			$indexable->{$indexable_key} = $this->empty_string_to_null( $this->meta->get_value( $meta_key, $post_id ) );
 		}
 
 		if ( empty( $indexable->breadcrumb_title ) ) {
@@ -149,8 +160,8 @@ class Indexable_Post_Builder {
 		$indexable->has_public_posts = $this->has_public_posts( $indexable );
 		$indexable->blog_id          = \get_current_blog_id();
 
-		$indexable->schema_page_type    = $this->get_meta_value( $post_id, 'schema_page_type' );
-		$indexable->schema_article_type = $this->get_meta_value( $post_id, 'schema_article_type' );
+		$indexable->schema_page_type    = $this->empty_string_to_null( $this->meta->get_value( 'schema_page_type', $post_id ) );
+		$indexable->schema_article_type = $this->empty_string_to_null( $this->meta->get_value( 'schema_article_type', $post_id ) );
 
 		$indexable->object_last_modified = $post->post_modified_gmt;
 		$indexable->object_published_at  = $post->post_date_gmt;
@@ -327,23 +338,6 @@ class Indexable_Post_Builder {
 	}
 
 	/**
-	 * Retrieves the current value for the meta field.
-	 *
-	 * @param int    $post_id  The post ID to use.
-	 * @param string $meta_key Meta key to fetch.
-	 *
-	 * @return mixed The value of the indexable entry to use.
-	 */
-	protected function get_meta_value( $post_id, $meta_key ) {
-		$value = WPSEO_Meta::get_value( $meta_key, $post_id );
-		if ( \is_string( $value ) && $value === '' ) {
-			return null;
-		}
-
-		return $value;
-	}
-
-	/**
 	 * Finds an alternative image for the social image.
 	 *
 	 * @param Indexable $indexable The indexable.
@@ -414,5 +408,20 @@ class Indexable_Post_Builder {
 	 */
 	protected function should_exclude_post( $post ) {
 		return $this->post_type_helper->is_excluded( $post->post_type );
+	}
+
+	/**
+	 * Transforms an empty string into null. Leaves non-empty strings intact.
+	 *
+	 * @param string $string The string.
+	 *
+	 * @return string|null The input string or null.
+	 */
+	protected function empty_string_to_null( $string ) {
+		if ( ! is_string( $string ) || $string === '' ) {
+			return null;
+		}
+
+		return $string;
 	}
 }

--- a/tests/unit/builders/indexable-post-builder-test.php
+++ b/tests/unit/builders/indexable-post-builder-test.php
@@ -8,6 +8,7 @@ use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Post_Builder;
 use Yoast\WP\SEO\Exceptions\Indexable\Post_Not_Found_Exception;
 use Yoast\WP\SEO\Helpers\Image_Helper;
+use Yoast\WP\SEO\Helpers\Meta_Helper;
 use Yoast\WP\SEO\Helpers\Open_Graph\Image_Helper as Open_Graph_Image_Helper;
 use Yoast\WP\SEO\Helpers\Post_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
@@ -104,7 +105,8 @@ class Indexable_Post_Builder_Test extends TestCase {
 		$this->instance = new Indexable_Post_Builder_Double(
 			$this->post,
 			$this->post_type_helper,
-			new Indexable_Builder_Versions()
+			new Indexable_Builder_Versions(),
+			new Meta_Helper()
 		);
 
 		$this->instance->set_indexable_repository( $this->indexable_repository );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When building post indexables on PHP 8.1 a deprecation is thrown when`meta-robots-adv` doesn't have a value. This is because `null` is passed to `explode`. This PR prevents that by removing the transformation from an empty string to null and leaving that behaviour intact for values that expect a null value.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a deprecation warning in building post indexables when leaving "Meta robots advanced" empty and while using PHP 8.1 or higher.

## Relevant technical choices:

* I used the newer Meta_Helper instead of the static call to WPSEO_Meta.
* There are still `'' -> null` conversions being done because the indexable model expects null values and not empty strings in those cases. I'd like to get rid of that eventually, but it's out of scope for this PR.
* I didn't mock the Meta_Helper in the existing tests. The helper is still a wrapper around WPSEO_Meta and the tests already contain mocks for the statically called WPSEO_Meta calls. It also covers some behaviour of WPSEO_Meta in relation to the indexableBuilder.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Use PHP 8.1 and WP 5.9.
* Publish a new post and do not touch any advanced robot settings.
* Check that you didn't get a deprecation warning.
* Check in the database that your post is present in the `{prefix}_yoast_indexable` table.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[Shopify]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

