### PR TITLE
LINGO-1287 Update category replacement variable when selecting from most used categories

### DIFF
--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -189,12 +189,21 @@ export const getPostDate = () => {
 };
 
 /**
- * Gets the post category checkboxes elements from the document.
+ * Gets the category checkboxes elements from the document, from the "All Categories" section.
  *
- * @returns {HTMLInputElement[]} The category checkboxes.
+ * @returns {HTMLInputElement[]} The category checkboxes from the "All Categories" section.
  */
 export const getPostCategoryCheckboxes = () => {
 	return [ ...document.querySelectorAll( "#categorychecklist input[type=checkbox]" ) ];
+};
+
+/**
+ * Gets the category checkboxes elements from the document, from the "Most Used" section.
+ *
+ * @returns {HTMLInputElement[]} The category checkboxes from the "Most Used" section.
+ */
+export const getPostMostUsedCategoryCheckboxes = () => {
+	return [ ...document.querySelectorAll( "#categorychecklist-pop input[type=checkbox]" ) ];
 };
 
 /**
@@ -203,6 +212,7 @@ export const getPostCategoryCheckboxes = () => {
  * @returns {{name: string, id: string}[]} The post's categories.
  */
 export const getPostCategories = () => {
+	// Only consider the "All Categories" section here, as including the "Most Used" section would yield duplicates.
 	const checkboxes = getPostCategoryCheckboxes();
 
 	if ( checkboxes ) {

--- a/packages/js/src/classic-editor/watcher.js
+++ b/packages/js/src/classic-editor/watcher.js
@@ -7,7 +7,7 @@ import { update as updateAdminBar } from "../ui/adminBar";
 import * as publishBox from "../ui/publishBox";
 import { update as updateTrafficLight } from "../ui/trafficLight";
 import * as dom from "./helpers/dom";
-import { getPostCategories, getPostCategoryCheckboxes } from "./helpers/dom";
+import { getPostCategories, getPostCategoryCheckboxes, getPostMostUsedCategoryCheckboxes } from "./helpers/dom";
 
 const SYNC_DEBOUNCE_TIME = 500;
 const { DOM_IDS, DOM_CLASSES, DOM_QUERIES } = dom;
@@ -148,7 +148,8 @@ const createCategoriesSync = ( updateCategories ) => {
 	 */
 	const watchCategoryCheckboxes = () => {
 		// Sync the categories whenever there are changes in the checkboxes.
-		const checkboxes = getPostCategoryCheckboxes();
+		// Watch both the "All Categories" and "Most Used" sections.
+		const checkboxes = [ ...getPostCategoryCheckboxes(), ...getPostMostUsedCategoryCheckboxes() ];
 		checkboxes.forEach(
 			checkbox => {
 				checkbox.removeEventListener( "input", syncCategories );
@@ -160,6 +161,7 @@ const createCategoriesSync = ( updateCategories ) => {
 	const categoryChecklist = document.getElementById( "categorychecklist" );
 	if ( categoryChecklist ) {
 		// Observe the category checklist for changes and update the categories if new categories are added.
+		// Consider only the "All Categories" section, because newly added categories will not end up in the "Most Used" section.
 		const observer = new MutationObserver( () => {
 			updateCategories( getPostCategories() );
 			watchCategoryCheckboxes();

--- a/packages/js/tests/classic-editor/helpers/dom.test.js
+++ b/packages/js/tests/classic-editor/helpers/dom.test.js
@@ -11,3 +11,46 @@ describe( "a test for retrieving data from dom", () => {
 			"tortoiseshell material. Like calicos, tortoiseshell cats are almost exclusively female." );
 	} );
 } );
+
+describe( "a test for retrieving categories from the DOM", () => {
+	const cat1 = document.createElement( "input" );
+	cat1.setAttribute( "type", "checkbox" );
+	cat1.setAttribute( "value", "cat1" );
+	const cat2 = document.createElement( "input" );
+	cat2.setAttribute( "type", "checkbox" );
+	cat2.setAttribute( "value", "cat2" );
+	const cat3 = document.createElement( "input" );
+	cat3.setAttribute( "type", "checkbox" );
+	cat3.setAttribute( "value", "cat3" );
+
+	const allCats = document.createElement( "div" );
+	allCats.setAttribute( "id", "categorychecklist" );
+	allCats.appendChild( cat1 );
+	allCats.appendChild( cat2 );
+	allCats.appendChild( cat3 );
+
+	const mostUsedCats = document.createElement( "div" );
+	mostUsedCats.setAttribute( "id", "categorychecklist-pop" );
+	mostUsedCats.appendChild( cat1.cloneNode() );
+	mostUsedCats.appendChild( cat2.cloneNode() );
+
+	document.body.appendChild( allCats );
+	document.body.appendChild( mostUsedCats );
+
+	it( "should return the categories from the 'All Categories' section", () => {
+		expect( dom.getPostCategoryCheckboxes() ).toEqual( [ cat1, cat2, cat3 ] );
+	} );
+	it( "should return the categories from the 'Most Used' section", () => {
+		expect( dom.getPostMostUsedCategoryCheckboxes() ).toEqual( [ cat1, cat2 ] );
+	} );
+	it( "should return the checked categories", () => {
+		expect( dom.getPostCategories() ).toEqual( [ ] );
+		cat1.checked = true;
+		expect( dom.getPostCategories()[ 0 ].id ).toEqual( "cat1"  );
+		cat1.checked = false;
+		cat2.checked = true;
+		expect( dom.getPostCategories()[ 0 ].id ).toEqual( "cat2"  );
+		cat2.checked = false;
+		expect( dom.getPostCategories() ).toEqual( [ ] );
+	} );
+} );

--- a/packages/js/tests/classic-editor/initial-state.test.js
+++ b/packages/js/tests/classic-editor/initial-state.test.js
@@ -1,6 +1,7 @@
 import { getInitialPostState, getInitialTermState } from "../../src/classic-editor/initial-state";
 
 jest.mock( "../../src/classic-editor/helpers/dom", () => ( {
+	...jest.requireActual( "../../src/classic-editor/helpers/dom" ),
 	getPostTitle: jest.fn( () => "Tortoiseshell cat" ),
 	getPostDate: jest.fn( () => "18 January 2022 12:17" ),
 	getPostPermalink: jest.fn( () => "www.sweetcat.com/123" ),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In [this PR](https://github.com/Yoast/wordpress-seo/pull/17973), we added categories to the watcher, so that it updates the "Category" replacement variable on selection of a category. However, the watcher only considered the categories in the "All Categories" section. This PR adds the category checkboxes in the "Most Used" section to the watcher.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds categories from the "Most Used" section to the watcher. As a result, the "Category" replacement variable is synced with the selected categories.

## Relevant technical choices:

* We only need to watch the "Most Used" section for changes, but we don't need to use that for fetching the current selected categories (as that would create duplicates with the "All Categories" section), nor do we need to watch it for new categories (those are not added to the "Most Used" section). 
* We've fixed a failing unit test in `packages/js/tests/classic-editor/initial-state.test.js` by adding default implementations for non-mocked functions.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new post or edit an existing post with the Classic Editor.
* Add the "Category" snippet variable to the SEO title or the Meta description field.
* Confirm that when you check one or multiple categories in the "Most Used" section, the snippet variable output is updated according to your selections (multiple category names should be separated by a comma (and a space)). 
* (regression) Confirm that when you check one or multiple categories in the "All Categories" section, the snippet variable output is updated according to your selections. 
* (regression) Confirm that adding a category and then selecting it also updates the snippet variable output.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The category replacement variable.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1287
