### PR TITLE
Facebook and Twitter preview images should use images, not backgrounds

### DIFF
--- a/packages/js/src/containers/FacebookEditor.js
+++ b/packages/js/src/containers/FacebookEditor.js
@@ -32,7 +32,7 @@ const imageCallback = ( image ) => {
 		return size.width >= idealWidth && size.height >= idealHeight;
 	} );
 
-	const imageUrl = idealImageSize ? idealImageSize.url : image.sizes.full.url;
+	const imageUrl = idealImageSize ? idealImageSize.url : image.url;
 
 	wpDataDispatch( "yoast-seo/editor" ).setFacebookPreviewImage( {
 		url: imageUrl,

--- a/packages/js/src/containers/FacebookEditor.js
+++ b/packages/js/src/containers/FacebookEditor.js
@@ -2,7 +2,7 @@
 import { compose } from "@wordpress/compose";
 import { withDispatch, withSelect, dispatch as wpDataDispatch } from "@wordpress/data";
 import { validateFacebookImage } from "@yoast/helpers";
-import { FACEBOOK_IMAGE_SIZES, determineFacebookImageMode } from "@yoast/social-metadata-previews/src/helpers/determineImageProperties";
+import { FACEBOOK_IMAGE_SIZES, determineFacebookImageMode } from "@yoast/social-metadata-previews";
 
 /* Internal dependencies */
 import FacebookWrapper from "../components/social/FacebookWrapper";

--- a/packages/js/src/containers/FacebookEditor.js
+++ b/packages/js/src/containers/FacebookEditor.js
@@ -2,6 +2,7 @@
 import { compose } from "@wordpress/compose";
 import { withDispatch, withSelect, dispatch as wpDataDispatch } from "@wordpress/data";
 import { validateFacebookImage } from "@yoast/helpers";
+import { FACEBOOK_IMAGE_SIZES, determineFacebookImageMode } from "@yoast/social-metadata-previews/src/helpers/determineImageProperties";
 
 /* Internal dependencies */
 import FacebookWrapper from "../components/social/FacebookWrapper";
@@ -21,8 +22,20 @@ const socialMediumName = "Facebook";
  * @returns {void}
  */
 const imageCallback = ( image ) => {
+	const { width, height } = image;
+	const imageMode = determineFacebookImageMode( { width, height } );
+
+	const idealWidth = FACEBOOK_IMAGE_SIZES[ imageMode + "Width" ];
+	const idealHeight = FACEBOOK_IMAGE_SIZES[ imageMode + "Height" ];
+
+	const idealImageSize = Object.values( image.sizes ).find( size => {
+		return size.width >= idealWidth && size.height >= idealHeight;
+	} );
+
+	const imageUrl = idealImageSize ? idealImageSize.url : image.sizes.full.url;
+
 	wpDataDispatch( "yoast-seo/editor" ).setFacebookPreviewImage( {
-		url: image.url,
+		url: imageUrl,
 		id: image.id,
 		warnings: validateFacebookImage( image ),
 	} );

--- a/packages/js/src/containers/TwitterEditor.js
+++ b/packages/js/src/containers/TwitterEditor.js
@@ -2,6 +2,8 @@
 import { compose } from "@wordpress/compose";
 import { withDispatch, withSelect, dispatch as wpDataDispatch } from "@wordpress/data";
 import { validateTwitterImage } from "@yoast/helpers";
+import { TWITTER_IMAGE_SIZES } from "@yoast/social-metadata-previews/src/helpers/determineImageProperties";
+import { get } from "lodash";
 
 /* Internal dependencies */
 import TwitterWrapper from "../components/social/TwitterWrapper";
@@ -21,8 +23,22 @@ const socialMediumName = "Twitter";
  * @returns {void}
  */
 const imageCallback = ( image ) => {
+	const twitterImageType = get( window, "wpseoScriptData.metabox.twitterCardType" );
+
+	const isLarge = twitterImageType !== "summary";
+	const imageMode = isLarge ? "landscape" : "square";
+
+	const idealWidth = TWITTER_IMAGE_SIZES[ imageMode + "Width" ];
+	const idealHeight = TWITTER_IMAGE_SIZES[ imageMode + "Height" ];
+
+	const idealImageSize = Object.values( image.sizes ).find( size => {
+		return size.width >= idealWidth && size.height >= idealHeight;
+	} );
+
+	const imageUrl = idealImageSize ? idealImageSize.url : image.sizes.full.url;
+
 	wpDataDispatch( "yoast-seo/editor" ).setTwitterPreviewImage( {
-		url: image.url,
+		url: imageUrl,
 		id: image.id,
 		warnings: validateTwitterImage( image ),
 	} );

--- a/packages/js/src/containers/TwitterEditor.js
+++ b/packages/js/src/containers/TwitterEditor.js
@@ -2,7 +2,7 @@
 import { compose } from "@wordpress/compose";
 import { withDispatch, withSelect, dispatch as wpDataDispatch } from "@wordpress/data";
 import { validateTwitterImage } from "@yoast/helpers";
-import { TWITTER_IMAGE_SIZES } from "@yoast/social-metadata-previews/src/helpers/determineImageProperties";
+import { TWITTER_IMAGE_SIZES } from "@yoast/social-metadata-previews";
 import { get } from "lodash";
 
 /* Internal dependencies */

--- a/packages/js/src/containers/TwitterEditor.js
+++ b/packages/js/src/containers/TwitterEditor.js
@@ -35,7 +35,7 @@ const imageCallback = ( image ) => {
 		return size.width >= idealWidth && size.height >= idealHeight;
 	} );
 
-	const imageUrl = idealImageSize ? idealImageSize.url : image.sizes.full.url;
+	const imageUrl = idealImageSize ? idealImageSize.url : image.url;
 
 	wpDataDispatch( "yoast-seo/editor" ).setTwitterPreviewImage( {
 		url: imageUrl,

--- a/packages/js/src/helpers/selectMedia.js
+++ b/packages/js/src/helpers/selectMedia.js
@@ -17,6 +17,7 @@ function getMedia( onSelect ) {
 			height: selected.attributes.height,
 			url: selected.attributes.url,
 			id: selected.attributes.id,
+			sizes: selected.attributes.sizes,
 		};
 		onSelect( image );
 	} );

--- a/packages/social-metadata-previews/src/index.js
+++ b/packages/social-metadata-previews/src/index.js
@@ -1,3 +1,4 @@
 export { default as FacebookPreview } from "./facebook/FacebookPreview";
 export { default as TwitterPreview } from "./twitter/TwitterPreview";
 export { default as SocialPreviewEditor } from "./editor/SocialPreviewEditor";
+export { TWITTER_IMAGE_SIZES, FACEBOOK_IMAGE_SIZES, determineFacebookImageMode } from "./helpers/determineImageProperties";

--- a/packages/social-metadata-previews/src/shared/SocialImage.js
+++ b/packages/social-metadata-previews/src/shared/SocialImage.js
@@ -15,6 +15,17 @@ const StyledImage = styled.img`
 	}
 `;
 
+const StyledLandscapeImage = styled.img`
+	max-height: 100%;
+	position: absolute;
+	width: 100%;
+	object-fit: cover;
+`;
+
+const WrapperDiv = styled.div`
+	padding-bottom: ${ props => props.aspectRatio }%;
+`;
+
 /**
  * Renders the SocialImage.
  *
@@ -26,25 +37,11 @@ export const SocialImage = ( props ) => {
 	const { imageProps, width, height, imageMode } = props;
 
 	if ( imageMode === "landscape" ) {
-		return <div
-			style={ {
-				paddingBottom: `${imageProps.aspectRatio}%`,
-				position: "relative",
-			} }
-		>
-			<StyledImage
-				src={ imageProps.src }
-				alt={ imageProps.alt }
-				imageProperties={ imageProps }
-
-				style={ {
-					maxHeight: "100%",
-					position: "absolute",
-					width: "100%",
-					objectFit: "cover",
-				} }
-			/>
-		</div>;
+		return (
+			<WrapperDiv aspectRatio={ imageProps.aspectRatio }>
+				<StyledLandscapeImage src={ imageProps.src } alt={ imageProps.alt } />
+			</WrapperDiv>
+		);
 	}
 
 	return <StyledImage

--- a/packages/social-metadata-previews/src/shared/SocialImage.js
+++ b/packages/social-metadata-previews/src/shared/SocialImage.js
@@ -28,12 +28,23 @@ export const SocialImage = ( props ) => {
 	if ( imageMode === "landscape" ) {
 		return <div
 			style={ {
-				background: `url(${ imageProps.src }) center / cover no-repeat`,
-				paddingBottom: `${ imageProps.aspectRatio }%`,
+				paddingBottom: `${imageProps.aspectRatio}%`,
+				position: "relative",
 			} }
-			role="img"
-			aria-label={ imageProps.alt }
-		/>;
+		>
+			<StyledImage
+				src={ imageProps.src }
+				alt={ imageProps.alt }
+				imageProperties={ imageProps }
+
+				style={ {
+					maxHeight: "100%",
+					position: "absolute",
+					width: "100%",
+					objectFit: "cover",
+				} }
+			/>
+		</div>;
 	}
 
 	return <StyledImage

--- a/packages/social-metadata-previews/src/shared/SocialImage.js
+++ b/packages/social-metadata-previews/src/shared/SocialImage.js
@@ -16,10 +16,12 @@ const StyledImage = styled.img`
 `;
 
 const StyledLandscapeImage = styled.img`
-	max-height: 100%;
-	position: absolute;
-	width: 100%;
-	object-fit: cover;
+	&&{
+		height: 100%;
+		position: absolute;
+		width: 100%;
+		object-fit: cover;
+	}
 `;
 
 const WrapperDiv = styled.div`


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Using a background image causes numerous performance issues / limitations, and should therefore be changed (e.g., an inability to use native lazy loading)
* Use a smaller image size if available

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] The Facebook and Twitter Preview now uses an image instead of a background image.
* [shopify-seo] The Facebook and Twitter Preview now uses image instead of a background image.
* [@yoast/social-metadata-previews] The Facebook and Twitter Preview now uses image instead of a background image.
* [@yoast/social-metadata-previews] Export the variables TWITTER_IMAGE_SIZES, FACEBOOK_IMAGE_SIZES and  determineFacebookImageMode.

## Relevant technical choices:

* Google preview uses an \<img> and object-fit approach, so we have precedent for this.
* Exposed `sizes` on the getMedia object
  * Used to calculate & filter the 'ideal' image size to use 
* Exported variables from the social-metadata-previews package
  * Used in the container components

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Pre test setup

* Checkout this branch
* In your terminal cd into: `packages/social-metadata-previews/`
* Enter `yarn link`
* Open the `wordpress-seo-premium` repo
* Open the terminal and enter `yarn link "@yoast/social-metadata-previews"`
* Execute the grunt build command `grunt build:js`

#### Test instructions (same for shopify)

* Add/edit a post
* Open the Yoast SEO `social` tab
* Add a Facebook and Twitter landscape image
  * Inspect element and verify an `img` tag is used instead of a `div` with a background image

#### Testing appropriately sized version of the image
* Test this with the following image sizes:
  * Facebook landscape and Twitter landscape(**See example below**):
    * Image that has a bigger width than height 
    * Make sure to change the Twitter card type to `Summary with large image`: Yoast SEO -> Social -> Twitter 
  * Facebook square and Twitter square:
    * Add a Facebook and Twitter image that has the same width as height
    * Make sure to change the Twitter card type to `Summary`: Yoast SEO -> Social -> Twitter 
  * Facebook portrait:
    * Add a Facebook image that has a bigger height than width

- **Example Landscape mode**
  * I have used https://dummyimage.com/ to generate images to test with
  * Generate a landscape image: https://dummyimage.com/2000x1000/000/fff
    * Save it as landscape.png
    * Upload it to the `(Facebook|Twitter) Preview`
    * Inspect element on the image
    * Verify a cropped version is used e.g. filename ending with: `...landscape-1024x512.png`
    * If no 'ideal' size is found it will default to the full image e.g. filename ending with: `...landscape.png`

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes P1-1117