### PR TITLE
Fixes warning on add_menu_page using WP 6.0 alpha

### DIFF
--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -57,7 +57,7 @@ class WPSEO_Admin_Menu extends WPSEO_Base_Menu {
 			$page_identifier,
 			$admin_page_callback,
 			$this->get_icon_svg(),
-			'99.31337'
+			'99'
 		);
 
 		// Wipe notification bits from hooks.

--- a/admin/menu/class-base-menu.php
+++ b/admin/menu/class-base-menu.php
@@ -131,7 +131,7 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 			$submenu_page[4],
 			$submenu_page[5],
 			$this->get_icon_svg(),
-			'99.31337'
+			'99'
 		);
 
 		// If necessary, add hooks for the submenu page.


### PR DESCRIPTION
## Context

Fixes #18003 

## Summary

It fixes the issue reported in #18003 

## Relevant technical choices:

I replaced the `99.31337` floating number with `99`.

## Test instructions

See #18003 

## Impact check

Admin facing warning.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

