### PR TITLE
Cleanup AIOSEO data

### DIFF
--- a/admin/import/plugins/class-import-aioseo-v4.php
+++ b/admin/import/plugins/class-import-aioseo-v4.php
@@ -5,7 +5,7 @@
  * @package WPSEO\Admin\Import\Plugins
  */
 
-use Yoast\WP\SEO\Actions\Importing\Aioseo_Posts_Importing_Action;
+use Yoast\WP\SEO\Actions\Importing\Aioseo_Cleanup_Action;
 /**
  * Class with functionality to import & clean All in One SEO Pack post metadata, versions 4 and up.
  */
@@ -220,9 +220,8 @@ class WPSEO_Import_AIOSEO_V4 extends WPSEO_Plugin_Importer {
 	 * @return bool Boolean indicating whether there is something to import.
 	 */
 	protected function detect() {
-		$aioseo_posts_import_action = YoastSEO()->classes->get( Aioseo_Posts_Importing_Action::class );
-		$limit                      = $aioseo_posts_import_action->get_limit();
-		return ( $aioseo_posts_import_action->get_limited_unindexed_count( $limit ) > 0 );
+		$aioseo_cleanup_action = YoastSEO()->classes->get( Aioseo_Cleanup_Action::class );
+		return ( $aioseo_cleanup_action->get_total_unindexed() > 0 );
 	}
 
 	/**

--- a/admin/import/plugins/class-import-aioseo-v4.php
+++ b/admin/import/plugins/class-import-aioseo-v4.php
@@ -231,6 +231,7 @@ class WPSEO_Import_AIOSEO_V4 extends WPSEO_Plugin_Importer {
 	 * @return void
 	 */
 	protected function import() {
+		// This is overriden from the import.js and never run.
 		$aioseo_posts_import_action = YoastSEO()->classes->get( Aioseo_Posts_Importing_Action::class );
 		$aioseo_posts_import_action->index();
 	}

--- a/admin/import/plugins/class-import-aioseo-v4.php
+++ b/admin/import/plugins/class-import-aioseo-v4.php
@@ -6,6 +6,7 @@
  */
 
 use Yoast\WP\SEO\Actions\Importing\Aioseo_Cleanup_Action;
+use Yoast\WP\SEO\Actions\Importing\Aioseo_Posts_Importing_Action;
 /**
  * Class with functionality to import & clean All in One SEO Pack post metadata, versions 4 and up.
  */
@@ -215,7 +216,7 @@ class WPSEO_Import_AIOSEO_V4 extends WPSEO_Plugin_Importer {
 	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 	/**
-	 * Detects whether there is AIOSEO data to import from their custom table.
+	 * Detects whether there is AIOSEO data to import by looking whether the AIOSEO data have been cleaned up.
 	 *
 	 * @return bool Boolean indicating whether there is something to import.
 	 */
@@ -225,7 +226,7 @@ class WPSEO_Import_AIOSEO_V4 extends WPSEO_Plugin_Importer {
 	}
 
 	/**
-	 * Actually AIOSEO data from their custom table.
+	 * Import AIOSEO post data from their custom indexable table. Not currently used.
 	 *
 	 * @return void
 	 */

--- a/packages/js/src/import.js
+++ b/packages/js/src/import.js
@@ -4,8 +4,8 @@ import IndexingService from "./services/IndexingService";
 
 const AioseoV4 = "WPSEO_Import_AIOSEO_V4";
 
-let cleanupButton, cleanupDropdown, cleanupForm, 
-	importButton, importDropdown, importForm, 
+let cleanupButton, cleanupDropdown, cleanupForm,
+	importButton, importDropdown, importForm,
 	spinner, loadingMessageCleanup, loadingMessageImport, checkMark;
 
 /**

--- a/packages/js/src/import.js
+++ b/packages/js/src/import.js
@@ -23,16 +23,16 @@ function addProgressElements() {
 /**
  * Function called when importing/cleanup progress is made.
  *
- * @param {bool} isImport Whether it's an import.
+ * @param {string} action The action it's being performed, import or cleanup.
  *
  * @returns {void}
  */
-function showProgress( isImport ) {
+function showProgress( action ) {
 	var actingForm = cleanupForm;
 	var loadingMessage = loadingMessageCleanup;
 	var actingButton = cleanupButton;
 
-	if ( isImport ) {
+	if ( action === "import" ) {
 		actingForm = importForm;
 		loadingMessage = loadingMessageImport;
 		actingButton = importButton;
@@ -53,7 +53,7 @@ function showProgress( isImport ) {
  * @returns {void}
  */
 function importingProgress( count ) { // eslint-disable-line no-unused-vars
-	showProgress( true );
+	showProgress( "import" );
 }
 
 /**
@@ -64,23 +64,23 @@ function importingProgress( count ) { // eslint-disable-line no-unused-vars
  * @returns {void}
  */
 function cleanupProgress( count ) { // eslint-disable-line no-unused-vars
-	showProgress( false );
+	showProgress( "cleanup" );
 }
 
 /**
  * Function called when importing/cleanup is completed succesfully.
  *
- * @param {bool} isImport Whether it's an import.
+ * @param {string} action The action it's being performed, import or cleanup.
  *
  * @returns {void}
  */
-function showSuccess( isImport ) {
+function showSuccess( action ) {
 	var actingForm = cleanupForm;
 	var loadingMessage = loadingMessageCleanup;
 	var actingButton = cleanupButton;
 	var actingDropdown = cleanupDropdown;
 
-	if ( isImport ) {
+	if ( action === "import" ) {
 		actingForm = importForm;
 		loadingMessage = loadingMessageImport;
 		actingButton = importButton;
@@ -112,7 +112,7 @@ function showSuccess( isImport ) {
  * @returns {void}
  */
 function importingSuccess() {
-	showSuccess( true );
+	showSuccess( "import" );
 }
 
 /**
@@ -121,24 +121,24 @@ function importingSuccess() {
  * @returns {void}
  */
 function cleanupSuccess() {
-	showSuccess( false );
+	showSuccess( "cleanup" );
 }
 
 /**
  * Function called when importing/cleanup is completed succesfully.
  *
  * @param {string} e The failure string.
- * @param {bool} isImport Whether it's an import.
+ * @param {string} action The action it's being performed, import or cleanup.
  *
  * @returns {void}
  */
-function showFailure( e, isImport ) {
+function showFailure( e, action ) {
 	var actingForm = cleanupForm;
 	var loadingMessage = loadingMessageCleanup;
 	var actingButton = cleanupButton;
 	var failureMessage = window.yoastImportData.assets.cleanup_failure;
 
-	if ( isImport ) {
+	if ( action === "import" ) {
 		actingForm = importForm;
 		loadingMessage = loadingMessageImport;
 		actingButton = importButton;
@@ -166,7 +166,7 @@ function showFailure( e, isImport ) {
  * @returns {void}
  */
 function importingFailure( e ) {
-	showFailure( e, true );
+	showFailure( e, "import" );
 }
 
 /**
@@ -177,7 +177,7 @@ function importingFailure( e ) {
  * @returns {void}
  */
 function cleanupFailure( e ) {
-	showFailure( e, false );
+	showFailure( e, "cleanup" );
 }
 
 /**

--- a/packages/js/src/import.js
+++ b/packages/js/src/import.js
@@ -1,11 +1,12 @@
 import jQuery from "jquery";
-import { act } from "react-test-renderer";
 
 import IndexingService from "./services/IndexingService";
 
 const AioseoV4 = "WPSEO_Import_AIOSEO_V4";
 
-let cleanupButton, cleanupDropdown, cleanupForm, importButton, importDropdown, importForm, spinner, loadingMessageCleanup, loadingMessageImport, checkMark;
+let cleanupButton, cleanupDropdown, cleanupForm, 
+	importButton, importDropdown, importForm, 
+	spinner, loadingMessageCleanup, loadingMessageImport, checkMark;
 
 /**
  * Adds Progress UI elements in the page.
@@ -110,7 +111,7 @@ function showSuccess( isImport ) {
  *
  * @returns {void}
  */
- function importingSuccess() {
+function importingSuccess() {
 	showSuccess( true );
 }
 
@@ -135,14 +136,12 @@ function showFailure( e, isImport ) {
 	var actingForm = cleanupForm;
 	var loadingMessage = loadingMessageCleanup;
 	var actingButton = cleanupButton;
-	var actingDropdown = cleanupDropdown;
 	var failureMessage = window.yoastImportData.assets.cleanup_failure;
 
 	if ( isImport ) {
 		actingForm = importForm;
 		loadingMessage = loadingMessageImport;
 		actingButton = importButton;
-		actingDropdown = importDropdown;
 		failureMessage = window.yoastImportData.assets.import_failure;
 	}
 

--- a/src/actions/importing/aioseo-cleanup-action.php
+++ b/src/actions/importing/aioseo-cleanup-action.php
@@ -146,12 +146,12 @@ class Aioseo_Cleanup_Action extends Abstract_Importing_Action {
 		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- Reason: There is no unescaped user input.
-		$meta_data  = $this->wpdb->query( $this->cleanup_postmeta_query() );
-		$indexables = $this->wpdb->query( $this->truncate_query() );
+		$meta_data                  = $this->wpdb->query( $this->cleanup_postmeta_query() );
+		$aioseo_table_truncate_done = $this->wpdb->query( $this->truncate_query() );
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 
-		if ( $meta_data === false && $indexables === false ) {
+		if ( $meta_data === false && $aioseo_table_truncate_done === false ) {
 			return false;
 		}
 
@@ -159,7 +159,7 @@ class Aioseo_Cleanup_Action extends Abstract_Importing_Action {
 
 		return [
 			'metadata_cleanup'   => $meta_data,
-			'indexables_cleanup' => $indexables,
+			'indexables_cleanup' => $aioseo_table_truncate_done,
 		];
 	}
 

--- a/src/actions/importing/aioseo-cleanup-action.php
+++ b/src/actions/importing/aioseo-cleanup-action.php
@@ -117,7 +117,7 @@ class Aioseo_Cleanup_Action extends Abstract_Importing_Action {
 			return 0;
 		}
 
-		return ( ! $this->get_completed() ) ? 1 : 0 ;
+		return ( ! $this->get_completed() ) ? 1 : 0;
 	}
 
 	/**
@@ -132,7 +132,7 @@ class Aioseo_Cleanup_Action extends Abstract_Importing_Action {
 			return 0;
 		}
 
-		return ( ! $this->get_completed() ) ? 1 : 0 ;
+		return ( ! $this->get_completed() ) ? 1 : 0;
 	}
 
 	/**

--- a/src/actions/importing/aioseo-cleanup-action.php
+++ b/src/actions/importing/aioseo-cleanup-action.php
@@ -117,7 +117,7 @@ class Aioseo_Cleanup_Action extends Abstract_Importing_Action {
 			return 0;
 		}
 
-		return ! $this->get_completed();
+		return ( ! $this->get_completed() ) ? 1 : 0 ;
 	}
 
 	/**
@@ -132,7 +132,7 @@ class Aioseo_Cleanup_Action extends Abstract_Importing_Action {
 			return 0;
 		}
 
-		return ! $this->get_completed();
+		return ( ! $this->get_completed() ) ? 1 : 0 ;
 	}
 
 	/**

--- a/src/actions/importing/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo-posts-importing-action.php
@@ -238,8 +238,6 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 	/**
 	 * Imports AIOSEO meta data and creates the respective Yoast indexables and postmeta.
 	 *
-	 * @todo: Replace the replace vars with Yoast ones.
-	 *
 	 * @return Indexable[]|false An array of created indexables or false if aioseo data was not found.
 	 */
 	public function index() {

--- a/src/integrations/admin/import-integration.php
+++ b/src/integrations/admin/import-integration.php
@@ -167,9 +167,9 @@ class Import_Integration implements Integration_Interface {
 	 * @return string The import failure alert.
 	 */
 	protected function get_import_failure_alert( $is_import ) {
-		$content  = \esc_html__( 'Cleanup failed with the following error:', 'wordpress-seo' );
+		$content = \esc_html__( 'Cleanup failed with the following error:', 'wordpress-seo' );
 		if ( $is_import ) {
-			$content  = \esc_html__( 'Import failed with the following error:', 'wordpress-seo' );
+			$content = \esc_html__( 'Import failed with the following error:', 'wordpress-seo' );
 		}
 
 		$content .= '<br/><br/>';

--- a/src/integrations/admin/import-integration.php
+++ b/src/integrations/admin/import-integration.php
@@ -95,20 +95,21 @@ class Import_Integration implements Integration_Interface {
 		\wp_enqueue_style( 'dashicons' );
 		$this->asset_manager->enqueue_script( 'import' );
 
-		$import_failure_alert = $this->get_import_failure_alert();
-
 		$data = [
 			'restApi' => [
 				'root'                => \esc_url_raw( \rest_url() ),
+				'cleanup_endpoints'   => $this->get_cleanup_endpoints(),
 				'importing_endpoints' => $this->get_importing_endpoints(),
 				'nonce'               => \wp_create_nonce( 'wp_rest' ),
 			],
 			'assets'  => [
-				'loading_msg'        => \esc_html__( 'The import can take a long time depending on your site\'s size.', 'wordpress-seo' ),
-				'select_placeholder' => \esc_html__( 'Select SEO plugin', 'wordpress-seo' ),
-				'no_data_msg'        => \esc_html__( 'No data found from other SEO plugins.', 'wordpress-seo' ),
-				'import_failure'     => $import_failure_alert,
-				'spinner'            => \admin_url( 'images/loading.gif' ),
+				'loading_msg_import'  => \esc_html__( 'The import can take a long time depending on your site\'s size.', 'wordpress-seo' ),
+				'loading_msg_cleanup' => \esc_html__( 'The cleanup can take a long time depending on your site\'s size.', 'wordpress-seo' ),
+				'select_placeholder'  => \esc_html__( 'Select SEO plugin', 'wordpress-seo' ),
+				'no_data_msg'         => \esc_html__( 'No data found from other SEO plugins.', 'wordpress-seo' ),
+				'import_failure'      => $this->get_import_failure_alert( true ),
+				'cleanup_failure'     => $this->get_import_failure_alert( false ),
+				'spinner'             => \admin_url( 'images/loading.gif' ),
 			],
 		];
 
@@ -128,7 +129,25 @@ class Import_Integration implements Integration_Interface {
 	 * @return array The endpoints.
 	 */
 	protected function get_importing_endpoints() {
-		$available_actions   = $this->importable_detector->detect();
+		$available_actions   = $this->importable_detector->detect_importers();
+		$importing_endpoints = [];
+
+		foreach ( $available_actions as $plugin => $types ) {
+			foreach ( $types as $type ) {
+				$importing_endpoints[ $plugin ][] = $this->importing_route->get_endpoint( $plugin, $type );
+			}
+		}
+
+		return $importing_endpoints;
+	}
+
+	/**
+	 * Retrieves a list of the importing endpoints to use.
+	 *
+	 * @return array The endpoints.
+	 */
+	protected function get_cleanup_endpoints() {
+		$available_actions   = $this->importable_detector->detect_cleanups();
 		$importing_endpoints = [];
 
 		foreach ( $available_actions as $plugin => $types ) {
@@ -143,10 +162,16 @@ class Import_Integration implements Integration_Interface {
 	/**
 	 * Gets the import failure alert using the Alert_Presenter.
 	 *
+	 * @param bool $is_import Wether it's an import or not.
+	 *
 	 * @return string The import failure alert.
 	 */
-	protected function get_import_failure_alert() {
-		$content  = \esc_html__( 'Import failed with the following error:', 'wordpress-seo' );
+	protected function get_import_failure_alert( $is_import ) {
+		$content  = \esc_html__( 'Cleanup failed with the following error:', 'wordpress-seo' );
+		if ( $is_import ) {
+			$content  = \esc_html__( 'Import failed with the following error:', 'wordpress-seo' );
+		}
+
 		$content .= '<br/><br/>';
 		$content .= \esc_html( '%s' );
 

--- a/src/integrations/admin/indexing-tool-integration.php
+++ b/src/integrations/admin/indexing-tool-integration.php
@@ -233,7 +233,7 @@ class Indexing_Tool_Integration implements Integration_Interface {
 	 * @return array The endpoints.
 	 */
 	protected function get_importing_endpoints() {
-		$available_actions   = $this->importable_detector->detect();
+		$available_actions   = $this->importable_detector->detect_importers();
 		$importing_endpoints = [];
 
 		foreach ( $available_actions as $plugin => $types ) {

--- a/src/integrations/admin/indexing-tool-integration.php
+++ b/src/integrations/admin/indexing-tool-integration.php
@@ -14,6 +14,8 @@ use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Indexing_Error_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Indexing_List_Item_Presenter;
+use Yoast\WP\SEO\Services\Importing\Importable_Detector;
+use Yoast\WP\SEO\Routes\Importing_Route;
 use Yoast\WP\SEO\Routes\Indexing_Route;
 
 /**
@@ -66,6 +68,20 @@ class Indexing_Tool_Integration implements Integration_Interface {
 	protected $product_helper;
 
 	/**
+	 * The Importable Detector service.
+	 *
+	 * @var Importable_Detector
+	 */
+	protected $importable_detector;
+
+	/**
+	 * The Importing Route class.
+	 *
+	 * @var Importing_Route
+	 */
+	protected $importing_route;
+
+	/**
 	 * Returns the conditionals based on which this integration should be active.
 	 *
 	 * @return array The array of conditionals.
@@ -87,6 +103,8 @@ class Indexing_Tool_Integration implements Integration_Interface {
 	 * @param Indexing_Helper           $indexing_helper     The indexing helper.
 	 * @param WPSEO_Addon_Manager       $addon_manager       The addon manager.
 	 * @param Product_Helper            $product_helper      The product helper.
+	 * @param Importable_Detector       $importable_detector The importable detector.
+	 * @param Importing_Route           $importing_route     The importing route.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
@@ -94,14 +112,18 @@ class Indexing_Tool_Integration implements Integration_Interface {
 		Short_Link_Helper $short_link_helper,
 		Indexing_Helper $indexing_helper,
 		WPSEO_Addon_Manager $addon_manager,
-		Product_Helper $product_helper
+		Product_Helper $product_helper,
+		Importable_Detector $importable_detector,
+		Importing_Route $importing_route
 	) {
-		$this->asset_manager     = $asset_manager;
-		$this->indexable_helper  = $indexable_helper;
-		$this->short_link_helper = $short_link_helper;
-		$this->indexing_helper   = $indexing_helper;
-		$this->addon_manager     = $addon_manager;
-		$this->product_helper    = $product_helper;
+		$this->asset_manager       = $asset_manager;
+		$this->indexable_helper    = $indexable_helper;
+		$this->short_link_helper   = $short_link_helper;
+		$this->indexing_helper     = $indexing_helper;
+		$this->addon_manager       = $addon_manager;
+		$this->product_helper      = $product_helper;
+		$this->importable_detector = $importable_detector;
+		$this->importing_route     = $importing_route;
 	}
 
 	/**
@@ -130,6 +152,7 @@ class Indexing_Tool_Integration implements Integration_Interface {
 			'restApi'                     => [
 				'root'                => \esc_url_raw( \rest_url() ),
 				'indexing_endpoints'  => $this->get_indexing_endpoints(),
+				'importing_endpoints' => $this->get_importing_endpoints(),
 				'nonce'               => \wp_create_nonce( 'wp_rest' ),
 			],
 		];
@@ -202,6 +225,24 @@ class Indexing_Tool_Integration implements Integration_Interface {
 		$endpoints['complete'] = Indexing_Route::FULL_COMPLETE_ROUTE;
 
 		return $endpoints;
+	}
+
+	/**
+	 * Retrieves a list of the importing endpoints to use.
+	 *
+	 * @return array The endpoints.
+	 */
+	protected function get_importing_endpoints() {
+		$available_actions   = $this->importable_detector->detect_importers();
+		$importing_endpoints = [];
+
+		foreach ( $available_actions as $plugin => $types ) {
+			foreach ( $types as $type ) {
+				$importing_endpoints[ $plugin ][] = $this->importing_route->get_endpoint( $plugin, $type );
+			}
+		}
+
+		return $importing_endpoints;
 	}
 
 	/**

--- a/src/integrations/admin/indexing-tool-integration.php
+++ b/src/integrations/admin/indexing-tool-integration.php
@@ -14,8 +14,6 @@ use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Indexing_Error_Presenter;
 use Yoast\WP\SEO\Presenters\Admin\Indexing_List_Item_Presenter;
-use Yoast\WP\SEO\Services\Importing\Importable_Detector;
-use Yoast\WP\SEO\Routes\Importing_Route;
 use Yoast\WP\SEO\Routes\Indexing_Route;
 
 /**
@@ -68,20 +66,6 @@ class Indexing_Tool_Integration implements Integration_Interface {
 	protected $product_helper;
 
 	/**
-	 * The Importable Detector service.
-	 *
-	 * @var Importable_Detector
-	 */
-	protected $importable_detector;
-
-	/**
-	 * The Importing Route class.
-	 *
-	 * @var Importing_Route
-	 */
-	protected $importing_route;
-
-	/**
 	 * Returns the conditionals based on which this integration should be active.
 	 *
 	 * @return array The array of conditionals.
@@ -103,8 +87,6 @@ class Indexing_Tool_Integration implements Integration_Interface {
 	 * @param Indexing_Helper           $indexing_helper     The indexing helper.
 	 * @param WPSEO_Addon_Manager       $addon_manager       The addon manager.
 	 * @param Product_Helper            $product_helper      The product helper.
-	 * @param Importable_Detector       $importable_detector The importable detector.
-	 * @param Importing_Route           $importing_route     The importing route.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
@@ -112,18 +94,14 @@ class Indexing_Tool_Integration implements Integration_Interface {
 		Short_Link_Helper $short_link_helper,
 		Indexing_Helper $indexing_helper,
 		WPSEO_Addon_Manager $addon_manager,
-		Product_Helper $product_helper,
-		Importable_Detector $importable_detector,
-		Importing_Route $importing_route
+		Product_Helper $product_helper
 	) {
-		$this->asset_manager       = $asset_manager;
-		$this->indexable_helper    = $indexable_helper;
-		$this->short_link_helper   = $short_link_helper;
-		$this->indexing_helper     = $indexing_helper;
-		$this->addon_manager       = $addon_manager;
-		$this->product_helper      = $product_helper;
-		$this->importable_detector = $importable_detector;
-		$this->importing_route     = $importing_route;
+		$this->asset_manager     = $asset_manager;
+		$this->indexable_helper  = $indexable_helper;
+		$this->short_link_helper = $short_link_helper;
+		$this->indexing_helper   = $indexing_helper;
+		$this->addon_manager     = $addon_manager;
+		$this->product_helper    = $product_helper;
 	}
 
 	/**
@@ -152,7 +130,6 @@ class Indexing_Tool_Integration implements Integration_Interface {
 			'restApi'                     => [
 				'root'                => \esc_url_raw( \rest_url() ),
 				'indexing_endpoints'  => $this->get_indexing_endpoints(),
-				'importing_endpoints' => $this->get_importing_endpoints(),
 				'nonce'               => \wp_create_nonce( 'wp_rest' ),
 			],
 		];
@@ -225,24 +202,6 @@ class Indexing_Tool_Integration implements Integration_Interface {
 		$endpoints['complete'] = Indexing_Route::FULL_COMPLETE_ROUTE;
 
 		return $endpoints;
-	}
-
-	/**
-	 * Retrieves a list of the importing endpoints to use.
-	 *
-	 * @return array The endpoints.
-	 */
-	protected function get_importing_endpoints() {
-		$available_actions   = $this->importable_detector->detect_importers();
-		$importing_endpoints = [];
-
-		foreach ( $available_actions as $plugin => $types ) {
-			foreach ( $types as $type ) {
-				$importing_endpoints[ $plugin ][] = $this->importing_route->get_endpoint( $plugin, $type );
-			}
-		}
-
-		return $importing_endpoints;
 	}
 
 	/**

--- a/src/services/importing/importable-detector.php
+++ b/src/services/importing/importable-detector.php
@@ -55,7 +55,7 @@ class Importable_Detector {
 	 *
 	 * @return array The detected importers that have data to work with.
 	 */
-	public function detect_cleanups( $plugin = null, $type = null ) {
+	public function detect_cleanups( $plugin = null ) {
 		$detectors = $this->filter_actions( $this->importers, $plugin, 'cleanup' );
 
 		$detected = [];

--- a/src/services/importing/importable-detector.php
+++ b/src/services/importing/importable-detector.php
@@ -35,8 +35,28 @@ class Importable_Detector {
 	 *
 	 * @return array The detected importers that have data to work with.
 	 */
-	public function detect( $plugin = null, $type = null ) {
+	public function detect_importers( $plugin = null, $type = null ) {
 		$detectors = $this->filter_actions( $this->importers, $plugin, $type );
+
+		$detected = [];
+		foreach ( $detectors as $detector ) {
+			if ( $detector->is_enabled() && $detector->get_type() !== 'cleanup' && ! $detector->get_completed() && $detector->get_limited_unindexed_count( 1 ) > 0 ) {
+				$detected[ $detector->get_plugin() ][] = $detector->get_type();
+			}
+		}
+
+		return $detected;
+	}
+
+	/**
+	 * Returns the detected cleanups that have data to work with.
+	 *
+	 * @param string $plugin The plugin name of the cleanup.
+	 *
+	 * @return array The detected importers that have data to work with.
+	 */
+	public function detect_cleanups( $plugin = null, $type = null ) {
+		$detectors = $this->filter_actions( $this->importers, $plugin, 'cleanup' );
 
 		$detected = [];
 		foreach ( $detectors as $detector ) {

--- a/tests/unit/actions/importing/aioseo-cleanup-action-test.php
+++ b/tests/unit/actions/importing/aioseo-cleanup-action-test.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Actions\Importing;
+
+use Mockery;
+use Yoast\WP\SEO\Actions\Importing\Aioseo_Cleanup_Action;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Wpdb_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Aioseo_Cleanup_Action_Test class
+ *
+ * @group actions
+ * @group importing
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Actions\Importing\Aioseo_Cleanup_Action
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+class Aioseo_Cleanup_Action_Test extends TestCase {
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Aioseo_Cleanup_Action
+	 */
+	protected $instance;
+
+	/**
+	 * The mocked WordPress database object.
+	 *
+	 * @var Mockery\MockInterface|\wpdb
+	 */
+	protected $wpdb;
+
+	/**
+	 * The mocked options helper.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper
+	 */
+	protected $options;
+
+	/**
+	 * The wpdb helper.
+	 *
+	 * @var Wpdb_Helper
+	 */
+	protected $wpdb_helper;
+
+	/**
+	 * Sets up the test class.
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->wpdb        = Mockery::mock( 'wpdb' );
+		$this->options     = Mockery::mock( Options_Helper::class );
+		$this->wpdb_helper = Mockery::mock( Wpdb_Helper::class );
+		$this->instance    = new Aioseo_Cleanup_Action( $this->wpdb, $this->options, $this->wpdb_helper );
+
+		$this->wpdb->prefix = 'wp_';
+	}
+
+	/**
+	 * Tests the checking if the cleanup has been completed in the past.
+	 *
+	 * @param bool  $table_exists        Whether the AIOSEO table exists.
+	 * @param array $completed_option    The persistent completed option.
+	 * @param int   $get_completed_times The times we're gonna get the persistent completed option.
+	 * @param int   $expected_result     The expected result.
+	 *
+	 * @dataProvider provider_get_unindexed
+	 * @covers ::get_total_unindexed
+	 */
+	public function test_get_total_unindexed( $table_exists, $completed_option, $get_completed_times, $expected_result ) {
+		$this->wpdb_helper->expects( 'table_exists' )
+			->with( 'wp_aioseo_posts' )
+			->andReturn( $table_exists );
+
+		$this->options->expects( 'get' )
+			->times( $get_completed_times )
+			->with( 'importing_completed', [] )
+			->andReturn( $completed_option );
+
+		$unindexed = $this->instance->get_total_unindexed();
+		$this->assertSame( $expected_result, $unindexed );
+	}
+
+	/**
+	 * Tests the checking if the cleanup has been completed in the past.
+	 *
+	 * @param bool  $table_exists        Whether the AIOSEO table exists.
+	 * @param array $completed_option    The persistent completed option.
+	 * @param int   $get_completed_times The times we're gonna get the persistent completed option.
+	 * @param int   $expected_result     The expected result.
+	 *
+	 * @dataProvider provider_get_unindexed
+	 * @covers ::get_limited_unindexed_count
+	 */
+	public function test_get_limited_unindexed_count( $table_exists, $completed_option, $get_completed_times, $expected_result ) {
+		$this->wpdb_helper->expects( 'table_exists' )
+			->with( 'wp_aioseo_posts' )
+			->andReturn( $table_exists );
+
+		$this->options->expects( 'get' )
+			->times( $get_completed_times )
+			->with( 'importing_completed', [] )
+			->andReturn( $completed_option );
+
+		$unindexed = $this->instance->get_limited_unindexed_count( 1 );
+		$this->assertSame( $expected_result, $unindexed );
+	}
+
+	/**
+	 * Tests the checking if the cleanup has been completed in the past.
+	 *
+	 * @param array     $completed_option   The persistent completed option.
+	 * @param int       $query_times        The times we're gonna run the cleanup queries.
+	 * @param int       $set_complete_times The times we're gonna set the persistent completed option.
+	 * @param int|false $postmeta_cleanup   The result of the postmeta cleanup query.
+	 * @param bool      $truncate_cleanup   The result of the truncate query.
+	 * @param array     $expected_result    The expected result.
+	 *
+	 * @dataProvider provider_index
+	 * @covers ::index
+	 * @covers ::cleanup_postmeta_query
+	 * @covers ::truncate_query
+	 * @covers ::get_postmeta_table
+	 * @covers ::get_aioseo_table
+	 */
+	public function test_index( $completed_option, $query_times, $set_complete_times, $postmeta_cleanup, $truncate_cleanup, $expected_result ) {
+		$this->options->expects( 'get' )
+			->once()
+			->with( 'importing_completed', [] )
+			->andReturn( $completed_option );
+
+		$expected_postmeta_query = 'DELETE FROM wp_postmeta WHERE meta_key IN (%s, %s, %s, %s, %s, %s)';
+		$this->wpdb->expects( 'prepare' )
+			->times( $query_times )
+			->with(
+				$expected_postmeta_query,
+				[
+					'_aioseo_title',
+					'_aioseo_description',
+					'_aioseo_og_title',
+					'_aioseo_og_description',
+					'_aioseo_twitter_title',
+					'_aioseo_twitter_description',
+				]
+			)
+			->andReturn(
+				"
+				DELETE FROM wp_postmeta
+				WHERE meta_key IN ('_aioseo_title','_aioseo_description','_aioseo_og_title','_aioseo_og_description','_aioseo_twitter_title','_aioseo_twitter_description')"
+			);
+
+		$this->wpdb->expects( 'query' )
+			->times( $query_times )
+			->with(
+				"
+				DELETE FROM wp_postmeta
+				WHERE meta_key IN ('_aioseo_title','_aioseo_description','_aioseo_og_title','_aioseo_og_description','_aioseo_twitter_title','_aioseo_twitter_description')"
+			)
+			->andReturn(
+				$postmeta_cleanup
+			);
+
+		$this->wpdb_helper->expects( 'table_exists' )
+			->times( $query_times )
+			->with( 'wp_aioseo_posts' )
+			->andReturn( true );
+
+		$expected_truncate_query = 'TRUNCATE TABLE wp_aioseo_posts';
+		$this->wpdb->expects( 'query' )
+			->times( $query_times )
+			->with( $expected_truncate_query )
+			->andReturn(
+				$truncate_cleanup
+			);
+
+		$this->options->expects( 'get' )
+			->times( $set_complete_times )
+			->with( 'importing_completed', [] )
+			->andReturn( [] );
+		$this->options->expects( 'set' )
+			->times( $set_complete_times )
+			->with( 'importing_completed', [ 'aioseo_cleanup' => true ] );
+
+		$cleanup_result = $this->instance->index();
+		$this->assertSame( $expected_result, $cleanup_result );
+	}
+
+	/**
+	 * Data provider for test_index().
+	 *
+	 * @return array
+	 */
+	public function provider_index() {
+		$successful_result = [
+			'metadata_cleanup'   => 10,
+			'indexables_cleanup' => true,
+		];
+		return [
+			[ [ 'aioseo_cleanup' => true ], 0, 0, 'irrelevant', 'irrelevant', [] ],
+			[ [], 1, 1, 10, true, $successful_result ],
+			[ [], 1, 0, false, false, false ],
+		];
+	}
+
+	/**
+	 * Data provider for test_get_total_unindexed() and test_get_limited_unindexed_count().
+	 *
+	 * @return array
+	 */
+	public function provider_get_unindexed() {
+		$completed                 = [
+			'aioseo_cleanup' => true,
+		];
+		$not_completed             = [
+			'aioseo_cleanup' => false,
+		];
+		$not_completed_with_no_key = [];
+
+		return [
+			[ false, [ 'irrelevant' ], 0, 0 ],
+			[ true, $completed, 1, 0 ],
+			[ true, $not_completed, 1, 1 ],
+			[ true, $not_completed_with_no_key, 1, 1 ],
+		];
+	}
+}

--- a/tests/unit/integrations/admin/import-integration-test.php
+++ b/tests/unit/integrations/admin/import-integration-test.php
@@ -150,19 +150,33 @@ class Import_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'rest_url' )
 			->andReturn( 'https://example.org/wp-ajax/' );
 
-		$expected_detections = [
+		$expected_import_detections = [
 			'aioseo' => [ 'posts' ],
 		];
 
+		$expected_cleanup_detections = [
+			'aioseo' => [ 'cleanup' ],
+		];
+
 		$this->importable_detector
-			->expects( 'detect' )
-			->andReturn( $expected_detections );
+			->expects( 'detect_importers' )
+			->andReturn( $expected_import_detections );
+
+		$this->importable_detector
+			->expects( 'detect_cleanups' )
+			->andReturn( $expected_cleanup_detections );
 
 		$this->importing_route
 			->expects( 'get_endpoint' )
 			->once()
 			->with( 'aioseo', 'posts' )
 			->andReturn( 'yoast/v1/import/aioseo/posts' );
+
+		$this->importing_route
+			->expects( 'get_endpoint' )
+			->once()
+			->with( 'aioseo', 'cleanup' )
+			->andReturn( 'yoast/v1/import/aioseo/cleanup' );
 
 		Monkey\Functions\expect( 'wp_create_nonce' )
 			->with( 'wp_rest' )
@@ -178,6 +192,11 @@ class Import_Integration_Test extends TestCase {
 		$injected_data = [
 			'restApi' => [
 				'root'                => 'https://example.org/wp-ajax/',
+				'cleanup_endpoints'   => [
+					'aioseo' => [
+						'yoast/v1/import/aioseo/cleanup',
+					],
+				],
 				'importing_endpoints' => [
 					'aioseo' => [
 						'yoast/v1/import/aioseo/posts',
@@ -186,11 +205,13 @@ class Import_Integration_Test extends TestCase {
 				'nonce'               => 'nonce_value',
 			],
 			'assets'  => [
-				'loading_msg'        => 'The import can take a long time depending on your site\'s size.',
-				'select_placeholder' => 'Select SEO plugin',
-				'no_data_msg'        => 'No data found from other SEO plugins.',
-				'import_failure'     => '<div class="yoast-alert yoast-alert--error"><span><img class="yoast-alert__icon" src="https://example.org/wp-content/plugins/images/alert-error-icon.svg" alt="" /></span><span>Import failed with the following error:<br/><br/>%s</span></div>',
-				'spinner'            => 'https://example.org/wp-admin/images/loading.gif',
+				'loading_msg_import'  => 'The import can take a long time depending on your site\'s size.',
+				'loading_msg_cleanup' => 'The cleanup can take a long time depending on your site\'s size.',
+				'select_placeholder'  => 'Select SEO plugin',
+				'no_data_msg'         => 'No data found from other SEO plugins.',
+				'import_failure'      => '<div class="yoast-alert yoast-alert--error"><span><img class="yoast-alert__icon" src="https://example.org/wp-content/plugins/images/alert-error-icon.svg" alt="" /></span><span>Import failed with the following error:<br/><br/>%s</span></div>',
+				'cleanup_failure'     => '<div class="yoast-alert yoast-alert--error"><span><img class="yoast-alert__icon" src="https://example.org/wp-content/plugins/images/alert-error-icon.svg" alt="" /></span><span>Cleanup failed with the following error:<br/><br/>%s</span></div>',
+				'spinner'             => 'https://example.org/wp-admin/images/loading.gif',
 			],
 		];
 

--- a/tests/unit/integrations/admin/indexing-tool-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-tool-integration-test.php
@@ -282,7 +282,7 @@ class Indexing_Tool_Integration_Test extends TestCase {
 		];
 
 		$this->importable_detector
-			->expects( 'detect' )
+			->expects( 'detect_importers' )
 			->andReturn( $expected_detections );
 
 		$this->importing_route

--- a/tests/unit/integrations/admin/indexing-tool-integration-test.php
+++ b/tests/unit/integrations/admin/indexing-tool-integration-test.php
@@ -14,8 +14,6 @@ use Yoast\WP\SEO\Helpers\Indexing_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Indexing_Tool_Integration;
-use Yoast\WP\SEO\Services\Importing\Importable_Detector;
-use Yoast\WP\SEO\Routes\Importing_Route;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -78,20 +76,6 @@ class Indexing_Tool_Integration_Test extends TestCase {
 	protected $product_helper;
 
 	/**
-	 * The Importable Detector service.
-	 *
-	 * @var Importable_Detector
-	 */
-	protected $importable_detector;
-
-	/**
-	 * The Importing Route class.
-	 *
-	 * @var Importing_Route
-	 */
-	protected $importing_route;
-
-	/**
 	 * Sets up the tests.
 	 */
 	protected function set_up() {
@@ -100,14 +84,12 @@ class Indexing_Tool_Integration_Test extends TestCase {
 		$this->stubTranslationFunctions();
 		$this->stubEscapeFunctions();
 
-		$this->asset_manager       = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
-		$this->indexable_helper    = Mockery::mock( Indexable_Helper::class );
-		$this->short_link_helper   = Mockery::mock( Short_Link_Helper::class );
-		$this->indexing_helper     = Mockery::mock( Indexing_Helper::class );
-		$this->addon_manager       = Mockery::mock( WPSEO_Addon_Manager::class );
-		$this->product_helper      = Mockery::mock( Product_Helper::class );
-		$this->importable_detector = Mockery::mock( Importable_Detector::class );
-		$this->importing_route     = Mockery::mock( Importing_Route::class );
+		$this->asset_manager     = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
+		$this->indexable_helper  = Mockery::mock( Indexable_Helper::class );
+		$this->short_link_helper = Mockery::mock( Short_Link_Helper::class );
+		$this->indexing_helper   = Mockery::mock( Indexing_Helper::class );
+		$this->addon_manager     = Mockery::mock( WPSEO_Addon_Manager::class );
+		$this->product_helper    = Mockery::mock( Product_Helper::class );
 
 		$this->instance = new Indexing_Tool_Integration(
 			$this->asset_manager,
@@ -115,9 +97,7 @@ class Indexing_Tool_Integration_Test extends TestCase {
 			$this->short_link_helper,
 			$this->indexing_helper,
 			$this->addon_manager,
-			$this->product_helper,
-			$this->importable_detector,
-			$this->importing_route
+			$this->product_helper
 		);
 	}
 
@@ -150,14 +130,6 @@ class Indexing_Tool_Integration_Test extends TestCase {
 		static::assertInstanceOf(
 			Product_Helper::class,
 			self::getPropertyValue( $this->instance, 'product_helper' )
-		);
-		static::assertInstanceOf(
-			Importable_Detector::class,
-			self::getPropertyValue( $this->instance, 'importable_detector' )
-		);
-		static::assertInstanceOf(
-			Importing_Route::class,
-			self::getPropertyValue( $this->instance, 'importing_route' )
 		);
 	}
 
@@ -194,7 +166,6 @@ class Indexing_Tool_Integration_Test extends TestCase {
 	 *
 	 * @covers ::enqueue_scripts
 	 * @covers ::get_indexing_endpoints
-	 * @covers ::get_importing_endpoints
 	 */
 	public function test_enqueue_scripts() {
 		$this->indexing_helper
@@ -257,11 +228,6 @@ class Indexing_Tool_Integration_Test extends TestCase {
 					'term_link'          => 'yoast/v1/link-indexing/terms',
 					'complete'           => 'yoast/v1/indexing/complete',
 				],
-				'importing_endpoints' => [
-					'aioseo' => [
-						'yoast/v1/import/aioseo/posts',
-					],
-				],
 				'nonce'               => 'nonce_value',
 			],
 		];
@@ -276,20 +242,6 @@ class Indexing_Tool_Integration_Test extends TestCase {
 		$this->asset_manager
 			->expects( 'localize_script' )
 			->with( 'indexation', 'yoastIndexingData', $injected_data );
-
-		$expected_detections = [
-			'aioseo' => [ 'posts' ],
-		];
-
-		$this->importable_detector
-			->expects( 'detect' )
-			->andReturn( $expected_detections );
-
-		$this->importing_route
-			->expects( 'get_endpoint' )
-			->once()
-			->with( 'aioseo', 'posts' )
-			->andReturn( 'yoast/v1/import/aioseo/posts' );
 
 		Monkey\Filters\expectApplied( 'wpseo_indexing_data' )
 			->with( $injected_data );

--- a/tests/unit/services/importing/importable-detector-test.php
+++ b/tests/unit/services/importing/importable-detector-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Services\Importing;
 
 use Mockery;
 use Yoast\WP\SEO\Actions\Importing\Aioseo_Posts_Importing_Action;
+use Yoast\WP\SEO\Actions\Importing\Aioseo_Cleanup_Action;
 use Yoast\WP\SEO\Helpers\Meta_Helper;
 use Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
@@ -41,6 +42,13 @@ class Importable_Detector_Test extends TestCase {
 	 * @var Aioseo_Posts_Importing_Action_Double
 	 */
 	protected $importing_action;
+
+	/**
+	 * The mocked importing action.
+	 *
+	 * @var Mockery\MockInterface|Aioseo_Cleanup_Action
+	 */
+	protected $cleanup_action;
 
 	/**
 	 * Represents the indexable repository.
@@ -144,11 +152,21 @@ class Importable_Detector_Test extends TestCase {
 			]
 		)->makePartial()->shouldAllowMockingProtectedMethods();
 
-		$this->instance      = new Importable_Detector( $this->importing_action );
+		$this->cleanup_action = Mockery::mock(
+			Aioseo_Cleanup_Action::class,
+			[
+				$this->wpdb,
+				$this->options,
+				$this->wpdb_helper,
+			]
+		)->makePartial()->shouldAllowMockingProtectedMethods();
+
+		$this->instance      = new Importable_Detector( $this->importing_action, $this->cleanup_action );
 		$this->mock_instance = Mockery::mock(
 			Importable_Detector_Double::class,
 			[
 				$this->importing_action,
+				$this->cleanup_action,
 			]
 		)->makePartial()->shouldAllowMockingProtectedMethods();
 	}
@@ -169,128 +187,190 @@ class Importable_Detector_Test extends TestCase {
 	}
 
 	/**
-	 * Tests if the detector detects when there are no importers.
+	 * Tests if the detector detects when there are no importers and cleanups.
 	 *
-	 * @covers ::detect
+	 * @covers ::detect_importers
+	 * @covers ::detect_cleanups
 	 */
 	public function test_detect_no_importers() {
+		$this->mock_instance->expects( 'filter_actions' )
+			->once()
+			->andReturn( [] );
 		$this->mock_instance->expects( 'filter_actions' )
 			->once()
 			->andReturn( [] );
 
 		$this->importing_action->expects( 'get_limited_unindexed_count' )
 			->never();
+		$this->cleanup_action->expects( 'get_limited_unindexed_count' )
+			->never();
 
-		$detected = $this->mock_instance->detect_importers();
+		$detected_importers = $this->mock_instance->detect_importers();
+		$detected_cleanups  = $this->mock_instance->detect_cleanups();
 
-		$this->assertTrue( \is_array( $detected ) );
-		$this->assertTrue( \count( $detected ) === 0 );
+		$this->assertTrue( \is_array( $detected_importers ) );
+		$this->assertTrue( \count( $detected_importers ) === 0 );
+		$this->assertTrue( \is_array( $detected_cleanups ) );
+		$this->assertTrue( \count( $detected_cleanups ) === 0 );
 	}
 
 	/**
 	 * Tests if the detector actually detects when there are unimported data and the action hasn't been finished.
 	 *
-	 * @covers ::detect
+	 * @covers ::detect_importers
+	 * @covers ::detect_cleanups
 	 */
 	public function test_detect_data_to_import_unifinished() {
 		$this->mock_instance->expects( 'filter_actions' )
-			->once()
+			->twice()
 			->andReturn( self::getPropertyValue( $this->instance, 'importers' ) );
 
 		$this->importing_action->expects( 'is_enabled' )
-				->once()
-				->andReturn( true );
+			->twice()
+			->andReturn( true );
+
+		$this->cleanup_action->expects( 'is_enabled' )
+			->twice()
+			->andReturn( true );
 
 		$this->importing_action->expects( 'get_completed' )
+			->twice()
+			->andReturn( false );
+		$this->cleanup_action->expects( 'get_completed' )
 			->once()
-			->andReturn( false ); // Any number between 1-25.
+			->andReturn( false );
 
 		$this->importing_action->expects( 'get_limited_unindexed_count' )
-			->once()
+			->twice()
 			->andReturn( 4 ); // Any number between 1-25.
+		$this->cleanup_action->expects( 'get_limited_unindexed_count' )
+			->once()
+			->andReturn( 1 ); // Any number between 1-25.
 
-		$detected = $this->mock_instance->detect_importers();
+		$detected_importers = $this->mock_instance->detect_importers();
+		$detected_cleanups  = $this->mock_instance->detect_cleanups();
 
-		$this->assertTrue( \is_array( $detected ) );
+		$this->assertTrue( \is_array( $detected_importers ) );
+		$this->assertTrue( \is_array( $detected_cleanups ) );
 
 		// Verify that we got data to import for the ONE importing action we have implemented at this point.
-		$this->assertTrue( \count( $detected ) === 1 );
-		$this->assertTrue( isset( $detected['aioseo'] ) );
-		$this->assertTrue( $detected['aioseo'][0] === 'posts' );
+		$this->assertTrue( \count( $detected_importers ) === 1 );
+		$this->assertTrue( isset( $detected_importers['aioseo'] ) );
+		$this->assertSame( $detected_importers['aioseo'][0], 'posts' );
+		// Verify that we got data to import for the ONE cleanup action we have implemented at this point.
+		$this->assertTrue( \count( $detected_cleanups ) === 1 );
+		$this->assertTrue( isset( $detected_cleanups['aioseo'] ) );
+		$this->assertSame( $detected_cleanups['aioseo'][1], 'cleanup' );
 	}
 
 	/**
 	 * Tests if the detector actually detects when there are unimported data but the action has been finished.
 	 *
-	 * @covers ::detect
+	 * @covers ::detect_importers
+	 * @covers ::detect_cleanups
 	 */
 	public function test_detect_data_to_import_finished() {
 		$this->mock_instance->expects( 'filter_actions' )
-			->once()
+			->twice()
 			->andReturn( self::getPropertyValue( $this->instance, 'importers' ) );
 
 		$this->importing_action->expects( 'is_enabled' )
-			->once()
+			->twice()
+			->andReturn( true );
+
+		$this->cleanup_action->expects( 'is_enabled' )
+			->twice()
 			->andReturn( true );
 
 		$this->importing_action->expects( 'get_completed' )
+			->twice()
+			->andReturn( true );
+
+		$this->cleanup_action->expects( 'get_completed' )
 			->once()
 			->andReturn( true );
 
 		$this->importing_action->expects( 'get_limited_unindexed_count' )
 			->never();
 
-		$detected = $this->mock_instance->detect_importers();
+		$detected_importers = $this->mock_instance->detect_importers();
+		$detected_cleanups  = $this->mock_instance->detect_cleanups();
 
-		$this->assertTrue( \is_array( $detected ) );
-		$this->assertTrue( \count( $detected ) === 0 );
+		$this->assertTrue( \is_array( $detected_importers ) );
+		$this->assertTrue( \count( $detected_importers ) === 0 );
+		$this->assertTrue( \is_array( $detected_cleanups ) );
+		$this->assertTrue( \count( $detected_cleanups ) === 0 );
 	}
 
 	/**
 	 * Tests if the detector detects when there are no unimported data but the action has not finished.
 	 *
-	 * @covers ::detect
+	 * @covers ::detect_importers
+	 * @covers ::detect_cleanups
 	 */
 	public function test_detect_no_data_to_import_unfinished() {
 		$this->mock_instance->expects( 'filter_actions' )
-			->once()
+			->twice()
 			->andReturn( self::getPropertyValue( $this->instance, 'importers' ) );
 
 		$this->importing_action->expects( 'is_enabled' )
-			->once()
+			->twice()
+			->andReturn( true );
+
+		$this->cleanup_action->expects( 'is_enabled' )
+			->twice()
 			->andReturn( true );
 
 		$this->importing_action->expects( 'get_completed' )
+			->twice()
+			->andReturn( false );
+
+		$this->cleanup_action->expects( 'get_completed' )
 			->once()
 			->andReturn( false );
 
 		$this->importing_action->expects( 'get_limited_unindexed_count' )
+			->twice()
+			->andReturn( 0 );
+
+		$this->cleanup_action->expects( 'get_limited_unindexed_count' )
 			->once()
 			->andReturn( 0 );
 
-		$detected = $this->mock_instance->detect_importers();
+		$detected_importers = $this->mock_instance->detect_importers();
+		$detected_cleanups  = $this->mock_instance->detect_cleanups();
 
-		$this->assertTrue( \is_array( $detected ) );
-		$this->assertTrue( \count( $detected ) === 0 );
+		$this->assertTrue( \is_array( $detected_importers ) );
+		$this->assertTrue( \count( $detected_importers ) === 0 );
+		$this->assertTrue( \is_array( $detected_cleanups ) );
+		$this->assertTrue( \count( $detected_cleanups ) === 0 );
 	}
 
 	/**
 	 * Tests if the detector detects when there are no enabled importers.
 	 *
-	 * @covers ::detect
+	 * @covers ::detect_importers
+	 * @covers ::detect_cleanups
 	 */
 	public function test_detect_no_data_when_no_enabled_importers() {
 		$this->mock_instance->expects( 'filter_actions' )
-			->once()
+			->twice()
 			->andReturn( self::getPropertyValue( $this->instance, 'importers' ) );
 
 		$this->importing_action->expects( 'is_enabled' )
-			->once()
+			->twice()
 			->andReturn( false );
 
-		$detected = $this->mock_instance->detect_importers();
+		$this->cleanup_action->expects( 'is_enabled' )
+			->twice()
+			->andReturn( false );
 
-		$this->assertTrue( \is_array( $detected ) );
-		$this->assertTrue( \count( $detected ) === 0 );
+		$detected_importers = $this->mock_instance->detect_importers();
+		$detected_cleanups  = $this->mock_instance->detect_cleanups();
+
+		$this->assertTrue( \is_array( $detected_importers ) );
+		$this->assertTrue( \count( $detected_importers ) === 0 );
+		$this->assertTrue( \is_array( $detected_cleanups ) );
+		$this->assertTrue( \count( $detected_cleanups ) === 0 );
 	}
 }

--- a/tests/unit/services/importing/importable-detector-test.php
+++ b/tests/unit/services/importing/importable-detector-test.php
@@ -181,7 +181,7 @@ class Importable_Detector_Test extends TestCase {
 		$this->importing_action->expects( 'get_limited_unindexed_count' )
 			->never();
 
-		$detected = $this->mock_instance->detect();
+		$detected = $this->mock_instance->detect_importers();
 
 		$this->assertTrue( \is_array( $detected ) );
 		$this->assertTrue( \count( $detected ) === 0 );
@@ -209,7 +209,7 @@ class Importable_Detector_Test extends TestCase {
 			->once()
 			->andReturn( 4 ); // Any number between 1-25.
 
-		$detected = $this->mock_instance->detect();
+		$detected = $this->mock_instance->detect_importers();
 
 		$this->assertTrue( \is_array( $detected ) );
 
@@ -240,7 +240,7 @@ class Importable_Detector_Test extends TestCase {
 		$this->importing_action->expects( 'get_limited_unindexed_count' )
 			->never();
 
-		$detected = $this->mock_instance->detect();
+		$detected = $this->mock_instance->detect_importers();
 
 		$this->assertTrue( \is_array( $detected ) );
 		$this->assertTrue( \count( $detected ) === 0 );
@@ -268,7 +268,7 @@ class Importable_Detector_Test extends TestCase {
 			->once()
 			->andReturn( 0 );
 
-		$detected = $this->mock_instance->detect();
+		$detected = $this->mock_instance->detect_importers();
 
 		$this->assertTrue( \is_array( $detected ) );
 		$this->assertTrue( \count( $detected ) === 0 );
@@ -288,7 +288,7 @@ class Importable_Detector_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
-		$detected = $this->mock_instance->detect();
+		$detected = $this->mock_instance->detect_importers();
 
 		$this->assertTrue( \is_array( $detected ) );
 		$this->assertTrue( \count( $detected ) === 0 );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to cleanup AIOSEO data, when the user clicks the Clean button

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the Data Cleanup functionality for AIOSEO 

## Relevant technical choices:

* When we perform the cleanup, we truncate the AIOSEO post indexable table and we delete any postmeta that contain AIOSEO data that we import in posts.
* The cleanups is not performed in chunks but rather in one go.
* We dont queue the cleanup action with the rest of the import actions but rather have it triggered solely by the Clean button

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**With the `YOAST_SEO_AIOSEO_V4_IMPORTER` feature flag both enabled and disabled**:
* Running `yoastImportData.restApi.cleanup_endpoints` in the Tools page's console, should return a `Uncaught ReferenceError: yoastImportData is not defined` message
* Running `yoastIndexingData.restApi.cleanup_endpoints` in the Tools page, should return `Undefined`

**With the `YOAST_SEO_AIOSEO_V4_IMPORTER` feature flag disabled**:
* Running `yoastIndexingData.restApi.importing_endpoints` in the Tools page, should return an empty array.
* Running `yoastImportData.restApi.importing_endpoints` in the Import/Export page, should return a  `Uncaught ReferenceError: yoastImportData is not defined` message
* Running `yoastImportData.restApi.cleanup_endpoints` in the Import/Export page, should return a  `Uncaught ReferenceError: yoastImportData is not defined` message
* Running 
```
( async function() {
    const a = await fetch( "/wp-json/yoast/v1/import/aioseo/cleanup" ,
        {
            method: "POST",
            headers: { "X-WP-Nonce": wpApiSettings.nonce }
        }
    );
    console.log( await a.json() );
} )();
```
in the Tools page or the Import/Export page, should return a **404 - No route was found matching the URL and request method** response.

**With the `YOAST_SEO_AIOSEO_V4_IMPORTER` feature flag enabled**:
* Running `yoastIndexingData.restApi.importing_endpoints` in the Tools page, should return a  `conflicting-plugins` action endpoint, 6 `AIOSEO` action endpoints but not the `yoast/v1/import/aioseo/cleanup` endpoint.
* Running `yoastImportData.restApi.importing_endpoints` in the Import/Export page, should return a  `conflicting-plugins` action endpoint, 6 `AIOSEO` action endpoints but not the `yoast/v1/import/aioseo/cleanup` endpoint.
* Running `yoastImportData.restApi.cleanup_endpoints` in the Import/Export page, should just return the `yoast/v1/import/aioseo/cleanup` endpoint.

* Going to the Import/Export page and having AIOSEO data in the site, there needs to be a AIOSEO Pack dropdpown available in the Step 5:
![image](https://user-images.githubusercontent.com/12400734/151787982-4810b4c4-367f-4b72-8e90-439203828145.png)
![image](https://user-images.githubusercontent.com/12400734/151788006-4bb1f2ea-4d8f-4915-a10e-037993ccbaba.png)
![image](https://user-images.githubusercontent.com/12400734/151788039-8cadd9eb-f397-44f1-ab1e-4c46dabbe960.png)
* Clicking Clean there, will start the cleanup of the AIOSEO data:
![image](https://user-images.githubusercontent.com/12400734/151788195-95262dbd-8d31-4b14-b43e-f87d93722137.png)
![image](https://user-images.githubusercontent.com/12400734/151788122-a7637542-4ba7-4282-95b8-efd135df8bcf.png)
* Once done, we should verify that AIOSEO data have been cleaned:
* * Check the `wp_aioseo_posts` table and verify that it's empty
* * Check the `wp_postmeta` table and verify that it has no entries with meta_key equal to `_aioseo_title` or `_aioseo_description` or `_aioseo_og_title` or `_aioseo_og_description` or `_aioseo_twitter_title` or `_aioseo_twitter_description`.
* Note that the Import dropdown will always be populated by the AIOSEO Pack option, until we Cleanup their data.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Check the SEO optimization page both with the feature flag enabled and disabled and run an optimization.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
