### PR TITLE
Use the best suiting version for PHPUnit with WP 5.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
       # Use 'trusty' to test against MySQL 5.6, 'xenial' contains 5.7 by default.
       dist: trusty
     - php: 7.3
-      env: WP_VERSION=master PHPUNIT=1
+      env: WP_VERSION=trunk PHPUNIT=1
     - php: 7.4
       env: WP_VERSION=latest PHPUNIT=1 PHPLINT=1
     - php: 8.0
@@ -110,7 +110,7 @@ jobs:
     # Allow failures for unstable builds.
     - php: "nightly"
     - php: 7.3
-      env: WP_VERSION=master PHPUNIT=1
+      env: WP_VERSION=trunk PHPUNIT=1
 
 cache:
   yarn: true
@@ -249,25 +249,34 @@ script:
   # PHP Unit
   - |
     if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:1} != "8" && $TRAVIS_PHP_VERSION != "nightly" ]]; then
+      # PHP < 8
       travis_fold start "PHP.integration-tests" && travis_time_start
       vendor/bin/phpunit -c phpunit-integration.xml.dist
       travis_time_finish && travis_fold end "PHP.integration-tests"
-    fi;
-  - |
-    if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    elif [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]] && [[ $WP_VERSION == "5.9" || $WP_VERSION == "latest" || $WP_VERSION == "trunk" ]]; then
+      # PHP >= 8 with WP >= 5.9
+      travis_fold start "PHP.integration-tests" && travis_time_start
+      travis_retry composer remove --dev phpunit/phpunit --no-update --no-interaction &&
+      travis_retry composer update yoast/wp-test-utils --no-interaction --with-dependencies --ignore-platform-req=php &&
+      vendor/bin/phpunit -c phpunit-integration.xml.dist
+      travis_time_finish && travis_fold end "PHP.integration-tests"
+    elif [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
+      # PHP >= 8 with WP < 5.9
       travis_fold start "PHP.integration-tests" && travis_time_start
       travis_retry composer require --dev phpunit/phpunit:"^7.5" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
       vendor/bin/phpunit -c phpunit-integration.xml.dist
       travis_time_finish && travis_fold end "PHP.integration-tests"
-    fi;
+    fi
   - |
     if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:1} != "8" && $TRAVIS_PHP_VERSION != "nightly" ]]; then
+      # PHP < 8
       travis_fold start "PHP.tests" && travis_time_start
       vendor/bin/phpunit
       travis_time_finish && travis_fold end "PHP.tests"
-    fi;
+    fi
   - |
     if [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
+      # PHP >= 8
       travis_fold start "PHP.tests" && travis_time_start
       travis_retry composer require --dev phpunit/phpunit:"^9.0" --update-with-dependencies --ignore-platform-reqs --no-interaction &&
       travis_retry composer update yoast/wp-test-utils --with-all-dependencies --ignore-platform-reqs --no-interaction &&


### PR DESCRIPTION
## Context

* Fix CI
* As of WP 5.9 we need to use PHPUnit 9 for our integrationtests. If we use 7.5 we get a deprecation warning.

## Summary

This PR can be summarized in the following changelog entry:

* Fix CI: PHP 8.0 integration tests

## Relevant technical choices:

* changed reference from master to trunk: [WP-develop changed their main branch](https://make.wordpress.org/core/2021/11/10/default-git-branch-for-wordpress-wordpress-develop/).
* Use PHPUnit 9 as per https://make.wordpress.org/core/2021/09/27/changes-to-the-wordpress-core-php-test-suite/

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See that the builds succeed


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off

