### PR TITLE
Recognise internal link if link host is same as the user's site domain

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/url/urlSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/url/urlSpec.js
@@ -201,6 +201,16 @@ describe( "A URL helper", function() {
 
 			expect( actual ).toBe( false );
 		} );
+
+		it( "returns true if the site URL is set to only the domain, and it's the same as the text link's host ", function() {
+			const urlA = "https://yoast.com/your-shopify-store-on-google/";
+			const host = null;
+			const siteUrl = "yoast.com";
+
+			const actual = url.isInternalLink( urlA, host, siteUrl );
+
+			expect( actual ).toBe( true );
+		} );
 	} );
 
 	describe( "getProtocol", function() {

--- a/packages/yoastseo/src/languageProcessing/helpers/link/getLinkType.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/link/getLinkType.js
@@ -23,7 +23,7 @@ export default function( text, url ) {
 		return "other";
 	}
 
-	if ( urlHelper.isInternalLink( anchorUrl, urlHelper.getHostname( url ) ) ) {
+	if ( urlHelper.isInternalLink( anchorUrl, urlHelper.getHostname( url ), url ) ) {
 		return "internal";
 	}
 

--- a/packages/yoastseo/src/languageProcessing/helpers/url/url.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/url/url.js
@@ -96,8 +96,9 @@ function getProtocol( url ) {
 /**
  * Determine whether a URL is internal.
  *
- * @param {string} url The URL to test.
- * @param {string} host The current host.
+ * @param {string} url 		The URL to test.
+ * @param {string} host 	The current host.
+ * @param {string} siteUrl  The current site's url (can also be only the domain part).
  *
  * @returns {boolean} Whether or not the URL is internal.
  */
@@ -120,7 +121,7 @@ function isInternalLink( url, host, siteUrl ) {
 
 	/*
      * It could be that the host is null if we only have access to the site's domain, not full url (this is the case with Shopify).
-     * In that case, a permalink identical to the parsedUrl's host would also indicate an internal link.
+     * In that case, a domain identical to the parsedUrl's host would also indicate an internal link.
      */
 	if ( parsedUrl.host === siteUrl ) {
 		return true;

--- a/packages/yoastseo/src/languageProcessing/helpers/url/url.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/url/url.js
@@ -101,7 +101,7 @@ function getProtocol( url ) {
  *
  * @returns {boolean} Whether or not the URL is internal.
  */
-function isInternalLink( url, host ) {
+function isInternalLink( url, host, siteUrl ) {
 	const parsedUrl = urlMethods.parse( url, false, true );
 	// Check if the URL starts with a single slash.
 	if ( url.indexOf( "//" ) === -1 && url.indexOf( "/" ) === 0 ) {
@@ -115,6 +115,14 @@ function isInternalLink( url, host ) {
 
 	// No host indicates an internal link.
 	if ( ! parsedUrl.host ) {
+		return true;
+	}
+
+	/*
+     * It could be that the host is null if we only have access to the site's domain, not full url (this is the case with Shopify).
+     * In that case, a permalink identical to the parsedUrl's host would also indicate an internal link.
+     */
+	if ( parsedUrl.host === siteUrl ) {
 		return true;
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This change fixes a Shopify bug where the internal linking assessment didn't recognise links using the primary domain, if the domain was different than the Shopify domain
* See the two other PRs that are part of this fix: https://github.com/Yoast/admin-ui/pull/230 https://github.com/Yoast/shopify-seo/pull/572
* In Wordpress, we compare the links in the text against the site url. However, in Shopify this causes a problem because the place where we retrieve the site url from uses the url with a `myshopify` domain. But many users have set a different primary domain, so we want to make sure we always compare the links against a url with the primary domain. As far as I know, in `shopify-seo` we don't have easy access to the url with the primary domain, but we do have access to the primary domain itself. So, in Shopify we choose to compare the text links against the domain, not the full url. That's why we add a step to compare the site url with the text url's host, in case the url is actually just the domain. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Recognises internal link if the site's host is null but the site domain and the link host are the same.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In Yoast SEO Free, create a new post and add a link to another page on your site. Make sure that the internal links assessment returns a green bullet.
* Test instructions for Shopify can be found here: https://github.com/Yoast/shopify-seo/pull/572 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
