### PR TITLE
P1-1193 create integer validator

### DIFF
--- a/src/exceptions/option/missing-configuration-key-exception.php
+++ b/src/exceptions/option/missing-configuration-key-exception.php
@@ -20,7 +20,7 @@ class Missing_Configuration_Key_Exception extends Abstract_Option_Exception {
 			\sprintf(
 			/* translators: %1$s expands to the name of the option. %2$s expands to the key that is missing. */
 				\esc_html__( 'The configuration of option "%1$s" does not have the "%2$s" key.', 'wordpress-seo' ),
-				$name,
+				\esc_html( $name ),
 				$key
 			)
 		);

--- a/src/exceptions/option/unknown-exception.php
+++ b/src/exceptions/option/unknown-exception.php
@@ -17,7 +17,7 @@ class Unknown_Exception extends Abstract_Option_Exception {
 			\sprintf(
 			/* translators: %s expands to the name of the option. */
 				\esc_html__( 'Option "%s" does not exist.', 'wordpress-seo' ),
-				$name
+				\esc_html( $name )
 			)
 		);
 	}

--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -45,7 +45,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'og_default_image_id'                         => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'empty_string', 'integer' ],
 		],
 		'og_frontpage_desc'                           => [
 			'default' => '',
@@ -57,7 +57,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'og_frontpage_image_id'                       => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'empty_string', 'integer' ],
 		],
 		'og_frontpage_title'                          => [
 			'default' => '',
@@ -177,7 +177,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 		// Titles.
 		'activation_redirect_timestamp_free'          => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'integer' ],
 		],
 		'alternate_website_name'                      => [
 			'default' => '',
@@ -229,7 +229,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'company_logo_id'                             => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'integer' ],
 		],
 		'company_logo_meta'                           => [
 			'default' => '',
@@ -245,7 +245,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'company_or_person_user_id'                   => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'integer' ],
 		],
 		'disable-attachment'                          => [
 			'default' => '',
@@ -333,7 +333,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'open_graph_frontpage_image_id'               => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'integer' ],
 		],
 		'open_graph_frontpage_title'                  => [
 			'default' => '',
@@ -345,7 +345,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'person_logo_id'                              => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'integer' ],
 		],
 		'person_logo_meta'                            => [
 			'default' => '',
@@ -401,23 +401,23 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'social-image-id-<PostTypeName>'              => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'integer' ],
 		],
 		'social-image-id-archive-wpseo'               => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'integer' ],
 		],
 		'social-image-id-author-wpseo'                => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'integer' ],
 		],
 		'social-image-id-ptarchive-<PostTypeName>'    => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'integer' ],
 		],
 		'social-image-id-tax-{TaxonomyName}'          => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'integer' ],
 		],
 		'social-image-url-<PostTypeName>'             => [
 			'default' => '',
@@ -575,7 +575,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'first_activated_on'                          => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'integer' ],
 		],
 		'first_time_install'                          => [
 			'default' => '',
@@ -619,7 +619,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'indexing_started'                            => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'integer' ],
 		],
 		'keyword_analysis_active'                     => [
 			'default' => '',

--- a/src/validators/integer-validator.php
+++ b/src/validators/integer-validator.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception;
+
+/**
+ * The integer validator class.
+ */
+class Integer_Validator implements Validator_Interface {
+
+	/**
+	 * Validates if a value is an integer.
+	 *
+	 * @param mixed $value The value to validate.
+	 *
+	 * @throws Invalid_Type_Exception When the type of the value is not an integer.
+	 *
+	 * @return int A valid integer.
+	 */
+	public function validate( $value ) {
+		$integer = \filter_var( $value, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE );
+
+		if ( $integer === null ) {
+			throw new Invalid_Type_Exception( \gettype( $value ), 'integer' );
+		}
+
+		return $integer;
+	}
+}

--- a/tests/unit/validators/empty-string-validator-test.php
+++ b/tests/unit/validators/empty-string-validator-test.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Empty_String_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Empty_String_Validator;
+
+/**
+ * Tests the Empty_String_Validator class.
+ *
+ * @group options
+ * @group validators
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Empty_String_Validator
+ */
+class Empty_String_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var Empty_String_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$this->instance = new Empty_String_Validator();
+	}
+
+	/**
+	 * Tests validation.
+	 *
+	 * @dataProvider string_provider
+	 *
+	 * @covers ::validate
+	 *
+	 * @param mixed  $value     The value to test/validate.
+	 * @param mixed  $expected  The expected result.
+	 * @param string $exception The expected exception class. Optional, use when the expected result is false.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_validate( $value, $expected, $exception = '' ) {
+		if ( $exception !== '' ) {
+			$this->expectException( $exception );
+			$this->instance->validate( $value );
+
+			return;
+		}
+
+		$this->assertEquals( $expected, $this->instance->validate( $value ) );
+	}
+
+	/**
+	 * Data provider to test multiple "strings".
+	 *
+	 * @return array A mapping of methods and expected inputs.
+	 */
+	public function string_provider() {
+		return [
+			'empty_string'     => [
+				'value'    => '',
+				'expected' => '',
+			],
+			'non-empty_string' => [
+				'value'     => 'text',
+				'expected' => '',
+				'exception' => Invalid_Empty_String_Exception::class,
+			],
+			'integer'          => [
+				'value'     => 123,
+				'expected' => '',
+				'exception' => Invalid_Type_Exception::class,
+			],
+		];
+	}
+}

--- a/tests/unit/validators/integer-validator-test.php
+++ b/tests/unit/validators/integer-validator-test.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Integer_Validator;
+
+/**
+ * Tests the Integer_Validator class.
+ *
+ * @group options
+ * @group validators
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Integer_Validator
+ */
+class Integer_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var Integer_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubTranslationFunctions();
+
+		$this->instance = new Integer_Validator();
+	}
+
+	/**
+	 * Tests validation.
+	 *
+	 * @dataProvider integer_provider
+	 *
+	 * @covers ::validate
+	 *
+	 * @param mixed  $value     The value to test/validate.
+	 * @param mixed  $expected  The expected result.
+	 * @param string $exception The expected exception class. Optional, use when the expected result is false.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_validate( $value, $expected, $exception = '' ) {
+		if ( ! $expected ) {
+			$this->expectException( $exception );
+			$this->instance->validate( $value );
+
+			return;
+		}
+
+		$this->assertEquals( $expected, $this->instance->validate( $value ) );
+	}
+
+	/**
+	 * Data provider to test multiple "integers".
+	 *
+	 * @return array A mapping of methods and expected inputs.
+	 */
+	public function integer_provider() {
+		return [
+			'integer'        => [
+				'value'    => 123,
+				'expected' => 123,
+			],
+			'integer_string' => [
+				'value'    => '123',
+				'expected' => 123,
+			],
+			'true'           => [
+				'value'    => true,
+				'expected' => 1,
+			],
+			'string'         => [
+				'value'     => '1abc23',
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+			// Note this does not work like `true`.
+			'false'          => [
+				'value'     => false,
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+			'float'          => [
+				'value'     => 1.23,
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+			'array'          => [
+				'value'     => [ 1 ],
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+			'object'         => [
+				'value'     => (object) [ 1 ],
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+			'null'           => [
+				'value'     => null,
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+		];
+	}
+}

--- a/tests/unit/validators/string-validator-test.php
+++ b/tests/unit/validators/string-validator-test.php
@@ -4,22 +4,22 @@ namespace Yoast\WP\SEO\Tests\Unit\Validators;
 
 use Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
-use Yoast\WP\SEO\Validators\Integer_Validator;
+use Yoast\WP\SEO\Validators\String_Validator;
 
 /**
- * Tests the Integer_Validator class.
+ * Tests the String_Validator class.
  *
  * @group options
  * @group validators
  *
- * @coversDefaultClass \Yoast\WP\SEO\Validators\Integer_Validator
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\String_Validator
  */
-class Integer_Validator_Test extends TestCase {
+class String_Validator_Test extends TestCase {
 
 	/**
 	 * Holds the instance to test.
 	 *
-	 * @var Integer_Validator
+	 * @var String_Validator
 	 */
 	protected $instance;
 
@@ -30,13 +30,13 @@ class Integer_Validator_Test extends TestCase {
 		parent::set_up();
 		$this->stubTranslationFunctions();
 
-		$this->instance = new Integer_Validator();
+		$this->instance = new String_Validator();
 	}
 
 	/**
 	 * Tests validation.
 	 *
-	 * @dataProvider integer_provider
+	 * @dataProvider string_provider
 	 *
 	 * @covers ::validate
 	 *
@@ -58,51 +58,42 @@ class Integer_Validator_Test extends TestCase {
 	}
 
 	/**
-	 * Data provider to test multiple "integers".
+	 * Data provider to test multiple "strings".
 	 *
 	 * @return array A mapping of methods and expected inputs.
 	 */
-	public function integer_provider() {
+	public function string_provider() {
 		return [
-			'integer'        => [
-				'value'    => 123,
-				'expected' => 123,
+			'string'  => [
+				'value'    => 'text',
+				'expected' => 'text',
 			],
-			'integer_string' => [
-				'value'    => '123',
-				'expected' => 123,
-			],
-			'true'           => [
-				'value'    => true,
-				'expected' => 1,
-			],
-			'string'         => [
-				'value'     => '1abc23',
+			'integer' => [
+				'value'     => 123,
 				'expected'  => false,
 				'exception' => Invalid_Type_Exception::class,
 			],
-			// Note this does not work like `true`.
-			'false'          => [
-				'value'     => false,
-				'expected'  => false,
-				'exception' => Invalid_Type_Exception::class,
-			],
-			'float'          => [
+			'float'   => [
 				'value'     => 1.23,
 				'expected'  => false,
 				'exception' => Invalid_Type_Exception::class,
 			],
-			'array'          => [
-				'value'     => [ 1 ],
+			'boolean' => [
+				'value'     => true,
 				'expected'  => false,
 				'exception' => Invalid_Type_Exception::class,
 			],
-			'object'         => [
-				'value'     => (object) [ 1 ],
+			'array'   => [
+				'value'     => [ 'text' ],
 				'expected'  => false,
 				'exception' => Invalid_Type_Exception::class,
 			],
-			'null'           => [
+			'object'  => [
+				'value'     => (object) [ 'text' ],
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+			'null'    => [
 				'value'     => null,
 				'expected'  => false,
 				'exception' => Invalid_Type_Exception::class,

--- a/tests/unit/validators/url-validator-test.php
+++ b/tests/unit/validators/url-validator-test.php
@@ -62,7 +62,7 @@ class Url_Validator_Test extends TestCase {
 	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
 	 */
 	public function test_validate( $value, $expected, $exception = '' ) {
-		if ( ! $expected ) {
+		if ( $exception !== '' ) {
 			$this->expectException( $exception );
 			$this->instance->validate( $value );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the integer validator.

## Relevant technical choices:

* Snuck in some more validator tests.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Tests should cover and pass.
* You can test the validator via:
```php

function _test_validate_int( $value ) {
	/** @var \Yoast\WP\SEO\Validators\Integer_Validator $validator */
	$validator = YoastSEO()->classes->get( \Yoast\WP\SEO\Validators\Integer_Validator::class );
	echo 'Value: ';
	var_dump( $value );
	echo '<br>Result: ';
	try {
		var_dump( $validator->validate( $value ) );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_validate_int( true );
_test_validate_int( false );
```
* Play around with it!


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* No need to test separately; part of larger feature.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [P1-1193](https://yoast.atlassian.net/browse/P1-1193)
