### PR TITLE
Add email validator

### DIFF
--- a/src/exceptions/validation/invalid-email-exception.php
+++ b/src/exceptions/validation/invalid-email-exception.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Validation;
+
+/**
+ * Invalid email validation exception class.
+ */
+class Invalid_Email_Exception extends Abstract_Validation_Exception {
+
+	/**
+	 * Constructs an invalid email validation exception instance.
+	 *
+	 * @param mixed $value The value that is not an email address.
+	 */
+	public function __construct( $value ) {
+		parent::__construct(
+			\sprintf(
+			/* translators: %s expands to an invalid email address. */
+				\esc_html__( '%s does not seem to be a valid email address.', 'wordpress-seo' ),
+				'<strong>' . \esc_html( $value ) . '</strong>'
+			)
+		);
+	}
+}

--- a/src/validators/email-validator.php
+++ b/src/validators/email-validator.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Email_Exception;
+
+/**
+ * The Email validator class.
+ */
+class Email_Validator extends String_Validator {
+
+	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- Reason: The parent validate can throw too.
+
+	/**
+	 * Validates if a value is an email.
+	 *
+	 * @param mixed $value The value to validate.
+	 *
+	 * @throws Invalid_Email_Exception When the value is an invalid email address.
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception When the value is not a string.
+	 *
+	 * @return string A valid email address.
+	 */
+	public function validate( $value ) {
+		$email = parent::validate( $value );
+
+		$email = \sanitize_email( $email );
+		$email = \is_email( $email );
+		if ( ! $email ) {
+			throw new Invalid_Email_Exception( $value );
+		}
+
+		return $email;
+	}
+
+	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
+}

--- a/tests/unit/validators/email-validator-test.php
+++ b/tests/unit/validators/email-validator-test.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Email_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Email_Validator;
+
+/**
+ * Tests the Email_Validator class.
+ *
+ * @group options
+ * @group validators
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Email_Validator
+ */
+class Email_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var Email_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$this->instance = new Email_Validator();
+	}
+
+	/**
+	 * Tests the validation' happy path.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate() {
+		$input    = 'info@example!.org';
+		$expected = 'info@example.org';
+
+		Monkey\Functions\expect( 'sanitize_email' )
+			->with( $input )
+			->once()
+			->andReturn( $expected );
+		Monkey\Functions\expect( 'is_email' )
+			->with( $expected )
+			->once()
+			->andReturn( $expected );
+
+		$this->assertEquals( $expected, $this->instance->validate( $input ) );
+	}
+
+	/**
+	 * Tests that a validation exception is thrown when is_email returns false.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate_no_email() {
+		$input    = 'info@example!.org';
+		$expected = 'info@example.org';
+
+		Monkey\Functions\expect( 'sanitize_email' )
+			->with( $input )
+			->once()
+			->andReturn( $expected );
+		Monkey\Functions\expect( 'is_email' )
+			->with( $expected )
+			->once()
+			->andReturn( false );
+
+		$this->expectException( Invalid_Email_Exception::class );
+
+		$this->instance->validate( $input );
+	}
+
+	/**
+	 * Tests that a validation exception is thrown when the input is not a string.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate_no_string() {
+		Monkey\Functions\expect( 'sanitize_email' )
+			->never();
+		Monkey\Functions\expect( 'is_email' )
+			->never();
+
+		$this->expectException( Invalid_Type_Exception::class );
+
+		$this->instance->validate( 123 );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the email validator.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Tests should make sense and cover the code
* You can run this somewhere and play around with feeding it different input:
```php
function _test_validate( $value ) {
	/** @var \Yoast\WP\SEO\Validators\Email_Validator $validator */
	$validator = YoastSEO()->classes->get( \Yoast\WP\SEO\Validators\Email_Validator::class );
	echo 'Value: ';
	var_dump( $value );
	echo '<br>Result: ';
	try {
		var_dump( $validator->validate( $value ) );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_validate( 'info@example!.org' );
```


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Part of a bigger feature, test when all done please!

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [P1-1190](https://yoast.atlassian.net/browse/P1-1190)
