### PR TITLE
P1-1195 create is equal validator

### DIFF
--- a/src/exceptions/validation/invalid-value-exception.php
+++ b/src/exceptions/validation/invalid-value-exception.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Validation;
+
+/**
+ * Invalid value validation exception class.
+ */
+class Invalid_Value_Exception extends Abstract_Validation_Exception {
+
+	/**
+	 * Constructs an invalid value validation exception instance.
+	 */
+	public function __construct() {
+		parent::__construct( \esc_html__( 'The input value is not as expected.', 'wordpress-seo' ) );
+	}
+}

--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -687,7 +687,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'version'                                     => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'is_equal' => [ 'equals' => WPSEO_VERSION ] ],
 		],
 		'wincher_automatically_add_keyphrases'        => [
 			'default' => '',

--- a/src/validators/array-validator.php
+++ b/src/validators/array-validator.php
@@ -10,11 +10,12 @@ class Array_Validator implements Validator_Interface {
 	/**
 	 * Validates if a value is an array.
 	 *
-	 * @param mixed $value The value to validate.
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
 	 *
 	 * @return bool Whether the value is an array.
 	 */
-	public function validate( $value ) {
+	public function validate( $value, array $settings = null ) {
 		return \is_array( $value );
 	}
 }

--- a/src/validators/boolean-validator.php
+++ b/src/validators/boolean-validator.php
@@ -12,13 +12,14 @@ class Boolean_Validator implements Validator_Interface {
 	/**
 	 * Validates if a value is a boolean.
 	 *
-	 * @param mixed $value The value to validate.
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
 	 *
 	 * @throws Invalid_Type_Exception When the type of the value is not a boolean.
 	 *
 	 * @return bool A valid boolean.
 	 */
-	public function validate( $value ) {
+	public function validate( $value, array $settings = null ) {
 		$bool = \filter_var( $value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE );
 
 		if ( $bool === null ) {

--- a/src/validators/email-validator.php
+++ b/src/validators/email-validator.php
@@ -14,14 +14,15 @@ class Email_Validator extends String_Validator {
 	/**
 	 * Validates if a value is an email.
 	 *
-	 * @param mixed $value The value to validate.
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
 	 *
 	 * @throws Invalid_Email_Exception When the value is an invalid email address.
 	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception When the value is not a string.
 	 *
 	 * @return string A valid email address.
 	 */
-	public function validate( $value ) {
+	public function validate( $value, array $settings = null ) {
 		$email = parent::validate( $value );
 
 		$email = \sanitize_email( $email );

--- a/src/validators/empty-string-validator.php
+++ b/src/validators/empty-string-validator.php
@@ -14,14 +14,15 @@ class Empty_String_Validator extends String_Validator {
 	/**
 	 * Validates if a value is a string.
 	 *
-	 * @param mixed $value The value to validate.
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
 	 *
 	 * @throws Invalid_Empty_String_Exception When the value is not an empty string.
 	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception When the value is not a string.
 	 *
 	 * @return string A valid string.
 	 */
-	public function validate( $value ) {
+	public function validate( $value, array $settings = null ) {
 		$string = parent::validate( $value );
 
 		if ( $string !== '' ) {

--- a/src/validators/integer-validator.php
+++ b/src/validators/integer-validator.php
@@ -12,13 +12,14 @@ class Integer_Validator implements Validator_Interface {
 	/**
 	 * Validates if a value is an integer.
 	 *
-	 * @param mixed $value The value to validate.
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
 	 *
 	 * @throws Invalid_Type_Exception When the type of the value is not an integer.
 	 *
 	 * @return int A valid integer.
 	 */
-	public function validate( $value ) {
+	public function validate( $value, array $settings = null ) {
 		$integer = \filter_var( $value, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE );
 
 		if ( $integer === null ) {

--- a/src/validators/is-equal-validator.php
+++ b/src/validators/is-equal-validator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Value_Exception;
+
+/**
+ * The is equal validator class.
+ */
+class Is_Equal_Validator implements Validator_Interface {
+
+	/**
+	 * Validates if a value equals another.
+	 *
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
+	 *
+	 * @throws Invalid_Value_Exception When the value does not equal the expected value.
+	 *
+	 * @return mixed The valid value.
+	 */
+	public function validate( $value, array $settings = null ) {
+		if ( $settings === null || ! \array_key_exists( 'equals', $settings ) ) {
+			return $value;
+		}
+
+		if ( $value !== $settings['equals'] ) {
+			throw new Invalid_Value_Exception();
+		}
+
+		return $value;
+	}
+}

--- a/src/validators/news-sitemap-content-type-validator.php
+++ b/src/validators/news-sitemap-content-type-validator.php
@@ -15,13 +15,14 @@ class News_Sitemap_Content_Type_Validator extends Array_Validator {
 	 * Validates if the value is an array.
 	 * Sets the passed content types to 'on'
 	 *
-	 * @param mixed $value The value to validate.
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.     *
 	 *
 	 * @throws Invalid_Type_Exception When the value is not an array.
 	 *
 	 * @return array Array with the content type keys set to value 'on'.
 	 */
-	public function validate( $value ) {
+	public function validate( $value, array $settings = null ) {
 		parent::validate( $value );
 
 		$new_value = [];

--- a/src/validators/string-validator.php
+++ b/src/validators/string-validator.php
@@ -12,13 +12,14 @@ class String_Validator implements Validator_Interface {
 	/**
 	 * Validates if a value is a string.
 	 *
-	 * @param mixed $value The value to validate.
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
 	 *
 	 * @throws Invalid_Type_Exception When the type of the value is not a string.
 	 *
 	 * @return string A valid string.
 	 */
-	public function validate( $value ) {
+	public function validate( $value, array $settings = null ) {
 		if ( ! \is_string( $value ) ) {
 			throw new Invalid_Type_Exception( \gettype( $value ), 'string' );
 		}

--- a/src/validators/url-validator.php
+++ b/src/validators/url-validator.php
@@ -14,14 +14,15 @@ class Url_Validator extends String_Validator {
 	/**
 	 * Validates if a value is a URL.
 	 *
-	 * @param mixed $value The value to validate.
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
 	 *
 	 * @throws Invalid_Url_Exception When the value is an invalid URL.
 	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception When the value is not a string.
 	 *
 	 * @return mixed A valid URL.
 	 */
-	public function validate( $value ) {
+	public function validate( $value, array $settings = null ) {
 		$url = parent::validate( $value );
 
 		$url = \trim( \htmlspecialchars( $url, ENT_COMPAT, $this->get_charset(), true ) );
@@ -71,7 +72,7 @@ class Url_Validator extends String_Validator {
 		if ( isset( $parts['path'] ) && \strpos( $parts['path'], '/' ) === 0 ) {
 			$path = \explode( '/', \wp_strip_all_tags( $parts['path'] ) );
 			$path = $this->sanitize_encoded_text_field( $path );
-			$url .= \implode( '/', $path );
+			$url  .= \implode( '/', $path );
 		}
 
 		if ( ! $url ) {

--- a/src/validators/validator-interface.php
+++ b/src/validators/validator-interface.php
@@ -10,11 +10,12 @@ interface Validator_Interface {
 	/**
 	 * Validates a value.
 	 *
-	 * @param mixed $value The value to validate.
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
 	 *
 	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When the value is "unfixable".
 	 *
 	 * @return mixed A valid value.
 	 */
-	public function validate( $value );
+	public function validate( $value, array $settings = null );
 }

--- a/tests/unit/helpers/validation-helper-test.php
+++ b/tests/unit/helpers/validation-helper-test.php
@@ -117,7 +117,7 @@ class Validation_Helper_Test extends TestCase {
 
 		$empty_string_validator
 			->expects( 'validate' )
-			->with( 'https://example.org', 'some settings' )
+			->with( 'https://example.org', null )
 			->once()
 			->andThrow( Invalid_Empty_String_Exception::class );
 		$url_validator
@@ -128,10 +128,7 @@ class Validation_Helper_Test extends TestCase {
 
 		$result = $this->instance->validate_as(
 			'https://example.org',
-			[
-				'empty_string' => 'some settings',
-				'url',
-			]
+			[ 'empty_string', 'url' ]
 		);
 		$this->assertEquals( 'https://example.org', $result );
 	}

--- a/tests/unit/validators/is-equal-validator-test.php
+++ b/tests/unit/validators/is-equal-validator-test.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Value_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Is_Equal_Validator;
+
+/**
+ * Tests the Is_Equal_Validator class.
+ *
+ * @group options
+ * @group validators
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Is_Equal_Validator
+ */
+class Is_Equal_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var Is_Equal_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubTranslationFunctions();
+
+		$this->instance = new Is_Equal_Validator();
+	}
+
+	/**
+	 * Tests validation.
+	 *
+	 * @dataProvider data_provider
+	 *
+	 * @covers ::validate
+	 *
+	 * @param mixed  $value     The value to test/validate.
+	 * @param array  $settings  The validator settings.
+	 * @param mixed  $expected  The expected result.
+	 * @param string $exception The expected exception class. Optional, use when the expected result is false.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_validate( $value, $settings, $expected, $exception = '' ) {
+		if ( $exception !== '' ) {
+			$this->expectException( $exception );
+			$this->instance->validate( $value, $settings );
+
+			return;
+		}
+
+		$this->assertEquals( $expected, $this->instance->validate( $value, $settings ) );
+	}
+
+	/**
+	 * Data provider to test multiple scenarios.
+	 *
+	 * @return array A mapping of methods and expected inputs.
+	 */
+	public function data_provider() {
+		return [
+			'string'  => [
+				'value'    => 'text',
+				'settings' => [ 'equals' => 'text' ],
+				'expected' => 'text',
+			],
+			'integer' => [
+				'value'    => 123,
+				'settings' => [ 'equals' => 123 ],
+				'expected' => 123,
+			],
+			'invalid' => [
+				'value'     => '123',
+				'settings'  => [ 'equals' => 123 ],
+				'expected'  => false,
+				'exception' => Invalid_Value_Exception::class,
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the is equal validator.

## Relevant technical choices:

* Added settings parameter to validate (helper already passed it). It should be an (object) array. This means the other validators need adjusting (and open PRs will still need to be adjusted).
* I left the exception intentionally vague. If the value would be output in the message, it should be able to handle things like array to string conversion errors in the exceptions. I didn't want to do that 😉 
* Only implementation for free

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Tests should make sense and cover the code
* You can play around with requesting validations, using this code:
```php
function _test_validate( $value, $equals ) {
	/** @var \Yoast\WP\SEO\Validators\Is_Equal_Validator:: $validator */
	$validator = YoastSEO()->classes->get( \Yoast\WP\SEO\Validators\Is_Equal_Validator::class );
	echo 'Value: ';
	var_dump( $value );
	echo '<br>Result: ';
	try {
		var_dump( $validator->validate( $value, [ 'equals' => $equals ] ) );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_validate( '18.1', WPSEO_VERSION );
```
* You can play with the setting of the version, using this code:
```php
function _test_set_version( $value ) {
	/** @var \Yoast\WP\SEO\Services\Options\Site_Options_Service $options */
	$options = YoastSEO()->classes->get( \Yoast\WP\SEO\Services\Options\Site_Options_Service::class );
	echo '<br>Before: ';
	var_dump( $options->version );
	echo '<br>After: ';
	try {
		$options->version = $value;
		var_dump( $options->version );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_set_version( '1.0' );
```


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Part of bigger feature, please test the whole feature when done.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [P1-1195](https://yoast.atlassian.net/browse/P1-1195)
