### PR TITLE
Check if default values in indexable fields before importing

### DIFF
--- a/src/actions/importing/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo-posts-importing-action.php
@@ -377,12 +377,6 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 				continue;
 			}
 
-			// For import of everything else.
-			// Do not overwrite any existing values.
-			if ( ! empty( $indexable->{$yoast_mapping['yoast_name']} ) ) {
-				continue;
-			}
-
 			if ( ! empty( $aioseo_indexable[ $aioseo_key ] ) ) {
 				$indexable->{$yoast_mapping['yoast_name']} = \call_user_func( [ $this, $yoast_mapping['transform_method'] ], $aioseo_indexable[ $aioseo_key ], $yoast_mapping );
 			}

--- a/src/actions/importing/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo-posts-importing-action.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Actions\Importing;
 
 use wpdb;
 use Yoast\WP\SEO\Conditionals\AIOSEO_V4_Importer_Conditional;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Sanitization_Helper;
@@ -124,6 +125,13 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 	protected $indexable_to_postmeta;
 
 	/**
+	 * The indexable helper.
+	 *
+	 * @var Indexable_Helper
+	 */
+	protected $indexable_helper;
+
+	/**
 	 * The wpdb helper.
 	 *
 	 * @var Wpdb_Helper
@@ -135,6 +143,7 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 	 *
 	 * @param Indexable_Repository              $indexable_repository  The indexables repository.
 	 * @param wpdb                              $wpdb                  The WordPress database instance.
+	 * @param Indexable_Helper                  $indexable_helper      The indexable helper.
 	 * @param Indexable_To_Postmeta_Helper      $indexable_to_postmeta The indexable_to_postmeta helper.
 	 * @param Options_Helper                    $options               The options helper.
 	 * @param Sanitization_Helper               $sanitization          The sanitization helper.
@@ -146,6 +155,7 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 	public function __construct(
 		Indexable_Repository $indexable_repository,
 		wpdb $wpdb,
+		Indexable_Helper $indexable_helper,
 		Indexable_To_Postmeta_Helper $indexable_to_postmeta,
 		Options_Helper $options,
 		Sanitization_Helper $sanitization,
@@ -157,6 +167,7 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 
 		$this->indexable_repository  = $indexable_repository;
 		$this->wpdb                  = $wpdb;
+		$this->indexable_helper      = $indexable_helper;
 		$this->indexable_to_postmeta = $indexable_to_postmeta;
 		$this->wpdb_helper           = $wpdb_helper;
 	}
@@ -270,7 +281,7 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 				continue;
 			}
 
-			if ( $this->check_if_default_indexable( $indexable, $check_defaults_fields ) ) {
+			if ( $this->indexable_helper->check_if_default_indexable( $indexable, $check_defaults_fields ) ) {
 				$indexable = $this->map( $indexable, $aioseo_indexable );
 				$indexable->save();
 
@@ -441,24 +452,5 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 		}
 
 		return $aioseo_robots_settings[ $aioseo_key ];
-	}
-
-	/**
-	 * Checks whether the indexable has default values.
-	 *
-	 * @param Indexable $indexable The Yoast indexable that we're checking.
-	 * @param array     $fields    The Yoast indexable fields that we're checking against.
-	 *
-	 * @return bool Whether the indexable has default values.
-	 */
-	protected function check_if_default_indexable( $indexable, $fields ) {
-		foreach ( $fields as $field ) {
-			$is_default = $indexable->check_if_default_field( $field );
-			if ( ! $is_default ) {
-				break;
-			}
-		}
-
-		return $is_default;
 	}
 }

--- a/src/actions/importing/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo-posts-importing-action.php
@@ -299,9 +299,13 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 		$completed = \count( $aioseo_indexables ) === 0;
 		$this->set_completed( $completed );
 
+		// Let's build the list of fields to check their defaults, to identify whether we're gonna import AIOSEO data in the indexable or not.
 		$check_defaults_fields = [];
 		foreach ( $this->aioseo_to_yoast_map as $yoast_mapping ) {
-			$check_defaults_fields[] = $yoast_mapping['yoast_name'];
+			// We don't want to check all the imported fields.
+			if ( ! \in_array( $yoast_mapping['yoast_name'], [ 'open_graph_image', 'twitter_image' ], true ) ) {
+				$check_defaults_fields[] = $yoast_mapping['yoast_name'];
+			}
 		}
 
 		$last_indexed_aioseo_id = 0;

--- a/src/helpers/indexable-helper.php
+++ b/src/helpers/indexable-helper.php
@@ -43,6 +43,53 @@ class Indexable_Helper {
 	protected $indexing_helper;
 
 	/**
+	 * Default values of certain columns.
+	 *
+	 * @var array
+	 */
+	protected $default_values = [
+		'title'                  => [
+			'default_value'   => null,
+		],
+		'description'            => [
+			'default_value'   => null,
+		],
+		'open_graph_title'       => [
+			'default_value'   => null,
+		],
+		'open_graph_description' => [
+			'default_value'   => null,
+		],
+		'twitter_title'          => [
+			'default_value'   => null,
+		],
+		'twitter_description'    => [
+			'default_value'   => null,
+		],
+		'canonical'              => [
+			'default_value'   => null,
+		],
+		'primary_focus_keyword'  => [
+			'default_value'   => null,
+		],
+		'is_robots_noindex'      => [
+			'default_value'   => null,
+		],
+		'is_robots_nofollow'     => [
+			'default_value'   => false,
+		],
+		'is_robots_noarchive'    => [
+			'default_value'   => null,
+		],
+		'is_robots_noimageindex' => [
+			'default_value'   => null,
+		],
+		'is_robots_nosnippet'    => [
+			'default_value'   => null,
+		],
+	];
+
+	/**
 	 * Indexable_Helper constructor.
 	 *
 	 * @param Options_Helper     $options_helper     The options helper.
@@ -158,5 +205,45 @@ class Indexable_Helper {
 	 */
 	public function finish_indexing() {
 		$this->options_helper->set( 'indexables_indexing_completed', true );
+	}
+
+	/**
+	 * Checks whether the indexable has default values in given fields.
+	 *
+	 * @param Indexable $indexable The Yoast indexable that we're checking.
+	 * @param array     $fields    The Yoast indexable fields that we're checking against.
+	 *
+	 * @return bool Whether the indexable has default values.
+	 */
+	public function check_if_default_indexable( $indexable, $fields ) {
+		foreach ( $fields as $field ) {
+			$is_default = $this->check_if_default_field( $indexable, $field );
+			if ( ! $is_default ) {
+				break;
+			}
+		}
+
+		return $is_default;
+	}
+
+	/**
+	 * Checks if an indexable field contains the default value.
+	 *
+	 * @param Indexable $indexable The Yoast indexable that we're checking.
+	 * @param string    $field     The field that we're checking.
+	 *
+	 * @return bool True if default value.
+	 */
+	protected function check_if_default_field( $indexable, $field ) {
+		$defaults = $this->default_values;
+		if ( ! isset( $defaults[ $field ] ) ) {
+			return true;
+		}
+
+		if ( $indexable->$field === $defaults[ $field ]['default_value'] ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/helpers/indexable-helper.php
+++ b/src/helpers/indexable-helper.php
@@ -234,7 +234,7 @@ class Indexable_Helper {
 	 *
 	 * @return bool True if default value.
 	 */
-	protected function check_if_default_field( $indexable, $field ) {
+	public function check_if_default_field( $indexable, $field ) {
 		$defaults = $this->default_values;
 		if ( ! isset( $defaults[ $field ] ) ) {
 			return true;

--- a/src/helpers/indexable-helper.php
+++ b/src/helpers/indexable-helper.php
@@ -237,7 +237,7 @@ class Indexable_Helper {
 	public function check_if_default_field( $indexable, $field ) {
 		$defaults = $this->default_values;
 		if ( ! isset( $defaults[ $field ] ) ) {
-			return true;
+			return false;
 		}
 
 		if ( $indexable->$field === $defaults[ $field ]['default_value'] ) {

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -136,53 +136,6 @@ class Indexable extends Model {
 	];
 
 	/**
-	 * Default values of certain columns.
-	 *
-	 * @var array
-	 */
-	protected $default_values = [
-		'title'                  => [
-			'default_value'   => null,
-		],
-		'description'            => [
-			'default_value'   => null,
-		],
-		'open_graph_title'       => [
-			'default_value'   => null,
-		],
-		'open_graph_description' => [
-			'default_value'   => null,
-		],
-		'twitter_title'          => [
-			'default_value'   => null,
-		],
-		'twitter_description'    => [
-			'default_value'   => null,
-		],
-		'canonical'              => [
-			'default_value'   => null,
-		],
-		'primary_focus_keyword'  => [
-			'default_value'   => null,
-		],
-		'is_robots_noindex'      => [
-			'default_value'   => null,
-		],
-		'is_robots_nofollow'     => [
-			'default_value'   => false,
-		],
-		'is_robots_noarchive'    => [
-			'default_value'   => null,
-		],
-		'is_robots_noimageindex' => [
-			'default_value'   => null,
-		],
-		'is_robots_nosnippet'    => [
-			'default_value'   => null,
-		],
-	];
-
-	/**
 	 * The loaded indexable extensions.
 	 *
 	 * @var Indexable_Extension[]
@@ -259,25 +212,5 @@ class Indexable extends Model {
 		}
 		// We never set the fragment as the fragment is intended to be client-only.
 		$this->permalink = $permalink;
-	}
-
-	/**
-	 * Checks if an indexable field contains the default value.
-	 *
-	 * @param string $field The field that we're checking.
-	 *
-	 * @return bool True if default value.
-	 */
-	public function check_if_default_field( $field ) {
-		$defaults = $this->default_values;
-		if ( ! isset( $defaults[ $field ] ) ) {
-			return true;
-		}
-
-		if ( $this->$field === $defaults[ $field ]['default_value'] ) {
-			return true;
-		}
-
-		return false;
 	}
 }

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -136,6 +136,27 @@ class Indexable extends Model {
 	];
 
 	/**
+	 * Default values of certain columns.
+	 *
+	 * @var array
+	 */
+	protected $default_values = [
+		'title'                  => null,
+		'description'            => null,
+		'open_graph_title'       => null,
+		'open_graph_description' => null,
+		'twitter_title'          => null,
+		'twitter_description'    => null,
+		'canonical'              => null,
+		'primary_focus_keyword'  => null,
+		'is_robots_noindex'      => null,
+		'is_robots_nofollow'     => false,
+		'is_robots_noarchive'    => null,
+		'is_robots_noimageindex' => null,
+		'is_robots_nosnippet'    => null,
+	];
+
+	/**
 	 * The loaded indexable extensions.
 	 *
 	 * @var Indexable_Extension[]
@@ -212,5 +233,21 @@ class Indexable extends Model {
 		}
 		// We never set the fragment as the fragment is intended to be client-only.
 		$this->permalink = $permalink;
+	}
+
+	/**
+	 * Checks if an indexable field contains the default value.
+	 *
+	 * @param string $field The field that we're checking.
+	 *
+	 * @return bool True if default value.
+	 */
+	public function check_if_default_field( $field ) {
+		$defaults = $this->default_values;
+		if ( $this->$field !== $defaults[ $field ] ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -141,19 +141,45 @@ class Indexable extends Model {
 	 * @var array
 	 */
 	protected $default_values = [
-		'title'                  => null,
-		'description'            => null,
-		'open_graph_title'       => null,
-		'open_graph_description' => null,
-		'twitter_title'          => null,
-		'twitter_description'    => null,
-		'canonical'              => null,
-		'primary_focus_keyword'  => null,
-		'is_robots_noindex'      => null,
-		'is_robots_nofollow'     => false,
-		'is_robots_noarchive'    => null,
-		'is_robots_noimageindex' => null,
-		'is_robots_nosnippet'    => null,
+		'title'                  => [
+			'default_value'   => null,
+		],
+		'description'            => [
+			'default_value'   => null,
+		],
+		'open_graph_title'       => [
+			'default_value'   => null,
+		],
+		'open_graph_description' => [
+			'default_value'   => null,
+		],
+		'twitter_title'          => [
+			'default_value'   => null,
+		],
+		'twitter_description'    => [
+			'default_value'   => null,
+		],
+		'canonical'              => [
+			'default_value'   => null,
+		],
+		'primary_focus_keyword'  => [
+			'default_value'   => null,
+		],
+		'is_robots_noindex'      => [
+			'default_value'   => null,
+		],
+		'is_robots_nofollow'     => [
+			'default_value'   => false,
+		],
+		'is_robots_noarchive'    => [
+			'default_value'   => null,
+		],
+		'is_robots_noimageindex' => [
+			'default_value'   => null,
+		],
+		'is_robots_nosnippet'    => [
+			'default_value'   => null,
+		],
 	];
 
 	/**
@@ -244,10 +270,14 @@ class Indexable extends Model {
 	 */
 	public function check_if_default_field( $field ) {
 		$defaults = $this->default_values;
-		if ( $this->$field !== $defaults[ $field ] ) {
-			return false;
+		if ( ! isset( $defaults[ $field ] ) ) {
+			return true;
 		}
 
-		return true;
+		if ( $this->$field === $defaults[ $field ]['default_value'] ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
@@ -313,8 +313,6 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 				'twitter_description',
 				'canonical',
 				'primary_focus_keyword',
-				'open_graph_image',
-				'twitter_image',
 				'is_robots_noindex',
 				'is_robots_nofollow',
 				'is_robots_noarchive',

--- a/tests/unit/builders/indexable-post-builder-test.php
+++ b/tests/unit/builders/indexable-post-builder-test.php
@@ -123,7 +123,16 @@ class Indexable_Post_Builder_Test extends TestCase {
 	 */
 	protected function set_indexable_set_expectations( $indexable_mock, $expectations ) {
 		foreach ( $expectations as $key => $value ) {
-			$indexable_mock->orm->expects( 'set' )->with( $key, $value );
+			$closure = function ( $actual_key, $actual_value ) use ( $key, $value ) {
+				if ( $actual_key === $key && $actual_value === $value ) {
+					return true;
+
+				}
+				else {
+					return false;
+				}
+			};
+			$indexable_mock->orm->expects( 'set' )->once()->withArgs( $closure );
 		}
 	}
 
@@ -204,35 +213,17 @@ class Indexable_Post_Builder_Test extends TestCase {
 
 	/**
 	 * Tests building a basic post indexable from postmeta.
+	 * If this starts failing, the $default_values of the Indexable_Helper maybe need changing too.
 	 *
+	 * @param array $postmeta        The postmeta of the post.
+	 * @param array $expected_result The expected indexable values.
+	 *
+	 * @dataProvider provider_build
 	 * @covers ::build
 	 */
-	public function test_build() {
+	public function test_build( $postmeta, $expected_result ) {
 		Monkey\Functions\expect( 'get_permalink' )->once()->with( 1 )->andReturn( 'https://permalink' );
-		Monkey\Functions\expect( 'get_post_custom' )->with( 1 )->andReturn(
-			[
-				'_yoast_wpseo_focuskw'                        => [ 'focuskeyword' ],
-				'_yoast_wpseo_linkdex'                        => [ '100' ],
-				'_yoast_wpseo_is_cornerstone'                 => [ '1' ],
-				'_yoast_wpseo_meta-robots-noindex'            => [ '1' ],
-				'_yoast_wpseo_meta-robots-adv'                => [ '' ],
-				'_yoast_wpseo_content_score'                  => [ '50' ],
-				'_yoast_wpseo_canonical'                      => [ 'https://canonical' ],
-				'_yoast_wpseo_meta-robots-nofollow'           => [ '1' ],
-				'_yoast_wpseo_title'                          => [ 'title' ],
-				'_yoast_wpseo_metadesc'                       => [ 'description' ],
-				'_yoast_wpseo_opengraph-title'                => [ 'open_graph_title' ],
-				'_yoast_wpseo_opengraph-image'                => [ 'open_graph_image' ],
-				'_yoast_wpseo_opengraph-image-id'             => [ 'open_graph_image_id' ],
-				'_yoast_wpseo_opengraph-description'          => [ 'open_graph_description' ],
-				'_yoast_wpseo_twitter-title'                  => [ 'twitter_title' ],
-				'_yoast_wpseo_twitter-image'                  => [ 'twitter_image' ],
-				'_yoast_wpseo_twitter-description'            => [ 'twitter_description' ],
-				'_yoast_wpseo_schema_page_type'               => [ 'FAQPage' ],
-				'_yoast_wpseo_schema_article_type'            => [ 'NewsArticle' ],
-				'_yoast_wpseo_estimated-reading-time-minutes' => [ '11' ],
-			]
-		);
+		Monkey\Functions\expect( 'get_post_custom' )->with( 1 )->andReturn( $postmeta );
 		Monkey\Functions\expect( 'maybe_unserialize' )->andReturnFirstArg();
 
 		$this->post->expects( 'get_post' )
@@ -262,46 +253,24 @@ class Indexable_Post_Builder_Test extends TestCase {
 			->andReturn( true );
 
 		$indexable_expectations = [
-			'object_id'                      => 1,
+			'object_id'                      => '1',
 			'object_type'                    => 'post',
 			'object_sub_type'                => 'post',
 			'permalink'                      => 'https://permalink',
-			'canonical'                      => 'https://canonical',
-			'title'                          => 'title',
 			'breadcrumb_title'               => 'breadcrumb_title',
-			'description'                    => 'description',
-			'open_graph_title'               => 'open_graph_title',
-			'open_graph_image'               => 'open_graph_image',
-			'open_graph_image_id'            => 'open_graph_image_id',
-			'open_graph_description'         => 'open_graph_description',
-			'twitter_title'                  => 'twitter_title',
-			'twitter_image'                  => 'twitter_image',
-			'twitter_image_id'               => null,
-			'twitter_description'            => 'twitter_description',
-			'is_cornerstone'                 => true,
-			'is_robots_noindex'              => true,
-			'is_robots_nofollow'             => true,
-			'is_robots_noarchive'            => false,
-			'is_robots_noimageindex'         => false,
-			'is_robots_nosnippet'            => false,
-			'primary_focus_keyword'          => 'focuskeyword',
-			'primary_focus_keyword_score'    => 100,
-			'readability_score'              => 50,
 			'number_of_pages'                => null,
-			'is_public'                      => 0,
+			'is_public'                      => '0',
 			'post_status'                    => 'publish',
-			'is_protected'                   => false,
-			'author_id'                      => 1,
-			'post_parent'                    => 0,
-			'has_public_posts'               => false,
-			'blog_id'                        => 1,
-			'schema_page_type'               => 'FAQPage',
-			'schema_article_type'            => 'NewsArticle',
-			'estimated_reading_time_minutes' => 11,
-			'version'                        => 2,
+			'is_protected'                   => '0',
+			'author_id'                      => '1',
+			'post_parent'                    => '0',
+			'has_public_posts'               => null,
+			'blog_id'                        => '1',
+			'version'                        => '2',
 			'object_published_at'            => '1234-12-12 00:00:00',
 			'object_last_modified'           => '1234-12-12 00:00:00',
 		];
+		$indexable_expectations = \array_merge( $indexable_expectations, $expected_result );
 
 		$this->indexable      = Mockery::mock( Indexable::class );
 		$this->indexable->orm = Mockery::mock( ORM::class );
@@ -368,6 +337,87 @@ class Indexable_Post_Builder_Test extends TestCase {
 		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
 
 		$this->instance->build( 1, $this->indexable );
+	}
+
+	/**
+	 * Provides data to the test_build function.
+	 *
+	 * @return array The data to provide.
+	 */
+	public function provider_build() {
+		$postmeta_set_with_missing_data                     = [
+			'_yoast_wpseo_linkdex'                        => [ '100' ],
+			'_yoast_wpseo_is_cornerstone'                 => [ '1' ],
+			'_yoast_wpseo_content_score'                  => [ '50' ],
+			'_yoast_wpseo_opengraph-image'                => [ 'open_graph_image' ],
+			'_yoast_wpseo_opengraph-image-id'             => [ 'open_graph_image_id' ],
+			'_yoast_wpseo_twitter-image'                  => [ 'twitter_image' ],
+			'_yoast_wpseo_schema_page_type'               => [ 'FAQPage' ],
+			'_yoast_wpseo_schema_article_type'            => [ 'NewsArticle' ],
+			'_yoast_wpseo_estimated-reading-time-minutes' => [ '11' ],
+		];
+		$indexable_with_default_values_for_missing_postmeta = [
+			'canonical'                      => null,
+			'title'                          => null,
+			'description'                    => null,
+			'open_graph_title'               => null,
+			'open_graph_image'               => 'open_graph_image',
+			'open_graph_image_id'            => 'open_graph_image_id',
+			'open_graph_description'         => null,
+			'twitter_title'                  => null,
+			'twitter_image'                  => 'twitter_image',
+			'twitter_image_id'               => null,
+			'twitter_description'            => null,
+			'is_cornerstone'                 => '1',
+			'is_robots_noindex'              => null,
+			'is_robots_nofollow'             => '0',
+			'is_robots_noarchive'            => null,
+			'is_robots_noimageindex'         => null,
+			'is_robots_nosnippet'            => null,
+			'primary_focus_keyword'          => null,
+			'primary_focus_keyword_score'    => null,
+			'readability_score'              => '50',
+			'schema_page_type'               => 'FAQPage',
+			'schema_article_type'            => 'NewsArticle',
+			'estimated_reading_time_minutes' => '11',
+		];
+
+		$extra_postmeta                      = [
+			'_yoast_wpseo_focuskw'                        => [ 'focuskeyword' ],
+			'_yoast_wpseo_meta-robots-noindex'            => [ '1' ],
+			'_yoast_wpseo_meta-robots-adv'                => [ '' ],
+			'_yoast_wpseo_canonical'                      => [ 'https://canonical' ],
+			'_yoast_wpseo_meta-robots-nofollow'           => [ '1' ],
+			'_yoast_wpseo_title'                          => [ 'title' ],
+			'_yoast_wpseo_metadesc'                       => [ 'description' ],
+			'_yoast_wpseo_opengraph-title'                => [ 'open_graph_title' ],
+			'_yoast_wpseo_opengraph-description'          => [ 'open_graph_description' ],
+			'_yoast_wpseo_twitter-title'                  => [ 'twitter_title' ],
+			'_yoast_wpseo_twitter-description'            => [ 'twitter_description' ],
+		];
+		$full_postmeta_set                   = \array_merge( $postmeta_set_with_missing_data, $extra_postmeta );
+		$indexable_values_for_extra_postmeta = [
+			'canonical'                      => 'https://canonical',
+			'title'                          => 'title',
+			'description'                    => 'description',
+			'open_graph_title'               => 'open_graph_title',
+			'open_graph_description'         => 'open_graph_description',
+			'twitter_title'                  => 'twitter_title',
+			'twitter_description'            => 'twitter_description',
+			'is_robots_noindex'              => '1',
+			'is_robots_nofollow'             => '1',
+			'is_robots_noarchive'            => null,
+			'is_robots_noimageindex'         => null,
+			'is_robots_nosnippet'            => null,
+			'primary_focus_keyword'          => 'focuskeyword',
+			'primary_focus_keyword_score'    => '100',
+		];
+		$indexable_with_full_postmeta_set    = \array_merge( $indexable_with_default_values_for_missing_postmeta, $indexable_values_for_extra_postmeta );
+
+		return [
+			[ $postmeta_set_with_missing_data, $indexable_with_default_values_for_missing_postmeta ],
+			[ $full_postmeta_set, $indexable_with_full_postmeta_set ],
+		];
 	}
 
 	/**

--- a/tests/unit/helpers/indexable-helper-test.php
+++ b/tests/unit/helpers/indexable-helper-test.php
@@ -199,4 +199,130 @@ class Indexable_Helper_Test extends TestCase {
 			[ null, false ],
 		];
 	}
+
+	/**
+	 * Tests check_if_default_indexable method.
+	 *
+	 * @dataProvider provider_check_if_default_indexable
+	 * @covers ::check_if_default_indexable
+	 *
+	 * @param array $indexable_fields The fields of the indexable that we're checking.
+	 * @param bool  $expected_result  Either true or false.
+	 */
+	public function test_check_if_default_indexable( $indexable_fields, $expected_result ) {
+		$indexable = Mockery::mock( Indexable_Mock::class );
+
+		foreach ( $indexable_fields as $field ) {
+			$field_name = $field['field_name'];
+
+			$indexable->$field_name = $field['field_value'];
+
+		}
+
+		$fields_to_check = [
+			'title',
+			'description',
+		];
+
+		$result = $this->instance->check_if_default_indexable( $indexable, $fields_to_check );
+		$this->assertSame( $expected_result, $result );
+	}
+
+	/**
+	 * DataProvider for test_check_if_default_indexable.
+	 *
+	 * @return array[]
+	 */
+	public function provider_check_if_default_indexable() {
+		$all_default_fields     = [
+			[
+				'field_name'  => 'title',
+				'field_value' => null,
+			],
+			[
+				'field_name'  => 'description',
+				'field_value' => null,
+			],
+		];
+		$one_non_default_field  = [
+			[
+				'field_name'  => 'title',
+				'field_value' => null,
+			],
+			[
+				'field_name'  => 'description',
+				'field_value' => 'not_null',
+			],
+		];
+		$all_non_default_fields = [
+			[
+				'field_name'  => 'title',
+				'field_value' => 'not_null',
+			],
+			[
+				'field_name'  => 'description',
+				'field_value' => 'not_null',
+			],
+		];
+
+		return [
+			[ $all_default_fields, true ],
+			[ $one_non_default_field, false ],
+			[ $all_non_default_fields, false ],
+		];
+	}
+
+	/**
+	 * Tests check_if_default_field method.
+	 *
+	 * @dataProvider provider_check_if_default_field
+	 * @covers ::check_if_default_field
+	 *
+	 * @param string $field_name      The indexable field we're checking.
+	 * @param string $field_value     The indexable field's value.
+	 * @param bool   $expected_result Either true or false.
+	 */
+	public function test_check_if_default_field( $field_name, $field_value, $expected_result ) {
+		$indexable              = Mockery::mock( Indexable_Mock::class );
+		$indexable->$field_name = $field_value;
+
+		$result = $this->instance->check_if_default_field( $indexable, $field_name );
+		$this->assertSame( $expected_result, $result );
+	}
+
+	/**
+	 * DataProvider for test_check_if_default_field.
+	 *
+	 * @return array[]
+	 */
+	public function provider_check_if_default_field() {
+		return [
+			[ 'title', null, true ],
+			[ 'title', 'not null', false ],
+			[ 'description', null, true ],
+			[ 'description', 'not null', false ],
+			[ 'open_graph_title', null, true ],
+			[ 'open_graph_title', 'not null', false ],
+			[ 'open_graph_description', null, true ],
+			[ 'open_graph_description', 'not null', false ],
+			[ 'twitter_title', null, true ],
+			[ 'twitter_title', 'not null', false ],
+			[ 'twitter_description', null, true ],
+			[ 'twitter_description', 'not null', false ],
+			[ 'canonical', null, true ],
+			[ 'canonical', 'not null', false ],
+			[ 'primary_focus_keyword', null, true ],
+			[ 'primary_focus_keyword', 'not null', false ],
+			[ 'is_robots_noindex', null, true ],
+			[ 'is_robots_noindex', 'not null', false ],
+			[ 'is_robots_nofollow', false, true ],
+			[ 'is_robots_nofollow', 'not false', false ],
+			[ 'is_robots_noarchive', null, true ],
+			[ 'is_robots_noarchive', 'not null', false ],
+			[ 'is_robots_noimageindex', null, true ],
+			[ 'is_robots_noimageindex', 'not null', false ],
+			[ 'is_robots_nosnippet', null, true ],
+			[ 'is_robots_nosnippet', 'not null', false ],
+		];
+	}
 }

--- a/tests/unit/helpers/indexable-helper-test.php
+++ b/tests/unit/helpers/indexable-helper-test.php
@@ -323,7 +323,7 @@ class Indexable_Helper_Test extends TestCase {
 			[ 'is_robots_noimageindex', 'not null', false ],
 			[ 'is_robots_nosnippet', null, true ],
 			[ 'is_robots_nosnippet', 'not null', false ],
-			[ 'schema_article_type', 'irrelevant', true ], // Checking for fields that don't have an explicit default will always return true.
+			[ 'schema_article_type', 'irrelevant', false ], // Checking for fields that don't have an explicit default will always return false.
 		];
 	}
 }

--- a/tests/unit/helpers/indexable-helper-test.php
+++ b/tests/unit/helpers/indexable-helper-test.php
@@ -323,6 +323,7 @@ class Indexable_Helper_Test extends TestCase {
 			[ 'is_robots_noimageindex', 'not null', false ],
 			[ 'is_robots_nosnippet', null, true ],
 			[ 'is_robots_nosnippet', 'not null', false ],
+			[ 'schema_article_type', 'irrelevant', true ], // Checking for fields that don't have an explicit default will always return true.
 		];
 	}
 }

--- a/tests/unit/services/importing/importable-detector-test.php
+++ b/tests/unit/services/importing/importable-detector-test.php
@@ -6,6 +6,7 @@ use Mockery;
 use Yoast\WP\SEO\Actions\Importing\Aioseo_Posts_Importing_Action;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Meta_Helper;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Sanitization_Helper;
@@ -80,6 +81,13 @@ class Importable_Detector_Test extends TestCase {
 	protected $indexable_to_postmeta;
 
 	/**
+	 * The mocked indexable helper.
+	 *
+	 * @var Mockery\MockInterface|Indexable_Helper
+	 */
+	protected $indexable_helper;
+
+	/**
 	 * The mocked options helper.
 	 *
 	 * @var Mockery\MockInterface|Options_Helper
@@ -137,6 +145,7 @@ class Importable_Detector_Test extends TestCase {
 		$this->indexable_repository   = Mockery::mock( Indexable_Repository::class );
 		$this->wpdb                   = Mockery::mock( 'wpdb' );
 		$this->meta                   = Mockery::mock( Meta_Helper::class );
+		$this->indexable_helper       = Mockery::mock( Indexable_Helper::class );
 		$this->indexable_to_postmeta  = Mockery::mock( Indexable_To_Postmeta_Helper::class, [ $this->meta ] );
 		$this->options                = Mockery::mock( Options_Helper::class );
 		$this->image                  = Mockery::mock( Image_Helper::class );
@@ -152,6 +161,7 @@ class Importable_Detector_Test extends TestCase {
 			[
 				$this->indexable_repository,
 				$this->wpdb,
+				$this->indexable_helper,
 				$this->indexable_to_postmeta,
 				$this->options,
 				$this->image,

--- a/tests/unit/services/importing/importer-action-filter-trait-test.php
+++ b/tests/unit/services/importing/importer-action-filter-trait-test.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Exception;
 use Yoast\WP\SEO\Actions\Importing\Aioseo_Posts_Importing_Action;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Meta_Helper;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Sanitization_Helper;
@@ -79,6 +80,13 @@ class Importer_Action_Filter_Trait_Test extends TestCase {
 	protected $indexable_to_postmeta;
 
 	/**
+	 * The mocked indexable helper.
+	 *
+	 * @var Mockery\MockInterface|Indexable_Helper
+	 */
+	protected $indexable_helper;
+
+	/**
 	 * The mocked options helper.
 	 *
 	 * @var Mockery\MockInterface|Options_Helper
@@ -136,6 +144,7 @@ class Importer_Action_Filter_Trait_Test extends TestCase {
 		$this->indexable_repository   = Mockery::mock( Indexable_Repository::class );
 		$this->wpdb                   = Mockery::mock( 'wpdb' );
 		$this->meta                   = Mockery::mock( Meta_Helper::class );
+		$this->indexable_helper       = Mockery::mock( Indexable_Helper::class );
 		$this->indexable_to_postmeta  = Mockery::mock( Indexable_To_Postmeta_Helper::class, [ $this->meta ] );
 		$this->options                = Mockery::mock( Options_Helper::class );
 		$this->image                  = Mockery::mock( Image_Helper::class );
@@ -151,6 +160,7 @@ class Importer_Action_Filter_Trait_Test extends TestCase {
 			[
 				$this->indexable_repository,
 				$this->wpdb,
+				$this->indexable_helper,
 				$this->indexable_to_postmeta,
 				$this->options,
 				$this->image,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to skip importing post data from AIOSEO when there's already Yoast data in even 1 meta setting for that post
* The settings we check if there are already Yoast data are **Meta Title**, **Meta Description**, **OG Title**, **OG Description**, **Twitter Title**, **Twitter Description**, **Canonical URL**, **Focus Keyphrase** and **Robots Settings**

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Checks if the Yoast indexable contains default values before importing AISOEO data to avoid overwriting Yoast data

## Relevant technical choices:

* We added a unit test in the Post Indexable Builder that checks for the current default values of the fields we check. If/when one of those default values changes in the future, that unit test will start failing 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* With AIOSEO activated and Yoast deactivated, create Post1, Post2, Post3
* Activate Yoast.
* The implemented logic checks if there's non-default values in the **Meta Title**, **Meta Description**, **OG Title**, **OG Description**, **Twitter Title**, **Twitter Description**, **Canonical URL**, **Focus Keyphrase** and **Robots Settings** of each post and if there's even one non-default value there, it doesn't import any AIOSEO data for that post.
* For that reason, refresh the Post2 edit page and put a value in either one of those settings and Update.
* Do the same with Post3 but this time Update without adding a value in those settings (so they keep their default ones)
* Go to Tools->Import/Export and Import the AIOSEO pack
* As per the above, the AIOSEO post data for Post1 and Post3 should be imported to the Yoast data for those post but they won't be imported for Post2
* Refresh the edit pages for all posts and confirm the above. Also do the same with the frontend of those posts.

**Notes:**
* The above are true regardless whether you have run an SEO optimization before import or not
* Without the feature flag, you won't be able to perform the Import as it won't be available in the Tools->Import/Export page

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* AIOSEO post import

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
