### PR TITLE
Fix the fallback value when there's no aioseo option to avoid PHP war…

### DIFF
--- a/src/actions/importing/abstract-aioseo-settings-importing-action.php
+++ b/src/actions/importing/abstract-aioseo-settings-importing-action.php
@@ -181,7 +181,7 @@ abstract class Abstract_Aioseo_Settings_Importing_Action extends Abstract_Import
 	 * @return array The (maybe chunked) unimported AiOSEO settings to import.
 	 */
 	protected function query( $limit = null ) {
-		$aioseo_settings = \json_decode( \get_option( $this->get_source_option_name(), [] ), true );
+		$aioseo_settings = \json_decode( \get_option( $this->get_source_option_name(), '' ), true );
 
 		if ( empty( $aioseo_settings ) || ! isset( $aioseo_settings['searchAppearance'][ $this->settings_tab ] ) ) {
 			return [];

--- a/src/services/importing/aioseo-robots-provider-service.php
+++ b/src/services/importing/aioseo-robots-provider-service.php
@@ -17,7 +17,7 @@ class Aioseo_Robots_Provider_Service {
 	 * @return bool Whether global robot settings enable or not the specific setting.
 	 */
 	public function get_global_robot_settings( $setting_name ) {
-		$aioseo_settings = \json_decode( \get_option( 'aioseo_options', [] ), true );
+		$aioseo_settings = \json_decode( \get_option( 'aioseo_options', '' ), true );
 		if ( empty( $aioseo_settings ) || ! isset( $aioseo_settings['searchAppearance']['advanced']['globalRobotsMeta'] ) ) {
 			return false;
 		}
@@ -38,7 +38,11 @@ class Aioseo_Robots_Provider_Service {
 	 * @return bool The robot setting.
 	 */
 	public function get_subtype_robot_setting( $mapping ) {
-		$aioseo_settings = \json_decode( \get_option( $mapping['option_name'], [] ), true );
+		$aioseo_settings = \json_decode( \get_option( $mapping['option_name'], '' ), true );
+
+		if ( ! isset( $aioseo_settings['searchAppearance'][ $mapping['type'] ][ $mapping['subtype'] ]['advanced']['robotsMeta'][ $mapping['robot_type'] ] ) ) {
+			return false;
+		}
 
 		return $aioseo_settings['searchAppearance'][ $mapping['type'] ][ $mapping['subtype'] ]['advanced']['robotsMeta'][ $mapping['robot_type'] ];
 	}

--- a/src/services/importing/aioseo-robots-transformer-service.php
+++ b/src/services/importing/aioseo-robots-transformer-service.php
@@ -39,7 +39,7 @@ class Aioseo_Robots_Transformer_Service {
 	 * @return bool The transformed robot setting.
 	 */
 	public function transform_robot_setting( $setting_name, $setting_value, $mapping ) {
-		$aioseo_settings = \json_decode( \get_option( $mapping['option_name'], [] ), true );
+		$aioseo_settings = \json_decode( \get_option( $mapping['option_name'], '' ), true );
 
 		// Let's check first if it defers to global robot settings.
 		if ( empty( $aioseo_settings ) || ! isset( $aioseo_settings['searchAppearance'][ $mapping['type'] ][ $mapping['subtype'] ]['advanced']['robotsMeta']['default'] ) ) {

--- a/tests/unit/actions/importing/aioseo-custom-archive-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-custom-archive-settings-importing-action-test.php
@@ -162,6 +162,7 @@ class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCase {
 	public function test_query( $query_results, $expected ) {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
+			->with( 'aioseo_options_dynamic', '' )
 			->andReturn( $query_results );
 
 		$this->mock_instance->shouldReceive( 'get_unimported_chunk' )

--- a/tests/unit/actions/importing/aioseo-default-archive-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-default-archive-settings-importing-action-test.php
@@ -165,6 +165,7 @@ class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCase {
 	public function test_query( $query_results, $expected ) {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
+			->with( 'aioseo_options', '' )
 			->andReturn( $query_results );
 
 		$this->mock_instance->shouldReceive( 'get_unimported_chunk' )

--- a/tests/unit/actions/importing/aioseo-general-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-general-settings-importing-action-test.php
@@ -145,6 +145,7 @@ class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	public function test_query( $query_results, $expected ) {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
+			->with( 'aioseo_options', '' )
 			->andReturn( $query_results );
 
 		$this->mock_instance->shouldReceive( 'get_unimported_chunk' )

--- a/tests/unit/actions/importing/aioseo-posttype-defaults-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posttype-defaults-settings-importing-action-test.php
@@ -179,6 +179,7 @@ class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends TestCase {
 	public function test_query( $query_results, $expected ) {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
+			->with( 'aioseo_options_dynamic', '' )
 			->andReturn( $query_results );
 
 		$this->mock_instance->shouldReceive( 'get_unimported_chunk' )

--- a/tests/unit/actions/importing/aioseo-taxonomy-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-taxonomy-settings-importing-action-test.php
@@ -165,6 +165,7 @@ class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 	public function test_query( $query_results, $expected ) {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
+			->with( 'aioseo_options_dynamic', '' )
 			->andReturn( $query_results );
 
 		$this->mock_instance->shouldReceive( 'get_unimported_chunk' )

--- a/tests/unit/services/importing/aioseo-robots-provider-service-test.php
+++ b/tests/unit/services/importing/aioseo-robots-provider-service-test.php
@@ -44,7 +44,7 @@ class Aioseo_Robots_Provider_Service_Test extends TestCase {
 	public function test_get_global_robot_settings( $aioseo_options, $setting, $expected_result ) {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
-			->with( 'aioseo_options', [] )
+			->with( 'aioseo_options', '' )
 			->andReturn( $aioseo_options );
 
 		$actual_result = $this->aioseo_robots_provider_service->get_global_robot_settings( $setting );
@@ -64,7 +64,7 @@ class Aioseo_Robots_Provider_Service_Test extends TestCase {
 	public function test_get_subtype_robot_setting( $aioseo_options, $mapping, $expected_result ) {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
-			->with( $mapping['option_name'], [] )
+			->with( $mapping['option_name'], '' )
 			->andReturn( $aioseo_options );
 
 		$actual_result = $this->aioseo_robots_provider_service->get_subtype_robot_setting( $mapping );
@@ -124,7 +124,7 @@ class Aioseo_Robots_Provider_Service_Test extends TestCase {
 	 * @return string
 	 */
 	public function provider_get_global_robot_settings() {
-		$empty_settings = [];
+		$empty_settings = '';
 
 		$no_global_robots_meta = [
 			'searchAppearance' => [

--- a/tests/unit/services/importing/aioseo-robots-transformer-service-test.php
+++ b/tests/unit/services/importing/aioseo-robots-transformer-service-test.php
@@ -57,7 +57,7 @@ class Aioseo_Robots_Transformer_Service_Test extends TestCase {
 	public function test_transform_robot_setting( $aioseo_options, $setting_name, $setting_value, $mapping, $get_global_robot_settings_times, $global_setting_value, $expected_result ) {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
-			->with( $mapping['option_name'], [] )
+			->with( $mapping['option_name'], '' )
 			->andReturn( $aioseo_options );
 
 		$this->robots_provider->expects( 'get_global_robot_settings' )
@@ -81,7 +81,7 @@ class Aioseo_Robots_Transformer_Service_Test extends TestCase {
 			'subtype'     => 'subtype',
 		];
 
-		$empty_settings = [];
+		$empty_settings = '';
 
 		$global_robots_meta = [
 			'searchAppearance' => [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to not throw PHP warning/notices when looking for AIOSEO db settings that don't exist
* We also want to apply the correct default values in the Yoast data when that happens

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where PHP warnings would be thrown if the AIOSEO settings would be partial due to lack of user configuration

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
Notes:
* Without the feature flag, you won't be able to perform the Import as it won't be available in the Tools->Import/Export page

* Install AIOSEO for the first time (if you don't have a cleaned db, you can follow [this article](https://aioseo.com/docs/how-to-remove-all-settings-and-data-when-you-uninstall-all-in-one-seo) on how to get your AIOSEO data cleaned out)
* Go only to create a post (do not go over to AIOSEO's search appearance settings)
* Activate Yoast and go to Tools->Import/Export page
* Perform the import

Without this PR:
* You would get the following entries (maybe multiple times) in your debug.log:
```
PHP Warning:  json_decode() expects parameter 1 to be string, array given in /var/www/html/wp-content/plugins/wordpress-seo/src/actions/importing/abstract-aioseo-settings-importing-action.php on line 184
PHP Warning:  json_decode() expects parameter 1 to be string, array given in /var/www/html/wp-content/plugins/wordpress-seo/src/services/importing/aioseo-robots-provider-service.php on line 41
PHP Notice:  Trying to access array offset on value of type null in /var/www/html/wp-content/plugins/wordpress-seo/src/services/importing/aioseo-robots-provider-service.php on line 43
PHP Warning:  json_decode() expects parameter 1 to be string, array given in /var/www/html/wp-content/plugins/wordpress-seo/src/services/importing/aioseo-robots-transformer-service.php on line 42
``` 
With this PR:
* You would get no such entries in the debug.log
* You would also see that the post that got imported has the same Yoast meta tags as AIOSEO does 

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* AIOSEO Post and settings import

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
