### PR TITLE
P1-1196 create regex validator

### DIFF
--- a/src/exceptions/validation/missing-settings-key-exception.php
+++ b/src/exceptions/validation/missing-settings-key-exception.php
@@ -18,7 +18,7 @@ class Missing_Settings_Key_Exception extends Abstract_Validation_Exception {
 		parent::__construct(
 			\sprintf(
 			/* translators: %s expands to the missing settings key. */
-				\esc_html__( 'The validation failed to missing settings %s.', 'wordpress-seo' ),
+				\esc_html__( 'The validation failed because configuration is missing: %s.', 'wordpress-seo' ),
 				'<strong>' . \esc_html( $key ) . '</strong>'
 			)
 		);

--- a/src/exceptions/validation/missing-settings-key-exception.php
+++ b/src/exceptions/validation/missing-settings-key-exception.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Validation;
+
+/**
+ * Missing settings key validation exception class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Exception is not part of the name.
+ */
+class Missing_Settings_Key_Exception extends Abstract_Validation_Exception {
+
+	/**
+	 * Constructs a missing settings key validation exception instance.
+	 *
+	 * @param string $key The missing settings key.
+	 */
+	public function __construct( $key ) {
+		parent::__construct(
+			\sprintf(
+			/* translators: %s expands to the missing settings key. */
+				\esc_html__( 'The validation failed to missing settings %s.', 'wordpress-seo' ),
+				'<strong>' . \esc_html( $key ) . '</strong>'
+			)
+		);
+	}
+}

--- a/src/exceptions/validation/no-regex-groups-exception.php
+++ b/src/exceptions/validation/no-regex-groups-exception.php
@@ -19,7 +19,7 @@ class No_Regex_Groups_Exception extends Abstract_Validation_Exception {
 		parent::__construct(
 			\sprintf(
 			/* translators: %1$s expands to the user input. %2$s expands to a regular expression pattern. */
-				\esc_html__( 'The value does not contain any of the groups in the pattern %s.', 'wordpress-seo' ),
+				\esc_html__( 'The value %1$s does not contain any of the groups in the pattern %2$s.', 'wordpress-seo' ),
 				'<strong>' . \esc_html( $value ) . '</strong>',
 				'<strong>' . \esc_html( $pattern ) . '</strong>'
 			)

--- a/src/exceptions/validation/no-regex-groups-exception.php
+++ b/src/exceptions/validation/no-regex-groups-exception.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Validation;
+
+/**
+ * No regex groups validation exception class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Exception is not part of the name.
+ */
+class No_Regex_Groups_Exception extends Abstract_Validation_Exception {
+
+	/**
+	 * Constructs a no regex group validation exception instance.
+	 *
+	 * @param string $pattern The regex pattern.
+	 */
+	public function __construct( $pattern ) {
+		parent::__construct(
+			\sprintf(
+			/* translators: %s expands to a regular expression pattern. */
+				\esc_html__( 'The value does not contain any of the groups in the pattern %s.', 'wordpress-seo' ),
+				'<strong>' . \esc_html( $pattern ) . '</strong>'
+			)
+		);
+	}
+}

--- a/src/exceptions/validation/no-regex-groups-exception.php
+++ b/src/exceptions/validation/no-regex-groups-exception.php
@@ -12,13 +12,15 @@ class No_Regex_Groups_Exception extends Abstract_Validation_Exception {
 	/**
 	 * Constructs a no regex group validation exception instance.
 	 *
+	 * @param string $value   The input value.
 	 * @param string $pattern The regex pattern.
 	 */
-	public function __construct( $pattern ) {
+	public function __construct( $value, $pattern ) {
 		parent::__construct(
 			\sprintf(
-			/* translators: %s expands to a regular expression pattern. */
+			/* translators: %1$s expands to the user input. %2$s expands to a regular expression pattern. */
 				\esc_html__( 'The value does not contain any of the groups in the pattern %s.', 'wordpress-seo' ),
+				'<strong>' . \esc_html( $value ) . '</strong>',
 				'<strong>' . \esc_html( $pattern ) . '</strong>'
 			)
 		);

--- a/src/exceptions/validation/no-regex-match-exception.php
+++ b/src/exceptions/validation/no-regex-match-exception.php
@@ -12,13 +12,15 @@ class No_Regex_Match_Exception extends Abstract_Validation_Exception {
 	/**
 	 * Constructs a no regex match validation exception instance.
 	 *
+	 * @param string $value   The input value.
 	 * @param string $pattern The regex pattern.
 	 */
-	public function __construct( $pattern ) {
+	public function __construct( $value, $pattern ) {
 		parent::__construct(
 			\sprintf(
-			/* translators: %s expands to a regular expression pattern. */
-				\esc_html__( 'The value does not conform to the pattern %s.', 'wordpress-seo' ),
+			/* translators: %1$s expands to the user input. %2$s expands to a regular expression pattern. */
+				\esc_html__( '%1$s does not conform to the pattern %2$s.', 'wordpress-seo' ),
+				'<strong>' . \esc_html( $value ) . '</strong>',
 				'<strong>' . \esc_html( $pattern ) . '</strong>'
 			)
 		);

--- a/src/exceptions/validation/no-regex-match-exception.php
+++ b/src/exceptions/validation/no-regex-match-exception.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Validation;
+
+/**
+ * No regex match validation exception class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Exception is not part of the name.
+ */
+class No_Regex_Match_Exception extends Abstract_Validation_Exception {
+
+	/**
+	 * Constructs a no regex match validation exception instance.
+	 *
+	 * @param string $pattern The regex pattern.
+	 */
+	public function __construct( $pattern ) {
+		parent::__construct(
+			\sprintf(
+			/* translators: %s expands to a regular expression pattern. */
+				\esc_html__( 'The value does not conform to the pattern %s.', 'wordpress-seo' ),
+				'<strong>' . \esc_html( $pattern ) . '</strong>'
+			)
+		);
+	}
+}

--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -73,7 +73,13 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'pinterestverify'                             => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [
+				'empty_string',
+				'regex' => [
+					'pattern' => '/(^[A-Fa-f0-9_-]+$)|content=([\'"])?([A-Fa-f0-9_-]+)(?:\2|[ \/>])/',
+					'groups'  => [ 1, 3 ],
+				],
+			],
 		],
 		'twitter'                                     => [
 			'default' => '',
@@ -511,7 +517,13 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'baiduverify'                                 => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [
+				'empty_string',
+				'regex' => [
+					'pattern' => '/(^[A-Za-z0-9_-]+$)|content=([\'"])?([A-Za-z0-9_-]+)(?:\2|[ \/>])/',
+					'groups'  => [ 1, 3 ],
+				],
+			],
 		],
 		'category_base_url'                           => [
 			'default' => '',
@@ -583,7 +595,13 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'googleverify'                                => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [
+				'empty_string',
+				'regex' => [
+					'pattern' => '/(^[A-Za-z0-9_-]+$)|content=([\'"])?([A-Za-z0-9_-]+)(?:\2|[ \/>])/',
+					'groups'  => [ 1, 3 ],
+				],
+			],
 		],
 		'has_multiple_authors'                        => [
 			'default' => '',
@@ -635,7 +653,13 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'msverify'                                    => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [
+				'empty_string',
+				'regex' => [
+					'pattern' => '/(^[A-Fa-f0-9_-]+$)|content=([\'"])?([A-Fa-f0-9_-]+)(?:\2|[ \/>])/',
+					'groups'  => [ 1, 3 ],
+				],
+			],
 		],
 		'myyoast-oauth'                               => [
 			'default' => '',
@@ -711,7 +735,13 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'yandexverify'                                => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [
+				'empty_string',
+				'regex' => [
+					'pattern' => '/(^[A-Fa-f0-9_-]+$)|content=([\'"])?([A-Fa-f0-9_-]+)(?:\2|[ \/>])/',
+					'groups'  => [ 1, 3 ],
+				],
+			],
 		],
 		'zapier_api_key'                              => [
 			'default' => '',

--- a/src/validators/regex-validator.php
+++ b/src/validators/regex-validator.php
@@ -38,7 +38,7 @@ class Regex_Validator extends String_Validator {
 	 * @throws No_Regex_Match_Exception When the value does not match a regex.
 	 * @throws No_Regex_Groups_Exception When the matches do not contain any of the specified groups.
 	 *
-	 * @return mixed The valid value.
+	 * @return string The valid value.
 	 */
 	public function validate( $value, array $settings = null ) {
 		$string = parent::validate( $value );
@@ -48,7 +48,7 @@ class Regex_Validator extends String_Validator {
 		}
 
 		if ( \preg_match( $settings[ self::PATTERN_KEY ], $string, $matches ) !== 1 ) {
-			throw new No_Regex_Match_Exception( $settings[ self::PATTERN_KEY ] );
+			throw new No_Regex_Match_Exception( $string, $settings[ self::PATTERN_KEY ] );
 		}
 
 		// If no groups are specified, this is the match.
@@ -64,7 +64,7 @@ class Regex_Validator extends String_Validator {
 			}
 		}
 
-		throw new No_Regex_Groups_Exception( $settings[ self::PATTERN_KEY ] );
+		throw new No_Regex_Groups_Exception( $string, $settings[ self::PATTERN_KEY ] );
 	}
 
 	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber

--- a/src/validators/regex-validator.php
+++ b/src/validators/regex-validator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Missing_Settings_Key_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\No_Regex_Match_Exception;
+
+/**
+ * The regex validator class.
+ */
+class Regex_Validator implements Validator_Interface {
+
+	/**
+	 * The setting' pattern key.
+	 *
+	 * @var string
+	 */
+	const PATTERN_KEY = 'pattern';
+
+	/**
+	 * Validates if a value matches a regex.
+	 *
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
+	 *
+	 * @throws Missing_Settings_Key_Exception When settings are missing.
+	 * @throws No_Regex_Match_Exception When the value does not match a regex.
+	 *
+	 * @return mixed The valid value.
+	 */
+	public function validate( $value, array $settings = null ) {
+		if ( $settings === null || ! \array_key_exists( self::PATTERN_KEY, $settings ) ) {
+			throw new Missing_Settings_Key_Exception( self::PATTERN_KEY );
+		}
+
+		if ( \preg_match( $settings[ self::PATTERN_KEY ], $value ) !== 1 ) {
+			throw new No_Regex_Match_Exception( $settings[ self::PATTERN_KEY ] );
+		}
+
+		return $value;
+	}
+}

--- a/src/validators/regex-validator.php
+++ b/src/validators/regex-validator.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Exceptions\Validation\No_Regex_Match_Exception;
 /**
  * The regex validator class.
  */
-class Regex_Validator implements Validator_Interface {
+class Regex_Validator extends String_Validator {
 
 	/**
 	 * The setting' pattern key.
@@ -25,12 +25,15 @@ class Regex_Validator implements Validator_Interface {
 	 */
 	const GROUPS_KEY = 'groups';
 
+	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- Reason: The parent validate can throw too.
+
 	/**
 	 * Validates if a value matches a regex.
 	 *
 	 * @param mixed $value    The value to validate.
 	 * @param array $settings Optional settings.
 	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception When the value is not a string.
 	 * @throws Missing_Settings_Key_Exception When settings are missing.
 	 * @throws No_Regex_Match_Exception When the value does not match a regex.
 	 * @throws No_Regex_Groups_Exception When the matches do not contain any of the specified groups.
@@ -38,17 +41,19 @@ class Regex_Validator implements Validator_Interface {
 	 * @return mixed The valid value.
 	 */
 	public function validate( $value, array $settings = null ) {
+		$string = parent::validate( $value );
+
 		if ( $settings === null || ! \array_key_exists( self::PATTERN_KEY, $settings ) ) {
 			throw new Missing_Settings_Key_Exception( self::PATTERN_KEY );
 		}
 
-		if ( \preg_match( $settings[ self::PATTERN_KEY ], $value, $matches ) !== 1 ) {
+		if ( \preg_match( $settings[ self::PATTERN_KEY ], $string, $matches ) !== 1 ) {
 			throw new No_Regex_Match_Exception( $settings[ self::PATTERN_KEY ] );
 		}
 
 		// If no groups are specified, this is the match.
 		if ( ! \array_key_exists( self::GROUPS_KEY, $settings ) ) {
-			return $value;
+			return $string;
 		}
 
 		// If a group is specified, try to change the value to the matched group.
@@ -61,4 +66,6 @@ class Regex_Validator implements Validator_Interface {
 
 		throw new No_Regex_Groups_Exception( $settings[ self::PATTERN_KEY ] );
 	}
+
+	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
 }

--- a/tests/unit/validators/regex-validator-test.php
+++ b/tests/unit/validators/regex-validator-test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Validators;
 
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception;
 use Yoast\WP\SEO\Exceptions\Validation\Missing_Settings_Key_Exception;
 use Yoast\WP\SEO\Exceptions\Validation\No_Regex_Groups_Exception;
 use Yoast\WP\SEO\Exceptions\Validation\No_Regex_Match_Exception;
@@ -133,6 +134,12 @@ class Regex_Validator_Test extends TestCase {
 				],
 				'expected'  => false,
 				'exception' => No_Regex_Groups_Exception::class,
+			],
+			'integer'                    => [
+				'value'     => 123,
+				'settings'  => [ 'pattern' => '/\d+/' ],
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
 			],
 		];
 	}

--- a/tests/unit/validators/regex-validator-test.php
+++ b/tests/unit/validators/regex-validator-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Validators;
 
 use Yoast\WP\SEO\Exceptions\Validation\Missing_Settings_Key_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\No_Regex_Groups_Exception;
 use Yoast\WP\SEO\Exceptions\Validation\No_Regex_Match_Exception;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Validators\Regex_Validator;
@@ -99,6 +100,39 @@ class Regex_Validator_Test extends TestCase {
 				'settings'  => null,
 				'expected'  => false,
 				'exception' => Missing_Settings_Key_Exception::class,
+			],
+			'group'                      => [
+				'value'    => '<meta name="site-verification" content="vIeAJm5qLB3z8izGaL6bKmNEE1YkE8c9y7iRko7AEk" />',
+				'settings' => [
+					'pattern' => '/content=([\'"])?([^\'"> ]+)(?:\1|[ \/>])/',
+					'groups'  => [ 2 ],
+				],
+				'expected' => 'vIeAJm5qLB3z8izGaL6bKmNEE1YkE8c9y7iRko7AEk',
+			],
+			'groups_match_1'             => [
+				'value'    => 'abcdef-ABCDEF_0123456789',
+				'settings' => [
+					'pattern' => '/(^[A-Fa-f0-9_-]+$)|content=([\'"])?([A-Fa-f0-9_-]+)(?:\2|[ \/>])/',
+					'groups'  => [ 1, 3 ],
+				],
+				'expected' => 'abcdef-ABCDEF_0123456789',
+			],
+			'groups_match_3'             => [
+				'value'    => '<meta name="site-verification" content="abcdef-ABCDEF_0123456789" />',
+				'settings' => [
+					'pattern' => '/(^[A-Fa-f0-9_-]+$)|content=([\'"])?([A-Fa-f0-9_-]+)(?:\2|[ \/>])/',
+					'groups'  => [ 1, 3 ],
+				],
+				'expected' => 'abcdef-ABCDEF_0123456789',
+			],
+			'no_groups'                  => [
+				'value'     => 'abcdef',
+				'settings'  => [
+					'pattern' => '/([a-c]+)/',
+					'groups'  => [ 'foo' ],
+				],
+				'expected'  => false,
+				'exception' => No_Regex_Groups_Exception::class,
 			],
 		];
 	}

--- a/tests/unit/validators/regex-validator-test.php
+++ b/tests/unit/validators/regex-validator-test.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Missing_Settings_Key_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\No_Regex_Match_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Regex_Validator;
+
+/**
+ * Tests the \Yoast\WP\SEO\Validators\Regex_Validator class.
+ *
+ * @group options
+ * @group validators
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Regex_Validator
+ */
+class Regex_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var \Yoast\WP\SEO\Validators\Regex_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$this->instance = new Regex_Validator();
+	}
+
+	/**
+	 * Tests validation.
+	 *
+	 * @dataProvider data_provider
+	 *
+	 * @covers ::validate
+	 *
+	 * @param mixed  $value     The value to test/validate.
+	 * @param array  $settings  The validator settings.
+	 * @param mixed  $expected  The expected result.
+	 * @param string $exception The expected exception class. Optional, use when the expected result is false.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_validate( $value, $settings, $expected, $exception = '' ) {
+		if ( $exception !== '' ) {
+			$this->expectException( $exception );
+			$this->instance->validate( $value, $settings );
+
+			return;
+		}
+
+		$this->assertEquals( $expected, $this->instance->validate( $value, $settings ) );
+	}
+
+	/**
+	 * Data provider to test multiple scenarios.
+	 *
+	 * @return array A mapping of methods and expected inputs.
+	 */
+	public function data_provider() {
+		return [
+			'exact'                      => [
+				'value'    => 'abc',
+				'settings' => [ 'pattern' => '/abc/' ],
+				'expected' => 'abc',
+			],
+			'ignore_case'                => [
+				'value'    => 'Hello World!',
+				'settings' => [ 'pattern' => '/[a-z\s]+/i' ],
+				'expected' => 'Hello World!',
+			],
+			'pattern_with_start_and_end' => [
+				'value'    => 'AbCdEf_0123-456789',
+				'settings' => [ 'pattern' => '/^[A-Fa-f0-9_-]+$/' ],
+				'expected' => 'AbCdEf_0123-456789',
+			],
+			'no_match'                   => [
+				'value'     => 'AbCdEf_0123-456789',
+				'settings'  => [ 'pattern' => '/^[A-F0-9_-]+$/' ],
+				'expected'  => false,
+				'exception' => No_Regex_Match_Exception::class,
+			],
+			'no_pattern_in_settings'     => [
+				'value'     => 'something',
+				'settings'  => [ 'irrelevant' => true ],
+				'expected'  => false,
+				'exception' => Missing_Settings_Key_Exception::class,
+			],
+			'null_settings'              => [
+				'value'     => 'something',
+				'settings'  => null,
+				'expected'  => false,
+				'exception' => Missing_Settings_Key_Exception::class,
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the regex validator.

## Relevant technical choices:

The solution, while I think it turned out ok. Feels overkill for what we do with it.
Perhaps we should consider rewriting over extending this to the perfect verify validators we do want. If not for the exception message alone.
Other than that:
* The original implementation split this up into 2 regexes, and calling `sanitize_text_field`. The latter is still missing now. Created [an issue](https://yoast.atlassian.net/browse/P1-1204) to fix that.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Tests should make sense and cover the code
* You can run this somewhere and play around with feeding it different input:
```php
function _test_validate( $value, $pattern ) {
	/** @var \Yoast\WP\SEO\Validators\Regex_Validator:: $validator */
	$validator = YoastSEO()->classes->get( \Yoast\WP\SEO\Validators\Regex_Validator::class );
	echo 'Value: ';
	var_dump( $value );
	echo '<br>Result: ';
	try {
		var_dump( $validator->validate( $value, [ 'pattern' => $pattern ] ) );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_validate( '18.1', '/^[1-7.]+$/' );
```
* You can test the setting of our verify options with the following base code:
```php
function _test_set_verify( $value ) {
	/** @var \Yoast\WP\SEO\Services\Options\Site_Options_Service $options */
	$options = YoastSEO()->classes->get( \Yoast\WP\SEO\Services\Options\Site_Options_Service::class );
	echo '<br>Before: ';
	var_dump( $options->googleverify );
	echo '<br>After: ';
	try {
		$options->googleverify = $value;
		var_dump( $options->googleverify );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_set_verify( '!!' );
```
* Play around with and adapt the above code to check the [affected options](https://github.com/Yoast/wordpress-seo/commit/a0685c32fef83f45bfb98a1f78e7b8e251e271d3).


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Part of bigger feature. Please test whole feature.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [P1-1196](https://yoast.atlassian.net/browse/P1-1196)
