### PR TITLE
P1 1189 create array of type validator

### DIFF
--- a/src/validators/array-validator.php
+++ b/src/validators/array-validator.php
@@ -16,11 +16,11 @@ class Array_Validator implements Validator_Interface {
 	 *
 	 * @throws Invalid_Type_Exception When the type of the value is not an array.
 	 *
-	 * @return array A valid string.
+	 * @return array A valid array.
 	 */
 	public function validate( $value ) {
 		if ( ! \is_array( $value ) ) {
-			throw new Invalid_Type_Exception( \gettype( $value ), 'string' );
+			throw new Invalid_Type_Exception( \gettype( $value ), 'array' );
 		}
 
 		return $value;

--- a/src/validators/array-validator.php
+++ b/src/validators/array-validator.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\Validators;
 
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception;
+
 /**
  * The array validator class.
  */
@@ -12,9 +14,15 @@ class Array_Validator implements Validator_Interface {
 	 *
 	 * @param mixed $value The value to validate.
 	 *
-	 * @return bool Whether the value is an array.
+	 * @throws Invalid_Type_Exception When the type of the value is not an array.
+	 *
+	 * @return array A valid string.
 	 */
 	public function validate( $value ) {
-		return \is_array( $value );
+		if ( ! \is_array( $value ) ) {
+			throw new Invalid_Type_Exception( \gettype( $value ), 'string' );
+		}
+
+		return $value;
 	}
 }

--- a/src/validators/news-sitemap-content-type-validator.php
+++ b/src/validators/news-sitemap-content-type-validator.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception;
+
+/**
+ * The news sitemap content type array validator class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+class News_Sitemap_Content_Type_Validator extends Array_Validator {
+
+	/**
+	 * Validates if the value is an array.
+	 * Sets the passed content types to 'on'
+	 *
+	 * @param mixed $value The value to validate.
+	 *
+	 * @throws Invalid_Type_Exception When the value is not an array.
+	 *
+	 * @return array Array with the content type keys set to value 'on'.
+	 */
+	public function validate( $value ) {
+		parent::validate( $value );
+
+		$new_value = [];
+
+		foreach ( $value as $name => $posted_value ) {
+			if ( \is_string( $name ) ) {
+				$new_value[ $name ] = 'on';
+			}
+		}
+
+		return $new_value;
+	}
+}

--- a/tests/unit/validators/news-sitemap-content-type-validator-test.php
+++ b/tests/unit/validators/news-sitemap-content-type-validator-test.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Validators;
 
-use Brain\Monkey;
 use Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Validators\News_Sitemap_Content_Type_Validator;
@@ -31,7 +30,6 @@ class News_Sitemap_Content_Type_Validator_Test extends TestCase {
 	 */
 	protected function set_up() {
 		parent::set_up();
-		$this->stubEscapeFunctions();
 		$this->stubTranslationFunctions();
 
 		$this->instance = new News_Sitemap_Content_Type_Validator();
@@ -43,9 +41,6 @@ class News_Sitemap_Content_Type_Validator_Test extends TestCase {
 	 * @dataProvider array_provider
 	 *
 	 * @covers ::validate
-	 * @covers ::sanitize
-	 * @covers ::sanitize_encoded_text_field
-	 * @covers ::get_charset
 	 *
 	 * @param mixed  $value     The value to test/validate.
 	 * @param mixed  $expected  The expected result.

--- a/tests/unit/validators/news-sitemap-content-type-validator-test.php
+++ b/tests/unit/validators/news-sitemap-content-type-validator-test.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\News_Sitemap_Content_Type_Validator;
+
+/**
+ * Tests the News_Sitemap_Content_Type_Validator class.
+ *
+ * @group options
+ * @group validators
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\News_Sitemap_Content_Type_Validator
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+class News_Sitemap_Content_Type_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var News_Sitemap_Content_Type_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$this->instance = new News_Sitemap_Content_Type_Validator();
+	}
+
+	/**
+	 * Tests validation.
+	 *
+	 * @dataProvider array_provider
+	 *
+	 * @covers ::validate
+	 * @covers ::sanitize
+	 * @covers ::sanitize_encoded_text_field
+	 * @covers ::get_charset
+	 *
+	 * @param mixed  $value     The value to test/validate.
+	 * @param mixed  $expected  The expected result.
+	 * @param string $exception The expected exception class. Optional, use when the expected result is false.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_validate( $value, $expected, $exception = '' ) {
+		if ( ! $expected && $expected !== [] ) {
+			$this->expectException( $exception );
+			$this->instance->validate( $value );
+
+			return;
+		}
+		$this->assertEquals( $expected, $this->instance->validate( $value ) );
+	}
+
+	/**
+	 * Data provider to test multiple arrays.
+	 *
+	 * @return array A mapping of methods and expected inputs.
+	 */
+	public function array_provider() {
+		return [
+			// Verify that the values are set to 'on'.
+			'array' => [
+				'value'    => [ 'post' => 'yes' ],
+				'expected' => [ 'post' => 'on' ],
+			],
+			'strip_non_string_keys' => [
+				'value'    => [
+					'post' => 'yes',
+					'page',
+					'books',
+				],
+				'expected' => [ 'post' => 'on' ],
+			],
+
+			// Invalid values.
+			'empty_array' => [
+				'value'    => [],
+				'expected' => [],
+			],
+			'integer_keys' => [
+				'value'    => [
+					'post',
+					'page',
+					2 => 'book',
+				],
+				'expected' => [],
+			],
+
+			// Invalid types.
+			'string' => [
+				'value'     => '',
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+			'integer' => [
+				'value'     => 1,
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+			'object' => [
+				'value'     => (object) [],
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+			'null' => [
+				'value'     => null,
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+			'boolean' => [
+				'value'     => false,
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+
+		];
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Two options(in `Local SEO`) their array values are sanitized to 'on' if the keys are strings.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the news sitemap content type validator .

## Relevant technical choices:

* The 'Array validator' throws an exception instead of returning a boolean.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


* Tests should cover and pass.
* You can test the validator via:
```php

function _test_validate_news_sitemap_content_type( $value ) {
	/** @var \Yoast\WP\SEO\Validators\News_Sitemap_Content_Type_Validator $validator */
	$validator = YoastSEO()->classes->get( \Yoast\WP\SEO\Validators\News_Sitemap_Content_Type_Validator::class );
	echo 'Value: ';
	var_dump( $value );
	echo '<br>Result: ';
	try {
		var_dump( $validator->validate( $value ) );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<hr>';
}
_test_validate_news_sitemap_content_type( [ 'post' => 'yes' ] );
_test_validate_news_sitemap_content_type( [ 'post' => 'yes', 'page', 'books' ] );
_test_validate_news_sitemap_content_type( [] );
_test_validate_news_sitemap_content_type( false );
```
* Play around with it!


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Part of bigger feature. Please test whole feature.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes P1-1189
