### PR TITLE
Plugin 1439 import wording changes

### DIFF
--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -22,7 +22,7 @@ if ( $tool_page === '' ) {
 
 	$tools['import-export'] = [
 		'title' => __( 'Import and Export', 'wordpress-seo' ),
-		'desc'  => __( 'Import settings from other SEO plugins and export your settings for re-use on (another) blog.', 'wordpress-seo' ),
+		'desc'  => __( 'Import settings from other SEO plugins and export your settings for re-use on (another) site.', 'wordpress-seo' ),
 	];
 
 	if ( WPSEO_Utils::allow_system_file_edit() === true && ! is_multisite() ) {

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -60,7 +60,7 @@ function wpseo_import_external_select( $name, $plugins ) {
 
 <div class="tab-block">
 	<h3><?php esc_html_e( 'Step 2: Import', 'wordpress-seo' ); ?></h3>
-	<p>
+	<p class="yoast-import-explanation">
 		<?php
 		printf(
 			/* translators: 1: expands to Yoast SEO */

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -105,7 +105,7 @@ function wpseo_import_external_select( $name, $plugins ) {
 
 <div class="tab-block">
 	<h3><?php esc_html_e( 'Step 5: Clean up', 'wordpress-seo' ); ?></h3>
-	<p>
+	<p class="yoast-cleanup-explanation">
 		<?php esc_html_e( 'Once you\'re certain your site is OK, you can clean up. This will remove all the original data.', 'wordpress-seo' ); ?>
 	</p>
 	<form action="<?php echo esc_url( admin_url( 'admin.php?page=wpseo_tools&tool=import-export#top#import-seo' ) ); ?>"

--- a/packages/js/src/import.js
+++ b/packages/js/src/import.js
@@ -6,7 +6,8 @@ const AioseoV4 = "WPSEO_Import_AIOSEO_V4";
 
 let cleanupButton, cleanupDropdown, cleanupForm,
 	importButton, importDropdown, importForm,
-	spinner, loadingMessageCleanup, loadingMessageImport, checkMark;
+	spinner, loadingMessageCleanup, loadingMessageImport, checkMark,
+	importExplanation;
 
 /**
  * Adds Progress UI elements in the page.
@@ -263,6 +264,8 @@ function initElements() {
 			color: "green",
 		} )
 		.hide();
+	importExplanation = jQuery( ".yoast-import-explanation" );
+	importExplanation.html( window.yoastImportData.assets.texts.select_plugin_text );
 }
 
 /**
@@ -274,12 +277,32 @@ function initElements() {
  */
 function watchSelect( dropdown ) {
 	var button = dropdown.closest( "form" ).find( "input[type=submit]" );
+	var selectedPlugin, text, textSource;
+
 	dropdown.on( "change", function() {
-		if ( jQuery( this ).find( "option:selected" ).attr( "value" ) === "" ) {
+		selectedPlugin = jQuery( this ).find( "option:selected" ).attr( "value" );
+
+		// Disable the Import button if no button is selected.
+		if ( selectedPlugin === "" ) {
 			button.prop( "disabled", true );
 			return;
 		}
 		button.prop( "disabled", false );
+
+		// Display the relevant text depending on which plugin is selected.
+		text = window.yoastImportData.assets.texts.select_header.replace( /%s/g, jQuery( this ).find( "option:selected" ).text() );
+		if ( selectedPlugin === AioseoV4 ) {
+			textSource = window.yoastImportData.assets.texts.plugins.aioseo;
+		} else {
+			textSource = window.yoastImportData.assets.texts.plugins.other;
+		}
+		text += "<ul style='list-style: disc; padding: 0 15px;'>";
+		textSource.forEach( function( dataItem ) {
+			text += "<li>" + dataItem.data_name + "<br/>" + dataItem.data_note + "</li>";
+		} );
+		text += "</ul>";
+
+		importExplanation.html( text );
 	} );
 }
 

--- a/packages/js/src/import.js
+++ b/packages/js/src/import.js
@@ -7,7 +7,7 @@ const AioseoV4 = "WPSEO_Import_AIOSEO_V4";
 let cleanupButton, cleanupDropdown, cleanupForm,
 	importButton, importDropdown, importForm,
 	spinner, loadingMessageCleanup, loadingMessageImport, checkMark,
-	importExplanation;
+	cleanupExplanation, importExplanation;
 
 /**
  * Adds Progress UI elements in the page.
@@ -228,11 +228,14 @@ function handleCleanupFormSubmission( event ) {
  */
 function initElements() {
 	cleanupButton = jQuery( "[name='clean_external']" );
+	cleanupButton.val( window.yoastImportData.assets.replacing_texts.cleanup_button );
 	cleanupDropdown = jQuery( "[name='clean_external_plugin']" );
 	cleanupForm = jQuery( cleanupButton ).parents( "form:first" );
 	importButton = jQuery( "[name='import_external']" );
 	importDropdown = jQuery( "[name='import_external_plugin']" );
 	importForm = jQuery( importButton ).parents( "form:first" );
+	importForm.after( jQuery( "<p></p>" )
+		.html( "<strong>" + window.yoastImportData.assets.note + "</strong>" + window.yoastImportData.assets.cleanup_after_import_msg ) );
 	spinner = jQuery( "<img>" )
 		.addClass( "yoast-import-spinner" )
 		.attr( "src", window.yoastImportData.assets.spinner )
@@ -265,7 +268,9 @@ function initElements() {
 		} )
 		.hide();
 	importExplanation = jQuery( ".yoast-import-explanation" );
-	importExplanation.html( window.yoastImportData.assets.texts.select_plugin_text );
+	importExplanation.html( window.yoastImportData.assets.replacing_texts.import_explanation );
+	cleanupExplanation = jQuery( ".yoast-cleanup-explanation" );
+	cleanupExplanation.html( window.yoastImportData.assets.replacing_texts.cleanup_explanation );
 }
 
 /**
@@ -289,20 +294,22 @@ function watchSelect( dropdown ) {
 		}
 		button.prop( "disabled", false );
 
-		// Display the relevant text depending on which plugin is selected.
-		text = window.yoastImportData.assets.texts.select_header.replace( /%s/g, jQuery( this ).find( "option:selected" ).text() );
-		if ( selectedPlugin === AioseoV4 ) {
-			textSource = window.yoastImportData.assets.texts.plugins.aioseo;
-		} else {
-			textSource = window.yoastImportData.assets.texts.plugins.other;
-		}
-		text += "<ul style='list-style: disc; padding: 0 15px;'>";
-		textSource.forEach( function( dataItem ) {
-			text += "<li>" + dataItem.data_name + "<br/>" + dataItem.data_note + "</li>";
-		} );
-		text += "</ul>";
+		// Display the relevant text depending on which plugin is selected for import.
+		if ( dropdown === importDropdown ) {
+			text = window.yoastImportData.assets.replacing_texts.select_header.replace( /%s/g, jQuery( this ).find( "option:selected" ).text() );
+			if ( selectedPlugin === AioseoV4 ) {
+				textSource = window.yoastImportData.assets.replacing_texts.plugins.aioseo;
+			} else {
+				textSource = window.yoastImportData.assets.replacing_texts.plugins.other;
+			}
+			text += "<ul style='list-style: disc; padding: 0 15px;'>";
+			textSource.forEach( function( dataItem ) {
+				text += "<li>" + dataItem.data_name + "<br/>" + dataItem.data_note + "</li>";
+			} );
+			text += "</ul>";
 
-		importExplanation.html( text );
+			importExplanation.html( text );
+		}
 	} );
 }
 

--- a/packages/js/src/import.js
+++ b/packages/js/src/import.js
@@ -304,7 +304,7 @@ function watchSelect( dropdown ) {
 			}
 			text += "<ul style='list-style: disc; padding: 0 15px;'>";
 			textSource.forEach( function( dataItem ) {
-				text += "<li>" + dataItem.data_name + "<br/>" + dataItem.data_note + "</li>";
+				text += "<li>" + dataItem.data_name + "<br/><i>" + dataItem.data_note + "</i></li>";
 			} );
 			text += "</ul>";
 

--- a/packages/js/src/import.js
+++ b/packages/js/src/import.js
@@ -1,4 +1,5 @@
 import jQuery from "jquery";
+import { sprintf } from "@wordpress/i18n";
 
 import IndexingService from "./services/IndexingService";
 
@@ -154,7 +155,12 @@ function showFailure( e, action ) {
 	// Add a failure alert too.
 	var failureAlert = jQuery( "<div>" )
 		.addClass( "yoast-measure yoast-import-failure" )
-		.html( failureMessage.replace( /%s/g, "<strong>" + e + "</strong>" ) );
+		.html(
+			sprintf(
+				failureMessage,
+				"<strong>" + e + "</strong>"
+			)
+		);
 
 	actingForm.after( failureAlert );
 }
@@ -296,7 +302,10 @@ function watchSelect( dropdown ) {
 
 		// Display the relevant text depending on which plugin is selected for import.
 		if ( dropdown === importDropdown ) {
-			text = window.yoastImportData.assets.replacing_texts.select_header.replace( /%s/g, jQuery( this ).find( "option:selected" ).text() );
+			text = sprintf(
+				window.yoastImportData.assets.replacing_texts.select_header,
+				jQuery( this ).find( "option:selected" ).text()
+			);
 			if ( selectedPlugin === AioseoV4 ) {
 				textSource = window.yoastImportData.assets.replacing_texts.plugins.aioseo;
 			} else {

--- a/src/integrations/admin/import-integration.php
+++ b/src/integrations/admin/import-integration.php
@@ -103,18 +103,23 @@ class Import_Integration implements Integration_Interface {
 				'nonce'               => \wp_create_nonce( 'wp_rest' ),
 			],
 			'assets'  => [
-				'loading_msg_import'  => \esc_html__( 'The import can take a long time depending on your site\'s size.', 'wordpress-seo' ),
-				'loading_msg_cleanup' => \esc_html__( 'The cleanup can take a long time depending on your site\'s size.', 'wordpress-seo' ),
-				'select_placeholder'  => \esc_html__( 'Select SEO plugin', 'wordpress-seo' ),
-				'no_data_msg'         => \esc_html__( 'No data found from other SEO plugins.', 'wordpress-seo' ),
-				'import_failure'      => $this->get_import_failure_alert( true ),
-				'cleanup_failure'     => $this->get_import_failure_alert( false ),
-				'spinner'             => \admin_url( 'images/loading.gif' ),
-				'texts'               => [
-					'select_plugin_text'  => \esc_html__( 'Please select an SEO plugin below to see what data can be imported.', 'wordpress-seo' ),
+				'loading_msg_import'       => \esc_html__( 'The import can take a long time depending on your site\'s size.', 'wordpress-seo' ),
+				'loading_msg_cleanup'      => \esc_html__( 'The cleanup can take a long time depending on your site\'s size.', 'wordpress-seo' ),
+				'note'                     => \esc_html__( 'Note: ', 'wordpress-seo' ),
+				'cleanup_after_import_msg' => \esc_html__( 'After you\'ve imported data from another SEO plugin, please make sure to clean up all the original data from that plugin. (step 5)', 'wordpress-seo' ),
+				'loading_msg_cleanup'      => \esc_html__( 'The cleanup can take a long time depending on your site\'s size.', 'wordpress-seo' ),
+				'select_placeholder'       => \esc_html__( 'Select SEO plugin', 'wordpress-seo' ),
+				'no_data_msg'              => \esc_html__( 'No data found from other SEO plugins.', 'wordpress-seo' ),
+				'import_failure'           => $this->get_import_failure_alert( true ),
+				'cleanup_failure'          => $this->get_import_failure_alert( false ),
+				'spinner'                  => \admin_url( 'images/loading.gif' ),
+				'replacing_texts'          => [
+					'cleanup_button'       => \esc_html__( 'Clean up', 'wordpress-seo' ),
+					'import_explanation'   => \esc_html__( 'Please select an SEO plugin below to see what data can be imported.', 'wordpress-seo' ),
+					'cleanup_explanation'  => \esc_html__( 'Once you\'re certain that your site is working properly with the imported data from another SEO plugin, you can clean up all the original data from that plugin.', 'wordpress-seo' ),
 					/* translators: %s: expands to the name of the plugin that is selected to be imported */
-					'select_header'       => \esc_html__( 'The import from %s includes:', 'wordpress-seo' ),
-					'plugins'             => [
+					'select_header'        => \esc_html__( 'The import from %s includes:', 'wordpress-seo' ),
+					'plugins'              => [
 						'aioseo' => [
 							[
 								'data_name' => \esc_html__( 'Post metadata (SEO titles and descriptions)', 'wordpress-seo' ),

--- a/src/integrations/admin/import-integration.php
+++ b/src/integrations/admin/import-integration.php
@@ -107,7 +107,6 @@ class Import_Integration implements Integration_Interface {
 				'loading_msg_cleanup'      => \esc_html__( 'The cleanup can take a long time depending on your site\'s size.', 'wordpress-seo' ),
 				'note'                     => \esc_html__( 'Note: ', 'wordpress-seo' ),
 				'cleanup_after_import_msg' => \esc_html__( 'After you\'ve imported data from another SEO plugin, please make sure to clean up all the original data from that plugin. (step 5)', 'wordpress-seo' ),
-				'loading_msg_cleanup'      => \esc_html__( 'The cleanup can take a long time depending on your site\'s size.', 'wordpress-seo' ),
 				'select_placeholder'       => \esc_html__( 'Select SEO plugin', 'wordpress-seo' ),
 				'no_data_msg'              => \esc_html__( 'No data found from other SEO plugins.', 'wordpress-seo' ),
 				'import_failure'           => $this->get_import_failure_alert( true ),

--- a/src/integrations/admin/import-integration.php
+++ b/src/integrations/admin/import-integration.php
@@ -122,7 +122,7 @@ class Import_Integration implements Integration_Interface {
 					'plugins'              => [
 						'aioseo' => [
 							[
-								'data_name' => \esc_html__( 'Post metadata (SEO titles and descriptions)', 'wordpress-seo' ),
+								'data_name' => \esc_html__( 'Post metadata (SEO titles, descriptions, etc.)', 'wordpress-seo' ),
 								'data_note' => \esc_html__( 'Note: This metadata will only be imported if there is no existing Yoast SEO metadata yet.', 'wordpress-seo' ),
 							],
 							[
@@ -132,7 +132,7 @@ class Import_Integration implements Integration_Interface {
 						],
 						'other' => [
 							[
-								'data_name' => \esc_html__( 'Post metadata (SEO titles and descriptions)', 'wordpress-seo' ),
+								'data_name' => \esc_html__( 'Post metadata (SEO titles, descriptions, etc.)', 'wordpress-seo' ),
 								'data_note' => \esc_html__( 'Note: This metadata will only be imported if there is no existing Yoast SEO metadata yet.', 'wordpress-seo' ),
 							],
 						],

--- a/src/integrations/admin/import-integration.php
+++ b/src/integrations/admin/import-integration.php
@@ -110,6 +110,29 @@ class Import_Integration implements Integration_Interface {
 				'import_failure'      => $this->get_import_failure_alert( true ),
 				'cleanup_failure'     => $this->get_import_failure_alert( false ),
 				'spinner'             => \admin_url( 'images/loading.gif' ),
+				'texts'               => [
+					'select_plugin_text'  => \esc_html__( 'Please select an SEO plugin below to see what data can be imported.', 'wordpress-seo' ),
+					/* translators: %s: expands to the name of the plugin that is selected to be imported */
+					'select_header'       => \esc_html__( 'The import from %s includes:', 'wordpress-seo' ),
+					'plugins'             => [
+						'aioseo' => [
+							[
+								'data_name' => \esc_html__( 'Post metadata (SEO titles and descriptions)', 'wordpress-seo' ),
+								'data_note' => \esc_html__( 'Note: This metadata will only be imported if there is no existing Yoast SEO metadata yet.', 'wordpress-seo' ),
+							],
+							[
+								'data_name' => \esc_html__( 'Default settings', 'wordpress-seo' ),
+								'data_note' => \esc_html__( 'Note: These settings will overwrite the default settings of Yoast SEO.', 'wordpress-seo' ),
+							],
+						],
+						'other' => [
+							[
+								'data_name' => \esc_html__( 'Post metadata (SEO titles and descriptions)', 'wordpress-seo' ),
+								'data_note' => \esc_html__( 'Note: This metadata will only be imported if there is no existing Yoast SEO metadata yet.', 'wordpress-seo' ),
+							],
+						],
+					],
+				],
 			],
 		];
 

--- a/tests/unit/integrations/admin/import-integration-test.php
+++ b/tests/unit/integrations/admin/import-integration-test.php
@@ -205,13 +205,39 @@ class Import_Integration_Test extends TestCase {
 				'nonce'               => 'nonce_value',
 			],
 			'assets'  => [
-				'loading_msg_import'  => 'The import can take a long time depending on your site\'s size.',
-				'loading_msg_cleanup' => 'The cleanup can take a long time depending on your site\'s size.',
-				'select_placeholder'  => 'Select SEO plugin',
-				'no_data_msg'         => 'No data found from other SEO plugins.',
-				'import_failure'      => '<div class="yoast-alert yoast-alert--error"><span><img class="yoast-alert__icon" src="https://example.org/wp-content/plugins/images/alert-error-icon.svg" alt="" /></span><span>Import failed with the following error:<br/><br/>%s</span></div>',
-				'cleanup_failure'     => '<div class="yoast-alert yoast-alert--error"><span><img class="yoast-alert__icon" src="https://example.org/wp-content/plugins/images/alert-error-icon.svg" alt="" /></span><span>Cleanup failed with the following error:<br/><br/>%s</span></div>',
-				'spinner'             => 'https://example.org/wp-admin/images/loading.gif',
+				'loading_msg_import'       => 'The import can take a long time depending on your site\'s size.',
+				'loading_msg_cleanup'      => 'The cleanup can take a long time depending on your site\'s size.',
+				'note'                     => 'Note: ',
+				'cleanup_after_import_msg' => 'After you\'ve imported data from another SEO plugin, please make sure to clean up all the original data from that plugin. (step 5)',
+				'select_placeholder'       => 'Select SEO plugin',
+				'no_data_msg'              => 'No data found from other SEO plugins.',
+				'import_failure'           => '<div class="yoast-alert yoast-alert--error"><span><img class="yoast-alert__icon" src="https://example.org/wp-content/plugins/images/alert-error-icon.svg" alt="" /></span><span>Import failed with the following error:<br/><br/>%s</span></div>',
+				'cleanup_failure'          => '<div class="yoast-alert yoast-alert--error"><span><img class="yoast-alert__icon" src="https://example.org/wp-content/plugins/images/alert-error-icon.svg" alt="" /></span><span>Cleanup failed with the following error:<br/><br/>%s</span></div>',
+				'spinner'                  => 'https://example.org/wp-admin/images/loading.gif',
+				'replacing_texts'          => [
+					'cleanup_button'       => 'Clean up',
+					'import_explanation'   => 'Please select an SEO plugin below to see what data can be imported.',
+					'cleanup_explanation'  => 'Once you\'re certain that your site is working properly with the imported data from another SEO plugin, you can clean up all the original data from that plugin.',
+					'select_header'        => 'The import from %s includes:',
+					'plugins'              => [
+						'aioseo' => [
+							[
+								'data_name' => 'Post metadata (SEO titles, descriptions, etc.)',
+								'data_note' => 'Note: This metadata will only be imported if there is no existing Yoast SEO metadata yet.',
+							],
+							[
+								'data_name' => 'Default settings',
+								'data_note' => 'Note: These settings will overwrite the default settings of Yoast SEO.',
+							],
+						],
+						'other' => [
+							[
+								'data_name' => 'Post metadata (SEO titles, descriptions, etc.)',
+								'data_note' => 'Note: This metadata will only be imported if there is no existing Yoast SEO metadata yet.',
+							],
+						],
+					],
+				],
 			],
 		];
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to change the wording of the import page, depending on whether the feature flag is enabled or not.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Impove texts in import pages

## Relevant technical choices:

* Added the `yoast-import-explanation` and `yoast-cleanup-explanation` classes in the import-seo.php file to be able to safely show the new copies or not depending on the feature flag.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**With the feature flag either enabled or disabled:**
* Changed the copy in the tools page from `Import settings from other SEO plugins and export your settings for re-use on (another) blog` to `Import settings from other SEO plugins and export your settings for re-use on (another) site`:
![image](https://user-images.githubusercontent.com/12400734/152354314-cf203934-c111-4016-8ad7-6a9b94688a23.png)

**With the feature flag enabled:**
* Step 2 should look like this:
![image](https://user-images.githubusercontent.com/12400734/152354463-85463803-ac60-4917-ae59-fc42839e420d.png)
![image](https://user-images.githubusercontent.com/12400734/152354503-de92c383-e540-49a0-ba03-dd584d614c29.png)
![image](https://user-images.githubusercontent.com/12400734/152355112-18c07262-f1b4-440f-bea3-97a5fc7ffa94.png)
* Step 5 should look like this:
![image](https://user-images.githubusercontent.com/12400734/152355241-34d352ae-15e8-4859-8e65-c2db1ff317db.png)
![image](https://user-images.githubusercontent.com/12400734/152355269-99f04b9d-5107-4df5-b556-6eba57aba112.png)

**With the feature flag disabled:**
* The import page should remain the same with older versions of the plugin

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Quickly smoke test whether the import and the cleanup of AIOSEO works as expected with the feature flag enabled
* Quickly smoke test whether the import and the cleanup of rankmath works as expected with the feature flag disabled

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
