### PR TITLE
Plugin 1441 use fb data for twitter

### DIFF
--- a/src/actions/importing/abstract-importing-action.php
+++ b/src/actions/importing/abstract-importing-action.php
@@ -225,7 +225,7 @@ abstract class Abstract_Importing_Action implements Importing_Action_Interface {
 	 *
 	 * @param string $meta_data The meta data to be imported.
 	 *
-	 * @return string The transformed meta data.
+	 * @return string The transformed URL.
 	 */
 	public function url_import( $meta_data ) {
 		// We put null as the allowed protocols here, to have the WP default allowed protocols, see https://developer.wordpress.org/reference/functions/wp_allowed_protocols.

--- a/src/actions/importing/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo-posts-importing-action.php
@@ -353,14 +353,14 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 			// For robots import.
 			if ( isset( $yoast_mapping['robots_import'] ) && $yoast_mapping['robots_import'] ) {
 				$yoast_mapping['subtype']                  = $indexable->object_sub_type;
-				$indexable->{$yoast_mapping['yoast_name']} = \call_user_func( [ $this, $yoast_mapping['transform_method'] ], $aioseo_indexable, $yoast_mapping, $aioseo_key );
+				$indexable->{$yoast_mapping['yoast_name']} = $this->transform_import_data( $yoast_mapping['transform_method'], $aioseo_indexable, $aioseo_key, $yoast_mapping, $indexable );
 
 				continue;
 			}
 
 			// For social images, like open graph and twitter image.
 			if ( isset( $yoast_mapping['social_image_import'] ) && $yoast_mapping['social_image_import'] ) {
-				$image_url = \call_user_func( [ $this, $yoast_mapping['transform_method'] ], $aioseo_indexable, $yoast_mapping, $indexable );
+				$image_url = $this->transform_import_data( $yoast_mapping['transform_method'], $aioseo_indexable, $aioseo_key, $yoast_mapping, $indexable );
 
 				// Update the indexable's social image only where there's actually a url to import, so as not to lose the social images that we came up with when we originally built the indexable.
 				if ( ! empty( $image_url ) ) {
@@ -380,11 +380,26 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 			}
 
 			if ( ! empty( $aioseo_indexable[ $aioseo_key ] ) ) {
-				$indexable->{$yoast_mapping['yoast_name']} = \call_user_func( [ $this, $yoast_mapping['transform_method'] ], $aioseo_indexable, $aioseo_key );
+				$indexable->{$yoast_mapping['yoast_name']} = $this->transform_import_data( $yoast_mapping['transform_method'], $aioseo_indexable, $aioseo_key, $yoast_mapping, $indexable );
 			}
 		}
 
 		return $indexable;
+	}
+
+	/**
+	 * Transforms the data to be imported.
+	 *
+	 * @param string    $transform_method The method that is going to be used for transforming the data.
+	 * @param array     $aioseo_indexable The data of the AIOSEO indexable data that is being imported.
+	 * @param string    $aioseo_key       The name of the specific set of data that is going to be transformed.
+	 * @param array     $yoast_mapping    Extra details for the import of the specific data that is going to be transformed.
+	 * @param Indexable $indexable        The Yoast indexable that we are going to import the transformed data into.
+	 *
+	 * @return string|bool|null The transformed data to be imported.
+	 */
+	protected function transform_import_data( $transform_method, $aioseo_indexable, $aioseo_key, $yoast_mapping, $indexable ) {
+		return \call_user_func( [ $this, $transform_method ], $aioseo_indexable, $aioseo_key, $yoast_mapping, $indexable );
 	}
 
 	/**
@@ -536,12 +551,12 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 	 * Imports the post's robots setting.
 	 *
 	 * @param bool   $aioseo_robots_settings AIOSEO's set of robot settings for the post.
-	 * @param array  $mapping The mapping of the setting we're working with.
 	 * @param string $aioseo_key The AIOSEO key that contains the robot setting we're working with.
+	 * @param array  $mapping The mapping of the setting we're working with.
 	 *
 	 * @return bool|null The value of Yoast's noindex setting for the post.
 	 */
-	public function post_general_robots_import( $aioseo_robots_settings, $mapping, $aioseo_key ) {
+	public function post_general_robots_import( $aioseo_robots_settings, $aioseo_key, $mapping ) {
 		$mapping['type']        = 'postTypes';
 		$mapping['option_name'] = 'aioseo_options_dynamic';
 
@@ -558,12 +573,13 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 	 * Imports the og and twitter image url.
 	 *
 	 * @param bool      $aioseo_social_image_settings AIOSEO's set of social image settings for the post.
+	 * @param string    $aioseo_key                   The AIOSEO key that contains the robot setting we're working with.
 	 * @param array     $mapping                      The mapping of the setting we're working with.
 	 * @param Indexable $indexable                    The Yoast indexable we're importing into.
 	 *
 	 * @return bool|null The url of the social image we're importing, null if there's none.
 	 */
-	public function social_image_url_import( $aioseo_social_image_settings, $mapping, $indexable ) {
+	public function social_image_url_import( $aioseo_social_image_settings, $aioseo_key, $mapping, $indexable ) {
 		if ( $mapping['social_setting_prefix_aioseo'] === 'twitter_' && $aioseo_social_image_settings['twitter_use_og'] ) {
 			$mapping['social_setting_prefix_aioseo'] = 'og_';
 		}

--- a/src/actions/importing/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo-posts-importing-action.php
@@ -43,31 +43,31 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 	protected $aioseo_to_yoast_map = [
 		'title'               => [
 			'yoast_name'       => 'title',
-			'transform_method' => 'simple_import',
+			'transform_method' => 'simple_import_post',
 		],
 		'description'         => [
 			'yoast_name'       => 'description',
-			'transform_method' => 'simple_import',
+			'transform_method' => 'simple_import_post',
 		],
 		'og_title'            => [
 			'yoast_name'       => 'open_graph_title',
-			'transform_method' => 'simple_import',
+			'transform_method' => 'simple_import_post',
 		],
 		'og_description'      => [
 			'yoast_name'       => 'open_graph_description',
-			'transform_method' => 'simple_import',
+			'transform_method' => 'simple_import_post',
 		],
 		'twitter_title'       => [
 			'yoast_name'       => 'twitter_title',
-			'transform_method' => 'simple_import',
+			'transform_method' => 'twitter_import',
 		],
 		'twitter_description' => [
 			'yoast_name'       => 'twitter_description',
-			'transform_method' => 'simple_import',
+			'transform_method' => 'twitter_import',
 		],
 		'canonical_url'       => [
 			'yoast_name'       => 'canonical',
-			'transform_method' => 'url_import',
+			'transform_method' => 'url_import_post',
 		],
 		'keyphrases'          => [
 			'yoast_name'       => 'primary_focus_keyword',
@@ -366,7 +366,7 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 			}
 
 			if ( ! empty( $aioseo_indexable[ $aioseo_key ] ) ) {
-				$indexable->{$yoast_mapping['yoast_name']} = \call_user_func( [ $this, $yoast_mapping['transform_method'] ], $aioseo_indexable[ $aioseo_key ], $yoast_mapping );
+				$indexable->{$yoast_mapping['yoast_name']} = \call_user_func( [ $this, $yoast_mapping['transform_method'] ], $aioseo_indexable, $aioseo_key );
 			}
 		}
 
@@ -440,14 +440,61 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 	}
 
 	/**
+	 * Minimally transforms data to be imported.
+	 *
+	 * @param array  $aioseo_data All of the AIOSEO data to be imported.
+	 * @param string $aioseo_key  The AIOSEO key that contains the setting we're working with.
+	 *
+	 * @return string The transformed meta data.
+	 */
+	public function simple_import_post( $aioseo_data, $aioseo_key ) {
+		return $this->simple_import( $aioseo_data[ $aioseo_key ] );
+	}
+
+	/**
+	 * Transforms URL to be imported.
+	 *
+	 * @param array  $aioseo_data All of the AIOSEO data to be imported.
+	 * @param string $aioseo_key  The AIOSEO key that contains the setting we're working with.
+	 *
+	 * @return string The transformed URL.
+	 */
+	public function url_import_post( $aioseo_data, $aioseo_key ) {
+		return $this->url_import( $aioseo_data[ $aioseo_key ] );
+	}
+
+	/**
+	 * Transforms twitter data to be imported.
+	 *
+	 * @param array  $aioseo_data All of the AIOSEO data to be imported.
+	 * @param string $aioseo_key  The AIOSEO key that contains the setting we're working with.
+	 *
+	 * @return string The transformed URL.
+	 */
+	public function twitter_import( $aioseo_data, $aioseo_key ) {
+		if ( $aioseo_data['twitter_use_og'] ) {
+			switch ( $aioseo_key ) {
+				case 'twitter_title':
+					$aioseo_key = 'og_title';
+					break;
+				case 'twitter_description':
+					$aioseo_key = 'og_description';
+					break;
+			}
+		}
+		return $this->simple_import( $aioseo_data[ $aioseo_key ] );
+	}
+
+	/**
 	 * Plucks the keyphrase to be imported from the AIOSEO array of keyphrase meta data.
 	 *
-	 * @param array $meta_data The keyphrase meta data to be imported.
+	 * @param array  $aioseo_data All of the AIOSEO data to be imported.
+	 * @param string $aioseo_key  The AIOSEO key that contains the setting we're working with, aka keyphrase.
 	 *
 	 * @return string|null The plucked keyphrase.
 	 */
-	public function keyphrase_import( $meta_data ) {
-		$meta_data = \json_decode( $meta_data, true );
+	public function keyphrase_import( $aioseo_data, $aioseo_key ) {
+		$meta_data = \json_decode( $aioseo_data[ $aioseo_key ], true );
 		if ( ! isset( $meta_data['focus']['keyphrase'] ) ) {
 			return null;
 		}

--- a/src/actions/importing/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo-posts-importing-action.php
@@ -60,11 +60,13 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 		],
 		'twitter_title'       => [
 			'yoast_name'       => 'twitter_title',
-			'transform_method' => 'twitter_import',
+			'transform_method' => 'simple_import_post',
+			'twitter_import'   => true,
 		],
 		'twitter_description' => [
 			'yoast_name'       => 'twitter_description',
-			'transform_method' => 'twitter_import',
+			'transform_method' => 'simple_import_post',
+			'twitter_import'   => true,
 		],
 		'canonical_url'       => [
 			'yoast_name'       => 'canonical',
@@ -379,6 +381,12 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 				continue;
 			}
 
+			// For twitter import, take the respective open graph data if the appropriate setting is enabled.
+			if ( isset( $yoast_mapping['twitter_import'] ) && $yoast_mapping['twitter_import'] && $aioseo_indexable['twitter_use_og'] ) {
+				$aioseo_indexable['twitter_title']       = $aioseo_indexable['og_title'];
+				$aioseo_indexable['twitter_description'] = $aioseo_indexable['og_description'];
+			}
+
 			if ( ! empty( $aioseo_indexable[ $aioseo_key ] ) ) {
 				$indexable->{$yoast_mapping['yoast_name']} = $this->transform_import_data( $yoast_mapping['transform_method'], $aioseo_indexable, $aioseo_key, $yoast_mapping, $indexable );
 			}
@@ -490,28 +498,6 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 	 */
 	public function url_import_post( $aioseo_data, $aioseo_key ) {
 		return $this->url_import( $aioseo_data[ $aioseo_key ] );
-	}
-
-	/**
-	 * Transforms twitter data to be imported.
-	 *
-	 * @param array  $aioseo_data All of the AIOSEO data to be imported.
-	 * @param string $aioseo_key  The AIOSEO key that contains the setting we're working with.
-	 *
-	 * @return string The transformed URL.
-	 */
-	public function twitter_import( $aioseo_data, $aioseo_key ) {
-		if ( $aioseo_data['twitter_use_og'] ) {
-			switch ( $aioseo_key ) {
-				case 'twitter_title':
-					$aioseo_key = 'og_title';
-					break;
-				case 'twitter_description':
-					$aioseo_key = 'og_description';
-					break;
-			}
-		}
-		return $this->simple_import( $aioseo_data[ $aioseo_key ] );
 	}
 
 	/**

--- a/src/actions/importing/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo-posts-importing-action.php
@@ -489,7 +489,7 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 	 * Plucks the keyphrase to be imported from the AIOSEO array of keyphrase meta data.
 	 *
 	 * @param array  $aioseo_data All of the AIOSEO data to be imported.
-	 * @param string $aioseo_key  The AIOSEO key that contains the setting we're working with, aka keyphrase.
+	 * @param string $aioseo_key  The AIOSEO key that contains the setting we're working with, aka keyphrases.
 	 *
 	 * @return string|null The plucked keyphrase.
 	 */

--- a/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
@@ -494,7 +494,7 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			),
 			'og_image_type'       => 'attach',
 			'twitter_image_type'  => 'auto',
-			'twitter_use_og'      => false,
+			'twitter_use_og'      => true,
 			'robots_default'      => true,
 			'robots_nofollow'     => true,
 			'robots_noarchive'    => false,
@@ -503,44 +503,24 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 		];
 
 		$this->replacevar_handler->shouldReceive( 'transform' )
-			->once()
+			->twice()
 			->with( $aioseio_indexable['og_title'] )
 			->andReturn( $aioseio_indexable['og_title'] );
 
 		$this->sanitization->shouldReceive( 'sanitize_text_field' )
-			->once()
+			->twice()
 			->with( $aioseio_indexable['og_title'] )
 			->andReturn( $aioseio_indexable['og_title'] );
 
 		$this->replacevar_handler->shouldReceive( 'transform' )
-			->once()
+			->twice()
 			->with( $aioseio_indexable['og_description'] )
 			->andReturn( $aioseio_indexable['og_description'] );
 
 		$this->sanitization->shouldReceive( 'sanitize_text_field' )
-			->once()
+			->twice()
 			->with( $aioseio_indexable['og_description'] )
 			->andReturn( $aioseio_indexable['og_description'] );
-
-		$this->replacevar_handler->shouldReceive( 'transform' )
-			->once()
-			->with( $aioseio_indexable['twitter_title'] )
-			->andReturn( $aioseio_indexable['twitter_title'] );
-
-		$this->sanitization->shouldReceive( 'sanitize_text_field' )
-			->once()
-			->with( $aioseio_indexable['twitter_title'] )
-			->andReturn( $aioseio_indexable['twitter_title'] );
-
-		$this->replacevar_handler->shouldReceive( 'transform' )
-			->once()
-			->with( $aioseio_indexable['twitter_description'] )
-			->andReturn( $aioseio_indexable['twitter_description'] );
-
-		$this->sanitization->shouldReceive( 'sanitize_text_field' )
-			->once()
-			->with( $aioseio_indexable['twitter_description'] )
-			->andReturn( $aioseio_indexable['twitter_description'] );
 
 		$this->sanitization->shouldReceive( 'sanitize_url' )
 			->once()
@@ -548,24 +528,14 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			->andReturn( $aioseio_indexable['canonical_url'] );
 
 		$this->social_images_provider->shouldReceive( 'get_first_attached_image' )
-			->once()
+			->twice()
 			->with( 123 )
 			->andReturn( 'https://example.com/image3.png' );
 
 		$this->sanitization->shouldReceive( 'sanitize_url' )
-			->once()
+			->twice()
 			->with( 'https://example.com/image3.png', null )
 			->andReturn( 'https://example.com/image3.png' );
-
-		$this->social_images_provider->shouldReceive( 'get_auto_image' )
-			->once()
-			->with( 123 )
-			->andReturn( 'https://example.com/image4.png' );
-
-		$this->sanitization->shouldReceive( 'sanitize_url' )
-			->once()
-			->with( 'https://example.com/image4.png', null )
-			->andReturn( 'https://example.com/image4.png' );
 
 		$this->robots_provider->shouldReceive( 'get_subtype_robot_setting' )
 			->andReturn( 'robot_setting' );
@@ -574,14 +544,9 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			->andReturn( 'robot_value' );
 
 		$this->image->shouldReceive( 'get_attachment_by_url' )
-			->once()
+			->twice()
 			->with( 'https://example.com/image3.png' )
 			->andReturn( '123' );
-
-		$this->image->shouldReceive( 'get_attachment_by_url' )
-			->once()
-			->with( 'https://example.com/image4.png' )
-			->andReturn( '234' );
 
 		$indexable = $this->instance->map( $indexable, $aioseio_indexable );
 
@@ -589,17 +554,17 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 		$this->assertSame( 'existing_dsc', $indexable->description );
 		$this->assertSame( 'og_title1', $indexable->open_graph_title );
 		$this->assertSame( 'og_description1', $indexable->open_graph_description );
-		$this->assertSame( 'twitter_title1', $indexable->twitter_title );
-		$this->assertSame( 'twitter_description1', $indexable->twitter_description );
+		$this->assertSame( 'og_title1', $indexable->twitter_title );
+		$this->assertSame( 'og_description1', $indexable->twitter_description );
 		$this->assertSame( 'https://example.com/', $indexable->canonical );
 		$this->assertSame( null, $indexable->primary_focus_keyword );
 		$this->assertSame( 'https://example.com/image3.png', $indexable->open_graph_image );
 		$this->assertSame( 'imported', $indexable->open_graph_image_source );
 		$this->assertSame( '123', $indexable->open_graph_image_id );
 		$this->assertSame( null, $indexable->open_graph_image_meta );
-		$this->assertSame( 'https://example.com/image4.png', $indexable->twitter_image );
+		$this->assertSame( 'https://example.com/image3.png', $indexable->twitter_image );
 		$this->assertSame( 'imported', $indexable->twitter_image_source );
-		$this->assertSame( '234', $indexable->twitter_image_id );
+		$this->assertSame( '123', $indexable->twitter_image_id );
 	}
 
 	/**

--- a/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
@@ -660,9 +660,13 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 		$indexable->twitter_description = null;
 
 		$aioseio_indexable = [
+			'og_title'             => '',
+			'og_description'       => '',
+			'robots_default'       => true,
 			'robots_default'       => true,
 			'robots_nofollow'      => true,
 			'robots_noarchive'     => false,
+			
 			'robots_nosnippet'     => true,
 			'robots_noimageindex'  => false,
 			'og_image_type'        => 'author',

--- a/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
@@ -666,7 +666,6 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			'robots_default'       => true,
 			'robots_nofollow'      => true,
 			'robots_noarchive'     => false,
-			
 			'robots_nosnippet'     => true,
 			'robots_noimageindex'  => false,
 			'og_image_type'        => 'author',
@@ -732,7 +731,7 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			->with( $expected_url, null )
 			->andReturn( $expected_url );
 
-		$image_url = $this->instance->social_image_url_import( $aioseo_social_image_settings, $mapping, $indexable );
+		$image_url = $this->instance->social_image_url_import( $aioseo_social_image_settings, 'not_used', $mapping, $indexable );
 
 		$this->assertSame( $expected_url, $image_url );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix the case when the user has selected to `Use Data from Facebook Tab` for the Twitter data

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where twitter data from AIOSEO wouldn't get correctly imported when the user had enabled to retrieve those from the respective fb data

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
Notes:
* Without the feature flag, you won't be able to perform the Import as it won't be available in the Tools->Import/Export page

* Create a post while having AIOSEO enabled
* In the Social->Twitter tab, enable the `Use Data from Facebook Tab` setting
* Activate Yoast, go to Tools->Import/Export page and perform the import
* Go to the frontend of the post and compare the twitter title, description and image
Without this PR:
* The twitter title and description from Yoast would not be the same with the ones from AIOSEO, as AIOSEO would show for those a copy of the og title and description
With this PR:
* The twitter title and description from Yoast would be the same with the ones from AIOSEO, which would be a copy of the og title and description.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Import of all post data. Do a regression test of importing all previous post data (not search appearance settings though).
* Also try once with twitter data *not* coming from the open graph.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
