### PR TITLE
Optimize faq and how to images

### DIFF
--- a/admin/tracking/class-tracking-default-data.php
+++ b/admin/tracking/class-tracking-default-data.php
@@ -17,15 +17,16 @@ class WPSEO_Tracking_Default_Data implements WPSEO_Collection {
 	 */
 	public function get() {
 		return [
-			'siteTitle'      => get_option( 'blogname' ),
-			'@timestamp'     => (int) date( 'Uv' ),
-			'wpVersion'      => $this->get_wordpress_version(),
-			'homeURL'        => home_url(),
-			'adminURL'       => admin_url(),
-			'isMultisite'    => is_multisite(),
-			'siteLanguage'   => get_bloginfo( 'language' ),
-			'gmt_offset'     => get_option( 'gmt_offset' ),
-			'timezoneString' => get_option( 'timezone_string' ),
+			'siteTitle'       => get_option( 'blogname' ),
+			'@timestamp'      => (int) date( 'Uv' ),
+			'wpVersion'       => $this->get_wordpress_version(),
+			'homeURL'         => home_url(),
+			'adminURL'        => admin_url(),
+			'isMultisite'     => is_multisite(),
+			'siteLanguage'    => get_bloginfo( 'language' ),
+			'gmt_offset'      => get_option( 'gmt_offset' ),
+			'timezoneString'  => get_option( 'timezone_string' ),
+			'migrationStatus' => get_option( 'yoast_migrations_free' ),
 		];
 	}
 

--- a/packages/js/src/structured-data-blocks/faq/components/Question.js
+++ b/packages/js/src/structured-data-blocks/faq/components/Question.js
@@ -243,7 +243,7 @@ export default class Question extends Component {
 		} = this.props;
 
 		let newAnswer = answer.slice();
-		const image   = <img key={ media.id } alt={ media.alt } src={ media.url } style="max-width:100%;" />;
+		const image   = <img className={ `wp-image-${ media.id }` } alt={ media.alt } src={ media.url } style="max-width:100%;" />;
 
 		if ( newAnswer.push ) {
 			newAnswer.push( image );

--- a/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
+++ b/packages/js/src/structured-data-blocks/how-to/components/HowToStep.js
@@ -231,7 +231,7 @@ export default class HowToStep extends Component {
 		} = this.props;
 
 		let newText = text.slice();
-		const image = <img key={ media.id } alt={ media.alt } src={ media.url } style="max-width:100%;" />;
+		const image = <img className={ `wp-image-${ media.id }` } alt={ media.alt } src={ media.url } style="max-width:100%;" />;
 
 		if ( newText.push ) {
 			newText.push( image );

--- a/src/integrations/blocks/structured-data-blocks.php
+++ b/src/integrations/blocks/structured-data-blocks.php
@@ -220,9 +220,11 @@ class Structured_Data_Blocks implements Integration_Interface {
 				if ( $style_matches && isset( $style_matches[1] ) ) {
 					$width        = (int) $style_matches[1];
 					$meta_data    = \wp_get_attachment_metadata( $attachment_id );
-					$aspect_ratio = ( $meta_data['height'] / $meta_data['width'] );
-					$height       = ( $width * $aspect_ratio );
-					$image_size   = [ $width, $height ];
+					if ( isset( $meta_data['height'] ) && isset( $meta_data['width'] ) && $meta_data['height'] > 0 && $meta_data['width'] > 0 ) {
+						$aspect_ratio = ( $meta_data['height'] / $meta_data['width'] );
+						$height       = ( $width * $aspect_ratio );
+						$image_size   = [ $width, $height ];
+					}
 				}
 
 				/**

--- a/src/integrations/blocks/structured-data-blocks.php
+++ b/src/integrations/blocks/structured-data-blocks.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Integrations\Blocks;
 
 use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
@@ -10,19 +11,14 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
  */
 class Structured_Data_Blocks implements Integration_Interface {
 
+	use No_Conditionals;
+
 	/**
 	 * An instance of the WPSEO_Admin_Asset_Manager class.
 	 *
 	 * @var WPSEO_Admin_Asset_Manager
 	 */
 	protected $asset_manager;
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public static function get_conditionals() {
-		return [];
-	}
 
 	/**
 	 * Structured_Data_Blocks constructor.
@@ -38,6 +34,76 @@ class Structured_Data_Blocks implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
+		$this->register_blocks();
+	}
+
+	/**
+	 * Registers the blocks.
+	 *
+	 * @return void
+	 */
+	public function register_blocks() {
+		\register_block_type(
+			'yoast/faq-block',
+			[
+				'render_callback' => [ $this, 'optimize_faq_images' ],
+				'attributes'      => [
+					'className' => [
+						'default' => '',
+						'type'    => 'string',
+					],
+					'questions' => [
+						'type' => 'array',
+					],
+					'additionalListCssClasses' => [
+						'type' => 'string',
+					],
+				],
+			]
+		);
+		\register_block_type(
+			'yoast/how-to-block',
+			[
+				'render_callback' => [ $this, 'optimize_how_to_images' ],
+				'attributes'      => [
+					'hasDuration' => [
+						'type' => 'boolean',
+					],
+					'days' => [
+						'type' => 'string',
+					],
+					'hours' => [
+						'type' => 'string',
+					],
+					'minutes' => [
+						'type' => 'string',
+					],
+					'description' => [
+						'type'     => 'array',
+						'source'   => 'children',
+						'selector' => '.schema-how-to-description',
+					],
+					'jsonDescription' => [
+						'type' => 'string',
+					],
+					'steps' => [
+						'type' => 'array',
+					],
+					'additionalListCssClasses' => [
+						'type' => 'string',
+					],
+					'unorderedList' => [
+						'type' => 'boolean',
+					],
+					'durationText' => [
+						'type' => 'string',
+					],
+					'defaultDurationText' => [
+						'type' => 'string',
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -55,5 +121,82 @@ class Structured_Data_Blocks implements Integration_Interface {
 
 		$this->asset_manager->enqueue_script( 'structured-data-blocks' );
 		$this->asset_manager->enqueue_style( 'structured-data-blocks' );
+	}
+
+	/**
+	 * Optimizes images in the FAQ blocks.
+	 *
+	 * @param array  $attributes The attributes.
+	 * @param string $content    The content.
+	 *
+	 * @return string The content with images optimized.
+	 */
+	public function optimize_faq_images( $attributes, $content ) {
+		if ( ! isset( $attributes['questions'] ) ) {
+			return $content;
+		}
+
+		return $this->optimize_images( $attributes['questions'], 'answer', $content );
+	}
+
+	/**
+	 * Optimizes images in the How-To blocks.
+	 *
+	 * @param array  $attributes The attributes.
+	 * @param string $content    The content.
+	 *
+	 * @return string The content with images optimized.
+	 */
+	public function optimize_how_to_images( $attributes, $content ) {
+		if ( ! isset( $attributes['steps'] ) ) {
+			return $content;
+		}
+
+		return $this->optimize_images( $attributes['steps'], 'text', $content );
+	}
+
+	/**
+	 * Optimizes images in structured data blocks.
+	 *
+	 * @param array  $data    The data from the attributes.
+	 * @param string $key     The key in the data to iterate over.
+	 * @param string $content The content.
+	 *
+	 * @return string The content with images optimized.
+	 */
+	private function optimize_images( $data, $key, $content ) {
+		// First grab all image IDs from the attributes.
+		$images = [];
+		foreach ( $data as $question ) {
+			if ( ! isset( $question[ $key ] ) ) {
+				continue;
+			}
+			foreach ( $question[ $key ] as $part ) {
+				if ( ! \is_array( $part ) || ! isset( $part['type'] ) || $part['type'] !== 'img' ) {
+					continue;
+				}
+
+				if ( ! isset( $part['key'] ) || ! isset( $part['props']['src'] ) ) {
+					continue;
+				}
+
+				$images[ $part['props']['src'] ] = (int) $part['key'];
+			}
+		}
+
+		// Then replace all images with optimized versions in the content.
+		$content = \preg_replace_callback(
+			'/<img[^>]+>/',
+			function ( $matches ) use ( $images ) {
+				preg_match( '/src="([^"]+)"/', $matches[0], $src_matches );
+				if ( ! $src_matches || ! isset( $src_matches[1] ) || ! isset( $images[ $src_matches[1] ] ) ) {
+					return $matches[0];
+				}
+				return \wp_get_attachment_image( $images[ $src_matches[1] ], 'full' );
+			},
+			$content
+		);
+
+		return $content;
 	}
 }

--- a/src/integrations/blocks/structured-data-blocks.php
+++ b/src/integrations/blocks/structured-data-blocks.php
@@ -192,7 +192,23 @@ class Structured_Data_Blocks implements Integration_Interface {
 				if ( ! $src_matches || ! isset( $src_matches[1] ) || ! isset( $images[ $src_matches[1] ] ) ) {
 					return $matches[0];
 				}
-				return \wp_get_attachment_image( $images[ $src_matches[1] ], 'full' );
+				$attachment_id = (int) $images[ $src_matches[1] ];
+
+				/**
+				 * Filter: 'wpseo_structured_data_blocks_image_size' - Allows adjusting the image size in structured data blocks.
+				 *
+				 * @param int    $attachment_id  The attachment ID.
+				 * @param string $attachment_src The attachment src.
+				 *
+				 * @api array $pieces The schema pieces.
+				 */
+				$image_size = \apply_filters(
+					'wpseo_structured_data_blocks_image_size',
+					'full',
+					$attachment_id,
+					$src_matches[1]
+				);
+				return \wp_get_attachment_image( $attachment_id, $image_size );
 			},
 			$content
 		);

--- a/src/integrations/blocks/structured-data-blocks.php
+++ b/src/integrations/blocks/structured-data-blocks.php
@@ -158,20 +158,20 @@ class Structured_Data_Blocks implements Integration_Interface {
 	/**
 	 * Optimizes images in structured data blocks.
 	 *
-	 * @param array  $data    The data from the attributes.
-	 * @param string $key     The key in the data to iterate over.
-	 * @param string $content The content.
+	 * @param array  $elements The list of elements from the block attributes.
+	 * @param string $key      The key in the data to iterate over.
+	 * @param string $content  The content.
 	 *
 	 * @return string The content with images optimized.
 	 */
-	private function optimize_images( $data, $key, $content ) {
+	private function optimize_images( $elements, $key, $content ) {
 		// First grab all image IDs from the attributes.
 		$images = [];
-		foreach ( $data as $question ) {
-			if ( ! isset( $question[ $key ] ) ) {
+		foreach ( $elements as $element ) {
+			if ( ! isset( $element[ $key ] ) ) {
 				continue;
 			}
-			foreach ( $question[ $key ] as $part ) {
+			foreach ( $element[ $key ] as $part ) {
 				if ( ! \is_array( $part ) || ! isset( $part['type'] ) || $part['type'] !== 'img' ) {
 					continue;
 				}
@@ -197,10 +197,11 @@ class Structured_Data_Blocks implements Integration_Interface {
 				/**
 				 * Filter: 'wpseo_structured_data_blocks_image_size' - Allows adjusting the image size in structured data blocks.
 				 *
-				 * @param int    $attachment_id  The attachment ID.
-				 * @param string $attachment_src The attachment src.
+				 * @since 18.2
 				 *
-				 * @api array $pieces The schema pieces.
+				 * @param string|int[] $image_size     The image size. Accepts any registered image size name, or an array of width and height values in pixels (in that order).
+				 * @param int          $attachment_id  The id of the attachment.
+				 * @param string       $attachment_src The attachment src.
 				 */
 				$image_size = \apply_filters(
 					'wpseo_structured_data_blocks_image_size',
@@ -208,7 +209,13 @@ class Structured_Data_Blocks implements Integration_Interface {
 					$attachment_id,
 					$src_matches[1]
 				);
-				return \wp_get_attachment_image( $attachment_id, $image_size );
+				$image_html = \wp_get_attachment_image( $attachment_id, $image_size );
+
+				if ( empty( $image_html ) ) {
+					return $matches[0];
+				}
+
+				return $image_html;
 			},
 			$content
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Optimizes the image output of FAQ and How To blocks.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Optimizes the images in FAQ and How To blocks to be more responsive and load faster.

## Relevant technical choices:

* A new filter `wpseo_structured_data_blocks_image_size` is added to allow adjusting attachment sizes.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a FAQ and How To block before updating to this PR.
* Update to this PR.
* The output of images in the FAQ and How To blocks should be lazily loaded and include a `srcset` attribute.
* Do the same for new FAQ and How To blocks.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The output of FAQ and How To blocks.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
