### PR TITLE
Hide canonical posts from sitemaps

### DIFF
--- a/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
+++ b/inc/sitemaps/abstract-class-indexable-sitemap-provider.php
@@ -100,6 +100,7 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
 		$query = $this->repository
 			->query_where_noindex( false, $this->get_object_type() )
 			->select_many( 'id', 'object_sub_type' )
+			->where_raw( '( `canonical` IS NULL OR `canonical` = `permalink` )' )
 			->order_by_asc( 'object_sub_type' )
 			->order_by_asc( 'object_last_modified' );
 
@@ -149,6 +150,7 @@ abstract class WPSEO_Indexable_Sitemap_Provider implements WPSEO_Sitemap_Provide
 			->select( 'object_sub_type' )
 			->select_expr( 'MAX(`object_last_modified`)', 'post_type_last_modified' )
 			->select_expr( 'COUNT(`id`)', 'number_of_posts' )
+			->where_raw( '( `canonical` IS NULL OR `canonical` = `permalink` )' )
 			->having_gt( 'number_of_posts', 0 )
 			->group_by( 'object_sub_type' );
 

--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -60,8 +60,6 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 * @return array
 	 */
 	public function get_index_links( $max_entries ) {
-		global $wpdb;
-
 		if ( ! $this->handles_type( 'author' ) ) {
 			return [];
 		}
@@ -111,6 +109,7 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		$query                         = $this->repository
 			->query_where_noindex( false, 'user', null, $noindex_authors_with_no_posts )
 			->select_many( 'id', 'object_id', 'permalink', 'object_last_modified' )
+			->where_raw( '( `canonical` IS NULL OR `canonical` = `permalink` )' )
 			->order_by_asc( 'object_last_modified' )
 			->offset( $offset )
 			->limit( $max_entries );
@@ -145,6 +144,7 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		$query = $this->repository
 			->query_where_noindex( false, 'user', null, $noindex_authors_with_no_posts )
 			->select( 'id' )
+			->where_raw( '( `canonical` IS NULL OR `canonical` = `permalink` )' )
 			->order_by_asc( 'object_last_modified' );
 
 		$users_to_exclude = $this->exclude_users();
@@ -185,6 +185,7 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			->query_where_noindex( false, 'user', null, $noindex_authors_with_no_posts )
 			->select_expr( 'MAX(`object_last_modified`)', 'most_recently_modified' )
 			->select_expr( 'COUNT(`id`)', 'number_of_authors' )
+			->where_raw( '( `canonical` IS NULL OR `canonical` = `permalink` )' )
 			->having_gt( 'number_of_authors', 0 );
 
 		if ( is_array( $users_to_exclude ) && count( $users_to_exclude ) > 0 ) {

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -82,6 +82,7 @@ class WPSEO_Post_Type_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider 
 		$query = $this->repository
 			->query_where_noindex( false, 'post', $type )
 			->select_many( 'id', 'object_id', 'permalink', 'object_last_modified' )
+			->where_raw( '( `canonical` IS NULL OR `canonical` = `permalink` )' )
 			->order_by_asc( 'object_last_modified' )
 			->offset( $offset )
 			->limit( $max_entries );

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -102,6 +102,7 @@ class WPSEO_Taxonomy_Sitemap_Provider extends WPSEO_Indexable_Sitemap_Provider i
 		$query = $this->repository
 			->query_where_noindex( false, 'term', $type )
 			->select_many( 'id', 'object_id', 'permalink', 'object_last_modified' )
+			->where_raw( '( `canonical` IS NULL OR `canonical` = `permalink` )' )
 			->order_by_asc( 'object_last_modified' )
 			->offset( $offset )
 			->limit( $steps );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Posts that have a canonical url set, shouldn't end up in the sitemaps.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where posts would still be in the sitemaps even though they have a canonical url set to another url.

## Relevant technical choices:

* I still include an entry if the sitemap if the canonical url matches the post permalink _exactly_. If the post is `/something` and the canonical is `/something/` it still is removed from the sitemap. This behaviour is now the same as in `trunk`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open the posts sitemaps
* Click a single entry in the sitemap and edit that post: under the Advanced section in the metabox, give it a canonical url. This can be any besides the url of the post.
* Save the post and visit the sitemap again. The edited post should no longer be visible in the sitemap
* Change the canonical url to the permalink of the post itself.
* Save the post and view the sitemap again. The post should be back in the sitemap.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
