### PR TITLE
LINGO-1267 Adjusts the meta description length limit for Japanese

### DIFF
--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -2,6 +2,7 @@
 import { flow, get, isEqual, set } from "lodash";
 import { excerptFromContent } from "../../helpers/replacementVariableHelpers";
 import { getContentTinyMce } from "../../lib/tinymce";
+import getContentLocale from "../../analysis/getContentLocale";
 
 export const DOM_IDS = {
 	// Post editor.
@@ -315,11 +316,19 @@ export const getPostPermalink = () => get( window, "wpseoScriptData.metabox.base
 export const getTermPermalink = () => get( window, "wpseoScriptData.metabox.base_url", "" ) + getTermSlug();
 
 /**
+ * Gets the limit for the meta description based on the locale.
+ *
+ * @returns {number} 80 for texts in Japanese, 156 for other languages.
+ */
+export const getMetaDescriptionLimit = () => getContentLocale() === "ja" ? 80 : 156;
+
+/**
  * Gets the post excerpt from the document.
  *
  * @returns {string} The post excerpt or an empty string.
  */
-export const getPostExcerpt = () => get( document.getElementById( DOM_IDS.POST_EXCERPT ), "value", "" ) || excerptFromContent( getPostContent() );
+export const getPostExcerpt = () => get( document.getElementById( DOM_IDS.POST_EXCERPT ), "value", "" ) ||
+	excerptFromContent( getPostContent(), getMetaDescriptionLimit() );
 
 /**
  * Gets the term excerpt from the document.

--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -335,7 +335,7 @@ export const getPostExcerpt = () => get( document.getElementById( DOM_IDS.POST_E
  *
  * @returns {string} The term excerpt.
  */
-export const getTermExcerpt = () => excerptFromContent( getTermDescription() );
+export const getTermExcerpt = () => excerptFromContent( getTermDescription(), getMetaDescriptionLimit() );
 
 /**
  * Gets the post featured image source if one is set.

--- a/packages/js/src/classic-editor/initial-state.js
+++ b/packages/js/src/classic-editor/initial-state.js
@@ -2,6 +2,7 @@ import * as dom from "./helpers/dom";
 import { FOCUS_KEYPHRASE_ID } from "@yoast/seo-integration";
 import isSeoAnalysisActive from "../analysis/isKeywordAnalysisActive";
 import isReadabilityAnalysisActive from "../analysis/isContentAnalysisActive";
+import getContentLocale from "../analysis/getContentLocale";
 
 /**
  * Gets the initial state for SEO store from post DOM.
@@ -24,6 +25,7 @@ export const getInitialPostState = () => ( {
 		content: dom.getPostContent(),
 		featuredImage: dom.getPostFeaturedImage(),
 		categories: dom.getPostCategories(),
+		locale: getContentLocale(),
 	},
 	form: {
 		seo: {
@@ -59,6 +61,7 @@ export const getInitialTermState = () => ( {
 		permalink: dom.getTermPermalink(),
 		excerpt: dom.getTermExcerpt(),
 		content: dom.getTermDescription(),
+		locale: getContentLocale(),
 	},
 	form: {
 		seo: {

--- a/packages/js/tests/classic-editor/helpers/dom.test.js
+++ b/packages/js/tests/classic-editor/helpers/dom.test.js
@@ -1,14 +1,50 @@
-import * as dom from "../../../src/classic-editor/helpers/dom";
+import { getMetaDescriptionLimit, getPostExcerpt, getTermExcerpt } from "../../../src/classic-editor/helpers/dom";
+import getContentLocale from "../../../src/analysis/getContentLocale";
 
-jest.mock( "../../../src/helpers/replacementVariableHelpers", () => ( {
-	excerptFromContent: jest.fn( () => "Tortoiseshell is a cat coat coloring named for its similarity to " +
-		"tortoiseshell material. Like calicos, tortoiseshell cats are almost exclusively female." ),
+jest.mock( "../../../src/lib/tinymce", () => ( {
+	getContentTinyMce: jest.fn().mockReturnValue(
+		"Tortoiseshell is a cat coat coloring named for its similarity to tortoiseshell material. " +
+		"Like calicos, tortoiseshell cats are almost exclusively female. " +
+		"Male tortoiseshells are rare and are usually sterile." ),
 } ) );
 
+jest.mock( "../../../src/analysis/getContentLocale", () => jest.fn( () => "" ) );
+
 describe( "a test for retrieving data from dom", () => {
+	it( "should return the term excerpt retrieved from post content", () => {
+		getContentLocale.mockImplementation( () => "en_US" );
+
+		expect( getMetaDescriptionLimit() ).toEqual( 156 );
+		expect( getPostExcerpt() ).toEqual(
+			"Tortoiseshell is a cat coat coloring named for its similarity to tortoiseshell material. " +
+			"Like calicos, tortoiseshell cats are almost exclusively female." );
+	} );
+
 	it( "should return the term excerpt retrieved from term content", () => {
-		expect( dom.getTermExcerpt() ).toEqual( "Tortoiseshell is a cat coat coloring named for its similarity to " +
-			"tortoiseshell material. Like calicos, tortoiseshell cats are almost exclusively female." );
+		getContentLocale.mockImplementation( () => "en_US" );
+
+		expect( getMetaDescriptionLimit() ).toEqual( 156 );
+		expect( getTermExcerpt() ).toEqual(
+			"Tortoiseshell is a cat coat coloring named for its similarity to tortoiseshell material. " +
+			"Like calicos, tortoiseshell cats are almost exclusively female." );
+	} );
+} );
+
+describe( "a test for retrieving data from dom with another locale setting", () => {
+	it( "should return the term excerpt retrieved from post content, but use the limit for Japanese", () => {
+		getContentLocale.mockImplementation( () => "ja" );
+
+		expect( getMetaDescriptionLimit() ).toEqual( 80 );
+		expect( getPostExcerpt() ).toEqual(
+			"Tortoiseshell is a cat coat coloring named for its similarity to tortoiseshell" );
+	} );
+
+	it( "should return the term excerpt retrieved from term content, but use the limit for Japanese", () => {
+		getContentLocale.mockImplementation( () => "ja" );
+
+		expect( getMetaDescriptionLimit() ).toEqual( 80 );
+		expect( getTermExcerpt() ).toEqual(
+			"Tortoiseshell is a cat coat coloring named for its similarity to tortoiseshell" );
 	} );
 } );
 

--- a/packages/js/tests/classic-editor/helpers/dom.test.js
+++ b/packages/js/tests/classic-editor/helpers/dom.test.js
@@ -1,4 +1,4 @@
-import { getMetaDescriptionLimit, getPostExcerpt, getTermExcerpt } from "../../../src/classic-editor/helpers/dom";
+import * as dom from "../../../src/classic-editor/helpers/dom";
 import getContentLocale from "../../../src/analysis/getContentLocale";
 
 jest.mock( "../../../src/lib/tinymce", () => ( {
@@ -14,8 +14,8 @@ describe( "a test for retrieving data from dom", () => {
 	it( "should return the term excerpt retrieved from post content", () => {
 		getContentLocale.mockImplementation( () => "en_US" );
 
-		expect( getMetaDescriptionLimit() ).toEqual( 156 );
-		expect( getPostExcerpt() ).toEqual(
+		expect( dom.getMetaDescriptionLimit() ).toEqual( 156 );
+		expect( dom.getPostExcerpt() ).toEqual(
 			"Tortoiseshell is a cat coat coloring named for its similarity to tortoiseshell material. " +
 			"Like calicos, tortoiseshell cats are almost exclusively female." );
 	} );
@@ -23,8 +23,8 @@ describe( "a test for retrieving data from dom", () => {
 	it( "should return the term excerpt retrieved from term content", () => {
 		getContentLocale.mockImplementation( () => "en_US" );
 
-		expect( getMetaDescriptionLimit() ).toEqual( 156 );
-		expect( getTermExcerpt() ).toEqual(
+		expect( dom.getMetaDescriptionLimit() ).toEqual( 156 );
+		expect( dom.getTermExcerpt() ).toEqual(
 			"Tortoiseshell is a cat coat coloring named for its similarity to tortoiseshell material. " +
 			"Like calicos, tortoiseshell cats are almost exclusively female." );
 	} );
@@ -34,16 +34,16 @@ describe( "a test for retrieving data from dom with another locale setting", () 
 	it( "should return the term excerpt retrieved from post content, but use the limit for Japanese", () => {
 		getContentLocale.mockImplementation( () => "ja" );
 
-		expect( getMetaDescriptionLimit() ).toEqual( 80 );
-		expect( getPostExcerpt() ).toEqual(
+		expect( dom.getMetaDescriptionLimit() ).toEqual( 80 );
+		expect( dom.getPostExcerpt() ).toEqual(
 			"Tortoiseshell is a cat coat coloring named for its similarity to tortoiseshell" );
 	} );
 
 	it( "should return the term excerpt retrieved from term content, but use the limit for Japanese", () => {
 		getContentLocale.mockImplementation( () => "ja" );
 
-		expect( getMetaDescriptionLimit() ).toEqual( 80 );
-		expect( getTermExcerpt() ).toEqual(
+		expect( dom.getMetaDescriptionLimit() ).toEqual( 80 );
+		expect( dom.getTermExcerpt() ).toEqual(
 			"Tortoiseshell is a cat coat coloring named for its similarity to tortoiseshell" );
 	} );
 } );

--- a/packages/js/tests/classic-editor/initial-state.test.js
+++ b/packages/js/tests/classic-editor/initial-state.test.js
@@ -33,6 +33,7 @@ describe( "a test for getting the initial state of a post or a term", () => {
 		expect( actual.editor.excerpt ).toEqual( "An example of excerpt from a content." );
 		expect( actual.editor.content ).toEqual( "Tortoiseshell is a cat coat coloring named for its similarity to tortoiseshell material." );
 		expect( actual.editor.featuredImage ).toEqual( {} );
+		expect( actual.editor.locale ).toEqual( "en_US" );
 		expect( actual.form.seo.title ).toEqual( "Tortoiseshell cat - All about cats" );
 		expect( actual.form.seo.description ).toEqual( "Cats with tortoiseshell coloration are believed to bring good luck." );
 		expect( actual.form.seo.slug ).toEqual( "www.sweetcat.com/tortoiseshell-cat" );
@@ -46,6 +47,7 @@ describe( "a test for getting the initial state of a post or a term", () => {
 		expect( actual.editor.permalink ).toEqual( "www.sweetcat.com/categories" );
 		expect( actual.editor.excerpt ).toEqual( "This is another meta description about another pretty little cat." );
 		expect( actual.editor.content ).toEqual( "This is to describe a cat, that deserves only good attributes to them." );
+		expect( actual.editor.locale ).toEqual( "en_US" );
 		expect( actual.form.seo.title ).toEqual( "A title befitting a beautiful cat" );
 		expect( actual.form.seo.description ).toEqual( "An example of a description for a cat." );
 		expect( actual.form.seo.slug ).toEqual( "www.sweetcat.com/categories/cat" );

--- a/packages/seo-integration/src/replacement-variables/configurations.js
+++ b/packages/seo-integration/src/replacement-variables/configurations.js
@@ -37,7 +37,11 @@ export const excerpt = {
 		const currentExcerpt = select( SEO_STORE_NAME ).selectExcerpt();
 		const currentContent = select( SEO_STORE_NAME ).selectContent();
 
-		return ( currentExcerpt === "" ) ? excerptFromContent( currentContent ) : currentExcerpt;
+		// Limit the excerpt to 80 characters for Japanese and to 156 characters for other languages.
+		const currentLocale = select( SEO_STORE_NAME ).selectLocale();
+		const limit = currentLocale === "ja" ? 80 : 156;
+
+		return ( currentExcerpt === "" ) ? excerptFromContent( currentContent, limit ) : currentExcerpt;
 	},
 };
 

--- a/packages/seo-integration/tests/replacement-variables/configurations.test.js
+++ b/packages/seo-integration/tests/replacement-variables/configurations.test.js
@@ -12,12 +12,13 @@ const selectContent = jest.fn().mockReturnValue( "A calico cat is a domestic cat
 	"caliby or a torbie (i.e. a tabby tortoiseshell)." );
 
 describe( "a test for getting the replacement of the variables", () => {
-	it( "should return the replacement for the excerpt variable when the current excerpt is an empty string: " +
-		"the excerpt should be extracted from the content", () => {
+	it( "should return the replacement for the excerpt variable when the current excerpt is an empty string and the locale is English: " +
+		"the excerpt should be extracted from the content, truncated in the 156th character", () => {
 		jest.spyOn( data, "select" ).mockImplementation( () => {
 			return {
 				selectExcerpt: jest.fn().mockReturnValue( "" ),
 				selectContent: selectContent,
+				selectLocale: jest.fn().mockReturnValue( "en" ),
 			};
 		} );
 
@@ -25,18 +26,35 @@ describe( "a test for getting the replacement of the variables", () => {
 			"commonly thought of as being typically 25% to 75% white with" );
 	} );
 
-	it( "should return the replacement for the excerpt variable when the current excerpt is not empty", () => {
+	it( "should return the replacement for the excerpt variable when the current excerpt is not empty and the locale is English", () => {
 		jest.spyOn( data, "select" ).mockImplementation( () => {
 			return {
 				selectExcerpt: jest.fn().mockReturnValue( "The cat (Felis catus) is a domestic species of a small carnivorous mammal. " +
 					"It is the only domesticated species in the family Felidae and is often referred to as the domestic cat to distinguish it " +
 					"from the wild members of the family." ),
 				selectContent: selectContent,
+				selectLocale: jest.fn().mockReturnValue( "en" ),
 			};
 		} );
 
 		expect( excerpt.getReplacement() ).toEqual( "The cat (Felis catus) is a domestic species of a small carnivorous mammal. " +
 			"It is the only domesticated species in the family Felidae and is often referred to as the domestic cat to distinguish it " +
 			"from the wild members of the family." );
+	} );
+
+	it( "should return the replacement for the excerpt variable when the current excerpt is empty and the locale is Japanese: " +
+		"the excerpt should be extracted from the content, truncated in the 80th character", () => {
+		jest.spyOn( data, "select" ).mockImplementation( () => {
+			return {
+				selectExcerpt: jest.fn().mockReturnValue( "" ),
+				selectContent: jest.fn().mockReturnValue( "腹げゆッ格装まー町告イナヲス情団リラまさ今裁ホウ応4相うごひ進夫更ヤヱ協書ッなにり野責ノワホ臨索フえ以天っ" +
+					"兆百ラヘチ全2意だ。近ゅめびル聞9白捕りラ何働成構くでみひ崎9新ルラ法触英クゃゅげ入待サ池稿ろしぶ点法ねレき権増サ禁一ワ心現ワキ表週暮枠トのや。者ヲミ試虚ずーラ" +
+					"格岐キロヘム哀7心ア校盤だ連植場つえめ軍島スチセ美属通んばトか動成き入博ス取詳態推よ。" ),
+				selectLocale: jest.fn().mockReturnValue( "ja" ),
+			};
+		} );
+
+		expect( excerpt.getReplacement() ).toEqual( "腹げゆッ格装まー町告イナヲス情団リラまさ今裁ホウ応4相うごひ進夫更ヤヱ協書ッなにり野責ノワホ臨索フえ以天っ" +
+			"兆百ラヘチ全2意だ。近ゅめびル聞9白捕りラ何働成構くで" );
 	} );
 } );

--- a/packages/seo-store/src/editor/slice.js
+++ b/packages/seo-store/src/editor/slice.js
@@ -9,6 +9,7 @@ export const defaultEditorState = {
 	date: "",
 	featuredImage: {},
 	categories: [],
+	locale: "",
 };
 
 const editorSlice = createSlice( {
@@ -36,6 +37,9 @@ const editorSlice = createSlice( {
 		updateCategories: ( state, action ) => {
 			state.categories = action.payload;
 		},
+		updateLocale: ( state, action ) => {
+			state.locale = action.payload;
+		},
 	},
 } );
 
@@ -48,6 +52,7 @@ export const editorSelectors = {
 	selectDate: ( state ) => get( state, "editor.date" ),
 	selectFeaturedImage: ( state ) => get( state, "editor.featuredImage" ),
 	selectCategories: ( state ) => get( state, "editor.categories" ),
+	selectLocale: ( state ) => get( state, "editor.locale" ),
 };
 
 export const editorActions = editorSlice.actions;

--- a/packages/seo-store/src/editor/tests.js
+++ b/packages/seo-store/src/editor/tests.js
@@ -105,25 +105,25 @@ describe( "Editor slice", () => {
 			const result = editorReducer( initialState, updateCategories( [
 				{
 					id: "1",
-					name: "category 1"
+					name: "category 1",
 				},
 				{
-					id: '2',
-					name: 'category 2'
-				}
+					id: "2",
+					name: "category 2",
+				},
 			] ) );
 
 			expect( result ).toEqual( {
 				...initialState,
 				categories: [
 					{
-						id: '1',
-						name: 'category 1'
+						id: "1",
+						name: "category 1",
 					},
 					{
-						id: '2',
-						name: 'category 2'
-					}
+						id: "2",
+						name: "category 2",
+					},
 				],
 			} );
 		} );

--- a/packages/seo-store/src/editor/tests.js
+++ b/packages/seo-store/src/editor/tests.js
@@ -11,6 +11,7 @@ describe( "Editor slice", () => {
 		excerpt: "",
 		date: "",
 		featuredImage: {},
+		locale: "",
 		categories: [],
 	};
 
@@ -87,13 +88,24 @@ describe( "Editor slice", () => {
 			} );
 		} );
 
+		test( "should update the locale", () => {
+			const { updateLocale } = editorActions;
+
+			const result = editorReducer( initialState, updateLocale( "ja" ) );
+
+			expect( result ).toEqual( {
+				...initialState,
+				locale: "ja",
+			} );
+		} );
+
 		test( "should update the categories", () => {
 			const { updateCategories } = editorActions;
 
 			const result = editorReducer( initialState, updateCategories( [
 				{
-					id: '1',
-					name: 'category 1'
+					id: "1",
+					name: "category 1"
 				},
 				{
 					id: '2',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In [this PR](https://github.com/Yoast/wordpress-seo/pull/17958), we added fallbacks for the excerpt when that is empty. This PR changes the functionality to adhere to the changes in [this PR](https://github.com/Yoast/wordpress-seo/pull/17907), where we adapted the recommended meta description length (and meta description preview limit) for Japanese. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets the recommended meta description length for Japanese to 80 characters.

## Relevant technical choices:

* We retrieve the locale not from the DOM (as that shows the user's locale, and not the site-wide locale), but from the `l10nObject` (in `packages/js/src/analysis/getContentLocale.js`). 
* The behaviour of live-updating the generated excerpt differs between new and existing posts. For new posts, the excerpt is updated while writing, but for existing posts, the excerpt is only updated after saving. This behaviour already exist in `analysis-integration` branch in which [a new separate issue](https://yoast.atlassian.net/browse/LINGO-1311) was created to address this problem.
* The auto-generated excerpt does not take into account the combined length of the date and separator (visible in the Google Preview for post and pages, though not for taxonomies), while the assessment does take this date into account. This will be addressed in [a separate issue](https://yoast.atlassian.net/browse/LINGO-1243).
* Unit tests were not yet added for changes made inside `seo-integration` package in this PR. This is because no testing framework has been set up for this package. [An issue](https://yoast.atlassian.net/browse/LINGO-1270) has been created to add one.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Test the behaviour for Japanese**
- Set a default title and meta description for Posts and Pages:
    - Go to `Yoast SEO > Search Appearance > Content Types`.
    - For both Posts and Pages, set the default meta description to `%%Excerpt%%`.
- Set your site language to Japanese.
- Activate the Classic editor
- Add a new post.
- Add some Japanese text, generate it through [this tool](https://generator.lorem-ipsum.info/_japanese).
- Save the post. 
- Confirm the meta description (in the Google Preview tab) displays the first 80 characters of the post's text. You can use [this tool](https://wordcounter.net/character-count) to check that.
- Add some text **without spaces** to the first 80 characters (e.g. add `testing`). 
- Save the post. 
- Confirm the meta description displays the first 80 characters of the post's text (the meta description should now include your added characters).
- Repeat the above steps for a category.

**Test the default behaviour (regression)**
- Set your site language to English.
- Activate the Classic editor
- Add a new post.
- Add some lorem ipsum text, generate it through [this tool](https://generator.lorem-ipsum.info/).
- Save the post. 
- Confirm the meta description (in the Google Preview tab) displays the first 156 characters of the post's text, stripped at the last space before 156 characters. You can use [this tool](https://wordcounter.net/character-count) to check that.
- Add some text to the first 156 characters (e.g. add `this is a test`). 
- Save the post. 
- Confirm the meta description displays the first 156 characters of the post's text, stripped at the last space before 156 characters (the meta description should now include your added characters).
- Repeat the above steps for a category.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Affects the meta description replacement variable.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[Shopify]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1267
