### PR TITLE
Dupp 216 add edit buttons and logic

### DIFF
--- a/css/src/tailwind.css
+++ b/css/src/tailwind.css
@@ -22,3 +22,7 @@
 .yst-button--remove {
 	@apply yst-button yst-text-red-600 yst-underline yst-rounded-md yst-px-1.5 yst-py-1 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-indigo-500;
 }
+
+.yst-button--small {
+	@apply yst-text-[12px] yst-px-2.5 yst-py-1.5;
+}

--- a/css/src/workouts.css
+++ b/css/src/workouts.css
@@ -23,6 +23,10 @@
 	@apply yst-button yst-text-red-600 yst-underline yst-rounded-md yst-px-1.5 yst-py-1 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-offset-2 focus:yst-ring-indigo-500;
 }
 
+.yst-button--small {
+	@apply yst-text-[12px] yst-px-2.5 yst-py-1.5;
+}
+
 #wpseo-workouts-container-free h1,
 #wpseo-workouts-container-free h3 {
 	color: #a4286a;

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -772,17 +772,19 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 				<Stepper
 					steps={ [
 						{ name: "The indexables", component: <IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } />, isSaved: isStepFinished( "configuration", steps.optimizeSeoData ) },
-						{ name: "Knowledge panel", description: "", component: <SiteRepresentationStep onOrganizationOrPersonChange={ onOrganizationOrPersonChange } dispatch={ dispatch } state={ state } siteRepresentsPerson={ siteRepresentsPerson } onSiteTaglineChange={ onSiteTaglineChange } siteRepresentationEmpty={ siteRepresentationEmpty } />, isSaved: isStepFinished( "configuration", steps.siteRepresentation ) },
+						{ name: "Knowledge panel", description: "", component: <SiteRepresentationStep
+							onOrganizationOrPersonChange={ onOrganizationOrPersonChange } dispatch={ dispatch } state={ state } siteRepresentsPerson={ siteRepresentsPerson } onSiteTaglineChange={ onSiteTaglineChange } siteRepresentationEmpty={ siteRepresentationEmpty }
+						/>, isSaved: isStepFinished( "configuration", steps.siteRepresentation ) },
 						{ name: "Social profiles", description: "", component: <SocialProfilesStep state={ state } dispatch={ dispatch } setErrorFields={ setErrorFields } siteRepresentsPerson={ siteRepresentsPerson } />, isSaved: isStepFinished( "configuration", steps.socialProfiles ) },
 						{ name: "Personal preferences", description: "", component: <PersonalPreferencesStep state={ state } setTracking={ setTracking } isTrackingOptionSelected={ isTrackingOptionSelected } />, isSaved: isStepFinished( "configuration", steps.newsletterSignup ) },
-						{ name: "Finish configuration", description: "", component: <FinishStep />, isSaved: isWorkoutFinished },
+						{ name: "Finish configuration", description: "", component: <FinishStep />, isSaved: isStepperFinished },
 					] }
 					setActiveStepIndex={ setActiveStepIndex }
 					saveStep={ ( stepIdx ) => finishSteps( "configuration", [ stepNumberNameMap[ stepIdx + 1 ] ] ) }
 					activeStepIndex={ activeStepIndex }
+					isStepperFinished={ isStepperFinished }
 				/>
 			</div>
-
 			<UnsavedChangesModal hasUnsavedChanges={ state.editedSteps.includes( activeStepIndex + 1 ) } />
 
 			<button

--- a/packages/js/src/workouts/components/StepHeader.js
+++ b/packages/js/src/workouts/components/StepHeader.js
@@ -1,0 +1,80 @@
+import { StepCircle } from "./StepCircle";
+import PropTypes from "prop-types";
+import { stepperTimings } from "../stepper-helper";
+
+/**
+ * Gets the classnames for the step name.
+ *
+ * @param {boolean} isSaved      Whether the step is saved.
+ * @param {boolean} isActiveStep Whether the step is active.
+ * @param {boolean} isLastStep   Whether it is the last step.
+ *
+ * @returns {string} The classnames for the step name.
+ */
+function getNameClassnames( isSaved, isActiveStep, isLastStep ) {
+	if ( isActiveStep && ! isLastStep ) {
+		return "yst-text-primary-500";
+	}
+	return isSaved ? "" : "yst-text-gray-500";
+}
+
+/**
+ * The Step header component.
+ *
+ * @param {Object}   props                 The props object.
+ * @param {number}   props.stepIndex       The index of the current step.
+ * @param {function} props.saveAndContinue A function to call when the primary button is clicked.
+ * @param {function} props.goBack          A function to call when the "Go Back" button is clicked.
+ *
+ * @returns {WPElement} The StepButtons component.
+ */
+export default function StepHeader( { step, isActiveStep, isSaved, isLastStep, showEditButton, editStep } ) {
+	const nameClassNames = getNameClassnames( isSaved, isActiveStep, isLastStep );
+
+	return <div className="yst-relative yst-flex yst-items-start yst-group" aria-current={ isActiveStep ? "step" : null }>
+		<span className="yst-flex yst-items-center" aria-hidden={ isActiveStep ? "true" : null }>
+			<StepCircle
+				isActive={ isActiveStep }
+				isSaved={ isSaved }
+				isLastStep={ isLastStep }
+				activationDelay={ stepperTimings.delayBeforeOpening }
+				deactivationDelay={ 0 }
+			/>
+		</span>
+		{ /* Name and description. */ }
+		<span className="yst-ml-4 yst-min-w-0 yst-flex yst-flex-col yst-self-center">
+			<span className={ "yst-text-xs yst-font-semibold yst-tracking-wide yst-uppercase " + nameClassNames }>
+				{ step.name }
+			</span>
+			{ step.description && <span className="yst-text-sm yst-text-gray-500">{ step.description }</span> }
+		</span>
+		{ ( showEditButton && ! isLastStep ) &&
+			<button
+				className="yst-button--secondary yst-button--small yst-ml-auto"
+				onClick={ editStep }
+			>
+				Edit
+			</button> }
+	</div>;
+}
+
+const stepShape = PropTypes.shape( {
+	name: PropTypes.string.isRequired,
+	description: PropTypes.string,
+	component: PropTypes.element.isRequired,
+	isSaved: PropTypes.bool.isRequired,
+} );
+
+StepHeader.propTypes = {
+	step: stepShape.isRequired,
+	isLastStep: PropTypes.bool.isRequired,
+	showEditButton: PropTypes.bool,
+	editStep: PropTypes.func,
+	isActiveStep: PropTypes.bool.isRequired,
+	isSaved: PropTypes.bool.isRequired,
+};
+
+StepHeader.defaultProps = {
+	editStep: null,
+	showEditButton: false,
+};

--- a/packages/js/src/workouts/components/StepHeader.js
+++ b/packages/js/src/workouts/components/StepHeader.js
@@ -39,7 +39,7 @@ export default function StepHeader( { step, isActiveStep, isSaved, isLastStep, i
 	const nameClassNames = getNameClassnames( isSaved, isActiveStep, isLastStep );
 
 	return <div className="yst-relative yst-flex yst-items-start yst-group" aria-current={ isActiveStep ? "step" : null }>
-		<span className="yst-flex yst-items-center" aria-hidden={ isActiveStep ? "true" : null }>
+		<span className="yst-flex yst-items-center yst-self-center" aria-hidden={ isActiveStep ? "true" : null }>
 			<StepCircle
 				isActive={ isActiveStep }
 				isSaved={ isSaved }

--- a/packages/js/src/workouts/components/StepHeader.js
+++ b/packages/js/src/workouts/components/StepHeader.js
@@ -1,6 +1,8 @@
 import { StepCircle } from "./StepCircle";
 import PropTypes from "prop-types";
-import { stepperTimings } from "../stepper-helper";
+import { stepperTimings, stepperTimingClasses } from "../stepper-helper";
+
+/* eslint-disable complexity, max-len */
 
 /**
  * Gets the classnames for the step name.
@@ -53,9 +55,12 @@ export default function StepHeader( { step, isActiveStep, isSaved, isLastStep, i
 			</span>
 			{ step.description && <span className="yst-text-sm yst-text-gray-500">{ step.description }</span> }
 		</span>
-		{ ( showEditButton && ! isLastStep && ! isStepBeingEdited ) &&
+		{ ( ! isLastStep ) &&
 			<button
-				className="yst-button--secondary yst-button--small yst-ml-auto yst-m-1"
+				className={ `yst-button--secondary yst-button--small yst-ml-auto yst-m-1 yst-transition-opacity yst-duration-1000 yst-relative yst-ease-out ${
+					( showEditButton && ! isStepBeingEdited )
+						? `${stepperTimingClasses.fadeDuration} yst-opacity-100`
+						: `${stepperTimingClasses.delayBeforeOpening} yst-opacity-0` }` }
 				onClick={ editStep }
 			>
 				Edit
@@ -85,4 +90,4 @@ StepHeader.defaultProps = {
 	editStep: null,
 };
 
-/* eslint-enable complexity */
+/* eslint-enable complexity, max-len */

--- a/packages/js/src/workouts/components/StepHeader.js
+++ b/packages/js/src/workouts/components/StepHeader.js
@@ -38,8 +38,8 @@ function getNameClassnames( isSaved, isActiveStep, isLastStep ) {
 export default function StepHeader( { step, isActiveStep, isSaved, isLastStep, isStepBeingEdited, showEditButton, editStep } ) {
 	const nameClassNames = getNameClassnames( isSaved, isActiveStep, isLastStep );
 
-	return <div className="yst-relative yst-flex yst-items-start yst-group" aria-current={ isActiveStep ? "step" : null }>
-		<span className="yst-flex yst-items-center yst-self-center" aria-hidden={ isActiveStep ? "true" : null }>
+	return <div className="yst-relative yst-flex yst-items-center yst-group" aria-current={ isActiveStep ? "step" : null }>
+		<span className="yst-flex yst-items-center" aria-hidden={ isActiveStep ? "true" : null }>
 			<StepCircle
 				isActive={ isActiveStep }
 				isSaved={ isSaved }
@@ -49,7 +49,7 @@ export default function StepHeader( { step, isActiveStep, isSaved, isLastStep, i
 			/>
 		</span>
 		{ /* Name and description. */ }
-		<span className="yst-ml-4 yst-min-w-0 yst-flex yst-flex-col yst-self-center">
+		<span className="yst-ml-4 yst-min-w-0 yst-flex yst-flex-col">
 			<span className={ "yst-text-xs yst-font-semibold yst-tracking-wide yst-uppercase " + nameClassNames }>
 				{ step.name }
 			</span>
@@ -57,7 +57,7 @@ export default function StepHeader( { step, isActiveStep, isSaved, isLastStep, i
 		</span>
 		{ ( ! isLastStep ) &&
 			<button
-				className={ `yst-button--secondary yst-button--small yst-ml-auto yst-m-1 yst-transition-opacity yst-duration-1000 yst-relative yst-ease-out ${
+				className={ `yst-button--secondary yst-button--small yst-ml-auto yst-mr-1 yst-transition-opacity yst-duration-1000 yst-relative yst-ease-out ${
 					( showEditButton && ! isStepBeingEdited )
 						? `${stepperTimingClasses.fadeDuration} yst-opacity-100`
 						: `${stepperTimingClasses.delayBeforeOpening} yst-opacity-0` }` }

--- a/packages/js/src/workouts/components/StepHeader.js
+++ b/packages/js/src/workouts/components/StepHeader.js
@@ -18,17 +18,22 @@ function getNameClassnames( isSaved, isActiveStep, isLastStep ) {
 	return isSaved ? "" : "yst-text-gray-500";
 }
 
+/* eslint-disable complexity */
 /**
  * The Step header component.
  *
- * @param {Object}   props                 The props object.
- * @param {number}   props.stepIndex       The index of the current step.
- * @param {function} props.saveAndContinue A function to call when the primary button is clicked.
- * @param {function} props.goBack          A function to call when the "Go Back" button is clicked.
+ * @param {Object}   props                   The props object.
+ * @param {Object}   props.step              An object representing a step.
+ * @param {boolean}  props.isActiveStep      Whether the step is active.
+ * @param {boolean}  props.isSaved           Whether the step is saved.
+ * @param {boolean}  props.isLastStep        Whether it is the last step.
+ * @param {boolean}  props.isStepBeingEdited Whether the step is being open for editing or not.
+ * @param {boolean}  props.showEditButton    Whether to show the edit button or not.
+ * @param {function} props.editStep          A function to call when the "Edit" button is pressed.
  *
- * @returns {WPElement} The StepButtons component.
+ * @returns {WPElement} The StepHeader component.
  */
-export default function StepHeader( { step, isActiveStep, isSaved, isLastStep, showEditButton, editStep } ) {
+export default function StepHeader( { step, isActiveStep, isSaved, isLastStep, isStepBeingEdited, showEditButton, editStep } ) {
 	const nameClassNames = getNameClassnames( isSaved, isActiveStep, isLastStep );
 
 	return <div className="yst-relative yst-flex yst-items-start yst-group" aria-current={ isActiveStep ? "step" : null }>
@@ -48,9 +53,9 @@ export default function StepHeader( { step, isActiveStep, isSaved, isLastStep, s
 			</span>
 			{ step.description && <span className="yst-text-sm yst-text-gray-500">{ step.description }</span> }
 		</span>
-		{ ( showEditButton && ! isLastStep ) &&
+		{ ( showEditButton && ! isLastStep && ! isStepBeingEdited ) &&
 			<button
-				className="yst-button--secondary yst-button--small yst-ml-auto"
+				className="yst-button--secondary yst-button--small yst-ml-auto yst-m-1"
 				onClick={ editStep }
 			>
 				Edit
@@ -67,14 +72,17 @@ const stepShape = PropTypes.shape( {
 
 StepHeader.propTypes = {
 	step: stepShape.isRequired,
-	isLastStep: PropTypes.bool.isRequired,
-	showEditButton: PropTypes.bool,
-	editStep: PropTypes.func,
 	isActiveStep: PropTypes.bool.isRequired,
 	isSaved: PropTypes.bool.isRequired,
+	isLastStep: PropTypes.bool.isRequired,
+	isStepBeingEdited: PropTypes.bool.isRequired,
+	showEditButton: PropTypes.bool,
+	editStep: PropTypes.func,
 };
 
 StepHeader.defaultProps = {
-	editStep: null,
 	showEditButton: false,
+	editStep: null,
 };
+
+/* eslint-enable complexity */

--- a/packages/js/src/workouts/components/Stepper.js
+++ b/packages/js/src/workouts/components/Stepper.js
@@ -205,7 +205,7 @@ export default function Stepper( { steps, setActiveStepIndex, saveStep, activeSt
 		}
 	}, [ isStepperFinished ] );
 	return (
-		<ol className="yst-overflow-hidden">
+		<ol>
 			{ steps.map( ( step, stepIndex ) => (
 				<li key={ step.name } className={ ( stepIndex === steps.length - 1 ? "" : "yst-pb-8" ) + " yst-mb-0 yst-relative" }>
 					<TailwindStep

--- a/packages/js/src/workouts/components/Stepper.js
+++ b/packages/js/src/workouts/components/Stepper.js
@@ -2,8 +2,8 @@ import { Fragment, useCallback, useState, useEffect } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import AnimateHeight from "react-animate-height";
 import PropTypes from "prop-types";
-import { StepCircle } from "./StepCircle";
 import { stepperTimings, stepperTimingClasses } from "../stepper-helper";
+import StepHeader from "./StepHeader";
 
 /* eslint-disable complexity, max-len */
 const {
@@ -49,23 +49,6 @@ StepButtons.propTypes = {
 	goBack: PropTypes.func.isRequired,
 };
 
-
-/**
- * Gets the classnames for the step name.
- *
- * @param {boolean} isSaved      Whether the step is saved.
- * @param {boolean} isActiveStep Whether the step is active.
- * @param {boolean} isLastStep   Whether it is the last step.
- *
- * @returns {string} The classnames for the step name.
- */
-function getNameClassnames( isSaved, isActiveStep, isLastStep ) {
-	if ( isActiveStep && ! isLastStep ) {
-		return "yst-text-primary-500";
-	}
-	return isSaved ? "" : "yst-text-gray-500";
-}
-
 const stepShape = PropTypes.shape( {
 	name: PropTypes.string.isRequired,
 	description: PropTypes.string,
@@ -83,24 +66,14 @@ const stepShape = PropTypes.shape( {
 function TailwindStep( { step, stepIndex, isLastStep, saveStep, activeStepIndex, setActiveStepIndex, showEditButton } ) {
 	const isActiveStep = activeStepIndex === stepIndex;
 	const isSaved = step.isSaved;
-	const nameClassNames = getNameClassnames( isSaved, isActiveStep, isLastStep );
 
 	const [ contentHeight, setContentHeight ] = useState( isActiveStep ? "auto" : 0 );
 	const [ isFaded, setIsFaded ] = useState( ! isActiveStep );
 
-	// const saveAndContinue = useCallback(
-	// 	() => {
-	// 		saveStep( stepIndex );
-	// 		setActiveStepIndex( stepIndex + 1 );
-	// 	},
-	// 	[ setActiveStepIndex, saveStep, stepIndex ]
-	// );
-
 	const saveEditedStep = useCallback(
 		() => {
 			saveStep( stepIndex );
-			// Check if there are edited steps which are not saved, find the last one and expand it
-			// If there are no edited steps left to save, expand the last step
+			// Expand the last step?
 		},
 		[ saveStep, stepIndex ]
 	);
@@ -154,32 +127,16 @@ function TailwindStep( { step, stepIndex, isLastStep, saveStep, activeStepIndex,
 					/>
 				</Fragment>
 			}
-			{ /* Bullet. */ }
-			<div className="yst-relative yst-flex yst-items-start yst-group" aria-current={ isActiveStep ? "step" : null }>
-				<span className="yst-flex yst-items-center" aria-hidden={ isActiveStep ? "true" : null }>
-					<StepCircle
-						isActive={ isActiveStep }
-						isSaved={ isSaved }
-						isLastStep={ isLastStep }
-						activationDelay={ delayBeforeOpening }
-						deactivationDelay={ 0 }
-					/>
-				</span>
-				{ /* Name and description. */ }
-				<span className="yst-ml-4 yst-min-w-0 yst-flex yst-flex-col yst-self-center">
-					<span className={ "yst-text-xs yst-font-semibold yst-tracking-wide yst-uppercase " + nameClassNames }>
-						{ step.name }
-					</span>
-					{ step.description && <span className="yst-text-sm yst-text-gray-500">{ step.description }</span> }
-				</span>
-				{ ( showEditButton && ! isLastStep ) &&
-					<button
-						className="yst-button--secondary yst-button--small yst-ml-auto"
-						onClick={ editStep }
-					>
-						Edit
-					</button> }
-			</div>
+
+			<StepHeader
+				step={ step }
+				isActiveStep={ isActiveStep }
+				isSaved={ isSaved }
+				isLastStep={ isLastStep }
+				showEditButton={ showEditButton }
+				editStep={ editStep }
+			/>
+
 			{ /* Child component and buttons. */ }
 			<AnimateHeight
 				id={ `content-${stepIndex}` }

--- a/packages/js/src/workouts/components/Stepper.js
+++ b/packages/js/src/workouts/components/Stepper.js
@@ -49,6 +49,7 @@ StepButtons.propTypes = {
 	goBack: PropTypes.func.isRequired,
 };
 
+
 /**
  * Gets the classnames for the step name.
  *
@@ -87,10 +88,34 @@ function TailwindStep( { step, stepIndex, isLastStep, saveStep, activeStepIndex,
 	const [ contentHeight, setContentHeight ] = useState( isActiveStep ? "auto" : 0 );
 	const [ isFaded, setIsFaded ] = useState( ! isActiveStep );
 
-	const saveAndContinue = useCallback(
+	// const saveAndContinue = useCallback(
+	// 	() => {
+	// 		saveStep( stepIndex );
+	// 		setActiveStepIndex( stepIndex + 1 );
+	// 	},
+	// 	[ setActiveStepIndex, saveStep, stepIndex ]
+	// );
+
+	const saveEditedStep = useCallback(
 		() => {
 			saveStep( stepIndex );
+			// Check if there are edited steps which are not saved, find the last one and expand it
+			// If there are no edited steps left to save, expand the last step
+		},
+		[ saveStep, stepIndex ]
+	);
+
+	const continueToNextStep = useCallback(
+		() => {
 			setActiveStepIndex( stepIndex + 1 );
+		},
+		[ setActiveStepIndex, stepIndex ]
+	);
+
+	const saveAndContinue = useCallback(
+		() => {
+			saveEditedStep();
+			continueToNextStep();
 		},
 		[ setActiveStepIndex, saveStep, stepIndex ]
 	);
@@ -111,8 +136,8 @@ function TailwindStep( { step, stepIndex, isLastStep, saveStep, activeStepIndex,
 	}, [ isActiveStep ] );
 
 	const editStep = useCallback( () => {
-		console.log( "clicked" );
-	}, [] );
+		setActiveStepIndex( stepIndex );
+	}, [ stepIndex, setActiveStepIndex ] );
 
 	return (
 		<Fragment>
@@ -165,12 +190,20 @@ function TailwindStep( { step, stepIndex, isLastStep, saveStep, activeStepIndex,
 			>
 				<div className={ `yst-transition-opacity ${ fadeDuration } yst-relative yst-ml-12 yst-mt-4 ${ isFaded ? "yst-opacity-0 yst-no-point-events" : "yst-opacity-100" }` }>
 					{ step.component }
-					{ ! isLastStep &&
+					{ ( ! isLastStep && ! showEditButton ) &&
 						<StepButtons
 							stepIndex={ stepIndex }
 							saveAndContinue={ saveAndContinue }
 							goBack={ goBack }
 						/>
+					}
+					{ ( ! isLastStep && showEditButton ) &&
+						<button
+							className="yst-button--primary"
+							onClick={ saveEditedStep }
+						>
+							Save Changes
+						</button>
 					}
 				</div>
 			</AnimateHeight>

--- a/packages/js/src/workouts/components/Stepper.js
+++ b/packages/js/src/workouts/components/Stepper.js
@@ -79,7 +79,7 @@ const stepShape = PropTypes.shape( {
  *
  * @returns {WPElement} The Step component.
  */
-function TailwindStep( { step, stepIndex, isLastStep, saveStep, activeStepIndex, setActiveStepIndex } ) {
+function TailwindStep( { step, stepIndex, isLastStep, saveStep, activeStepIndex, setActiveStepIndex, showEditButton } ) {
 	const isActiveStep = activeStepIndex === stepIndex;
 	const isSaved = step.isSaved;
 	const nameClassNames = getNameClassnames( isSaved, isActiveStep, isLastStep );
@@ -109,6 +109,10 @@ function TailwindStep( { step, stepIndex, isLastStep, saveStep, activeStepIndex,
 			setContentHeight( 0 );
 		}
 	}, [ isActiveStep ] );
+
+	const editStep = useCallback( () => {
+		console.log( "clicked" );
+	}, [] );
 
 	return (
 		<Fragment>
@@ -143,6 +147,13 @@ function TailwindStep( { step, stepIndex, isLastStep, saveStep, activeStepIndex,
 					</span>
 					{ step.description && <span className="yst-text-sm yst-text-gray-500">{ step.description }</span> }
 				</span>
+				{ ( showEditButton && ! isLastStep ) &&
+					<button
+						className="yst-button--secondary yst-button--small yst-ml-auto"
+						onClick={ editStep }
+					>
+						Edit
+					</button> }
 			</div>
 			{ /* Child component and buttons. */ }
 			<AnimateHeight
@@ -173,9 +184,11 @@ TailwindStep.propTypes = {
 	setActiveStepIndex: PropTypes.func.isRequired,
 	saveStep: PropTypes.func,
 	activeStepIndex: PropTypes.number.isRequired,
+	showEditButton: PropTypes.bool,
 };
 TailwindStep.defaultProps = {
 	saveStep: () => { },
+	showEditButton: false,
 };
 
 /**
@@ -185,7 +198,7 @@ TailwindStep.defaultProps = {
  *
  * @returns {WPElement} The Stepper component.
  */
-export default function Stepper( { steps, setActiveStepIndex, saveStep, activeStepIndex } ) {
+export default function Stepper( { steps, setActiveStepIndex, saveStep, activeStepIndex, isStepperFinished } ) {
 	return (
 		<ol className="yst-overflow-hidden">
 			{ steps.map( ( step, stepIndex ) => (
@@ -197,6 +210,7 @@ export default function Stepper( { steps, setActiveStepIndex, saveStep, activeSt
 						setActiveStepIndex={ setActiveStepIndex }
 						saveStep={ saveStep }
 						activeStepIndex={ activeStepIndex }
+						showEditButton={ isStepperFinished }
 					/>
 				</li>
 			) ) }
@@ -208,6 +222,7 @@ Stepper.propTypes = {
 	setActiveStepIndex: PropTypes.func.isRequired,
 	saveStep: PropTypes.func,
 	activeStepIndex: PropTypes.number.isRequired,
+	isStepperFinished: PropTypes.bool.isRequired,
 };
 Stepper.defaultProps = {
 	saveStep: () => { },


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Once a user finishes the workout, each step should be individually editable by means of an _Edit_ button which appears aside the step's title

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds edit buttons and logic to a finished stepper's (editable) steps

## Relevant technical choices:

* Stepper `saveAndContinue` function has been split into `saveEditedStep` and `continueToNextStep` to enhance reuse
* `StepHeader` component has been derived by `TailwindStep` component in order to better isolate state variables
* Edit button transitions uses the Tailwind classes declared in `stepperTimingClasses` object in order to (try to) b synchronised with the other steps transitions

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Start the configuration workout from scratch
* Verify there are no _Edit_ buttons aside the steps' titles
* When you reach the _Personal Preferences_ step, click the  _Save and Continue_ button and check that aside all the steps except the last one (_Finish Configuration_) the _Edit_ button appears
* Click on any Edit button and verify that:
1. the corresponding step expands
2. all the _Edit_ buttons disappear
* Edit a field inside the step and verify the button used to save now says _Save Changes_ and not _Save and Continue_, as well as no _Go Back_ button is present
* Press the _Save Changes_ button and verify:
1. The steps closes and the _Finish Configuration_ step opens
2. The _Edit_ buttons re-appear aside the steps titles 
* Expand the edited step again (by clicking on the corresponding _Edit_ button) and verify the modifications persist

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
