### PR TITLE
Never filter the title presenter on a REST request

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -389,10 +389,7 @@ class Front_End_Integration implements Integration_Interface {
 	private function get_needed_presenters( $page_type ) {
 		$presenters = $this->get_presenters_for_page_type( $page_type );
 
-		if ( ! \get_theme_support( 'title-tag' ) && ! $this->options->get( 'forcerewritetitle', false ) ) {
-			// Remove the title presenter if the theme is hardcoded to output a title tag so we don't have two title tags.
-			$presenters = \array_diff( $presenters, [ 'Title' ] );
-		}
+		$presenters = $this->maybe_remove_title_presenter( $presenters );
 
 		$callback   = static function ( $presenter ) {
 			return "Yoast\WP\SEO\Presenters\\{$presenter}_Presenter";
@@ -456,5 +453,26 @@ class Front_End_Integration implements Integration_Interface {
 		}
 
 		return \array_merge( $presenters, $this->closing_presenters );
+	}
+
+	/**
+	 * Checks if the Title presenter needs to be removed.
+	 *
+	 * @param string[] $presenters The presenters.
+	 *
+	 * @return string[] The presenters.
+	 */
+	private function maybe_remove_title_presenter( $presenters ) {
+		// Do not remove the title if we're on a REST request.
+		if ( $this->request->is_rest_request() ) {
+			return $presenters;
+		}
+
+		// Remove the title presenter if the theme is hardcoded to output a title tag so we don't have two title tags.
+		if ( ! \get_theme_support( 'title-tag' ) && ! $this->options->get( 'forcerewritetitle', false ) ) {
+			$presenters = \array_diff( $presenters, [ 'Title' ] );
+		}
+
+		return $presenters;
 	}
 }

--- a/tests/unit/integrations/front-end-integration-test.php
+++ b/tests/unit/integrations/front-end-integration-test.php
@@ -205,6 +205,11 @@ class Front_End_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $this->context );
 
+		$this->request
+			->expects( 'is_rest_request' )
+			->once()
+			->andReturnFalse();
+
 		$expected = [
 			'Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter',
 			'Yoast\WP\SEO\Presenters\Title_Presenter',
@@ -266,6 +271,11 @@ class Front_End_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $this->context );
 
+		$this->request
+			->expects( 'is_rest_request' )
+			->once()
+			->andReturnFalse();
+
 		$callback = static function( $presenter ) {
 			return \get_class( $presenter );
 		};
@@ -317,6 +327,11 @@ class Front_End_Integration_Test extends TestCase {
 			->expects( 'for_current_page' )
 			->once()
 			->andReturn( $this->context );
+
+		$this->request
+			->expects( 'is_rest_request' )
+			->once()
+			->andReturnFalse();
 
 		$callback = static function( $presenter ) {
 			return \get_class( $presenter );
@@ -378,6 +393,11 @@ class Front_End_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $this->context );
 
+		$this->request
+			->expects( 'is_rest_request' )
+			->once()
+			->andReturnFalse();
+
 		$callback = static function( $presenter ) {
 			return \get_class( $presenter );
 		};
@@ -386,6 +406,52 @@ class Front_End_Integration_Test extends TestCase {
 		$this->assertEquals(
 			[
 				'Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter',
+				'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
+				'Yoast\WP\SEO\Presenters\Robots_Presenter',
+				'Yoast\WP\SEO\Presenters\Open_Graph\Locale_Presenter',
+				'Yoast\WP\SEO\Presenters\Open_Graph\Title_Presenter',
+				'Yoast\WP\SEO\Presenters\Open_Graph\Site_Name_Presenter',
+				'Yoast\WP\SEO\Presenters\Schema_Presenter',
+				'Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter',
+			],
+			$actual
+		);
+	}
+
+	/**
+	 * Tests retrieval of the presenters on a REST request.
+	 *
+	 * @covers ::get_presenters
+	 * @covers ::get_needed_presenters
+	 * @covers ::get_presenters_for_page_type
+	 * @covers ::get_all_presenters
+	 */
+	public function test_get_presenters_for_theme_on_rest_request() {
+
+		$this->options
+			->expects( 'get' )
+			->with( 'opengraph' )
+			->andReturnTrue();
+
+		$this->context_memoizer
+			->expects( 'for_current_page' )
+			->once()
+			->andReturn( $this->context );
+
+		$this->request
+			->expects( 'is_rest_request' )
+			->once()
+			->andReturnTrue();
+
+		$callback = static function( $presenter ) {
+			return \get_class( $presenter );
+		};
+		$actual   = \array_map( $callback, \array_values( $this->instance->get_presenters( 'Error_Page' ) ) );
+
+		$this->assertEquals(
+			[
+				'Yoast\WP\SEO\Presenters\Debug\Marker_Open_Presenter',
+				'Yoast\WP\SEO\Presenters\Title_Presenter',
 				'Yoast\WP\SEO\Presenters\Meta_Description_Presenter',
 				'Yoast\WP\SEO\Presenters\Robots_Presenter',
 				'Yoast\WP\SEO\Presenters\Open_Graph\Locale_Presenter',
@@ -424,6 +490,11 @@ class Front_End_Integration_Test extends TestCase {
 			->expects( 'for_current_page' )
 			->once()
 			->andReturn( $this->context );
+
+		$this->request
+			->expects( 'is_rest_request' )
+			->once()
+			->andReturnFalse();
 
 		$callback = static function( $presenter ) {
 			return \get_class( $presenter );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We strip the title presenter when a theme does not support the `title-tag` and we don't force a rewrite of the title. This is correct behavior for the frontend, but the title should always get included in a get_head route via REST.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the title of a page would not get included in our `get_head` REST route.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install WordPress 5.9 with a FSE theme (like twenty twentytwo) or a theme without `title-tags` support.
* Install wordpress-seo 18.1
* Check the output of a `get_head` rest route. My example is on `http://standalone.wordpress.test/wp-json/yoast/v1/get_head?url=http://standalone.wordpress.test/hello-world/`
  * Without this PR, it will not include a `title` attribute, not in the html and not in the json output.
  * With this PR, the title is shown in both locations.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/IM-1689
