### PR TITLE
Don't index on staging sites

### DIFF
--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -14,8 +14,8 @@ use Yoast\WP\SEO\Actions\Indexing\Indexation_Action_Interface;
 use Yoast\WP\SEO\Actions\Indexing\Indexing_Prepare_Action;
 use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Main;
-use Yoast\WP\SEO\Helpers\Environment_Helper;
 
 /**
  * Command to generate indexables for all posts and terms.
@@ -81,9 +81,9 @@ class Index_Command implements Command_Interface {
 	/**
 	 * Represents the environment helper.
 	 *
-	 * @var Environment_Helper
+	 * @var Indexable_Helper
 	 */
-	protected $environment_helper;
+	protected $indexable_helper;
 
 	/**
 	 * Generate_Indexables_Command constructor.
@@ -104,7 +104,7 @@ class Index_Command implements Command_Interface {
 	 *                                                                                           action.
 	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action           The term link indexation
 	 *                                                                                           action.
-	 * @param Environment_Helper                            $environment_helper                  The Environment helper.
+	 * @param Indexable_Helper                              $indexable_helper                    The Environment helper.
 	 */
 	public function __construct(
 		Indexable_Post_Indexation_Action $post_indexation_action,
@@ -115,7 +115,7 @@ class Index_Command implements Command_Interface {
 		Indexing_Prepare_Action $prepare_indexing_action,
 		Post_Link_Indexing_Action $post_link_indexing_action,
 		Term_Link_Indexing_Action $term_link_indexing_action,
-		Environment_Helper $environment_helper
+		Indexable_Helper $indexable_helper
 	) {
 		$this->post_indexation_action              = $post_indexation_action;
 		$this->term_indexation_action              = $term_indexation_action;
@@ -125,7 +125,7 @@ class Index_Command implements Command_Interface {
 		$this->prepare_indexing_action             = $prepare_indexing_action;
 		$this->post_link_indexing_action           = $post_link_indexing_action;
 		$this->term_link_indexing_action           = $term_link_indexing_action;
-		$this->environment_helper                  = $environment_helper;
+		$this->indexable_helper                    = $indexable_helper;
 	}
 
 	/**
@@ -169,8 +169,9 @@ class Index_Command implements Command_Interface {
 	 * @return void
 	 */
 	public function index( $args = null, $assoc_args = null ) {
-		if ( ! $this->environment_helper->is_production_mode() ) {
+		if ( ! $this->indexable_helper->should_index_indexables() ) {
 			WP_CLI::log( 'Your WordPress environment is running on a non-production site. Indexables can only be created on production environments. Please check your `WP_ENVIRONMENT_TYPE` settings.' );
+
 			return;
 		}
 

--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -15,6 +15,7 @@ use Yoast\WP\SEO\Actions\Indexing\Indexing_Prepare_Action;
 use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Main;
+use Yoast\WP\SEO\Helpers\Environment_Helper;
 
 /**
  * Command to generate indexables for all posts and terms.
@@ -78,6 +79,13 @@ class Index_Command implements Command_Interface {
 	private $prepare_indexing_action;
 
 	/**
+	 * Represents the environment helper.
+	 *
+	 * @var Environment_Helper
+	 */
+	protected $environment_helper;
+
+	/**
 	 * Generate_Indexables_Command constructor.
 	 *
 	 * @param Indexable_Post_Indexation_Action              $post_indexation_action              The post indexation
@@ -96,6 +104,7 @@ class Index_Command implements Command_Interface {
 	 *                                                                                           action.
 	 * @param Term_Link_Indexing_Action                     $term_link_indexing_action           The term link indexation
 	 *                                                                                           action.
+	 * @param Environment_Helper                            $environment_helper                  The Environment helper.
 	 */
 	public function __construct(
 		Indexable_Post_Indexation_Action $post_indexation_action,
@@ -105,7 +114,8 @@ class Index_Command implements Command_Interface {
 		Indexable_Indexing_Complete_Action $complete_indexation_action,
 		Indexing_Prepare_Action $prepare_indexing_action,
 		Post_Link_Indexing_Action $post_link_indexing_action,
-		Term_Link_Indexing_Action $term_link_indexing_action
+		Term_Link_Indexing_Action $term_link_indexing_action,
+		Environment_Helper $environment_helper
 	) {
 		$this->post_indexation_action              = $post_indexation_action;
 		$this->term_indexation_action              = $term_indexation_action;
@@ -115,6 +125,7 @@ class Index_Command implements Command_Interface {
 		$this->prepare_indexing_action             = $prepare_indexing_action;
 		$this->post_link_indexing_action           = $post_link_indexing_action;
 		$this->term_link_indexing_action           = $term_link_indexing_action;
+		$this->environment_helper                  = $environment_helper;
 	}
 
 	/**
@@ -158,6 +169,11 @@ class Index_Command implements Command_Interface {
 	 * @return void
 	 */
 	public function index( $args = null, $assoc_args = null ) {
+		if ( ! $this->environment_helper->is_production_mode() ) {
+			WP_CLI::log( 'Your WordPress environment is running on a non-production site. Indexables can only be created on production environments. Please check your `WP_ENVIRONMENT_TYPE` settings.' );
+			return;
+		}
+
 		if ( ! isset( $assoc_args['network'] ) ) {
 			$this->run_indexation_actions( $assoc_args );
 

--- a/tests/unit/commands/index-command-test.php
+++ b/tests/unit/commands/index-command-test.php
@@ -13,13 +13,14 @@ use Yoast\WP\SEO\Actions\Indexing\Indexing_Prepare_Action;
 use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
 use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
 use Yoast\WP\SEO\Commands\Index_Command;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
  * Class Index_Command_Test.
  *
- * @group commands
+ * @group  commands
  *
  * @coversDefaultClass \Yoast\WP\SEO\Commands\Index_Command
  * @covers \Yoast\WP\SEO\Commands\Index_Command
@@ -83,6 +84,13 @@ class Index_Command_Test extends TestCase {
 	private $prepare_indexing_action;
 
 	/**
+	 * The indexable helper.
+	 *
+	 * @var Indexable_Helper|Mockery\MockInterface
+	 */
+	protected $indexable_helper;
+
+	/**
 	 * The instance
 	 *
 	 * @var Index_Command
@@ -103,6 +111,7 @@ class Index_Command_Test extends TestCase {
 		$this->term_link_indexation_action         = Mockery::mock( Term_Link_Indexing_Action::class );
 		$this->complete_indexation_action          = Mockery::mock( Indexable_Indexing_Complete_Action::class );
 		$this->prepare_indexing_action             = Mockery::mock( Indexing_Prepare_Action::class );
+		$this->indexable_helper                    = Mockery::mock( Indexable_Helper::class );
 
 		$this->instance = new Index_Command(
 			$this->post_indexation_action,
@@ -112,7 +121,8 @@ class Index_Command_Test extends TestCase {
 			$this->complete_indexation_action,
 			$this->prepare_indexing_action,
 			$this->post_link_indexation_action,
-			$this->term_link_indexation_action
+			$this->term_link_indexation_action,
+			$this->indexable_helper
 		);
 	}
 
@@ -168,6 +178,8 @@ class Index_Command_Test extends TestCase {
 				->andReturn( \array_fill( 0, 25, true ), \array_fill( 0, 5, true ) );
 		}
 
+		$this->indexable_helper->expects( 'should_index_indexables' )->once()->andReturn( true );
+
 		$this->prepare_indexing_action->expects( 'prepare' )->once();
 
 		$this->complete_indexation_action->expects( 'complete' )->once();
@@ -210,6 +222,8 @@ class Index_Command_Test extends TestCase {
 				->times( 2 )
 				->andReturn( \array_fill( 0, 25, true ), \array_fill( 0, 5, true ) );
 		}
+
+		$this->indexable_helper->expects( 'should_index_indexables' )->once()->andReturn( true );
 
 		$this->complete_indexation_action->expects( 'complete' )->once();
 
@@ -323,6 +337,8 @@ class Index_Command_Test extends TestCase {
 					\array_fill( 0, 5, true )
 				);
 		}
+
+		$this->indexable_helper->expects( 'should_index_indexables' )->once()->andReturn( true );
 
 		// Expect the complete and prepare actions twice: once for each site in the multisite.
 		$this->complete_indexation_action->expects( 'complete' )->twice();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want staging sites to get any indexables when they index their site, as that is known to give issues with pushing to production. WP-Cron indexing and (re)indexing with WP-CLI should no longer generate any indexables.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where indexables were created when using the `wp yoast index` command on a staging site.
* Fixes an unreleased bug where indexables were created with WP-Cron background indexing on a staging site.

## Relevant technical choices:

* I chose to use a setter function for injecting the helper. Otherwise I'd have to update every constructor of every class that extends the Abstract_Indexing_Action.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add `define( 'WP_ENVIRONMENT_TYPE', 'staging' );` to your wp-config.php
* Run `wp yoast index`.
* You should get a notice stating that nothing will be indexed because of the staging env your site is set to.
* Check that no indexables were created in the database
* Run `wp cron event run 'Yoast\WP\SEO\index'`
* Check that no indexables were created in the database
* Remove the WP_ENV... line or change the value to `production`.
* Run `wp cron event run 'Yoast\WP\SEO\index'
* Check that 15 indexables were created
* Run `wp yoast index`
* Check that all indexables were created.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes QA-2885
