### PR TITLE
Fix failing tests with partial mocks with functions that take reference args

### DIFF
--- a/patchwork.json
+++ b/patchwork.json
@@ -1,6 +1,0 @@
-{
-  "redefinable-internals": [
-	"register_shutdown_function",
-	"time"
-  ]
-}

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -171,7 +171,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 */
 	public function register_shutdown_indexing() {
 		if ( $this->should_index_on_shutdown( $this->get_shutdown_limit() ) ) {
-			\register_shutdown_function( [ $this, 'index' ] );
+			$this->register_shutdown_function( 'index' );
 		}
 	}
 
@@ -300,5 +300,17 @@ class Background_Indexing_Integration implements Integration_Interface {
 		if ( $scheduled ) {
 			wp_unschedule_event( $scheduled, 'Yoast\WP\SEO\index' );
 		}
+	}
+
+	/**
+	 * Registers a method to be executed on shutdown.
+	 * This wrapper mostly exists for making this class more unittestable.
+	 *
+	 * @param string $method_name The name of the method on the current instance to register.
+	 *
+	 * @return void
+	 */
+	protected function register_shutdown_function( $method_name ) {
+		\register_shutdown_function( [ $this, $method_name ] );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When you redefine mockable internals with Patchwork, it will change the way mocks are handled. There's a known bug there, which will make all functions that take references instead of values on a (partially) mocked class result in failing tests.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes unittests with partial mocks in our addons.

## Relevant technical choices:

* Since we can't `expect` calls of `register_shutdown_function` I created a wrapper which I then mock. That's the only way I could think of that would allow us to test the class as close to 100% as possible. I considered creating a scheduler class, but that can still not be tested because of the fact that we can't mock php internals while this bug is in place. 
* I also removed some `time` mocks, which weren't needed for the tests. Just a case of copy-pasting I guess.
* I do call `time()` instead of using a fixed value in the tests. That's because now we can't mock time. The internals call `time()` as well when they call the function we're testing. This will likely fail once every so often due to a second difference. I wan't able to get it to fail locally, so I deemed the chance small enough. But it's definitely a thing we can and should inprove. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See tests succeed


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Once merged, the unittests for premium should stop to fail when using the latest version of free:trunk.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
