### PR TITLE
Should index filter

### DIFF
--- a/src/helpers/indexable-helper.php
+++ b/src/helpers/indexable-helper.php
@@ -177,11 +177,23 @@ class Indexable_Helper {
 	/**
 	 * Determines whether indexing indexables is appropriate at this time.
 	 *
-	 * @return bool Whether or not the indexables should be indexed.
+	 * @return bool Whether the indexables should be indexed.
 	 */
 	public function should_index_indexables() {
-		// Currently the only reason to index is when we're on a production website.
-		return $this->environment_helper->is_production_mode();
+		// Currently, the only reason to index is when we're on a production website.
+		$should_index = $this->environment_helper->is_production_mode();
+
+		/**
+		 * Filter: 'Yoast\WP\SEO\should_index_indexables' - Allow developers to enable / disable
+		 * creating indexables. Warning: overriding
+		 * the intended action may cause problems when moving from a staging to a
+		 * production environment because indexable permalinks may get set incorrectly.
+		 *
+		 * @since 18.2
+		 *
+		 * @param bool $should_index Whether the site's indexables should be created.
+		 */
+		return (bool) \apply_filters( 'Yoast\WP\SEO\should_index_indexables', $should_index );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This introduces a filter to enable/disable indexing globally. Currently, we only have `wpseo_should_save_indexable` which is only used in the Indexable Builders.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: 
* [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: 
* [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a filter to enable/disable creating indexables: `Yoast\WP\SEO\should_index_indexables`

## Relevant technical choices:

* I considered moving the existing filter from the Indexable_Builder to the `Indexable_Helper::should_index_indexables` function, but the existing filter accepts a single indexable object to determine whether it should index or not. Since the `should_index_indexables` function globally determines whether we should index it can't have a single indexable to pass to the filter.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add define( 'WP_ENVIRONMENT_TYPE', 'staging' ); to your wp-config.php
* Make sure your site has more than 25 posts.
* Run wp yoast index.
* For sites with more than 25 posts, this will end up in an endless loop.
* stop the process with ctrl+c
* Add `add_filters( 'Yoast\WP\SEO\should_index_indexables', function(){return true;}); to your wp-config.php
* Run wp yoast index.
* All indexables should be created as expected.



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The introduced filter has the same impact on background WP-Cron indexing. Without the filter on staging sites, it won't index (or won't fully. There's a known bug that it indexes posts with internal links). With the filter set to true, as in the test instructions, it will just index as if on a production site.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

