### PR TITLE
P1-1192 create in array validator

### DIFF
--- a/src/config/schema-types.php
+++ b/src/config/schema-types.php
@@ -108,6 +108,27 @@ class Schema_Types {
 	}
 
 	/**
+	 * Gets the schema article types.
+	 *
+	 * @return string[] The schema article types.
+	 */
+	public function get_article_types() {
+		/**
+		 * Filter: 'wpseo_schema_article_types' - Allow developers to filter the available article types.
+		 *
+		 * Make sure when you filter this to also filter `wpseo_schema_article_types_labels`.
+		 *
+		 * @api array $schema_article_types The available schema article types.
+		 */
+		$article_types = \apply_filters( 'wpseo_schema_article_types', self::ARTICLE_TYPES );
+		if ( ! \is_array( $article_types ) ) {
+			$article_types = self::ARTICLE_TYPES;
+		}
+
+		return \array_keys( $article_types );
+	}
+
+	/**
 	 * Gets the article type options.
 	 *
 	 * @return array[] The schema article type options.

--- a/src/config/separator-options.php
+++ b/src/config/separator-options.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Yoast\WP\SEO\Config;
+
+/**
+ * Holds the separator options.
+ */
+class Separator_Options {
+
+	/**
+	 * Gets the keys of the separator options.
+	 *
+	 * Used to validate the separator option.
+	 *
+	 * @return string[] The separator keys.
+	 */
+	public function get_separator_keys() {
+		return \array_keys( $this->get_separator_options() );
+	}
+
+	/**
+	 * Get the available separator options.
+	 *
+	 * @return array
+	 */
+	public function get_separator_options() {
+		$separators = \wp_list_pluck( $this->get_separator_option_list(), 'option' );
+
+		/**
+		 * Allow altering the array with separator options.
+		 *
+		 * @api array $separator_options Array with the separator options.
+		 */
+		$filtered_separators = \apply_filters( 'wpseo_separator_options', $separators );
+
+		if ( \is_array( $filtered_separators ) && $filtered_separators !== [] ) {
+			$separators = \array_merge( $separators, $filtered_separators );
+		}
+
+		return $separators;
+	}
+
+	/**
+	 * Gets the available separator options aria-labels.
+	 *
+	 * @return array Array with the separator options aria-labels.
+	 */
+	public function get_separator_options_for_display() {
+		$separators     = $this->get_separator_options();
+		$separator_list = $this->get_separator_option_list();
+
+		$separator_options = [];
+
+		foreach ( $separators as $key => $label ) {
+			$aria_label = isset( $separator_list[ $key ]['label'] ) ? $separator_list[ $key ]['label'] : '';
+
+			$separator_options[ $key ] = [
+				'label'      => $label,
+				'aria_label' => $aria_label,
+			];
+		}
+
+		return $separator_options;
+	}
+
+	/**
+	 * Retrieves a list of separator options.
+	 *
+	 * @return array An array of the separator options.
+	 */
+	protected function get_separator_option_list() {
+		$separators = [
+			'sc-dash'   => [
+				'option' => '-',
+				'label'  => __( 'Dash', 'wordpress-seo' ),
+			],
+			'sc-ndash'  => [
+				'option' => '&ndash;',
+				'label'  => __( 'En dash', 'wordpress-seo' ),
+			],
+			'sc-mdash'  => [
+				'option' => '&mdash;',
+				'label'  => __( 'Em dash', 'wordpress-seo' ),
+			],
+			'sc-colon'  => [
+				'option' => ':',
+				'label'  => __( 'Colon', 'wordpress-seo' ),
+			],
+			'sc-middot' => [
+				'option' => '&middot;',
+				'label'  => __( 'Middle dot', 'wordpress-seo' ),
+			],
+			'sc-bull'   => [
+				'option' => '&bull;',
+				'label'  => __( 'Bullet', 'wordpress-seo' ),
+			],
+			'sc-star'   => [
+				'option' => '*',
+				'label'  => __( 'Asterisk', 'wordpress-seo' ),
+			],
+			'sc-smstar' => [
+				'option' => '&#8902;',
+				'label'  => __( 'Low asterisk', 'wordpress-seo' ),
+			],
+			'sc-pipe'   => [
+				'option' => '|',
+				'label'  => __( 'Vertical bar', 'wordpress-seo' ),
+			],
+			'sc-tilde'  => [
+				'option' => '~',
+				'label'  => __( 'Small tilde', 'wordpress-seo' ),
+			],
+			'sc-laquo'  => [
+				'option' => '&laquo;',
+				'label'  => __( 'Left angle quotation mark', 'wordpress-seo' ),
+			],
+			'sc-raquo'  => [
+				'option' => '&raquo;',
+				'label'  => __( 'Right angle quotation mark', 'wordpress-seo' ),
+			],
+			'sc-lt'     => [
+				'option' => '&lt;',
+				'label'  => __( 'Less than sign', 'wordpress-seo' ),
+			],
+			'sc-gt'     => [
+				'option' => '&gt;',
+				'label'  => __( 'Greater than sign', 'wordpress-seo' ),
+			],
+		];
+
+		/**
+		 * Allows altering the separator options array.
+		 *
+		 * @api array $separators Array with the separator options.
+		 */
+		$separator_list = \apply_filters( 'wpseo_separator_option_list', $separators );
+
+		if ( ! \is_array( $separator_list ) ) {
+			return $separators;
+		}
+
+		return $separator_list;
+	}
+}

--- a/src/exceptions/validation/invalid-settings-exception.php
+++ b/src/exceptions/validation/invalid-settings-exception.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Validation;
+
+/**
+ * Invalid settings validation exception class.
+ */
+class Invalid_Settings_Exception extends Abstract_Validation_Exception {
+
+	/**
+	 * Constructs an invalid settings validation exception instance.
+	 */
+	public function __construct() {
+		parent::__construct(
+			\esc_html__(
+				'The validation failed because the configuration\' settings are invalid.',
+				'wordpress-seo'
+			)
+		);
+	}
+}

--- a/src/exceptions/validation/missing-settings-key-exception.php
+++ b/src/exceptions/validation/missing-settings-key-exception.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Validation;
+
+/**
+ * Missing settings key validation exception class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Exception is not part of the name.
+ */
+class Missing_Settings_Key_Exception extends Abstract_Validation_Exception {
+
+	/**
+	 * Constructs a missing settings key validation exception instance.
+	 *
+	 * @param string $key The missing settings key.
+	 */
+	public function __construct( $key ) {
+		parent::__construct(
+			\sprintf(
+			/* translators: %s expands to the missing settings key. */
+				\esc_html__( 'The validation failed because configuration is missing: %s.', 'wordpress-seo' ),
+				'<strong>' . \esc_html( $key ) . '</strong>'
+			)
+		);
+	}
+}

--- a/src/exceptions/validation/not-in-array-exception.php
+++ b/src/exceptions/validation/not-in-array-exception.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Validation;
+
+use WPSEO_Utils;
+
+/**
+ * Not in array validation exception class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Exception should not count.
+ */
+class Not_In_Array_Exception extends Abstract_Validation_Exception {
+
+	/**
+	 * Constructs a not in array validation exception instance.
+	 *
+	 * @param array $allow The values that are allowed.
+	 */
+	public function __construct( $allow ) {
+		parent::__construct(
+			\sprintf(
+			/* translators: %s expands to a list of values that are allowed. */
+				\esc_html__( 'Please change the value to be one of: %s.', 'wordpress-seo' ),
+				'<strong>' . \esc_html( WPSEO_Utils::format_json_encode( $allow ) ) . '</strong>'
+			)
+		);
+	}
+}

--- a/src/helpers/taxonomy-helper.php
+++ b/src/helpers/taxonomy-helper.php
@@ -62,6 +62,18 @@ class Taxonomy_Helper {
 	}
 
 	/**
+	 * Returns an array with the taxonomies.
+	 *
+	 * @param string $output The output type to use.
+	 *
+	 * @return string[]|WP_Taxonomy[] Array with all the public taxonomies.
+	 *                                The type depends on the specified output variable.
+	 */
+	public function get_taxonomies( $output = 'names' ) {
+		return \get_taxonomies( [], $output );
+	}
+
+	/**
 	 * Retrieves the term description (without tags).
 	 *
 	 * @param int $term_id Term ID.

--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -2,6 +2,10 @@
 
 namespace Yoast\WP\SEO\Services\Options;
 
+use Yoast\WP\SEO\Config\Schema_Types;
+use Yoast\WP\SEO\Config\Separator_Options;
+use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
+
 /**
  * The single site options service class.
  */
@@ -80,8 +84,15 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'string' ],
 		],
 		'twitter_card_type'                           => [
-			'default' => '',
-			'types'   => [ 'string' ],
+			'default' => 'summary_large_image',
+			'types'   => [
+				'in_array' => [
+					'allow' => [
+						'summary',
+						'summary_large_image',
+					],
+				],
+			],
 		],
 		'twitter_site'                                => [
 			'default' => '',
@@ -240,8 +251,15 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'string' ],
 		],
 		'company_or_person'                           => [
-			'default' => '',
-			'types'   => [ 'string' ],
+			'default' => 'company',
+			'types'   => [
+				'in_array' => [
+					'allow' => [
+						'company',
+						'person',
+					],
+				],
+			],
 		],
 		'company_or_person_user_id'                   => [
 			'default' => '',
@@ -355,9 +373,17 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => '',
 			'types'   => [ 'string' ],
 		],
-		'post_types-<PostTypeName>-maintax'           => [
+		'post_types_<PostTypeName>_maintax'           => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [
+				'in_array_provider' => [
+					'provider' => [
+						'class'  => Taxonomy_Helper::class,
+						'method' => 'get_taxonomies',
+					],
+				],
+				'is_equal',
+			],
 		],
 		'rssafter'                                    => [
 			'default' => '',
@@ -368,16 +394,34 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'string' ],
 		],
 		'schema-article-type-<PostTypeName>'          => [
-			'default' => '',
-			'types'   => [ 'string' ],
+			'default' => 'None',
+			'types'   => [
+				'in_array_provider' => [
+					'provider' => [
+						'class'  => Schema_Types::class,
+						'method' => 'get_article_types',
+					],
+				],
+			],
 		],
 		'schema-page-type-<PostTypeName>'             => [
-			'default' => '',
-			'types'   => [ 'string' ],
+			'default' => 'WebPage',
+			'types'   => [
+				'in_array_key' => [
+					'allow' => Schema_Types::PAGE_TYPES,
+				],
+			],
 		],
 		'separator'                                   => [
-			'default' => '',
-			'types'   => [ 'string' ],
+			'default' => 'sc-dash',
+			'types'   => [
+				'in_array_provider' => [
+					'provider' => [
+						'class'  => Separator_Options::class,
+						'method' => 'get_separator_keys',
+					],
+				],
+			],
 		],
 		'social-description-<PostTypeName>'           => [
 			'default' => '',
@@ -571,7 +615,12 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'environment_type'                            => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [
+				'empty_string',
+				'in_array' => [
+					'allow' => [ 'production', 'staging', 'development' ],
+				],
+			],
 		],
 		'first_activated_on'                          => [
 			'default' => '',
@@ -587,7 +636,12 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'has_multiple_authors'                        => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [
+				'empty_string',
+				'in_array' => [
+					'allow' => [ true, false ],
+				],
+			],
 		],
 		'home_url'                                    => [
 			'default' => '',
@@ -675,7 +729,19 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'site_type'                                   => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [
+				'empty_string',
+				'in_array' => [
+					'allow' => [
+						'blog',
+						'shop',
+						'news',
+						'smallBusiness',
+						'corporateOther',
+						'personalOther',
+					],
+				],
+			],
 		],
 		'tag_base_url'                                => [
 			'default' => '',

--- a/src/validators/in-array-keys-validator.php
+++ b/src/validators/in-array-keys-validator.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Missing_Settings_Key_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Not_In_Array_Exception;
+
+/**
+ * The in array keys validator class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Validator should not count.
+ */
+class In_Array_Keys_Validator extends In_Array_Validator {
+
+	/**
+	 * The setting' allow-list key.
+	 *
+	 * @var string
+	 */
+	const ALLOW_KEY = 'allow';
+
+	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- Reason: The parent validate can throw too.
+
+	/**
+	 * Validates if a value is in the allow-list (as a key).
+	 *
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
+	 *
+	 * @throws Missing_Settings_Key_Exception When settings are missing.
+	 * @throws Not_In_Array_Exception When the value is not in the allow-list.
+	 *
+	 * @return mixed A valid value.
+	 */
+	public function validate( $value, array $settings = null ) {
+		if ( $settings === null || ! \array_key_exists( self::ALLOW_KEY, $settings ) ) {
+			throw new Missing_Settings_Key_Exception( self::ALLOW_KEY );
+		}
+
+		$settings[ self::ALLOW_KEY ] = \array_keys( $settings[ self::ALLOW_KEY ] );
+
+		return parent::validate( $value, $settings );
+	}
+
+	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
+}

--- a/src/validators/in-array-provider-validator.php
+++ b/src/validators/in-array-provider-validator.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Settings_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Missing_Settings_Key_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Not_In_Array_Exception;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * The in array provider validator class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Validator should not count.
+ */
+class In_Array_Provider_Validator extends In_Array_Validator {
+
+	/**
+	 * The setting' provider key.
+	 *
+	 * @var string
+	 */
+	const PROVIDER_KEY = 'provider';
+
+	/**
+	 * The setting' provider class key.
+	 *
+	 * Should represent the class of the provider.
+	 *
+	 * @var string
+	 */
+	const CLASS_KEY = 'class';
+
+	/**
+	 * The setting' provider method key.
+	 *
+	 * Should represent the name of the class method to call.
+	 *
+	 * @var string
+	 */
+	const METHOD_KEY = 'method';
+
+	/**
+	 * The setting' provider arguments key.
+	 *
+	 * Should contain the arguments that should be passed to the method.
+	 *
+	 * @var string
+	 */
+	const ARGUMENTS_KEY = 'arguments';
+
+	/**
+	 * Holds the dependency injection container interface instance.
+	 *
+	 * @var ContainerInterface
+	 */
+	protected $container;
+
+	/**
+	 * Constructs an in array provider validation instance.
+	 *
+	 * @param ContainerInterface $container The container interface.
+	 */
+	public function __construct( ContainerInterface $container ) {
+		$this->container = $container;
+	}
+
+	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- Reason: The parent validate can throw too.
+
+	/**
+	 * Validates if a value is in the allow-list.
+	 *
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
+	 *
+	 * @throws Missing_Settings_Key_Exception When settings are missing.
+	 * @throws Invalid_Settings_Exception When the settings are invalid.
+	 * @throws Not_In_Array_Exception When the value is not in the allow-list.
+	 *
+	 * @return mixed A valid value.
+	 */
+	public function validate( $value, array $settings = null ) {
+		if ( $settings === null ) {
+			throw new Missing_Settings_Key_Exception( self::ALLOW_KEY );
+		}
+
+		if ( ! \array_key_exists( self::PROVIDER_KEY, $settings ) ) {
+			throw new Missing_Settings_Key_Exception( self::PROVIDER_KEY );
+		}
+
+		$provider = $settings[ self::PROVIDER_KEY ];
+
+		if (
+			! \is_array( $settings[ self::PROVIDER_KEY ] )
+			|| ! \array_key_exists( self::CLASS_KEY, $provider )
+			|| ! \array_key_exists( self::METHOD_KEY, $provider )
+		) {
+			throw new Invalid_Settings_Exception();
+		}
+
+		if ( ! $this->container->has( $provider[ self::CLASS_KEY ] ) ) {
+			throw new Invalid_Settings_Exception();
+		}
+
+		$instance = $this->container->get( $provider[ self::CLASS_KEY ] );
+		if ( \array_key_exists( self::ARGUMENTS_KEY, $provider ) && \is_array( $provider[ self::ARGUMENTS_KEY ] ) ) {
+			$values = \call_user_func_array(
+				[
+					$instance,
+					$provider[ self::METHOD_KEY ],
+				],
+				$provider[ self::ARGUMENTS_KEY ]
+			);
+		}
+		else {
+			$values = \call_user_func( [ $instance, $provider[ self::METHOD_KEY ] ] );
+		}
+
+		if ( ! \is_array( $values ) ) {
+			throw new Invalid_Settings_Exception();
+		}
+
+		return parent::validate( $value, [ parent::ALLOW_KEY => $values ] );
+	}
+
+	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
+}

--- a/src/validators/in-array-validator.php
+++ b/src/validators/in-array-validator.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Missing_Settings_Key_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Not_In_Array_Exception;
+
+/**
+ * The in array validator class.
+ */
+class In_Array_Validator implements Validator_Interface {
+
+	/**
+	 * The setting' allow-list key.
+	 *
+	 * @var string
+	 */
+	const ALLOW_KEY = 'allow';
+
+	/**
+	 * The setting' provider key.
+	 *
+	 * @var string
+	 */
+	const PROVIDER_KEY = 'provider';
+
+	/**
+	 * Validates if a value is in the allow-list.
+	 *
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
+	 *
+	 * @throws Missing_Settings_Key_Exception When settings are missing.
+	 * @throws Not_In_Array_Exception When the value is not in the allow-list.
+	 *
+	 * @return mixed A valid value.
+	 */
+	public function validate( $value, array $settings = null ) {
+		if ( $settings === null || ! \array_key_exists( self::ALLOW_KEY, $settings ) ) {
+			throw new Missing_Settings_Key_Exception( self::ALLOW_KEY );
+		}
+
+		if ( ! \in_array( $value, $settings[ self::ALLOW_KEY ], true ) ) {
+			throw new Not_In_Array_Exception( $settings[ self::ALLOW_KEY ] );
+		}
+
+		return $value;
+	}
+}

--- a/tests/unit/helpers/taxonomy-helper-test.php
+++ b/tests/unit/helpers/taxonomy-helper-test.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Class Robots_Helper_Test
+ * Class Taxonomy_Helper_Test.
  *
  * @group helpers
  *
@@ -104,6 +104,34 @@ class Taxonomy_Helper_Test extends TestCase {
 			->andReturn( [] );
 
 		$this->instance->get_public_taxonomies( 'objects' );
+	}
+
+	/**
+	 * Tests that the WordPress function is called with the expected parameters.
+	 *
+	 * @covers ::get_taxonomies
+	 */
+	public function test_get_taxonomies() {
+		Functions\expect( 'get_taxonomies' )
+			->once()
+			->with( [], 'names' )
+			->andReturn( [] );
+
+		$this->instance->get_taxonomies();
+	}
+
+	/**
+	 * Tests that the WordPress function is called with the expected parameters.
+	 *
+	 * @covers ::get_taxonomies
+	 */
+	public function test_get_taxonomies_with_objects() {
+		Functions\expect( 'get_taxonomies' )
+			->once()
+			->with( [], 'objects' )
+			->andReturn( [] );
+
+		$this->instance->get_taxonomies( 'objects' );
 	}
 
 	/**

--- a/tests/unit/validators/in-array-keys-validator-test.php
+++ b/tests/unit/validators/in-array-keys-validator-test.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Missing_Settings_Key_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Not_In_Array_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\In_Array_Keys_Validator;
+
+/**
+ * Tests the In_Array_Keys_Validator class.
+ *
+ * @group options
+ * @group validators
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\In_Array_Keys_Validator
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Validator should not count.
+ */
+class In_Array_Keys_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var In_Array_Keys_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$this->instance = new In_Array_Keys_Validator();
+	}
+
+	/**
+	 * Tests validation.
+	 *
+	 * @dataProvider data_provider
+	 *
+	 * @covers ::validate
+	 *
+	 * @param mixed  $value     The value to test/validate.
+	 * @param array  $settings  The validator settings.
+	 * @param mixed  $expected  The expected result.
+	 * @param string $exception The expected exception class. Optional, use when the expected result is false.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_validate( $value, $settings, $expected, $exception = '' ) {
+		if ( $exception !== '' ) {
+			$this->expectException( $exception );
+			$this->instance->validate( $value, $settings );
+
+			return;
+		}
+
+		$this->assertEquals( $expected, $this->instance->validate( $value, $settings ) );
+	}
+
+	/**
+	 * Data provider to test multiple inputs.
+	 *
+	 * @return array A mapping of methods and expected inputs.
+	 */
+	public function data_provider() {
+		return [
+			'allow'                => [
+				'value'    => 'summary_large_image',
+				'settings' => [
+					'allow' => [
+						'summary'             => '',
+						'summary_large_image' => '',
+					],
+				],
+				'expected' => 'summary_large_image',
+			],
+			'allow_integer'        => [
+				'value'    => 3,
+				'settings' => [
+					'allow' => [
+						1 => '',
+						2 => '',
+						3 => '',
+					],
+				],
+				'expected' => 3,
+			],
+			'not_allowed'          => [
+				'value'     => 'a',
+				'settings'  => [
+					'allow' => [
+						'summary'             => 'a',
+						'summary_large_image' => 'b',
+					],
+				],
+				'expected'  => false,
+				'exception' => Not_In_Array_Exception::class,
+			],
+			'missing_settings'     => [
+				'value'     => 'something',
+				'settings'  => null,
+				'expected'  => false,
+				'exception' => Missing_Settings_Key_Exception::class,
+			],
+			'missing_settings_key' => [
+				'value'     => 'something',
+				'settings'  => [ 'hi' => 'world' ],
+				'expected'  => false,
+				'exception' => Missing_Settings_Key_Exception::class,
+			],
+		];
+	}
+}

--- a/tests/unit/validators/in-array-provider-validator-test.php
+++ b/tests/unit/validators/in-array-provider-validator-test.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Mockery;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Settings_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Missing_Settings_Key_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Not_In_Array_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\In_Array_Provider_Validator;
+use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Tests the In_Array_Provider_Validator class.
+ *
+ * @group options
+ * @group validators
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\In_Array_Provider_Validator
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Validator should not count.
+ */
+class In_Array_Provider_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var In_Array_Provider_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the dependency injection container.
+	 *
+	 * @var ContainerInterface
+	 */
+	protected $container;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$this->container = Mockery::mock( ContainerInterface::class );
+
+		$this->instance = new In_Array_Provider_Validator( $this->container );
+	}
+
+	/**
+	 * Tests the attributes after constructing.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf( In_Array_Provider_Validator::class, $this->instance );
+		$this->assertInstanceOf(
+			ContainerInterface::class,
+			$this->getPropertyValue( $this->instance, 'container' )
+		);
+	}
+
+	/**
+	 * Tests validation.
+	 *
+	 * @dataProvider data_provider
+	 *
+	 * @covers ::validate
+	 *
+	 * @param mixed  $value     The value to test/validate.
+	 * @param array  $settings  The validator settings.
+	 * @param mixed  $expected  The expected result.
+	 * @param string $exception The expected exception class. Optional, use when the expected result is false.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_validate( $value, $settings, $expected, $exception = '' ) {
+		if ( $exception !== '' ) {
+			$this->expectException( $exception );
+			$this->instance->validate( $value, $settings );
+
+			return;
+		}
+
+		$this->container->expects( 'has' )->andReturn( true );
+		$this->container->expects( 'get' )->andReturn( $this );
+
+		$this->assertEquals( $expected, $this->instance->validate( $value, $settings ) );
+	}
+
+	/**
+	 * Tests invalid validation.
+	 *
+	 * @covers ::validate
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_invalid() {
+		$this->container->expects( 'has' )->andReturn( true );
+		$this->container->expects( 'get' )->andReturn( $this );
+
+		$this->expectException( Not_In_Array_Exception::class );
+
+		$this->instance->validate(
+			2,
+			[
+				'provider' => [
+					'class'  => self::class,
+					'method' => 'get_test_values',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Tests invalid validation with arguments.
+	 *
+	 * @covers ::validate
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_invalid_with_arguments() {
+		$this->container->expects( 'has' )->andReturn( true );
+		$this->container->expects( 'get' )->andReturn( $this );
+
+		$this->expectException( Not_In_Array_Exception::class );
+
+		$this->instance->validate(
+			'two',
+			[
+				'provider' => [
+					'class'     => self::class,
+					'method'    => 'get_test_values',
+					'arguments' => [ true ],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Tests an exception is thrown when the class does not exist.
+	 *
+	 * @covers ::validate
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_class_not_existing() {
+		$this->container->expects( 'has' )->andReturn( false );
+		$this->container->expects( 'get' )->never();
+
+		$this->expectException( Invalid_Settings_Exception::class );
+
+		$this->instance->validate(
+			'two',
+			[
+				'provider' => [
+					'class'  => self::class,
+					'method' => 'get_test_values',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Tests an exception is thrown when the method does not return an array.
+	 *
+	 * @covers ::validate
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_wrong_return_type() {
+		$this->container->expects( 'has' )->andReturn( true );
+		$this->container->expects( 'get' )->andReturn( $this );
+
+		$this->expectException( Invalid_Settings_Exception::class );
+
+		$this->instance->validate(
+			'two',
+			[
+				'provider' => [
+					'class'  => self::class,
+					'method' => 'get_test_wrong_return_type',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Data provider to test multiple inputs.
+	 *
+	 * @return array A mapping of methods and expected inputs.
+	 */
+	public function data_provider() {
+		return [
+			'allow' => [
+				'value'    => 'two',
+				'settings' => [
+					'provider' => [
+						'class'  => self::class,
+						'method' => 'get_test_values',
+					],
+				],
+				'expected' => 'two',
+			],
+
+			'null_settings'                    => [
+				'value'     => '',
+				'settings'  => null,
+				'expected'  => false,
+				'exception' => Missing_Settings_Key_Exception::class,
+			],
+			'missing_provider_settings'        => [
+				'value'     => '',
+				'settings'  => [],
+				'expected'  => false,
+				'exception' => Missing_Settings_Key_Exception::class,
+			],
+			'invalid_provider_settings'        => [
+				'value'     => '',
+				'settings'  => [
+					'provider' => 'invalid',
+				],
+				'expected'  => false,
+				'exception' => Invalid_Settings_Exception::class,
+			],
+			'invalid_provider_class_settings'  => [
+				'value'     => '',
+				'settings'  => [
+					'provider' => [
+						'method' => 'get_test_values',
+					],
+				],
+				'expected'  => false,
+				'exception' => Invalid_Settings_Exception::class,
+			],
+			'invalid_provider_method_settings' => [
+				'value'     => '',
+				'settings'  => [
+					'provider' => [
+						'class' => self::class,
+					],
+				],
+				'expected'  => false,
+				'exception' => Invalid_Settings_Exception::class,
+			],
+		];
+	}
+
+	/**
+	 * Provides values for the valid tests.
+	 *
+	 * @param bool $filter Whether to filter out `two` or not.
+	 *
+	 * @return string[] The return values.
+	 */
+	public function get_test_values( $filter = false ) {
+		if ( $filter ) {
+			return [ 'one', 'three' ];
+		}
+
+		return [ 'one', 'two', 'three' ];
+	}
+
+	/**
+	 * Provides a value for the wrong return type test.
+	 *
+	 * @return string A string.
+	 */
+	public function get_test_wrong_return_type() {
+		return 'string';
+	}
+}

--- a/tests/unit/validators/in-array-validator-test.php
+++ b/tests/unit/validators/in-array-validator-test.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Missing_Settings_Key_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Not_In_Array_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\In_Array_Validator;
+
+/**
+ * Tests the In_Array_Validator class.
+ *
+ * @group options
+ * @group validators
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\In_Array_Validator
+ */
+class In_Array_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var In_Array_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$this->instance = new In_Array_Validator();
+	}
+
+	/**
+	 * Tests validation.
+	 *
+	 * @dataProvider data_provider
+	 *
+	 * @covers ::validate
+	 *
+	 * @param mixed  $value     The value to test/validate.
+	 * @param array  $settings  The validator settings.
+	 * @param mixed  $expected  The expected result.
+	 * @param string $exception The expected exception class. Optional, use when the expected result is false.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_validate( $value, $settings, $expected, $exception = '' ) {
+		if ( $exception !== '' ) {
+			$this->expectException( $exception );
+			$this->instance->validate( $value, $settings );
+
+			return;
+		}
+
+		$this->assertEquals( $expected, $this->instance->validate( $value, $settings ) );
+	}
+
+	/**
+	 * Data provider to test multiple inputs.
+	 *
+	 * @return array A mapping of methods and expected inputs.
+	 */
+	public function data_provider() {
+		return [
+			'allow' => [
+				'value'    => 'summary_large_image',
+				'settings' => [ 'allow' => [ 'summary', 'summary_large_image' ] ],
+				'expected' => 'summary_large_image',
+			],
+			'allow_integer' => [
+				'value'    => 3,
+				'settings' => [ 'allow' => [ 1, 2, 3 ] ],
+				'expected' => 3,
+			],
+			'allow_array' => [
+				'value'    => [ 1, 2, 3 ],
+				'settings' => [ 'allow' => [ 'string', [ 1, 2, 3 ] ] ],
+				'expected' => [ 1, 2, 3 ],
+			],
+
+			/*
+			 * Objects are not detected properly due to the strict comparison.
+			 * We could make a special object check and then do a loose comparison.
+			 *
+			 * If you use a variable of an object and put that as value and as allowed, it will be allowed.
+			 * E.g. $obj = (object) [ 'foo' => 'bar' ];
+			 */
+			'allow_object' => [
+				'value'     => (object) [ 'foo' => 'bar' ],
+				'settings'  => [ 'allow' => [ (object) [ 'foo' => 'bar' ] ] ],
+				'expected'  => false,
+				'exception' => Not_In_Array_Exception::class,
+			],
+
+			'not_allowed'          => [
+				'value'     => 'something',
+				'settings'  => [ 'allow' => [ 'summary', 'summary_large_image' ] ],
+				'expected'  => false,
+				'exception' => Not_In_Array_Exception::class,
+			],
+			'missing_settings'     => [
+				'value'     => 'something',
+				'settings'  => null,
+				'expected'  => false,
+				'exception' => Missing_Settings_Key_Exception::class,
+			],
+			'missing_settings_key' => [
+				'value'     => 'something',
+				'settings'  => [ 'hi' => 'world' ],
+				'expected'  => false,
+				'exception' => Missing_Settings_Key_Exception::class,
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the in array validator.
* Adds the in array key validator.
* Adds the in array provider validator. Where you can configure a method in class to give back the allow list (array).

## Relevant technical choices:

* Left the `In_Array` name we decided upon earlier. Even though our name length sniff gave some protest there. Was pondering about:
  * `Contains` -- but that could also indicate a string? Which is not what it does.
  *  `Allow_List` -- that isn't shorter! But does convey some more meaning maybe.
* Added key and provider variants to have a slightly broader default range we can use them for. But still there will have to be some very specific validators that are almost these. 
* Copied over (instead of removing right away) some code to put in classes for the in array provider to use. This will need removal of the old places later.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Tests should make sense and cover the code
* You can play around with requesting validations (set up for In_Array, but you can code, right?), using this code:
```php
function _test_validate( $value, array $allowed ) {
	/** @var \Yoast\WP\SEO\Validators\In_Array_Validator $validator */
	$validator = YoastSEO()->classes->get( \Yoast\WP\SEO\Validators\In_Array_Validator::class );
	echo 'Value: ';
	var_dump( $value );
	echo '<br>Result: ';
	try {
		var_dump( $validator->validate( $value, [ 'allow' => $allowed ] ) );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_validate( 2, [ 1, 2, 3 ] );
```
* You can play with the setting (please see [the commit](https://github.com/Yoast/wordpress-seo/commit/8db01579d530dbea68a6dc66e1aa3a03acc136fa), to see other options and change the code), using this code:
```php
function _test_set( $value ) {
	/** @var \Yoast\WP\SEO\Services\Options\Site_Options_Service $options */
	$options = YoastSEO()->classes->get( \Yoast\WP\SEO\Services\Options\Site_Options_Service::class );
	echo '<br>Before: ';
	var_dump( $options->environment_type );
	echo '<br>After: ';
	try {
		$options->environment_type = $value;
		var_dump( $options->environment_type );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_set( 'invalid' );
```

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Part of bigger feature, please test the whole feature when done.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [P1-1192](https://yoast.atlassian.net/browse/P1-1192)
