### PR TITLE
Improve support for automation with background indexing

### DIFF
--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -157,7 +157,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'admin_init', [ $this, 'register_shutdown_indexing' ] );
-		\add_action( 'Yoast\WP\SEO\index', [ $this, 'index' ] );
+		\add_action( 'wpseo_indexable_index_batch', [ $this, 'index' ] );
 		// phpcs:ignore WordPress.WP.CronInterval -- The sniff doesn't understand values with parentheses. https://github.com/WordPress/WordPress-Coding-Standards/issues/2025
 		\add_filter( 'cron_schedules', [ $this, 'add_cron_schedule' ] );
 		\add_action( 'init', [ $this, 'schedule_cron_indexing' ], 11 );
@@ -225,8 +225,8 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function schedule_cron_indexing() {
-		if ( ! wp_next_scheduled( 'Yoast\WP\SEO\index' ) && $this->should_index_on_cron() ) {
-			wp_schedule_event( time(), 'fifteen_minutes', 'Yoast\WP\SEO\index' );
+		if ( ! wp_next_scheduled( 'wpseo_indexable_index_batch' ) && $this->should_index_on_cron() ) {
+			wp_schedule_event( time(), 'fifteen_minutes', 'wpseo_indexable_index_batch' );
 		}
 	}
 
@@ -296,9 +296,9 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	protected function unschedule_cron_indexing() {
-		$scheduled = wp_next_scheduled( 'Yoast\WP\SEO\index' );
+		$scheduled = wp_next_scheduled( 'wpseo_indexable_index_batch' );
 		if ( $scheduled ) {
-			wp_unschedule_event( $scheduled, 'Yoast\WP\SEO\index' );
+			wp_unschedule_event( $scheduled, 'wpseo_indexable_index_batch' );
 		}
 	}
 

--- a/tests/unit/integrations/admin/background-indexing-integration-test.php
+++ b/tests/unit/integrations/admin/background-indexing-integration-test.php
@@ -207,7 +207,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 	 */
 	public function test_register_hooks() {
 		Monkey\Actions\expectAdded( 'admin_init' );
-		Monkey\Actions\expectAdded( 'Yoast\WP\SEO\index' );
+		Monkey\Actions\expectAdded( 'wpseo_indexable_index_batch' );
 		Monkey\Filters\expectAdded( 'cron_schedules' );
 		Monkey\Actions\expectAdded( 'init' );
 		Monkey\Filters\expectAdded( 'wpseo_post_indexation_limit' );
@@ -408,8 +408,8 @@ class Background_Indexing_Integration_Test extends TestCase {
 			->with( true )
 			->andReturn( false );
 
-		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( 12345 );
-		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12345, 'Yoast\WP\SEO\index' );
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( 12345 );
+		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12345, 'wpseo_indexable_index_batch' );
 
 		$this->instance->index();
 	}
@@ -434,8 +434,8 @@ class Background_Indexing_Integration_Test extends TestCase {
 			->andReturn( true );
 
 
-		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( 12345 );
-		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12345, 'Yoast\WP\SEO\index' );
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( 12345 );
+		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12345, 'wpseo_indexable_index_batch' );
 
 		$this->instance->index();
 	}
@@ -460,21 +460,21 @@ class Background_Indexing_Integration_Test extends TestCase {
 			->andReturn( true );
 
 
-		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_unschedule_event' )->never();
 
 		$this->instance->index();
 	}
 
 	/**
-	 * Tests that the schedule_cron_indexing function schedules a cron job that performs the Yoast\WP\SEO\index action.
+	 * Tests that the schedule_cron_indexing function schedules a cron job that performs the wpseo_indexable_index_batch action.
 	 *
 	 * @covers ::schedule_cron_indexing
 	 */
 	public function test_schedule_cron_indexing() {
-		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( false );
 		$this->indexing_helper->expects( 'is_index_up_to_date' )->once()->andReturn( false );
-		Monkey\Functions\expect( 'wp_schedule_event' )->once()->with( time(), 'fifteen_minutes', 'Yoast\WP\SEO\index' );
+		Monkey\Functions\expect( 'wp_schedule_event' )->once()->with( time(), 'fifteen_minutes', 'wpseo_indexable_index_batch' );
 
 		$this->instance->schedule_cron_indexing();
 	}
@@ -485,7 +485,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 	 * @covers ::schedule_cron_indexing
 	 */
 	public function test_schedule_cron_indexing_already_scheduled() {
-		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( 987654321 );
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( 987654321 );
 		Monkey\Functions\expect( 'wp_schedule_event' )->never();
 
 		$this->instance->schedule_cron_indexing();
@@ -497,7 +497,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 	 * @covers ::schedule_cron_indexing
 	 */
 	public function test_schedule_cron_indexing_cron_indexing_disabled() {
-		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( false );
 		Monkey\Filters\expectApplied( 'Yoast\WP\SEO\enable_cron_indexing' )->with( true )->andReturn( false );
 		Monkey\Functions\expect( 'wp_schedule_event' )->never();
 
@@ -510,7 +510,7 @@ class Background_Indexing_Integration_Test extends TestCase {
 	 * @covers ::schedule_cron_indexing
 	 */
 	public function test_schedule_cron_indexing_index_complete() {
-		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'Yoast\WP\SEO\index' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( false );
 		$this->indexing_helper->expects( 'is_index_up_to_date' )->once()->andReturn( true );
 		Monkey\Functions\expect( 'wp_schedule_event' )->never();
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The previous background indexing hook had "\" characters in its handle. This may cause issues with automations that use bash (in combination with WP-CLI) for instance, which sees that as a escaping character.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Change unreleased hook name from `Yoast\WP\SEO\index` to `wpseo_indexable_index_batch`

## Relevant technical choices:

* most wpseo hooks include their domain in the name, I wanted to do the same here and be a bit more descriptive of what the action is for.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* run `wp cron event run wpseo_indexable_index_batch`
* It should not fail


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* n/a

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes QA-2886
