### PR TITLE
Update helpscout beacon session details

### DIFF
--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -179,7 +179,6 @@ class HelpScout_Beacon implements Integration_Interface {
 			'name'               => \trim( $current_user->user_firstname . ' ' . $current_user->user_lastname ),
 			'email'              => $current_user->user_email,
 			'WordPress Version'  => $this->get_wordpress_version(),
-			'Is multisite'       => \is_multisite() ? 'True' : 'False',
 			$this->get_server_info(),
 			'Theme'              => $this->get_theme_info(),
 			'Plugins'            => $this->get_active_plugins(),
@@ -242,10 +241,11 @@ class HelpScout_Beacon implements Integration_Interface {
 			return '';
 		}
 
-		$product_info  = '<table>';
-		$product_info .= '<tr><td>Version</td><td>' . $plugin->product->version . '</td></tr>';
-		$product_info .= '<tr><td>Expiration date</td><td>' . $plugin->expiry_date . '</td></tr>';
-		$product_info .= '</table>';
+		$product_info = \sprintf(
+			'Version: %1$s, expiration date: 2$s',
+			$plugin->product->version,
+			$plugin->expiry_date
+		);
 
 		return $product_info;
 	}
@@ -260,7 +260,7 @@ class HelpScout_Beacon implements Integration_Interface {
 
 		$wordpress_version = $wp_version;
 		if ( \is_multisite() ) {
-			$wordpress_version .= ' MULTI-SITE';
+			$wordpress_version .= ' (multisite enabled)';
 		}
 
 		return $wordpress_version;
@@ -275,15 +275,14 @@ class HelpScout_Beacon implements Integration_Interface {
 		$theme = \wp_get_theme();
 
 		$theme_info = \sprintf(
-			'<a href="%1$s">%2$s</a> v%3$s by %4$s',
-			\esc_attr( $theme->display( 'ThemeURI' ) ),
+			'%1$s (Version %2$s, URL %3$s)',
 			\esc_html( $theme->display( 'Name' ) ),
 			\esc_html( $theme->display( 'Version' ) ),
-			\esc_html( $theme->display( 'Author' ) )
+			\esc_attr( $theme->display( 'ThemeURI' ) ),
 		);
 
 		if ( \is_child_theme() ) {
-			$theme_info .= \sprintf( '<br />Child theme of: %1$s', \esc_html( $theme->display( 'Template' ) ) );
+			$theme_info .= \sprintf( ', this is a child theme of: %1$s', \esc_html( $theme->display( 'Template' ) ) );
 		}
 
 		return $theme_info;

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -175,17 +175,18 @@ class HelpScout_Beacon implements Integration_Interface {
 		$current_user = \wp_get_current_user();
 
 		// Do not make these strings translatable! They are for our support agents, the user won't see them!
-		$data = [
-			'name'               => \trim( $current_user->user_firstname . ' ' . $current_user->user_lastname ),
-			'email'              => $current_user->user_email,
-		];
-
-		$data = array_merge( $data, $this->get_server_info(), 
-		[
-			'WordPress Version'  => $this->get_wordpress_version(),
-			'Active theme'       => $this->get_theme_info(),
-			'Active plugins'     => $this->get_active_plugins(),
-		] );
+		$data = array_merge(
+			[
+				'name'               => \trim( $current_user->user_firstname . ' ' . $current_user->user_lastname ),
+				'email'              => $current_user->user_email,
+			],
+			$this->get_server_info(),
+			[
+				'WordPress Version'  => $this->get_wordpress_version(),
+				'Active theme'       => $this->get_theme_info(),
+				'Active plugins'     => $this->get_active_plugins(),
+			]
+		);
 
 		if ( ! empty( $this->products ) ) {
 			$addon_manager = new WPSEO_Addon_Manager();
@@ -214,7 +215,7 @@ class HelpScout_Beacon implements Integration_Interface {
 		$server_data          = $server_data['server'];
 
 		$fields_to_use = [
-			'Server IP'       => 'ip',
+			'Server IP'        => 'ip',
 			'PHP Version'      => 'PhpVersion',
 			'cURL Version'     => 'CurlVersion',
 		];
@@ -225,7 +226,7 @@ class HelpScout_Beacon implements Integration_Interface {
 
 		foreach ( $fields_to_use as $label => $field_to_use ) {
 			if ( isset( $server_data[ $field_to_use ] ) ) {
-				$server_info[ $label ] = \esc_html( $server_data[ $field_to_use ] ) ;
+				$server_info[ $label ] = \esc_html( $server_data[ $field_to_use ] );
 			}
 		}
 

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -231,6 +231,18 @@ class HelpScout_Beacon implements Integration_Interface {
 			}
 		}
 
+		// Get the memory limits for the server and, if different, from WordPress as well.
+		$memory_limit                   = ini_get('memory_limit');
+		$server_info[ 'Memory limits' ] = 'Server memory limit: ' . $memory_limit;
+		
+		if ( $memory_limit != WP_MEMORY_LIMIT ) {
+			$server_info[ 'Memory limits' ] .= ', WP_MEMORY_LIMIT: '. WP_MEMORY_LIMIT;
+		}
+
+		if ( $memory_limit != WP_MAX_MEMORY_LIMIT ) {
+			$server_info[ 'Memory limits' ] .= ', WP_MAX_MEMORY_LIMIT: '. WP_MAX_MEMORY_LIMIT;
+		}
+
 		return $server_info;
 	}
 
@@ -331,28 +343,14 @@ class HelpScout_Beacon implements Integration_Interface {
 	 * @return string The active plugins.
 	 */
 	private function get_mustuse_and_dropins() {
-		$updates_available = \get_site_transient( 'update_plugins' );
-
-		$active_plugins = '';
-		foreach ( \wp_get_active_and_valid_plugins() as $plugin ) {
-			$plugin_data             = \get_plugin_data( $plugin );
-			$plugin_file             = \str_replace( \trailingslashit( \WP_PLUGIN_DIR ), '', $plugin );
-			$plugin_update_available = '';
-
-			if ( isset( $updates_available->response[ $plugin_file ] ) ) {
-				$plugin_update_available = ' [update available]';
-			}
-
-			$active_plugins .= \sprintf(
-				'%1$s (Version %2$s%3$s, %4$s), ',
-				\esc_html( $plugin_data['Name'] ),
-				\esc_html( $plugin_data['Version'] ),
-				$plugin_update_available,
-				\esc_attr( $plugin_data['PluginURI'] )
-			);
+		if ( ! \is_array( $dropins = \get_dropins() ) ) {
+			$dropins = [];
+		}
+		if ( ! \is_array( $mustuse_plugins = \get_mu_plugins() ) ) {
+			$mustuse_plugins = [];
 		}
 
-		return $active_plugins;
+		return \sprintf( 'Must-Use plugins: %1$d, Drop-ins: %2$d', \count( $mustuse_plugins ), \count( $dropins ) );
 	}
 
 	/**

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -360,7 +360,7 @@ class HelpScout_Beacon implements Integration_Interface {
 	}
 
 	/**
-	 * Returns a CSV list of all must-use and rop-in plugins.
+	 * Returns a CSV list of all must-use and drop-in plugins.
 	 *
 	 * @return string The active plugins.
 	 */

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -221,7 +221,7 @@ class HelpScout_Beacon implements Integration_Interface {
 		}
 
 		// Store the data in a transient for 5 minutes to prevent overhead on every backend pageload.
-		\set_transient( 'yoast_beacon_session_data', $data, 5 * MINUTE_IN_SECONDS );
+		\set_transient( 'yoast_beacon_session_data', $data, ( 5 * MINUTE_IN_SECONDS ) );
 
 		return WPSEO_Utils::format_json_encode( $data );
 	}

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -415,7 +415,7 @@ class HelpScout_Beacon implements Integration_Interface {
 		$language_settings = sprintf(
 			'Site locale: %1$s, user locale: %2$s',
 			( is_string( $site_locale ) ) ? \esc_html( $site_locale ) : 'unknown',
-			( is_string( $user_locale ) ) ? \esc_html( $user_locale) : 'unknown'
+			( is_string( $user_locale ) ) ? \esc_html( $user_locale ) : 'unknown'
 		);
 
 		return $language_settings;

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -176,12 +176,13 @@ class HelpScout_Beacon implements Integration_Interface {
 
 		// Do not make these strings translatable! They are for our support agents, the user won't see them!
 		$data = [
-			'name'                                                   => \trim( $current_user->user_firstname . ' ' . $current_user->user_lastname ),
-			'email'                                                  => $current_user->user_email,
-			'WordPress Version'                                      => $this->get_wordpress_version(),
-			'Server'                                                 => $this->get_server_info(),
-			'<a href="' . \admin_url( 'themes.php' ) . '">Theme</a>' => $this->get_theme_info(),
-			'<a href="' . \admin_url( 'plugins.php' ) . '">Plugins</a>' => $this->get_active_plugins(),
+			'name'               => \trim( $current_user->user_firstname . ' ' . $current_user->user_lastname ),
+			'email'              => $current_user->user_email,
+			'Is multisite'       => \is_multisite() ? 'True' : 'False',
+			'WordPress Version'  => $this->get_wordpress_version(),
+			'Server'             => $this->get_server_info(),
+			'Theme'              => $this->get_theme_info(),
+			'Plugins'            => $this->get_active_plugins(),
 		];
 
 		if ( ! empty( $this->products ) ) {

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -182,6 +182,13 @@ class HelpScout_Beacon implements Integration_Interface {
 	 * @return string The data to pass as identifying data.
 	 */
 	protected function get_session_data() {
+		// Short-circuit if we can get the needed data from a transient.
+		$transient_data = \get_transient( 'yoast_beacon_session_data' );
+
+		if ( is_array( $transient_data ) ) {
+			return WPSEO_Utils::format_json_encode( $transient_data );
+		}
+
 		$current_user = \wp_get_current_user();
 
 		// Do not make these strings translatable! They are for our support agents, the user won't see them!
@@ -212,6 +219,9 @@ class HelpScout_Beacon implements Integration_Interface {
 				$data[ $subscription->product->name ] = $this->get_product_info( $subscription );
 			}
 		}
+
+		// Store the data in a transient for 5 minutes to prevent overhead on every backend pageload.
+		\set_transient( 'yoast_beacon_session_data', $data, 5 * MINUTE_IN_SECONDS );
 
 		return WPSEO_Utils::format_json_encode( $data );
 	}

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -372,7 +372,7 @@ class HelpScout_Beacon implements Integration_Interface {
 
 		foreach( ['free', 'premium' ] as $migration_name ) {
 			if ( $current_status = $this->migration_status->get_error( $migration_name ) ) {
-				$indexables_status .= 'Migration status: ' . $current_status;
+				$indexables_status .= 'Migration error: ' . $current_status[ 'message' ];
 			};
 		}
 

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -178,9 +178,9 @@ class HelpScout_Beacon implements Integration_Interface {
 		$data = [
 			'name'               => \trim( $current_user->user_firstname . ' ' . $current_user->user_lastname ),
 			'email'              => $current_user->user_email,
-			'Is multisite'       => \is_multisite() ? 'True' : 'False',
 			'WordPress Version'  => $this->get_wordpress_version(),
-			'Server'             => $this->get_server_info(),
+			'Is multisite'       => \is_multisite() ? 'True' : 'False',
+			$this->get_server_info(),
 			'Theme'              => $this->get_theme_info(),
 			'Plugins'            => $this->get_active_plugins(),
 		];
@@ -213,23 +213,19 @@ class HelpScout_Beacon implements Integration_Interface {
 
 		$fields_to_use = [
 			'IP'       => 'ip',
-			'Hostname' => 'Hostname',
-			'OS'       => 'os',
 			'PHP'      => 'PhpVersion',
 			'CURL'     => 'CurlVersion',
 		];
 
 		$server_data['CurlVersion'] = $server_data['CurlVersion']['version'] . '(SSL Support' . $server_data['CurlVersion']['sslSupport'] . ')';
 
-		$server_info = '<table>';
+		$server_info = [];
 
 		foreach ( $fields_to_use as $label => $field_to_use ) {
 			if ( isset( $server_data[ $field_to_use ] ) ) {
-				$server_info .= \sprintf( '<tr><td>%1$s</td><td>%2$s</td></tr>', \esc_html( $label ), \esc_html( $server_data[ $field_to_use ] ) );
+				$server_info[ $field_to_use ] = \esc_html( $server_data[ $field_to_use ] ) ;
 			}
 		}
-
-		$server_info .= '</table>';
 
 		return $server_info;
 	}

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -414,8 +414,8 @@ class HelpScout_Beacon implements Integration_Interface {
 
 		$language_settings = sprintf(
 			'Site locale: %1$s, user locale: %2$s',
-			( is_string( $site_locale ) ) ? $site_locale : 'unknown',
-			( is_string( $user_locale ) ) ? $user_locale : 'unknown'
+			( is_string( $site_locale ) ) ? \esc_html( $site_locale ) : 'unknown',
+			( is_string( $user_locale ) ) ? \esc_html( $user_locale) : 'unknown'
 		);
 
 		return $language_settings;

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -330,7 +330,7 @@ class HelpScout_Beacon implements Integration_Interface {
 	}
 
 	/**
-	 * Returns a CSV list of all active plugins.
+	 * Returns a stringified list of all active plugins, separated by a pipe.
 	 *
 	 * @return string The active plugins.
 	 */
@@ -348,7 +348,7 @@ class HelpScout_Beacon implements Integration_Interface {
 			}
 
 			$active_plugins .= \sprintf(
-				'%1$s (Version %2$s%3$s, %4$s), ',
+				'%1$s (Version %2$s%3$s, %4$s) | ',
 				\esc_html( $plugin_data['Name'] ),
 				\esc_html( $plugin_data['Version'] ),
 				$plugin_update_available,

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -264,7 +264,9 @@ class HelpScout_Beacon implements Integration_Interface {
 
 		$wordpress_version = $wp_version;
 		if ( \is_multisite() ) {
-			$wordpress_version .= ' (multisite enabled)';
+			$wordpress_version .= ' (multisite: yes)';
+		} else {
+			$wordpress_version .= ' (multisite: no)';
 		}
 
 		return $wordpress_version;

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -234,7 +234,7 @@ class HelpScout_Beacon implements Integration_Interface {
 		// Get the memory limits for the server and, if different, from WordPress as well.
 		$memory_limit                   = ini_get('memory_limit');
 		$server_info[ 'Memory limits' ] = 'Server memory limit: ' . $memory_limit;
-		
+
 		if ( $memory_limit != WP_MEMORY_LIMIT ) {
 			$server_info[ 'Memory limits' ] .= ', WP_MEMORY_LIMIT: '. WP_MEMORY_LIMIT;
 		}
@@ -259,8 +259,7 @@ class HelpScout_Beacon implements Integration_Interface {
 		}
 
 		$product_info = \sprintf(
-			'Version %1$s, expiration date %2$s',
-			$plugin->product->version,
+			'Expiration date %1$s',
 			$plugin->expiry_date
 		);
 

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -196,6 +196,7 @@ class HelpScout_Beacon implements Integration_Interface {
 			[
 				'name'               => \trim( $current_user->user_firstname . ' ' . $current_user->user_lastname ),
 				'email'              => $current_user->user_email,
+				'Languages'          => $this->get_language_settings(),
 			],
 			$this->get_server_info(),
 			[
@@ -400,6 +401,24 @@ class HelpScout_Beacon implements Integration_Interface {
 		}
 
 		return $indexables_status;
+	}
+
+	/**
+	 * Returns language settings for the website and the current user.
+	 *
+	 * @return string The locale settings of the site and user.
+	 */
+	private function get_language_settings() {
+		$site_locale = \get_locale();
+		$user_locale = \get_user_locale();
+
+		$language_settings = sprintf(
+			'Site locale: %1$s, user locale: %2$s',
+			( is_string( $site_locale ) ) ? $site_locale : 'unknown',
+			( is_string( $user_locale ) ) ? $user_locale : 'unknown'
+		);
+
+		return $language_settings;
 	}
 
 	/**

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -185,6 +185,7 @@ class HelpScout_Beacon implements Integration_Interface {
 				'WordPress Version'  => $this->get_wordpress_version(),
 				'Active theme'       => $this->get_theme_info(),
 				'Active plugins'     => $this->get_active_plugins(),
+				'Must-use and dropins' => $this->get_mustuse_and_dropins(),
 			]
 		);
 
@@ -255,7 +256,7 @@ class HelpScout_Beacon implements Integration_Interface {
 	}
 
 	/**
-	 * Returns the WordPress version + a suffix if current WP is multi site.
+	 * Returns the WordPress version + a suffix about the multisite status.
 	 *
 	 * @return string The WordPress version string.
 	 */
@@ -273,7 +274,7 @@ class HelpScout_Beacon implements Integration_Interface {
 	}
 
 	/**
-	 * Returns a formatted HTML string for the current theme.
+	 * Returns information about the current theme.
 	 *
 	 * @return string The theme info as string.
 	 */
@@ -295,11 +296,41 @@ class HelpScout_Beacon implements Integration_Interface {
 	}
 
 	/**
-	 * Returns a formatted HTML list of all active plugins.
+	 * Returns a CSV list of all active plugins.
 	 *
 	 * @return string The active plugins.
 	 */
 	private function get_active_plugins() {
+		$updates_available = \get_site_transient( 'update_plugins' );
+
+		$active_plugins = '';
+		foreach ( \wp_get_active_and_valid_plugins() as $plugin ) {
+			$plugin_data             = \get_plugin_data( $plugin );
+			$plugin_file             = \str_replace( \trailingslashit( \WP_PLUGIN_DIR ), '', $plugin );
+			$plugin_update_available = '';
+
+			if ( isset( $updates_available->response[ $plugin_file ] ) ) {
+				$plugin_update_available = ' [update available]';
+			}
+
+			$active_plugins .= \sprintf(
+				'%1$s (Version %2$s%3$s, %4$s), ',
+				\esc_html( $plugin_data['Name'] ),
+				\esc_html( $plugin_data['Version'] ),
+				$plugin_update_available,
+				\esc_attr( $plugin_data['PluginURI'] )
+			);
+		}
+
+		return $active_plugins;
+	}
+
+	/**
+	 * Returns a CSV list of all must-use and rop-in plugins.
+	 *
+	 * @return string The active plugins.
+	 */
+	private function get_mustuse_and_dropins() {
 		$updates_available = \get_site_transient( 'update_plugins' );
 
 		$active_plugins = '';

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -379,13 +379,13 @@ class HelpScout_Beacon implements Integration_Interface {
 		$indexing_reason    = $this->options->get( 'indexing_reason' );
 
 		$indexables_status .= ( $indexing_completed ) ? 'yes' : 'no';
-		$indexables_status .= ( $indexing_reason ) ? ', latest indexing reason: ' . $indexing_reason : '';
+		$indexables_status .= ( $indexing_reason ) ? ', latest indexing reason: ' . esc_html( $indexing_reason ) : '';
 
 		foreach ( [ 'free', 'premium' ] as $migration_name ) {
 			$current_status = $this->migration_status->get_error( $migration_name );
 
 			if ( is_array( $current_status ) && isset( $current_status['message'] ) ) {
-				$indexables_status .= ', migration error: ' . $current_status['message'];
+				$indexables_status .= ', migration error: ' . esc_html( $current_status['message'] );
 			};
 		}
 

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -368,11 +368,16 @@ class HelpScout_Beacon implements Integration_Interface {
 	 * @return string The indexables status in a string.
 	 */
 	private function get_indexables_status() {
-		$indexables_status = '';
+		$indexables_status  = 'Indexing completed: ';
+		$indexing_completed = $this->options->get( 'indexables_indexing_completed' );
+		$indexing_reason    = $this->options->get( 'indexing_reason' );
+
+		$indexables_status .= $indexing_completed ? 'yes' : 'no';
+		$indexables_status .= $indexing_reason ? ', latest indexing reason: ' . $indexing_reason : '';
 
 		foreach( ['free', 'premium' ] as $migration_name ) {
 			if ( $current_status = $this->migration_status->get_error( $migration_name ) ) {
-				$indexables_status .= 'Migration error: ' . $current_status[ 'message' ];
+				$indexables_status .= ', migration error: ' . $current_status[ 'message' ];
 			};
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The session details that we send to HelpScout when a user uses our beacon were outdated. This PR aims to:
  * Remove all HTML tags for a cleaner look (they were not parsed anymore)
  * Remove unused details (like host OS and name)
  * Remove the version of our own separate plugin fields, as it was not working correctly
  * Add PHP Memory information
  * Add information about mu-plugins and dropins (count)
  * Add information about indexables and migrations status
  * Add information about the site and user locale settings
  * Add transient caching for 5 minutes to prevent having to request all this information on every backend pageload

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates and caches the session details that our HelpScout beacon sends to our support team.

## Relevant technical choices:

* To prevent all this data from being collected on every pageload I opted to cache the data in a transient for 5 minutes. This may cause some information to not always be up-to-date when the beacon is called. However, saving resources and time outweighs this minor inconvenience in my opinion. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install this version of Yoast + some addons and other plugins
* Open the HelpScout beacon on one of our plugin pages
* Send an e-mail via the beacon
* Check the beacon details in HelpScout (or ask a friendly neighborhood support engineer to check for you) and make sure they are correct. Documentation for the details can be found here: https://yoast.atlassian.net/wiki/spaces/SUP/pages/2342944816/


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Additionally, make sure there are no errors on admin pages where the beacon gets loaded (all pages under SEO)

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
