### PR TITLE
Revert "Fix failing tests with partial mocks with functions that take reference args"

### DIFF
--- a/patchwork.json
+++ b/patchwork.json
@@ -1,0 +1,6 @@
+{
+  "redefinable-internals": [
+	"register_shutdown_function",
+	"time"
+  ]
+}

--- a/src/integrations/admin/background-indexing-integration.php
+++ b/src/integrations/admin/background-indexing-integration.php
@@ -171,7 +171,7 @@ class Background_Indexing_Integration implements Integration_Interface {
 	 */
 	public function register_shutdown_indexing() {
 		if ( $this->should_index_on_shutdown( $this->get_shutdown_limit() ) ) {
-			$this->register_shutdown_function( 'index' );
+			\register_shutdown_function( [ $this, 'index' ] );
 		}
 	}
 
@@ -300,17 +300,5 @@ class Background_Indexing_Integration implements Integration_Interface {
 		if ( $scheduled ) {
 			wp_unschedule_event( $scheduled, 'Yoast\WP\SEO\index' );
 		}
-	}
-
-	/**
-	 * Registers a method to be executed on shutdown.
-	 * This wrapper mostly exists for making this class more unittestable.
-	 *
-	 * @param string $method_name The name of the method on the current instance to register.
-	 *
-	 * @return void
-	 */
-	protected function register_shutdown_function( $method_name ) {
-		\register_shutdown_function( [ $this, $method_name ] );
 	}
 }


### PR DESCRIPTION
Reverts Yoast/wordpress-seo#18050