### PR TITLE
Add a fallback value when no primary category is explicitly selected

### DIFF
--- a/packages/js/src/classic-editor/replacement-variables/configurations.js
+++ b/packages/js/src/classic-editor/replacement-variables/configurations.js
@@ -54,7 +54,19 @@ export const primaryCategory = {
 		const primaryTaxonomyId = primaryTaxonomyIdFromStore || initialPrimaryTaxonomyId;
 		const categories = select( SEO_STORE_NAME ).selectCategories();
 
-		return categories.find( cat => cat.id === primaryTaxonomyId.toString() ).name;
+		const foundPrimaryCategory = categories.find( cat => cat.id === primaryTaxonomyId.toString() );
+		if ( foundPrimaryCategory ) {
+			return foundPrimaryCategory.name;
+		}
+		/*
+		  * If no primary category is found, we check further whether there is a checked category present. If there is,
+		  * it is also assigned as the primary category, otherwise an empty string is returned.
+		 */
+		if ( categories.length === 1 ) {
+			return categories[ 0 ].name;
+		}
+
+		return "";
 	},
 };
 

--- a/packages/js/tests/classic-editor/replacement-variables/configurations.test.js
+++ b/packages/js/tests/classic-editor/replacement-variables/configurations.test.js
@@ -9,7 +9,7 @@ self.wpseoPrimaryCategoryL10n = {
 	},
 };
 
-const categories = jest.fn().mockReturnValue( [
+let selectCategories = jest.fn().mockReturnValue( [
 	{
 		id: "1",
 		name: "category 1",
@@ -25,7 +25,7 @@ describe( "a test for getting the replacement of the variables in classic editor
 		jest.spyOn( data, "select" ).mockImplementation( () => {
 			return {
 				getPrimaryTaxonomyId: jest.fn().mockReturnValue( 2 ),
-				selectCategories: categories,
+				selectCategories: selectCategories,
 			};
 		} );
 
@@ -36,10 +36,57 @@ describe( "a test for getting the replacement of the variables in classic editor
 		jest.spyOn( data, "select" ).mockImplementation( () => {
 			return {
 				getPrimaryTaxonomyId: jest.fn().mockReturnValue( undefined ),
-				selectCategories: categories,
+				selectCategories: selectCategories,
 			};
 		} );
 
 		expect( primaryCategory.getReplacement() ).toEqual( "category 1" );
+	} );
+
+	it( "should return the replacement for primary category variable when the id from both the store " +
+		"and from wpseoPrimaryCategoryL10n is undefined, but there is one category that is selected for a post:" +
+		" the selected category is also assigned as the primary", () => {
+		self.wpseoPrimaryCategoryL10n = {
+			taxonomies: {
+				category: {
+					primary: "",
+				},
+			},
+		};
+		selectCategories = jest.fn().mockReturnValue( [
+			{
+				id: "4",
+				name: "a new category",
+			},
+		] );
+		jest.spyOn( data, "select" ).mockImplementation( () => {
+			return {
+				getPrimaryTaxonomyId: jest.fn().mockReturnValue( undefined ),
+				selectCategories: selectCategories,
+			};
+		} );
+
+		expect( primaryCategory.getReplacement() ).toEqual( "a new category" );
+	} );
+
+	it( "should return the replacement for primary category variable when the id from both the store " +
+		"and from wpseoPrimaryCategoryL10n is undefined, and there is no category that is selected for a post:" +
+		" the primary category should be an empty string", () => {
+		self.wpseoPrimaryCategoryL10n = {
+			taxonomies: {
+				category: {
+					primary: "",
+				},
+			},
+		};
+		selectCategories = jest.fn().mockReturnValue( [] );
+		jest.spyOn( data, "select" ).mockImplementation( () => {
+			return {
+				getPrimaryTaxonomyId: jest.fn().mockReturnValue( undefined ),
+				selectCategories: selectCategories,
+			};
+		} );
+
+		expect( primaryCategory.getReplacement() ).toEqual( "" );
 	} );
 } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When creating a post without assigning any category, `Uncategorized` will be automatically assigned as the category. Upon reopening the post, `Uncategorized` is also expected to be assigned as the primary category as well, which wan't the case. This PR fix this problem.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Selects the only checked category as the primary category in Classic editor.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Requirements:
* Install and activate Classic editor
* Create a post without assigning any category
* Save the post and go to the posts overview page

**Test if `Uncategorized` is also assigned as `primary category`**
* Reopen the post that you just created
* Confirm that `Uncategorized` is checked as the category
* Use `primary category` variable in SEO title and meta description field
* Confirm that `Uncategorized` is displayed in Google preview both in the Title (link) and the metadescription
* Uncheck and check again `Uncategorized` in the categories list
* Save the post
* Go to the front end of the post
* Confirm that `Uncategorized` also shows in the meta tag of the source code, e.g. `<meta name="description" content="Uncategorized" />`

**Test a situation when no category is checked**
* Open the post that was created previously
* Use `primary category` variable in SEO title and meta description field
* Uncheck `Uncategorized` so now there is no category assigned to the post
* Confirm that the value that is displayed in Google preview reflects this change, i.e. no primary category is displayed
* Save the post
* Go to the front end of the post
* Confirm that no primary category also shows in the meta tag of the source code

**Test a situation when one category is checked**
* Open the post that was created previously
* Use `primary category` variable in SEO title and meta description field
* Check one category other than `Uncategorized`
* Confirm that the category that you checked is also displayed as the primary category in Google preview both in the Title (link) and the metadescription
* Save the post
* Go to the front end of the post
* Confirm that the category that you checked also shows in the meta tag of the source code, e.g. `<meta name="description" content="Category name" />`



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #https://yoast.atlassian.net/jira/software/c/projects/LINGO/boards/99?modal=detail&selectedIssue=LINGO-1310
