### PR TITLE
Facilitate removing partial mocks from the new import framework

### DIFF
--- a/src/actions/importing/aioseo/abstract-aioseo-settings-importing-action.php
+++ b/src/actions/importing/aioseo/abstract-aioseo-settings-importing-action.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Actions\Importing\Aioseo;
 
 use Exception;
 use Yoast\WP\SEO\Actions\Importing\Abstract_Aioseo_Importing_Action;
+use Yoast\WP\SEO\Helpers\Import_Helper;
 use Yoast\WP\SEO\Conditionals\AIOSEO_V4_Importer_Conditional;
 
 /**
@@ -57,11 +58,29 @@ abstract class Abstract_Aioseo_Settings_Importing_Action extends Abstract_Aioseo
 	protected $replace_vars_edited_map = [];
 
 	/**
+	 * The import helper.
+	 *
+	 * @var Import_Helper
+	 */
+	protected $import_helper;
+
+	/**
 	 * Builds the mapping that ties AOISEO option keys with Yoast ones and their data transformation method.
 	 *
 	 * @return void
 	 */
 	abstract protected function build_mapping();
+
+	/**
+	 * Sets the import helper.
+	 *
+	 * @required
+	 *
+	 * @param Import_Helper $import_helper The import helper.
+	 */
+	public function set_import_helper( Import_Helper $import_helper ) {
+		$this->import_helper = $import_helper;
+	}
 
 	/**
 	 * Retrieves the source option_name.
@@ -193,31 +212,9 @@ abstract class Abstract_Aioseo_Settings_Importing_Action extends Abstract_Aioseo
 			return [];
 		}
 
-		$flattened_settings = $this->flatten_settings( $settings_values );
+		$flattened_settings = $this->import_helper->flatten_settings( $settings_values );
 
 		return $this->get_unimported_chunk( $flattened_settings, $limit );
-	}
-
-	/**
-	 * Flattens the multidimensional array of AIOSEO settings. Recursive.
-	 *
-	 * @param array  $array      The array to be flattened.
-	 * @param string $key_prefix The key to be used as a base.
-	 *
-	 * @return array The flattened array.
-	 */
-	protected function flatten_settings( $array, $key_prefix = '' ) {
-		$result = [];
-		foreach ( $array as $key => $value ) {
-			if ( is_array( $value ) ) {
-				$result = array_merge( $result, $this->flatten_settings( $value, $key_prefix . '/' . $key ) );
-			}
-			else {
-				$result[ $key_prefix . '/' . $key ] = $value;
-			}
-		}
-
-		return $result;
 	}
 
 	/**

--- a/src/actions/importing/aioseo/aioseo-custom-archive-settings-importing-action.php
+++ b/src/actions/importing/aioseo/aioseo-custom-archive-settings-importing-action.php
@@ -4,7 +4,6 @@
 namespace Yoast\WP\SEO\Actions\Importing\Aioseo;
 
 use Yoast\WP\SEO\Helpers\Import_Cursor_Helper;
-use Yoast\WP\SEO\Helpers\Import_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Sanitization_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;

--- a/src/actions/importing/aioseo/aioseo-custom-archive-settings-importing-action.php
+++ b/src/actions/importing/aioseo/aioseo-custom-archive-settings-importing-action.php
@@ -4,6 +4,7 @@
 namespace Yoast\WP\SEO\Actions\Importing\Aioseo;
 
 use Yoast\WP\SEO\Helpers\Import_Cursor_Helper;
+use Yoast\WP\SEO\Helpers\Import_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Sanitization_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;

--- a/src/helpers/import-helper.php
+++ b/src/helpers/import-helper.php
@@ -13,7 +13,7 @@ class Import_Helper {
 	 * Flattens a multidimensional array of settings. Recursive.
 	 *
 	 * @param array  $array      The array to be flattened.
-	 * @param string $key_prefix The key to be used as a base.
+	 * @param string $key_prefix The key to be used as a prefix.
 	 *
 	 * @return array The flattened array.
 	 */

--- a/src/helpers/import-helper.php
+++ b/src/helpers/import-helper.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Yoast\WP\SEO\Helpers;
+
+use Yoast\WP\SEO\Helpers\Options_Helper;
+
+/**
+ * The Import Helper.
+ */
+class Import_Helper {
+
+	/**
+	 * Flattens a multidimensional array of settings. Recursive.
+	 *
+	 * @param array  $array      The array to be flattened.
+	 * @param string $key_prefix The key to be used as a base.
+	 *
+	 * @return array The flattened array.
+	 */
+	public function flatten_settings( $array, $key_prefix = '' ) {
+		$result = [];
+		foreach ( $array as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$result = array_merge( $result, $this->flatten_settings( $value, $key_prefix . '/' . $key ) );
+			}
+			else {
+				$result[ $key_prefix . '/' . $key ] = $value;
+			}
+		}
+
+		return $result;
+	}
+}

--- a/tests/unit/actions/importing/aioseo-custom-archive-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-custom-archive-settings-importing-action-test.php
@@ -6,6 +6,7 @@ use Mockery;
 use Brain\Monkey;
 use Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Custom_Archive_Settings_Importing_Action;
 use Yoast\WP\SEO\Helpers\Import_Cursor_Helper;
+use Yoast\WP\SEO\Helpers\Import_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Sanitization_Helper;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
@@ -67,6 +68,13 @@ class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCase {
 	 * @var Mockery\MockInterface|Post_Type_Helper
 	 */
 	protected $post_type;
+
+	/**
+	 * The import helper.
+	 *
+	 * @var Mockery\MockInterface|Import_Helper
+	 */
+	protected $import_helper;
 
 	/**
 	 * The replacevar handler.
@@ -142,11 +150,15 @@ class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCase {
 		$this->replacevar_handler = Mockery::mock( Aioseo_Replacevar_Service::class );
 		$this->robots_provider    = Mockery::mock( Aioseo_Robots_Provider_Service::class );
 		$this->robots_transformer = Mockery::mock( Aioseo_Robots_Transformer_Service::class );
+		$this->import_helper      = Mockery::mock( Import_Helper::class );
 		$this->instance           = new Aioseo_Custom_Archive_Settings_Importing_Action( $this->import_cursor, $this->options, $this->sanitization, $this->post_type, $this->replacevar_handler, $this->robots_provider, $this->robots_transformer );
-		$this->mock_instance      = Mockery::mock(
+		$this->instance->set_import_helper( $this->import_helper );
+
+		$this->mock_instance = Mockery::mock(
 			Aioseo_Custom_Archive_Settings_Importing_Action_Double::class,
 			[ $this->import_cursor, $this->options, $this->sanitization, $this->post_type, $this->replacevar_handler, $this->robots_provider, $this->robots_transformer ]
 		)->makePartial()->shouldAllowMockingProtectedMethods();
+		$this->mock_instance->set_import_helper( $this->import_helper );
 	}
 
 	/**
@@ -162,21 +174,28 @@ class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCase {
 	/**
 	 * Tests retrieving unimported AiOSEO settings.
 	 *
-	 * @param array $query_results The results from the query.
-	 * @param bool  $expected      The expected retrieved data.
+	 * @param array $query_results        The results from the query.
+	 * @param bool  $expected_unflattened The expected unflattened retrieved data.
+	 * @param bool  $expected             The expected retrieved data.
+	 * @param int   $times                The expected times we will look for the chunked unimported settings.
 	 *
 	 * @dataProvider provider_query
 	 * @covers ::query
 	 */
-	public function test_query( $query_results, $expected ) {
+	public function test_query( $query_results, $expected_unflattened, $expected, $times ) {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
 			->with( 'aioseo_options_dynamic', '' )
 			->andReturn( $query_results );
 
+		$this->import_helper->shouldReceive( 'flatten_settings' )
+			->with( $expected_unflattened )
+			->times( $times )
+			->andReturn( $expected );
+
 		$this->mock_instance->shouldReceive( 'get_unimported_chunk' )
 			->with( $expected, null )
-			->zeroOrMoreTimes()
+			->times( $times )
 			->andReturn( $expected );
 
 		$settings_to_import = $this->mock_instance->query();
@@ -326,9 +345,8 @@ class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCase {
 		$malformed_settings_expected = [];
 
 		return [
-			[ \json_encode( $full_settings ), $full_settings_expected ],
-			[ \json_encode( $missing_settings ), $missing_settings_expected ],
-			[ \json_encode( $missing_settings ), $missing_settings_expected ],
+			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
+			[ \json_encode( $missing_settings ), 'irrelevant', $missing_settings_expected, 0 ],
 		];
 	}
 }

--- a/tests/unit/actions/importing/aioseo-custom-archive-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-custom-archive-settings-importing-action-test.php
@@ -184,18 +184,6 @@ class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCase {
 	}
 
 	/**
-	 * Tests flattening AIOSEO custom archive settings.
-	 *
-	 * @covers ::flatten_settings
-	 */
-	public function test_flatten_settings() {
-		$flattened_sesttings = $this->mock_instance->flatten_settings( $this->full_settings_to_import );
-		$expected_result     = $this->flattened_settings_to_import;
-
-		$this->assertSame( $expected_result, $flattened_sesttings );
-	}
-
-	/**
 	 * Tests mapping AIOSEO custom archive settings.
 	 *
 	 * @param string $setting                The setting at hand, eg. post or movie-category, separator etc.

--- a/tests/unit/actions/importing/aioseo-default-archive-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-default-archive-settings-importing-action-test.php
@@ -6,6 +6,7 @@ use Mockery;
 use Brain\Monkey;
 use Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Default_Archive_Settings_Importing_Action;
 use Yoast\WP\SEO\Helpers\Import_Cursor_Helper;
+use Yoast\WP\SEO\Helpers\Import_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Sanitization_Helper;
 use Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Replacevar_Service;
@@ -59,6 +60,13 @@ class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCase {
 	 * @var Mockery\MockInterface|Sanitization_Helper
 	 */
 	protected $sanitization;
+
+	/**
+	 * The import helper.
+	 *
+	 * @var Mockery\MockInterface|Import_Helper
+	 */
+	protected $import_helper;
 
 	/**
 	 * The replacevar handler.
@@ -145,11 +153,15 @@ class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCase {
 		$this->replacevar_handler = Mockery::mock( Aioseo_Replacevar_Service::class );
 		$this->robots_provider    = Mockery::mock( Aioseo_Robots_Provider_Service::class );
 		$this->robots_transformer = Mockery::mock( Aioseo_Robots_Transformer_Service::class );
+		$this->import_helper      = Mockery::mock( Import_Helper::class );
 		$this->instance           = new Aioseo_Default_Archive_Settings_Importing_Action( $this->import_cursor, $this->options, $this->sanitization, $this->replacevar_handler, $this->robots_provider, $this->robots_transformer );
-		$this->mock_instance      = Mockery::mock(
+		$this->instance->set_import_helper( $this->import_helper );
+
+		$this->mock_instance = Mockery::mock(
 			Aioseo_Default_Archive_Settings_Importing_Action_Double::class,
 			[ $this->import_cursor, $this->options, $this->sanitization, $this->replacevar_handler, $this->robots_provider, $this->robots_transformer ]
 		)->makePartial()->shouldAllowMockingProtectedMethods();
+		$this->mock_instance->set_import_helper( $this->import_helper );
 	}
 
 	/**
@@ -165,21 +177,28 @@ class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCase {
 	/**
 	 * Tests retrieving unimported AiOSEO settings.
 	 *
-	 * @param array $query_results The results from the query.
-	 * @param bool  $expected      The expected retrieved data.
+	 * @param array $query_results        The results from the query.
+	 * @param bool  $expected_unflattened The expected unflattened retrieved data.
+	 * @param bool  $expected             The expected retrieved data.
+	 * @param int   $times                The expected times we will look for the chunked unimported settings.
 	 *
 	 * @dataProvider provider_query
 	 * @covers ::query
 	 */
-	public function test_query( $query_results, $expected ) {
+	public function test_query( $query_results, $expected_unflattened, $expected, $times ) {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
 			->with( 'aioseo_options', '' )
 			->andReturn( $query_results );
 
+		$this->import_helper->shouldReceive( 'flatten_settings' )
+			->with( $expected_unflattened )
+			->times( $times )
+			->andReturn( $expected );
+
 		$this->mock_instance->shouldReceive( 'get_unimported_chunk' )
 			->with( $expected, null )
-			->zeroOrMoreTimes()
+			->times( $times )
 			->andReturn( $expected );
 
 		$settings_to_import = $this->mock_instance->query();
@@ -313,9 +332,8 @@ class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCase {
 		$malformed_settings_expected = [];
 
 		return [
-			[ \json_encode( $full_settings ), $full_settings_expected ],
-			[ \json_encode( $missing_settings ), $missing_settings_expected ],
-			[ \json_encode( $missing_settings ), $missing_settings_expected ],
+			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
+			[ \json_encode( $missing_settings ), 'irrelevant', $missing_settings_expected, 0 ],
 		];
 	}
 }

--- a/tests/unit/actions/importing/aioseo-default-archive-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-default-archive-settings-importing-action-test.php
@@ -187,18 +187,6 @@ class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCase {
 	}
 
 	/**
-	 * Tests flattening AIOSEO default archive settings.
-	 *
-	 * @covers ::flatten_settings
-	 */
-	public function test_flatten_settings() {
-		$flattened_sesttings = $this->mock_instance->flatten_settings( $this->full_settings_to_import );
-		$expected_result     = $this->flattened_settings_to_import;
-
-		$this->assertSame( $expected_result, $flattened_sesttings );
-	}
-
-	/**
 	 * Tests mapping AIOSEO default archive settings.
 	 *
 	 * @param string $setting                The setting at hand, eg. post or movie-category, separator etc.

--- a/tests/unit/actions/importing/aioseo-general-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-general-settings-importing-action-test.php
@@ -6,6 +6,7 @@ use Mockery;
 use Brain\Monkey;
 use Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_General_Settings_Importing_Action;
 use Yoast\WP\SEO\Helpers\Import_Cursor_Helper;
+use Yoast\WP\SEO\Helpers\Import_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Sanitization_Helper;
 use Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Replacevar_Service;
@@ -59,6 +60,13 @@ class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	 * @var Mockery\MockInterface|Sanitization_Helper
 	 */
 	protected $sanitization;
+
+	/**
+	 * The import helper.
+	 *
+	 * @var Mockery\MockInterface|Import_Helper
+	 */
+	protected $import_helper;
 
 	/**
 	 * The replacevar handler.
@@ -125,11 +133,15 @@ class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 		$this->replacevar_handler = Mockery::mock( Aioseo_Replacevar_Service::class );
 		$this->robots_provider    = Mockery::mock( Aioseo_Robots_Provider_Service::class );
 		$this->robots_transformer = Mockery::mock( Aioseo_Robots_Transformer_Service::class );
+		$this->import_helper      = Mockery::mock( Import_Helper::class );
 		$this->instance           = new Aioseo_General_Settings_Importing_Action( $this->import_cursor, $this->options, $this->sanitization, $this->replacevar_handler, $this->robots_provider, $this->robots_transformer );
-		$this->mock_instance      = Mockery::mock(
+		$this->instance->set_import_helper( $this->import_helper );
+
+		$this->mock_instance = Mockery::mock(
 			Aioseo_General_Settings_Importing_Action_Double::class,
 			[ $this->import_cursor, $this->options, $this->sanitization, $this->replacevar_handler, $this->robots_provider, $this->robots_transformer ]
 		)->makePartial()->shouldAllowMockingProtectedMethods();
+		$this->mock_instance->set_import_helper( $this->import_helper );
 	}
 
 	/**
@@ -145,21 +157,28 @@ class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	/**
 	 * Tests retrieving unimported AiOSEO settings.
 	 *
-	 * @param array $query_results The results from the query.
-	 * @param bool  $expected      The expected retrieved data.
+	 * @param array $query_results        The results from the query.
+	 * @param bool  $expected_unflattened The expected unflattened retrieved data.
+	 * @param bool  $expected             The expected retrieved data.
+	 * @param int   $times                The expected times we will look for the chunked unimported settings.
 	 *
 	 * @dataProvider provider_query
 	 * @covers ::query
 	 */
-	public function test_query( $query_results, $expected ) {
+	public function test_query( $query_results, $expected_unflattened, $expected, $times ) {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
 			->with( 'aioseo_options', '' )
 			->andReturn( $query_results );
 
+		$this->import_helper->shouldReceive( 'flatten_settings' )
+			->with( $expected_unflattened )
+			->times( $times )
+			->andReturn( $expected );
+
 		$this->mock_instance->shouldReceive( 'get_unimported_chunk' )
 			->with( $expected, null )
-			->zeroOrMoreTimes()
+			->times( $times )
 			->andReturn( $expected );
 
 		$settings_to_import = $this->mock_instance->query();
@@ -347,9 +366,8 @@ class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 		$malformed_settings_expected = [];
 
 		return [
-			[ \json_encode( $full_settings ), $full_settings_expected ],
-			[ \json_encode( $missing_settings ), $missing_settings_expected ],
-			[ \json_encode( $missing_settings ), $missing_settings_expected ],
+			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
+			[ \json_encode( $missing_settings ), 'irrelevant', $missing_settings_expected, 0 ],
 		];
 	}
 }

--- a/tests/unit/actions/importing/aioseo-general-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-general-settings-importing-action-test.php
@@ -167,18 +167,6 @@ class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	}
 
 	/**
-	 * Tests flattening AIOSEO general settings.
-	 *
-	 * @covers ::flatten_settings
-	 */
-	public function test_flatten_settings() {
-		$flattened_sesttings = $this->mock_instance->flatten_settings( $this->full_settings_to_import );
-		$expected_result     = $this->flattened_settings_to_import;
-
-		$this->assertSame( $expected_result, $flattened_sesttings );
-	}
-
-	/**
 	 * Tests mapping AIOSEO general settings.
 	 *
 	 * @param string $setting         The setting at hand, eg. post or movie-category, separator etc.

--- a/tests/unit/actions/importing/aioseo-posttype-defaults-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posttype-defaults-settings-importing-action-test.php
@@ -6,6 +6,7 @@ use Mockery;
 use Brain\Monkey;
 use Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Posttype_Defaults_Settings_Importing_Action;
 use Yoast\WP\SEO\Helpers\Import_Cursor_Helper;
+use Yoast\WP\SEO\Helpers\Import_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Sanitization_Helper;
 use Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Replacevar_Service;
@@ -59,6 +60,13 @@ class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends TestCase {
 	 * @var Mockery\MockInterface|Sanitization_Helper
 	 */
 	protected $sanitization;
+
+	/**
+	 * The import helper.
+	 *
+	 * @var Mockery\MockInterface|Import_Helper
+	 */
+	protected $import_helper;
 
 	/**
 	 * The replacevar handler.
@@ -159,11 +167,15 @@ class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends TestCase {
 		$this->replacevar_handler = Mockery::mock( Aioseo_Replacevar_Service::class );
 		$this->robots_provider    = Mockery::mock( Aioseo_Robots_Provider_Service::class );
 		$this->robots_transformer = Mockery::mock( Aioseo_Robots_Transformer_Service::class );
+		$this->import_helper      = Mockery::mock( Import_Helper::class );
 		$this->instance           = new Aioseo_Posttype_Defaults_Settings_Importing_Action( $this->import_cursor, $this->options, $this->sanitization, $this->replacevar_handler, $this->robots_provider, $this->robots_transformer );
-		$this->mock_instance      = Mockery::mock(
+		$this->instance->set_import_helper( $this->import_helper );
+
+		$this->mock_instance = Mockery::mock(
 			Aioseo_Posttype_Defaults_Settings_Importing_Action_Double::class,
 			[ $this->import_cursor, $this->options, $this->sanitization, $this->replacevar_handler, $this->robots_provider, $this->robots_transformer ]
 		)->makePartial()->shouldAllowMockingProtectedMethods();
+		$this->mock_instance->set_import_helper( $this->import_helper );
 	}
 
 	/**
@@ -179,21 +191,28 @@ class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends TestCase {
 	/**
 	 * Tests retrieving unimported AiOSEO settings.
 	 *
-	 * @param array $query_results The results from the query.
-	 * @param bool  $expected      The expected retrieved data.
+	 * @param array $query_results        The results from the query.
+	 * @param bool  $expected_unflattened The expected unflattened retrieved data.
+	 * @param bool  $expected             The expected retrieved data.
+	 * @param int   $times                The expected times we will look for the chunked unimported settings.
 	 *
 	 * @dataProvider provider_query
 	 * @covers ::query
 	 */
-	public function test_query( $query_results, $expected ) {
+	public function test_query( $query_results, $expected_unflattened, $expected, $times ) {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
 			->with( 'aioseo_options_dynamic', '' )
 			->andReturn( $query_results );
 
+		$this->import_helper->shouldReceive( 'flatten_settings' )
+			->with( $expected_unflattened )
+			->times( $times )
+			->andReturn( $expected );
+
 		$this->mock_instance->shouldReceive( 'get_unimported_chunk' )
 			->with( $expected, null )
-			->zeroOrMoreTimes()
+			->times( $times )
 			->andReturn( $expected );
 
 		$settings_to_import = $this->mock_instance->query();
@@ -359,9 +378,8 @@ class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends TestCase {
 		$malformed_settings_expected = [];
 
 		return [
-			[ \json_encode( $full_settings ), $full_settings_expected ],
-			[ \json_encode( $missing_settings ), $missing_settings_expected ],
-			[ \json_encode( $missing_settings ), $missing_settings_expected ],
+			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
+			[ \json_encode( $missing_settings ), 'irrelevant', $missing_settings_expected, 0 ],
 		];
 	}
 }

--- a/tests/unit/actions/importing/aioseo-posttype-defaults-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posttype-defaults-settings-importing-action-test.php
@@ -201,18 +201,6 @@ class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends TestCase {
 	}
 
 	/**
-	 * Tests flattening AIOSEO Posttype Defaults settings.
-	 *
-	 * @covers ::flatten_settings
-	 */
-	public function test_flatten_settings() {
-		$flattened_sesttings = $this->mock_instance->flatten_settings( $this->full_settings_to_import );
-		$expected_result     = $this->flattened_settings_to_import;
-
-		$this->assertSame( $expected_result, $flattened_sesttings );
-	}
-
-	/**
 	 * Tests mapping AIOSEO Posttype Defaults settings.
 	 *
 	 * @param string $setting                The setting at hand, eg. post or movie-category, separator etc.

--- a/tests/unit/actions/importing/aioseo-taxonomy-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-taxonomy-settings-importing-action-test.php
@@ -187,18 +187,6 @@ class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 	}
 
 	/**
-	 * Tests flattening AIOSEO Taxonomy settings.
-	 *
-	 * @covers ::flatten_settings
-	 */
-	public function test_flatten_settings() {
-		$flattened_sesttings = $this->mock_instance->flatten_settings( $this->full_settings_to_import );
-		$expected_result     = $this->flattened_settings_to_import;
-
-		$this->assertSame( $expected_result, $flattened_sesttings );
-	}
-
-	/**
 	 * Tests mapping AIOSEO Taxonomy settings.
 	 *
 	 * @param string $setting                The setting at hand, eg. post or movie-category, separator etc.

--- a/tests/unit/actions/importing/aioseo-taxonomy-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-taxonomy-settings-importing-action-test.php
@@ -6,6 +6,7 @@ use Mockery;
 use Brain\Monkey;
 use Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_Taxonomy_Settings_Importing_Action;
 use Yoast\WP\SEO\Helpers\Import_Cursor_Helper;
+use Yoast\WP\SEO\Helpers\Import_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Sanitization_Helper;
 use Yoast\WP\SEO\Services\Importing\Aioseo\Aioseo_Replacevar_Service;
@@ -59,6 +60,13 @@ class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 	 * @var Mockery\MockInterface|Sanitization_Helper
 	 */
 	protected $sanitization;
+
+	/**
+	 * The import helper.
+	 *
+	 * @var Mockery\MockInterface|Import_Helper
+	 */
+	protected $import_helper;
 
 	/**
 	 * The replacevar handler.
@@ -145,11 +153,15 @@ class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 		$this->replacevar_handler = Mockery::mock( Aioseo_Replacevar_Service::class );
 		$this->robots_provider    = Mockery::mock( Aioseo_Robots_Provider_Service::class );
 		$this->robots_transformer = Mockery::mock( Aioseo_Robots_Transformer_Service::class );
+		$this->import_helper      = Mockery::mock( Import_Helper::class );
 		$this->instance           = new Aioseo_Taxonomy_Settings_Importing_Action( $this->import_cursor, $this->options, $this->sanitization, $this->replacevar_handler, $this->robots_provider, $this->robots_transformer );
-		$this->mock_instance      = Mockery::mock(
+		$this->instance->set_import_helper( $this->import_helper );
+
+		$this->mock_instance = Mockery::mock(
 			Aioseo_Taxonomy_Settings_Importing_Action_Double::class,
 			[ $this->import_cursor, $this->options, $this->sanitization, $this->replacevar_handler, $this->robots_provider, $this->robots_transformer ]
 		)->makePartial()->shouldAllowMockingProtectedMethods();
+		$this->mock_instance->set_import_helper( $this->import_helper );
 	}
 
 	/**
@@ -165,21 +177,28 @@ class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 	/**
 	 * Tests retrieving unimported AiOSEO settings.
 	 *
-	 * @param array $query_results The results from the query.
-	 * @param bool  $expected      The expected retrieved data.
+	 * @param array $query_results        The results from the query.
+	 * @param bool  $expected_unflattened The expected unflattened retrieved data.
+	 * @param bool  $expected             The expected retrieved data.
+	 * @param int   $times                The expected times we will look for the chunked unimported settings.
 	 *
 	 * @dataProvider provider_query
 	 * @covers ::query
 	 */
-	public function test_query( $query_results, $expected ) {
+	public function test_query( $query_results, $expected_unflattened, $expected, $times ) {
 		Monkey\Functions\expect( 'get_option' )
 			->once()
 			->with( 'aioseo_options_dynamic', '' )
 			->andReturn( $query_results );
 
+		$this->import_helper->shouldReceive( 'flatten_settings' )
+			->with( $expected_unflattened )
+			->times( $times )
+			->andReturn( $expected );
+
 		$this->mock_instance->shouldReceive( 'get_unimported_chunk' )
 			->with( $expected, null )
-			->zeroOrMoreTimes()
+			->times( $times )
 			->andReturn( $expected );
 
 		$settings_to_import = $this->mock_instance->query();
@@ -313,9 +332,8 @@ class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 		$malformed_settings_expected = [];
 
 		return [
-			[ \json_encode( $full_settings ), $full_settings_expected ],
-			[ \json_encode( $missing_settings ), $missing_settings_expected ],
-			[ \json_encode( $missing_settings ), $missing_settings_expected ],
+			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
+			[ \json_encode( $missing_settings ), 'irrelevant', $missing_settings_expected, 0 ],
 		];
 	}
 }

--- a/tests/unit/doubles/actions/importing/aioseo-custom-archive-settings-importing-action-double.php
+++ b/tests/unit/doubles/actions/importing/aioseo-custom-archive-settings-importing-action-double.php
@@ -32,18 +32,6 @@ abstract class Aioseo_Custom_Archive_Settings_Importing_Action_Double extends Ai
 	}
 
 	/**
-	 * Flattens the multidimensional array of AIOSEO settings. Recursive.
-	 *
-	 * @param array  $array    The array to be flattened.
-	 * @param string $main_key The key to be used as a base.
-	 *
-	 * @return array The flattened array.
-	 */
-	public function flatten_settings( $array, $main_key = '' ) {
-		return parent::flatten_settings( $array, $main_key );
-	}
-
-	/**
 	 * Maps/imports AIOSEO settings into the respective Yoast settings.
 	 *
 	 * @param string|array $setting_value The value of the AIOSEO setting at hand.

--- a/tests/unit/doubles/actions/importing/aioseo-default-archive-settings-importing-action-double.php
+++ b/tests/unit/doubles/actions/importing/aioseo-default-archive-settings-importing-action-double.php
@@ -32,18 +32,6 @@ abstract class Aioseo_Default_Archive_Settings_Importing_Action_Double extends A
 	}
 
 	/**
-	 * Flattens the multidimensional array of AIOSEO settings. Recursive.
-	 *
-	 * @param array  $array    The array to be flattened.
-	 * @param string $main_key The key to be used as a base.
-	 *
-	 * @return array The flattened array.
-	 */
-	public function flatten_settings( $array, $main_key = '' ) {
-		return parent::flatten_settings( $array, $main_key );
-	}
-
-	/**
 	 * Maps/imports AIOSEO settings into the respective Yoast settings.
 	 *
 	 * @param string|array $setting_value The value of the AIOSEO setting at hand.

--- a/tests/unit/doubles/actions/importing/aioseo-general-settings-importing-action-double.php
+++ b/tests/unit/doubles/actions/importing/aioseo-general-settings-importing-action-double.php
@@ -32,18 +32,6 @@ abstract class Aioseo_General_Settings_Importing_Action_Double extends Aioseo_Ge
 	}
 
 	/**
-	 * Flattens the multidimensional array of AIOSEO settings. Recursive.
-	 *
-	 * @param array  $array    The array to be flattened.
-	 * @param string $main_key The key to be used as a base.
-	 *
-	 * @return array The flattened array.
-	 */
-	public function flatten_settings( $array, $main_key = '' ) {
-		return parent::flatten_settings( $array, $main_key );
-	}
-
-	/**
 	 * Maps/imports AIOSEO settings into the respective Yoast settings.
 	 *
 	 * @param string|array $setting_value The value of the AIOSEO setting at hand.

--- a/tests/unit/doubles/actions/importing/aioseo-posttype-defaults-settings-importing-action-double.php
+++ b/tests/unit/doubles/actions/importing/aioseo-posttype-defaults-settings-importing-action-double.php
@@ -32,18 +32,6 @@ abstract class Aioseo_Posttype_Defaults_Settings_Importing_Action_Double extends
 	}
 
 	/**
-	 * Flattens the multidimensional array of AIOSEO settings. Recursive.
-	 *
-	 * @param array  $array    The array to be flattened.
-	 * @param string $main_key The key to be used as a base.
-	 *
-	 * @return array The flattened array.
-	 */
-	public function flatten_settings( $array, $main_key = '' ) {
-		return parent::flatten_settings( $array, $main_key );
-	}
-
-	/**
 	 * Maps/imports AIOSEO settings into the respective Yoast settings.
 	 *
 	 * @param string|array $setting_value The value of the AIOSEO setting at hand.

--- a/tests/unit/doubles/actions/importing/aioseo-taxonomy-settings-importing-action-double.php
+++ b/tests/unit/doubles/actions/importing/aioseo-taxonomy-settings-importing-action-double.php
@@ -32,18 +32,6 @@ abstract class Aioseo_Taxonomy_Settings_Importing_Action_Double extends Aioseo_T
 	}
 
 	/**
-	 * Flattens the multidimensional array of AIOSEO settings. Recursive.
-	 *
-	 * @param array  $array    The array to be flattened.
-	 * @param string $main_key The key to be used as a base.
-	 *
-	 * @return array The flattened array.
-	 */
-	public function flatten_settings( $array, $main_key = '' ) {
-		return parent::flatten_settings( $array, $main_key );
-	}
-
-	/**
 	 * Maps/imports AIOSEO settings into the respective Yoast settings.
 	 *
 	 * @param string|array $setting_value The value of the AIOSEO setting at hand.

--- a/tests/unit/helpers/import-helper-test.php
+++ b/tests/unit/helpers/import-helper-test.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Helpers;
+
+use Mockery;
+use Yoast\WP\SEO\Helpers\Import_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+/**
+ * Class Import_Helper_Test
+ *
+ * @group actions
+ * @group importing
+ *
+ * @package Yoast\WP\SEO\Tests\Unit\Actions\Importing
+ *
+ * @coversDefaultClass Yoast\WP\SEO\Helpers\Import_Helper
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+class Import_Helper_Test extends TestCase {
+
+	/**
+	 * Represents the instance to test.
+	 *
+	 * @var Import_Helper
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test class.
+	 */
+	public function set_up() {
+		$this->instance = new Import_Helper();
+	}
+
+	/**
+	 * Tests flattening settings.
+	 *
+	 * @param array $unflattened_settings        An array of settings to be flattened.
+	 * @param array $expected_flattened_settings The expected flattened settings.
+	 *
+	 * @dataProvider provider_flatten_settings
+	 * @covers ::flatten_settings
+	 */
+	public function test_flatten_settings( $unflattened_settings, $expected_flattened_settings ) {
+		$flattened_settings = $this->instance->flatten_settings( $unflattened_settings );
+
+		$this->assertSame( $expected_flattened_settings, $flattened_settings );
+	}
+
+	/**
+	 * Data provider for test_map().
+	 *
+	 * @return array
+	 */
+	public function provider_flatten_settings() {
+
+		$full_custom_archive_settings_to_import      = [
+			'book'  => [
+				'show'            => true,
+				'title'           => 'Book Title',
+				'metaDescription' => 'Book Desc',
+				'advanced'        => [
+					'showDateInGooglePreview' => true,
+				],
+			],
+			'movie' => [
+				'show'            => true,
+				'title'           => 'Movie Title',
+				'metaDescription' => 'Movie Desc',
+				'advanced'        => [
+					'showDateInGooglePreview' => true,
+				],
+			],
+		];
+		$flattened_custom_archive_settings_to_import = [
+			'/book/show'                              => true,
+			'/book/title'                             => 'Book Title',
+			'/book/metaDescription'                   => 'Book Desc',
+			'/book/advanced/showDateInGooglePreview'  => true,
+			'/movie/show'                             => true,
+			'/movie/title'                            => 'Movie Title',
+			'/movie/metaDescription'                  => 'Movie Desc',
+			'/movie/advanced/showDateInGooglePreview' => true,
+		];
+
+		$full_default_archive_settings_to_import      = [
+			'author' => [
+				'show'            => true,
+				'title'           => 'Author Title',
+				'metaDescription' => 'Author Desc',
+				'advanced'        => [
+					'showDateInGooglePreview' => true,
+				],
+			],
+			'date'   => [
+				'show'            => true,
+				'title'           => 'Date Title',
+				'metaDescription' => 'Date Desc',
+				'advanced'        => [
+					'showDateInGooglePreview' => true,
+				],
+			],
+			'search' => [
+				'show'            => true,
+				'title'           => 'Search Title',
+				'metaDescription' => 'Search Desc',
+				'advanced'        => [
+					'showDateInGooglePreview' => true,
+				],
+			],
+		];
+		$flattened_default_archive_settings_to_import = [
+			'/author/show'                             => true,
+			'/author/title'                            => 'Author Title',
+			'/author/metaDescription'                  => 'Author Desc',
+			'/author/advanced/showDateInGooglePreview' => true,
+			'/date/show'                               => true,
+			'/date/title'                              => 'Date Title',
+			'/date/metaDescription'                    => 'Date Desc',
+			'/date/advanced/showDateInGooglePreview'   => true,
+			'/search/show'                             => true,
+			'/search/title'                            => 'Search Title',
+			'/search/metaDescription'                  => 'Search Desc',
+			'/search/advanced/showDateInGooglePreview' => true,
+		];
+
+		$full_general_settings_to_import      = [
+			'separator'       => '&larr;',
+			'siteTitle'       => 'Site Title',
+			'metaDescription' => 'Site Desc',
+			'schema'          => [
+				'siteRepresents'   => 'person',
+				'person'           => 60,
+				'organizationName' => 'Org Name',
+				'organizationLogo' => 'http://basic.wordpress.test/wp-content/uploads/2021/11/WordPress8-20.jpg',
+			],
+		];
+		$flattened_general_settings_to_import = [
+			'/separator'               => '&larr;',
+			'/siteTitle'               => 'Site Title',
+			'/metaDescription'         => 'Site Desc',
+			'/schema/siteRepresents'   => 'person',
+			'/schema/person'           => 60,
+			'/schema/organizationName' => 'Org Name',
+			'/schema/organizationLogo' => 'http://basic.wordpress.test/wp-content/uploads/2021/11/WordPress8-20.jpg',
+		];
+
+		$full_posttype_defaults_settings_to_import      = [
+			'post'       => [
+				'show'            => true,
+				'title'           => 'Post Title',
+				'metaDescription' => 'Post Desc',
+				'advanced'        => [
+					'robotsMeta' => [
+						'default' => true,
+						'noindex' => false,
+					],
+				],
+			],
+			'attachment' => [
+				'show'                   => true,
+				'title'                  => 'Media Title',
+				'metaDescription'        => 'Media Desc',
+				'advanced'               => [
+					'robotsMeta' => [
+						'default' => true,
+						'noindex' => false,
+					],
+				],
+				'redirectAttachmentUrls' => 'attachment_parent',
+			],
+			'page'       => [
+				'show'            => true,
+				'title'           => 'Page Title',
+				'metaDescription' => 'Page Desc',
+				'advanced'        => [
+					'robotsMeta' => [
+						'default' => false,
+						'noindex' => true,
+					],
+				],
+			],
+		];
+		$flattened_posttype_defaults_settings_to_import = [
+			'/post/show'                              => true,
+			'/post/title'                             => 'Post Title',
+			'/post/metaDescription'                   => 'Post Desc',
+			'/post/advanced/robotsMeta/default'       => true,
+			'/post/advanced/robotsMeta/noindex'       => false,
+			'/attachment/show'                        => true,
+			'/attachment/title'                       => 'Media Title',
+			'/attachment/metaDescription'             => 'Media Desc',
+			'/attachment/advanced/robotsMeta/default' => true,
+			'/attachment/advanced/robotsMeta/noindex' => false,
+			'/attachment/redirectAttachmentUrls'      => 'attachment_parent',
+			'/page/show'                              => true,
+			'/page/title'                             => 'Page Title',
+			'/page/metaDescription'                   => 'Page Desc',
+			'/page/advanced/robotsMeta/default'       => false,
+			'/page/advanced/robotsMeta/noindex'       => true,
+		];
+
+		$full_taxonomy_settings_to_import      = [
+			'category'      => [
+				'show'            => true,
+				'title'           => 'Category Title',
+				'metaDescription' => 'Category Desc',
+				'advanced'        => [
+					'showDateInGooglePreview' => true,
+				],
+			],
+			'post_tag'      => [
+				'show'            => true,
+				'title'           => 'Tag Title',
+				'metaDescription' => 'Tag Desc',
+				'advanced'        => [
+					'showDateInGooglePreview' => true,
+				],
+			],
+			'book-category' => [
+				'show'            => true,
+				'title'           => 'Category Title',
+				'metaDescription' => 'Category Desc',
+				'advanced'        => [
+					'showDateInGooglePreview' => true,
+				],
+			],
+		];
+		$flattened_taxonomy_settings_to_import = [
+			'/category/show'                                  => true,
+			'/category/title'                                 => 'Category Title',
+			'/category/metaDescription'                       => 'Category Desc',
+			'/category/advanced/showDateInGooglePreview'      => true,
+			'/post_tag/show'                                  => true,
+			'/post_tag/title'                                 => 'Tag Title',
+			'/post_tag/metaDescription'                       => 'Tag Desc',
+			'/post_tag/advanced/showDateInGooglePreview'      => true,
+			'/book-category/show'                             => true,
+			'/book-category/title'                            => 'Category Title',
+			'/book-category/metaDescription'                  => 'Category Desc',
+			'/book-category/advanced/showDateInGooglePreview' => true,
+		];
+		return [
+			[ $full_custom_archive_settings_to_import, $flattened_custom_archive_settings_to_import ],
+			[ $full_default_archive_settings_to_import, $flattened_default_archive_settings_to_import ],
+			[ $full_general_settings_to_import, $flattened_general_settings_to_import ],
+			[ $full_posttype_defaults_settings_to_import, $flattened_posttype_defaults_settings_to_import ],
+			[ $full_taxonomy_settings_to_import, $flattened_taxonomy_settings_to_import ],
+		];
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to get closer to removing partial mocks in the new import framework

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Creates import helper to facilitate removing partial mocks from the new import framework in the future

## Relevant technical choices:

* Created the Import_Helper to contain the flatten_settings() method, so that importing actions can use it from there.
* Added the Import_Helper as a dependency for Importing AIOSEO Settings actions via `@required`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow the steps from the **For removing the import-cursor-manager-trait** section of the https://github.com/Yoast/wordpress-seo/pull/18047 PR


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The above instructions are basically regression testing, so nothing additional required here

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
