### PR TITLE
Refactor Stepper to use a Compound Component pattern

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -47,6 +47,7 @@
     "@yoast/style-guide": "^0.13.0",
     "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#master",
     "babel-polyfill": "^6.26.0",
+    "classnames": "^2.2.5",
     "draft-js": "^0.11.7",
     "find-with-regex": "~1.0.2",
     "interpolate-components": "^1.1.0",

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -22,7 +22,7 @@ import SocialInputPersonSection from "./SocialInputPersonSection";
 import Stepper, { Step } from "../tailwind-components/Stepper";
 import { ContinueButton, EditButton, ConfigurationStepButtons } from "../tailwind-components/ConfigurationStepperButtons";
 import { STEPS, WORKOUTS } from "../config";
-import { getInitialActiveStepIndex } from "../stepper-helper";
+import { getInitialActiveStepIndex, stepperTimingClasses } from "../stepper-helper";
 import { scrollToStep } from "../helpers";
 import AnimateHeight from "react-animate-height";
 
@@ -893,7 +893,13 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							name="SEO data optimization"
 							isFinished={ isStep1Finished }
 						>
-							{ showEditButton && <EditButton beforeGo={ beforeEditing } additionalClasses="yst-ml-auto"> { __( "Edit", "wordpress-seo" ) } </EditButton> }
+							<EditButton
+								beforeGo={ beforeEditing }
+								isVisible={ showEditButton }
+								additionalClasses={ "yst-ml-auto" }
+							>
+								{ __( "Edit", "wordpress-seo" ) }
+							</EditButton>
 						</Step.Header>
 						<Step.Content>
 							<IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } />
@@ -911,7 +917,13 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							name="Site representation"
 							isFinished={ isStep2Finished }
 						>
-							{ showEditButton && <EditButton beforeGo={ beforeEditing } additionalClasses="yst-ml-auto"> { __( "Edit", "wordpress-seo" ) } </EditButton> }
+							<EditButton
+								beforeGo={ beforeEditing }
+								isVisible={ showEditButton }
+								additionalClasses={ "yst-ml-auto" }
+							>
+								{ __( "Edit", "wordpress-seo" ) }
+							</EditButton>
 						</Step.Header>
 						<Step.Content>
 							<SiteRepresentationStep onOrganizationOrPersonChange={ onOrganizationOrPersonChange } dispatch={ dispatch } state={ state } siteRepresentsPerson={ siteRepresentsPerson } onSiteTaglineChange={ onSiteTaglineChange } siteRepresentationEmpty={ siteRepresentationEmpty } />
@@ -923,7 +935,13 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							name="Social profiles"
 							isFinished={ isStep3Finished }
 						>
-							{ showEditButton && <EditButton beforeGo={ beforeEditing } additionalClasses="yst-ml-auto"> { __( "Edit", "wordpress-seo" ) } </EditButton> }
+							<EditButton
+								beforeGo={ beforeEditing }
+								isVisible={ showEditButton }
+								additionalClasses={ "yst-ml-auto" }
+							>
+								{ __( "Edit", "wordpress-seo" ) }
+							</EditButton>
 						</Step.Header>
 						<Step.Content>
 							<SocialProfilesStep state={ state } dispatch={ dispatch } setErrorFields={ setErrorFields } siteRepresentsPerson={ siteRepresentsPerson } />
@@ -935,7 +953,13 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							name="Personal preferences"
 							isFinished={ isStep4Finished }
 						>
-							{ showEditButton && <EditButton beforeGo={ beforeEditing } additionalClasses="yst-ml-auto"> { __( "Edit", "wordpress-seo" ) } </EditButton> }
+							<EditButton
+								beforeGo={ beforeEditing }
+								isVisible={ showEditButton }
+								additionalClasses={ "yst-ml-auto" }
+							>
+								{ __( "Edit", "wordpress-seo" ) }
+							</EditButton>
 						</Step.Header>
 						<Step.Content>
 							<PersonalPreferencesStep state={ state } setTracking={ setTracking } isTrackingOptionSelected={ isTrackingOptionSelected } />
@@ -945,7 +969,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 					<Step>
 						<Step.Header
 							name="Finish configuration"
-							isFinished={ isWorkoutFinished }
+							isFinished={ isStepperFinished }
 						/>
 						<Step.Content>
 							<FinishStep />

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -12,14 +12,14 @@ import { NewButton as Button, RadioButtonGroup, SingleSelect, TextInput } from "
 import { ReactComponent as WorkoutDoneImage } from "../../../../../images/mirrored_fit_bubble_woman_1_optim.svg";
 import { ReactComponent as WorkoutStartImage } from "../../../images/motivated_bubble_woman_1_optim.svg";
 import { addLinkToString } from "../../helpers/stringHelpers.js";
-import { Step, Steps, FinishButtonSection } from "./Steps";
+import { Step as OldStep, Steps, FinishButtonSection } from "./Steps";
 import { OrganizationSection } from "./OrganizationSection";
 import { PersonSection } from "./PersonSection";
 import { NewsletterSignup } from "./NewsletterSignup";
 import { ConfigurationIndexation } from "../tailwind-components/ConfigurationIndexation";
 import SocialInputSection from "./SocialInputSection";
 import SocialInputPersonSection from "./SocialInputPersonSection";
-import Stepper from "../tailwind-components/Stepper";
+import Stepper, { Step } from "../tailwind-components/Stepper";
 import { STEPS, WORKOUTS } from "../config";
 import { getInitialActiveStepIndex } from "../stepper-helper";
 import { scrollToStep } from "../helpers";
@@ -857,47 +857,87 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 					activeStepIndex={ activeStepIndex }
 					isStepperFinished={ isStepperFinished }
 				>
-					<Stepper.Step
-						name="SEO data optimization"
+					<Step
 						isFinished={ isStep1Finished }
 					>
-						<IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } />
-						<Stepper.Continue
-							beforeContinue={ beforeContinueIndexationStep }
+						<Step.Header
+							name="SEO data optimization"
+							isFinished={ true }
 						>
-							{ __( "Continue", "wordpress-seo" ) }
-						</Stepper.Continue>
-					</Stepper.Step>
-					<Stepper.Step
-						name="Site representation"
+							<p>Karlijn is leaving sad</p>
+							{ isStepperFinished && <Step.Edit className="yst-button--secondary yst-button--small yst-ml-auto" /> }
+						</Step.Header>
+						<Step.Content>
+							<IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } />
+							<Step.Continue
+								beforeContinue={ beforeContinueIndexationStep }
+							>
+								{ __( "Continue", "wordpress-seo" ) }
+							</Step.Continue>
+						</Step.Content>
+					</Step>
+					<Step
 						isFinished={ isStep2Finished }
 					>
-						<SiteRepresentationStep onOrganizationOrPersonChange={ onOrganizationOrPersonChange } dispatch={ dispatch } state={ state } siteRepresentsPerson={ siteRepresentsPerson } onSiteTaglineChange={ onSiteTaglineChange } siteRepresentationEmpty={ siteRepresentationEmpty } />
-						<Stepper.Buttons beforeContinue={ updateOnFinishSiteRepresentation } continueLabel={ __( "Save and continue", "wordpress-seo" ) } backLabel="Cool custom back label" />
-					</Stepper.Step>
-					<Stepper.Step
-						name="Social profiles"
+						<Step.Header
+							name="Site representation"
+							isFinished={ true }
+						>
+							<p>Karlijn is leaving sad</p>
+							{ isStepperFinished && <Step.Edit className="yst-button--secondary yst-button--small yst-ml-auto" /> }
+						</Step.Header>
+						<Step.Content>
+							<SiteRepresentationStep onOrganizationOrPersonChange={ onOrganizationOrPersonChange } dispatch={ dispatch } state={ state } siteRepresentsPerson={ siteRepresentsPerson } onSiteTaglineChange={ onSiteTaglineChange } siteRepresentationEmpty={ siteRepresentationEmpty } />
+							<Step.Buttons beforeContinue={ updateOnFinishSiteRepresentation } continueLabel={ __( "Save and continue", "wordpress-seo" ) } backLabel="Cool custom back label" />
+						</Step.Content>
+					</Step>
+					<Step
 						isFinished={ isStep3Finished }
 					>
-						<SocialProfilesStep state={ state } dispatch={ dispatch } setErrorFields={ setErrorFields } siteRepresentsPerson={ siteRepresentsPerson } />
-						<Stepper.Buttons beforeContinue={ updateOnFinishSocialProfiles } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />
-					</Stepper.Step>
-					<Stepper.Step
-						name="Personal preferences"
+						<Step.Header
+							name="Social profiles"
+							isFinished={ true }
+						>
+							<p>Karlijn is leaving sad</p>
+							{ isStepperFinished && <Step.Edit className="yst-button--secondary yst-button--small yst-ml-auto" /> }
+						</Step.Header>
+						<Step.Content>
+							<SocialProfilesStep state={ state } dispatch={ dispatch } setErrorFields={ setErrorFields } siteRepresentsPerson={ siteRepresentsPerson } />
+							<Step.Buttons beforeContinue={ updateOnFinishSocialProfiles } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />
+						</Step.Content>
+					</Step>
+					<Step
 						isFinished={ isStep4Finished }
 					>
-						<PersonalPreferencesStep state={ state } setTracking={ setTracking } isTrackingOptionSelected={ isTrackingOptionSelected } />
-						<Stepper.Buttons beforeContinue={ updateOnFinishEnableTracking } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />
-					</Stepper.Step>
-					<Stepper.Step
-						name="Finish configuration"
+						<Step.Header
+							name="Personal preferences"
+							isFinished={ true }
+						>
+							<p>Karlijn is leaving sad</p>
+							{ isStepperFinished && <Step.Edit className="yst-button--secondary yst-button--small yst-ml-auto" /> }
+						</Step.Header>
+						<Step.Content>
+							<PersonalPreferencesStep state={ state } setTracking={ setTracking } isTrackingOptionSelected={ isTrackingOptionSelected } />
+							<Step.Buttons beforeContinue={ updateOnFinishEnableTracking } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />
+						</Step.Content>
+					</Step>
+					<Step
 						isFinished={ isWorkoutFinished }
 					>
-						<FinishStep />
-						<Stepper.Back className="yst-button yst-ml-3 yst-bg-cyan-600">
-							Cool back functionality
-						</Stepper.Back>
-					</Stepper.Step>
+						<Step.Header
+							name="Finish configuration"
+							isFinished={ true }
+						>
+							<p>Karlijn is leaving sad</p>
+							{ isStepperFinished && <Step.Edit className="yst-button--secondary yst-button--small yst-ml-auto" /> }
+						</Step.Header>
+						<Step.Content>
+							<FinishStep />
+							<Step.Back className="yst-button yst-ml-3 yst-bg-cyan-600">
+								Cool back functionality
+							</Step.Back>
+						</Step.Content>
+					</Step>
 				</Stepper>
 			</div>
 
@@ -915,7 +955,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 
 			<div className={ `workflow ${ hideOriginal ? "yst-hidden" : "" }` }>
 				<Steps id="yoast-configuration-workout-steps">
-					<Step
+					<OldStep
 						id="yoast-configuration-workout-step-optimize-seo-data"
 						title={ __( "Optimize SEO data", "wordpress-seo" ) }
 						subtitle={ addLinkToString(
@@ -974,7 +1014,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							isFinished={ isStep1Finished }
 							isReady={ isStepReady( 1 ) }
 						/>
-					</Step>
+					</OldStep>
 					<p className="extra-list-content">
 						{
 							createInterpolateElement(
@@ -993,7 +1033,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							)
 						}
 					</p>
-					<Step
+					<OldStep
 						id="yoast-configuration-workout-step-site-representation"
 						title={ __( "Site representation", "wordpress-seo" ) }
 						subtitle={ __( "Tell Google what kind of site you have and increase the chance it gets features in a Google Knowledge Panel. Select ‘Organization’ if you are working on a site for a business or an organization. Select ‘Person’ if you have, say, a personal blog.", "wordpress-seo" ) }
@@ -1075,8 +1115,8 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							isFinished={ isStep2Finished }
 							isReady={ isStepReady( 2 ) }
 						/>
-					</Step>
-					<Step
+					</OldStep>
+					<OldStep
 						id="yoast-configuration-workout-step-social-profiles"
 						title={ __( "Social profiles", "wordpress-seo" ) }
 						subtitle={ state.companyOrPerson === "company" ?  __( "Do you have profiles for your site on social media? Then, add all of their URLs here, so your social profiles may also appear in a Google Knowledge Panel.", "wordpress-seo" ) : "" }
@@ -1099,8 +1139,8 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							isFinished={ isStep3Finished }
 							isReady={ isStepReady( 3 ) }
 						/>
-					</Step>
-					<Step
+					</OldStep>
+					<OldStep
 						id="yoast-configuration-workout-step-tracking"
 						title={ __( "Help us improve Yoast SEO", "wordpress-seo" ) }
 						isFinished={ isStep4Finished }
@@ -1163,15 +1203,15 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							additionalButtonProps={ { disabled: ! isTrackingOptionSelected } }
 							isReady={ isStepReady( 4 ) }
 						/>
-					</Step>
-					<Step
+					</OldStep>
+					<OldStep
 						id="yoast-configuration-workout-step-newsletter"
 						title={ __( "Sign up for the Yoast newsletter!", "wordpress-seo" ) }
 						isFinished={ isStep5Finished }
 					>
 						<br />
 						<NewsletterSignup gdprLink={ window.wpseoWorkoutsData.configuration.shortlinks.gdpr } />
-					</Step>
+					</OldStep>
 					<FinishButtonSection
 						buttonId="yoast-configuration-workout-finish-workout-button"
 						finishText={ isWorkoutFinished ? __( "Do workout again", "wordpress-seo" ) : __( "Finish this workout", "wordpress-seo" ) }

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -19,7 +19,7 @@ import { NewsletterSignup } from "./NewsletterSignup";
 import { ConfigurationIndexation } from "../tailwind-components/ConfigurationIndexation";
 import SocialInputSection from "./SocialInputSection";
 import SocialInputPersonSection from "./SocialInputPersonSection";
-import Stepper, { TailwindStep } from "../tailwind-components/Stepper";
+import Stepper from "../tailwind-components/Stepper";
 import { STEPS, WORKOUTS } from "../config";
 import { getInitialActiveStepIndex } from "../stepper-helper";
 import { scrollToStep } from "../helpers";
@@ -887,63 +887,71 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 				<Stepper
 					setActiveStepIndex={ setActiveStepIndex }
 					activeStepIndex={ activeStepIndex }
+					isStepperFinished={ isStepperFinished }
 				>
-					<TailwindStep
+					<Stepper.Step
 						name="indexation"
 						isSaved={ true }
 						beforeContinue={ beforeContinueIndexationStep }
 					>
 						<IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } />
-					</TailwindStep>
-					<TailwindStep
+						<Stepper.Buttons continueFunction={ () => { console.log( "Did an extra save thing" ); } } />
+					</Stepper.Step>
+					<Stepper.Step
 						name="Site representation"
 						isSaved={ true }
 						beforeContinue={ () => { console.log( "saved" ); return true; } }
 					>
 						<SiteRepresentationStep onOrganizationOrPersonChange={ onOrganizationOrPersonChange } dispatch={ dispatch } state={ state } siteRepresentsPerson={ siteRepresentsPerson } onSiteTaglineChange={ onSiteTaglineChange } siteRepresentationEmpty={ siteRepresentationEmpty } />
-					</TailwindStep>
-					<TailwindStep
+						<Stepper.Buttons continueFunction={ () => { console.log( "Did an extra save thing" ); } } backFunction={ () => console.log( "Back it up" ) } backLabel="back it up!" />
+					</Stepper.Step>
+					<Stepper.Step
 						name="test"
 						isSaved={ true }
 						beforeContinue={ () => { console.log( "saved" ); return true; } }
 					>
 						<SocialProfilesStep state={ state } dispatch={ dispatch } setErrorFields={ setErrorFields } siteRepresentsPerson={ siteRepresentsPerson } />
-					</TailwindStep>
-					<TailwindStep
+						<Stepper.Buttons continueFunction={ () => { console.log( "Did an extra save thing" ); } } backFunction={ () => console.log( "Back it up" ) } backLabel="back it up!" />
+					</Stepper.Step>
+					<Stepper.Step
 						name="test"
 						isSaved={ true }
 						beforeContinue={ () => { console.log( "saved" ); return true; } }
 					>
 						<PersonalPreferencesStep state={ state } setTracking={ setTracking } isTrackingOptionSelected={ isTrackingOptionSelected } />
-					</TailwindStep>
-					<TailwindStep
+						<Stepper.Buttons continueFunction={ () => { console.log( "Did an extra save thing" ); } } backFunction={ () => console.log( "Back it up" ) } backLabel="back it up!" />
+					</Stepper.Step>
+					<Stepper.Step
 						name="test"
 						isSaved={ true }
 						beforeContinue={ () => { console.log( "saved" ); return true; } }
 					>
 						<NewsletterSignup />
-					</TailwindStep>
-					<TailwindStep
+						<Stepper.Buttons continueFunction={ () => { console.log( "Did an extra save thing" ); } } backFunction={ () => console.log( "Back it up" ) } backLabel="back it up!" />
+					</Stepper.Step>
+					<Stepper.Step
 						name="test"
 						isSaved={ true }
 						beforeContinue={ () => { console.log( "saved" ); return true; } }
 					>
 						<div><p>hoi Karlijn and Paolo</p></div>
-					</TailwindStep>
-					<TailwindStep
+						<Stepper.Buttons continueLabel="NO GOING BACK NOW" continueFunction={ () => { console.log( "NO GOING BACK HERE" ); } } />
+					</Stepper.Step>
+					<Stepper.Step
 						name="test"
 						isSaved={ true }
 						beforeContinue={ () => { console.log( "saved" ); return true; } }
 					>
 						<div className="yst-bg-yellow-400"><p className="yst-bg-blue-500">RED</p></div>
-					</TailwindStep>
-					<TailwindStep
+						<Stepper.Buttons continueFunction={ () => { console.log( "Did an extra save thing" ); } } backFunction={ () => console.log( "Back it up" ) } backLabel="back it up!" />
+					</Stepper.Step>
+					<Stepper.Step
 						name="test"
 						isSaved={ true }
 						beforeContinue={ () => { console.log( "saved" ); return true; } }
 					>
 						<FinishStep />
-					</TailwindStep>
+					</Stepper.Step>
 				</Stepper>
 			</div>
 

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -19,7 +19,7 @@ import { NewsletterSignup } from "./NewsletterSignup";
 import { ConfigurationIndexation } from "../tailwind-components/ConfigurationIndexation";
 import SocialInputSection from "./SocialInputSection";
 import SocialInputPersonSection from "./SocialInputPersonSection";
-import Stepper from "../tailwind-components/Stepper";
+import Stepper, { TailwindStep } from "../tailwind-components/Stepper";
 import { STEPS, WORKOUTS } from "../config";
 import { getInitialActiveStepIndex } from "../stepper-helper";
 import { scrollToStep } from "../helpers";
@@ -844,7 +844,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 			</p>
 			{ /* eslint-disable react/jsx-no-bind */ }
 			<div className="yst-mt-8">
-				<Stepper
+				{ /* <Stepper
 					steps={ [
 						{ name: "SEO data optimization",
 							component: <IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } showRunIndexationAlert={ showRunIndexationAlert } />,
@@ -881,10 +881,70 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							beforeContinue: finishStep,
 						},
 					] }
-					setActiveStepIndex={ setActiveStepIndex }
 					activeStepIndex={ activeStepIndex }
 					isStepperFinished={ isStepperFinished }
-				/>
+				/> */ }
+				<Stepper
+					setActiveStepIndex={ setActiveStepIndex }
+					activeStepIndex={ activeStepIndex }
+				>
+					<TailwindStep
+						name="indexation"
+						isSaved={ true }
+						beforeContinue={ beforeContinueIndexationStep }
+					>
+						<IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } />
+					</TailwindStep>
+					<TailwindStep
+						name="Site representation"
+						isSaved={ true }
+						beforeContinue={ () => { console.log( "saved" ); return true; } }
+					>
+						<SiteRepresentationStep onOrganizationOrPersonChange={ onOrganizationOrPersonChange } dispatch={ dispatch } state={ state } siteRepresentsPerson={ siteRepresentsPerson } onSiteTaglineChange={ onSiteTaglineChange } siteRepresentationEmpty={ siteRepresentationEmpty } />
+					</TailwindStep>
+					<TailwindStep
+						name="test"
+						isSaved={ true }
+						beforeContinue={ () => { console.log( "saved" ); return true; } }
+					>
+						<SocialProfilesStep state={ state } dispatch={ dispatch } setErrorFields={ setErrorFields } siteRepresentsPerson={ siteRepresentsPerson } />
+					</TailwindStep>
+					<TailwindStep
+						name="test"
+						isSaved={ true }
+						beforeContinue={ () => { console.log( "saved" ); return true; } }
+					>
+						<PersonalPreferencesStep state={ state } setTracking={ setTracking } isTrackingOptionSelected={ isTrackingOptionSelected } />
+					</TailwindStep>
+					<TailwindStep
+						name="test"
+						isSaved={ true }
+						beforeContinue={ () => { console.log( "saved" ); return true; } }
+					>
+						<NewsletterSignup />
+					</TailwindStep>
+					<TailwindStep
+						name="test"
+						isSaved={ true }
+						beforeContinue={ () => { console.log( "saved" ); return true; } }
+					>
+						<div><p>hoi Karlijn and Paolo</p></div>
+					</TailwindStep>
+					<TailwindStep
+						name="test"
+						isSaved={ true }
+						beforeContinue={ () => { console.log( "saved" ); return true; } }
+					>
+						<div className="yst-bg-yellow-400"><p className="yst-bg-blue-500">RED</p></div>
+					</TailwindStep>
+					<TailwindStep
+						name="test"
+						isSaved={ true }
+						beforeContinue={ () => { console.log( "saved" ); return true; } }
+					>
+						<FinishStep />
+					</TailwindStep>
+				</Stepper>
 			</div>
 
 			<UnsavedChangesModal hasUnsavedChanges={ state.editedSteps.includes( activeStepIndex + 1 ) } />

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -20,6 +20,7 @@ import { ConfigurationIndexation } from "../tailwind-components/ConfigurationInd
 import SocialInputSection from "./SocialInputSection";
 import SocialInputPersonSection from "./SocialInputPersonSection";
 import Stepper, { Step } from "../tailwind-components/Stepper";
+import { ContinueButton, StepButtons } from "../tailwind-components/ConfigurationStepperButtons";
 import { STEPS, WORKOUTS } from "../config";
 import { getInitialActiveStepIndex } from "../stepper-helper";
 import { scrollToStep } from "../helpers";
@@ -864,16 +865,16 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							name="SEO data optimization"
 							isFinished={ true }
 						>
-							<p>Karlijn is leaving sad</p>
-							{ isStepperFinished && <Step.Edit className="yst-button--secondary yst-button--small yst-ml-auto" /> }
+							{ isStepperFinished && <Step.EditButton className="yst-button--secondary yst-button--small yst-ml-auto" /> }
 						</Step.Header>
 						<Step.Content>
 							<IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } />
-							<Step.Continue
-								beforeContinue={ beforeContinueIndexationStep }
+							<ContinueButton
+								additionalClasses="yst-mt-12"
+								beforeGo={ beforeContinueIndexationStep }
 							>
 								{ __( "Continue", "wordpress-seo" ) }
-							</Step.Continue>
+							</ContinueButton>
 						</Step.Content>
 					</Step>
 					<Step
@@ -883,12 +884,11 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							name="Site representation"
 							isFinished={ true }
 						>
-							<p>Karlijn is leaving sad</p>
-							{ isStepperFinished && <Step.Edit className="yst-button--secondary yst-button--small yst-ml-auto" /> }
+							{ isStepperFinished && <Step.EditButton className="yst-button--secondary yst-button--small yst-ml-auto" /> }
 						</Step.Header>
 						<Step.Content>
 							<SiteRepresentationStep onOrganizationOrPersonChange={ onOrganizationOrPersonChange } dispatch={ dispatch } state={ state } siteRepresentsPerson={ siteRepresentsPerson } onSiteTaglineChange={ onSiteTaglineChange } siteRepresentationEmpty={ siteRepresentationEmpty } />
-							<Step.Buttons beforeContinue={ updateOnFinishSiteRepresentation } continueLabel={ __( "Save and continue", "wordpress-seo" ) } backLabel="Cool custom back label" />
+							<StepButtons beforeContinue={ updateOnFinishSiteRepresentation } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />
 						</Step.Content>
 					</Step>
 					<Step
@@ -898,12 +898,11 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							name="Social profiles"
 							isFinished={ true }
 						>
-							<p>Karlijn is leaving sad</p>
-							{ isStepperFinished && <Step.Edit className="yst-button--secondary yst-button--small yst-ml-auto" /> }
+							{ isStepperFinished && <Step.EditButton className="yst-button--secondary yst-button--small yst-ml-auto" /> }
 						</Step.Header>
 						<Step.Content>
 							<SocialProfilesStep state={ state } dispatch={ dispatch } setErrorFields={ setErrorFields } siteRepresentsPerson={ siteRepresentsPerson } />
-							<Step.Buttons beforeContinue={ updateOnFinishSocialProfiles } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />
+							<StepButtons beforeContinue={ updateOnFinishSocialProfiles } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />
 						</Step.Content>
 					</Step>
 					<Step
@@ -913,12 +912,11 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							name="Personal preferences"
 							isFinished={ true }
 						>
-							<p>Karlijn is leaving sad</p>
-							{ isStepperFinished && <Step.Edit className="yst-button--secondary yst-button--small yst-ml-auto" /> }
+							{ isStepperFinished && <Step.EditButton className="yst-button--secondary yst-button--small yst-ml-auto" /> }
 						</Step.Header>
 						<Step.Content>
 							<PersonalPreferencesStep state={ state } setTracking={ setTracking } isTrackingOptionSelected={ isTrackingOptionSelected } />
-							<Step.Buttons beforeContinue={ updateOnFinishEnableTracking } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />
+							<StepButtons beforeContinue={ updateOnFinishEnableTracking } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />
 						</Step.Content>
 					</Step>
 					<Step
@@ -928,14 +926,13 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							name="Finish configuration"
 							isFinished={ true }
 						>
-							<p>Karlijn is leaving sad</p>
-							{ isStepperFinished && <Step.Edit className="yst-button--secondary yst-button--small yst-ml-auto" /> }
+							{ isStepperFinished && <Step.EditButton className="yst-button--secondary yst-button--small yst-ml-auto" /> }
 						</Step.Header>
 						<Step.Content>
 							<FinishStep />
-							<Step.Back className="yst-button yst-ml-3 yst-bg-cyan-600">
+							<Step.GoButton className="yst-button yst-ml-3 yst-bg-cyan-600" destination="first">
 								Cool back functionality
-							</Step.Back>
+							</Step.GoButton>
 						</Step.Content>
 					</Step>
 				</Stepper>

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -20,7 +20,7 @@ import { ConfigurationIndexation } from "../tailwind-components/ConfigurationInd
 import SocialInputSection from "./SocialInputSection";
 import SocialInputPersonSection from "./SocialInputPersonSection";
 import Stepper, { Step } from "../tailwind-components/Stepper";
-import { ContinueButton, StepButtons } from "../tailwind-components/ConfigurationStepperButtons";
+import { ContinueButton, EditButton, ConfigurationStepButtons } from "../tailwind-components/ConfigurationStepperButtons";
 import { STEPS, WORKOUTS } from "../config";
 import { getInitialActiveStepIndex } from "../stepper-helper";
 import { scrollToStep } from "../helpers";
@@ -774,6 +774,10 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 		return true;
 	}
 
+	const [ stepperFinishedOnce, setStepperFinishedOnce ] = useState( isStepperFinished );
+	const [ isStepBeingEdited, setIsStepBeingEdited ] = useState( false );
+	const [ showEditButton, setShowEditButton ] = useState( stepperFinishedOnce && ! isStepBeingEdited );
+
 	/**
 	 * Save and continue functionality for the Indexation step.
 	 *
@@ -787,9 +791,35 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 			return false;
 		}
 
+		setIsStepBeingEdited( false );
 		finishStep( stepIdx );
 		return true;
 	}
+
+	/**
+	 * Save and continue functionality for the Indexation step.
+	 *
+	 * @param {int} stepIdx The step index of the indexation step.
+	 *
+	 * @returns {boolean} Whether the stepper can continue to the next step.
+	 */
+	function beforeEditing() {
+		setShowEditButton( false );
+		setIsStepBeingEdited( true );
+		return true;
+	}
+
+	// The first time isStepperFinished is true, set stepperFinishedOnce to true.
+	useEffect( () => {
+		if ( isStepperFinished ) {
+			setStepperFinishedOnce( true );
+		}
+	}, [ isStepperFinished ] );
+
+	// If stepperFinishedOnce changes or isStepBeingEdited changes, evaluate edit button state.
+	useEffect( () => {
+		setShowEditButton( stepperFinishedOnce && ! isStepBeingEdited );
+	}, [ stepperFinishedOnce, isStepBeingEdited ] );
 
 	// AND HERE....
 	/* eslint-disable max-len */
@@ -858,81 +888,67 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 					activeStepIndex={ activeStepIndex }
 					isStepperFinished={ isStepperFinished }
 				>
-					<Step
-						isFinished={ isStep1Finished }
-					>
+					<Step>
 						<Step.Header
 							name="SEO data optimization"
-							isFinished={ true }
+							isFinished={ isStep1Finished }
 						>
-							{ isStepperFinished && <Step.EditButton className="yst-button--secondary yst-button--small yst-ml-auto" /> }
+							{ showEditButton && <EditButton beforeGo={ beforeEditing } additionalClasses="yst-ml-auto"> { __( "Edit", "wordpress-seo" ) } </EditButton> }
 						</Step.Header>
 						<Step.Content>
 							<IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } />
 							<ContinueButton
 								additionalClasses="yst-mt-12"
 								beforeGo={ beforeContinueIndexationStep }
+								destination={ stepperFinishedOnce ? "last" : 1 }
 							>
 								{ __( "Continue", "wordpress-seo" ) }
 							</ContinueButton>
 						</Step.Content>
 					</Step>
-					<Step
-						isFinished={ isStep2Finished }
-					>
+					<Step>
 						<Step.Header
 							name="Site representation"
-							isFinished={ true }
+							isFinished={ isStep2Finished }
 						>
-							{ isStepperFinished && <Step.EditButton className="yst-button--secondary yst-button--small yst-ml-auto" /> }
+							{ showEditButton && <EditButton beforeGo={ beforeEditing } additionalClasses="yst-ml-auto"> { __( "Edit", "wordpress-seo" ) } </EditButton> }
 						</Step.Header>
 						<Step.Content>
 							<SiteRepresentationStep onOrganizationOrPersonChange={ onOrganizationOrPersonChange } dispatch={ dispatch } state={ state } siteRepresentsPerson={ siteRepresentsPerson } onSiteTaglineChange={ onSiteTaglineChange } siteRepresentationEmpty={ siteRepresentationEmpty } />
-							<StepButtons beforeContinue={ updateOnFinishSiteRepresentation } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />
+							<ConfigurationStepButtons stepperFinishedOnce={ stepperFinishedOnce } saveFunction={ updateOnFinishSiteRepresentation } setEditState={ setIsStepBeingEdited } />
 						</Step.Content>
 					</Step>
-					<Step
-						isFinished={ isStep3Finished }
-					>
+					<Step>
 						<Step.Header
 							name="Social profiles"
-							isFinished={ true }
+							isFinished={ isStep3Finished }
 						>
-							{ isStepperFinished && <Step.EditButton className="yst-button--secondary yst-button--small yst-ml-auto" /> }
+							{ showEditButton && <EditButton beforeGo={ beforeEditing } additionalClasses="yst-ml-auto"> { __( "Edit", "wordpress-seo" ) } </EditButton> }
 						</Step.Header>
 						<Step.Content>
 							<SocialProfilesStep state={ state } dispatch={ dispatch } setErrorFields={ setErrorFields } siteRepresentsPerson={ siteRepresentsPerson } />
-							<StepButtons beforeContinue={ updateOnFinishSocialProfiles } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />
+							<ConfigurationStepButtons stepperFinishedOnce={ stepperFinishedOnce } saveFunction={ updateOnFinishSocialProfiles } setEditState={ setIsStepBeingEdited } />
 						</Step.Content>
 					</Step>
-					<Step
-						isFinished={ isStep4Finished }
-					>
+					<Step>
 						<Step.Header
 							name="Personal preferences"
-							isFinished={ true }
+							isFinished={ isStep4Finished }
 						>
-							{ isStepperFinished && <Step.EditButton className="yst-button--secondary yst-button--small yst-ml-auto" /> }
+							{ showEditButton && <EditButton beforeGo={ beforeEditing } additionalClasses="yst-ml-auto"> { __( "Edit", "wordpress-seo" ) } </EditButton> }
 						</Step.Header>
 						<Step.Content>
 							<PersonalPreferencesStep state={ state } setTracking={ setTracking } isTrackingOptionSelected={ isTrackingOptionSelected } />
-							<StepButtons beforeContinue={ updateOnFinishEnableTracking } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />
+							<ConfigurationStepButtons stepperFinishedOnce={ stepperFinishedOnce } saveFunction={ updateOnFinishEnableTracking } setEditState={ setIsStepBeingEdited } />
 						</Step.Content>
 					</Step>
-					<Step
-						isFinished={ isWorkoutFinished }
-					>
+					<Step>
 						<Step.Header
 							name="Finish configuration"
-							isFinished={ true }
-						>
-							{ isStepperFinished && <Step.EditButton className="yst-button--secondary yst-button--small yst-ml-auto" /> }
-						</Step.Header>
+							isFinished={ isWorkoutFinished }
+						/>
 						<Step.Content>
 							<FinishStep />
-							<Step.GoButton className="yst-button yst-ml-3 yst-bg-cyan-600" destination="first">
-								Cool back functionality
-							</Step.GoButton>
 						</Step.Content>
 					</Step>
 				</Stepper>

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -623,17 +623,19 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 			state.companyOrPerson === "company" &&
 			( ! state.companyName || ! state.companyLogo ) ) {
 			setSiteRepresentationEmpty( true );
+			return false;
 		} else if ( ! siteRepresentationEmpty &&
 			state.companyOrPerson === "person" &&
 			( ! state.personId || ! state.personLogo ) ) {
 			setSiteRepresentationEmpty( true );
-		} else {
-			setSiteRepresentationEmpty( false );
-			updateSiteRepresentation( state )
-				.then( () => setStepIsSaved( 2 ) )
-				.then( () => finishSteps( "configuration", [ steps.siteRepresentation ] ) );
-			scrollToStep( 3 );
+			return false;
 		}
+		setSiteRepresentationEmpty( false );
+		updateSiteRepresentation( state )
+			.then( () => setStepIsSaved( 2 ) )
+			.then( () => finishSteps( "configuration", [ steps.siteRepresentation ] ) );
+		scrollToStep( 3 );
+		return true;
 	}
 
 	/**
@@ -642,12 +644,15 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 	 * @returns {void}
 	 */
 	function updateOnFinishSocialProfiles() {
-		updateSocialProfiles( state )
+		return updateSocialProfiles( state )
 			.then( () => setStepIsSaved( 3 ) )
 			.then( () => {
 				setErrorFields( [] );
 				finishSteps( "configuration", [ steps.socialProfiles ] );
 				scrollToStep( 4 );
+			} )
+			.then( () => {
+				return true;
 			} )
 			.catch(
 				( e ) => {
@@ -665,10 +670,13 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 	 * @returns {void}
 	 */
 	function updateOnFinishEnableTracking() {
-		updateTracking( state )
+		return updateTracking( state )
 			.then( () => setStepIsSaved( 4 ) )
-			.then( () => finishSteps( "configuration", [ steps.enableTracking ] ) );
-		scrollToStep( 5 );
+			.then( () => finishSteps( "configuration", [ steps.enableTracking ] ) )
+			.then( () => {
+				scrollToStep( 5 );
+				return true;
+			} );
 	}
 
 	const toggleConfigurationWorkout = useCallback(
@@ -844,113 +852,51 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 			</p>
 			{ /* eslint-disable react/jsx-no-bind */ }
 			<div className="yst-mt-8">
-				{ /* <Stepper
-					steps={ [
-						{ name: "SEO data optimization",
-							component: <IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } showRunIndexationAlert={ showRunIndexationAlert } />,
-							isSaved: isStepFinished( "configuration", steps.optimizeSeoData ),
-							beforeContinue: beforeContinueIndexationStep,
-						},
-						{ name: "Knowledge panel",
-							component: <SiteRepresentationStep onOrganizationOrPersonChange={ onOrganizationOrPersonChange } dispatch={ dispatch } state={ state } siteRepresentsPerson={ siteRepresentsPerson } onSiteTaglineChange={ onSiteTaglineChange } siteRepresentationEmpty={ siteRepresentationEmpty } />,
-							isSaved: isStepFinished( "configuration", steps.siteRepresentation ),
-							beforeContinue: () => {
-								finishStep( 1 );
-								return true;
-							},
-						},
-						{ name: "Social profiles",
-							component: <SocialProfilesStep state={ state } dispatch={ dispatch } setErrorFields={ setErrorFields } siteRepresentsPerson={ siteRepresentsPerson } />,
-							isSaved: isStepFinished( "configuration", steps.socialProfiles ),
-							beforeContinue: () => {
-								finishStep( 2 );
-								return true;
-							},
-						},
-						{ name: "Personal preferences",
-							component: <PersonalPreferencesStep state={ state } setTracking={ setTracking } isTrackingOptionSelected={ isTrackingOptionSelected } />,
-							isSaved: isStepFinished( "configuration", steps.newsletterSignup ),
-							beforeContinue: () => {
-								finishStep( 3 );
-								return true;
-							},
-						},
-						{ name: "Finish configuration",
-							component: <FinishStep />,
-							isSaved: isStepperFinished,
-							beforeContinue: finishStep,
-						},
-					] }
-					activeStepIndex={ activeStepIndex }
-					isStepperFinished={ isStepperFinished }
-				/> */ }
 				<Stepper
 					setActiveStepIndex={ setActiveStepIndex }
 					activeStepIndex={ activeStepIndex }
 					isStepperFinished={ isStepperFinished }
 				>
 					<Stepper.Step
-						name="indexation"
-						isSaved={ true }
-						beforeContinue={ beforeContinueIndexationStep }
+						name="SEO data optimization"
+						isFinished={ isStep1Finished }
 					>
 						<IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } />
-						<Stepper.Buttons continueFunction={ () => { console.log( "Did an extra save thing" ); } } />
+						<Stepper.Continue
+							beforeContinue={ beforeContinueIndexationStep }
+						>
+							{ __( "Continue", "wordpress-seo" ) }
+						</Stepper.Continue>
 					</Stepper.Step>
 					<Stepper.Step
 						name="Site representation"
-						isSaved={ true }
-						beforeContinue={ () => { console.log( "saved" ); return true; } }
+						isFinished={ isStep2Finished }
 					>
 						<SiteRepresentationStep onOrganizationOrPersonChange={ onOrganizationOrPersonChange } dispatch={ dispatch } state={ state } siteRepresentsPerson={ siteRepresentsPerson } onSiteTaglineChange={ onSiteTaglineChange } siteRepresentationEmpty={ siteRepresentationEmpty } />
-						<Stepper.Buttons continueFunction={ () => { console.log( "Did an extra save thing" ); } } backFunction={ () => console.log( "Back it up" ) } backLabel="back it up!" />
+						<Stepper.Buttons beforeContinue={ updateOnFinishSiteRepresentation } continueLabel={ __( "Save and continue", "wordpress-seo" ) } backLabel="Cool custom back label" />
 					</Stepper.Step>
 					<Stepper.Step
-						name="test"
-						isSaved={ true }
-						beforeContinue={ () => { console.log( "saved" ); return true; } }
+						name="Social profiles"
+						isFinished={ isStep3Finished }
 					>
 						<SocialProfilesStep state={ state } dispatch={ dispatch } setErrorFields={ setErrorFields } siteRepresentsPerson={ siteRepresentsPerson } />
-						<Stepper.Buttons continueFunction={ () => { console.log( "Did an extra save thing" ); } } backFunction={ () => console.log( "Back it up" ) } backLabel="back it up!" />
+						<Stepper.Buttons beforeContinue={ updateOnFinishSocialProfiles } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />
 					</Stepper.Step>
 					<Stepper.Step
-						name="test"
-						isSaved={ true }
-						beforeContinue={ () => { console.log( "saved" ); return true; } }
+						name="Personal preferences"
+						isFinished={ isStep4Finished }
 					>
 						<PersonalPreferencesStep state={ state } setTracking={ setTracking } isTrackingOptionSelected={ isTrackingOptionSelected } />
-						<Stepper.Buttons continueFunction={ () => { console.log( "Did an extra save thing" ); } } backFunction={ () => console.log( "Back it up" ) } backLabel="back it up!" />
+						<Stepper.Buttons beforeContinue={ updateOnFinishEnableTracking } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />
 					</Stepper.Step>
 					<Stepper.Step
-						name="test"
-						isSaved={ true }
-						beforeContinue={ () => { console.log( "saved" ); return true; } }
-					>
-						<NewsletterSignup />
-						<Stepper.Buttons continueFunction={ () => { console.log( "Did an extra save thing" ); } } backFunction={ () => console.log( "Back it up" ) } backLabel="back it up!" />
-					</Stepper.Step>
-					<Stepper.Step
-						name="test"
-						isSaved={ true }
-						beforeContinue={ () => { console.log( "saved" ); return true; } }
-					>
-						<div><p>hoi Karlijn and Paolo</p></div>
-						<Stepper.Buttons continueLabel="NO GOING BACK NOW" continueFunction={ () => { console.log( "NO GOING BACK HERE" ); } } />
-					</Stepper.Step>
-					<Stepper.Step
-						name="test"
-						isSaved={ true }
-						beforeContinue={ () => { console.log( "saved" ); return true; } }
-					>
-						<div className="yst-bg-yellow-400"><p className="yst-bg-blue-500">RED</p></div>
-						<Stepper.Buttons continueFunction={ () => { console.log( "Did an extra save thing" ); } } backFunction={ () => console.log( "Back it up" ) } backLabel="back it up!" />
-					</Stepper.Step>
-					<Stepper.Step
-						name="test"
-						isSaved={ true }
-						beforeContinue={ () => { console.log( "saved" ); return true; } }
+						name="Finish configuration"
+						isFinished={ isWorkoutFinished }
 					>
 						<FinishStep />
+						<Stepper.Back className="yst-button yst-ml-3 yst-bg-cyan-600">
+							Cool back functionality
+						</Stepper.Back>
 					</Stepper.Step>
 				</Stepper>
 			</div>

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -5,9 +5,9 @@ import { createInterpolateElement, useCallback, useReducer, useState, useEffect,
 import { __, sprintf } from "@wordpress/i18n";
 import { cloneDeep } from "lodash";
 import PropTypes from "prop-types";
+
 import UnsavedChangesModal from "../tailwind-components/UnsavedChangesModal";
 import Alert from "../tailwind-components/alert";
-
 import { NewButton as Button, RadioButtonGroup, SingleSelect, TextInput } from "@yoast/components";
 import { ReactComponent as WorkoutDoneImage } from "../../../../../images/mirrored_fit_bubble_woman_1_optim.svg";
 import { ReactComponent as WorkoutStartImage } from "../../../images/motivated_bubble_woman_1_optim.svg";
@@ -22,7 +22,7 @@ import SocialInputPersonSection from "./SocialInputPersonSection";
 import Stepper, { Step } from "../tailwind-components/Stepper";
 import { ContinueButton, EditButton, ConfigurationStepButtons } from "../tailwind-components/ConfigurationStepperButtons";
 import { STEPS, WORKOUTS } from "../config";
-import { getInitialActiveStepIndex, stepperTimingClasses } from "../stepper-helper";
+import { getInitialActiveStepIndex } from "../stepper-helper";
 import { scrollToStep } from "../helpers";
 import AnimateHeight from "react-animate-height";
 

--- a/packages/js/src/workouts/tailwind-components/ConfigurationStepperButtons.js
+++ b/packages/js/src/workouts/tailwind-components/ConfigurationStepperButtons.js
@@ -1,6 +1,7 @@
+import { __ } from "@wordpress/i18n";
+import { useCallback } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { Step } from "./Stepper";
-import { __ } from "@wordpress/i18n";
 
 /**
  * A ContinueButton that always goes to the next step.
@@ -34,12 +35,43 @@ ContinueButton.defaultProps = {
 };
 
 /**
- * A ContinueButton that always goes to the next step.
+ * A EditButton that opens the current step.
  *
  * @param {Object}   props    The props.
  * @param {NodeList} children The Component children.
  *
- * @returns {WPElement} The ContinueButton, that always goes to the next step.
+ * @returns {WPElement} The EditButton, that always goes to the next step.
+ */
+export function EditButton( { beforeGo, children, additionalClasses, ...restProps } ) {
+	return ( <Step.GoButton
+		className={ `yst-button--secondary yst-button--small ${ additionalClasses }` }
+		destination={ 0 }
+		beforeGo={ beforeGo }
+		{ ...restProps }
+	>
+		{ children }
+	</Step.GoButton> );
+}
+
+EditButton.propTypes = {
+	additionalClasses: PropTypes.string,
+	beforeGo: PropTypes.func,
+	children: PropTypes.node,
+};
+
+EditButton.defaultProps = {
+	additionalClasses: "",
+	beforeGo: null,
+	children: null,
+};
+
+/**
+ * A BackButton that always goes to the previous step.
+ *
+ * @param {Object}   props    The props.
+ * @param {NodeList} children The Component children.
+ *
+ * @returns {WPElement} The BackButton, that always goes to the previous step.
  */
 export function BackButton( { beforeGo, children, additionalClasses, ...restProps } ) {
 	return ( <Step.GoButton
@@ -94,4 +126,37 @@ StepButtons.defaultProps = {
 	continueLabel: __( "Continue", "wordpress-seo" ),
 	beforeBack: null,
 	backLabel: __( "Go Back", "wordpress-seo" ),
+};
+
+/**
+ * A convenience class for the ConfigurationWorkout buttons:
+ * "Save and continue" and "Go back" when the stepper is in progress, "Save changes" when the Stepper has been completed once.
+ *
+ * @param {Object}   props                     The props for the StepButtons.
+ * @param {boolean}  props.stepperFinishedOnce Wether the stepper has been completed once.
+ * @param {function} props.saveFunction        A function to call upon clicking the "Save Changes" button.
+ * @param {string}   props.setEditState        A function to set the edit state of the Stepper.
+ *
+ * @returns {WPElement} The most common stepper buttons: continue and back.
+ */
+export function ConfigurationStepButtons( { stepperFinishedOnce, saveFunction, setEditState } ) {
+	const onSaveClick = useCallback( () => {
+		saveFunction();
+		setEditState( false );
+		return true;
+	} );
+
+	if ( stepperFinishedOnce ) {
+		return <Step.GoButton className="yst-button--primary yst-mt-12" destination="last" beforeGo={ onSaveClick }>
+			{ __( "Save changes", "wordpress-seo" ) }
+		</Step.GoButton>;
+	}
+
+	return <StepButtons beforeContinue={ saveFunction } continueLabel={ __( "Save and continue", "wordpress-seo" ) } />;
+}
+
+ConfigurationStepButtons.propTypes = {
+	stepperFinishedOnce: PropTypes.bool.isRequired,
+	saveFunction: PropTypes.func.isRequired,
+	setEditState: PropTypes.func.isRequired,
 };

--- a/packages/js/src/workouts/tailwind-components/ConfigurationStepperButtons.js
+++ b/packages/js/src/workouts/tailwind-components/ConfigurationStepperButtons.js
@@ -2,6 +2,8 @@ import { __ } from "@wordpress/i18n";
 import { useCallback } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { Step } from "./Stepper";
+import { stepperTimingClasses } from "../stepper-helper";
+import classNames from "classnames";
 
 /**
  * A ContinueButton that always goes to the next step.
@@ -40,11 +42,20 @@ ContinueButton.defaultProps = {
  * @param {Object}   props    The props.
  * @param {NodeList} children The Component children.
  *
- * @returns {WPElement} The EditButton, that always goes to the next step.
+ * @returns {WPElement} The EditButton, that always goes to the step it is placed in.
  */
-export function EditButton( { beforeGo, children, additionalClasses, ...restProps } ) {
+export function EditButton( { beforeGo, isVisible, children, additionalClasses, ...restProps } ) {
+	const transitionClasses = `yst-transition-opacity ${stepperTimingClasses.slideDuration} yst-ease-out ${ isVisible
+		? "yst-opacity-100"
+		: `${stepperTimingClasses.delayBeforeOpening} yst-opacity-0 yst-pointer-events-none` }`;
+
+
 	return ( <Step.GoButton
-		className={ `yst-button--secondary yst-button--small ${ additionalClasses }` }
+		className={ classNames(
+			"yst-button--secondary yst-button--small",
+			transitionClasses,
+			additionalClasses
+		) }
 		destination={ 0 }
 		beforeGo={ beforeGo }
 		{ ...restProps }
@@ -55,12 +66,14 @@ export function EditButton( { beforeGo, children, additionalClasses, ...restProp
 
 EditButton.propTypes = {
 	additionalClasses: PropTypes.string,
+	isVisible: PropTypes.bool,
 	beforeGo: PropTypes.func,
 	children: PropTypes.node,
 };
 
 EditButton.defaultProps = {
 	additionalClasses: "",
+	isVisible: true,
 	beforeGo: null,
 	children: null,
 };

--- a/packages/js/src/workouts/tailwind-components/ConfigurationStepperButtons.js
+++ b/packages/js/src/workouts/tailwind-components/ConfigurationStepperButtons.js
@@ -112,11 +112,11 @@ BackButton.defaultProps = {
 /**
  * A convenience class for the most common configuration of Stepper buttons: continue and back.
  *
- * @param {Object} props The props for the StepButtons.
+ * @param {Object}   props                The props for the StepButtons.
  * @param {function} props.beforeContinue A function to call before continueing. Should return true when ready to continue.
- * @param {function} props.beforeBack A function to call before going back. Should return true when ready to go back.
- * @param {string} props.continueLabel A label to display on the Continue Button.
- * @param {string} props.backLabel A label to display on the Back Button.
+ * @param {function} props.beforeBack     A function to call before going back. Should return true when ready to go back.
+ * @param {string}   props.continueLabel  A label to display on the Continue Button.
+ * @param {string}   props.backLabel      A label to display on the Back Button.
  *
  * @returns {WPElement} The most common stepper buttons: continue and back.
  */
@@ -146,7 +146,7 @@ StepButtons.defaultProps = {
  * "Save and continue" and "Go back" when the stepper is in progress, "Save changes" when the Stepper has been completed once.
  *
  * @param {Object}   props                     The props for the StepButtons.
- * @param {boolean}  props.stepperFinishedOnce Wether the stepper has been completed once.
+ * @param {boolean}  props.stepperFinishedOnce Whether the stepper has been completed once.
  * @param {function} props.saveFunction        A function to call upon clicking the "Save Changes" button.
  * @param {string}   props.setEditState        A function to set the edit state of the Stepper.
  *

--- a/packages/js/src/workouts/tailwind-components/ConfigurationStepperButtons.js
+++ b/packages/js/src/workouts/tailwind-components/ConfigurationStepperButtons.js
@@ -1,0 +1,97 @@
+import PropTypes from "prop-types";
+import { Step } from "./Stepper";
+import { __ } from "@wordpress/i18n";
+
+/**
+ * A ContinueButton that always goes to the next step.
+ *
+ * @param {Object}   props    The props.
+ * @param {NodeList} children The Component children.
+ *
+ * @returns {WPElement} The ContinueButton, that always goes to the next step.
+ */
+export function ContinueButton( { beforeGo, children, additionalClasses, ...restProps } ) {
+	return ( <Step.GoButton
+		className={ `yst-button--primary ${ additionalClasses }` }
+		destination={ 1 }
+		beforeGo={ beforeGo }
+		{ ...restProps }
+	>
+		{ children }
+	</Step.GoButton> );
+}
+
+ContinueButton.propTypes = {
+	additionalClasses: PropTypes.string,
+	beforeGo: PropTypes.func,
+	children: PropTypes.node,
+};
+
+ContinueButton.defaultProps = {
+	additionalClasses: "",
+	beforeGo: null,
+	children: null,
+};
+
+/**
+ * A ContinueButton that always goes to the next step.
+ *
+ * @param {Object}   props    The props.
+ * @param {NodeList} children The Component children.
+ *
+ * @returns {WPElement} The ContinueButton, that always goes to the next step.
+ */
+export function BackButton( { beforeGo, children, additionalClasses, ...restProps } ) {
+	return ( <Step.GoButton
+		className={ `yst-button--secondary ${ additionalClasses }` }
+		destination={ -1 }
+		beforeGo={ beforeGo }
+		{ ...restProps }
+	>
+		{ children }
+	</Step.GoButton> );
+}
+
+BackButton.propTypes = {
+	additionalClasses: PropTypes.string,
+	beforeGo: PropTypes.func,
+	children: PropTypes.node,
+};
+
+BackButton.defaultProps = {
+	additionalClasses: "",
+	beforeGo: null,
+	children: null,
+};
+
+/**
+ * A convenience class for the most common configuration of Stepper buttons: continue and back.
+ *
+ * @param {Object} props The props for the StepButtons.
+ * @param {function} props.beforeContinue A function to call before continueing. Should return true when ready to continue.
+ * @param {function} props.beforeBack A function to call before going back. Should return true when ready to go back.
+ * @param {string} props.continueLabel A label to display on the Continue Button.
+ * @param {string} props.backLabel A label to display on the Back Button.
+ *
+ * @returns {WPElement} The most common stepper buttons: continue and back.
+ */
+export function StepButtons( { beforeContinue, continueLabel, beforeBack, backLabel } ) {
+	return <div className="yst-mt-12">
+		<ContinueButton beforeGo={ beforeContinue }>{ continueLabel }</ContinueButton>
+		<BackButton additionalClasses="yst-ml-3" beforeGo={ beforeBack }>{ backLabel }</BackButton>
+	</div>;
+}
+
+StepButtons.propTypes = {
+	beforeContinue: PropTypes.func,
+	continueLabel: PropTypes.string,
+	beforeBack: PropTypes.func,
+	backLabel: PropTypes.string,
+};
+
+StepButtons.defaultProps = {
+	beforeContinue: null,
+	continueLabel: __( "Continue", "wordpress-seo" ),
+	beforeBack: null,
+	backLabel: __( "Go Back", "wordpress-seo" ),
+};

--- a/packages/js/src/workouts/tailwind-components/ConfigurationStepperButtons.js
+++ b/packages/js/src/workouts/tailwind-components/ConfigurationStepperButtons.js
@@ -154,9 +154,11 @@ StepButtons.defaultProps = {
  */
 export function ConfigurationStepButtons( { stepperFinishedOnce, saveFunction, setEditState } ) {
 	const onSaveClick = useCallback( () => {
-		saveFunction();
-		setEditState( false );
-		return true;
+		const saveSuccesful = saveFunction();
+
+		// If save is not succesful: we are still editing
+		setEditState( ! saveSuccesful );
+		return saveSuccesful;
 	} );
 
 	if ( stepperFinishedOnce ) {

--- a/packages/js/src/workouts/tailwind-components/StepCircle.js
+++ b/packages/js/src/workouts/tailwind-components/StepCircle.js
@@ -2,6 +2,7 @@ import { CheckIcon } from "@heroicons/react/solid";
 import { useState, useEffect } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { stepperTimingClasses } from "../stepper-helper";
+import { useStepperContext } from "./Stepper";
 /* eslint-disable complexity, max-len */
 
 const { slideDuration, delayUntilStepFaded } = stepperTimingClasses;
@@ -97,47 +98,44 @@ UpcomingCircle.defaultProps = {
  *
  * @returns {WPElement} The StepCircle component.
  */
-export function StepCircle( { activationDelay, isLastStep, deactivationDelay, isActive, isSaved } ) {
-	const [ circleType, setCircleType ] = useState( () => {
-		if ( isActive ) {
-			return isLastStep ? "saved" : "active";
-		}
-		return isSaved ? "saved" : "upcoming";
+export function StepCircle( { activationDelay, deactivationDelay, isFinished } ) {
+	const { activeStepIndex, stepIndex, lastStepIndex } = useStepperContext();
+	const isLastStep = stepIndex === lastStepIndex;
+	const isActive = activeStepIndex === stepIndex;
+	const [ isCircleActive, setCircleActive ] = useState( () => {
+		// Only return true if isActive and not the last step.
+		return isActive ? ! isLastStep : false;
 	} );
 
 	useEffect( () => {
 		if ( isActive ) {
-			// Set deactivation delay on the active class.
 			setTimeout( () => {
-				setCircleType( isLastStep ? "saved" : "active" );
+				setCircleActive( true );
 			}, activationDelay );
 			return;
 		}
 		// Set activation delay on the inactive class.
 		setTimeout( () => {
-			setCircleType( isSaved ? "saved" : "upcoming" );
+			setCircleActive( false );
 		}, deactivationDelay );
-	}, [ isActive, isLastStep, activationDelay, deactivationDelay, isSaved ] );
+	}, [ isActive, isLastStep, activationDelay, deactivationDelay ] );
 
 	return <span
 		className={ "yst-relative yst-z-10 yst-w-8 yst-h-8 yst-rounded-full" }
 	>
 		<UpcomingCircle isVisible={ true } />
-		<SavedCircle isVisible={ circleType === "saved" } />
-		<ActiveCircle isVisible={ circleType === "active" } />
+		<SavedCircle isVisible={ isFinished } />
+		<ActiveCircle isVisible={ isCircleActive } />
 	</span>;
 }
 
 StepCircle.propTypes = {
-	isActive: PropTypes.bool.isRequired,
-	isSaved: PropTypes.bool.isRequired,
-	isLastStep: PropTypes.bool,
+	isFinished: PropTypes.bool.isRequired,
 	activationDelay: PropTypes.number,
 	deactivationDelay: PropTypes.number,
 };
 
 StepCircle.defaultProps = {
-	isLastStep: false,
 	activationDelay: 0,
 	deactivationDelay: 0,
 };

--- a/packages/js/src/workouts/tailwind-components/StepCircle.js
+++ b/packages/js/src/workouts/tailwind-components/StepCircle.js
@@ -125,7 +125,7 @@ export function StepCircle( { activationDelay, deactivationDelay, isFinished } )
 	>
 		<UpcomingCircle isVisible={ true } />
 		<SavedCircle isVisible={ isFinished } />
-		<ActiveCircle isVisible={ isCircleActive } />
+		<ActiveCircle isVisible={ isCircleActive && ! isLastStep } />
 	</span>;
 }
 

--- a/packages/js/src/workouts/tailwind-components/StepHeader.js
+++ b/packages/js/src/workouts/tailwind-components/StepHeader.js
@@ -35,7 +35,7 @@ function getNameClassnames( isSaved, isActiveStep, isLastStep ) {
  *
  * @returns {WPElement} The StepHeader component.
  */
-export default function StepHeader( { step, isActiveStep, isSaved, isLastStep, isStepBeingEdited, showEditButton, editStep } ) {
+export default function StepHeader( { name, description, isActiveStep, isSaved, isLastStep, isStepBeingEdited, showEditButton, editStep } ) {
 	const nameClassNames = getNameClassnames( isSaved, isActiveStep, isLastStep );
 
 	return <div className="yst-relative yst-flex yst-items-center yst-group" aria-current={ isActiveStep ? "step" : null }>
@@ -51,9 +51,9 @@ export default function StepHeader( { step, isActiveStep, isSaved, isLastStep, i
 		{ /* Name and description. */ }
 		<span className="yst-ml-4 yst-min-w-0 yst-flex yst-flex-col">
 			<span className={ "yst-text-xs yst-font-[650] yst-tracking-wide yst-uppercase " + nameClassNames }>
-				{ step.name }
+				{ name }
 			</span>
-			{ step.description && <span className="yst-text-sm yst-text-gray-500">{ step.description }</span> }
+			{ description && <span className="yst-text-sm yst-text-gray-500">{ description }</span> }
 		</span>
 		{ ( ! isLastStep ) &&
 			<button
@@ -68,24 +68,19 @@ export default function StepHeader( { step, isActiveStep, isSaved, isLastStep, i
 	</div>;
 }
 
-const stepShape = PropTypes.shape( {
-	name: PropTypes.string.isRequired,
-	description: PropTypes.string,
-	component: PropTypes.element.isRequired,
-	isSaved: PropTypes.bool.isRequired,
-} );
-
 StepHeader.propTypes = {
-	step: stepShape.isRequired,
+	name: PropTypes.string.isRequired,
 	isActiveStep: PropTypes.bool.isRequired,
 	isSaved: PropTypes.bool.isRequired,
 	isLastStep: PropTypes.bool.isRequired,
 	isStepBeingEdited: PropTypes.bool.isRequired,
+	description: PropTypes.string,
 	showEditButton: PropTypes.bool,
 	editStep: PropTypes.func,
 };
 
 StepHeader.defaultProps = {
+	description: "",
 	showEditButton: false,
 	editStep: null,
 };

--- a/packages/js/src/workouts/tailwind-components/StepHeader.js
+++ b/packages/js/src/workouts/tailwind-components/StepHeader.js
@@ -1,6 +1,7 @@
 import { StepCircle } from "./StepCircle";
 import PropTypes from "prop-types";
-import { stepperTimings, stepperTimingClasses } from "../stepper-helper";
+import { stepperTimings } from "../stepper-helper";
+import { useStepperContext } from "./Stepper";
 
 /* eslint-disable complexity, max-len */
 
@@ -35,7 +36,10 @@ function getNameClassnames( isFinished, isActiveStep, isLastStep ) {
  *
  * @returns {WPElement} The StepHeader component.
  */
-export default function StepHeader( { name, description, isActiveStep, isFinished, isLastStep, isStepBeingEdited, showEditButton, editStep } ) {
+export default function StepHeader( { name, description, isFinished, children } ) {
+	const { stepIndex, activeStepIndex, lastStepIndex } = useStepperContext();
+	const isActiveStep = activeStepIndex === stepIndex;
+	const isLastStep = lastStepIndex === stepIndex;
 	const nameClassNames = getNameClassnames( isFinished, isActiveStep, isLastStep );
 
 	return <div className="yst-relative yst-flex yst-items-center yst-group" aria-current={ isActiveStep ? "step" : null }>
@@ -55,34 +59,20 @@ export default function StepHeader( { name, description, isActiveStep, isFinishe
 			</span>
 			{ description && <span className="yst-text-sm yst-text-gray-500">{ description }</span> }
 		</span>
-		{ ( ! isLastStep ) &&
-			<button
-				className={ `yst-button--secondary yst-button--small yst-ml-auto yst-mr-1 yst-transition-opacity yst-duration-1000 yst-relative yst-ease-out ${
-					( showEditButton && ! isStepBeingEdited )
-						? `${stepperTimingClasses.fadeDuration} yst-opacity-100`
-						: `${stepperTimingClasses.delayBeforeOpening} yst-opacity-0` }` }
-				onClick={ editStep }
-			>
-				Edit
-			</button> }
+		{ children }
 	</div>;
 }
 
 StepHeader.propTypes = {
-	name: PropTypes.string.isRequired,
-	isActiveStep: PropTypes.bool.isRequired,
+	name: PropTypes.bool.isRequired,
 	isFinished: PropTypes.bool.isRequired,
-	isLastStep: PropTypes.bool.isRequired,
-	isStepBeingEdited: PropTypes.bool.isRequired,
 	description: PropTypes.string,
-	showEditButton: PropTypes.bool,
-	editStep: PropTypes.func,
+	children: PropTypes.node,
 };
 
 StepHeader.defaultProps = {
 	description: "",
-	showEditButton: false,
-	editStep: null,
+	children: [],
 };
 
 /* eslint-enable complexity, max-len */

--- a/packages/js/src/workouts/tailwind-components/StepHeader.js
+++ b/packages/js/src/workouts/tailwind-components/StepHeader.js
@@ -45,11 +45,9 @@ export default function StepHeader( { name, description, isFinished, children } 
 	return <div className="yst-relative yst-flex yst-items-center yst-group" aria-current={ isActiveStep ? "step" : null }>
 		<span className="yst-flex yst-items-center" aria-hidden={ isActiveStep ? "true" : null }>
 			<StepCircle
-				isActive={ isActiveStep }
-				isFinished={ isFinished }
-				isLastStep={ isLastStep }
 				activationDelay={ stepperTimings.delayBeforeOpening }
 				deactivationDelay={ 0 }
+				isFinished={ isFinished }
 			/>
 		</span>
 		{ /* Name and description. */ }
@@ -64,7 +62,7 @@ export default function StepHeader( { name, description, isFinished, children } 
 }
 
 StepHeader.propTypes = {
-	name: PropTypes.bool.isRequired,
+	name: PropTypes.string.isRequired,
 	isFinished: PropTypes.bool.isRequired,
 	description: PropTypes.string,
 	children: PropTypes.node,

--- a/packages/js/src/workouts/tailwind-components/StepHeader.js
+++ b/packages/js/src/workouts/tailwind-components/StepHeader.js
@@ -7,17 +7,17 @@ import { stepperTimings, stepperTimingClasses } from "../stepper-helper";
 /**
  * Gets the classnames for the step name.
  *
- * @param {boolean} isSaved      Whether the step is saved.
+ * @param {boolean} isFinished   Whether the step is finished.
  * @param {boolean} isActiveStep Whether the step is active.
  * @param {boolean} isLastStep   Whether it is the last step.
  *
  * @returns {string} The classnames for the step name.
  */
-function getNameClassnames( isSaved, isActiveStep, isLastStep ) {
+function getNameClassnames( isFinished, isActiveStep, isLastStep ) {
 	if ( isActiveStep && ! isLastStep ) {
 		return "yst-text-primary-500";
 	}
-	return isSaved ? "" : "yst-text-gray-500";
+	return isFinished ? "" : "yst-text-gray-500";
 }
 
 /* eslint-disable complexity */
@@ -27,7 +27,7 @@ function getNameClassnames( isSaved, isActiveStep, isLastStep ) {
  * @param {Object}   props                   The props object.
  * @param {Object}   props.step              An object representing a step.
  * @param {boolean}  props.isActiveStep      Whether the step is active.
- * @param {boolean}  props.isSaved           Whether the step is saved.
+ * @param {boolean}  props.isFinished        Whether the step is finished.
  * @param {boolean}  props.isLastStep        Whether it is the last step.
  * @param {boolean}  props.isStepBeingEdited Whether the step is being open for editing or not.
  * @param {boolean}  props.showEditButton    Whether to show the edit button or not.
@@ -35,14 +35,14 @@ function getNameClassnames( isSaved, isActiveStep, isLastStep ) {
  *
  * @returns {WPElement} The StepHeader component.
  */
-export default function StepHeader( { name, description, isActiveStep, isSaved, isLastStep, isStepBeingEdited, showEditButton, editStep } ) {
-	const nameClassNames = getNameClassnames( isSaved, isActiveStep, isLastStep );
+export default function StepHeader( { name, description, isActiveStep, isFinished, isLastStep, isStepBeingEdited, showEditButton, editStep } ) {
+	const nameClassNames = getNameClassnames( isFinished, isActiveStep, isLastStep );
 
 	return <div className="yst-relative yst-flex yst-items-center yst-group" aria-current={ isActiveStep ? "step" : null }>
 		<span className="yst-flex yst-items-center" aria-hidden={ isActiveStep ? "true" : null }>
 			<StepCircle
 				isActive={ isActiveStep }
-				isSaved={ isSaved }
+				isFinished={ isFinished }
 				isLastStep={ isLastStep }
 				activationDelay={ stepperTimings.delayBeforeOpening }
 				deactivationDelay={ 0 }
@@ -71,7 +71,7 @@ export default function StepHeader( { name, description, isActiveStep, isSaved, 
 StepHeader.propTypes = {
 	name: PropTypes.string.isRequired,
 	isActiveStep: PropTypes.bool.isRequired,
-	isSaved: PropTypes.bool.isRequired,
+	isFinished: PropTypes.bool.isRequired,
 	isLastStep: PropTypes.bool.isRequired,
 	isStepBeingEdited: PropTypes.bool.isRequired,
 	description: PropTypes.string,

--- a/packages/js/src/workouts/tailwind-components/Stepper.js
+++ b/packages/js/src/workouts/tailwind-components/Stepper.js
@@ -203,22 +203,12 @@ Content.propTypes = {
  *
  * @returns {WPElement} The Stepper component.
  */
-export default function Stepper( { children, setActiveStepIndex, activeStepIndex, isStepperFinished } ) {
-	const [ isStepBeingEdited, setIsStepBeingEdited ] = useState( false );
-	const [ showEditButton, setShowEditButton ] = useState( isStepperFinished );
-	// The stepper needs to signal to each step to not to show edit buttons when a step is being edited (needs a function here to pass to each tailwindstep)
-
-	useEffect( () => {
-		if ( isStepperFinished ) {
-			setShowEditButton( isStepperFinished );
-		}
-	}, [ isStepperFinished ] );
-
+export default function Stepper( { children, setActiveStepIndex, activeStepIndex } ) {
 	return (
 		<ol>
 			{ children.map( ( child, stepIndex ) => {
 				return <li key={ `${ child.props.name }-${ stepIndex }` } className={ ( stepIndex === children.length - 1 ? "" : "yst-pb-8" ) + " yst-mb-0 yst-relative" }>
-					<StepperContext.Provider value={ { stepIndex, activeStepIndex, setActiveStepIndex, lastStepIndex: children.length - 1, isStepBeingEdited, setIsStepBeingEdited, showEditButton } }>
+					<StepperContext.Provider value={ { stepIndex, activeStepIndex, setActiveStepIndex, lastStepIndex: children.length - 1 } }>
 						{ child }
 					</StepperContext.Provider>
 				</li>;
@@ -230,7 +220,6 @@ export default function Stepper( { children, setActiveStepIndex, activeStepIndex
 Stepper.propTypes = {
 	setActiveStepIndex: PropTypes.func.isRequired,
 	activeStepIndex: PropTypes.number.isRequired,
-	isStepperFinished: PropTypes.bool.isRequired,
 	children: PropTypes.node.isRequired,
 };
 

--- a/packages/js/src/workouts/tailwind-components/Stepper.js
+++ b/packages/js/src/workouts/tailwind-components/Stepper.js
@@ -184,7 +184,7 @@ function Content( { children } ) {
 				easing="ease-in-out"
 				duration={ slideDuration }
 			>
-				<div className={ `yst-transition-opacity ${ fadeDuration } yst-relative yst-ml-12 yst-mt-4 ${ isFaded ? "yst-opacity-0 yst-no-point-events" : "yst-opacity-100" }` }>
+				<div className={ `yst-transition-opacity ${ fadeDuration } yst-relative yst-ml-12 yst-mt-4 ${ isFaded ? "yst-opacity-0 yst-pointer-events-none" : "yst-opacity-100" }` }>
 					{ children }
 				</div>
 			</AnimateHeight>

--- a/packages/js/src/workouts/tailwind-components/Stepper.js
+++ b/packages/js/src/workouts/tailwind-components/Stepper.js
@@ -78,10 +78,40 @@ ContinueButton.defaultProps = {
 /**
  * The StepButtons component.
  *
- * @param {Object}   props                 The props object.
- * @param {number}   props.stepIndex       The index of the current step.
- * @param {function} props.saveAndContinue A function to call when the primary button is clicked.
- * @param {function} props.goBack          A function to call when the "Go Back" button is clicked.
+ * @param {Object}   props The props object.
+ *
+ * @returns {WPElement} The EditButton component.
+ */
+function EditButton( { children, ...restProps } ) {
+	const { stepIndex, setActiveStepIndex } = useStepperContext();
+
+	const editFunction = useCallback( () => {
+		setActiveStepIndex( stepIndex );
+	}, [ setActiveStepIndex, stepIndex ] );
+
+	return <button
+		onClick={ editFunction }
+		className="yst-button--secondary yst-button--small"
+		{ ...restProps }
+	>
+		{ children }
+	</button>;
+}
+
+EditButton.propTypes = {
+	children: PropTypes.node,
+};
+
+EditButton.defaultProps = {
+	children: <Fragment>{ __( "Edit", "wordpress-seo" ) }</Fragment>,
+};
+
+/**
+ * The StepButtons component.
+ *
+ * @param {Object}   props            The props object.
+ * @param {number}   props.children   The children of the component.
+ * @param {function} props.beforeBack A function to call when the "Go Back" button is clicked.
  *
  * @returns {WPElement} The StepButtons component.
  */
@@ -147,13 +177,47 @@ StepButtons.defaultProps = {
 };
 
 /**
+ * 
+ * @returns 
+ */
+export function Step( { children } ) {
+	const { lastStepIndex, stepIndex, activeStepIndex } = useStepperContext();
+	return <Fragment>
+		{ /* Line. */ }
+		{ stepIndex !== lastStepIndex &&
+			<Fragment>
+				<div
+					className={ "yst--ml-px yst-absolute yst-left-4 yst-w-0.5 yst-h-full yst-bg-gray-300 yst--bottom-6" }
+					aria-hidden="true"
+				/>
+				<div
+					className={ `yst-h-12 yst-transition-transform ${ delayUntilStepFaded } yst-ease-linear ${ slideDurationClass } ${ stepIndex < activeStepIndex  ? "yst-scale-y-1" : "yst-scale-y-0" } yst-origin-top yst--ml-px yst-absolute yst-left-4 yst-w-0.5 yst-bg-primary-500 yst-top-8` }
+					aria-hidden="true"
+				/>
+			</Fragment>
+		}
+		{/* <StepHeader
+			name={ name }
+			description={ description }
+			isActiveStep={ isActiveStep }
+			isFinished={ isFinished }
+			isLastStep={ isLastStep }
+			showEditButton={ showEditButton }
+			editStep={ editStep }
+			isStepBeingEdited={ isStepBeingEdited }
+		/> */}
+		{ children }
+	</Fragment>;
+};
+
+/**
  * The (Tailwind) Step component
  *
  * @param {Object} props The props.
  *
  * @returns {WPElement} The Step component.
  */
-function Step( { name, description, isFinished, children } ) {
+function Content( { name, description, isFinished, children } ) {
 	const { activeStepIndex, stepIndex, setActiveStepIndex, lastStepIndex, showEditButton, isStepBeingEdited, setIsStepBeingEdited } = useStepperContext();
 	const isLastStep = stepIndex === lastStepIndex;
 	const isActiveStep = activeStepIndex === stepIndex;
@@ -179,29 +243,6 @@ function Step( { name, description, isFinished, children } ) {
 
 	return (
 		<Fragment>
-			{ /* Line. */ }
-			{ ! isLastStep &&
-				<Fragment>
-					<div
-						className={ "yst--ml-px yst-absolute yst-left-4 yst-w-0.5 yst-h-full yst-bg-gray-300 yst--bottom-6" }
-						aria-hidden="true"
-					/>
-					<div
-						className={ `yst-h-12 yst-transition-transform ${ delayUntilStepFaded } yst-ease-linear ${ slideDurationClass } ${ stepIndex < activeStepIndex  ? "yst-scale-y-1" : "yst-scale-y-0" } yst-origin-top yst--ml-px yst-absolute yst-left-4 yst-w-0.5 yst-bg-primary-500 yst-top-8` }
-						aria-hidden="true"
-					/>
-				</Fragment>
-			}
-			<StepHeader
-				name={ name }
-				description={ description }
-				isActiveStep={ isActiveStep }
-				isFinished={ isFinished }
-				isLastStep={ isLastStep }
-				showEditButton={ showEditButton }
-				editStep={ editStep }
-				isStepBeingEdited={ isStepBeingEdited }
-			/>
 			{ /* Child component and buttons. */ }
 			<AnimateHeight
 				id={ `content-${stepIndex}` }
@@ -218,16 +259,13 @@ function Step( { name, description, isFinished, children } ) {
 	);
 }
 
-Step.propTypes = {
-	name: PropTypes.string.isRequired,
+Content.propTypes = {
 	children: PropTypes.node.isRequired,
 	isFinished: PropTypes.bool,
-	description: PropTypes.string,
 };
 
-Step.defaultProps = {
+Content.defaultProps = {
 	isFinished: false,
-	description: "",
 };
 
 /**
@@ -268,8 +306,10 @@ Stepper.propTypes = {
 	children: PropTypes.node.isRequired,
 };
 
-Stepper.Step = Step;
-Stepper.Continue = ContinueButton;
-Stepper.Back = BackButton;
-Stepper.Buttons = StepButtons;
+Step.Content = Content;
+Step.Header = StepHeader;
+Step.Continue = ContinueButton;
+Step.Back = BackButton;
+Step.Edit = EditButton;
+Step.Buttons = StepButtons;
 /* eslint-enable complexity, max-len */

--- a/packages/js/src/workouts/tailwind-components/Stepper.js
+++ b/packages/js/src/workouts/tailwind-components/Stepper.js
@@ -35,9 +35,9 @@ export function useStepperContext() {
 /**
  * The component button used to navigate the steps
  *
- * @param {Object}   props            The props object.
- * @param {number}   props.children   The children of the component.
- * @param {function} props.beforeGo A function to call when the button is clicked.
+ * @param {Object}     props             The props object.
+ * @param {number}     props.children    The children of the component.
+ * @param {function}   props.beforeGo    A function to call when the button is clicked.
  * @param {int|string} props.destination A number of steps to take relative to the current step or "first" or "last".
  *
  * @returns {WPElement} The button element.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In the initial implementation of the Stepper we tried to encapsulate all its behaviours via the props resulting in excessive prop threading throughout various components, and a massive API to use the Stepper.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor the Tailwind Stepper component to use a compound component pattern.

## Relevant technical choices:

* After lots of headaches we read some articles ( https://kentcdodds.com/blog/compound-components-with-react-hooks%20https://kentcdodds.com/blog/inversion-of-control ) and realised that we tried to control everything on the definition side, whereas actually we should be giving control to the implementation side.
* The solution we choose is a Compound Component pattern using React `useContext`.
* The resulting code on the implementation side can look a bit daunting but it's actually very flexible.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Mostly this is a code refactor, so the brunt of "testing" should be in the code review.
* Basically, there should be no noticeable behavioural differences between the `feature/tailwind-workouts` branch, and this branch.
* It's probably easiest to just compare the Configuration Workout to the design, and verify that it works the same (apart from the content of the steps).


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* This will be hard to test for QA, as it's only a pattern change that should not result in UX changes. Furthermore QA can only test this feature when we merge it back to trunk.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-275
