### PR TITLE
P1-1058 console warning image alt text is undefined

### DIFF
--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -91,7 +91,7 @@ export default ImageSelect;
 ImageSelect.propTypes = {
 	defaultImageUrl: PropTypes.string,
 	imageUrl: PropTypes.string,
-	imageAltText: PropTypes.string.isRequired,
+	imageAltText: PropTypes.string,
 	hasPreview: PropTypes.bool.isRequired,
 	label: PropTypes.string.isRequired,
 	onClick: PropTypes.func,
@@ -110,6 +110,7 @@ ImageSelect.propTypes = {
 ImageSelect.defaultProps = {
 	defaultImageUrl: "",
 	imageUrl: "",
+	imageAltText: "",
 	onClick: () => {},
 	onMouseEnter: () => {},
 	onMouseLeave: () => {},

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "test": "jest -u",
-    "lint": "eslint src tests --max-warnings=153"
+    "lint": "eslint src tests --max-warnings=152"
   },
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/tests/setupTests.js",

--- a/packages/js/src/components/ImageSelectComponent.js
+++ b/packages/js/src/components/ImageSelectComponent.js
@@ -18,6 +18,7 @@ const ImageSelectComponent = ( { hiddenField, hiddenFieldImageId, hasImageValida
 	const [ image, setImage ] = useState( {
 		url: hiddenFieldElement ? hiddenFieldElement.value : "",
 		id: hiddenFieldImageIdElement ? parseInt( hiddenFieldImageIdElement.value, 10 ) : "",
+		alt: "",
 	} );
 	const [ warnings, setWarnings ] = useState( [] );
 
@@ -48,6 +49,7 @@ const ImageSelectComponent = ( { hiddenField, hiddenFieldImageId, hasImageValida
 		{ ...imageSelectProps }
 		imageUrl={ image.url }
 		imageId={ image.id }
+		imageAltText={ image.alt }
 		onClick={ selectImage }
 		onRemoveImageClick={ removeImage }
 		warnings={ warnings }

--- a/packages/js/src/components/ImageSelectComponent.js
+++ b/packages/js/src/components/ImageSelectComponent.js
@@ -1,195 +1,67 @@
-/* External dependencies */
-import PropTypes from "prop-types";
-import { Component } from "@wordpress/element";
-
-/* Yoast dependencies */
+import { useCallback, useEffect, useMemo, useState } from "@wordpress/element";
 import { ImageSelect } from "@yoast/components";
 import { validateFacebookImage } from "@yoast/helpers";
-
-/* Internal dependencies */
+import PropTypes from "prop-types";
 import { openMedia } from "../helpers/selectMedia";
-
 
 /**
  * Renders the ImageSelect.
+ *
+ * Using WP media to get an attachment and syncing to hidden fields.
+ *
+ * @returns {JSX.Element} The ImageSelectComponent.
  */
-class ImageSelectComponent extends Component {
-	/**
-	 * The ImageSelectComponent constructor.
-	 *
-	 * @param {Object} props The components props.
-	 */
-	constructor( props ) {
-		super( props );
+const ImageSelectComponent = ( { hiddenField, hiddenFieldImageId, hasImageValidation, ...imageSelectProps } ) => {
+	const hiddenFieldElement = useMemo( () => document.getElementById( hiddenField ) );
+	const hiddenFieldImageIdElement = useMemo( () => document.getElementById( hiddenFieldImageId ) );
 
-		this.hiddenField = document.getElementById( this.props.hiddenField );
-		this.hiddenFieldImageId = document.getElementById( this.props.hiddenFieldImageId );
-		this.state = {
-			imageUrl: this.getInitialValue(),
-			imageId: this.getInitialId(),
-			warnings: [],
-		};
+	const [ image, setImage ] = useState( {
+		url: hiddenFieldElement ? hiddenFieldElement.value : "",
+		id: hiddenFieldImageIdElement ? parseInt( hiddenFieldImageIdElement.value, 10 ) : "",
+	} );
+	const [ warnings, setWarnings ] = useState( [] );
 
-		this.setMyImageUrl = this.setMyImageUrl.bind( this );
-		this.setMyImageId = this.setMyImageId.bind( this );
-		this.onClick = this.onClick.bind( this );
-		this.removeImage = this.removeImage.bind( this );
-		this.setWarnings = this.setWarnings.bind( this );
-	}
-
-	/**
-	 * Gets the initial value from the hidden input field.
-	 *
-	 * @returns {string} The image url.
-	 */
-	getInitialValue() {
-		return this.hiddenField.value;
-	}
-
-	/**
-	 * Gets the initial value from the hidden input field for the image id, if it exists.
-	 *
-	 * @returns {string} The image id.
-	 */
-	getInitialId() {
-		if ( this.hiddenFieldImageId !== null ) {
-			return this.hiddenFieldImageId.value;
+	const updateHiddenFields = useCallback( data => {
+		if ( hiddenFieldElement ) {
+			hiddenFieldElement.value = data.url;
 		}
-	}
-
-	/**
-	 * Handles change event for the image select.
-	 *
-	 * First updates its internal state and then updates the hidden input for the image.
-	 *
-	 * @param {string} imageUrl The image url.
-	 *
-	 * @returns {void}
-	 */
-	setMyImageUrl( imageUrl ) {
-		this.setState( { imageUrl }, () => {
-			this.hiddenField.value = imageUrl;
-		} );
-	}
-
-	/**
-	 * Handles change event for the image select.
-	 *
-	 * First updates its internal state and then updates the hidden input for the image id.
-	 *
-	 * @param {string} imageId The image id.
-	 *
-	 * @returns {void}
-	 */
-	setMyImageId( imageId ) {
-		this.setState( { imageId }, () => {
-			this.hiddenFieldImageId.value = imageId;
-		} );
-	}
-
-	/**
-	 * Function called when ImageSelect component button is clicked.
-	 *
-	 * @returns {void}
-	 */
-	onClick() {
-		/**
-		 * Callback function for selectMedia. Performs actions with the 'image' Object that it gets as an argument.
-		 *
-		 * @param {Object} image Object containing data about the selected image.
-		 *
-		 * @param {Function} onSelect Callback function received from openMedia. Gets object image' as an argument.
-		 *
-		 * @returns {void}
-		 */
-		const imageCallback = ( image ) => {
-			if ( this.props.hasImageValidation ) {
-				this.setWarnings( validateFacebookImage( image ) );
-			}
-
-			this.setMyImageUrl( image.url );
-			if ( this.hiddenFieldImageId !== null ) {
-				this.setMyImageId( image.id );
-			}
-		};
-		openMedia( imageCallback );
-	}
-
-	/**
-	 * Function called when 'remove image' button of ImageSelect component is clicked.
-	 *
-	 * @returns {void}
-	 */
-	removeImage() {
-		const imageUrl = "";
-		const imageId = "";
-		this.setMyImageUrl( imageUrl );
-		if ( this.hiddenFieldImageId !== null ) {
-			this.setMyImageId( imageId );
+		if ( hiddenFieldImageIdElement ) {
+			hiddenFieldImageIdElement.value = data.id;
 		}
-	}
+	} );
 
-	/**
-	 * Sets the image warnings.
-	 *
-	 * @param {array} warnings The validation warnings.
-	 *
-	 * @returns {void} Void.
-	 */
-	setWarnings( warnings ) {
-		this.setState( { warnings: warnings } );
-	}
+	const selectImage = useCallback( () => openMedia( data => {
+		setImage( data );
+		updateHiddenFields( data );
+		if ( hasImageValidation ) {
+			setWarnings( validateFacebookImage( data ) );
+		}
+	} ), [ hasImageValidation, updateHiddenFields ] );
+	const removeImage = useCallback( () => {
+		const emptyImage = { url: "", id: "", alt: "" };
+		setImage( emptyImage );
+		updateHiddenFields( emptyImage );
+		setWarnings( [] );
+	}, [ updateHiddenFields ] );
 
-	/**
-	 * Renders the ImageSelect component.
-	 *
-	 * @returns {wp.Element} The rendered component.
-	 */
-	render() {
-		return (
-			<ImageSelect
-				label={ this.props.label }
-				hasPreview={ this.props.hasPreview }
-				imageUrl={ this.state.imageUrl }
-				imageId={ this.state.imageId }
-				onClick={ this.onClick }
-				onRemoveImageClick={ this.removeImage }
-				selectImageButtonId={ this.props.selectImageButtonId }
-				replaceImageButtonId={ this.props.replaceImageButtonId }
-				removeImageButtonId={ this.props.removeImageButtonId }
-				hasNewBadge={ this.props.hasNewBadge }
-				isDisabled={ this.props.isDisabled }
-				hasPremiumBadge={ this.props.hasPremiumBadge }
-				warnings={ this.state.warnings }
-			/>
-		);
-	}
-}
+	return <ImageSelect
+		{ ...imageSelectProps }
+		imageUrl={ image.url }
+		imageId={ image.id }
+		onClick={ selectImage }
+		onRemoveImageClick={ removeImage }
+		warnings={ warnings }
+	/>;
+};
 
 ImageSelectComponent.propTypes = {
 	hiddenField: PropTypes.string.isRequired,
 	hiddenFieldImageId: PropTypes.string,
-	label: PropTypes.string,
-	hasPreview: PropTypes.bool,
-	selectImageButtonId: PropTypes.string,
-	replaceImageButtonId: PropTypes.string,
-	removeImageButtonId: PropTypes.string,
-	hasNewBadge: PropTypes.bool,
-	isDisabled: PropTypes.bool,
-	hasPremiumBadge: PropTypes.bool,
 	hasImageValidation: PropTypes.bool,
 };
 
 ImageSelectComponent.defaultProps = {
 	hiddenFieldImageId: "",
-	label: "",
-	hasPreview: true,
-	selectImageButtonId: "",
-	replaceImageButtonId: "",
-	removeImageButtonId: "",
-	hasNewBadge: false,
-	isDisabled: false,
-	hasPremiumBadge: false,
 	hasImageValidation: false,
 };
 

--- a/packages/js/src/components/ImageSelectComponent.js
+++ b/packages/js/src/components/ImageSelectComponent.js
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "@wordpress/element";
 import { ImageSelect } from "@yoast/components";
 import { validateFacebookImage } from "@yoast/helpers";
 import PropTypes from "prop-types";
-import { openMedia } from "../helpers/selectMedia";
+import { fetchAttachment, openMedia } from "../helpers/selectMedia";
 
 /**
  * Renders the ImageSelect.
@@ -44,6 +44,12 @@ const ImageSelectComponent = ( { hiddenField, hiddenFieldImageId, hasImageValida
 		updateHiddenFields( emptyImage );
 		setWarnings( [] );
 	}, [ updateHiddenFields ] );
+
+	useEffect( () => {
+		if ( image.id && ! image.alt ) {
+			fetchAttachment( image.id ).then( data => setImage( data ) );
+		}
+	}, [ image ] );
 
 	return <ImageSelect
 		{ ...imageSelectProps }

--- a/packages/js/src/components/social/SocialForm.js
+++ b/packages/js/src/components/social/SocialForm.js
@@ -118,6 +118,7 @@ class SocialPreviewEditor extends Component {
 			description,
 			descriptionInputPlaceholder,
 			imageUrl,
+			alt,
 			title,
 			titleInputPlaceholder,
 			replacementVariables,
@@ -137,6 +138,7 @@ class SocialPreviewEditor extends Component {
 					onRemoveImageClick={ onRemoveImageClick }
 					imageSelected={ !! imageUrl }
 					imageUrl={ imageUrl }
+					imageAltText={ alt }
 					onTitleChange={ onTitleChange }
 					onSelectImageClick={ onSelectImageClick }
 					description={ description }
@@ -173,6 +175,7 @@ SocialPreviewEditor.propTypes = {
 	replacementVariables: replacementVariablesShape,
 	recommendedReplacementVariables: recommendedReplacementVariablesShape,
 	location: PropTypes.string,
+	alt: PropTypes.string,
 };
 
 SocialPreviewEditor.defaultProps = {
@@ -183,6 +186,7 @@ SocialPreviewEditor.defaultProps = {
 	descriptionInputPlaceholder: "",
 	titleInputPlaceholder: "",
 	location: "",
+	alt: "",
 };
 
 export default SocialPreviewEditor;

--- a/packages/js/src/containers/FacebookEditor.js
+++ b/packages/js/src/containers/FacebookEditor.js
@@ -38,6 +38,7 @@ const imageCallback = ( image ) => {
 		url: imageUrl,
 		id: image.id,
 		warnings: validateFacebookImage( image ),
+		alt: image.alt ?? "",
 	} );
 };
 
@@ -70,6 +71,7 @@ export default compose( [
 			getSeoDescriptionTemplate,
 			getSocialDescriptionTemplate,
 			getReplacedExcerpt,
+			getFacebookAltText,
 		} = select( "yoast-seo/editor" );
 
 		const titleInputPlaceholder  = "";
@@ -99,6 +101,7 @@ export default compose( [
 			titleInputPlaceholder,
 			descriptionInputPlaceholder,
 			socialMediumName,
+			alt: getFacebookAltText(),
 		};
 	} ),
 

--- a/packages/js/src/containers/FacebookEditor.js
+++ b/packages/js/src/containers/FacebookEditor.js
@@ -1,46 +1,14 @@
 /* External dependencies */
 import { compose } from "@wordpress/compose";
 import { withDispatch, withSelect, dispatch as wpDataDispatch } from "@wordpress/data";
-import { validateFacebookImage } from "@yoast/helpers";
-import { FACEBOOK_IMAGE_SIZES, determineFacebookImageMode } from "@yoast/social-metadata-previews";
 
 /* Internal dependencies */
 import FacebookWrapper from "../components/social/FacebookWrapper";
 import getL10nObject from "../analysis/getL10nObject";
 import withLocation from "../helpers/withLocation";
-import { openMedia } from "../helpers/selectMedia";
+import { openMedia, prepareFacebookPreviewImage } from "../helpers/selectMedia";
 
 const socialMediumName = "Facebook";
-
-/**
- * Callback function for selectMedia. Performs actions with the 'image' Object that it gets as an argument.
- *
- * @param {Object} image Object containing data about the selected image.
- *
- * @param {Function} onSelect Callback function received from openMedia. Gets object image' as an argument.
- *
- * @returns {void}
- */
-const imageCallback = ( image ) => {
-	const { width, height } = image;
-	const imageMode = determineFacebookImageMode( { width, height } );
-
-	const idealWidth = FACEBOOK_IMAGE_SIZES[ imageMode + "Width" ];
-	const idealHeight = FACEBOOK_IMAGE_SIZES[ imageMode + "Height" ];
-
-	const idealImageSize = Object.values( image.sizes ).find( size => {
-		return size.width >= idealWidth && size.height >= idealHeight;
-	} );
-
-	const imageUrl = idealImageSize ? idealImageSize.url : image.url;
-
-	wpDataDispatch( "yoast-seo/editor" ).setFacebookPreviewImage( {
-		url: imageUrl,
-		id: image.id,
-		warnings: validateFacebookImage( image ),
-		alt: image.alt || "",
-	} );
-};
 
 /**
  * Lazy function to open the media instance.
@@ -48,7 +16,7 @@ const imageCallback = ( image ) => {
  * @returns {void}
  */
 const selectMedia = () => {
-	openMedia( imageCallback );
+	openMedia( ( image ) => wpDataDispatch( "yoast-seo/editor" ).setFacebookPreviewImage( prepareFacebookPreviewImage( image ) ) );
 };
 
 /* eslint-disable complexity */

--- a/packages/js/src/containers/FacebookEditor.js
+++ b/packages/js/src/containers/FacebookEditor.js
@@ -38,7 +38,7 @@ const imageCallback = ( image ) => {
 		url: imageUrl,
 		id: image.id,
 		warnings: validateFacebookImage( image ),
-		alt: image.alt ?? "",
+		alt: image.alt || "",
 	} );
 };
 

--- a/packages/js/src/containers/TwitterEditor.js
+++ b/packages/js/src/containers/TwitterEditor.js
@@ -1,49 +1,14 @@
 /* External dependencies */
 import { compose } from "@wordpress/compose";
 import { withDispatch, withSelect, dispatch as wpDataDispatch } from "@wordpress/data";
-import { validateTwitterImage } from "@yoast/helpers";
-import { TWITTER_IMAGE_SIZES } from "@yoast/social-metadata-previews";
-import { get } from "lodash";
 
 /* Internal dependencies */
 import TwitterWrapper from "../components/social/TwitterWrapper";
 import getL10nObject from "../analysis/getL10nObject";
 import withLocation from "../helpers/withLocation";
-import { openMedia } from "../helpers/selectMedia";
+import { openMedia, prepareTwitterPreviewImage } from "../helpers/selectMedia";
 
 const socialMediumName = "Twitter";
-
-/**
- * Callback function for selectMedia. Performs actions with the 'image' Object that it gets as an argument.
- *
- * @param {Object} image Object containing data about the selected image.
- *
- * @param {Function} onSelect Callback function received from openMedia. Gets object image' as an argument.
- *
- * @returns {void}
- */
-const imageCallback = ( image ) => {
-	const twitterImageType = get( window, "wpseoScriptData.metabox.twitterCardType" );
-
-	const isLarge = twitterImageType !== "summary";
-	const imageMode = isLarge ? "landscape" : "square";
-
-	const idealWidth = TWITTER_IMAGE_SIZES[ imageMode + "Width" ];
-	const idealHeight = TWITTER_IMAGE_SIZES[ imageMode + "Height" ];
-
-	const idealImageSize = Object.values( image.sizes ).find( size => {
-		return size.width >= idealWidth && size.height >= idealHeight;
-	} );
-
-	const imageUrl = idealImageSize ? idealImageSize.url : image.url;
-
-	wpDataDispatch( "yoast-seo/editor" ).setTwitterPreviewImage( {
-		url: imageUrl,
-		id: image.id,
-		warnings: validateTwitterImage( image ),
-		alt: image.alt || "",
-	} );
-};
 
 /**
  * Lazy function to open the media instance.
@@ -51,7 +16,7 @@ const imageCallback = ( image ) => {
  * @returns {void}
  */
 const selectMedia = () => {
-	openMedia( imageCallback );
+	openMedia( ( image ) => wpDataDispatch( "yoast-seo/editor" ).setTwitterPreviewImage( prepareTwitterPreviewImage( image ) ) );
 };
 
 /* eslint-disable complexity */

--- a/packages/js/src/containers/TwitterEditor.js
+++ b/packages/js/src/containers/TwitterEditor.js
@@ -41,7 +41,7 @@ const imageCallback = ( image ) => {
 		url: imageUrl,
 		id: image.id,
 		warnings: validateTwitterImage( image ),
-		alt: image.alt ?? "",
+		alt: image.alt || "",
 	} );
 };
 

--- a/packages/js/src/containers/TwitterEditor.js
+++ b/packages/js/src/containers/TwitterEditor.js
@@ -41,6 +41,7 @@ const imageCallback = ( image ) => {
 		url: imageUrl,
 		id: image.id,
 		warnings: validateTwitterImage( image ),
+		alt: image.alt ?? "",
 	} );
 };
 
@@ -77,6 +78,7 @@ export default compose( [
 			getSeoDescriptionTemplate,
 			getSocialDescriptionTemplate,
 			getReplacedExcerpt,
+			getTwitterAltText,
 		} = select( "yoast-seo/editor" );
 
 		const titleInputPlaceholder  = "";
@@ -109,6 +111,7 @@ export default compose( [
 			titleInputPlaceholder,
 			descriptionInputPlaceholder,
 			socialMediumName,
+			alt: getTwitterAltText(),
 		};
 	} ),
 

--- a/packages/js/src/elementor/containers/FacebookEditor.js
+++ b/packages/js/src/elementor/containers/FacebookEditor.js
@@ -38,6 +38,7 @@ const getMedia = () => {
 				url: selected.attributes.url,
 				id: selected.attributes.id,
 				warnings: validateFacebookImage( image ),
+				alt: selected.attributes.alt,
 			} );
 		} );
 	}
@@ -73,6 +74,7 @@ export default compose( [
 			getSeoDescriptionTemplate,
 			getSocialDescriptionTemplate,
 			getEditorDataExcerptWithFallback,
+			getFacebookAltText,
 		} = select( "yoast-seo/editor" );
 
 		const titleInputPlaceholder  = "";
@@ -102,6 +104,7 @@ export default compose( [
 			titleInputPlaceholder,
 			descriptionInputPlaceholder,
 			socialMediumName,
+			alt: getFacebookAltText(),
 		};
 	} ),
 

--- a/packages/js/src/elementor/containers/FacebookEditor.js
+++ b/packages/js/src/elementor/containers/FacebookEditor.js
@@ -1,58 +1,23 @@
 /* External dependencies */
 import { compose } from "@wordpress/compose";
 import { withDispatch, withSelect, dispatch as wpDataDispatch } from "@wordpress/data";
-import { validateFacebookImage } from "@yoast/helpers";
 
 /* Internal dependencies */
 import FacebookWrapper from "../../components/social/FacebookWrapper";
 import getL10nObject from "../../analysis/getL10nObject";
 import withLocation from "../../helpers/withLocation";
 import { getCurrentReplacementVariablesForEditor } from "../replaceVars/elementor-replacevar-plugin";
+import { openMedia, prepareFacebookPreviewImage } from "../../helpers/selectMedia";
 
 const socialMediumName = "Facebook";
-
-/**
- * The cached instance of the media object.
- *
- * @type {wp.media} The media object
- */
-let media = null;
-
-/**
- * Lazy function to get the media object and hook the right action dispatchers.
- *
- * @returns {void}
- */
-const getMedia = () => {
-	if ( ! media ) {
-		media = window.wp.media();
-		// Listens for the selection of an image. Then gets the right data and dispatches the data to the store.
-		media.on( "select", () => {
-			const selected = media.state().get( "selection" ).first();
-			const image = {
-				type: selected.attributes.subtype,
-				width: selected.attributes.width,
-				height: selected.attributes.height,
-			};
-			wpDataDispatch( "yoast-seo/editor" ).setFacebookPreviewImage( {
-				url: selected.attributes.url,
-				id: selected.attributes.id,
-				warnings: validateFacebookImage( image ),
-				alt: selected.attributes.alt,
-			} );
-		} );
-	}
-
-	return media;
-};
 
 /**
  * Lazy function to open the media instance.
  *
  * @returns {void}
  */
-const openMedia = () => {
-	return getMedia().open();
+const selectMedia = () => {
+	openMedia( ( image ) => wpDataDispatch( "yoast-seo/editor" ).setFacebookPreviewImage( prepareFacebookPreviewImage( image ) ) );
 };
 
 /* eslint-disable complexity */
@@ -116,7 +81,7 @@ export default compose( [
 			loadFacebookPreviewData,
 		} = dispatch( "yoast-seo/editor" );
 		return {
-			onSelectImageClick: openMedia,
+			onSelectImageClick: selectMedia,
 			onRemoveImageClick: clearFacebookPreviewImage,
 			onDescriptionChange: setFacebookPreviewDescription,
 			onTitleChange: setFacebookPreviewTitle,

--- a/packages/js/src/elementor/containers/TwitterEditor.js
+++ b/packages/js/src/elementor/containers/TwitterEditor.js
@@ -38,6 +38,7 @@ const getMedia = () => {
 				url: selected.attributes.url,
 				id: selected.attributes.id,
 				warnings: validateTwitterImage( image ),
+				alt: selected.attributes.alt,
 			} );
 		} );
 	}
@@ -77,6 +78,7 @@ export default compose( [
 			getSeoDescriptionTemplate,
 			getSocialDescriptionTemplate,
 			getEditorDataExcerptWithFallback,
+			getFacebookAltText,
 		} = select( "yoast-seo/editor" );
 
 		const titleInputPlaceholder  = "";
@@ -109,6 +111,7 @@ export default compose( [
 			titleInputPlaceholder,
 			descriptionInputPlaceholder,
 			socialMediumName,
+			alt: getFacebookAltText(),
 		};
 	} ),
 

--- a/packages/js/src/elementor/containers/TwitterEditor.js
+++ b/packages/js/src/elementor/containers/TwitterEditor.js
@@ -1,58 +1,23 @@
 /* External dependencies */
 import { compose } from "@wordpress/compose";
 import { withDispatch, withSelect, dispatch as wpDataDispatch } from "@wordpress/data";
-import { validateTwitterImage } from "@yoast/helpers";
 
 /* Internal dependencies */
 import TwitterWrapper from "../../components/social/TwitterWrapper";
 import getL10nObject from "../../analysis/getL10nObject";
 import withLocation from "../../helpers/withLocation";
 import { getCurrentReplacementVariablesForEditor } from "../replaceVars/elementor-replacevar-plugin";
+import { openMedia, prepareTwitterPreviewImage } from "../../helpers/selectMedia";
 
 const socialMediumName = "Twitter";
-
-/**
- * The cached instance of the media object.
- *
- * @type {wp.media} The media object
- */
-let media = null;
-
-/**
- * Lazy function to get the media object and hook the right action dispatchers.
- *
- * @returns {void}
- */
-const getMedia = () => {
-	if ( ! media ) {
-		media = window.wp.media();
-		// Listens for the selection of an image. Then gets the right data and dispatches the data to the store.
-		media.on( "select", () => {
-			const selected = media.state().get( "selection" ).first();
-			const image = {
-				type: selected.attributes.subtype,
-				width: selected.attributes.width,
-				height: selected.attributes.height,
-			};
-			wpDataDispatch( "yoast-seo/editor" ).setTwitterPreviewImage( {
-				url: selected.attributes.url,
-				id: selected.attributes.id,
-				warnings: validateTwitterImage( image ),
-				alt: selected.attributes.alt,
-			} );
-		} );
-	}
-
-	return media;
-};
 
 /**
  * Lazy function to open the media instance.
  *
  * @returns {void}
  */
-const openMedia = () => {
-	return getMedia().open();
+const selectMedia = () => {
+	openMedia( ( image ) => wpDataDispatch( "yoast-seo/editor" ).setTwitterPreviewImage( prepareTwitterPreviewImage( image ) ) );
 };
 
 /* eslint-disable complexity */
@@ -78,7 +43,7 @@ export default compose( [
 			getSeoDescriptionTemplate,
 			getSocialDescriptionTemplate,
 			getEditorDataExcerptWithFallback,
-			getFacebookAltText,
+			getTwitterAltText,
 		} = select( "yoast-seo/editor" );
 
 		const titleInputPlaceholder  = "";
@@ -111,7 +76,7 @@ export default compose( [
 			titleInputPlaceholder,
 			descriptionInputPlaceholder,
 			socialMediumName,
-			alt: getFacebookAltText(),
+			alt: getTwitterAltText(),
 		};
 	} ),
 
@@ -124,7 +89,7 @@ export default compose( [
 		} = dispatch( "yoast-seo/editor" );
 
 		return {
-			onSelectImageClick: openMedia,
+			onSelectImageClick: selectMedia,
 			onRemoveImageClick:	clearTwitterPreviewImage,
 			onDescriptionChange: setTwitterPreviewDescription,
 			onTitleChange: setTwitterPreviewTitle,

--- a/packages/js/src/helpers/selectMedia.js
+++ b/packages/js/src/helpers/selectMedia.js
@@ -1,28 +1,60 @@
 /**
+ * Strips an attachment to an object with what we want.
+ *
+ * @param {wp.media.model.Attachment} attachment A WordPress media attachment.
+ *
+ * @returns {Object} Image attributes.
+ */
+const toImage = ( attachment ) => ( {
+	type: attachment.subtype,
+	width: attachment.width,
+	height: attachment.height,
+	url: attachment.url,
+	id: attachment.id,
+	sizes: attachment.sizes,
+	// Use fallbacks: the media title or the filename without extension.
+	alt: attachment.alt || attachment.title || attachment.name,
+} );
+
+/**
  * Function to get the media object and hook the right action dispatchers.
  *
  * @param {Function} onSelect Callback function received from openMedia. Gets object image' as an argument.
  *
- * @returns {void}
+ * @returns {wp.media.view.MediaFrame} A media workflow.
  */
 function getMedia( onSelect ) {
-	let media = null;
-	media = window.wp.media();
+	const media = window.wp.media();
+
 	// Listens for the selection of an image. Then gets the right data and dispatches the data to the store.
 	media.on( "select", () => {
 		const selected = media.state().get( "selection" ).first();
-		const image = {
-			type: selected.attributes.subtype,
-			width: selected.attributes.width,
-			height: selected.attributes.height,
-			url: selected.attributes.url,
-			id: selected.attributes.id,
-			sizes: selected.attributes.sizes,
-		};
-		onSelect( image );
+
+		onSelect( toImage( selected.attributes ) );
 	} );
 
 	return media;
+}
+
+/**
+ * Fetches the attachment via WP media.
+ *
+ * @param {number|string} id The attachment ID to fetch.
+ *
+ * @returns {Promise} The promise of an attachment. Can be rejected.
+ */
+export function fetchAttachment( id ) {
+	return new Promise( ( resolve, reject ) => {
+		if ( ! window.wp.media.attachment ) {
+			reject();
+		}
+
+		window.wp.media.attachment( id ).fetch()
+			.then( attachment => {
+				resolve( toImage( attachment ) );
+			} )
+			.catch( () => reject() );
+	} );
 }
 
 /**
@@ -33,5 +65,5 @@ function getMedia( onSelect ) {
  * @returns {void}
  */
 export function openMedia( onSelect ) {
-	return getMedia( onSelect ).open();
+	getMedia( onSelect ).open();
 }

--- a/packages/js/src/redux/reducers/facebookEditor.js
+++ b/packages/js/src/redux/reducers/facebookEditor.js
@@ -20,6 +20,8 @@ const initialState = {
 	},
 };
 
+/* eslint-disable complexity */
+
 /**
  * A reducer for the FacebookPreview object.
  *
@@ -65,5 +67,7 @@ const facebookReducer = ( state = initialState, action ) => {
 			return state;
 	}
 };
+
+/* eslint-enable complexity */
 
 export default facebookReducer;

--- a/packages/js/src/redux/reducers/facebookEditor.js
+++ b/packages/js/src/redux/reducers/facebookEditor.js
@@ -1,9 +1,9 @@
 import {
+	CLEAR_FACEBOOK_IMAGE,
 	LOAD_FACEBOOK_PREVIEW,
-	SET_FACEBOOK_TITLE,
 	SET_FACEBOOK_DESCRIPTION,
 	SET_FACEBOOK_IMAGE,
-	CLEAR_FACEBOOK_IMAGE,
+	SET_FACEBOOK_TITLE,
 } from "../actions/facebookEditor";
 
 /**
@@ -16,6 +16,7 @@ const initialState = {
 	image: {
 		url: "",
 		id: "",
+		alt: "",
 	},
 };
 
@@ -36,28 +37,31 @@ const facebookReducer = ( state = initialState, action ) => {
 				description: action.description,
 				image: { id: action.id, url: action.imageUrl },
 			};
-		case SET_FACEBOOK_TITLE :
+		case SET_FACEBOOK_TITLE:
 			return { ...state, title: action.title };
 		case SET_FACEBOOK_DESCRIPTION :
 			return { ...state, description: action.description };
-		case SET_FACEBOOK_IMAGE :
+		case SET_FACEBOOK_IMAGE:
 			return {
 				...state,
 				warnings: action.image.warnings,
 				image: {
 					id: action.image.id,
 					url: action.image.url,
+					alt: action.image.alt || "",
 				},
 			};
 		case CLEAR_FACEBOOK_IMAGE :
-			return { ...state,
+			return {
+				...state,
 				image: {
 					url: "",
 					id: "",
+					alt: "",
 				},
 				warnings: [],
 			};
-	  default:
+		default:
 			return state;
 	}
 };

--- a/packages/js/src/redux/reducers/twitterEditor.js
+++ b/packages/js/src/redux/reducers/twitterEditor.js
@@ -14,6 +14,8 @@ const initialState = {
 	},
 };
 
+/* eslint-disable complexity */
+
 /**
  * A reducer for the TwitterPreview object.
  *
@@ -59,5 +61,7 @@ const twitterReducer = ( state = initialState, action ) => {
 			return state;
 	}
 };
+
+/* eslint-enable complexity */
 
 export default twitterReducer;

--- a/packages/js/src/redux/reducers/twitterEditor.js
+++ b/packages/js/src/redux/reducers/twitterEditor.js
@@ -1,10 +1,4 @@
-import {
-	LOAD_TWITTER_PREVIEW,
-	SET_TWITTER_TITLE,
-	SET_TWITTER_DESCRIPTION,
-	SET_TWITTER_IMAGE,
-	CLEAR_TWITTER_IMAGE,
-} from "../actions/twitterEditor";
+import { CLEAR_TWITTER_IMAGE, LOAD_TWITTER_PREVIEW, SET_TWITTER_DESCRIPTION, SET_TWITTER_IMAGE, SET_TWITTER_TITLE } from "../actions/twitterEditor";
 
 /**
  * Initial state
@@ -16,6 +10,7 @@ const initialState = {
 	image: {
 		url: "",
 		id: "",
+		alt: "",
 	},
 };
 
@@ -36,22 +31,31 @@ const twitterReducer = ( state = initialState, action ) => {
 				description: action.description,
 				image: { id: action.id, url: action.imageUrl },
 			};
-		case SET_TWITTER_TITLE :
+		case SET_TWITTER_TITLE:
 			return { ...state, title: action.title };
 		case SET_TWITTER_DESCRIPTION :
 			return { ...state, description: action.description };
-		case SET_TWITTER_IMAGE :
-			return { ...state, image: { id: action.image.id, url: action.image.url }, warnings: action.image.warnings };
-		case CLEAR_TWITTER_IMAGE :
+		case SET_TWITTER_IMAGE:
+			return {
+				...state,
+				image: {
+					id: action.image.id,
+					url: action.image.url,
+					alt: action.image.alt || "",
+				},
+				warnings: action.image.warnings,
+			};
+		case CLEAR_TWITTER_IMAGE:
 			return {
 				...state,
 				image: {
 					url: "",
 					id: "",
+					alt: "",
 				},
 				warnings: [],
 			};
-	  default:
+		default:
 			return state;
 	}
 };

--- a/packages/js/src/redux/selectors/facebookEditor.js
+++ b/packages/js/src/redux/selectors/facebookEditor.js
@@ -37,6 +37,15 @@ export const getFacebookImageUrl = state => get( state, "facebookEditor.image.ur
 export const getFacebookImageSrc = state => get( state, "facebookEditor.image.src", "" );
 
 /**
+ * Gets the facebook alt text from the state.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {String} Facebook alt text.
+ */
+export const getFacebookAltText = state => get( state, "facebookEditor.image.alt", "" );
+
+/**
  * Gets the facebook warnings from the state.
  *
  * @param {Object} state The state.

--- a/packages/js/src/redux/selectors/twitterEditor.js
+++ b/packages/js/src/redux/selectors/twitterEditor.js
@@ -46,6 +46,15 @@ export const getTwitterImageType = state => get( state, "settings.socialPreviews
 export const getTwitterImageSrc = state => get( state, "twitterEditor.image.src", "" );
 
 /**
+ * Gets the Twitter alt text from the state.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {String} Twitter alt text.
+ */
+export const getTwitterAltText = state => get( state, "twitterEditor.image.alt", "" );
+
+/**
  * Gets the Twitter warnings from the state.
  *
  * @param {Object} state The state.

--- a/packages/js/src/settings.js
+++ b/packages/js/src/settings.js
@@ -1,14 +1,20 @@
 /* global wpseoScriptData */
+import domReady from "@wordpress/dom-ready";
 import jQuery from "jquery";
-
 import initAdmin from "./initializers/admin";
 import initAdminMedia from "./initializers/admin-media";
 import initSearchAppearance from "./initializers/search-appearance";
 import initSettingsStore from "./initializers/settings-store";
 import initSocialSettings from "./initializers/social-settings";
 
-initAdmin( jQuery );
-if ( wpseoScriptData ) {
+// eslint-disable-next-line complexity
+domReady( () => {
+	initAdmin( jQuery );
+
+	if ( ! wpseoScriptData ) {
+		return;
+	}
+
 	if ( typeof wpseoScriptData.media !== "undefined" ) {
 		initAdminMedia( jQuery );
 	}
@@ -24,4 +30,4 @@ if ( wpseoScriptData ) {
 	if ( typeof wpseoScriptData.social !== "undefined" ) {
 		initSocialSettings();
 	}
-}
+} );

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -167,6 +167,7 @@ class SocialMetadataPreviewForm extends Component {
 			recommendedReplacementVariables,
 			imageWarnings,
 			imageUrl,
+			imageAltText,
 			idSuffix,
 		} = this.props;
 
@@ -194,6 +195,7 @@ class SocialMetadataPreviewForm extends Component {
 					isActive={ activeField === "image" }
 					isHovered={ hoveredField === "image" }
 					imageUrl={ imageUrl }
+					imageAltText={ imageAltText }
 					hasPreview={ ! isPremium }
 					imageUrlInputId={ join( [ lowerCaseSocialMediumName, "url-input", idSuffix ] ) }
 					selectImageButtonId={ join( [ lowerCaseSocialMediumName, "select-button", idSuffix ] ) }
@@ -257,6 +259,7 @@ SocialMetadataPreviewForm.propTypes = {
 	recommendedReplacementVariables: PropTypes.arrayOf( PropTypes.string ),
 	imageWarnings: PropTypes.array,
 	imageUrl: PropTypes.string,
+	imageAltText: PropTypes.string,
 	titleInputPlaceholder: PropTypes.string,
 	descriptionInputPlaceholder: PropTypes.string,
 	setEditorRef: PropTypes.func,
@@ -272,6 +275,7 @@ SocialMetadataPreviewForm.defaultProps = {
 	activeField: "",
 	onSelect: () => {},
 	imageUrl: "",
+	imageAltText: "",
 	titleInputPlaceholder: "",
 	descriptionInputPlaceholder: "",
 	isPremium: false,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix up the alt texts for our image selector a bit.
* Not quite done, creating more issues for:
  * Editor: no alt text on page load
  * Editor: Twitter fallback does not have an alt text

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a warning would be thrown on pages with our image selector.
* Uses the alt texts from WordPress attachments when selecting images in the editor or in the settings.
* [shopify-seo] Fixes a bug where a warning would be thrown on pages with our image selector.
* [@yoast/components] Changes the `imageAltText` prop from the `ImageSelect` component to no longer be required.
* [@yoast/social-metadata-forms] Adds an `imageAltText` prop to the `SocialMetadataPreviewForm` component.

## Relevant technical choices:

* Alt text is no longer required. The URL is not required, so it makes sense the alt text is also not required.
* Pass the alt text along (way too long a chain) so the socials can have a real alt text if available.
* In the settings (or `ImageSelectComponent` rather): fetch an attachment on load to get the alt text.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Before
* Please test with Premium code: https://github.com/Yoast/wordpress-seo-premium/pull/3531
* This should work in the classic, block and elementor editors
* Open the inspector to see any JS warnings (the one from the issue should be gone)

#### Editor socials
* Edit a post, open the social tab
* Select a Facebook image that has an alt text
* Inspect the HTML, the image should have the `alt` attribute
* If the selected image does not have an alt text, it should use the title as alt instead
* If the selected image does not have an alt text or a title, it should use the filename without the extension instead
* The Twitter image should work the same
* Note that there are two missing features here still:
  * Saving and loading the page again will result in an empty alt text
  * Select a Facebook image while no Twitter image is selected will not result in the Twitter image having the alt text
* Repeat these steps in Elementor, the code can differ

#### Settings images
* Go to the Yoast SEO settings
* Both search appearance -> content types (or taxonomies or archives) and social -> facebook should work
* Select a Facebook image that has an alt text
* Inspect the HTML, the image should have the `alt` attribute
* If the selected image does not have an alt text, it should use the title as alt instead
* If the selected image does not have an alt text or a title, it should use the filename without the extension instead
* Save (and reload the page)
* The alt text should be present (it gets requested after page load)

#### No more warning
* On any of these pages with an image select, the JS warning about the `imageAltText` prop should no longer be there

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Shopify!

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [P1-1058](https://yoast.atlassian.net/browse/P1-1058)
