### PR TITLE
Add extra check to prevent accessing non-existent array element

### DIFF
--- a/src/integrations/blocks/structured-data-blocks.php
+++ b/src/integrations/blocks/structured-data-blocks.php
@@ -271,7 +271,7 @@ class Structured_Data_Blocks implements Integration_Interface {
 	 */
 	public function maybe_save_used_caches() {
 		foreach ( $this->used_caches as $post_id => $used_cache ) {
-			if ( $used_cache === $this->caches[ $post_id ] ) {
+			if ( isset( $this->caches[ $post_id ] ) && $used_cache === $this->caches[ $post_id ] ) {
 				continue;
 			}
 			\update_post_meta( $post_id, 'yoast-structured-data-blocks-images-cache', $used_cache );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In the block editor, if you add to the footer both the Yoast FAQ and Yoast How-to blocks, a PHP notice is displayed in the frontend footer of the site.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased  bug  where a PHP notice would displayed in the frontend when using a FAQ or How-To block in the FSE.

## Relevant technical choices:

* An extra existence condition has been added to avoid accessing a non-existent array element

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Set up clean local env (WP 5.9, Twenty Twenty Two theme)
2. Install and activate Yoast Free 18.2
3. Go to `Appearance` -> `Editor`
4. Click on the Footer block to highlight it
5. Click it again to highligh the group inside the Footer block and click the `+` sign in the lower right corner
6. In the search field type: _yoast_ and select `Yoast How-to`
7. Repeat steps 4. and 5.
8. In the search field type: _yoast_ and select `Yoast FAQ`
9. Check the home page: in the footer you should see the following message: `Notice: Undefined offset: 1 in /var/www/html/wp-content/plugins/wordpress-seo/src/integrations/blocks/structured-data-blocks.php on line 274`
10. Apply this patch
11. Check the homepage: the above message should be gone

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
