### PR TITLE
Don't import social image url if featured image is selected

### DIFF
--- a/src/actions/importing/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo-posts-importing-action.php
@@ -592,8 +592,7 @@ class Aioseo_Posts_Importing_Action extends Abstract_Importing_Action {
 				$image_url = $aioseo_social_image_settings[ $mapping['social_setting_prefix_aioseo'] . 'image_custom_url' ];
 				break;
 			case 'featured':
-				$image_url = $this->social_images_provider->get_featured_image( $indexable->object_id );
-				break;
+				return null; // Our auto-calculation when the indexable is built/updated will take care of it, so it's not needed to transfer any data now.
 			case 'author':
 				return null;
 			case 'custom':

--- a/src/helpers/indexable-to-postmeta-helper.php
+++ b/src/helpers/indexable-to-postmeta-helper.php
@@ -57,19 +57,19 @@ class Indexable_To_Postmeta_Helper {
 		],
 		'open_graph_image'       => [
 			'post_meta_key' => 'opengraph-image',
-			'map_method'    => 'simple_map',
+			'map_method'    => 'social_image_map',
 		],
 		'open_graph_image_id'    => [
 			'post_meta_key' => 'opengraph-image-id',
-			'map_method'    => 'string_map',
+			'map_method'    => 'social_image_map',
 		],
 		'twitter_image'          => [
 			'post_meta_key' => 'twitter-image',
-			'map_method'    => 'simple_map',
+			'map_method'    => 'social_image_map',
 		],
 		'twitter_image_id'       => [
 			'post_meta_key' => 'twitter-image-id',
-			'map_method'    => 'string_map',
+			'map_method'    => 'social_image_map',
 		],
 		'is_robots_noindex'      => [
 			'post_meta_key' => 'meta-robots-noindex',
@@ -125,7 +125,7 @@ class Indexable_To_Postmeta_Helper {
 	}
 
 	/**
-	 * Uses a simple set_value for non-empty data that are being cast to string.
+	 * Map social image data only if social image is explicitly set.
 	 *
 	 * @param Indexable $indexable        The Yoast indexable.
 	 * @param string    $post_meta_key    The post_meta key that will be populated.
@@ -133,14 +133,28 @@ class Indexable_To_Postmeta_Helper {
 	 *
 	 * @return void.
 	 */
-	public function string_map( $indexable, $post_meta_key, $indexable_column ) {
+	public function social_image_map( $indexable, $post_meta_key, $indexable_column ) {
 		if ( empty( $indexable->{$indexable_column} ) ) {
 			return;
 		}
 
-		$value = (string) $indexable->{$indexable_column};
+		switch ( $indexable_column ) {
+			case 'open_graph_image':
+			case 'open_graph_image_id':
+				$source = $indexable->open_graph_image_source;
+				break;
+			case 'twitter_image':
+			case 'twitter_image_id':
+				$source = $indexable->twitter_image_source;
+				break;
+		}
 
-		$this->meta->set_value( $post_meta_key, $value, $indexable->object_id );
+		// Map the social image data only when the social image is explicitly set.
+		if ( $source === 'set-by-user' || $source === 'imported' ) {
+			$value = (string) $indexable->{$indexable_column};
+
+			$this->meta->set_value( $post_meta_key, $value, $indexable->object_id );
+		}
 	}
 
 	/**

--- a/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
@@ -825,14 +825,14 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			[ $aioseo_og_auto, $open_graph_mapping, $image, 1, 'get_auto_image', 1, 0, 'og' ],
 			[ $aioseo_og_content, $open_graph_mapping, $image, 1, 'get_first_image_in_content', 1, 0, 'og' ],
 			[ $aioseo_og_custom, $open_graph_mapping, null, 0, 'irrelevant', 0, 0, 'og' ],
-			[ $aioseo_og_featured, $open_graph_mapping, $image, 1, 'get_featured_image', 1, 0, 'og' ],
+			[ $aioseo_og_featured, $open_graph_mapping, null, 0, 'irrelevant', 0, 0, 'og' ],
 			[ $aioseo_twitter_custom_image, $twitter_mapping, $image, 1, 'irrelevant', 0, 0, 'twitter' ],
 			[ $aioseo_twitter_attach, $twitter_mapping, $image, 1, 'get_first_attached_image', 1, 0, 'twitter' ],
 			[ $aioseo_twitter_author, $twitter_mapping, null, 0, 'irrelevant', 0, 0, 'twitter' ],
 			[ $aioseo_twitter_auto, $twitter_mapping, $image, 1, 'get_auto_image', 1, 0, 'twitter' ],
 			[ $aioseo_twitter_content, $twitter_mapping, $image, 1, 'get_first_image_in_content', 1, 0, 'twitter' ],
 			[ $aioseo_twitter_custom, $twitter_mapping, null, 0, 'irrelevant', 0, 0, 'twitter' ],
-			[ $aioseo_twitter_featured, $twitter_mapping, $image, 1, 'get_featured_image', 1, 0, 'twitter' ],
+			[ $aioseo_twitter_featured, $twitter_mapping, null, 0, 'irrelevant', 0, 0, 'og' ],
 			[ $aioseo_twitter_from_og, $twitter_mapping, $image, 1, 'irrelevant', 0, 0, 'og' ],
 		];
 	}

--- a/tests/unit/helpers/indexable-to-postmeta-helper-test.php
+++ b/tests/unit/helpers/indexable-to-postmeta-helper-test.php
@@ -53,24 +53,26 @@ class Indexable_To_Postmeta_Helper_Test extends TestCase {
 		$indexable      = Mockery::mock( Indexable_Mock::class );
 		$indexable->orm = Mockery::mock( ORM::class );
 
-		$indexable->title                  = 'title1';
-		$indexable->description            = 'description1';
-		$indexable->open_graph_title       = 'open_graph_title1';
-		$indexable->open_graph_description = 'open_graph_description1';
-		$indexable->twitter_title          = 'twitter_title1';
-		$indexable->twitter_description    = 'twitter_description1';
-		$indexable->canonical              = 'https://example.com/';
-		$indexable->primary_focus_keyword  = 'key phrase';
-		$indexable->open_graph_image       = 'https://example.com/og-image.png';
-		$indexable->open_graph_image_id    = 111;
-		$indexable->twitter_image          = 'https://example.com/twitter-image.png';
-		$indexable->twitter_image_id       = 222;
-		$indexable->is_robots_noindex      = true;
-		$indexable->is_robots_nofollow     = true;
-		$indexable->is_robots_noimageindex = true;
-		$indexable->is_robots_noarchive    = true;
-		$indexable->is_robots_nosnippet    = true;
-		$indexable->object_id              = 123;
+		$indexable->title                   = 'title1';
+		$indexable->description             = 'description1';
+		$indexable->open_graph_title        = 'open_graph_title1';
+		$indexable->open_graph_description  = 'open_graph_description1';
+		$indexable->twitter_title           = 'twitter_title1';
+		$indexable->twitter_description     = 'twitter_description1';
+		$indexable->canonical               = 'https://example.com/';
+		$indexable->primary_focus_keyword   = 'key phrase';
+		$indexable->open_graph_image        = 'https://example.com/og-image.png';
+		$indexable->open_graph_image_id     = 111;
+		$indexable->open_graph_image_source = 'set-by-user';
+		$indexable->twitter_image           = 'https://example.com/twitter-image.png';
+		$indexable->twitter_image_id        = 222;
+		$indexable->twitter_image_source    = 'featured-image';
+		$indexable->is_robots_noindex       = true;
+		$indexable->is_robots_nofollow      = true;
+		$indexable->is_robots_noimageindex  = true;
+		$indexable->is_robots_noarchive     = true;
+		$indexable->is_robots_nosnippet     = true;
+		$indexable->object_id               = 123;
 
 		$this->meta->expects( 'set_value' )
 			->with( 'title', 'title1', 123 )
@@ -103,9 +105,11 @@ class Indexable_To_Postmeta_Helper_Test extends TestCase {
 			->with( 'opengraph-image-id', '111', 123 )
 			->andReturn( true );
 		$this->meta->expects( 'set_value' )
+			->never()
 			->with( 'twitter-image', 'https://example.com/twitter-image.png', 123 )
 			->andReturn( true );
 		$this->meta->expects( 'set_value' )
+			->never()
 			->with( 'twitter-image-id', '222', 123 )
 			->andReturn( true );
 		$this->meta->expects( 'set_value' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to keep the dynamic behavior when a user has set `featured-image` as a og or twitter image. That is, if after the import, the user changes the featured-image, the og/twitter image should be updated to the new featured image (only when og/twiter image source is `featured image` ofc)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the import of og and twitter image to retain the dynamic behavior when featured image is selected for social images

## Relevant technical choices:

* When for a post `featured image` is selected as the source of og/twitter image in AIOSEO, we don't import anything and we let the Yoast's inherent calculation of og/twitter images when the indexable is built, to set the og/twitter image from the featured image
* In order for that to work, we had to adjust the mapping to postmeta to happen only when the og/twitter image is set to an explicit image, and not when it's being plucked from the featured image.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* With AIOSEO enabled, create a post and set in the Social tab for Facebook or Twitter, the `Featured Image` as the **Image Source**
* Make sure that the post has a featured image and then Save the post
* Go to Yoast->Tools->Import/Export and perform the AIOSEO import (if the feature flag is disabled, you won't be able to do so)
* Refresh the edit page of the post and confirm that no explicit image has been set in the Yoast's metabox, in the social tab
* Also go to the frontend of the post and confirm that the og/twitter image tag is being outputted by Yoast and that indeed contains the featured image URL.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
