### PR TITLE
Fix potential fatal error from array_key_exists on PHP8

### DIFF
--- a/src/config/wincher-pkce-provider.php
+++ b/src/config/wincher-pkce-provider.php
@@ -235,7 +235,9 @@ class Wincher_PKCE_Provider extends GenericProvider {
 
 		$this->checkResponse( $response, $parsed );
 
-		if ( ! \is_array( $parsed ) && $parsed === '' ) {
+		// We always expect an array from the API except for on DELETE requests.
+		// We convert to an array here to prevent problems with array_key_exists on PHP8.
+		if ( ! \is_array( $parsed ) ) {
 			$parsed = [ 'data' => [] ];
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Prevent a fatal error that could occur on PHP8 when the Wincher API:s returns unexpected responses.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where array_key_exists could throw a fatal error on PHP8.  

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Testing this is a bit convoluted because you need to trigger a non-json error response. An example of how to do this:

* Install WordPress and Yoast on PHP8
* Enable Wincher integration and connect
* Apply this diff:

```diff
diff --git a/src/actions/wincher/wincher-keyphrases-action.php b/src/actions/wincher/wincher-keyphrases-action.php
index 3345e25e3a..ccafe4ff70 100644
--- a/src/actions/wincher/wincher-keyphrases-action.php
+++ b/src/actions/wincher/wincher-keyphrases-action.php
@@ -207,17 +207,8 @@ class Wincher_Keyphrases_Action {
 				$this->options_helper->get( 'wincher_website_id' )
 			);
 
-			$results = $this->client->post(
-				$endpoint,
-				\WPSEO_Utils::format_json_encode(
-					[
-						'keywords' => $used_keyphrases,
-						'url'      => $permalink,
-					]
-				),
-				[
-					'timeout' => 60,
-				]
+			$results = $this->client->get(
+				'https://httpstat.us/429',
 			);
 
 			if ( ! \array_key_exists( 'data', $results ) ) {
```
* Open the Track SEO Performance modal or metabox.
* Ensure that the `yoast/v1/wincher/keyphrases` request returned 429 rather than 500.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Wincher integration

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
