### PR TITLE
Fix more broken replacevars in taxonomies

### DIFF
--- a/src/actions/importing/aioseo/aioseo-taxonomy-settings-importing-action.php
+++ b/src/actions/importing/aioseo/aioseo-taxonomy-settings-importing-action.php
@@ -47,7 +47,19 @@ class Aioseo_Taxonomy_Settings_Importing_Action extends Abstract_Aioseo_Settings
 	 * @see https://yoast.com/help/list-available-snippet-variables-yoast-seo/
 	 */
 	protected $replace_vars_edited_map = [
-		'#taxonomy_title' => '%%term_title%%',
+		'#breadcrumb_404_error_format'         => '', // Empty string, as AIOSEO shows nothing for that tag.
+		'#breadcrumb_archive_post_type_format' => '', // Empty string, as AIOSEO shows nothing for that tag.
+		'#breadcrumb_archive_post_type_name'   => '', // Empty string, as AIOSEO shows nothing for that tag.
+		'#breadcrumb_author_display_name'      => '', // Empty string, as AIOSEO shows nothing for that tag.
+		'#breadcrumb_author_first_name'        => '', // Empty string, as AIOSEO shows nothing for that tag.
+		'#breadcrumb_blog_page_title'          => '', // Empty string, as AIOSEO shows nothing for that tag.
+		'#breadcrumb_label'                    => '', // Empty string, as AIOSEO shows nothing for that tag.
+		'#breadcrumb_link'                     => '', // Empty string, as AIOSEO shows nothing for that tag.
+		'#breadcrumb_search_result_format'     => '', // Empty string, as AIOSEO shows nothing for that tag.
+		'#breadcrumb_search_string'            => '', // Empty string, as AIOSEO shows nothing for that tag.
+		'#breadcrumb_separator'                => '', // Empty string, as AIOSEO shows nothing for that tag.
+		'#breadcrumb_taxonomy_title'           => '', // Empty string, as AIOSEO shows nothing for that tag.
+		'#taxonomy_title'                      => '%%term_title%%',
 	];
 
 	/**

--- a/src/services/importing/aioseo/aioseo-replacevar-service.php
+++ b/src/services/importing/aioseo/aioseo-replacevar-service.php
@@ -25,8 +25,6 @@ class Aioseo_Replacevar_Service {
 		'#author_last_name'          => '%%author_last_name%%',
 		'#author_name'               => '%%name%%',
 		'#blog_title'                => '%%sitename%%', // Same with #site_title.
-		'#breadcrumb_taxonomy_title' => '', // Empty string, as AIOSEO shows nothing for that tag.
-		'#breadcrumb_separator'      => '', // Empty string, as AIOSEO shows nothing for that tag.
 		'#categories'                => '%%category%%',
 		'#current_date'              => '%%currentdate%%',
 		'#current_day'               => '%%currentday%%',

--- a/tests/unit/actions/importing/aioseo-taxonomy-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-taxonomy-settings-importing-action-test.php
@@ -258,6 +258,81 @@ class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 	}
 
 	/**
+	 * Tests composing the replacevar map.
+	 *
+	 * @covers ::index
+	 */
+	public function test_composer_replacevar_map() {
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_aioseo_taxonomy_settings_indexation_limit', 25 )
+			->andReturn( 25 );
+
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'aioseo_options_dynamic', '' )
+			->andReturn( '' );
+
+		$this->mock_instance->expects( 'set_completed' )
+			->once()
+			->with( true );
+
+		$this->mock_instance->expects( 'build_mapping' )
+			->once();
+
+		// Here comes the things we want to actually check.
+		$this->replacevar_handler->expects( 'compose_map' )
+			->once()
+			->with( '#breadcrumb_404_error_format', '' );
+		$this->replacevar_handler->expects( 'compose_map' )
+			->once()
+			->with( '#breadcrumb_archive_post_type_format', '' );
+		$this->replacevar_handler->expects( 'compose_map' )
+			->once()
+			->with( '#breadcrumb_archive_post_type_name', '' );
+		$this->replacevar_handler->expects( 'compose_map' )
+			->once()
+			->with( '#breadcrumb_author_display_name', '' );
+		$this->replacevar_handler->expects( 'compose_map' )
+			->once()
+			->with( '#breadcrumb_author_first_name', '' );
+		$this->replacevar_handler->expects( 'compose_map' )
+			->once()
+			->with( '#breadcrumb_blog_page_title', '' );
+		$this->replacevar_handler->expects( 'compose_map' )
+			->once()
+			->with( '#breadcrumb_label', '' );
+		$this->replacevar_handler->expects( 'compose_map' )
+			->once()
+			->with( '#breadcrumb_link', '' );
+		$this->replacevar_handler->expects( 'compose_map' )
+			->once()
+			->with( '#breadcrumb_search_result_format', '' );
+		$this->replacevar_handler->expects( 'compose_map' )
+			->once()
+			->with( '#breadcrumb_search_string', '' );
+		$this->replacevar_handler->expects( 'compose_map' )
+			->once()
+			->with( '#breadcrumb_separator', '' );
+		$this->replacevar_handler->expects( 'compose_map' )
+			->once()
+			->with( '#breadcrumb_taxonomy_title', '' );
+		$this->replacevar_handler->expects( 'compose_map' )
+			->once()
+			->with( '#taxonomy_title', '%%term_title%%' );
+
+		$this->mock_instance->expects( 'get_cursor_id' )
+			->once()
+			->andReturn( 'cursor_id' );
+
+		$this->import_cursor->expects( 'set_cursor' )
+			->once()
+			->with( 'cursor_id', '' );
+
+		$this->mock_instance->index();
+	}
+
+	/**
 	 * Data provider for test_map().
 	 *
 	 * @return array

--- a/tests/unit/services/importing/aioseo-replacevar-service-test.php
+++ b/tests/unit/services/importing/aioseo-replacevar-service-test.php
@@ -83,14 +83,6 @@ class Aioseo_Replacevar_Service_Test extends TestCase {
 				'expected_yoast_data' => '%%sitename%%',
 			],
 			[
-				'aioseo_data'         => '#breadcrumb_taxonomy_title',
-				'expected_yoast_data' => '',
-			],
-			[
-				'aioseo_data'         => '#breadcrumb_separator',
-				'expected_yoast_data' => '',
-			],
-			[
 				'aioseo_data'         => '#categories',
 				'expected_yoast_data' => '%%category%%',
 			],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* AIOSEO has a bug with the default replacevar tags of custom taxonomies where it adds some irrelevant tags which are always being translated into empty strings. This PR manages to transform those into empty strings while importing to Yoast SEO.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where some broken replacevar tags from AIOSEO in custom taxonomies would be transformed into Yoast tags

## Relevant technical choices:

* While still using partial mocks for testing the settings import actions, the unit tests for the new code should be improved with https://yoast.atlassian.net/browse/PLUGIN-1449

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate AIOSEO and WooCommerce
* Go to AIOSEO->Search Appearance page, in the Taxonomies tab and add the following in the `Product Categories` meta description:
* `Permalink`
* `Label`
* `Blog Page Title`
* `Category Title`
* `Author Display Name`
* `Author First Name`
* `Search Result Format`
* `404 Error Format`
* `Search String`
* `Archive format`
* `Post type name`
* Go to the frontend of a WooCommerce category and confirm that the above tags are showing as empty strings

Without this PR:
* After import, we are showing a `#breadcrump_<tag> for the respective tags
With this PR:
* After import, we are not showing anything for those tags
* Go to the frontend and confirm that, like AIOSEO, we show empty strings in the place where those tags existed in AIOSEO


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Quick smoke test of replacevar tags import in Taxonomies

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
