### PR TITLE
Removed index.php from list of pages that the "admin and dashboard" conditional fits

### DIFF
--- a/src/conditionals/yoast-admin-and-dashboard-conditional.php
+++ b/src/conditionals/yoast-admin-and-dashboard-conditional.php
@@ -25,7 +25,6 @@ class Yoast_Admin_And_Dashboard_Conditional implements Conditional {
 		}
 
 		$target_pages = [
-			'index.php',
 			'plugins.php',
 			'update-core.php',
 			'options-permalink.php',


### PR DESCRIPTION
I was tracking down a slowdown on a project and noticed that the "background indexing integration" also runs in the frontend. I noticed that the "admin and dashboard conditional" is true when on the home page, because then the $pagenow variable is set to "index.php". So I think this filename should not be in the list of "target pages".