### PR TITLE
Don't import social image url if auto image is selected and there is …

### DIFF
--- a/src/actions/importing/aioseo/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo/aioseo-posts-importing-action.php
@@ -586,6 +586,10 @@ class Aioseo_Posts_Importing_Action extends Abstract_Aioseo_Importing_Action {
 				$image_url = $this->social_images_provider->get_first_attached_image( $indexable->object_id );
 				break;
 			case 'auto':
+				if ( $this->social_images_provider->get_featured_image( $indexable->object_id ) ) {
+					// If there's a featured image, lets not import it, as our indexable calculation has already set that as active social image. That way we achieve dynamicality.
+					return null;
+				}
 				$image_url = $this->social_images_provider->get_auto_image( $indexable->object_id );
 				break;
 			case 'content':
@@ -595,7 +599,7 @@ class Aioseo_Posts_Importing_Action extends Abstract_Aioseo_Importing_Action {
 				$image_url = $aioseo_social_image_settings[ $mapping['social_setting_prefix_aioseo'] . 'image_custom_url' ];
 				break;
 			case 'featured':
-				return null; // Our auto-calculation when the indexable is built/updated will take care of it, so it's not needed to transfer any data now.
+				return null; // Our auto-calculation when the indexable was built/updated has taken care of it, so it's not needed to transfer any data now.
 			case 'author':
 				return null;
 			case 'custom':

--- a/src/services/importing/aioseo/aioseo-social-images-provider-service.php
+++ b/src/services/importing/aioseo/aioseo-social-images-provider-service.php
@@ -155,11 +155,7 @@ class Aioseo_Social_Images_Provider_Service {
 	 * @return string The url of the featured image.
 	 */
 	public function get_auto_image( $post_id ) {
-		$image = $this->get_featured_image( $post_id );
-
-		if ( ! $image ) {
-			$image = $this->get_first_attached_image( $post_id );
-		}
+		$image = $this->get_first_attached_image( $post_id );
 
 		if ( ! $image ) {
 			$image = $this->get_first_image_in_content( $post_id );

--- a/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
@@ -484,6 +484,11 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 			->with( 'https://example.com/image1.png', null )
 			->andReturn( 'https://example.com/image1.png' );
 
+		$this->social_images_provider->shouldReceive( 'get_featured_image' )
+			->once()
+			->with( 123 )
+			->andReturn( '' );
+
 		$this->social_images_provider->shouldReceive( 'get_auto_image' )
 			->once()
 			->with( 123 )
@@ -721,7 +726,7 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 	 * @dataProvider provider_social_image_url_import
 	 * @covers ::social_image_url_import
 	 */
-	public function test_social_image_url_import( $aioseo_social_image_settings, $mapping, $expected_url, $sanitize_url_times, $provider_method, $provider_times, $get_default_times, $social_setting ) {
+	public function test_social_image_url_import( $aioseo_social_image_settings, $mapping, $expected_url, $sanitize_url_times, $provider_method, $provider_times, $provider_result, $get_default_times, $social_setting ) {
 		$indexable      = Mockery::mock( Indexable_Mock::class );
 		$indexable->orm = Mockery::mock( ORM::class );
 
@@ -730,7 +735,7 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 		$this->social_images_provider->shouldReceive( $provider_method )
 			->times( $provider_times )
 			->with( 123 )
-			->andReturn( $expected_url );
+			->andReturn( $provider_result );
 
 		$this->social_images_provider->shouldReceive( 'get_default_custom_social_image' )
 			->times( $get_default_times )
@@ -748,7 +753,7 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 	}
 
 	/**
-	 * Data provider for test_transform_separator().
+	 * Data provider for test_social_image_url_import().
 	 *
 	 * @return array
 	 */
@@ -830,21 +835,21 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 		];
 
 		return [
-			[ $aioseo_og_custom_image, $open_graph_mapping, $image, 1, 'irrelevant', 0, 0, 'og' ],
-			[ $aioseo_og_attach, $open_graph_mapping, $image, 1, 'get_first_attached_image', 1, 0, 'og' ],
-			[ $aioseo_og_author, $open_graph_mapping, null, 0, 'irrelevant', 0, 0, 'og' ],
-			[ $aioseo_og_auto, $open_graph_mapping, $image, 1, 'get_auto_image', 1, 0, 'og' ],
-			[ $aioseo_og_content, $open_graph_mapping, $image, 1, 'get_first_image_in_content', 1, 0, 'og' ],
-			[ $aioseo_og_custom, $open_graph_mapping, null, 0, 'irrelevant', 0, 0, 'og' ],
-			[ $aioseo_og_featured, $open_graph_mapping, null, 0, 'irrelevant', 0, 0, 'og' ],
-			[ $aioseo_twitter_custom_image, $twitter_mapping, $image, 1, 'irrelevant', 0, 0, 'twitter' ],
-			[ $aioseo_twitter_attach, $twitter_mapping, $image, 1, 'get_first_attached_image', 1, 0, 'twitter' ],
-			[ $aioseo_twitter_author, $twitter_mapping, null, 0, 'irrelevant', 0, 0, 'twitter' ],
-			[ $aioseo_twitter_auto, $twitter_mapping, $image, 1, 'get_auto_image', 1, 0, 'twitter' ],
-			[ $aioseo_twitter_content, $twitter_mapping, $image, 1, 'get_first_image_in_content', 1, 0, 'twitter' ],
-			[ $aioseo_twitter_custom, $twitter_mapping, null, 0, 'irrelevant', 0, 0, 'twitter' ],
-			[ $aioseo_twitter_featured, $twitter_mapping, null, 0, 'irrelevant', 0, 0, 'og' ],
-			[ $aioseo_twitter_from_og, $twitter_mapping, $image, 1, 'irrelevant', 0, 0, 'og' ],
+			[ $aioseo_og_custom_image, $open_graph_mapping, $image, 1, 'irrelevant', 0, $image, 0, 'og' ],
+			[ $aioseo_og_attach, $open_graph_mapping, $image, 1, 'get_first_attached_image', 1, $image, 0, 'og' ],
+			[ $aioseo_og_author, $open_graph_mapping, null, 0, 'irrelevant', 0, 'irrelevant', 0, 'og' ],
+			[ $aioseo_og_auto, $open_graph_mapping, null, 0, 'get_featured_image', 1, 'https://example.com/featured-image.png', 0, 'og' ],
+			[ $aioseo_og_content, $open_graph_mapping, $image, 1, 'get_first_image_in_content', 1, $image, 0, 'og' ],
+			[ $aioseo_og_custom, $open_graph_mapping, null, 0, 'irrelevant', 0, 'irrelevant', 0, 'og' ],
+			[ $aioseo_og_featured, $open_graph_mapping, null, 0, 'irrelevant', 0, 'irrelevant', 0, 'og' ],
+			[ $aioseo_twitter_custom_image, $twitter_mapping, $image, 1, 'irrelevant', 0, $image, 0, 'twitter' ],
+			[ $aioseo_twitter_attach, $twitter_mapping, $image, 1, 'get_first_attached_image', 1, $image, 0, 'twitter' ],
+			[ $aioseo_twitter_author, $twitter_mapping, null, 0, 'irrelevant', 0, 'irrelevant', 0, 'twitter' ],
+			[ $aioseo_twitter_auto, $twitter_mapping, null, 0, 'get_featured_image', 1, 'https://example.com/featured-image.png', 0, 'twitter' ],
+			[ $aioseo_twitter_content, $twitter_mapping, $image, 1, 'get_first_image_in_content', 1, $image, 0, 'twitter' ],
+			[ $aioseo_twitter_custom, $twitter_mapping, null, 0, 'irrelevant', 0, 'irrelevant', 0, 'twitter' ],
+			[ $aioseo_twitter_featured, $twitter_mapping, null, 0, 'irrelevant', 0, 'irrelevant', 0, 'og' ],
+			[ $aioseo_twitter_from_og, $twitter_mapping, $image, 1, 'irrelevant', 0, 'irrelevant', 0, 'og' ],
 		];
 	}
 }

--- a/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posts-importing-action-test.php
@@ -720,6 +720,7 @@ class Aioseo_Posts_Importing_Action_Test extends TestCase {
 	 * @param int    $sanitize_url_times          The times we're sanitizing the retrieved url.
 	 * @param string $provider_method             The method we're using from the social images provider.
 	 * @param int    $provider_times              The times we're using the social images provider.
+	 * @param mixed  $provider_result             The result the social images provider returns.
 	 * @param int    $get_default_times           The times we're getting the default url.
 	 * @param string $social_setting              The social settings we use to get the default url.
 	 *


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to keep the dynamic behavior when a user has set `auto` as a og or twitter image and there is a featured image in the post. That is, if after the import, the user changes the featured-image, the og/twitter image should be updated to the new featured image

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the import of og and twitter image to retain the dynamic behavior when `First Available Image` image is selected for social images and there is a featured image

## Relevant technical choices:

* When for a post `First Available Image` is selected as the source of og/twitter image in AIOSEO *and* there is a featured image in the post, we don't import anything and we let the Yoast's inherent calculation of og/twitter images when the indexable is built, to set the og/twitter image from the featured image

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* With AIOSEO enabled, create a post and set in the Social tab for Facebook or Twitter, the `First Available Image` as the **Image Source**
* Make sure that the post has a featured image and then Save the post
* Go to Yoast->Tools->Import/Export and perform the AIOSEO import (if the feature flag is disabled, you won't be able to do so)
* Refresh the edit page of the post and confirm that no explicit image has been set in the Yoast's metabox, in the social tab
* Also go to the frontend of the post and confirm that the og/twitter image tag is being outputted by Yoast and that indeed contains the featured image URL.
* Now do the same but for a post that doesn't have a featured image.
* The logic here is that the og/twitter image should be an attached image and if that doesn't exist a image from the content.
* Verify that after the import the og/twitter image tag that is being outputted by Yoast is the same that it outputted by AIOSEO.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Og/Twitter image import but only for when `First Available Image` is selected. Everything else has stayed the same

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
