### PR TITLE
Remove QR code after print and only display if there is a URL

### DIFF
--- a/src/integrations/front-end/print-qrcode-embed.php
+++ b/src/integrations/front-end/print-qrcode-embed.php
@@ -53,10 +53,11 @@ class Print_QRCode_Embed implements Integration_Interface {
 	 */
 	public function generate_qr_code() {
 		$nonce = \wp_create_nonce( 'yoast_seo_qr_code' );
-		$url   = $this->meta_surface->for_current_page()->canonical;
+		$meta  = $this->meta_surface->for_current_page();
+		$url   = $meta->canonical;
 
 		if ( empty( $url ) ) {
-			return;
+			$url = $meta->indexable->permalink;
 		}
 
 		$alt_text  = __( 'QR Code for current page\'s URL.', 'wordpress-seo' );

--- a/src/integrations/front-end/print-qrcode-embed.php
+++ b/src/integrations/front-end/print-qrcode-embed.php
@@ -52,19 +52,28 @@ class Print_QRCode_Embed implements Integration_Interface {
 	 * @return void
 	 */
 	public function generate_qr_code() {
-		$nonce     = \wp_create_nonce( 'yoast_seo_qr_code' );
-		$url       = $this->meta_surface->for_current_page()->canonical;
+		$nonce = \wp_create_nonce( 'yoast_seo_qr_code' );
+		$url   = $this->meta_surface->for_current_page()->canonical;
+
+		if ( empty( $url ) ) {
+			return;
+		}
+
 		$alt_text  = __( 'QR Code for current page\'s URL.', 'wordpress-seo' );
 		$text      = __( 'Scan the QR code or go to the URL below to read this article online.', 'wordpress-seo' );
 		$image_url = \trailingslashit( \get_site_url() ) . '?nonce=' . $nonce . '&yoast_qr_code=' . rawurlencode( $url );
 		\printf(
-			'<script id="yoast_seo_print_qrcode">' .
+			'<script id="yoast_seo_print_qrcode_script">' .
 				'window.addEventListener( "beforeprint", function() {' .
 					'var div = document.createElement( "div" );' .
 					'div.innerHTML = "<img src=\"%4$s\" width=\"150\" height=\"150\" alt=\"%1$s\" /><p>%2$s<br/>%3$s</p>";' .
 					'div.style = "text-align:center;";' .
-					'var script = document.getElementById( "yoast_seo_print_qrcode" );' .
+					'div.id = "yoast_seo_print_qrcode";' .
+					'var script = document.getElementById( "yoast_seo_print_qrcode_script" );' .
 					'script.parentNode.insertBefore( div, script );' .
+				'} );' .
+				'window.addEventListener( "afterprint", function() {' .
+					'document.getElementById( "yoast_seo_print_qrcode" ).remove();' .
 				'} );' .
 			'</script>' . PHP_EOL,
 			\esc_attr( $alt_text ),


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the QR code not being removed after the print dialog is closed.
* Fixes a fatal error when attempting to display the QR code on pages that have no canonical.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to any page.
* Open the print dialog.
* You should see a QR code at the bottom.
* Close the dialog.
* You should not see a QR code at the bottom of the normal page.
* Go to a page which is noindexed.
* Open the print dialog.
* You should not see a QR code.
* There should be no errors in your console.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Printing QR codes at the bottom of the page.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://github.com/Yoast/wordpress-seo/pull/18089#issuecomment-1046806509
