### PR TITLE
Fix detecting images as external when they are not

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -253,7 +253,7 @@ script:
       travis_fold start "PHP.integration-tests" && travis_time_start
       vendor/bin/phpunit -c phpunit-integration.xml.dist
       travis_time_finish && travis_fold end "PHP.integration-tests"
-    elif [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]] && [[ $WP_VERSION == "5.9" || $WP_VERSION == "latest" || $WP_VERSION == "trunk" ]]; then
+    elif [[ "$PHPUNIT" == "1" ]] && [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]] && [[ ${WP_VERSION:0:3} == "5.9" || ${WP_VERSION:0:1} == "6" || $WP_VERSION == "trunk" ]]; then
       # PHP >= 8 with WP >= 5.9
       travis_fold start "PHP.integration-tests" && travis_time_start
       travis_retry composer remove --dev phpunit/phpunit --no-update --no-interaction &&

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -76,6 +76,7 @@ class WPSEO_Upgrade {
 			'17.2-RC0'   => 'upgrade_172',
 			'17.7.1-RC0' => 'upgrade_1771',
 			'17.9-RC0'   => 'upgrade_179',
+			'18.3-RC0'   => 'upgrade_183',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -860,6 +861,13 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_179() {
 		WPSEO_Options::set( 'wincher_integration_active', true );
+	}
+
+	/**
+	 * Performs the 18.3 upgrade routine.
+	 */
+	private function upgrade_183() {
+		$this->delete_post_meta( 'yoast-structured-data-blocks-images-cache' );
 	}
 
 	/**

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Helpers;
 
 use WPSEO_Image_Utils;
+use Yoast\WP\SEO\Models\SEO_Links;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
@@ -36,7 +37,14 @@ class Image_Helper {
 	 *
 	 * @var Options_Helper
 	 */
-	private $options;
+	private $options_helper;
+
+	/**
+	 * The URL helper.
+	 *
+	 * @var Url_Helper
+	 */
+	private $url_helper;
 
 	/**
 	 * Image_Helper constructor.
@@ -44,9 +52,14 @@ class Image_Helper {
 	 * @param Indexable_Repository $indexable_repository The indexable repository.
 	 * @param Options_Helper       $options              The options helper.
 	 */
-	public function __construct( Indexable_Repository $indexable_repository, Options_Helper $options ) {
+	public function __construct(
+		Indexable_Repository $indexable_repository,
+		Options_Helper $options,
+		Url_Helper $url_helper
+	) {
 		$this->indexable_repository = $indexable_repository;
-		$this->options              = $options;
+		$this->options_helper       = $options;
+		$this->url_helper           = $url_helper;
 	}
 
 	/**
@@ -281,7 +294,7 @@ class Image_Helper {
 		$url = \preg_replace( '/(.*)-\d+x\d+\.(jpeg|jpg|png|gif)$/', '$1.$2', $url );
 
 		// Don't try to do this for external URLs.
-		if ( \strpos( $url, \get_site_url() ) !== 0 ) {
+		if ( $this->url_helper->get_link_type( $url ) === SEO_Links::TYPE_EXTERNAL ) {
 			return 0;
 		}
 
@@ -325,15 +338,15 @@ class Image_Helper {
 	 * @return array|bool Array with image details when the image is found, boolean when it's not found.
 	 */
 	public function get_attachment_meta_from_settings( $setting ) {
-		$image_meta = $this->options->get( $setting . '_meta', false );
+		$image_meta = $this->options_helper->get( $setting . '_meta', false );
 		if ( ! $image_meta ) {
-			$image_id = $this->options->get( $setting . '_id', false );
+			$image_id = $this->options_helper->get( $setting . '_id', false );
 			if ( $image_id ) {
 				// There is not an option to put a URL in an image field in the settings anymore, only to upload it through the media manager.
 				// This means an attachment always exists, so doing this is only needed once.
 				$image_meta = $this->get_best_attachment_variation( $image_id );
 				if ( $image_meta ) {
-					$this->options->set( $setting . '_meta', $image_meta );
+					$this->options_helper->set( $setting . '_meta', $image_meta );
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an issue where HowTo images would not be optimized if they did not start with the site URL.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have a site URL that's different from your Home URL ( such as on yoast.com )
* Create a HowTo block, add an image to it and change the image's width.
* View that image on the frontend.
* It should be optimized with, among other things, the `loading="lazy"` attribute.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Images in structured data blocks when the site URL is different from the home URL.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
