### PR TITLE
Url_Helper check for wp_parse_url returning null

### DIFF
--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -100,13 +100,18 @@ class Url_Helper {
 	/**
 	 * Gets the path from the passed URL.
 	 *
-	 * @codeCoverageIgnore It only wraps a WordPress function.
-	 *
 	 * @param string $url The URL to get the path from.
 	 *
 	 * @return string The path of the URL. Returns an empty string if URL parsing fails.
 	 */
 	public function get_url_path( $url ) {
+		if ( \is_string( $url ) === false
+			&& \is_object( $url ) === false
+			|| ( \is_object( $url ) === true && \method_exists( $url, '__toString' ) === false )
+		) {
+			return '';
+		}
+
 		return (string) \wp_parse_url( $url, \PHP_URL_PATH );
 	}
 
@@ -120,7 +125,7 @@ class Url_Helper {
 	public function get_extension_from_url( $url ) {
 		$path = $this->get_url_path( $url );
 
-		if ( $path === '' || $path === null ) {
+		if ( $path === '' ) {
 			return '';
 		}
 

--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -120,7 +120,7 @@ class Url_Helper {
 	public function get_extension_from_url( $url ) {
 		$path = $this->get_url_path( $url );
 
-		if ( $path === '' ) {
+		if ( $path === '' || $path === null ) {
 			return '';
 		}
 

--- a/tests/unit/helpers/url-helper-test.php
+++ b/tests/unit/helpers/url-helper-test.php
@@ -107,6 +107,23 @@ class Url_Helper_Test extends TestCase {
 	}
 
 	/**
+	 * Tests retrieving of the file extension.
+	 *
+	 * @covers ::get_extension_from_url
+	 * @covers ::get_url_path
+	 */
+	public function test_get_extension_from_url_null() {
+		Monkey\Functions\expect( 'wp_parse_url' )
+			->with( 'https://example.com', \PHP_URL_PATH )
+			->andReturn( null );
+
+		$expected = '';
+		$actual   = $this->instance->get_extension_from_url( 'https://example.com' );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
 	 * Tests retrieving of the file extension with no path present.
 	 *
 	 * @covers ::get_extension_from_url

--- a/tests/unit/helpers/url-helper-test.php
+++ b/tests/unit/helpers/url-helper-test.php
@@ -4,8 +4,10 @@ namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 
 use Brain\Monkey;
 use Mockery;
+use stdClass;
 use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Models\SEO_Links;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Stringable_Object_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -90,10 +92,88 @@ class Url_Helper_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that get_url_path() always returns a string and handles unexpected input gracefully.
+	 *
+	 * @dataProvider data_get_url_path
+	 *
+	 * @covers ::get_url_path
+	 *
+	 * @param mixed  $url_input Input to pass to the get_url_path() function.
+	 * @param string $expected  Output expected from the get_url_path() function.
+	 *
+	 * @return void
+	 */
+	public function test_get_url_path( $url_input, $expected ) {
+		Monkey\Functions\stubs(
+			[
+				'wp_parse_url' => static function( $url, $component ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- Mocking wp_parse_url(), this is fine.
+					return \parse_url( $url, $component );
+				},
+			]
+		);
+
+		$this->assertSame( $expected, $this->instance->get_url_path( $url_input ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_get_url_path() {
+		return [
+			'URL is an empty string' => [
+				'url_input' => '',
+				'expected'  => '',
+			],
+			'URL with domain, no path' => [
+				'url_input' => 'https://example.com',
+				'expected'  => '',
+			],
+			'URL with domain, path is only slash' => [
+				'url_input' => 'https://example.com/',
+				'expected'  => '/',
+			],
+			'URL with domain and full path' => [
+				'url_input' => 'https://example.com/this/is/the/path',
+				'expected'  => '/this/is/the/path',
+			],
+			'URL with domain and full path and trailing slash' => [
+				'url_input' => 'https://example.com/this/is/the/path/',
+				'expected'  => '/this/is/the/path/',
+			],
+			'URL with domain, no path via a stringable object' => [
+				'url_input' => new Stringable_Object_Mock( 'https://example.com' ),
+				'expected'  => '',
+			],
+			'URL with domain and full path via a stringable object' => [
+				'url_input' => new Stringable_Object_Mock( 'https://example.com/this/is/the/path' ),
+				'expected'  => '/this/is/the/path',
+			],
+			'URL is not a string: null' => [
+				'url_input' => null,
+				'expected'  => '',
+			],
+			'URL is not a string: boolean true' => [
+				'url_input' => true,
+				'expected'  => '',
+			],
+			'URL is not a string: array' => [
+				'url_input' => [],
+				'expected'  => '',
+			],
+			'URL is not a string: object, but not stringable' => [
+				'url_input' => new stdClass(),
+				'expected'  => '',
+			],
+		];
+	}
+
+	/**
 	 * Tests retrieving of the file extension.
 	 *
 	 * @covers ::get_extension_from_url
-	 * @covers ::get_url_path
 	 */
 	public function test_get_extension_from_url() {
 		Monkey\Functions\expect( 'wp_parse_url' )
@@ -107,27 +187,9 @@ class Url_Helper_Test extends TestCase {
 	}
 
 	/**
-	 * Tests retrieving of the file extension.
-	 *
-	 * @covers ::get_extension_from_url
-	 * @covers ::get_url_path
-	 */
-	public function test_get_extension_from_url_null() {
-		Monkey\Functions\expect( 'wp_parse_url' )
-			->with( 'https://example.com', \PHP_URL_PATH )
-			->andReturn( null );
-
-		$expected = '';
-		$actual   = $this->instance->get_extension_from_url( 'https://example.com' );
-
-		$this->assertEquals( $expected, $actual );
-	}
-
-	/**
 	 * Tests retrieving of the file extension with no path present.
 	 *
 	 * @covers ::get_extension_from_url
-	 * @covers ::get_url_path
 	 */
 	public function test_get_extension_from_url_no_path() {
 		Monkey\Functions\expect( 'wp_parse_url' )
@@ -144,7 +206,6 @@ class Url_Helper_Test extends TestCase {
 	 * Tests retrieving of the file extension with no extension present.
 	 *
 	 * @covers ::get_extension_from_url
-	 * @covers ::get_url_path
 	 */
 	public function test_get_extension_from_url_no_extension() {
 		Monkey\Functions\expect( 'wp_parse_url' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Workshop PHP 8.1 compatibility 2022-02-24

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a check and unit test for the Url_Helper, to cover when wp_parse_url returns null

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Tests should run and pass.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
