### PR TITLE
Dupp 297 fix how to images custom width

### DIFF
--- a/src/integrations/blocks/structured-data-blocks.php
+++ b/src/integrations/blocks/structured-data-blocks.php
@@ -218,8 +218,10 @@ class Structured_Data_Blocks implements Integration_Interface {
 				if ( $attachment_id === 0 ) {
 					return $matches[0];
 				}
+
 				$image_size  = 'full';
 				$image_style = [ 'style' => 'max-width: 100%; height: auto;' ];
+
 				\preg_match( '/style="[^"]*width:\s*(\d+)px[^"]*"/', $matches[0], $style_matches );
 				if ( $style_matches && isset( $style_matches[1] ) ) {
 					$width     = (int) $style_matches[1];

--- a/src/integrations/blocks/structured-data-blocks.php
+++ b/src/integrations/blocks/structured-data-blocks.php
@@ -218,10 +218,8 @@ class Structured_Data_Blocks implements Integration_Interface {
 				if ( $attachment_id === 0 ) {
 					return $matches[0];
 				}
-
 				$image_size  = 'full';
 				$image_style = [ 'style' => 'max-width: 100%; height: auto;' ];
-
 				\preg_match( '/style="[^"]*width:\s*(\d+)px[^"]*"/', $matches[0], $style_matches );
 				if ( $style_matches && isset( $style_matches[1] ) ) {
 					$width     = (int) $style_matches[1];

--- a/src/integrations/blocks/structured-data-blocks.php
+++ b/src/integrations/blocks/structured-data-blocks.php
@@ -218,7 +218,8 @@ class Structured_Data_Blocks implements Integration_Interface {
 				if ( $attachment_id === 0 ) {
 					return $matches[0];
 				}
-				$image_size = 'full';
+				$image_size  = 'full';
+				$image_style = [ 'style' => 'max-width: 100%; height: auto;' ];
 				\preg_match( '/style="[^"]*width:\s*(\d+)px[^"]*"/', $matches[0], $style_matches );
 				if ( $style_matches && isset( $style_matches[1] ) ) {
 					$width     = (int) $style_matches[1];
@@ -228,6 +229,7 @@ class Structured_Data_Blocks implements Integration_Interface {
 						$height       = ( $width * $aspect_ratio );
 						$image_size   = [ $width, $height ];
 					}
+					$image_style = '';
 				}
 
 				/**
@@ -249,7 +251,7 @@ class Structured_Data_Blocks implements Integration_Interface {
 					$attachment_id,
 					$image_size,
 					false,
-					[ 'style' => 'max-width: 100%; height: auto;' ]
+					$image_style
 				);
 
 				if ( empty( $image_html ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix a bug in the Twenty Twenty-One theme, where setting a custom width in a HowTo image wouldn't be applied in the frontend

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where HowTo images with custom width would lose their custom width in the Twenty Twenty-One theme.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have the Twenty Twenty-One theme active and create a new post
* In the post add a HowTo block with an image in one of the steps.
* After adding the image, click on it and add a custom width that's lower than the width of the image.
* Go to the frontend
Without this PR:
* The image would be shown in its original width, ignoring the width we set in the edit post page
With this PR:
* The image would be shown in the width we set it to be in the the edit post page.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Regression test https://github.com/Yoast/wordpress-seo/pull/18077/files

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
