### PR TITLE
Change Indexation step success alert copy

### DIFF
--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -358,9 +358,17 @@ function calculateInitialState( windowObject, isStepFinished ) {
 		savedSteps: [],
 	};
 }
+
+/**
+ * A function that returns true for completed indexingstates.
+ *
+ * @param {string} indexingState The indexation state.
+ *
+ * @returns {bool} Whether indexation is done.
+ */
 function isIndexationDone( indexingState ) {
 	return [ "completed", "already_done" ].includes( indexingState );
-};
+}
 
 /* eslint-enable max-len, react/prop-types */
 

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -358,6 +358,9 @@ function calculateInitialState( windowObject, isStepFinished ) {
 		savedSteps: [],
 	};
 }
+function isIndexationDone( indexingState ) {
+	return [ "completed", "already_done" ].includes( indexingState );
+};
 
 /* eslint-enable max-len, react/prop-types */
 
@@ -376,7 +379,8 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 	const [ state, dispatch ] = useReducer( configurationWorkoutReducer, {
 		...calculateInitialState( window.wpseoWorkoutsData.configuration, isStepFinished ),
 	} );
-	const [ indexingState, setIndexingState ] = useState( () => window.yoastIndexingData.amount === "0" ? "completed" : "idle" );
+	const [ indexingState, setIndexingState ] = useState( () => window.yoastIndexingData.amount === "0" ? "already_done" : "idle" );
+	console.log( indexingState );
 	const [ siteRepresentationEmpty, setSiteRepresentationEmpty ] = useState( false );
 	const [ showRunIndexationAlert, setShowRunIndexationAlert ] = useState( false );
 	const steps = STEPS.configuration;
@@ -430,7 +434,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 	function isStepReady( stepNumber ) {
 		switch ( stepNumber ) {
 			case 1:
-				return [ "in_progress", "completed" ].includes( indexingState );
+				return [ "in_progress", "completed", "already_done" ].includes( indexingState );
 			case 2:
 				if ( state.companyOrPerson === "company" ) {
 					return Boolean( state.companyLogo && state.companyName );
@@ -440,7 +444,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 			case 4:
 				return true;
 			case 5:
-				return [ isStep1Finished, isStep2Finished, isStep3Finished, isStep4Finished ].every( Boolean ) && indexingState === "completed";
+				return [ isStep1Finished, isStep2Finished, isStep3Finished, isStep4Finished ].every( Boolean ) && isIndexationDone( indexingState );
 			default:
 				return false;
 		}
@@ -742,7 +746,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 							</EditButton>
 						</Step.Header>
 						<Step.Content>
-							<IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } showRunIndexationAlert={ showRunIndexationAlert } />
+							<IndexationStep setIndexingState={ setIndexingState } indexingState={ indexingState } showRunIndexationAlert={ showRunIndexationAlert }  isStepperFinished={ isStepperFinished } />
 							<ContinueButton
 								additionalClasses="yst-mt-12"
 								beforeGo={ beforeContinueIndexationStep }
@@ -872,7 +876,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 								indexingState={ indexingState }
 							/>
 						</div>
-						{ ( window.wpseoWorkoutsData.shouldUpdatePremium && indexingState !== "completed" ) && <Alert type="warning">
+						{ ( window.wpseoWorkoutsData.shouldUpdatePremium && ! isIndexationDone( indexingState ) ) && <Alert type="warning">
 							<p>{
 								// translators: %1$s is replaced by a version number.
 								sprintf( __( "This workout step is currently disabled, because you're not running the latest version of Yoast SEO Premium. " +
@@ -1099,7 +1103,7 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 						onFinishClick={ toggleConfigurationWorkout }
 						isFinished={ false }
 						isReady={ isWorkoutFinished ? false : isStepReady( 5 ) }
-						additionalButtonProps={ { disabled: indexingState !== "completed" || ! isTrackingOptionSelected } }
+						additionalButtonProps={ { disabled: ! isIndexationDone( indexingState ) || ! isTrackingOptionSelected } }
 					>
 						{ indexingState !== "completed" && <Alert type="warning">
 							{ indexingState === "idle" && __( "Before you finish this workout, please start the SEO data optimization in step 1 and wait until it is completed...", "wordpress-seo" ) }

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -380,7 +380,6 @@ export function ConfigurationWorkout( { finishSteps, reviseStep, toggleWorkout, 
 		...calculateInitialState( window.wpseoWorkoutsData.configuration, isStepFinished ),
 	} );
 	const [ indexingState, setIndexingState ] = useState( () => window.yoastIndexingData.amount === "0" ? "already_done" : "idle" );
-	console.log( indexingState );
 	const [ siteRepresentationEmpty, setSiteRepresentationEmpty ] = useState( false );
 	const [ showRunIndexationAlert, setShowRunIndexationAlert ] = useState( false );
 	const steps = STEPS.configuration;

--- a/packages/js/src/workouts/tailwind-components/Stepper.js
+++ b/packages/js/src/workouts/tailwind-components/Stepper.js
@@ -203,12 +203,12 @@ Content.propTypes = {
  *
  * @returns {WPElement} The Stepper component.
  */
-export default function Stepper( { children, setActiveStepIndex, activeStepIndex } ) {
+export default function Stepper( { children, setActiveStepIndex, activeStepIndex, isStepperFinished } ) {
 	return (
 		<ol>
 			{ children.map( ( child, stepIndex ) => {
 				return <li key={ `${ child.props.name }-${ stepIndex }` } className={ ( stepIndex === children.length - 1 ? "" : "yst-pb-8" ) + " yst-mb-0 yst-relative" }>
-					<StepperContext.Provider value={ { stepIndex, activeStepIndex, setActiveStepIndex, lastStepIndex: children.length - 1 } }>
+					<StepperContext.Provider value={ { stepIndex, activeStepIndex, setActiveStepIndex, lastStepIndex: children.length - 1, isStepperFinished } }>
 						{ child }
 					</StepperContext.Provider>
 				</li>;
@@ -220,7 +220,12 @@ export default function Stepper( { children, setActiveStepIndex, activeStepIndex
 Stepper.propTypes = {
 	setActiveStepIndex: PropTypes.func.isRequired,
 	activeStepIndex: PropTypes.number.isRequired,
+	isStepperFinished: PropTypes.bool,
 	children: PropTypes.node.isRequired,
+};
+
+Stepper.defaultProps = {
+	isStepperFinished: false,
 };
 
 Step.Content = Content;

--- a/packages/js/src/workouts/tailwind-components/Stepper.js
+++ b/packages/js/src/workouts/tailwind-components/Stepper.js
@@ -208,7 +208,9 @@ export default function Stepper( { children, setActiveStepIndex, activeStepIndex
 		<ol>
 			{ children.map( ( child, stepIndex ) => {
 				return <li key={ `${ child.props.name }-${ stepIndex }` } className={ ( stepIndex === children.length - 1 ? "" : "yst-pb-8" ) + " yst-mb-0 yst-relative" }>
-					<StepperContext.Provider value={ { stepIndex, activeStepIndex, setActiveStepIndex, lastStepIndex: children.length - 1, isStepperFinished } }>
+					<StepperContext.Provider
+						value={ { stepIndex, activeStepIndex, setActiveStepIndex, lastStepIndex: children.length - 1, isStepperFinished } }
+					>
 						{ child }
 					</StepperContext.Provider>
 				</li>;

--- a/packages/js/src/workouts/tailwind-components/steps/indexation/ConfigurationIndexation.js
+++ b/packages/js/src/workouts/tailwind-components/steps/indexation/ConfigurationIndexation.js
@@ -18,6 +18,7 @@ window.yoast.indexing = window.yoast.indexing || {};
  * @param {function} props.indexingStateCallback The function to call back on state updates.
  * @param {Boolean}  props.isEnabled             Whether the indexation component should be real or a dummy.
  * @param {string}   props.indexingState         The state of the indexation.
+ * @param {Boolean}  props.isStepperFinished     Whether the stepper has been completed.
  *
  * @returns {WPElement} A wrapped Indexation for the first-time configuration.
  */
@@ -63,10 +64,12 @@ ConfigurationIndexation.propTypes = {
 	indexingStateCallback: PropTypes.func.isRequired,
 	indexingState: PropTypes.string.isRequired,
 	isEnabled: PropTypes.bool,
+	isStepperFinished: PropTypes.bool,
 };
 
 ConfigurationIndexation.defaultProps = {
 	isEnabled: true,
+	isStepperFinished: false,
 };
 
 /**

--- a/packages/js/src/workouts/tailwind-components/steps/indexation/ConfigurationIndexation.js
+++ b/packages/js/src/workouts/tailwind-components/steps/indexation/ConfigurationIndexation.js
@@ -1,5 +1,9 @@
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
+import { Transition } from "@headlessui/react";
+
+import Indexation from "./Indexation";
+import Alert from "./alert";
 
 import Indexation from "./Indexation";
 import Alert from "../../base/alert";
@@ -20,11 +24,11 @@ window.yoast.indexing = window.yoast.indexing || {};
  *
  * @returns {WPElement} A wrapped Indexation for the first-time configuration.
  */
-export function ConfigurationIndexation( { indexingStateCallback, indexingState, isEnabled } ) {
+export function ConfigurationIndexation( { indexingStateCallback, indexingState, isEnabled, isStepperFinished } ) {
 	if ( ! isEnabled ) {
 		if ( indexingState === "completed" ) {
 			return <Alert type="success">
-				{ __( "We’ve already successfully analyzed your site. You can move on to the next step.", "wordpress-seo" ) }
+				{ __( "We've already successfully analyzed your site. You can move on to the next step.", "wordpress-seo" ) }
 			</Alert>;
 		}
 		return <button
@@ -39,7 +43,23 @@ export function ConfigurationIndexation( { indexingStateCallback, indexingState,
 		preIndexingActions={ preIndexingActions }
 		indexingActions={ indexingActions }
 		indexingStateCallback={ indexingStateCallback }
-	/>;
+	>
+		<Transition
+			unmount={ false }
+			appear={ true }
+			show={ [ "completed", "already_done" ].includes( indexingState ) }
+			enter="yst-transition-opacity yst-duration-1000"
+			enterFrom="yst-opacity-0"
+			enterTo="yst-opacity-100"
+		>
+			<Alert type="success">
+				{ indexingState === "already_done" && ! isStepperFinished
+					? __( "We've already successfully analyzed your site. You can move on to the next step.", "wordpress-seo" )
+					: __( "We've successfully analyzed your site!", "wordpress-seo" )
+				}
+			</Alert>
+		</Transition>
+	</Indexation>;
 }
 
 ConfigurationIndexation.propTypes = {

--- a/packages/js/src/workouts/tailwind-components/steps/indexation/ConfigurationIndexation.js
+++ b/packages/js/src/workouts/tailwind-components/steps/indexation/ConfigurationIndexation.js
@@ -3,9 +3,6 @@ import { __ } from "@wordpress/i18n";
 import { Transition } from "@headlessui/react";
 
 import Indexation from "./Indexation";
-import Alert from "./alert";
-
-import Indexation from "./Indexation";
 import Alert from "../../base/alert";
 
 const preIndexingActions = {};

--- a/packages/js/src/workouts/tailwind-components/steps/indexation/Indexation.js
+++ b/packages/js/src/workouts/tailwind-components/steps/indexation/Indexation.js
@@ -223,7 +223,7 @@ export class Indexation extends Component {
 			return;
 		}
 
-		this.props.indexingStateCallback( this.state.amount === 0 ? "completed" : this.state.state );
+		this.props.indexingStateCallback( this.state.amount === 0 ? "already_done" : this.state.state );
 
 		const shouldStart = new URLSearchParams( window.location.search ).get( "start-indexation" ) === "true";
 
@@ -390,21 +390,7 @@ export class Indexation extends Component {
 
 		return (
 			<div className="yst-relative">
-				<Transition
-					unmount={ false }
-					appear={ true }
-					show={ this.isState( STATE.COMPLETED ) }
-					enter="yst-transition-opacity yst-duration-1000"
-					enterFrom="yst-opacity-0"
-					enterTo="yst-opacity-100"
-				>
-					<Alert type="success">{ __( "We’ve successfully analyzed your site!", "wordpress-seo" ) }</Alert>
-				</Transition>
-				{ ( this.isState( STATE.IDLE ) && this.state.amount === 0 ) &&
-					<Alert type="success">
-						{ __( "We’ve already successfully analyzed your site. You can move on to the next step.", "wordpress-seo" ) }
-					</Alert>
-				}
+				{ this.props.children }
 				<Transition
 					unmount={ false }
 					show={ this.isState( STATE.IN_PROGRESS ) || ( this.isState( STATE.IDLE ) && this.state.amount > 0 ) }
@@ -428,12 +414,14 @@ Indexation.propTypes = {
 	indexingActions: PropTypes.object,
 	preIndexingActions: PropTypes.object,
 	indexingStateCallback: PropTypes.func,
+	children: PropTypes.node,
 };
 
 Indexation.defaultProps = {
 	indexingActions: {},
 	preIndexingActions: {},
 	indexingStateCallback: () => {},
+	children: null,
 };
 
 export default Indexation;

--- a/packages/js/src/workouts/tailwind-components/steps/indexation/Indexation.js
+++ b/packages/js/src/workouts/tailwind-components/steps/indexation/Indexation.js
@@ -267,7 +267,7 @@ export class Indexation extends Component {
 	 */
 	renderFirstIndexationNotice() {
 		return (
-			<Alert type={ "info" }>
+			<Alert type={ "info" } className="yst-mb-6">
 				{ __( "This feature includes and replaces the Text Link Counter and Internal Linking Analysis", "wordpress-seo" ) }
 			</Alert>
 		);

--- a/packages/js/src/workouts/tailwind-components/steps/indexation/indexation-step.js
+++ b/packages/js/src/workouts/tailwind-components/steps/indexation/indexation-step.js
@@ -5,12 +5,7 @@ import PropTypes from "prop-types";
 import Alert, { FadeInAlert } from "../../base/alert";
 import { addLinkToString } from "../../../../helpers/stringHelpers.js";
 import { ConfigurationIndexation } from "./ConfigurationIndexation";
-<<<<<<< HEAD:packages/js/src/workouts/tailwind-components/steps/indexation/indexation-step.js
 import { ReactComponent as WorkoutStartImage } from "../../../../../images/motivated_bubble_woman_1_optim.svg";
-=======
-import { ReactComponent as WorkoutStartImage } from "../../../images/motivated_bubble_woman_1_optim.svg";
-import { useStepperContext } from "./Stepper";
->>>>>>> 1dfd03ec32 (Add fourth state to indexingstate WIP):packages/js/src/workouts/tailwind-components/indexation-step.js
 
 /* eslint-disable complexity */
 
@@ -20,10 +15,11 @@ import { useStepperContext } from "./Stepper";
  * @param {string}   indexingState          The indexing state.
  * @param {Function} setIndexingState       A callback to set the indexing state.
  * @param {boolean}  showRunIndexationAlert Whether the alert to run indexation needs to be shown.
+ * @param {boolean}  isStepperFinished      Whether the stepper is finished.
  *
  * @returns {WPElement} The indexation step.
  */
-export default function IndexationStep( { indexingState, setIndexingState, showRunIndexationAlert } ) {
+export default function IndexationStep( { indexingState, setIndexingState, showRunIndexationAlert, isStepperFinished } ) {
 	return <Fragment>
 		<div className="yst-flex yst-flex-row yst-justify-between yst-flex-wrap yst-mb-8">
 			<p className="yst-text-sm yst-whitespace-pre-line yst-w-[463px]">
@@ -91,7 +87,9 @@ IndexationStep.propTypes = {
 	indexingState: PropTypes.string.isRequired,
 	setIndexingState: PropTypes.func.isRequired,
 	showRunIndexationAlert: PropTypes.bool,
+	isStepperFinished: PropTypes.bool,
 };
 IndexationStep.defaultProps = {
 	showRunIndexationAlert: false,
+	isStepperFinished: false,
 };

--- a/packages/js/src/workouts/tailwind-components/steps/indexation/indexation-step.js
+++ b/packages/js/src/workouts/tailwind-components/steps/indexation/indexation-step.js
@@ -5,8 +5,14 @@ import PropTypes from "prop-types";
 import Alert, { FadeInAlert } from "../../base/alert";
 import { addLinkToString } from "../../../../helpers/stringHelpers.js";
 import { ConfigurationIndexation } from "./ConfigurationIndexation";
+<<<<<<< HEAD:packages/js/src/workouts/tailwind-components/steps/indexation/indexation-step.js
 import { ReactComponent as WorkoutStartImage } from "../../../../../images/motivated_bubble_woman_1_optim.svg";
+=======
+import { ReactComponent as WorkoutStartImage } from "../../../images/motivated_bubble_woman_1_optim.svg";
+import { useStepperContext } from "./Stepper";
+>>>>>>> 1dfd03ec32 (Add fourth state to indexingstate WIP):packages/js/src/workouts/tailwind-components/indexation-step.js
 
+/* eslint-disable complexity */
 
 /**
  * The indexation step.
@@ -42,6 +48,7 @@ export default function IndexationStep( { indexingState, setIndexingState, showR
 				indexingStateCallback={ setIndexingState }
 				isEnabled={ ! window.wpseoWorkoutsData.shouldUpdatePremium }
 				indexingState={ indexingState }
+				isStepperFinished={ isStepperFinished }
 			/>
 		</div>
 		{ ( window.wpseoWorkoutsData.shouldUpdatePremium && indexingState !== "completed" ) && <Alert type="warning">


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* If indexation is already done, but the stepper has not yet been finished, the copy needed to be different.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changed the copy of the success alert when indexation had already been done and the configuration was not yet finished.

## Relevant technical choices:

* Introduced a fourth state to distinguish between "just finished" ( `completed` ) and "already done" ( `already_done` )

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have Yoast Test Helper active, reset indexation
* Run indexation in the configuration stepper
* When it completes, the text should read: We’ve succesfully analyzed your site
* Refresh the page (as if you got here with indexation already done), text should be: We've already successfully analyzed your site. You can move on to the next step.
* Go forward a step, save it, and refresh.
* Go back to the indexation step, the copy is now: We've already successfully analyzed your site. You can move on to the next step.
* Finish the stepper, click edit on the indexation step: it should read: We’ve succesfully analyzed your site
* Refresh the page, click edit on the indexation step: it should read We’ve succesfully analyzed your site




### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-276
