### PR TITLE
Fix URL and permalink preview

### DIFF
--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -15,6 +15,8 @@ export const DOM_IDS = {
 	POST_FEATURED_IMAGE_REMOVE: "remove-post-thumbnail",
 	POST_SLUG_NEW: "new-post-slug",
 	POST_SLUG_EDIT: "editable-post-name-full",
+	POST_SLUG: "editable-post-name",
+	POST_NAME: "post_name",
 	POST_SLUG_EDIT_PARENT: "edit-slug-box",
 	POST_DATE_MONTH: "mm",
 	POST_DATE_DAY: "jj",
@@ -281,18 +283,56 @@ export const getTermIsCornerstone = () => isEqual( get( document.getElementById(
 export const getPostNewSlug = () => get( document.getElementById( DOM_IDS.POST_SLUG_NEW ), "value" );
 
 /**
- * Gets the post edit slug from the document.
+ * Gets the post edit full length slug from the document.
  *
- * @returns {string} The post edit slug or an empty string.
+ * @returns {string} The post edit full length slug or an empty string.
  */
-export const getPostEditSlug = () => get( document.getElementById( DOM_IDS.POST_SLUG_EDIT ), "textContent" );
+export const getPostEditSlugFull = () => get( document.getElementById( DOM_IDS.POST_SLUG_EDIT ), "textContent" );
+
+/**
+ * Sets the post edit full length slug value prop on its DOM element.
+ *
+ * @returns {HTMLElement} The DOM element.
+ */
+export const setPostSlugFull = createSetDomElementProp( DOM_IDS.POST_SLUG_EDIT, "textContent" );
+
+/**
+ * Gets the post edit shortened slug from the document.
+ * When the slug is too long, WordPress shortens it for the preview purpose.
+ *
+ * @returns {string} The post edit shortened slug or an empty string.
+ */
+export const getPostEditSlug = () => get( document.getElementById( DOM_IDS.POST_SLUG ), "textContent" );
+
+/**
+ * Sets the post edit shortened slug value prop on its DOM element.
+ *
+ * @returns {HTMLElement} The DOM element.
+ */
+export const setPostSlug = createSetDomElementProp( DOM_IDS.POST_SLUG, "textContent" );
+
+/**
+ * Gets the post name from the document.
+ *
+ * @returns {string} The post name or an empty string.
+ */
+export const getPostName = () => get( document.getElementById( DOM_IDS.POST_NAME ), "value" );
+
+/**
+ * Sets the post name value prop on its DOM element.
+ *
+ * @returns {HTMLElement} The DOM element.
+ */
+export const setPostName = createSetDomElementProp( DOM_IDS.POST_NAME );
 
 /**
  * Gets the post slug from the document.
  *
  * @returns {string} The post slug or an empty string.
  */
-export const getPostSlug = () => getPostNewSlug() || getPostEditSlug();
+export const getPostSlug = () => {
+	return getPostNewSlug() || getPostEditSlugFull() || "";
+};
 
 /**
  * Gets the term slug from the document.

--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -341,6 +341,13 @@ export const getPostSlug = () => {
 export const getTermSlug = createGetDomElementProp( DOM_IDS.TERM_SLUG );
 
 /**
+ * Sets the term slug value prop on its DOM element.
+ *
+ * @returns {HTMLElement} The DOM element.
+ */
+export const setTermSlug = createSetDomElementProp( DOM_IDS.TERM_SLUG );
+
+/**
  * Gets the post permalink from the document.
  *
  * @returns {string} The post permalink or an empty string.

--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -1,6 +1,5 @@
 /* global moment */
 import { flow, get, isEqual, set } from "lodash";
-import { excerptFromContent } from "../../helpers/replacementVariableHelpers";
 import { getContentTinyMce } from "../../lib/tinymce";
 import getContentLocale from "../../analysis/getContentLocale";
 

--- a/packages/js/src/classic-editor/watcher.js
+++ b/packages/js/src/classic-editor/watcher.js
@@ -334,6 +334,7 @@ const syncTermToStore = () => {
 const syncStoreToTerm = () => {
 	const selectors = select( SEO_STORE_NAME );
 	// Sync simple store changes to hidden inputs.
+	createDomSync( selectors.selectSlug, { domGet: dom.getTermSlug, domSet: dom.setTermSlug }, "slug" );
 	createDomSync( selectors.selectSeoTitle, { domGet: dom.getTermSeoTitle, domSet: dom.setTermSeoTitle }, "seoTitle" );
 	createDomSync( selectors.selectMetaDescription, { domGet: dom.getTermMetaDescription, domSet: dom.setTermMetaDescription }, "metaDescription" );
 	createDomSync( selectors.selectKeyphrase, { domGet: dom.getTermFocusKeyphrase, domSet: dom.setTermFocusKeyphrase }, "focusKeyphrase" );

--- a/packages/js/src/classic-editor/watcher.js
+++ b/packages/js/src/classic-editor/watcher.js
@@ -277,6 +277,9 @@ const syncPostToStore = () => {
 const syncStoreToPost = () => {
 	const selectors = select( SEO_STORE_NAME );
 	// Sync simple store changes to hidden inputs.
+	createDomSync( selectors.selectSlug, { domGet: dom.getPostEditSlugFull, domSet: dom.setPostSlugFull }, "slug" );
+	createDomSync( selectors.selectSlug, { domGet: dom.getPostEditSlug, domSet: dom.setPostSlug }, "shortSlug" );
+	createDomSync( selectors.selectSlug, { domGet: dom.getPostName, domSet: dom.setPostName }, "postName" );
 	createDomSync( selectors.selectSeoTitle, { domGet: dom.getPostSeoTitle, domSet: dom.setPostSeoTitle }, "seoTitle" );
 	createDomSync( selectors.selectMetaDescription, { domGet: dom.getPostMetaDescription, domSet: dom.setPostMetaDescription }, "metaDescription" );
 	createDomSync( selectors.selectKeyphrase, { domGet: dom.getPostFocusKeyphrase, domSet: dom.setPostFocusKeyphrase }, "focusKeyphrase" );

--- a/packages/js/tests/classic-editor/helpers/dom.test.js
+++ b/packages/js/tests/classic-editor/helpers/dom.test.js
@@ -73,3 +73,57 @@ describe( "a test for retrieving categories from the DOM", () => {
 		expect( dom.getPostCategories() ).toEqual( [ ] );
 	} );
 } );
+
+describe( "a test for retrieving post slugs from the DOM", () => {
+	const fullLengthSlugElement = document.createElement( "span" );
+	fullLengthSlugElement.setAttribute( "id", "editable-post-name-full" );
+
+	const fullLengthSlugText = document.createTextNode( "best-cat-food" );
+	fullLengthSlugElement.appendChild( fullLengthSlugText );
+
+	const shortSlugElement = document.createElement( "span" );
+	shortSlugElement.setAttribute( "id", "editable-post-name" );
+
+	const shortSlugText = document.createTextNode( "best-cat" );
+	shortSlugElement.appendChild( shortSlugText );
+
+	const newSlug = document.createElement( "input" );
+	newSlug.setAttribute( "id", "new-post-slug" );
+	newSlug.setAttribute( "value", "cat-snack" );
+
+	const slugEditDiv = document.createElement( "div" );
+	slugEditDiv.appendChild( fullLengthSlugElement );
+	slugEditDiv.appendChild( shortSlugElement );
+
+	const postNameElement = document.createElement( "input" );
+	postNameElement.setAttribute( "id", "post_name" );
+	postNameElement.setAttribute( "value", "cat-toys" );
+
+	document.body.appendChild( slugEditDiv );
+	document.body.appendChild( postNameElement );
+
+	it( "should return the post full length slug", () => {
+		expect( dom.getPostEditSlugFull() ).toEqual( "best-cat-food" );
+	} );
+	it( "should overwrite the full length slug text with the new value that is passed", () => {
+		expect( dom.setPostSlugFull( "best-cat-food-2" ) ).toEqual( fullLengthSlugElement );
+		expect( dom.getPostEditSlugFull() ).toEqual( "best-cat-food-2" );
+	} );
+	it( "should return the post shortened slug", () => {
+		expect( dom.getPostEditSlug() ).toEqual( "best-cat" );
+	} );
+	it( "should overwrite the short slug text with the new value that is passed", () => {
+		expect( dom.setPostSlug( "best-cat-2" ) ).toEqual( shortSlugElement );
+		expect( dom.getPostEditSlug() ).toEqual( "best-cat-2" );
+	} );
+	it( "should return the post name", () => {
+		expect( dom.getPostName() ).toEqual( "cat-toys" );
+	} );
+	it( "should overwrite the post name value with the new value that is passed", () => {
+		expect( dom.setPostName( "cat-toys-2" ) ).toEqual( postNameElement );
+		expect( dom.getPostName() ).toEqual( "cat-toys-2" );
+	} );
+	it( "should return the new slug if it's not undefined", () => {
+		expect( dom.getPostSlug() ).toEqual( "cat-snacks" );
+	} );
+} );

--- a/packages/js/tests/classic-editor/helpers/dom.test.js
+++ b/packages/js/tests/classic-editor/helpers/dom.test.js
@@ -87,10 +87,6 @@ describe( "a test for retrieving post slugs from the DOM", () => {
 	const shortSlugText = document.createTextNode( "best-cat" );
 	shortSlugElement.appendChild( shortSlugText );
 
-	const newSlug = document.createElement( "input" );
-	newSlug.setAttribute( "id", "new-post-slug" );
-	newSlug.setAttribute( "value", "cat-snack" );
-
 	const slugEditDiv = document.createElement( "div" );
 	slugEditDiv.appendChild( fullLengthSlugElement );
 	slugEditDiv.appendChild( shortSlugElement );
@@ -123,7 +119,37 @@ describe( "a test for retrieving post slugs from the DOM", () => {
 		expect( dom.setPostName( "cat-toys-2" ) ).toEqual( postNameElement );
 		expect( dom.getPostName() ).toEqual( "cat-toys-2" );
 	} );
+	it( "should return the slug from post edit if there is no new slug available", () => {
+		expect( dom.getPostSlug() ).toEqual( "best-cat-food-2" );
+	} );
 	it( "should return the new slug if it's not undefined", () => {
+		const newSlug = document.createElement( "input" );
+		newSlug.setAttribute( "id", "new-post-slug" );
+		newSlug.setAttribute( "value", "cat-snacks" );
+		slugEditDiv.appendChild( newSlug );
+
 		expect( dom.getPostSlug() ).toEqual( "cat-snacks" );
+	} );
+	it( "should return an empty string if the new slug and slug from post edit are undefined", () => {
+		slugEditDiv.removeChild( slugEditDiv.firstChild );
+		slugEditDiv.removeChild( slugEditDiv.lastChild );
+
+		expect( dom.getPostSlug() ).toEqual( "" );
+	} );
+} );
+
+describe( "a test for retrieving term slug from the DOM", () => {
+	const slugElement = document.createElement( "input" );
+	slugElement.setAttribute( "id", "slug" );
+	slugElement.setAttribute( "value", "cat-adoption" );
+
+	document.body.appendChild( slugElement );
+
+	it( "should return the term slug", () => {
+		expect( dom.getTermSlug() ).toEqual( "cat-adoption" );
+	} );
+	it( "should overwrite the term slug value with the new value that is passed", () => {
+		expect( dom.setTermSlug( "how-to-adopt-cat" ) ).toEqual( slugElement );
+		expect( dom.getTermSlug() ).toEqual( "how-to-adopt-cat" );
 	} );
 } );

--- a/packages/seo-integration/src/google-preview-container.js
+++ b/packages/seo-integration/src/google-preview-container.js
@@ -41,30 +41,33 @@ const useGooglePreviewReplacementVariables = () => {
 
 /**
  * Retrieves the base URL from the permalink.
- *
  * Uses a fallback URL in order to keep working when there is no permalink (development environment).
+ *
+ * @param {string} permalink    The permalink.
+ * @param {string} slug         The slug.
  *
  * @returns {string} The base URL.
  */
-const useBaseUrl = () => {
-	const permalink = useSelect( select => select( SEO_STORE_NAME ).selectPermalink() );
-
+const useBaseUrl = ( permalink, slug ) => {
 	return useMemo( () => {
-		// Strip the last part of the permalink.
 		let url;
+		let baseUrl = "";
 		try {
 			url = new URL( permalink );
+			baseUrl = url.href;
 		} catch ( e ) {
 			// Fallback on current href
-			return window.location.href;
+			baseUrl = window.location.href;
 		}
 
+		// Strip slug from the url.
+		baseUrl = baseUrl.replace( new RegExp( slug + "$" ), "" );
 		// Enforce ending with a slash because of the internal handling in the SnippetEditor component.
-		if ( ! url.pathname.endsWith( "/" ) ) {
-			url.pathname += "/";
+		if ( ! baseUrl.endsWith( "/" ) ) {
+			baseUrl += "/";
 		}
 
-		return url.href;
+		return baseUrl;
 	}, [ permalink ] );
 };
 
@@ -84,6 +87,7 @@ const GooglePreviewContainer = ( { as: Component, ...restProps } ) => {
 	const focusKeyphrase = useSelect( select => select( SEO_STORE_NAME ).selectKeyphrase() );
 	const morphologyResults = useSelect( select => select( SEO_STORE_NAME ).selectResearchResults( "morphology" ) );
 	const isCornerstone = useSelect( select => select( SEO_STORE_NAME ).selectIsCornerstone() );
+	const permalink = useSelect( select => select( SEO_STORE_NAME ).selectPermalink() );
 	const [ previewMode, setPreviewMode ] = useState( "mobile" );
 	const { updateSlug, updateSeoTitle, updateMetaDescription } = useDispatch( SEO_STORE_NAME );
 
@@ -99,7 +103,8 @@ const GooglePreviewContainer = ( { as: Component, ...restProps } ) => {
 		} ), [ date ] );
 	}
 
-	const baseUrl = useBaseUrl();
+	const baseUrl = useBaseUrl( permalink, slug );
+
 	const {
 		replacementVariables,
 		recommendedReplacementVariables,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* There were some problems related to slug, url and permalink preview that are fixed in this PR:
   * the slug in url preview was previewed twice after the base url
   * when a post doesn't have a title, the path name in url preview shows `undefined`
   * any changes made in the slug field inside snippet editor is not saved even after clicking `Save` or `Update` button
   * any changes made in the slug field inside snippet editor is not immediately reflected in the permalink field and in the WordPress `Slug` field
   * the title will be assigned as the slug, overwriting the slug value that was saved inside the snippet editor

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets an empty string as the fallback value for Post slug.
* Excludes slug from the base URL that is previewed in Google preview container.
* Syncs slug changes from the store to the post or term.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Requirement:
* Install and activate Classic editor

**Test for Post**
   * Create a post without a title and leave the slug field empty
   * Confirm that the url preview doesn't display `undefined` after the base url

<img width="396" alt="C795A8ED-59EA-4B7C-9E13-20A5A62647BD" src="https://user-images.githubusercontent.com/48715883/156004653-71889bcd-7bb8-4d96-8974-102ed08c7765.png">

   * Inside the post, go to `Screen Options` on top of the page and check `Slug` box
   * Add a slug in the slug field inside the snippet editor in Google preview
   * Confirm that the slug that you've just added is displayed once in the url preview
   * Confirm that the slug that you've added is also immediately displayed in the permalink

![873CA888-CB98-4D80-A2A0-E72FA740D001_4_5005_c](https://user-images.githubusercontent.com/48715883/156005717-1bf31795-1f0d-4108-8a20-c2d311d7116c.jpeg)

   * Confirm that the slug that you've added is also immediately displayed in the WordPress `Slug` in the bottom of your post
![A244EDCD-9C82-4202-A0DD-B0DE4D1F7D27_4_5005_c](https://user-images.githubusercontent.com/48715883/156007355-11832b94-cc28-45f6-a6c3-25b63d09c382.jpeg)

   * Save your changes
   * Confirm that the slug changes are saved and reflected correctly in the url preview, in permalink preview and in WordPress `Slug`

**Test for Term (category or tag)**
   * Create a category or a tag
   * Fill in the slug field if it's empty
   * Confirm that the slug that you've just added is displayed once in URL preview in Google preview
      * For categories, by default, the slug should be added in this order `base URL` + `category` + `slug`
      * For tags, by default, the slug should be added in this order `base URL` + `tag` + `slug` 
   * Save your changes
   * Confirm that the changes still hold after saving
      
**Test for slug fallback value**
   * Create a post with some text but without a title
   * Fill in the slug field inside the snippet editor and save your changes
   * Remove the slug and save your changes
   * Confirm that WordPress generates a numeric value and assign as the slug and reflected correctly in the url preview, in permalink preview and in WordPress `Slug`
   * Remove the slug
   * Add a title to your post and save your changes
   * Confirm that the title is also assigned as the slug and reflected correctly in the url preview, in permalink preview and in WordPress `Slug`
   * Make some changes to your post title, e.g. adding more words
   * Save your changes
   * Confirm that the slug value displayed is not overwritten by the title value

**Optional exploratory testing for Post**
* Change the setting for Permalink display by going to Settings > Permalinks > Common settings
* For example pick `Day and name`
* Make sure that the date is previewed both in the URL and Permalink preview for the post

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1346 & https://yoast.atlassian.net/browse/LINGO-1342
