### PR TITLE
P1-1198 create sanitize option validator

### DIFF
--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -531,7 +531,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [
 				'empty_string',
 				'sanitize_option' => [
-					'option' => 'category_base_url',
+					'option' => 'category_base',
 				],
 			],
 		],
@@ -731,7 +731,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [
 				'empty_string',
 				'sanitize_option' => [
-					'option' => 'tag_base_url',
+					'option' => 'tag_base',
 				],
 			],
 		],

--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -63,7 +63,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'opengraph'                                   		  => [
+		'opengraph'                                           => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
@@ -81,7 +81,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 				],
 			],
 		],
-		'twitter'                                     		  => [
+		'twitter'                                             => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
@@ -201,15 +201,15 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => '',
 			'types'   => [ 'string' ],
 		],
-		'breadcrumbs-boldlast'                        		  => [
+		'breadcrumbs-boldlast'                                => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'breadcrumbs-display-blog-page'               		  => [
+		'breadcrumbs-display-blog-page'                       => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
-		'breadcrumbs-enable'                          		  => [
+		'breadcrumbs-enable'                                  => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
@@ -253,31 +253,31 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => '',
 			'types'   => [ 'integer' ],
 		],
-		'disable-attachment'                          		  => [
+		'disable-attachment'                                  => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
-		'disable-author'                              		  => [
+		'disable-author'                                      => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'disable-date'                                		  => [
+		'disable-date'                                        => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'disable-post_format'                         		  => [
+		'disable-post_format'                                 => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'display-metabox-pt-<PostTypeName>'           		  => [
+		'display-metabox-pt-<PostTypeName>'                   => [
 			'default' => false, // True for public post types.
 			'types'   => [ 'boolean' ],
 		],
-		'display-metabox-tax-<TaxonomyName>'          		  => [
+		'display-metabox-tax-<TaxonomyName>'                  => [
 			'default' => false, // True for public taxonomies.
 			'types'   => [ 'boolean' ],
 		],
-		'forcerewritetitle'                           		  => [
+		'forcerewritetitle'                                   => [
 			'default'    => false,
 			'types'      => [ 'boolean' ],
 			'ms_exclude' => true,
@@ -306,27 +306,27 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => '',
 			'types'   => [ 'text_field' ],
 		],
-		'noindex-<PostTypeName>'                      		  => [
+		'noindex-<PostTypeName>'                              => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'noindex-archive-wpseo'                       		  => [
+		'noindex-archive-wpseo'                               => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
-		'noindex-author-noposts-wpseo'                		  => [
+		'noindex-author-noposts-wpseo'                        => [
 			'default' => true,
 			'types'   => [ 'boolean' ],
 		],
-		'noindex-author-wpseo'                        		  => [
+		'noindex-author-wpseo'                                => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'noindex-ptarchive-<PostTypeName>'            		  => [
+		'noindex-ptarchive-<PostTypeName>'                    => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'noindex-tax-<TaxonomyName>'                  		  => [
+		'noindex-tax-<TaxonomyName>'                          => [
 			'default' => false, // Except when the taxonomy name === 'post_format'.
 			'types'   => [ 'boolean' ],
 		],
@@ -466,7 +466,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => '%%term_title%% Archives', // Needs translation.
 			'types'   => [ 'text_field' ],
 		],
-		'stripcategorybase'                           		  => [
+		'stripcategorybase'                                   => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
@@ -512,7 +512,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 
 		// WPSEO.
-		'algolia_integration_active'                  		  => [
+		'algolia_integration_active'                          => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
@@ -528,9 +528,14 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'category_base_url'                                   => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [
+				'empty_string',
+				'sanitize_option' => [
+					'option' => 'category_base_url',
+				],
+			],
 		],
-		'content_analysis_active'                     		  => [
+		'content_analysis_active'                             => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
@@ -539,55 +544,55 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => '',
 			'types'   => [ 'string' ],
 		],
-		'disableadvanced_meta'                        		  => [
+		'disableadvanced_meta'                                => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'dismiss_configuration_workout_notice'        		  => [
+		'dismiss_configuration_workout_notice'                => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'dynamic_permalinks'                          		  => [
+		'dynamic_permalinks'                                  => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
-		'enable_admin_bar_menu'                       		  => [
+		'enable_admin_bar_menu'                               => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'enable_cornerstone_content'                  		  => [
+		'enable_cornerstone_content'                          => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'enable_enhanced_slack_sharing'               => [
+		'enable_enhanced_slack_sharing'                       => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'enable_headless_rest_endpoints'              		  => [
+		'enable_headless_rest_endpoints'                      => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'enable_link_suggestions'                     		  => [
+		'enable_link_suggestions'                             => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'enable_metabox_insights'                     		  => [
+		'enable_metabox_insights'                             => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'enable_text_link_counter'                    		  => [
+		'enable_text_link_counter'                            => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
-		'enable_xml_sitemap'                          		  => [
+		'enable_xml_sitemap'                                  => [
 			'default'   => true,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
@@ -600,7 +605,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => '',
 			'types'   => [ 'integer' ],
 		],
-		'first_time_install'                          		  => [
+		'first_time_install'                                  => [
 			'default' => false,
 			'types'   => [ 'boolean' ],
 		],
@@ -680,7 +685,12 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'permalink_structure'                                 => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [
+				'empty_string',
+				'sanitize_option' => [
+					'option' => 'permalink_structure',
+				],
+			],
 		],
 		'previous_version'                                    => [
 			'default' => '',
@@ -718,7 +728,12 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'tag_base_url'                                        => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [
+				'empty_string',
+				'sanitize_option' => [
+					'option' => 'tag_base_url',
+				],
+			],
 		],
 		'tracking'                                            => [
 			'default'   => null,

--- a/src/validators/sanitize-option-validator.php
+++ b/src/validators/sanitize-option-validator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Missing_Settings_Key_Exception;
+
+/**
+ * The sanitize option validator class.
+ */
+class Sanitize_Option_Validator implements Validator_Interface {
+
+	/**
+	 * The setting' option key.
+	 *
+	 * @var string
+	 */
+	const OPTION_KEY = 'option';
+
+	/**
+	 * Calls WordPress `sanitize_option`.
+	 *
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings The settings.
+	 *
+	 * @throws Missing_Settings_Key_Exception When settings are missing.
+	 *
+	 * @return string A valid string.
+	 */
+	public function validate( $value, array $settings = null ) {
+		if ( $settings === null || ! \array_key_exists( self::OPTION_KEY, $settings ) ) {
+			throw new Missing_Settings_Key_Exception( self::OPTION_KEY );
+		}
+
+		return \sanitize_option( $settings[ self::OPTION_KEY ], $value );
+	}
+}

--- a/tests/unit/validators/sanitize-option-validator-test.php
+++ b/tests/unit/validators/sanitize-option-validator-test.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Exceptions\Validation\Missing_Settings_Key_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Sanitize_Option_Validator;
+
+/**
+ * Tests the Sanitize_Option_Validator class.
+ *
+ * @group options
+ * @group validators
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Sanitize_Option_Validator
+ */
+class Sanitize_Option_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var Sanitize_Option_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		Monkey\Functions\stubs(
+			[
+				'sanitize_option' => static function ( $option, $value ) {
+					return $value;
+				},
+			]
+		);
+
+		$this->instance = new Sanitize_Option_Validator();
+	}
+
+	/**
+	 * Tests validation.
+	 *
+	 * @dataProvider data_provider
+	 *
+	 * @covers ::validate
+	 *
+	 * @param mixed  $value     The value to test/validate.
+	 * @param array  $settings  The validator settings.
+	 * @param mixed  $expected  The expected result.
+	 * @param string $exception The expected exception class. Optional, use when the expected result is false.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_validate( $value, $settings, $expected, $exception = '' ) {
+		if ( $exception !== '' ) {
+			$this->expectException( $exception );
+			$this->instance->validate( $value, $settings );
+
+			return;
+		}
+
+		$this->assertEquals( $expected, $this->instance->validate( $value, $settings ) );
+	}
+
+	/**
+	 * Data provider to test multiple inputs.
+	 *
+	 * @return array A mapping of methods and expected inputs.
+	 */
+	public function data_provider() {
+		return [
+			'category_base_url' => [
+				'value'    => 'category',
+				'settings' => [ 'option' => 'category_base_url' ],
+				'expected' => 'category',
+			],
+
+			'missing_settings'     => [
+				'value'     => 'something',
+				'settings'  => null,
+				'expected'  => false,
+				'exception' => Missing_Settings_Key_Exception::class,
+			],
+			'missing_settings_key' => [
+				'value'     => 'something',
+				'settings'  => [ 'hi' => 'world' ],
+				'expected'  => false,
+				'exception' => Missing_Settings_Key_Exception::class,
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the sanitize option validator.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Tests should make sense and cover the code
* You can play around with requesting validations, using this code:
```php
function _test_validate( $value, $option ) {
	/** @var \Yoast\WP\SEO\Validators\Sanitize_Option_Validator $validator */
	$validator = YoastSEO()->classes->get( \Yoast\WP\SEO\Validators\Sanitize_Option_Validator::class );
	echo 'Value: ';
	var_dump( $value );
	echo '<br>Result: ';
	try {
		var_dump( $validator->validate( $value, [ 'option' => $option ] ) );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_validate( 'category', 'category_base_url' );
```
* You can play with the setting (`category_base_url`, `tag_base_url` and `permalink_structure`), to see other options and change the code), using this code:
```php
function _test_set( $value ) {
	/** @var \Yoast\WP\SEO\Services\Options\Site_Options_Service $options */
	$options = YoastSEO()->classes->get( \Yoast\WP\SEO\Services\Options\Site_Options_Service::class );
	echo '<br>Before: ';
	var_dump( $options->category_base_url );
	echo '<br>After: ';
	try {
		$options->category_base_url = $value;
		var_dump( $options->category_base_url );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_set( 'cat' );
```

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Part of bigger feature, please test the whole feature when done.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [P1-1198](https://yoast.atlassian.net/browse/P1-1198)
