### PR TITLE
P1-1200 create wp kses post validator

### DIFF
--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -194,12 +194,12 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'text_field' ],
 		],
 		'breadcrumbs-404crumb'                                => [
-			'default' => '',
-			'types'   => [ 'string' ],
+			'default' => 'Error 404: Page not found',
+			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
 		'breadcrumbs-archiveprefix'                           => [
-			'default' => '',
-			'types'   => [ 'string' ],
+			'default' => 'Archives for',
+			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
 		'breadcrumbs-boldlast'                        		  => [
 			'default' => false,
@@ -214,20 +214,20 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'boolean' ],
 		],
 		'breadcrumbs-home'                                    => [
-			'default' => '',
-			'types'   => [ 'string' ],
+			'default' => 'Home',
+			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
 		'breadcrumbs-prefix'                                  => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
 		'breadcrumbs-searchprefix'                            => [
-			'default' => '',
-			'types'   => [ 'string' ],
+			'default' => 'You searched for',
+			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
 		'breadcrumbs-sep'                                     => [
-			'default' => '',
-			'types'   => [ 'string' ],
+			'default' => '&raquo;',
+			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
 		'company_logo'                                        => [
 			'default' => '',
@@ -367,12 +367,12 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'string' ],
 		],
 		'rssafter'                                            => [
-			'default' => '',
-			'types'   => [ 'string' ],
+			'default' => 'The post %%POSTLINK%% appeared first on %%BLOGLINK%%',
+			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
 		'rssbefore'                                           => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
 		'schema-article-type-<PostTypeName>'                  => [
 			'default' => '',

--- a/src/validators/wp-kses-post-validator.php
+++ b/src/validators/wp-kses-post-validator.php
@@ -3,7 +3,7 @@
 namespace Yoast\WP\SEO\Validators;
 
 /**
- * The sanitize option validator class.
+ * The Wp_Kses_Post_Validator class.
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */

--- a/src/validators/wp-kses-post-validator.php
+++ b/src/validators/wp-kses-post-validator.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+/**
+ * The sanitize option validator class.
+ */
+class Wp_Kses_Post_Validator extends String_Validator {
+
+	/**
+	 * Calls WordPress `wp_kses_post`.
+	 *
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings The settings.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception If the value is not a string.
+	 *
+	 * @return string A valid string.
+	 */
+	public function validate( $value, array $settings = null ) {
+		$string = parent::validate( $value, $settings );
+
+		return \wp_kses_post( $string );
+	}
+}

--- a/src/validators/wp-kses-post-validator.php
+++ b/src/validators/wp-kses-post-validator.php
@@ -4,6 +4,8 @@ namespace Yoast\WP\SEO\Validators;
 
 /**
  * The sanitize option validator class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Wp_Kses_Post_Validator extends String_Validator {
 

--- a/tests/unit/validators/wp-kses-post-validator-test.php
+++ b/tests/unit/validators/wp-kses-post-validator-test.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Wp_Kses_Post_Validator;
+
+/**
+ * Tests the Wp_Kses_Post_Validator class.
+ *
+ * @group options
+ * @group validators
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Wp_Kses_Post_Validator
+ */
+class Wp_Kses_Post_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var Wp_Kses_Post_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubTranslationFunctions();
+
+		$this->instance = new Wp_Kses_Post_Validator();
+	}
+
+	/**
+	 * Tests validation.
+	 *
+	 * @dataProvider data_provider
+	 *
+	 * @covers ::validate
+	 *
+	 * @param mixed  $value     The value to test/validate.
+	 * @param array  $settings  The validator settings.
+	 * @param mixed  $expected  The expected result.
+	 * @param string $exception The expected exception class. Optional, use when the expected result is false.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_validate( $value, $settings, $expected, $exception = '' ) {
+		if ( $exception !== '' ) {
+			$this->expectException( $exception );
+			$this->instance->validate( $value, $settings );
+
+			return;
+		}
+
+		$this->assertEquals( $expected, $this->instance->validate( $value, $settings ) );
+	}
+
+	/**
+	 * Data provider to test multiple inputs.
+	 *
+	 * @return array A mapping of methods and expected inputs.
+	 */
+	public function data_provider() {
+		return [
+			'default' => [
+				'value'    => 'foo',
+				'settings' => null,
+				'expected' => 'foo',
+			],
+
+			// Invalid types.
+			'integer' => [
+				'value'     => 1,
+				'settings'  => null,
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+			'array'   => [
+				'value'     => [],
+				'settings'  => null,
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+			'object'  => [
+				'value'     => (object) [],
+				'settings'  => null,
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+			'null'    => [
+				'value'     => null,
+				'settings'  => null,
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+			'boolean' => [
+				'value'     => false,
+				'settings'  => null,
+				'expected'  => false,
+				'exception' => Invalid_Type_Exception::class,
+			],
+		];
+	}
+}

--- a/tests/unit/validators/wp-kses-post-validator-test.php
+++ b/tests/unit/validators/wp-kses-post-validator-test.php
@@ -13,6 +13,8 @@ use Yoast\WP\SEO\Validators\Wp_Kses_Post_Validator;
  * @group validators
  *
  * @coversDefaultClass \Yoast\WP\SEO\Validators\Wp_Kses_Post_Validator
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Wp_Kses_Post_Validator_Test extends TestCase {
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the wp kses post validator.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Tests should make sense and cover the code
* You can play around with requesting validations, using this code:
```php
function _test_validate( $value ) {
	/** @var \Yoast\WP\SEO\Validators\Wp_Kses_Post_Validator $validator */
	$validator = YoastSEO()->classes->get( \Yoast\WP\SEO\Validators\Wp_Kses_Post_Validator::class );
	echo 'Value: ';
	var_dump( $value );
	echo '<br>Result: ';
	try {
		var_dump( $validator->validate( $value ) );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_validate( 123 );
```
* You can play with the setting (see [this commit](https://github.com/Yoast/wordpress-seo/pull/18136/commits/45815bd1313a27d86b5c8a3778777f15aab44436), to see other options and change the code), using this code:
```php
function _test_set( $value ) {
	/** @var \Yoast\WP\SEO\Services\Options\Site_Options_Service $options */
	$options = YoastSEO()->classes->get( \Yoast\WP\SEO\Services\Options\Site_Options_Service::class );
	echo '<br>Before: ';
	var_dump( $options->__get( 'breadcrumbs-404crumb' ) );
	echo '<br>After: ';
	try {
		$options->__set( 'breadcrumbs-404crumb', $value );
		var_dump( $options->__get( 'breadcrumbs-404crumb' ) );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_set( 'Error 404: Page not found<script>alert("danger");</script>' );
```

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Part of bigger feature, please test the whole feature when done.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [P1-1200](https://yoast.atlassian.net/browse/P1-1200)
