### PR TITLE
DUPP-301 Catch exceptions from the QR code lib

### DIFF
--- a/src/integrations/front-end/print-qrcode-embed.php
+++ b/src/integrations/front-end/print-qrcode-embed.php
@@ -13,6 +13,13 @@ use Yoast\WP\SEO\Surfaces\Meta_Surface;
 class Print_QRCode_Embed implements Integration_Interface {
 
 	/**
+	 * The maximum length in characted that we're outputting a QR code for.
+	 *
+	 * @var int
+	 */
+	const MAX_URL_LENGTH = 2953;
+
+	/**
 	 * The meta surface.
 	 *
 	 * @var Meta_Surface
@@ -64,6 +71,15 @@ class Print_QRCode_Embed implements Integration_Interface {
 			return;
 		}
 
+		if ( $this->is_url_too_long( $url ) ) {
+			$home_meta = $this->meta_surface->for_home_page();
+			$url       = $home_meta->canonical;
+		}
+
+		if ( empty( $url ) || $this->is_url_too_long( $url ) ) {
+			return;
+		}
+
 		$alt_text  = __( 'QR Code for current page\'s URL.', 'wordpress-seo' );
 		$text      = __( 'Scan the QR code or go to the URL below to read this article online.', 'wordpress-seo' );
 		$image_url = \trailingslashit( \get_site_url() ) . '?nonce=' . $nonce . '&yoast_qr_code=' . rawurlencode( $url );
@@ -86,5 +102,20 @@ class Print_QRCode_Embed implements Integration_Interface {
 			\esc_html( $url ),
 			\esc_url_raw( $image_url )
 		);
+	}
+
+	/**
+	 * Checks if URL is too long for outputting its QR code.
+	 *
+	 * @param string $url The url under question.
+	 *
+	 * @return bool Whether the url is too long for outputting its QR code
+	 */
+	public function is_url_too_long( $url ) {
+		if ( \strlen( $url ) > self::MAX_URL_LENGTH ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/integrations/front-end/print-qrcode-render.php
+++ b/src/integrations/front-end/print-qrcode-render.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Integrations\Front_End;
 
+use Exception;
 use YoastSEO_Vendor\chillerlan\QRCode\QRCode;
 use YoastSEO_Vendor\chillerlan\QRCode\QROptions;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
@@ -47,12 +48,20 @@ class Print_QRCode_Render implements Integration_Interface {
 			\wp_die( 'This is not a QR code endpoint for public consumption.' );
 		}
 
-		$options = new QROptions( [ 'outputType' => QRCode::OUTPUT_MARKUP_SVG ] );
-		$qr_code = new QRCode( $options );
+		try {
+			$options = new QROptions( [ 'outputType' => QRCode::OUTPUT_MARKUP_SVG ] );
+			$qr_code = new QRCode( $options );
 
-		\header( 'Content-type: image/svg+xml', true );
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We trust the QR class to output safe content.
-		echo $qr_code->render( $url );
-		exit( 200 );
+			\header( 'Content-type: image/svg+xml', true );
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We trust the QR class to output safe content.
+			echo $qr_code->render( $url );
+			exit( 200 );
+		}
+		catch ( Exception $e ) {
+			header( 'Content-Type: text/plain', true, 400 );
+			/* translators: %1$s expands to the error message */
+			echo esc_html( sprintf( __( 'Failed to generate QR Code: %s', 'wordpress-seo' ), $e->getMessage() ) );
+			exit();
+		}
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to catch exceptions coming from the QR code lib and show a `400 - error message` instead
* We also want to show a QR code for the homepage if the URL is too long

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enhances the QR code feature by catching fatal errors from the QR code lib and gracefully showing the error in the frontend.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to a page in the frontend, check it's page source and find the `yoast_seo_print_qrcode_script` script
* In the `<img src="http://basic.wordpress.test/?nonce=e7707d3e54&yoast_qr_code=http%3A%2F%2Fbasic.wordpress.test%2F\"` tag there, copy that url and open it in a different tab
* Confirm that you'll see a QR code there
* Now take the part in that url, after the `yoast_qr_code=` , remove it, eg. `http://basic.wordpress.test/?nonce=e7707d3e54&yoast_qr_code=` and go to that page.
* Confirm that you get a `Failed to generate QR Code: QRCode::getMatrix() No data given.` message there, no fatal errors are being thrown and that the request returned with a 400 code (you can see that in the Network tab of your browser)

Also, to confirm that a URL that's too long, shows a QR code that redirecting to the homepage:
* Change the `const MAX_URL_LENGTH = 2953;` line in the `src/integrations/front-end/print-qrcode-embed.php` file to something lower, like `const MAX_URL_LENGTH = 200;`
* Go to a page with a URL of over 200 characters
* Check it's page source and find the `yoast_seo_print_qrcode_script` script
* Verify that the `yoast_qr_code=` part is showing the homepage URL instead of the URL of the current page


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* https://github.com/Yoast/wordpress-seo/pull/18089

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
