### PR TITLE
P1-1204 fix regex validator to sanitize like text instead of string

### DIFF
--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -75,10 +75,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => '',
 			'types'   => [
 				'empty_string',
-				'regex' => [
-					'pattern' => '/(^[A-Fa-f0-9_-]+$)|content=([\'"])?([A-Fa-f0-9_-]+)(?:\2|[ \/>])/',
-					'groups'  => [ 1, 3 ],
-				],
+				'verification' => [ 'pattern' => '`^[A-Fa-f0-9_-]+$`' ],
 			],
 		],
 		'twitter'                                     		  => [
@@ -520,10 +517,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => '',
 			'types'   => [
 				'empty_string',
-				'regex' => [
-					'pattern' => '/(^[A-Za-z0-9_-]+$)|content=([\'"])?([A-Za-z0-9_-]+)(?:\2|[ \/>])/',
-					'groups'  => [ 1, 3 ],
-				],
+				'verification' => [ 'pattern' => '`^[A-Za-z0-9_-]+$`' ],
 			],
 		],
 		'category_base_url'                                   => [
@@ -608,10 +602,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => '',
 			'types'   => [
 				'empty_string',
-				'regex' => [
-					'pattern' => '/(^[A-Za-z0-9_-]+$)|content=([\'"])?([A-Za-z0-9_-]+)(?:\2|[ \/>])/',
-					'groups'  => [ 1, 3 ],
-				],
+				'verification' => [ 'pattern' => '`^[A-Za-z0-9_-]+$`' ],
 			],
 		],
 		'has_multiple_authors'                                => [
@@ -668,10 +659,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => '',
 			'types'   => [
 				'empty_string',
-				'regex' => [
-					'pattern' => '/(^[A-Fa-f0-9_-]+$)|content=([\'"])?([A-Fa-f0-9_-]+)(?:\2|[ \/>])/',
-					'groups'  => [ 1, 3 ],
-				],
+				'verification' => [ 'pattern' => '`^[A-Fa-f0-9_-]+$`' ],
 			],
 		],
 		'myyoast-oauth'                                       => [
@@ -754,10 +742,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'default' => '',
 			'types'   => [
 				'empty_string',
-				'regex' => [
-					'pattern' => '/(^[A-Fa-f0-9_-]+$)|content=([\'"])?([A-Fa-f0-9_-]+)(?:\2|[ \/>])/',
-					'groups'  => [ 1, 3 ],
-				],
+				'verification' => [ 'pattern' => '`^[A-Fa-f0-9_-]+$`' ],
 			],
 		],
 		'zapier_api_key'                                      => [

--- a/src/validators/verification-validator.php
+++ b/src/validators/verification-validator.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception;
+
+/**
+ * The verification validator class.
+ */
+class Verification_Validator extends String_Validator {
+
+	/**
+	 * Holds the regex validator instance.
+	 *
+	 * @var Regex_Validator
+	 */
+	protected $regex_validator;
+
+	/**
+	 * Constructs a verification validator instance.
+	 *
+	 * @param Regex_Validator $regex_validator The regex validator.
+	 */
+	public function __construct( Regex_Validator $regex_validator ) {
+		$this->regex_validator = $regex_validator;
+	}
+
+	/**
+	 * Validates if a value is a verification, using two regex validations.
+	 *
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings The settings. Expects Regex_Validator::PATTERN_KEY and Regex_Validator::GROUPS_KEY.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception When the value is not a string.
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Missing_Settings_Key_Exception When settings are missing.
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\No_Regex_Match_Exception When the value does not match a regex.
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\No_Regex_Groups_Exception When the matches do not contain any of the
+	 *                                                                       specified groups.
+	 * @return string The valid value.
+	 */
+	public function validate( $value, array $settings = null ) {
+		$string = parent::validate( $value );
+
+		// Make sure we only have the real key, not a complete meta tag.
+		if ( \strpos( $string, 'content=' ) ) {
+			try {
+				$string = $this->regex_validator->validate(
+					$string,
+					[
+						'pattern' => '`content=([\'"])?([^\'"> ]+)(?:\1|[ />])`',
+						'groups'  => [ 2 ],
+					]
+				);
+			} catch ( Abstract_Validation_Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
+				// Ignore meta tag validation failure to validate it as the real key.
+			}
+		}
+
+		// Sanitize the string.
+		$string = \sanitize_text_field( $string );
+
+		// Sanitize as a regex.
+		return $this->regex_validator->validate( $string, $settings );
+	}
+}

--- a/tests/unit/validators/verification-validator-test.php
+++ b/tests/unit/validators/verification-validator-test.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Mockery;
+use Yoast\WP\SEO\Exceptions\Validation\No_Regex_Match_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Regex_Validator;
+use Yoast\WP\SEO\Validators\Verification_Validator;
+
+/**
+ * Tests the \Yoast\WP\SEO\Validators\Verification_Validator class.
+ *
+ * @group options
+ * @group validators
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Verification_Validator
+ */
+class Verification_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var \Yoast\WP\SEO\Validators\Verification_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the regex validator mock.
+	 *
+	 * @var Mockery\Mock|Regex_Validator
+	 */
+	protected $regex_validator;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+
+		$this->regex_validator = Mockery::mock( Regex_Validator::class );
+
+		$this->instance = new Verification_Validator( $this->regex_validator );
+	}
+
+	/**
+	 * Tests if the needed attributes are set correctly.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct() {
+		$this->assertInstanceOf( Verification_Validator::class, $this->instance );
+		$this->assertInstanceOf(
+			Regex_Validator::class,
+			$this->getPropertyValue( $this->instance, 'regex_validator' )
+		);
+	}
+
+	/**
+	 * Tests validation's happy path.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate() {
+		$this->regex_validator
+			->expects( 'validate' )
+			->andReturnUsing( static function ( $string ) {
+				return $string;
+			} );
+
+		$actual = $this->instance->validate( 'abcd', [ 'pattern' => '`^[A-Fa-f0-9_-]+$`' ] );
+
+		$this->assertEquals( 'abcd', $actual );
+	}
+
+	/**
+	 * Tests validation can handle meta tag.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate_meta_tag() {
+		$this->regex_validator
+			->expects( 'validate' )
+			->twice()
+			->andReturnUsing( static function ( $string, $settings ) {
+				if ( $settings['pattern'] === '`content=([\'"])?([^\'"> ]+)(?:\1|[ />])`' ) {
+					return 'abcd';
+				}
+
+				return $string;
+			} );
+
+		$actual = $this->instance->validate( '<meta name="p:domain_verify" content="abcd"/>', [ 'pattern' => '`^[A-Fa-f0-9_-]+$`' ] );
+
+		$this->assertEquals( 'abcd', $actual );
+	}
+
+	/**
+	 * Tests validation ignores a validation exception in the meta tag regex validator.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate_meta_tag_throw() {
+		$this->regex_validator
+			->expects( 'validate' )
+			->twice()
+			->andReturnUsing( static function ( $string, $settings ) {
+				if ( $settings['pattern'] === '`content=([\'"])?([^\'"> ]+)(?:\1|[ />])`' ) {
+					throw new No_Regex_Match_Exception( $string, $settings['pattern'] );
+				}
+
+				return $string;
+			} );
+
+		$actual = $this->instance->validate( '<meta name="p:domain_verify" content="abcd"/>', [ 'pattern' => '`^[A-Fa-f0-9_-]+$`' ] );
+
+		$this->assertEquals( '<meta name="p:domain_verify" content="abcd"/>', $actual );
+	}
+
+	/**
+	 * Tests validation can throw exceptions.
+	 *
+	 * @covers ::validate
+	 */
+	public function test_validate_throw() {
+		$this->regex_validator
+			->expects( 'validate' )
+			->twice()
+			->andReturnUsing( static function ( $string, $settings ) {
+				throw new No_Regex_Match_Exception( $string, $settings['pattern'] );
+			} );
+
+		$this->expectException( No_Regex_Match_Exception::class );
+
+		$this->instance->validate( '<meta name="p:domain_verify" content="abcd"/>', [ 'pattern' => '`^[A-Fa-f0-9_-]+$`' ] );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes a leftover issue from https://github.com/Yoast/wordpress-seo/pull/18023 where the verification options did not sanitize the input like the original (running `sanitize_text_field`).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the verification validator.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Tests should make sense and cover the code
* You can run this somewhere and play around with feeding it different input:
```php
function _test_validate( $value, $settings ) {
	/** @var \Yoast\WP\SEO\Validators\Verification_Validator $validator */
	$validator = YoastSEO()->classes->get( \Yoast\WP\SEO\Validators\Verification_Validator::class );
	echo 'Value: ';
	var_dump( $value );
	echo '<br>Result: ';
	try {
		var_dump( $validator->validate( $value, $settings ) );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_validate( 'hi', [ 'pattern' => '/^[A-Fa-f0-9_-]+$/' ] );
```
* You can test the setting of our verify options with the following base code:
```php
function _test_set( $value ) {
	/** @var \Yoast\WP\SEO\Services\Options\Site_Options_Service $options */
	$options = YoastSEO()->classes->get( \Yoast\WP\SEO\Services\Options\Site_Options_Service::class );
	echo '<br>Before: ';
	var_dump( $options->pinterestverify );
	echo '<br>After: ';
	try {
		$options->pinterestverify = $value;
		var_dump( $options->pinterestverify );
	} catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
		echo $exception->getMessage();
	}
	echo '<br>';
}
_test_set( '<meta name="p:domain_verify" content="abc"/>' );
```
* Play around with and adapt the above code to check the [affected options](https://github.com/Yoast/wordpress-seo/commit/f34d6b58c83ec3d98c0a669df0971758d7cefe9d).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Part of bigger feature. Please test whole feature.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [P1-1204](https://yoast.atlassian.net/browse/P1-1204)
