### PR TITLE
[QA-2937] Restore load order of settings Redux store in settings entry point

### DIFF
--- a/packages/js/src/settings.js
+++ b/packages/js/src/settings.js
@@ -1,5 +1,4 @@
 /* global wpseoScriptData */
-import domReady from "@wordpress/dom-ready";
 import jQuery from "jquery";
 import initAdmin from "./initializers/admin";
 import initAdminMedia from "./initializers/admin-media";
@@ -7,14 +6,10 @@ import initSearchAppearance from "./initializers/search-appearance";
 import initSettingsStore from "./initializers/settings-store";
 import initSocialSettings from "./initializers/social-settings";
 
+initAdmin( jQuery );
+
 // eslint-disable-next-line complexity
-domReady( () => {
-	initAdmin( jQuery );
-
-	if ( ! wpseoScriptData ) {
-		return;
-	}
-
+if ( wpseoScriptData ) {
 	if ( typeof wpseoScriptData.media !== "undefined" ) {
 		initAdminMedia( jQuery );
 	}
@@ -30,4 +25,6 @@ domReady( () => {
 	if ( typeof wpseoScriptData.social !== "undefined" ) {
 		initSocialSettings();
 	}
-} );
+}
+
+

--- a/packages/js/src/settings.js
+++ b/packages/js/src/settings.js
@@ -24,6 +24,7 @@ if ( wpseoScriptData ) {
 	}
 
 	domReady( () => {
+		// Init social settings on DOM ready because it relies on global WP APIs
 		if ( typeof wpseoScriptData.social !== "undefined" ) {
 			initSocialSettings();
 		}

--- a/packages/js/src/settings.js
+++ b/packages/js/src/settings.js
@@ -1,4 +1,5 @@
 /* global wpseoScriptData */
+import domReady from "@wordpress/dom-ready";
 import jQuery from "jquery";
 import initAdmin from "./initializers/admin";
 import initAdminMedia from "./initializers/admin-media";
@@ -22,9 +23,11 @@ if ( wpseoScriptData ) {
 		initSearchAppearance();
 	}
 
-	if ( typeof wpseoScriptData.social !== "undefined" ) {
-		initSocialSettings();
-	}
+	domReady( () => {
+		if ( typeof wpseoScriptData.social !== "undefined" ) {
+			initSocialSettings();
+		}
+	} );
 }
 
 

--- a/packages/js/src/settings.js
+++ b/packages/js/src/settings.js
@@ -19,16 +19,15 @@ if ( wpseoScriptData ) {
 	if ( isSearchAppearancePage || typeof wpseoScriptData.dismissedAlerts !== "undefined" ) {
 		initSettingsStore();
 	}
-	if ( isSearchAppearancePage ) {
-		initSearchAppearance();
-	}
 
 	domReady( () => {
+		if ( isSearchAppearancePage ) {
+			initSearchAppearance();
+		}
+
 		// Init social settings on DOM ready because it relies on global WP APIs
 		if ( typeof wpseoScriptData.social !== "undefined" ) {
 			initSocialSettings();
 		}
 	} );
 }
-
-


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes an unreleased bug where the News Addon settings page would break because of the settings Redux store being unavailable.
* Bug was caused by changes to settings entrypoint in [this PR](https://github.com/Yoast/wordpress-seo/pull/18071/files?file-filters%5B%5D=.js&show-viewed-files=true#diff-72fe1c8bb99ec64963d955519e9fa74bb74b25bf6708dfcf4d45c013dd5d9482R2).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the News Addon settings page would break because of the settings Redux store being unavailable.

## Relevant technical choices:

* Reverted changes to settings entry point from [this PR](https://github.com/Yoast/wordpress-seo/pull/18071/files?file-filters%5B%5D=.js&show-viewed-files=true#diff-72fe1c8bb99ec64963d955519e9fa74bb74b25bf6708dfcf4d45c013dd5d9482R2).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**News Addon**
1. Install and activate Yoast SEO: News 13.1
2. With the JS console open navigate to SEO → News SEO
3. No console errors should be visible and a 'Genres' notification should be visible at the top of page.

<img width="623" alt="image" src="https://user-images.githubusercontent.com/24573520/156171517-7c6d0830-769a-4507-8919-71949cd7c384.png">

**Settings images**
1. Go to the Yoast SEO settings
2. Both search appearance -> content types (or taxonomies or archives) and social -> facebook should work
3. Select a Facebook image that has an alt text
4. Inspect the HTML, the image should have the alt attribute
5. If the selected image does not have an alt text, it should use the title as alt instead
6. If the selected image does not have an alt text or a title, it should use the filename without the extension instead
7. Save (and reload the page)
8. The alt text should be present (it gets requested after page load)
9. No JS console errors mentioning an `undefined property 'attachment'` should be present.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
