### PR TITLE
DUPP-302 Fix case when organization logo exists before import

### DIFF
--- a/src/actions/importing/aioseo/aioseo-general-settings-importing-action.php
+++ b/src/actions/importing/aioseo/aioseo-general-settings-importing-action.php
@@ -54,7 +54,7 @@ class Aioseo_General_Settings_Importing_Action extends Abstract_Aioseo_Settings_
 	protected $image;
 
 	/**
-	 * Aioseo_Custom_Archive_Settings_Importing_Action constructor.
+	 * Aioseo_General_Settings_Importing_Action constructor.
 	 *
 	 * @param Import_Cursor_Helper              $import_cursor      The import cursor helper.
 	 * @param Options_Helper                    $options            The options helper.

--- a/src/actions/importing/aioseo/aioseo-general-settings-importing-action.php
+++ b/src/actions/importing/aioseo/aioseo-general-settings-importing-action.php
@@ -111,11 +111,11 @@ class Aioseo_General_Settings_Importing_Action extends Abstract_Aioseo_Settings_
 			],
 			'/schema/organizationLogo' => [
 				'yoast_name'       => 'company_logo',
-				'transform_method' => 'import_org_logo',
+				'transform_method' => 'import_company_logo',
 			],
 			'/schema/personLogo'       => [
 				'yoast_name'       => 'person_logo',
-				'transform_method' => 'simple_import',
+				'transform_method' => 'import_person_logo',
 			],
 		];
 	}
@@ -123,19 +123,37 @@ class Aioseo_General_Settings_Importing_Action extends Abstract_Aioseo_Settings_
 	/**
 	 * Imports the organization logo while also accounting for the id of the log to be saved in the separate Yoast option.
 	 *
-	 * @param string $site_represents The site represents setting.
+	 * @param string $logo_url The company logo url coming from AIOSEO settings.
 	 *
-	 * @return string The transformed site represents setting.
+	 * @return string The transformed company logo url.
 	 */
-	public function import_org_logo( $logo ) {
-		$logo_id = $this->image->get_attachment_by_url( $logo );
+	public function import_company_logo( $logo_url ) {
+		$logo_id = $this->image->get_attachment_by_url( $logo_url );
 		$this->options->set( 'company_logo_id', $logo_id );
 
 		$this->options->set( 'company_logo_meta', false );
 		$logo_meta = $this->image->get_attachment_meta_from_settings( 'company_logo' );
 		$this->options->set( 'company_logo_meta', $logo_meta );
 
-		return $this->url_import( $logo );
+		return $this->url_import( $logo_url );
+	}
+
+	/**
+	 * Imports the person logo while also accounting for the id of the log to be saved in the separate Yoast option.
+	 *
+	 * @param string $logo_url The person logo url coming from AIOSEO settings.
+	 *
+	 * @return string The transformed person logo url.
+	 */
+	public function import_person_logo( $logo_url ) {
+		$logo_id = $this->image->get_attachment_by_url( $logo_url );
+		$this->options->set( 'person_logo_id', $logo_id );
+
+		$this->options->set( 'person_logo_meta', false );
+		$logo_meta = $this->image->get_attachment_meta_from_settings( 'person_logo' );
+		$this->options->set( 'person_logo_meta', $logo_meta );
+
+		return $this->url_import( $logo_url );
 	}
 
 	/**

--- a/tests/unit/actions/importing/aioseo-general-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-general-settings-importing-action-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Actions\Importing;
 use Mockery;
 use Brain\Monkey;
 use Yoast\WP\SEO\Actions\Importing\Aioseo\Aioseo_General_Settings_Importing_Action;
+use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Import_Cursor_Helper;
 use Yoast\WP\SEO\Helpers\Import_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
@@ -67,6 +68,13 @@ class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	 * @var Mockery\MockInterface|Import_Helper
 	 */
 	protected $import_helper;
+
+	/**
+	 * The image helper.
+	 *
+	 * @var Mockery\MockInterface|Image_Helper
+	 */
+	protected $image;
 
 	/**
 	 * The replacevar handler.
@@ -134,12 +142,13 @@ class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 		$this->robots_provider    = Mockery::mock( Aioseo_Robots_Provider_Service::class );
 		$this->robots_transformer = Mockery::mock( Aioseo_Robots_Transformer_Service::class );
 		$this->import_helper      = Mockery::mock( Import_Helper::class );
-		$this->instance           = new Aioseo_General_Settings_Importing_Action( $this->import_cursor, $this->options, $this->sanitization, $this->replacevar_handler, $this->robots_provider, $this->robots_transformer );
+		$this->image              = Mockery::mock( Image_Helper::class );
+		$this->instance           = new Aioseo_General_Settings_Importing_Action( $this->import_cursor, $this->options, $this->sanitization, $this->image, $this->replacevar_handler, $this->robots_provider, $this->robots_transformer );
 		$this->instance->set_import_helper( $this->import_helper );
 
 		$this->mock_instance = Mockery::mock(
 			Aioseo_General_Settings_Importing_Action_Double::class,
-			[ $this->import_cursor, $this->options, $this->sanitization, $this->replacevar_handler, $this->robots_provider, $this->robots_transformer ]
+			[ $this->import_cursor, $this->options, $this->sanitization, $this->image, $this->replacevar_handler, $this->robots_provider, $this->robots_transformer ]
 		)->makePartial()->shouldAllowMockingProtectedMethods();
 		$this->mock_instance->set_import_helper( $this->import_helper );
 	}
@@ -192,11 +201,13 @@ class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	 * @param string $setting_value   The value of the AIOSEO setting at hand.
 	 * @param int    $times           The times that we will import each setting, if any.
 	 * @param int    $transform_times The times that we will transform each setting, if any.
+	 * @param int    $image_times     The times that we will use the image helper.
+	 * @param int    $set_image_times The times that we will set image data.
 	 *
 	 * @dataProvider provider_map
 	 * @covers ::map
 	 */
-	public function test_map( $setting, $setting_value, $times, $transform_times ) {
+	public function test_map( $setting, $setting_value, $times, $transform_times, $image_times, $set_image_times ) {
 		$this->mock_instance->build_mapping();
 		$aioseo_options_to_yoast_map = $this->mock_instance->get_aioseo_options_to_yoast_map();
 
@@ -209,9 +220,27 @@ class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 			->with( $setting_value )
 			->andReturn( $setting_value );
 
+		$this->image->shouldReceive( 'get_attachment_by_url' )
+			->times( $image_times )
+			->with( $setting_value )
+			->andReturn( 123 );
+
+		$this->options->shouldReceive( 'set' )
+			->times( $set_image_times );
+
+		$this->image->shouldReceive( 'get_attachment_meta_from_settings' )
+			->times( $image_times )
+			->with( 'company_logo' )
+			->andReturn( [ 'meta' ] );
+
 		$this->sanitization->shouldReceive( 'sanitize_text_field' )
 			->times( $transform_times )
 			->with( $setting_value )
+			->andReturn( $setting_value );
+
+		$this->sanitization->shouldReceive( 'sanitize_url' )
+			->times( $image_times )
+			->with( $setting_value, null )
 			->andReturn( $setting_value );
 
 		$this->options->shouldReceive( 'set' )
@@ -289,14 +318,14 @@ class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 	 */
 	public function provider_map() {
 		return [
-			[ '/separator', '&larr;', 1, 0 ],
-			[ '/siteTitle', 'Site Title', 1, 1 ],
-			[ '/metaDescription', 'Site Desc', 1, 1 ],
-			[ '/schema/siteRepresents', 'person', 1, 0 ],
-			[ '/schema/person', 60, 1, 1 ],
-			[ '/schema/organizationName', 'Org Name', 1, 1 ],
-			[ '/schema/organizationLogo', 'http://basic.wordpress.test/wp-content/uploads/2021/11/WordPress8-20.jpg', 1, 1 ],
-			[ '/randomSetting', 'randomeValue', 0, 0 ],
+			[ '/separator', '&larr;', 1, 0, 0, 0 ],
+			[ '/siteTitle', 'Site Title', 1, 1, 0, 0 ],
+			[ '/metaDescription', 'Site Desc', 1, 1, 0, 0 ],
+			[ '/schema/siteRepresents', 'person', 1, 0, 0, 0 ],
+			[ '/schema/person', 60, 1, 1, 0, 0 ],
+			[ '/schema/organizationName', 'Org Name', 1, 1, 0, 0 ],
+			[ '/schema/organizationLogo', 'http://basic.wordpress.test/wp-content/uploads/2021/11/WordPress8-20.jpg', 1, 0, 1, 3 ],
+			[ '/randomSetting', 'randomeValue', 0, 0, 0, 0 ],
 		];
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix cases where the user has already set an organization or person logo in their schema general settings
* To do so, we need to initialize again the logo id and meta in the db, before importing the AIOSEO organization or person logo
* We also produce the id and meta after we import the logo url

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where organization and person logos in the Knowledge Graph wouldn't be updated if there were already there before AIOSEO import

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have Yoast active and set an Organization logo in Search Appearance->General
* Activate AIOSEO and in their Appearance->General set a Organization Name but leave the Organization Logo empty
* Import AIOSEO to Yoast

Without this PR:
* You'll get a `A company name and logo need to be set for structured data to work properly.` warning in the **Knowledge Graph & Schema.org** section, even though it shows you have both

With this PR:
* You'll get a `A company name and logo need to be set for structured data to work properly.` warning in the **Knowledge Graph & Schema.org** section, but that's expected because it shows you only have the Company name set (as it should)

The above goes for Person logo as well.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Organization and person logo import

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
