### PR TITLE
Fix rendering of React in Elementor Yoast tab

### DIFF
--- a/packages/js/src/initializers/elementor-editor-integration.js
+++ b/packages/js/src/initializers/elementor-editor-integration.js
@@ -167,20 +167,6 @@ export default function initElementEditorIntegration() {
 	window.YoastSEO = window.YoastSEO || {};
 	window.YoastSEO._registerReactComponent = registerReactComponent;
 
-	// Check whether the route to our tab is active. If so, render our React root.
-	window.$e.routes.on( "run:after", function( component, route ) {
-		if ( route === "panel/page-settings/yoast-tab" ) {
-			renderReactRoot( "elementor-panel-page-settings-controls", (
-				<StyleSheetManager target={ document.getElementById( "elementor-panel-inner" ) }>
-					<div className="yoast yoast-elementor-panel__fills">
-						<ElementorSlot />
-						<ElementorFill />
-					</div>
-				</StyleSheetManager>
-			) );
-		}
-	} );
-
 	initializePostStatusListener();
 
 	// Hook into the save.
@@ -209,11 +195,21 @@ export default function initElementEditorIntegration() {
 		callback: () => {
 			try {
 				window.$e.routes.run( "panel/page-settings/yoast-tab" );
-			} catch ( error ) {
-				// The yoast tab is only available if the page settings have been visited.
+			} catch {
+				// The yoast tab is only available if the page settings has been visited.
 				window.$e.routes.run( "panel/page-settings/settings" );
 				window.$e.routes.run( "panel/page-settings/yoast-tab" );
 			}
+
+			// Render React
+			renderReactRoot( "elementor-panel-page-settings-controls", (
+				<StyleSheetManager target={ document.getElementById( "elementor-panel-inner" ) }>
+					<div className="yoast yoast-elementor-panel__fills">
+						<ElementorSlot />
+						<ElementorFill />
+					</div>
+				</StyleSheetManager>
+			) );
 		},
 	}, "more" );
 

--- a/packages/js/src/initializers/elementor-editor-integration.js
+++ b/packages/js/src/initializers/elementor-editor-integration.js
@@ -222,8 +222,11 @@ export default function initElementEditorIntegration() {
 		},
 	}, "more" );
 
-	// Listen for Yoast tab activation from within settings panel to start rendering the Yoast tab React content.
-	jQuery( document ).on( "click", "[data-tab=\"yoast-tab\"] > a", renderYoastTabReactContent );
+	/*
+	 * Listen for Yoast tab activation from within settings panel to start rendering the Yoast tab React content.
+	 * Note the `.not` in the selector, this is to prevent rendering the React content multiple times.
+	 */
+	jQuery( document ).on( "click", "[data-tab=\"yoast-tab\"]:not(.elementor-active) > a", renderYoastTabReactContent );
 
 	yoastInputs = document.querySelectorAll( "input[name^='yoast']" );
 	storeAllValuesAsOldValues();

--- a/packages/js/src/initializers/elementor-editor-integration.js
+++ b/packages/js/src/initializers/elementor-editor-integration.js
@@ -158,6 +158,23 @@ function sendFormData( form ) {
 }
 
 /**
+ * Renders the Yoast tab React content.
+ * @returns {void}
+ */
+function renderYoastTabReactContent() {
+	setTimeout( () => {
+		renderReactRoot( "elementor-panel-page-settings-controls", (
+			<StyleSheetManager target={ document.getElementById( "elementor-panel-inner" ) }>
+				<div className="yoast yoast-elementor-panel__fills">
+					<ElementorSlot />
+					<ElementorFill />
+				</div>
+			</StyleSheetManager>
+		) );
+	}, 200 );
+}
+
+/**
  * Initializes the Yoast elementor editor integration.
  *
  * @returns {void}
@@ -194,27 +211,23 @@ export default function initElementEditorIntegration() {
 		type: "page",
 		callback: () => {
 			try {
-				window.$e.routes.run( "panel/page-settings/yoast-tab" );
-			} catch {
+				window.$e.route( "panel/page-settings/yoast-tab" );
+			} catch ( error ) {
 				// The yoast tab is only available if the page settings has been visited.
-				window.$e.routes.run( "panel/page-settings/settings" );
-				window.$e.routes.run( "panel/page-settings/yoast-tab" );
+				window.$e.route( "panel/page-settings/settings" );
+				window.$e.route( "panel/page-settings/yoast-tab" );
 			}
-
-			// Render React
-			renderReactRoot( "elementor-panel-page-settings-controls", (
-				<StyleSheetManager target={ document.getElementById( "elementor-panel-inner" ) }>
-					<div className="yoast yoast-elementor-panel__fills">
-						<ElementorSlot />
-						<ElementorFill />
-					</div>
-				</StyleSheetManager>
-			) );
+			// Start rendering the Yoast tab React content.
+			renderYoastTabReactContent();
 		},
 	}, "more" );
+
+	// Listen for Yoast tab activation from within settings panel to start rendering the Yoast tab React content.
+	jQuery( document ).on( "click", "[data-tab=\"yoast-tab\"] > a", renderYoastTabReactContent );
 
 	yoastInputs = document.querySelectorAll( "input[name^='yoast']" );
 	storeAllValuesAsOldValues();
 
 	setInterval( () => yoastInputs.forEach( detectChange ), 500 );
 }
+

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -199,7 +199,7 @@ class Elementor implements Integration_Interface {
 		$document->start_controls_section(
 			'yoast_temporary_section',
 			[
-				'label' => \__( 'Yoast SEO', 'wordpress-seo' ),
+				'label' => \__( 'Loading Yoast SEO...', 'wordpress-seo' ),
 				'tab'   => self::YOAST_TAB,
 			]
 		);

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -181,7 +181,7 @@ class Elementor implements Integration_Interface {
 	 * Register a panel tab slug, in order to allow adding controls to this tab.
 	 */
 	public function add_yoast_panel_tab() {
-		Controls_Manager::add_tab( $this::YOAST_TAB, \__( 'Yoast SEO', 'wordpress-seo' ) );
+		Controls_Manager::add_tab( $this::YOAST_TAB, 'Yoast SEO' );
 	}
 
 	/**
@@ -199,7 +199,7 @@ class Elementor implements Integration_Interface {
 		$document->start_controls_section(
 			'yoast_temporary_section',
 			[
-				'label' => \__( 'Loading Yoast SEO...', 'wordpress-seo' ),
+				'label' => 'Yoast SEO',
 				'tab'   => self::YOAST_TAB,
 			]
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In Elementor 3.6.0, our way of rendering React in the Elementor Yoast tab is broken. This PR fixes that by changing the place React is rendered.
* The problem is caused by the `run:after` event not being triggered on the `$e.routes` API anymore since [a major Elementor JS refactor](https://github.com/elementor/elementor/commit/9badffae32291ed567412dae9c85cd524cbcc67b#diff-76c13bdd5dc28b8e7fd6da876614f16a39bd59a9ce5f2eaf8701966b77d87c61R475).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an incompatibility with Elementor 3.6.0 where the React contents of the Yoast tab in Elementor are not rendered.

## Relevant technical choices:

* Move rendering of React in Yoast tab from `run:after` event callback to [menu item callback](https://github.com/Yoast/wordpress-seo/pull/18146/files#diff-0d2d7e68459adafb1863b8249cb8e3d5d6594429c2251d23bfe0dbd66430dd17R221).
* Add custom Yoast tab link click listener with `jQuery` for rendering React when a user is already in the settings menu (menu item callback is not triggered when switching tabs within the same menu).
* Added a 200ms timeout before rendering React because we want to wait for Elementor to finish their own DOM manipulations first. Not beautiful, but seems to work well.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Elementor <3.6.0***
1. Install the Elementor 3.5.* plugin.
2. Complete below Shared testing steps.

**Elementor 3.6.***
1. Install the Elementor Beta (Developer Edition) plugin.
2. Update Elementor to the latest beta release (3.6.0-dev*).
3. Complete below Shared testing steps.

**Shared testing steps**
1. Edit a post or page in Elementor.
2. From the top-left hamburger menu, navigate to the Yoast SEO settings.

<img width="298" alt="image" src="https://user-images.githubusercontent.com/24573520/156393942-d6f2fa24-f979-4d3b-a0b4-65c65a2c1152.png">

3. Verify that the Yoast tab opens and our settings render correctly.
4. Now within the same settings menu, switch to a random other tab ie. "settings" or "style" and then back to the Yoast SEO tab.

<img width="301" alt="image" src="https://user-images.githubusercontent.com/24573520/156396886-73b08c0d-13ed-4107-beec-9d890d0ba104.png">

5. Verify that the Yoast tab opens and our settings render correctly.
6. Are there other ways to reach the Yoast tab next to the menu and tab links?

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
