### PR TITLE
Replace QR code nonce with salted code

### DIFF
--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -74,6 +74,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'custom_taxonomy_slugs'                    => [],
 		'enable_enhanced_slack_sharing'            => true,
 		'enable_print_qr_code'                     => true,
+		'print_qr_code_salt'                       => '',
 		'zapier_integration_active'                => false,
 		'zapier_subscription'                      => [],
 		'zapier_api_key'                           => '',
@@ -274,6 +275,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				case 'semrush_country_code':
 				case 'license_server_version':
 				case 'home_url':
+				case 'print_qr_code_salt':
 				case 'zapier_api_key':
 				case 'wincher_website_id':
 					if ( isset( $dirty[ $key ] ) ) {

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -74,7 +74,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'custom_taxonomy_slugs'                    => [],
 		'enable_enhanced_slack_sharing'            => true,
 		'enable_print_qr_code'                     => true,
-		'print_qr_code_salt'                       => '',
 		'zapier_integration_active'                => false,
 		'zapier_subscription'                      => [],
 		'zapier_api_key'                           => '',
@@ -275,7 +274,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				case 'semrush_country_code':
 				case 'license_server_version':
 				case 'home_url':
-				case 'print_qr_code_salt':
 				case 'zapier_api_key':
 				case 'wincher_website_id':
 					if ( isset( $dirty[ $key ] ) ) {

--- a/src/integrations/front-end/print-qrcode-embed.php
+++ b/src/integrations/front-end/print-qrcode-embed.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Integrations\Front_End;
 
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Conditionals\Print_QRCode_Enabled_Conditional;
-use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Surfaces\Meta_Surface;
 
@@ -28,24 +27,12 @@ class Print_QRCode_Embed implements Integration_Interface {
 	private $meta_surface;
 
 	/**
-	 * The Options_Helper instance.
-	 *
-	 * @var Options_Helper
-	 */
-	private $options_helper;
-
-	/**
 	 * Print_QRCode_Embed constructor.
 	 *
-	 * @param Meta_Surface   $meta_surface   The meta surface.
-	 * @param Options_Helper $options_helper The options helper.
+	 * @param Meta_Surface $meta_surface The meta surface.
 	 */
-	public function __construct(
-		Meta_Surface $meta_surface,
-		Options_Helper $options_helper
-	) {
-		$this->meta_surface   = $meta_surface;
-		$this->options_helper = $options_helper;
+	public function __construct( Meta_Surface $meta_surface ) {
+		$this->meta_surface = $meta_surface;
 	}
 
 	/**
@@ -74,7 +61,6 @@ class Print_QRCode_Embed implements Integration_Interface {
 	public function generate_qr_code() {
 		$meta = $this->meta_surface->for_current_page();
 		$url  = $meta->canonical;
-		$salt = $this->options_helper->get( 'print_qr_code_salt' );
 
 		if ( empty( $url ) ) {
 			$url = $meta->indexable->permalink;
@@ -93,12 +79,7 @@ class Print_QRCode_Embed implements Integration_Interface {
 			return;
 		}
 
-		if ( empty( $salt ) ) {
-			$salt = \wp_generate_password();
-			$this->options_helper->set( 'print_qr_code_salt', $salt );
-		}
-
-		$code      = \md5( $salt . $url );
+		$code      = \wp_hash( $url );
 		$alt_text  = __( 'QR Code for current page\'s URL.', 'wordpress-seo' );
 		$text      = __( 'Scan the QR code or go to the URL below to read this article online.', 'wordpress-seo' );
 		$image_url = \trailingslashit( \get_site_url() ) . '?code=' . $code . '&yoast_qr_code=' . rawurlencode( $url );

--- a/src/integrations/front-end/print-qrcode-render.php
+++ b/src/integrations/front-end/print-qrcode-render.php
@@ -5,7 +5,6 @@ namespace Yoast\WP\SEO\Integrations\Front_End;
 use Exception;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Conditionals\Print_QRCode_Enabled_Conditional;
-use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use YoastSEO_Vendor\chillerlan\QRCode\QRCode;
 use YoastSEO_Vendor\chillerlan\QRCode\QROptions;
@@ -14,24 +13,6 @@ use YoastSEO_Vendor\chillerlan\QRCode\QROptions;
  * Class that renders a QR code for URLs.
  */
 class Print_QRCode_Render implements Integration_Interface {
-
-	/**
-	 * The Options_Helper instance.
-	 *
-	 * @var Options_Helper
-	 */
-	private $options_helper;
-
-	/**
-	 * Print_QRCode_Embed constructor.
-	 *
-	 * @param Options_Helper $options_helper The options helper.
-	 */
-	public function __construct(
-		Options_Helper $options_helper
-	) {
-		$this->options_helper = $options_helper;
-	}
 
 	/**
 	 * Register the hooks.
@@ -63,8 +44,7 @@ class Print_QRCode_Render implements Integration_Interface {
 		}
 
 		$code = \filter_input( INPUT_GET, 'code', FILTER_SANITIZE_STRING );
-		$salt = $this->options_helper->get( 'print_qr_code_salt' );
-		if ( \md5( $salt . $url ) !== $code ) {
+		if ( \wp_hash( $url ) !== $code ) {
 			\header( 'Content-Type: text/plain', true, 400 );
 			echo \esc_html( __( 'This is not a QR code endpoint for public consumption.', 'wordpress-seo' ) );
 			exit();

--- a/src/integrations/front-end/print-qrcode-render.php
+++ b/src/integrations/front-end/print-qrcode-render.php
@@ -44,7 +44,7 @@ class Print_QRCode_Render implements Integration_Interface {
 		}
 
 		$code = \filter_input( INPUT_GET, 'code', FILTER_SANITIZE_STRING );
-		if ( \wp_hash( $url ) !== $code ) {
+		if ( ! \hash_equals( \wp_hash( $url ), $code ) ) {
 			\header( 'Content-Type: text/plain', true, 400 );
 			echo \esc_html( __( 'This is not a QR code endpoint for public consumption.', 'wordpress-seo' ) );
 			exit();

--- a/src/integrations/front-end/print-qrcode-render.php
+++ b/src/integrations/front-end/print-qrcode-render.php
@@ -3,16 +3,35 @@
 namespace Yoast\WP\SEO\Integrations\Front_End;
 
 use Exception;
-use YoastSEO_Vendor\chillerlan\QRCode\QRCode;
-use YoastSEO_Vendor\chillerlan\QRCode\QROptions;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Conditionals\Print_QRCode_Enabled_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
+use YoastSEO_Vendor\chillerlan\QRCode\QRCode;
+use YoastSEO_Vendor\chillerlan\QRCode\QROptions;
 
 /**
  * Class that renders a QR code for URLs.
  */
 class Print_QRCode_Render implements Integration_Interface {
+
+	/**
+	 * The Options_Helper instance.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options_helper;
+
+	/**
+	 * Print_QRCode_Embed constructor.
+	 *
+	 * @param Options_Helper $options_helper The options helper.
+	 */
+	public function __construct(
+		Options_Helper $options_helper
+	) {
+		$this->options_helper = $options_helper;
+	}
 
 	/**
 	 * Register the hooks.
@@ -43,9 +62,12 @@ class Print_QRCode_Render implements Integration_Interface {
 			return;
 		}
 
-		$nonce = \filter_input( INPUT_GET, 'nonce', FILTER_SANITIZE_STRING );
-		if ( ! \wp_verify_nonce( $nonce, 'yoast_seo_qr_code' ) ) {
-			\wp_die( 'This is not a QR code endpoint for public consumption.' );
+		$code = \filter_input( INPUT_GET, 'code', FILTER_SANITIZE_STRING );
+		$salt = $this->options_helper->get( 'print_qr_code_salt' );
+		if ( \md5( $salt . $url ) !== $code ) {
+			\header( 'Content-Type: text/plain', true, 400 );
+			echo \esc_html( __( 'This is not a QR code endpoint for public consumption.', 'wordpress-seo' ) );
+			exit();
 		}
 
 		try {
@@ -58,9 +80,9 @@ class Print_QRCode_Render implements Integration_Interface {
 			exit( 200 );
 		}
 		catch ( Exception $e ) {
-			header( 'Content-Type: text/plain', true, 400 );
+			\header( 'Content-Type: text/plain', true, 400 );
 			/* translators: %1$s expands to the error message */
-			echo esc_html( sprintf( __( 'Failed to generate QR Code: %s', 'wordpress-seo' ), $e->getMessage() ) );
+			echo \esc_html( \sprintf( __( 'Failed to generate QR Code: %s', 'wordpress-seo' ), $e->getMessage() ) );
 			exit();
 		}
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Replaces the QR code nonce with a salted code. This has several advantages:
  * It can be cached for more than one day.
  * It can be cached for one user and server to another.
  * The endpoint can only be used with the specific URL we generate rather than any URL ( including vastly more computationally expensive ones ).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the QR code not working when a page is cached for user A but served to user B.
* Fixes the QR code not working if it's served from a cache with an expired nonce.
* Fixes the QR code endpoint being usable with any URL.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* The QR code endpoint should always work on yoast.com, even when logging in as different users.
* The QR code endpoint shouldn't accept any URL you enter.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Generating QR codes when printing.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
