### PR TITLE
Don't use $class as parameter name in free

### DIFF
--- a/src/initializers/migration-runner.php
+++ b/src/initializers/migration-runner.php
@@ -144,20 +144,20 @@ class Migration_Runner implements Initializer_Interface {
 	/**
 	 * Runs a single migration.
 	 *
-	 * @param string $version The version.
-	 * @param string $class   The migration class.
+	 * @param string $version         The version.
+	 * @param string $migration_class The migration class.
 	 *
 	 * @return void
 	 *
 	 * @throws Exception If the migration failed. Caught by the run_migrations function.
 	 */
-	protected function run_migration( $version, $class ) {
+	protected function run_migration( $version, $migration_class ) {
 		/**
 		 * The migration to run.
 		 *
 		 * @var Migration
 		 */
-		$migration = new $class( $this->adapter );
+		$migration = new $migration_class( $this->adapter );
 		try {
 			$this->adapter->start_transaction();
 			$migration->up();
@@ -165,7 +165,7 @@ class Migration_Runner implements Initializer_Interface {
 			$this->adapter->commit_transaction();
 		} catch ( Exception $e ) {
 			$this->adapter->rollback_transaction();
-			throw new Exception( \sprintf( '%s - %s', $class, $e->getMessage() ), 0, $e );
+			throw new Exception( \sprintf( '%s - %s', $migration_class, $e->getMessage() ), 0, $e );
 		}
 	}
 }

--- a/src/loader.php
+++ b/src/loader.php
@@ -64,62 +64,62 @@ class Loader {
 	/**
 	 * Registers an integration.
 	 *
-	 * @param string $class The class name of the integration to be loaded.
+	 * @param string $integration_class The class name of the integration to be loaded.
 	 *
 	 * @return void
 	 */
-	public function register_integration( $class ) {
-		$this->integrations[] = $class;
+	public function register_integration( $integration_class ) {
+		$this->integrations[] = $integration_class;
 	}
 
 	/**
 	 * Registers an initializer.
 	 *
-	 * @param string $class The class name of the initializer to be loaded.
+	 * @param string $initializer_class The class name of the initializer to be loaded.
 	 *
 	 * @return void
 	 */
-	public function register_initializer( $class ) {
-		$this->initializers[] = $class;
+	public function register_initializer( $initializer_class ) {
+		$this->initializers[] = $initializer_class;
 	}
 
 	/**
 	 * Registers a route.
 	 *
-	 * @param string $class The class name of the route to be loaded.
+	 * @param string $route_class The class name of the route to be loaded.
 	 *
 	 * @return void
 	 */
-	public function register_route( $class ) {
-		$this->routes[] = $class;
+	public function register_route( $route_class ) {
+		$this->routes[] = $route_class;
 	}
 
 	/**
 	 * Registers a command.
 	 *
-	 * @param string $class The class name of the command to be loaded.
+	 * @param string $command_class The class name of the command to be loaded.
 	 *
 	 * @return void
 	 */
-	public function register_command( $class ) {
-		$this->commands[] = $class;
+	public function register_command( $command_class ) {
+		$this->commands[] = $command_class;
 	}
 
 	/**
 	 * Registers a migration.
 	 *
-	 * @param string $plugin  The plugin the migration belongs to.
-	 * @param string $version The version of the migration.
-	 * @param string $class   The class name of the migration to be loaded.
+	 * @param string $plugin          The plugin the migration belongs to.
+	 * @param string $version         The version of the migration.
+	 * @param string $migration_class The class name of the migration to be loaded.
 	 *
 	 * @return void
 	 */
-	public function register_migration( $plugin, $version, $class ) {
+	public function register_migration( $plugin, $version, $migration_class ) {
 		if ( ! \array_key_exists( $plugin, $this->migrations ) ) {
 			$this->migrations[ $plugin ] = [];
 		}
 
-		$this->migrations[ $plugin ][ $version ] = $class;
+		$this->migrations[ $plugin ][ $version ] = $migration_class;
 	}
 
 	/**
@@ -220,12 +220,12 @@ class Loader {
 	/**
 	 * Checks if all conditionals of a given integration are met.
 	 *
-	 * @param Loadable_Interface $class The class name of the integration.
+	 * @param Loadable_Interface $integration_class The class name of the integration.
 	 *
 	 * @return bool Whether or not all conditionals of the integration are met.
 	 */
-	protected function conditionals_are_met( $class ) {
-		$conditionals = $class::get_conditionals();
+	protected function conditionals_are_met( $integration_class ) {
+		$conditionals = $integration_class::get_conditionals();
 		foreach ( $conditionals as $conditional ) {
 			if ( ! $this->container->get( $conditional )->is_met() ) {
 				return false;

--- a/src/surfaces/classes-surface.php
+++ b/src/surfaces/classes-surface.php
@@ -23,11 +23,11 @@ class Classes_Surface {
 	/**
 	 * Returns the instance of a class. Handy for unhooking things.
 	 *
-	 * @param string $class The class to get the instance of.
+	 * @param string $class_name The class to get the instance of.
 	 *
 	 * @return mixed The instance of the class.
 	 */
-	public function get( $class ) {
-		return $this->container->get( $class );
+	public function get( $class_name ) {
+		return $this->container->get( $class_name );
 	}
 }

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -48,11 +48,11 @@ if ( ! defined( 'WPSEO_NAMESPACES' ) ) {
 /**
  * Autoload our class files.
  *
- * @param string $class Class name.
+ * @param string $class_name Class name.
  *
  * @return void
  */
-function wpseo_auto_load( $class ) {
+function wpseo_auto_load( $class_name ) {
 	static $classes = null;
 
 	if ( $classes === null ) {
@@ -62,9 +62,9 @@ function wpseo_auto_load( $class ) {
 		];
 	}
 
-	$cn = strtolower( $class );
+	$cn = strtolower( $class_name );
 
-	if ( ! class_exists( $class ) && isset( $classes[ $cn ] ) ) {
+	if ( ! class_exists( $class_name ) && isset( $classes[ $cn ] ) ) {
 		require_once $classes[ $cn ];
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* For php8 compatibility we should avoid using reserved parameter names.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Avoids usage of the reserved parameter name "$class".

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* These changes should all be internal to methods, so no behaviour should be affected. For clarity, the areas touched are:
	* Migration (so migrating the database from version to version should still work)
	* Loader (so autoloading should still work)
	* wp-seo-main (so _everything_ should still work - but loading specifically)
	* classes_surface (this is a helper function used throughout the plugin, so falls in the category "everything should still work").


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-310
