### PR TITLE
Fix a few reserved parameters in the integrations folder

### DIFF
--- a/src/integrations/admin/admin-columns-cache-integration.php
+++ b/src/integrations/admin/admin-columns-cache-integration.php
@@ -216,7 +216,7 @@ class Admin_Columns_Cache_Integration implements Integration_Interface {
 	 *
 	 * @param array $children_pages The full map of child pages.
 	 * @param int   $count          The number of pages already processed.
-	 * @param int   $parent         The parent that's currently being processed.
+	 * @param int   $parent_id      The id of the parent that's currently being processed.
 	 * @param int   $start          The number at which the current overview starts.
 	 * @param int   $end            The number at which the current overview ends.
 	 * @param int   $to_display     The page IDs to be shown.
@@ -224,12 +224,12 @@ class Admin_Columns_Cache_Integration implements Integration_Interface {
 	 *
 	 * @return void
 	 */
-	private function get_child_page_ids( &$children_pages, &$count, $parent, $start, $end, &$to_display, &$pages_map ) {
-		if ( ! isset( $children_pages[ $parent ] ) ) {
+	private function get_child_page_ids( &$children_pages, &$count, $parent_id, $start, $end, &$to_display, &$pages_map ) {
+		if ( ! isset( $children_pages[ $parent_id ] ) ) {
 			return;
 		}
 
-		foreach ( $children_pages[ $parent ] as $page ) {
+		foreach ( $children_pages[ $parent_id ] as $page ) {
 			if ( $count >= $end ) {
 				break;
 			}
@@ -266,6 +266,6 @@ class Admin_Columns_Cache_Integration implements Integration_Interface {
 			$this->get_child_page_ids( $children_pages, $count, $page->ID, $start, $end, $to_display, $pages_map );
 		}
 
-		unset( $children_pages[ $parent ] ); // Required in order to keep track of orphans.
+		unset( $children_pages[ $parent_id ] ); // Required in order to keep track of orphans.
 	}
 }

--- a/src/integrations/third-party/woocommerce-permalinks.php
+++ b/src/integrations/third-party/woocommerce-permalinks.php
@@ -63,11 +63,11 @@ class Woocommerce_Permalinks implements Integration_Interface {
 	/**
 	 * Resets the indexables for WooCommerce based on the changed permalink fields.
 	 *
-	 * @param array $old The old value.
-	 * @param array $new The new value.
+	 * @param array $old_value The old value.
+	 * @param array $new_value The new value.
 	 */
-	public function reset_woocommerce_permalinks( $old, $new ) {
-		$changed_options = \array_diff( $old, $new );
+	public function reset_woocommerce_permalinks( $old_value, $new_value ) {
+		$changed_options = \array_diff( $old_value, $new_value );
 
 		if ( \array_key_exists( 'product_base', $changed_options ) ) {
 			$this->indexable_helper->reset_permalink_indexables( 'post', 'product' );

--- a/src/integrations/watchers/indexable-permalink-watcher.php
+++ b/src/integrations/watchers/indexable-permalink-watcher.php
@@ -120,11 +120,11 @@ class Indexable_Permalink_Watcher implements Integration_Interface {
 	/**
 	 * Resets the term indexables when the base has been changed.
 	 *
-	 * @param string $old  Unused. The old option value.
-	 * @param string $new  Unused. The new option value.
-	 * @param string $type The option name.
+	 * @param string $old_value Unused. The old option value.
+	 * @param string $new_value Unused. The new option value.
+	 * @param string $type      The option name.
 	 */
-	public function reset_permalinks_term( $old, $new, $type ) {
+	public function reset_permalinks_term( $old_value, $new_value, $type ) {
 		$subtype = $type;
 
 		$reason = Indexing_Reasons::REASON_PERMALINK_SETTINGS;

--- a/tests/unit/integrations/third-party/woocommerce-permalinks-test.php
+++ b/tests/unit/integrations/third-party/woocommerce-permalinks-test.php
@@ -113,14 +113,14 @@ class WooCommerce_Permalinks_Test extends TestCase {
 			->once()
 			->with( 'post', 'product' );
 
-		$old = [
+		$old_value = [
 			'product_base' => 'bar',
 		];
-		$new = [
+		$new_value = [
 			'product_base' => 'foo',
 		];
 
-		$this->instance->reset_woocommerce_permalinks( $old, $new );
+		$this->instance->reset_woocommerce_permalinks( $old_value, $new_value );
 	}
 
 	/**
@@ -147,14 +147,14 @@ class WooCommerce_Permalinks_Test extends TestCase {
 			->with( 'my_attribute' )
 			->andReturn( 'my_attribute' );
 
-		$old = [
+		$old_value = [
 			'attribute_base' => 'bar',
 		];
-		$new = [
+		$new_value = [
 			'attribute_base' => 'foo',
 		];
 
-		$this->instance->reset_woocommerce_permalinks( $old, $new );
+		$this->instance->reset_woocommerce_permalinks( $old_value, $new_value );
 	}
 
 	/**
@@ -173,17 +173,17 @@ class WooCommerce_Permalinks_Test extends TestCase {
 			->once()
 			->with( 'term', 'product_tag' );
 
-		$old = [
+		$old_value = [
 			'category_base' => 'bar',
 			'tag_base'      => 'bar',
 			'no_base'       => 'bar',
 		];
-		$new = [
+		$new_value = [
 			'category_base' => 'foo',
 			'tag_base'      => 'foo',
 			'no_base'       => 'foo',
 		];
 
-		$this->instance->reset_woocommerce_permalinks( $old, $new );
+		$this->instance->reset_woocommerce_permalinks( $old_value, $new_value );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* For php8 compatibility we should avoid using reserved parameter names.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Avoids usage of the reserved parameter name "$parent".
* Avoids usage of the reserved parameter name "$new".

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* These changes should all be internal to methods, so no behaviour should be affected. For clarity, the areas touched are:
	* admin_columns_cache_integration -> so areas where we add tables in the admin (e.g. internal link count in post overview) should still work.
	* woocommerce-permalinks -> a function that runs on this action `update_option_woocommerce_permalinks` was affected, so likely changing permalinks in woocommerce should still work.
	* permalink-watcher -> Handles updates to the permalink_structure for the Indexables table. So that should still be working.

All of these are covered by unit tests and all changes are self-contained. So testing is not strictly necessary, just mentioned the areas in case something breaks.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-311
