### PR TITLE
Don't use $bool as a parameter name in integration tests function

### DIFF
--- a/tests/integration/admin/import/test-class-import-aioseo.php
+++ b/tests/integration/admin/import/test-class-import-aioseo.php
@@ -233,12 +233,12 @@ class WPSEO_Import_AIOSEO_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**

--- a/tests/integration/admin/import/test-class-import-greg-high-performance-seo.php
+++ b/tests/integration/admin/import/test-class-import-greg-high-performance-seo.php
@@ -126,12 +126,12 @@ class WPSEO_Import_Greg_SEO_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**

--- a/tests/integration/admin/import/test-class-import-headspace.php
+++ b/tests/integration/admin/import/test-class-import-headspace.php
@@ -128,12 +128,12 @@ class WPSEO_Import_HeadSpace_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**

--- a/tests/integration/admin/import/test-class-import-jetpack.php
+++ b/tests/integration/admin/import/test-class-import-jetpack.php
@@ -123,12 +123,12 @@ class WPSEO_Import_Jetpack_SEO_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**

--- a/tests/integration/admin/import/test-class-import-platinum-seo-pack.php
+++ b/tests/integration/admin/import/test-class-import-platinum-seo-pack.php
@@ -133,12 +133,12 @@ class WPSEO_Import_Platinum_SEO_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**

--- a/tests/integration/admin/import/test-class-import-premium-seo-pack.php
+++ b/tests/integration/admin/import/test-class-import-premium-seo-pack.php
@@ -243,12 +243,12 @@ class WPSEO_Import_Premium_SEO_Pack_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**

--- a/tests/integration/admin/import/test-class-import-rankmath.php
+++ b/tests/integration/admin/import/test-class-import-rankmath.php
@@ -148,12 +148,12 @@ class RankMath_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**

--- a/tests/integration/admin/import/test-class-import-seo-framework.php
+++ b/tests/integration/admin/import/test-class-import-seo-framework.php
@@ -135,12 +135,12 @@ class WPSEO_Import_SEO_Framework_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**

--- a/tests/integration/admin/import/test-class-import-seopressor.php
+++ b/tests/integration/admin/import/test-class-import-seopressor.php
@@ -135,12 +135,12 @@ class WPSEO_Import_SEOPressor_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**

--- a/tests/integration/admin/import/test-class-import-smartcrawl.php
+++ b/tests/integration/admin/import/test-class-import-smartcrawl.php
@@ -276,12 +276,12 @@ class WPSEO_Import_Smartcrawl_SEO_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**

--- a/tests/integration/admin/import/test-class-import-squirrly.php
+++ b/tests/integration/admin/import/test-class-import-squirrly.php
@@ -277,12 +277,12 @@ class WPSEO_Import_Squirrly_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**

--- a/tests/integration/admin/import/test-class-import-ultimate-seo.php
+++ b/tests/integration/admin/import/test-class-import-ultimate-seo.php
@@ -130,12 +130,12 @@ class WPSEO_Import_Ultimate_SEO_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**

--- a/tests/integration/admin/import/test-class-import-woothemes-seo.php
+++ b/tests/integration/admin/import/test-class-import-woothemes-seo.php
@@ -135,12 +135,12 @@ class WPSEO_Import_WooThemes_SEO_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**

--- a/tests/integration/admin/import/test-class-import-wp-meta-seo.php
+++ b/tests/integration/admin/import/test-class-import-wp-meta-seo.php
@@ -130,12 +130,12 @@ class WPSEO_Import_WP_Meta_SEO_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**

--- a/tests/integration/admin/import/test-class-import-wpseo.php
+++ b/tests/integration/admin/import/test-class-import-wpseo.php
@@ -183,12 +183,12 @@ class WPSEO_Import_WPSEO_Test extends WPSEO_UnitTestCase {
 	 * Returns a WPSEO_Import_Status object to check against.
 	 *
 	 * @param string $action The action to return.
-	 * @param bool   $bool   The status.
+	 * @param bool   $status The status.
 	 *
 	 * @return WPSEO_Import_Status Import status object.
 	 */
-	private function status( $action, $bool ) {
-		return new WPSEO_Import_Status( $action, $bool );
+	private function status( $action, $status ) {
+		return new WPSEO_Import_Status( $action, $status );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* For php8 compatibility we should avoid using reserved parameter names.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Avoids usage of the reserved parameter name "$bool" in the integration tests.
* 
## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* These changes should all be internal to methods, so no behaviour should be affected. For clarity, the areas touched are:
	* integration tests

All of these are integration tests and all changes are self-contained. So testing is done by running the tests anyways, just mentioned the areas in case something breaks.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-314
