### PR TITLE
Dont use $string in replacevar function

### DIFF
--- a/src/presenters/abstract-indexable-presenter.php
+++ b/src/presenters/abstract-indexable-presenter.php
@@ -70,11 +70,11 @@ abstract class Abstract_Indexable_Presenter extends Abstract_Presenter {
 	/**
 	 * Replace replacement variables in a string.
 	 *
-	 * @param string $string The string.
+	 * @param string $replacevar_string The string with replacement variables.
 	 *
 	 * @return string The string with replacement variables replaced.
 	 */
-	protected function replace_vars( $string ) {
-		return $this->replace_vars->replace( $string, $this->presentation->source );
+	protected function replace_vars( $replacevar_string ) {
+		return $this->replace_vars->replace( $replacevar_string, $this->presentation->source );
 	}
 }

--- a/src/presenters/admin/light-switch-presenter.php
+++ b/src/presenters/admin/light-switch-presenter.php
@@ -77,7 +77,7 @@ class Light_Switch_Presenter extends Abstract_Presenter {
 	/**
 	 * Light_Switch_Presenter constructor.
 	 *
-	 * @param string      $var                The variable to create the checkbox for.
+	 * @param string      $variable           The variable to create the checkbox for.
 	 * @param string      $label              The visual label text for the toggle.
 	 * @param array       $buttons            Array of two visual labels for the buttons (defaults Disabled/Enabled).
 	 * @param string      $name               The name of the underlying checkbox.
@@ -89,7 +89,7 @@ class Light_Switch_Presenter extends Abstract_Presenter {
 	 * @param string      $disabled_attribute Optional. The disabled HTML attribute. Default is empty.
 	 */
 	public function __construct(
-		$var,
+		$variable,
 		$label,
 		$buttons,
 		$name,
@@ -99,7 +99,7 @@ class Light_Switch_Presenter extends Abstract_Presenter {
 		$strong = false,
 		$disabled_attribute = ''
 	) {
-		$this->var                = $var;
+		$this->var                = $variable;
 		$this->label              = $label;
 		$this->buttons            = $buttons;
 		$this->name               = $name;

--- a/tests/unit/builders/indexable-link-builder-test.php
+++ b/tests/unit/builders/indexable-link-builder-test.php
@@ -89,12 +89,12 @@ class Indexable_Link_Builder_Test extends TestCase {
 		$this->instance->set_dependencies( $this->indexable_repository, $this->image_helper );
 
 		Functions\expect( 'wp_list_pluck' )->andReturnUsing(
-			static function ( $array, $prop ) {
+			static function ( $haystack, $prop ) {
 				return \array_map(
 					static function ( $e ) use ( $prop ) {
 						return $e->{$prop};
 					},
-					$array
+					$haystack
 				);
 			}
 		);

--- a/tests/unit/helpers/pagination-helper-test.php
+++ b/tests/unit/helpers/pagination-helper-test.php
@@ -235,12 +235,12 @@ class Pagination_Helper_Test extends TestCase {
 		Monkey\Functions\expect( 'get_query_var' )
 			->twice()
 			->andReturnUsing(
-				static function( $query_var, $default ) {
+				static function( $query_var, $default_response ) {
 					if ( $query_var === 'page' ) {
-						$default = 2;
+						$default_response = 2;
 					}
 
-					return $default;
+					return $default_response;
 				}
 			);
 

--- a/tests/unit/helpers/schema/replace-vars-helper-test.php
+++ b/tests/unit/helpers/schema/replace-vars-helper-test.php
@@ -287,14 +287,14 @@ class Replace_Vars_Helper_Test extends TestCase {
 	/**
 	 * Returns all the values of the given nested array as one flat array.
 	 *
-	 * @param array $array A nested array of key-value pairs.
+	 * @param array $nested_array A nested array of key-value pairs.
 	 *
 	 * @return array All of the values in the nested array.
 	 */
-	protected function array_values_recursively( $array ) {
+	protected function array_values_recursively( $nested_array ) {
 		$merged = [];
 
-		foreach ( $array as $value ) {
+		foreach ( $nested_array as $value ) {
 			if ( \is_array( $value ) ) {
 				$merged[] = $this->array_values_recursively( $value );
 			}

--- a/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
+++ b/tests/unit/integrations/watchers/indexable-ancestor-watcher-test.php
@@ -331,12 +331,12 @@ class Indexable_Ancestor_Watcher_Test extends TestCase {
 		$term_id = 1;
 
 		Functions\expect( 'wp_list_pluck' )->andReturnUsing(
-			static function ( $array, $prop ) {
+			static function ( $haystack, $prop ) {
 				return \array_map(
 					static function ( $e ) use ( $prop ) {
 						return $e->{$prop};
 					},
-					$array
+					$haystack
 				);
 			}
 		);

--- a/tests/unit/presenters/meta-description-presenter-test.php
+++ b/tests/unit/presenters/meta-description-presenter-test.php
@@ -86,8 +86,8 @@ class Meta_Description_Presenter_Test extends TestCase {
 			->expects( 'replace' )
 			->once()
 			->andReturnUsing(
-				static function( $string ) {
-					return $string;
+				static function( $replace_string ) {
+					return $replace_string;
 				}
 			);
 
@@ -119,8 +119,8 @@ class Meta_Description_Presenter_Test extends TestCase {
 			->expects( 'replace' )
 			->once()
 			->andReturnUsing(
-				static function( $string ) {
-					return $string;
+				static function( $replace_string ) {
+					return $replace_string;
 				}
 			);
 
@@ -151,8 +151,8 @@ class Meta_Description_Presenter_Test extends TestCase {
 			->expects( 'replace' )
 			->once()
 			->andReturnUsing(
-				static function( $string ) {
-					return $string;
+				static function( $replace_string ) {
+					return $replace_string;
 				}
 			);
 

--- a/tests/unit/presenters/open-graph/description-presenter-test.php
+++ b/tests/unit/presenters/open-graph/description-presenter-test.php
@@ -61,8 +61,8 @@ class Description_Presenter_Test extends TestCase {
 			->expects( 'replace' )
 			->once()
 			->andReturnUsing(
-				static function ( $string ) {
-					return $string;
+				static function ( $str ) {
+					return $str;
 				}
 			);
 	}

--- a/tests/unit/presenters/open-graph/title-presenter-test.php
+++ b/tests/unit/presenters/open-graph/title-presenter-test.php
@@ -73,8 +73,8 @@ class Title_Presenter_Test extends TestCase {
 			->withAnyArgs()
 			->once()
 			->andReturnUsing(
-				static function( $string ) {
-					return $string;
+				static function( $str ) {
+					return $str;
 				}
 			);
 	}

--- a/tests/unit/presenters/title-presenter-test.php
+++ b/tests/unit/presenters/title-presenter-test.php
@@ -75,8 +75,8 @@ class Title_Presenter_Test extends TestCase {
 			->withAnyArgs()
 			->once()
 			->andReturnUsing(
-				static function ( $string ) {
-					return $string;
+				static function ( $str ) {
+					return $str;
 				}
 			);
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* For php8 compatibility we should avoid using reserved parameter names.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Avoids usage of the reserved parameter name "$default" in the unit tests.
* Avoids usage of the reserved parameter name "$string" in the unit tests and abstract indexable presenter.
* Avoids usage of the reserved parameter name "$array" in the unit tests.
* Avoids usage of the reserved parameter name "$var" in the light switch presenter.


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* These changes should all be internal to methods, so no behaviour should be affected. For clarity, the areas touched are:
	* unit tests
	* presenters (light switch and abstract indexable presenter)

Most of these are unit tests and all changes are self-contained. So testing is done by running the tests anyways, just mentioned the areas in case something breaks.
If a yoast form light switch acts weirdly, this PR could technically have caused that, but in practice, it cannot have (due to the self-contained changes).


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-315
