### PR TITLE
GH Actions/CodeQL: various improvements

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,15 +26,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,11 +1,9 @@
 name: "CodeQL"
 
 on:
-  # push:
-  #  branches: [develop]
-  #pull_request:
-    # The branches below must be a subset of the branches above
-  #  branches: [develop]
+  pull_request:
+    paths:
+      - '.github/workflows/codeql-analysis.yml'
   schedule:
     - cron: '0 20 * * 2'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
## Context

* Improves CI

## Summary

This PR can be summarized in the following changelog entry:

* Improves CI

## Relevant technical choices:

### GH Actions/CodeQL: remove redundant step

As this workflow is currently only being run via a cron job, the `pull_request` condition will never be met.

Additionally, this step triggers the following warning on GH Actions:
```
Warning: 1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary. Please remove this step as Code Scanning recommends analyzing the merge commit for best results.
```

### GH Actions/CodeQL: version update for various predefined actions

A number of predefined actions have had major release, which warrant an update the workflow(s).

These updates don't actually contain any changed functionality, they are mostly just a change of the Node version used by the action itself (from Node 14 to Node 16).

Refs:
* https://github.com/actions/checkout/releases

### GH Actions/CodeQL: update run triggers

This commit:
* Removes previously commented out `on` triggers to clean up the workflow.
* And adds a new trigger to run this workflow whenever the actual file containing the workflow is changed to allow for verifying that those changes are correct.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ With the third commit of this PR in place, if the build passes, we're good ;-)