### PR TITLE
Add reusable block change listener

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@draft-js-plugins/mention": "^5.0.0",
+    "@wordpress/blocks": "^11.1.2",
     "@wordpress/data": "^4.10.0",
     "@wordpress/dom-ready": "^2.10.0",
     "@wordpress/element": "^2.19.1",

--- a/packages/js/src/analysis/plugins/reusable-blocks-plugin.js
+++ b/packages/js/src/analysis/plugins/reusable-blocks-plugin.js
@@ -39,6 +39,8 @@ class YoastReusableBlocksPlugin {
 
 	/**
 	 * Checks the store for any reusable block changes, and requests a new analysis when so.
+	 *
+	 * @returns {void}
 	 */
 	reusableBlockChangeListener() {
 		const { blocks } = this._selectCoreEditor.getPostEdits();

--- a/packages/js/src/analysis/plugins/reusable-blocks-plugin.js
+++ b/packages/js/src/analysis/plugins/reusable-blocks-plugin.js
@@ -86,7 +86,12 @@ class YoastReusableBlocksPlugin {
 			return content;
 		}
 
-		return content.replace( reusableBlockRegex, ( match, blockId ) => this._reusableBlocks[ blockId ]?.content ?? content );
+		return content.replace( reusableBlockRegex, ( match, blockId ) => {
+			if ( this._reusableBlocks[ blockId ] && this._reusableBlocks[ blockId ].content ) {
+				return this._reusableBlocks[ blockId ].content;
+			}
+			return content;
+		} );
 	}
 
 	/**

--- a/packages/js/src/analysis/plugins/reusable-blocks-plugin.js
+++ b/packages/js/src/analysis/plugins/reusable-blocks-plugin.js
@@ -1,3 +1,7 @@
+import { __unstableSerializeAndClean, isReusableBlock } from "@wordpress/blocks";
+import { select, subscribe } from "@wordpress/data";
+import { isFunction } from "lodash";
+
 /**
  * Plugin to parse reusable blocks in the content before it is analyzed.
  */
@@ -7,22 +11,65 @@ class YoastReusableBlocksPlugin {
 	 *
 	 * @param {Function} registerPlugin        Function to register this plugin.
 	 * @param {Function} registerModification  Function to register a modification of this plugin.
-	 * @param {Object}   blockEditorDataModule The WordPress block editor data module. E.g. `window.wp.data.select("core/block-editor")`
+	 * @param {Function} refreshAnalysis       Function to refresh the analysis.
 	 */
-	constructor( registerPlugin, registerModification, blockEditorDataModule ) {
+	constructor( registerPlugin, registerModification, refreshAnalysis ) {
 		this._registerPlugin = registerPlugin;
 		this._registerModification = registerModification;
-		this.blockEditorDataModule = blockEditorDataModule;
+		this._refreshAnalysis = refreshAnalysis;
+
+		this._reusableBlocks = {};
+		this._selectCore = select( "core" );
+		this._selectCoreEditor = select( "core/editor" );
+
+		this.reusableBlockChangeListener = this.reusableBlockChangeListener.bind( this );
+		this.parseReusableBlocks = this.parseReusableBlocks.bind( this );
 	}
 
 	/**
-	 * Registers the plugin and modification with YoastSEO.js
+	 * Registers listeners: the plugin modifications and store subscriber.
 	 *
 	 * @returns {void}
 	 */
 	register() {
 		this._registerPlugin( "YoastReusableBlocksPlugin", { status: "ready" } );
-		this._registerModification( "content", this.parseReusableBlocks.bind( this ), "YoastReusableBlocksPlugin", 1 );
+		this._registerModification( "content", this.parseReusableBlocks, "YoastReusableBlocksPlugin", 1 );
+		subscribe( this.reusableBlockChangeListener );
+	}
+
+	/**
+	 * Checks the store for any reusable block changes, and requests a new analysis when so.
+	 */
+	reusableBlockChangeListener() {
+		const { blocks } = this._selectCoreEditor.getPostEdits();
+
+		if ( ! blocks ) {
+			return;
+		}
+
+		let hasChanged = false;
+		blocks.forEach( block => {
+			if ( ! isReusableBlock( block ) ) {
+				return;
+			}
+
+			const content = this.getBlockContent( block.attributes.ref );
+			if ( ! this._reusableBlocks[ block.attributes.ref ] ) {
+				this._reusableBlocks[ block.attributes.ref ] = {
+					id: block.attributes.ref,
+					clientId: block.clientId,
+					content,
+				};
+				hasChanged = true;
+			} else if ( this._reusableBlocks[ block.attributes.ref ].content !== content ) {
+				this._reusableBlocks[ block.attributes.ref ].content = content;
+				hasChanged = true;
+			}
+		} );
+
+		if ( hasChanged ) {
+			this._refreshAnalysis();
+		}
 	}
 
 	/**
@@ -39,20 +86,32 @@ class YoastReusableBlocksPlugin {
 			return content;
 		}
 
-		const { __experimentalReusableBlocks } = this.blockEditorDataModule.getSettings();
+		return content.replace( reusableBlockRegex, ( match, blockId ) => this._reusableBlocks[ blockId ]?.content ?? content );
+	}
 
-		if ( ! __experimentalReusableBlocks ) {
-			return content;
+	/**
+	 * Retrieves the (reusable) block content.
+	 *
+	 * Workaround the static ref block of reusable blocks that the `getEditedPostContent` returns.
+	 * Based on the editor selector: `getEditedPostContent`.
+	 *
+	 * @param {number} blockId The block ID.
+	 * @returns {string} The block content.
+	 */
+	getBlockContent( blockId ) {
+		const record = this._selectCore.getEditedEntityRecord( "postType", "wp_block", blockId );
+
+		if ( record ) {
+			if ( isFunction( record.content ) ) {
+				return record.content( record );
+			} else if ( record.blocks ) {
+				return __unstableSerializeAndClean( record.blocks );
+			} else if ( record.content ) {
+				return record.content;
+			}
 		}
 
-		return content.replace( reusableBlockRegex, ( match, blockId ) => {
-			const reusableBlockId = parseInt( blockId, 10 );
-			const reusableBlock = __experimentalReusableBlocks.find( item => item.id === reusableBlockId );
-
-			if ( reusableBlock ) {
-				return reusableBlock.content.raw;
-			}
-		} );
+		return "";
 	}
 }
 

--- a/packages/js/src/analysis/plugins/reusable-blocks-plugin.js
+++ b/packages/js/src/analysis/plugins/reusable-blocks-plugin.js
@@ -1,6 +1,6 @@
 import { __unstableSerializeAndClean, isReusableBlock } from "@wordpress/blocks";
 import { select, subscribe } from "@wordpress/data";
-import { isFunction } from "lodash";
+import { isFunction, debounce } from "lodash";
 
 /**
  * Plugin to parse reusable blocks in the content before it is analyzed.
@@ -34,7 +34,7 @@ class YoastReusableBlocksPlugin {
 	register() {
 		this._registerPlugin( "YoastReusableBlocksPlugin", { status: "ready" } );
 		this._registerModification( "content", this.parseReusableBlocks, "YoastReusableBlocksPlugin", 1 );
-		subscribe( this.reusableBlockChangeListener );
+		subscribe( debounce( this.reusableBlockChangeListener, 500 ) );
 	}
 
 	/**

--- a/packages/js/src/initializers/post-scraper.js
+++ b/packages/js/src/initializers/post-scraper.js
@@ -418,8 +418,6 @@ export default function initPostScraper( $, store, editorData ) {
 		const appArgs = getAppArgs( store );
 		app = new App( appArgs );
 
-		const blockEditorDataModule = select( "core/block-editor" );
-
 		// Content analysis
 		window.YoastSEO = window.YoastSEO || {};
 		window.YoastSEO.app = app;
@@ -431,7 +429,7 @@ export default function initPostScraper( $, store, editorData ) {
 			store,
 			customAnalysisData,
 			app.pluggable,
-			blockEditorDataModule
+			select( "core/block-editor" )
 		);
 		window.YoastSEO.analysis.applyMarks = ( paper, marks ) => getApplyMarks()( paper, marks );
 
@@ -477,7 +475,7 @@ export default function initPostScraper( $, store, editorData ) {
 		} );
 
 		if ( isBlockEditor() ) {
-			const reusableBlocksPlugin = new YoastReusableBlocksPlugin( app.registerPlugin, app.registerModification, blockEditorDataModule );
+			const reusableBlocksPlugin = new YoastReusableBlocksPlugin( app.registerPlugin, app.registerModification, window.YoastSEO.app.refresh );
 			reusableBlocksPlugin.register();
 		}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,6 +1169,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.16.0", "@babel/runtime@^7.9.2":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
+  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.4.2":
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.2.tgz#f5ab6897320f16decd855eed70b705908a313fe8"
@@ -3027,6 +3034,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
 
+"@types/lodash@^4.14.172":
+  version "4.14.179"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.179.tgz#490ec3288088c91295780237d2497a3aa9dfb5c5"
+  integrity sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==
+
 "@types/lodash@^4.14.175":
   version "4.14.177"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.177.tgz#f70c0d19c30fab101cad46b52be60363c43c4578"
@@ -3048,6 +3060,11 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
+
+"@types/mousetrap@^1.6.8":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@types/mousetrap/-/mousetrap-1.6.9.tgz#f1ef9adbd1eac3466f21b6988b1c82c633a45340"
+  integrity sha512-HUAiN65VsRXyFCTicolwb5+I7FM6f72zjMWr+ajGk+YTvzBgXqa2A5U7d+rtsouAkunJ5U4Sb5lNJjo9w+nmXg==
 
 "@types/node@*", "@types/node@>=8.9.0":
   version "14.14.35"
@@ -3091,6 +3108,13 @@
   dependencies:
     "@types/react" "^16"
 
+"@types/react-dom@^17.0.11":
+  version "17.0.13"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.13.tgz#a3323b974ee4280070982b3112351bb1952a7809"
+  integrity sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-test-renderer@^16.9.5":
   version "16.9.5"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.5.tgz#edab67da470f7c3e997f58d55dcfe2643cc30a68"
@@ -3102,6 +3126,15 @@
   version "16.14.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.5.tgz#2c39b5cadefaf4829818f9219e5e093325979f4d"
   integrity sha512-YRRv9DNZhaVTVRh9Wmmit7Y0UFhEVqXqCSw3uazRWMxa2x85hWQZ5BN24i7GXZbaclaLXEcodEeIHsjBA8eAMw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17.0.37":
+  version "17.0.39"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
+  integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -3583,6 +3616,13 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@wordpress/autop@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/autop/-/autop-3.3.1.tgz#f1ce103e2bf39a8493db047cd600b8baea842c61"
+  integrity sha512-x8c0Xy7PHrx2PPpox+8G0P8ch7m81yvroTXgHjLX7GoZFgPrBMKz36qdqatO/IfJXYvN1X4k7hEWEW1E8mvfgQ==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+
 "@wordpress/babel-plugin-import-jsx-pragma@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.0.3.tgz#d6a091371fd66fa78d1aaa1e9bcdfc0895663af7"
@@ -3616,6 +3656,13 @@
   integrity sha512-r78o1Rni+ZezCFP4o+85bdssBL/y1eiRwQPAm7cCQGUH9Pv2uf5I3utjV3OA04GsJHQmQVASFw3ZORoH7uiBfQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@wordpress/blob@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/blob/-/blob-3.3.1.tgz#ac632572ddef6a812a64d7be9a0cf92ffc04d7c8"
+  integrity sha512-+KOf5Mvna6nffpIg6eAYI8gzCSV3ZFihzIjUmY2+vKiLeFocol5OYxp2YxiohDiwRoghFo1raVu3VhnDFtudAw==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
 
 "@wordpress/block-editor@^5.3.1":
   version "5.3.1"
@@ -3666,6 +3713,40 @@
   integrity sha512-8hz+t9YUWnmuh2P5LpAotj5Xt2hXR6OobdtEFahTl21X+UcSVEKVhnWsHQESQ8uxwUm5k+3ZCdn5FjJK+XOdTw==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@wordpress/block-serialization-default-parser@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.3.1.tgz#54dc29095a29091dd3ffdfbdc4ca9c9ea2ae628d"
+  integrity sha512-zYg759iJBFsJ4jaG8cSjcSmcUVPWsj2gVvAO95iTWt6GhnQWV/b29x2BugxgzhZcwjEd8X15cTgzbJZwSzlTJA==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+
+"@wordpress/blocks@^11.1.2":
+  version "11.2.2"
+  resolved "https://registry.yarnpkg.com/@wordpress/blocks/-/blocks-11.2.2.tgz#ae914a94335896476505a8eb093c72bb88a96858"
+  integrity sha512-0xfAMYNLP/IK6H8FtULeM7LoaoQzwR1U5BqUn1tjU3yQifBxd4SUtjTw7sqzHe3+1NLg+gkv1YrdoPeAWlZksg==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    "@wordpress/autop" "^3.3.1"
+    "@wordpress/blob" "^3.3.1"
+    "@wordpress/block-serialization-default-parser" "^4.3.1"
+    "@wordpress/compose" "^5.1.2"
+    "@wordpress/data" "^6.3.0"
+    "@wordpress/deprecated" "^3.3.1"
+    "@wordpress/dom" "^3.3.2"
+    "@wordpress/element" "^4.1.1"
+    "@wordpress/hooks" "^3.3.1"
+    "@wordpress/html-entities" "^3.3.1"
+    "@wordpress/i18n" "^4.3.1"
+    "@wordpress/is-shallow-equal" "^4.3.1"
+    "@wordpress/shortcode" "^3.3.1"
+    colord "^2.7.0"
+    hpq "^1.3.0"
+    lodash "^4.17.21"
+    rememo "^3.0.0"
+    showdown "^1.9.1"
+    simple-html-tokenizer "^0.5.7"
+    uuid "^8.3.0"
 
 "@wordpress/blocks@^8.0.1":
   version "8.0.1"
@@ -3794,6 +3875,26 @@
     react-resize-aware "^3.1.0"
     use-memo-one "^1.1.1"
 
+"@wordpress/compose@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-5.1.2.tgz#09445e535f286e2f78d7149a6545605c60877130"
+  integrity sha512-JfJ4hPIyeukPHlJwCfKtF1Bw2aqK/z7GuFdyzXYzp6z2DpJSpTp+Qbbe9LsbKwpJ9pkb+Pras/As7xBVqCbq8g==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    "@types/lodash" "^4.14.172"
+    "@types/mousetrap" "^1.6.8"
+    "@wordpress/deprecated" "^3.3.1"
+    "@wordpress/dom" "^3.3.2"
+    "@wordpress/element" "^4.1.1"
+    "@wordpress/is-shallow-equal" "^4.3.1"
+    "@wordpress/keycodes" "^3.3.1"
+    "@wordpress/priority-queue" "^2.3.1"
+    clipboard "^2.0.8"
+    lodash "^4.17.21"
+    mousetrap "^1.6.5"
+    react-resize-aware "^3.1.0"
+    use-memo-one "^1.1.1"
+
 "@wordpress/core-data@^2.26.1":
   version "2.26.1"
   resolved "https://registry.yarnpkg.com/@wordpress/core-data/-/core-data-2.26.1.tgz#1517ffaa27289b2e077f292828928bec09d5743b"
@@ -3862,6 +3963,25 @@
     turbo-combine-reducers "^1.0.2"
     use-memo-one "^1.1.1"
 
+"@wordpress/data@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/data/-/data-6.3.0.tgz#715824749ac67c2ee9ee88fa57757dba9e68b365"
+  integrity sha512-HHTVp2+zqlHU4wT0rFgiwoBjotqon7YmF3pKTKMPWTcyV7lDsrV0pERu7fy7WdoNwJodnL498Zqs6Ll6BoMtwg==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    "@wordpress/compose" "^5.1.2"
+    "@wordpress/deprecated" "^3.3.1"
+    "@wordpress/element" "^4.1.1"
+    "@wordpress/is-shallow-equal" "^4.3.1"
+    "@wordpress/priority-queue" "^2.3.1"
+    "@wordpress/redux-routine" "^4.3.1"
+    equivalent-key-map "^0.2.2"
+    is-promise "^4.0.0"
+    lodash "^4.17.21"
+    redux "^4.1.2"
+    turbo-combine-reducers "^1.0.2"
+    use-memo-one "^1.1.1"
+
 "@wordpress/date@^3.15.0":
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/@wordpress/date/-/date-3.15.0.tgz#7c265e6a196e5a2731d3d4a2317390351115d121"
@@ -3919,6 +4039,14 @@
     "@babel/runtime" "^7.13.10"
     "@wordpress/hooks" "^3.1.1"
 
+"@wordpress/deprecated@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/deprecated/-/deprecated-3.3.1.tgz#2fbc79560daf5bf809bd3ccca428c1d8655cf9cb"
+  integrity sha512-odAidoqFhyOXdK+NnTykELBzmaOmQFBeYm5ZaT8FB6Jqw0jiKWaNu8VfUukyWsV7EQj1XcwO/6R3unj9pjSiVA==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    "@wordpress/hooks" "^3.3.1"
+
 "@wordpress/dom-ready@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@wordpress/dom-ready/-/dom-ready-1.2.0.tgz#d95877eb6f929532ec971983b55e731babb78d9c"
@@ -3947,6 +4075,14 @@
   integrity sha512-NkNkgczdQweWXXiP7uaXmuu58JsRU/WN9OTWT0pVTZumTQKsvm0Fcs55jt3NBG+X/F80DC+DPVW6+sTKv0Lqxg==
   dependencies:
     "@babel/runtime" "^7.13.10"
+    lodash "^4.17.21"
+
+"@wordpress/dom@^3.3.2":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@wordpress/dom/-/dom-3.3.2.tgz#f207546f499ee96e508bc65fe67805230dc3adf6"
+  integrity sha512-ZWbPpaDf33MRSnLZhNvXrKSfMGAqKopVHcCFFmAI/v+b3C5Y+YxtgafL2C9rptDuKp32hNAKNz81oaMy1wAa4Q==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
     lodash "^4.17.21"
 
 "@wordpress/e2e-test-utils@^5.1.2":
@@ -4049,6 +4185,19 @@
     react "^16.13.1"
     react-dom "^16.13.1"
 
+"@wordpress/element@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-4.1.1.tgz#3d403eba33227d80f75c6b3cc3d80529d900096c"
+  integrity sha512-lzrCvQOtzyRguw+VlG8EVzy8aexJ2Fk3tN8ifefvvTN0vNJeFdoEaSZGqYCoVvRKHKXpLfX9vMsVp0Ug0EWPcQ==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    "@types/react" "^17.0.37"
+    "@types/react-dom" "^17.0.11"
+    "@wordpress/escape-html" "^2.3.1"
+    lodash "^4.17.21"
+    react "^17.0.2"
+    react-dom "^17.0.2"
+
 "@wordpress/escape-html@^1.12.1":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-1.12.1.tgz#1ecb9a269786706bbc7a4c06ddf2b949dca272d3"
@@ -4076,6 +4225,13 @@
   integrity sha512-ZIkLxGLBhXkZu3t0yF82/brPV5aCOGCXGiH0EMV8GCohhXCNIfQwwFrZ5gd5NyNX5Q8alTLsiA84azJd+n0XiQ==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@wordpress/escape-html@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-2.3.1.tgz#81dd894f2b1d8ae38f60df20f42397154b083701"
+  integrity sha512-7lqbW1NiIQOlAwxc6iAfZ69v7sf2/2lZOfS5ntIrdB+erqHURkgwvqAOGJ2VwJcjQadaKbDIMf8YPZPwYY66+A==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
 
 "@wordpress/eslint-plugin@^9.0.3":
   version "9.0.3"
@@ -4120,12 +4276,26 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@wordpress/hooks@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-3.3.1.tgz#7fe7291788350dc4d00b9d5cb20db69debcf8a40"
+  integrity sha512-Eyc5YYX8010Ihr6Ab4lq9G7J9DmPiLnGf6C4WwEMf0iQ9SBw8hcp2TCwkSyC12DU7iY0o11FYGfgdGW3UpPiYA==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+
 "@wordpress/html-entities@^2.11.1":
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/@wordpress/hooks/-/hooks-2.11.1.tgz#86ad30cb20a8212f8c119894ff197574c84360e4"
   integrity sha512-20nsvmLH5/iw9P6M7kiEBBQ7X7G3pEbqED/aN5dqkMCklDyar+OZqYBzdpGGsthXVYgomfNy6QQZWELkGJbcbw==
   dependencies:
     "@babel/runtime" "^7.12.5"
+
+"@wordpress/html-entities@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/html-entities/-/html-entities-3.3.1.tgz#8a5149913c9a33737526b95ecad649ac5d89e43b"
+  integrity sha512-vMF8XN7kE07fdqUB27PnvKbQsWXnJmSw1WEVhHGCSHZJcw2i29lDwUwdLxDwHi+M5R3y677bw1XAHnHH2JZ7Lg==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
 
 "@wordpress/i18n@^1.1.0", "@wordpress/i18n@^1.2.3":
   version "1.2.3"
@@ -4158,6 +4328,19 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@wordpress/hooks" "^3.1.1"
+    gettext-parser "^1.3.1"
+    lodash "^4.17.21"
+    memize "^1.1.0"
+    sprintf-js "^1.1.1"
+    tannin "^1.2.0"
+
+"@wordpress/i18n@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-4.3.1.tgz#919b336614c53123567da3e76275208f289a923d"
+  integrity sha512-4xeGUOhZL+Xl97VPSEslWJxCjQPuK2I8AEJWe5cb1u/YOcgTzOav2QN7T7wYzt3Os5bfqNBmTFMfOr+1goFPrw==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    "@wordpress/hooks" "^3.3.1"
     gettext-parser "^1.3.1"
     lodash "^4.17.21"
     memize "^1.1.0"
@@ -4202,6 +4385,13 @@
   integrity sha512-Bc782s4Kte98RKLtuDXOaUBpyJWUgN4XZJevEoFasKQTpABZUDF+Y2C0/dhnlJeYF5TDEd8TQgFfpF5csxEUNw==
   dependencies:
     "@babel/runtime" "^7.13.10"
+
+"@wordpress/is-shallow-equal@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/is-shallow-equal/-/is-shallow-equal-4.3.1.tgz#7cffd6c40481eb81d471567261c0bd4d82ee84a0"
+  integrity sha512-aLtWAhQVVZxpGpTi+dAwQmeyIGbiFH7mb4vUu97kuTHJnA4wGl7UMLVTr/zqDHMuSQk1jfvomD2smVSyfRbPVg==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
 
 "@wordpress/jest-console@^4.0.3":
   version "4.0.3"
@@ -4252,6 +4442,15 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@wordpress/i18n" "^4.1.1"
+    lodash "^4.17.21"
+
+"@wordpress/keycodes@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/keycodes/-/keycodes-3.3.1.tgz#9fe207e13966af26b72aaf19bf973fbe56ce25e6"
+  integrity sha512-d/8wCjqB8c5426i8kLSRDxR/tezZFR0R/OOPFLoh/XnKiuRda/8OuPdSTUDmsLCam+yjV9K5uRm0KcMiZeFu7A==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    "@wordpress/i18n" "^4.3.1"
     lodash "^4.17.21"
 
 "@wordpress/media-utils@^1.20.1":
@@ -4355,6 +4554,13 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@wordpress/priority-queue@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/priority-queue/-/priority-queue-2.3.1.tgz#3898e3b25cd46f15e3872f3b7cfb5308cb2da0ea"
+  integrity sha512-nDrQ2/6cn5plHn+8gq7MhrMmmjeCn6jOXMufR9ADAzmBejRGAKnKsoZBFVNpkeUOv20A6xv7dvylpxtwo46J+A==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+
 "@wordpress/redux-routine@^3.14.1":
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/@wordpress/redux-routine/-/redux-routine-3.14.1.tgz#f0e88802f55e970b01617eec4a9fe44a64b9f98f"
@@ -4373,6 +4579,16 @@
     "@babel/runtime" "^7.4.4"
     is-promise "^2.1.0"
     lodash "^4.17.15"
+    rungen "^0.3.2"
+
+"@wordpress/redux-routine@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/redux-routine/-/redux-routine-4.3.1.tgz#f909eb46dc0f3f1678b983ab81c234f09c786f19"
+  integrity sha512-6IDRh8XtUowbP5BDhP2OBSRlDplbWQdZ7qEwnYyVLAd0Mx4aTibfNPhzhrJm1/Foiv0zplOqBLeZG2E0CDpwpw==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    is-promise "^4.0.0"
+    lodash "^4.17.21"
     rungen "^0.3.2"
 
 "@wordpress/reusable-blocks@^1.2.1":
@@ -4490,6 +4706,15 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     lodash "^4.17.19"
+    memize "^1.1.0"
+
+"@wordpress/shortcode@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@wordpress/shortcode/-/shortcode-3.3.1.tgz#25bd19bb05560d0abd98a56d681ec4087c0f6dee"
+  integrity sha512-nuFwDrPRSU73rCiR+nUkaW3R0ykUKj5+rS5Sv1Yz10E2F5gtFyFySQNKlSVIwgpxeHKIKDs1AopAZupUqxK/Rw==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    lodash "^4.17.21"
     memize "^1.1.0"
 
 "@wordpress/stylelint-config@^19.0.3":
@@ -7490,6 +7715,15 @@ clipboard@^2.0.1:
     select "^1.1.2"
     tiny-emitter "^2.0.0"
 
+clipboard@^2.0.8:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.10.tgz#e61f6f7139ac5044c58c0484dcac9fb2a918bfd6"
+  integrity sha512-cz3m2YVwFz95qSEbCDi2fzLN/epEN9zXBvfgAoGkvGOJZATMl9gtTDVOtBYkx2ODUJl2kvmud7n32sV2BpYR4g==
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
@@ -7687,6 +7921,11 @@ color@^3.0.0:
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.4"
+
+colord@^2.7.0:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.2.tgz#25e2bacbbaa65991422c07ea209e2089428effb1"
+  integrity sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==
 
 colorette@^1.2.1, colorette@^1.2.2:
   version "1.2.2"
@@ -18840,6 +19079,15 @@ react-dock@^0.3.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
+
 react-event-listener@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.4.5.tgz#e3e895a0970cf14ee8f890113af68197abf3d0b1"
@@ -19110,6 +19358,14 @@ react-with-styles@^3.2.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
+
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -19494,6 +19750,13 @@ redux@^4.0.0, redux@^4.0.1:
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
+
+redux@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
+  integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 reflect.ownkeys@^0.2.0:
   version "0.2.0"
@@ -20187,6 +20450,14 @@ scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -21493,6 +21764,11 @@ svgo@^1.2.2:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+  integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
 
 symbol-observable@^1.0.3, symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Pick up reusable block changes in the analysis.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where reusable block content would not be updated in our analysis when changed in the editor.

## Relevant technical choices:

* Note that this gets all the content of all the blocks on every store change... far from optimal. I failed to find a better ways to fix this.
* Added the `@wordpress/blocks` dependency at the version that should be in WP now (`11.9` according to https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create/edit a post in the block editor
* Add some blocks
* Convert/add a couple of reusable blocks
* Verify the analysis text gets the correct content. I use debug output: e.g. put `define( 'YOAST_SEO_DEBUG_ANALYSIS_WORKER', 'TRACE' );` in the PHP somewhere (config?). Alternatively, you can verify the text length analysis counted the right amount of words.
* Edit a reusable block and verify the analysis triggered (the text length analysis should adjust?)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Because this implementation is rather crude. It would be worth testing this on posts with a LOT of reusable blocks, to see if the performance impact is acceptable.

Wrapped the 'change' listener in a `debounce` function
* [Video demonstrating the debounce](https://user-images.githubusercontent.com/20287474/157442097-9d964eb3-9fd3-4979-a96a-3abc00d7a5f1.mov)
  * Note: the console log is removed

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [P1-1225](https://yoast.atlassian.net/browse/P1-1225)
