### PR TITLE
Dupp 290 remove social profiles controls

### DIFF
--- a/admin/pages/social.php
+++ b/admin/pages/social.php
@@ -15,7 +15,7 @@ $yform = Yoast_Form::get_instance();
 $yform->admin_header( true, 'wpseo_social' );
 
 $social_tabs = new WPSEO_Option_Tabs( 'social' );
-$social_tabs->add_tab( new WPSEO_Option_Tab( 'accounts', __( 'Accounts', 'wordpress-seo' ) ) );
+$social_tabs->add_tab( new WPSEO_Option_Tab( 'accounts', __( 'Accounts', 'wordpress-seo' ), [ 'save_button' => false ] ) );
 $social_tabs->add_tab( new WPSEO_Option_Tab( 'facebook', __( 'Facebook', 'wordpress-seo' ) ) );
 $social_tabs->add_tab( new WPSEO_Option_Tab( 'twitterbox', __( 'Twitter', 'wordpress-seo' ) ) );
 $social_tabs->add_tab( new WPSEO_Option_Tab( 'pinterest', __( 'Pinterest', 'wordpress-seo' ) ) );

--- a/admin/views/tabs/social/accounts.php
+++ b/admin/views/tabs/social/accounts.php
@@ -23,89 +23,47 @@ $social_profiles_help = new WPSEO_Admin_Help_Panel(
 
 $company_or_person = WPSEO_Options::get( 'company_or_person', '' );
 
-$organization_social_fields = [
-	[
-		'id'         => 'facebook_site',
-		'label'      => __( 'Facebook Page URL', 'wordpress-seo' ),
-		'attributes' => [ 'type' => 'url' ],
-	],
-	[
-		'id'         => 'twitter_site',
-		'label'      => __( 'Twitter Username', 'wordpress-seo' ),
-		'attributes' => [ 'type' => 'text' ],
-	],
-	[
-		'id'         => 'instagram_url',
-		'label'      => __( 'Instagram URL', 'wordpress-seo' ),
-		'attributes' => [ 'type' => 'url' ],
-	],
-	[
-		'id'         => 'linkedin_url',
-		'label'      => __( 'LinkedIn URL', 'wordpress-seo' ),
-		'attributes' => [ 'type' => 'url' ],
-	],
-	[
-		'id'         => 'myspace_url',
-		'label'      => __( 'MySpace URL', 'wordpress-seo' ),
-		'attributes' => [ 'type' => 'url' ],
-	],
-	[
-		'id'         => 'pinterest_url',
-		'label'      => __( 'Pinterest URL', 'wordpress-seo' ),
-		'attributes' => [ 'type' => 'url' ],
-	],
-	[
-		'id'         => 'youtube_url',
-		'label'      => __( 'YouTube URL', 'wordpress-seo' ),
-		'attributes' => [ 'type' => 'url' ],
-	],
-	[
-		'id'         => 'wikipedia_url',
-		'label'      => __( 'Wikipedia URL', 'wordpress-seo' ),
-		'attributes' => [ 'type' => 'url' ],
-	],
-];
-
-$yform = Yoast_Form::get_instance();
-
 if ( $company_or_person === 'person' ) {
 	echo '<div class="paper tab-block">';
-	echo '<h2><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Your website is currently configured to represent a Person', 'wordpress-seo' ) . '</h2>';
-	echo '<p><em>';
-	esc_html_e( 'That means that the form and information below is disabled, and not used.', 'wordpress-seo' );
-	echo '</em></p>';
+	echo '<h2>' . esc_html__( 'Personal social profiles', 'wordpress-seo' ) . '</h2>';
 	echo '<p>';
 	$user_id = WPSEO_Options::get( 'company_or_person_user_id', '' );
 	$person  = get_userdata( $user_id );
 	printf(
 		/* translators: 1: link to edit user page. */
-		esc_html__( 'To change the social accounts used for your site, update the details for %1$s.', 'wordpress-seo' ),
+		esc_html__( 'Your website is currently configured to represent a person. If you want to edit the social accounts for your site, please go to the user profile of the selected person: %1$s.', 'wordpress-seo' ),
 		'<a href="' . esc_url( admin_url( 'user-edit.php?user_id=' . $user_id ) ) . '">' . esc_html( $person->display_name ) . '</a>'
 	);
-	echo ' ';
+	echo '</p>';
+	echo '<p>';
 	printf(
 		/* translators: 1: link tag to the relevant WPSEO admin page; 2: link close tag. */
-		esc_html__( 'To make your site represent a Company or Organization go to %1$sSearch Appearance%2$s and set Organization or Person to "Organization".', 'wordpress-seo' ),
+		esc_html__( 'If you want your site to represent an Organization, please select \'Organization\' in the \'Knowledge Graph & Schema.org\' section of the %1$sSearch Appearance%2$s settings.', 'wordpress-seo' ),
 		'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_titles' ) ) . '">',
 		'</a>'
 	);
 	echo '</p></div>';
-
-	// Organization social fields should still be rendered, because other wise the values are lost on save.
-	foreach ( $organization_social_fields as $organization ) {
-		$yform->hidden( $organization['id'] );
-	}
 }
 
 if ( $company_or_person === 'company' ) {
-	// phpcs:ignore WordPress.Security.EscapeOutput -- get_button_html() output is properly escaped.
-	echo '<h2 class="help-button-inline">' . esc_html__( 'Organization social profiles', 'wordpress-seo' ) . $social_profiles_help->get_button_html() . '</h2>';
-	// phpcs:ignore WordPress.Security.EscapeOutput -- get_panel_html() output is properly escaped.
-	echo $social_profiles_help->get_panel_html();
-
-	foreach ( $organization_social_fields as $organization ) {
-		$yform->textinput( $organization['id'], $organization['label'], $organization['attributes'] );
-	}
+	// phpcs:ignore WordPress.Security.EscapeOutput -- string is properly escaped.
+	echo '<h2>' . esc_html__( 'Organization\'s social profiles', 'wordpress-seo' ) . '</h2>';
+	echo '<p>';
+	printf(
+		/* translators: 1: link tag to the first time configuration; 2: link close tag. */
+		esc_html__( 'Your website is currently configured to represent an Organization. If you want to edit the social accounts for your site, please go to the \'Social profiles\' step of the  %1$sfirst time configuration%2$s.', 'wordpress-seo' ),
+		'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_workouts#configuration' ) ) . '">',
+		'</a>'
+	);
+	echo '</p>';
+	echo '<p>';
+	printf(
+		/* translators: 1: link tag to the relevant WPSEO admin page; 2: link close tag. */
+		esc_html__( 'If you want your site to represent a Person, please select \'Person\' in the \'Knowledge Graph & Schema.org\' section of the %1$sSearch Appearance%2$s settings.', 'wordpress-seo' ),
+		'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_titles' ) ) . '">',
+		'</a>'
+	);
+	echo '</p>';
 }
 
 do_action( 'wpseo_admin_other_section' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Organizations currently specify information related to their social profiles in the _Accounts_ tab of the _Social_ page in the admin menu sidebar. With the introduction of the _First time configuration_ workout users will specify this information in the _Social profiles_ step instead, so the form in the _Accounts_ tab of the _Social_ page must be removed. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*  Remove social accounts form for Organization and update both Person and Organization text

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
* Click on on _Search Appearance_ in the _SEO_ submenu of the admin menu sidebar
* Make sure that in the _Knowledge Graph & Schema.org_ section _Organization_ is selected from the first drop-down menu
* Click on _Social_ in the _SEO_ submenu of the admin menu sidebar and verify the following screen appears:
<img width="715" alt="Screenshot 2022-03-07 at 15 51 29" src="https://user-images.githubusercontent.com/68744851/157057664-02491357-d48e-4024-b1aa-f64cfd80b239.png">

* Verify that both the _first time configuration_ and  _Search Appearance_ links work as intended
* Click on _Search Appearance_ in the _SEO_ submenu of the admin menu sidebar
* In the _Knowledge Graph & Schema.org_ section select _Person_ from the first drop-down menu
* Click on  _Social_ in the _SEO_ submenu of the admin menu sidebar and verify the following screen appears:
<img width="734" alt="Screenshot 2022-03-07 at 15 51 45" src="https://user-images.githubusercontent.com/68744851/157058173-c8c46ecd-a6f8-43ab-a0ef-d79e069d15f8.png">
* Verify that both the user's profile and _Search Appearance_ links work as intended


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-290]


[DUPP-290]: https://yoast.atlassian.net/browse/DUPP-290?atlOrigin=eyJpIjoiYzA1MTRjN2NiNDE4NDhiNmFjOGY4OWQ0MDBhNmVkMjgiLCJwIjoiaiJ9