### PR TITLE
Use tailwind combobox as user-select dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.13.10",
     "@slack/webhook": "^5.0.2",
+    "@tailwindcss/forms": "^0.5.0",
     "@typescript-eslint/eslint-plugin": "^4.24.0",
     "@typescript-eslint/parser": "^4.24.0",
     "@wordpress/dependency-extraction-webpack-plugin": "^3.1.0",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@draft-js-plugins/mention": "^5.0.0",
-    "@headlessui/react": "^1.4.2",
+    "@headlessui/react": "^1.5",
     "@heroicons/react": "^1.0.5",
     "@wordpress/data": "^4.10.0",
     "@wordpress/dom-ready": "^2.10.0",

--- a/packages/js/src/workouts/components/ConfigurationWorkout.js
+++ b/packages/js/src/workouts/components/ConfigurationWorkout.js
@@ -119,9 +119,10 @@ function configurationWorkoutReducer( state, action ) {
 			newState.personLogo = "";
 			newState.personLogoId = "";
 			return newState;
-		case "SET_PERSON_ID":
+		case "SET_PERSON":
 			newState = handleStepEdit( newState, 2 );
-			newState.personId = action.payload;
+			newState.personId = action.payload.value;
+			newState.personName = action.payload.label;
 			return newState;
 		case "CHANGE_SOCIAL_PROFILE":
 			newState = handleStepEdit( newState, 3 );

--- a/packages/js/src/workouts/tailwind-components/base/alert.js
+++ b/packages/js/src/workouts/tailwind-components/base/alert.js
@@ -67,7 +67,7 @@ Alert.defaultProps = {
  * @returns {WPElement} An Alert that expands and fades in.
  */
 export function FadeInAlert( { id, isVisible, expandDuration, type, children, className } ) {
-	const [ alertOpacity, setAlertOpacity ] = useState( "yst-opacity-0" );
+	const [ alertOpacity, setAlertOpacity ] = useState( isVisible ? "yst-opacity-100" : "yst-opacity-0" );
 	const startOpacityTransition = useCallback( () => {
 		setAlertOpacity( "yst-opacity-100" );
 	} );

--- a/packages/js/src/workouts/tailwind-components/base/combo-box.js
+++ b/packages/js/src/workouts/tailwind-components/base/combo-box.js
@@ -54,6 +54,16 @@ export default function YoastComboBox( { value, label, onChange, options, onInpu
 		setFilteredOptions( options );
 	}, [ options ] );
 
+	/**
+	 * Returns a function that is used by the Combobox.Option className prop.
+	 * Otherwise we have no option of overriding the selected prop that they pass (and avoid arrow functions in the render).
+	 */
+	const getOptionBasedStyles = useCallback( ( optionValue, selectedValue ) => {
+		return ( { selected, active } ) => {
+			return getOptionActiveStyles( { selected: selected || optionValue === selectedValue, active } );
+		};
+	}, [ getOptionActiveStyles ] );
+
 	return <Combobox as="div" value={ value } onChange={ onChange }>
 		{
 			( { open } ) => {
@@ -79,9 +89,7 @@ export default function YoastComboBox( { value, label, onChange, options, onInpu
 									return <Combobox.Option
 										key={ `yst-option-${ option.value }` }
 										value={ option }
-										className={ ( { selected, active } ) => {
-											return getOptionActiveStyles( { selected: selected || option.value === value.value, active } );
-										} }
+										className={ getOptionBasedStyles( option.value, value.value ) }
 									>
 										{ ( { selected } ) => (
 											<>

--- a/packages/js/src/workouts/tailwind-components/base/combo-box.js
+++ b/packages/js/src/workouts/tailwind-components/base/combo-box.js
@@ -64,7 +64,7 @@ export default function YoastComboBox( { value, label, onChange, options, onInpu
 		};
 	}, [ getOptionActiveStyles ] );
 
-	return <Combobox as="div" value={ value } onChange={ onChange }>
+	return <Combobox id="configuration-user-select" as="div" value={ value } onChange={ onChange }>
 		{
 			( { open } ) => {
 				return <Fragment>

--- a/packages/js/src/workouts/tailwind-components/base/combo-box.js
+++ b/packages/js/src/workouts/tailwind-components/base/combo-box.js
@@ -23,10 +23,12 @@ function getDisplayValue( selectedOption ) {
  *
  * @returns {string} Styles for an active option.
  */
-function getOptionActiveStyles( { active } ) {
+function getOptionActiveStyles( { active, selected } ) {
 	return classNames(
-		"yst-relative yst-cursor-default yst-select-none yst-py-2 yst-pl-3 yst-pr-9",
-		active ? "yst-bg-primary-500 yst-text-white" : "yst-text-gray-900"
+		"yst-relative yst-cursor-default yst-select-none yst-py-2 yst-pl-3 yst-pr-9 yst-my-0",
+		selected && "yst-bg-primary-500 yst-text-white",
+		( active && ! selected ) && "yst-bg-primary-200 yst-text-gray-900",
+		( ! active && ! selected ) && "yst-text-gray-900"
 	);
 }
 
@@ -77,18 +79,17 @@ export default function YoastComboBox( { value, label, onChange, options, onInpu
 									return <Combobox.Option
 										key={ `yst-option-${ option.value }` }
 										value={ option }
-										className={ getOptionActiveStyles }
+										className={ ( { selected, active } ) => {
+											return getOptionActiveStyles( { selected: selected || option.value === value.value, active } );
+										} }
 									>
-										{ ( { active, selected } ) => (
+										{ ( { selected } ) => (
 											<>
 												<span className={ classNames( "yst-block yst-truncate", selected && "yst-font-semibold" ) }>{ option.label }</span>
 
 												{ ( selected || value.value === option.value ) && (
 													<span
-														className={ classNames(
-															"yst-absolute yst-inset-y-0 yst-right-0 yst-flex yst-items-center yst-pr-4",
-															active ? "yst-text-white" : "yst-text-primary-500"
-														) }
+														className={ "yst-absolute yst-inset-y-0 yst-right-0 yst-flex yst-items-center yst-pr-4 yst-text-white" }
 													>
 														<CheckIcon className="yst-h-5 yst-w-5" aria-hidden="true" />
 													</span>

--- a/packages/js/src/workouts/tailwind-components/base/combo-box.js
+++ b/packages/js/src/workouts/tailwind-components/base/combo-box.js
@@ -45,7 +45,7 @@ export default function YoastComboBox( { value, label, onChange, onQueryChange, 
 		if ( onQueryChange ) {
 			onQueryChange( query );
 		} else {
-			setFilteredOptions( options.filter( option => option.label.includes( query ) ) );
+			setFilteredOptions( options.filter( option => option.label.toLowerCase().includes( query.toLowerCase() ) ) );
 		}
 	}, [ query, onQueryChange ] );
 

--- a/packages/js/src/workouts/tailwind-components/base/combo-box.js
+++ b/packages/js/src/workouts/tailwind-components/base/combo-box.js
@@ -22,7 +22,7 @@ function getDisplayValue( selectedOption ) {
  * The Yoast version of a Tailwind Combobox.
  *
  * @param {Object}   props               The props object.
- * @param {Object}   props.value         Selected user in the form of {id, name}.
+ * @param {Object}   props.value         Selected option with shape {id, option_name}.
  * @param {string}   props.label         Combobox label.
  * @param {function} props.onChange      Function to manage a selected option.
  * @param {function} props.onQueryChange Function to be called when the text inside the text input changes.

--- a/packages/js/src/workouts/tailwind-components/base/combo-box.js
+++ b/packages/js/src/workouts/tailwind-components/base/combo-box.js
@@ -21,7 +21,13 @@ function getDisplayValue( selectedOption ) {
 /**
  * The Yoast version of a Tailwind Combobox.
  *
- * @param {Object} props The props object.
+ * @param {Object}   props               The props object.
+ * @param {Object}   props.value         Selected user in the form of {id, name}.
+ * @param {string}   props.label         Combobox label.
+ * @param {function} props.onChange      Function to manage a selected option.
+ * @param {function} props.onQueryChange Function to be called when the text inside the text input changes.
+ * @param {array}    props.options       Combobox select options.
+ * @param {string}   props.placeholder   Combobox text input placeholder.
  *
  * @returns {WPElement} The Yoast version of a Tailwind Combobox.
  */

--- a/packages/js/src/workouts/tailwind-components/base/combo-box.js
+++ b/packages/js/src/workouts/tailwind-components/base/combo-box.js
@@ -94,7 +94,7 @@ export default function YoastComboBox( { value, label, onChange, onQueryChange, 
 						</Combobox.Button>
 
 						{ ( filteredOptions.length > 0 ) && (
-							<Combobox.Options className="yst-absolute yst-z-10 yst-mt-1 yst-max-h-60 yst-w-full yst-overflow-auto yst-rounded-md yst-bg-white yst-py-1 yst-text-base yst-shadow-lg yst-ring-1 yst-ring-black yst-ring-opacity-5 focus:yst-outline-none sm:yst-text-sm">
+							<Combobox.Options className="yst-absolute yst-z-10 yst-mt-1 yst-max-h-60 yst-w-full yst-overflow-auto yst-rounded-md yst-bg-white yst-text-base yst-shadow-lg yst-ring-1 yst-ring-black yst-ring-opacity-5 focus:yst-outline-none sm:yst-text-sm">
 								{ filteredOptions.map( ( option ) => {
 									return <Combobox.Option
 										key={ `yst-option-${ option.value }` }

--- a/packages/js/src/workouts/tailwind-components/base/combo-box.js
+++ b/packages/js/src/workouts/tailwind-components/base/combo-box.js
@@ -37,7 +37,7 @@ function getOptionActiveStyles( { active } ) {
  *
  * @returns {WPElement} The Yoast version of a Tailwind Combobox.
  */
-export default function YoastComboBox( { value, onChange, options, onInputChange, placeholder } ) {
+export default function YoastComboBox( { value, label, onChange, options, onInputChange, placeholder } ) {
 	const [ filteredOptions, setFilteredOptions ] = useState( options );
 
 	const handleInputChange = useCallback( ( event ) => {
@@ -56,7 +56,7 @@ export default function YoastComboBox( { value, onChange, options, onInputChange
 		{
 			( { open } ) => {
 				return <Fragment>
-					<Combobox.Label className="yst-block yst-text-sm yst-font-medium yst-text-gray-700">{ __( "Name", "wordpress-seo" ) }</Combobox.Label>
+					{ label && <Combobox.Label className="yst-block yst-max-w-sm yst-text-sm yst-font-medium yst-text-gray-700">{ label }</Combobox.Label> }
 					<div className="yst-h-[45px] yst-max-w-sm yst-relative yst-mt-1">
 						<Combobox.Input
 							className="yst-w-full yst-rounded-md yst-border yst-border-gray-300 yst-bg-white yst-py-2 yst-pl-3 yst-pr-10 yst-shadow-sm focus:yst-border-primary-500 focus:yst-outline-none focus:yst-ring-1 focus:yst-ring-primary-500 sm:yst-text-sm"
@@ -113,12 +113,14 @@ YoastComboBox.propTypes = {
 		value: PropTypes.number,
 		label: PropTypes.string,
 	} ),
+	label: PropTypes.string,
 	onInputChange: PropTypes.func,
 	placeholder: PropTypes.string,
 };
 
 YoastComboBox.defaultProps = {
 	value: null,
+	label: "",
 	onInputChange: null,
 	placeholder: __( "Select an option", "wordpress-seo" ),
 };

--- a/packages/js/src/workouts/tailwind-components/base/combo-box.js
+++ b/packages/js/src/workouts/tailwind-components/base/combo-box.js
@@ -22,7 +22,9 @@ function getDisplayValue( selectedOption ) {
  * The Yoast version of a Tailwind Combobox.
  *
  * @param {Object}   props               The props object.
- * @param {Object}   props.value         Selected option with shape {id, option_name}.
+ * @param {Object}   props.value         Selected option with shape {value, label}.
+ * @param {*}        props.value.value   The id of the selected option
+ * @param {string}   props.value.label   The display label of the selected option
  * @param {string}   props.label         Combobox label.
  * @param {function} props.onChange      Function to manage a selected option.
  * @param {function} props.onQueryChange Function to be called when the text inside the text input changes.

--- a/packages/js/src/workouts/tailwind-components/base/combo-box.js
+++ b/packages/js/src/workouts/tailwind-components/base/combo-box.js
@@ -1,0 +1,125 @@
+import { Combobox } from "@headlessui/react";
+import { CheckIcon, SelectorIcon } from "@heroicons/react/solid";
+import { __ } from "@wordpress/i18n";
+import { Fragment, useState, useEffect, useCallback } from "@wordpress/element";
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import { noop } from "lodash";
+
+/**
+ * A function needed to extract the label to display when a person is selected.
+ *
+ * @param {*} selectedOption The object to get a display value for.
+ *
+ * @returns {string|null} The value to display. Returns null if there is no label.
+ */
+function getDisplayValue( selectedOption ) {
+	return selectedOption && selectedOption.label ? selectedOption.label : null;
+}
+
+/**
+ * Helper function to get active styles for select options.
+ *
+ * @param {boolean} options.active Whether the option is active.
+ *
+ * @returns {string} Styles for an active option.
+ */
+function getOptionActiveStyles( { active } ) {
+	return classNames(
+		"yst-relative yst-cursor-default yst-select-none yst-py-2 yst-pl-3 yst-pr-9",
+		active ? "yst-bg-primary-500 yst-text-white" : "yst-text-gray-900"
+	);
+}
+
+/**
+ * The Yoast version of a Tailwind Combobox.
+ *
+ * @param {Object} props The props object.
+ *
+ * @returns {WPElement} The Yoast version of a Tailwind Combobox.
+ */
+export default function YoastComboBox( { value, onChange, options, onInputChange, placeholder } ) {
+	const [ filteredOptions, setFilteredOptions ] = useState( options );
+
+	const handleInputChange = useCallback( ( event ) => {
+		if ( onInputChange ) {
+			onInputChange( event );
+		} else {
+			setFilteredOptions( options.filter( option => option.label.includes( event.target.value ) ) );
+		}
+	}, [ options, onInputChange ] );
+
+	useEffect( () => {
+		setFilteredOptions( options );
+	}, [ options ] );
+
+	return <Combobox as="div" value={ value } onChange={ onChange }>
+		{
+			( { open } ) => {
+				return <Fragment>
+					<Combobox.Label className="yst-block yst-text-sm yst-font-medium yst-text-gray-700">{ __( "Name", "wordpress-seo" ) }</Combobox.Label>
+					<div className="yst-h-[45px] yst-max-w-sm yst-relative yst-mt-1">
+						<Combobox.Input
+							className="yst-w-full yst-rounded-md yst-border yst-border-gray-300 yst-bg-white yst-py-2 yst-pl-3 yst-pr-10 yst-shadow-sm focus:yst-border-primary-500 focus:yst-outline-none focus:yst-ring-1 focus:yst-ring-primary-500 sm:yst-text-sm"
+							onChange={ handleInputChange }
+							displayValue={ getDisplayValue }
+							placeholder={ placeholder }
+						/>
+						<Combobox.Button
+							id="configuration-user-select-button"
+							className="yst-absolute yst-inset-y-0 yst-right-0 yst-flex yst-items-center yst-rounded-r-md yst-px-2 focus:yst-outline-none"
+						>
+							<SelectorIcon className="yst-h-5 yst-w-5 yst-text-gray-400" aria-hidden="true" />
+						</Combobox.Button>
+
+						{ ( filteredOptions.length > 0 && open ) && (
+							<Combobox.Options static={ true } className="yst-absolute yst-z-10 yst-mt-1 yst-max-h-60 yst-w-full yst-overflow-auto yst-rounded-md yst-bg-white yst-py-1 yst-text-base yst-shadow-lg yst-ring-1 yst-ring-black yst-ring-opacity-5 focus:yst-outline-none sm:yst-text-sm">
+								{ filteredOptions.map( ( option ) => {
+									return <Combobox.Option
+										key={ `yst-option-${ option.value }` }
+										value={ option }
+										className={ getOptionActiveStyles }
+									>
+										{ ( { active, selected } ) => (
+											<>
+												<span className={ classNames( "yst-block yst-truncate", selected && "yst-font-semibold" ) }>{ option.label }</span>
+
+												{ ( selected || value.value === option.value ) && (
+													<span
+														className={ classNames(
+															"yst-absolute yst-inset-y-0 yst-right-0 yst-flex yst-items-center yst-pr-4",
+															active ? "yst-text-white" : "yst-text-primary-500"
+														) }
+													>
+														<CheckIcon className="yst-h-5 yst-w-5" aria-hidden="true" />
+													</span>
+												) }
+											</>
+										) }
+									</Combobox.Option>;
+								} ) }
+							</Combobox.Options>
+						) }
+					</div>
+				</Fragment>;
+			}
+		}
+	</Combobox>;
+}
+
+YoastComboBox.propTypes = {
+	onChange: PropTypes.func.isRequired,
+	options: PropTypes.array.isRequired,
+	value: PropTypes.shape( {
+		value: PropTypes.number,
+		label: PropTypes.string,
+	} ),
+	onInputChange: PropTypes.func,
+	placeholder: PropTypes.string,
+};
+
+YoastComboBox.defaultProps = {
+	value: null,
+	onInputChange: null,
+	placeholder: __( "Select an option", "wordpress-seo" ),
+};

--- a/packages/js/src/workouts/tailwind-components/base/combo-box.js
+++ b/packages/js/src/workouts/tailwind-components/base/combo-box.js
@@ -4,7 +4,6 @@ import { __ } from "@wordpress/i18n";
 import { Fragment, useState, useEffect, useCallback } from "@wordpress/element";
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import { noop } from "lodash";
 
 /**
  * A function needed to extract the label to display when a person is selected.

--- a/packages/js/src/workouts/tailwind-components/base/single-select.js
+++ b/packages/js/src/workouts/tailwind-components/base/single-select.js
@@ -71,7 +71,7 @@ export default function Select( { id, value, choices, label, onChange, error } )
 												<li
 													className={ classNames(
 														active ? "yst-text-white yst-bg-primary-600" : "yst-text-gray-900",
-														"yst-cursor-default yst-select-none yst-relative yst-py-2 yst-pl-3 yst-pr-9"
+														"yst-cursor-default yst-select-none yst-relative yst-py-2 yst-pl-3 yst-pr-9 yst-my-0"
 													) }
 												>
 													<span

--- a/packages/js/src/workouts/tailwind-components/base/single-select.js
+++ b/packages/js/src/workouts/tailwind-components/base/single-select.js
@@ -4,7 +4,7 @@ import { Fragment, useMemo } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import classNames from "classnames";
 import { PropTypes } from "prop-types";
-import { getErrorAriaProps, getErrorId } from "../helpers";
+import { getErrorAriaProps, getErrorId, getOptionActiveStyles } from "../helpers";
 import MultiLineText from "./multi-line-text";
 
 /**
@@ -30,7 +30,7 @@ export default function Select( { id, value, choices, label, onChange, error } )
 		<Listbox value={ value } onChange={ onChange }>
 			{ ( { open } ) => (
 				<>
-					{ label && <Listbox.Label className="yst-block yst-max-w-sm yst-mb-2 yst-text-sm yst-font-medium yst-text-gray-700">{ label }</Listbox.Label> }
+					{ label && <Listbox.Label className="yst-block yst-max-w-sm yst-mb-1 yst-text-sm yst-font-medium yst-text-gray-700">{ label }</Listbox.Label> }
 					<div className="yst-max-w-sm">
 						<div className="yst-relative">
 							<Listbox.Button
@@ -69,10 +69,7 @@ export default function Select( { id, value, choices, label, onChange, error } )
 										>
 											{ ( { selected, active } ) => (
 												<li
-													className={ classNames(
-														active ? "yst-text-white yst-bg-primary-600" : "yst-text-gray-900",
-														"yst-cursor-default yst-select-none yst-relative yst-py-2 yst-pl-3 yst-pr-9 yst-my-0"
-													) }
+													className={ getOptionActiveStyles( { selected, active } ) }
 												>
 													<span
 														className={ classNames(
@@ -86,8 +83,7 @@ export default function Select( { id, value, choices, label, onChange, error } )
 													{ selected ? (
 														<span
 															className={ classNames(
-																active ? "yst-text-white" : "yst-text-primary-600",
-																"yst-absolute yst-inset-y-0 yst-right-0 yst-flex yst-items-center yst-pr-4"
+																"yst-text-white yst-absolute yst-inset-y-0 yst-right-0 yst-flex yst-items-center yst-pr-4"
 															) }
 														>
 															<CheckIcon className="yst-w-5 yst-h-5" aria-hidden="true" />

--- a/packages/js/src/workouts/tailwind-components/base/single-select.js
+++ b/packages/js/src/workouts/tailwind-components/base/single-select.js
@@ -59,7 +59,7 @@ export default function Select( { id, value, choices, label, onChange, error } )
 							>
 								<Listbox.Options
 									static={ true }
-									className="yst-absolute yst-z-10 yst-w-full yst-py-1 yst-mt-1 yst-overflow-auto yst-bg-white yst-rounded-md yst-shadow-lg yst-max-h-60 yst-ring-1 yst-ring-black yst-ring-opacity-5 focus:yst-outline-none sm:yst-text-sm"
+									className="yst-absolute yst-z-10 yst-w-full yst-mt-1 yst-overflow-auto yst-bg-white yst-rounded-md yst-shadow-lg yst-max-h-60 yst-ring-1 yst-ring-black yst-ring-opacity-5 focus:yst-outline-none sm:yst-text-sm"
 								>
 									{ choices.map( ( choice ) => (
 										<Listbox.Option

--- a/packages/js/src/workouts/tailwind-components/base/single-select.js
+++ b/packages/js/src/workouts/tailwind-components/base/single-select.js
@@ -30,7 +30,7 @@ export default function Select( { id, value, choices, label, onChange, error } )
 		<Listbox value={ value } onChange={ onChange }>
 			{ ( { open } ) => (
 				<>
-					{ label && <Listbox.Label className="yst-block yst-mb-2 yst-text-sm yst-font-medium yst-text-gray-700">{ label }</Listbox.Label> }
+					{ label && <Listbox.Label className="yst-block yst-max-w-sm yst-mb-2 yst-text-sm yst-font-medium yst-text-gray-700">{ label }</Listbox.Label> }
 					<div className="yst-max-w-sm">
 						<div className="yst-relative">
 							<Listbox.Button

--- a/packages/js/src/workouts/tailwind-components/helpers/index.js
+++ b/packages/js/src/workouts/tailwind-components/helpers/index.js
@@ -1,3 +1,5 @@
+import classNames from "classnames";
+
 /**
  * Creates the error ID for the error component.
  *
@@ -21,3 +23,18 @@ export const getErrorAriaProps = ( inputId, { isVisible } ) => isVisible ? {
 	"aria-describedby": getErrorId( inputId ),
 } : {};
 
+/**
+ * Helper function to get active styles for select options.
+ *
+ * @param {boolean} options.active Whether the option is active.
+ *
+ * @returns {string} Styles for an active option.
+ */
+export function getOptionActiveStyles( { active, selected } ) {
+	return classNames(
+		"yst-relative yst-cursor-default yst-select-none yst-py-2 yst-pl-3 yst-pr-9 yst-my-0",
+		selected && "yst-bg-primary-500 yst-text-white",
+		( active && ! selected ) && "yst-bg-primary-200 yst-text-gray-900",
+		( ! active && ! selected ) && "yst-text-gray-900"
+	);
+}

--- a/packages/js/src/workouts/tailwind-components/steps/indexation/ConfigurationIndexation.js
+++ b/packages/js/src/workouts/tailwind-components/steps/indexation/ConfigurationIndexation.js
@@ -44,7 +44,6 @@ export function ConfigurationIndexation( { indexingStateCallback, indexingState,
 	>
 		<Transition
 			unmount={ false }
-			appear={ true }
 			show={ [ "completed", "already_done" ].includes( indexingState ) }
 			enter="yst-transition-opacity yst-duration-1000"
 			enterFrom="yst-opacity-0"

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/person-section.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/person-section.js
@@ -29,8 +29,8 @@ export function PersonSection( { dispatch, imageUrl, personId } ) {
 	} );
 
 	const onUserChange = useCallback(
-		( value, name ) => {
-			setPersonName( name );
+		( { value, label } ) => {
+			setPersonName( label );
 			dispatch( { type: "SET_PERSON_ID", payload: value } );
 		},
 		[ dispatch ]

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/person-section.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/person-section.js
@@ -1,4 +1,4 @@
-import { useCallback, useState, createInterpolateElement, Fragment } from "@wordpress/element";
+import { useCallback, createInterpolateElement, Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 
@@ -16,8 +16,7 @@ import ImageSelect from "../../base/image-select";
  * @param {bool}     isDisabled   A flag to disable the field.
  * @returns {WPElement} The person section.
  */
-export function PersonSection( { dispatch, imageUrl, personId } ) {
-	const [ personName, setPersonName ] = useState( "" );
+export function PersonSection( { dispatch, imageUrl, person } ) {
 	const openImageSelect = useCallback( () => {
 		openMedia( ( selectedImage ) => {
 			dispatch( { type: "SET_PERSON_LOGO", payload: { ...selectedImage } } );
@@ -29,9 +28,8 @@ export function PersonSection( { dispatch, imageUrl, personId } ) {
 	} );
 
 	const onUserChange = useCallback(
-		( { value, label } ) => {
-			setPersonName( label );
-			dispatch( { type: "SET_PERSON_ID", payload: value } );
+		( selectedPerson ) => {
+			dispatch( { type: "SET_PERSON", payload: selectedPerson } );
 		},
 		[ dispatch ]
 	);
@@ -43,7 +41,7 @@ export function PersonSection( { dispatch, imageUrl, personId } ) {
 				"You have selected the user %1$s as the person this site represents. This user profile information will now be used in search results. %2$sUpdate this profile to make sure the information is correct%3$s.",
 				"wordpress-seo"
 			),
-			`<b>${ personName }</b>`,
+			`<b>${ person.name }</b>`,
 			"<a>",
 			"</a>"
 		),
@@ -52,7 +50,7 @@ export function PersonSection( { dispatch, imageUrl, personId } ) {
 			// eslint-disable-next-line jsx-a11y/anchor-has-content
 			a: <a
 				id="yoast-configuration-workout-user-selector-user-link"
-				href={ window.wpseoScriptData.searchAppearance.userEditUrl.replace( "{user_id}", personId ) }
+				href={ window.wpseoScriptData.searchAppearance.userEditUrl.replace( "{user_id}", person.id ) }
 				target="_blank" rel="noopener noreferrer"
 			/>,
 		}
@@ -61,14 +59,14 @@ export function PersonSection( { dispatch, imageUrl, personId } ) {
 	return (
 		<Fragment>
 			<UserSelector
-				initialValue={ personId }
+				initialValue={ person }
 				onChangeCallback={ onUserChange }
 				name={ "person_id" }
 				placeholder={ __( "Select a user", "wordpress-seo" ) }
 			/>
 			<FadeInAlert
 				id="user-representation-alert"
-				isVisible={ personId !== 0 }
+				isVisible={ person.id !== 0 }
 				type="info"
 				className="yst-mt-5"
 			>
@@ -91,10 +89,16 @@ export function PersonSection( { dispatch, imageUrl, personId } ) {
 PersonSection.propTypes = {
 	dispatch: PropTypes.func.isRequired,
 	imageUrl: PropTypes.string,
-	personId: PropTypes.number,
+	person: PropTypes.shape( {
+		id: PropTypes.number,
+		name: PropTypes.string,
+	} ),
 };
 
 PersonSection.defaultProps = {
 	imageUrl: "",
-	personId: 0,
+	person: {
+		id: 0,
+		name: "",
+	},
 };

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/person-section.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/person-section.js
@@ -60,13 +60,11 @@ export function PersonSection( { dispatch, imageUrl, personId } ) {
 
 	return (
 		<Fragment>
-			<label className="yst-block yst-mt-6 yst-mb-2 yst-font-medium" htmlFor={ "person_id" }>
-				{ __( "Name", "wordpress-seo" ) }
-			</label>
 			<UserSelector
-				value={ personId }
-				onChange={ onUserChange }
+				initialValue={ personId }
+				onChangeCallback={ onUserChange }
 				name={ "person_id" }
+				placeholder={ __( "Select a user", "wordpress-seo" ) }
 			/>
 			<FadeInAlert
 				id="user-representation-alert"

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/site-representation-step.js
@@ -33,7 +33,7 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 		{  window.wpseoWorkoutsData.configuration.knowledgeGraphMessage &&  <Alert type="warning">
 			{  window.wpseoWorkoutsData.configuration.knowledgeGraphMessage }
 		</Alert> }
-		<p className="yst-text-sm yst-whitespace-pre-line yst-mb-8">
+		<p className="yst-text-sm yst-whitespace-pre-line yst-mb-6">
 			{
 				addLinkToString(
 					sprintf(
@@ -76,7 +76,7 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 			easing="linear"
 			onAnimationEnd={ startOpacityTransition }
 		>
-			<div className={ classNames( "yst-transition-opacity yst-duration-300", sectionOpacity ) }>
+			<div className={ classNames( "yst-transition-opacity yst-duration-300 yst-mt-6", sectionOpacity ) }>
 				{ state.companyOrPerson === "company" && <OrganizationSection
 					dispatch={ dispatch }
 					imageUrl={ state.companyLogo }

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/site-representation-step.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/site-representation-step.js
@@ -85,7 +85,10 @@ export default function SiteRepresentationStep( { onOrganizationOrPersonChange, 
 				{ state.companyOrPerson === "person" && <PersonSection
 					dispatch={ dispatch }
 					imageUrl={ state.personLogo }
-					personId={ state.personId }
+					person={ {
+						id: state.personId,
+						name: state.personName,
+					} }
 				/> }
 			</div>
 		</ReactAnimateHeight>

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
@@ -27,10 +27,12 @@ function fetchUsers( query = "" ) {
 /**
  * A user selector based on a headlessui combobox.
  *
- * @param {Object}   props            The props.
- * @param {Object}   initialValue     The option selected by default in the combo box select with shape {id, name}.
- * @param {function} onChangeCallback Function to manage a selected option.
- * @param {string}   placeholder      YoastCombobox text input placeholder.
+ * @param {Object}   props                    The props.
+ * @param {Object}   props.initialValue       The option selected by default in the combo box select with shape {id, name}.
+ * @param {number}   props.initialValue.value The id of the selected user.
+ * @param {string}   props.initialValue.label The name of the selected user.
+ * @param {function} props.onChangeCallback   Function to manage a selected option.
+ * @param {string}   props.placeholder        YoastCombobox text input placeholder.
  *
  * @returns {WPElement} A user selector based on a headlessui combobox.
  */

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
@@ -1,11 +1,9 @@
 /* global wpApiSettings */
-
-import Select from "react-select/async";
 import { Combobox } from "@headlessui/react";
 import { CheckIcon, SelectorIcon } from "@heroicons/react/solid";
-import { Component, Fragment, useState, useEffect, useCallback } from "@wordpress/element";
+import { Fragment, useState, useEffect, useCallback } from "@wordpress/element";
 import PropTypes from "prop-types";
-import { debounce } from "lodash-es";
+import { debounce, noop } from "lodash";
 import { __ } from "@wordpress/i18n";
 import { sendRequest } from "@yoast/helpers";
 import classNames from "classnames";
@@ -16,10 +14,52 @@ const HEADERS = {
 
 const REST_ROUTE = wpApiSettings.root;
 
-async function fetchUser( id ) {
-	const user = await sendRequest( `${ REST_ROUTE }wp/v2/users/${ id }`, { method: "GET", headers: HEADERS } );
-	console.log( "in fetch user: ", user );
-	return user;
+/**
+ * Fetches a user.
+ *
+ * @param {Integer} id The id belonging to the user to fetch.
+ *
+ * @returns {Promise} Returns the request response as a promise.
+ */
+function fetchUser( id ) {
+	return sendRequest( `${ REST_ROUTE }wp/v2/users/${ id }`, { method: "GET", headers: HEADERS } );
+}
+
+/**
+ * Fetches a list of users. Filterable.
+ *
+ * @param {String} query A search string to search users by.
+ *
+ * @returns {Promise} Returns the request response as a promise.
+ */
+function fetchUsers( query = "" ) {
+	const url = `${ REST_ROUTE }wp/v2/users?per_page=10${ query ? `&search=${ encodeURIComponent( query ) }` : "" }`;
+	return sendRequest( url, { method: "GET", headers: HEADERS } );
+}
+
+/**
+ * A function needed to extract the label to display when a person is selected.
+ *
+ * @param {*} person The object to get a display value for.
+ *
+ * @returns {string|null} The value to display. Returns null if there is no label.
+ */
+function getDisplayValue( person ) {
+	return person && person.label ? person.label : null;
+}
+
+/**
+ * Helper function to get active styles for select options.
+ *
+ * @param {boolean} options.active Whether the option is active.
+ *
+ * @returns {string} Styles for an active option.
+ */
+function getOptionActiveStyles( { active } ) {
+	return classNames(
+		"yst-relative yst-cursor-default yst-select-none yst-py-2 yst-pl-3 yst-pr-9",
+		active ? "yst-bg-primary-500 yst-text-white" : "yst-text-gray-900"
+	);
 }
 
 /**
@@ -29,30 +69,40 @@ async function fetchUser( id ) {
  *
  * @returns {WPElement} A user selector based on a headlessui combobox.
  */
-function UserSelector( { value, onChange } ) {
+export default function UserSelector( { initialValue, onChangeCallback, placeholder } ) {
 	const [ users, setUsers ] = useState( [] );
-	const [ showOptions, setShowOptions ] = useState( false );
-	const [ selectedPerson, setSelectedPerson ] = useState( users[ 0 ] );
+	const [ selectedPerson, setSelectedPerson ] = useState( null );
 	const [ query, setQuery ] = useState( "" );
 
-	const fetchUsers = useCallback( debounce( async( input ) => {
-		const params = {
-			/* eslint-disable-next-line camelcase */
-			per_page: 10,
-			search: input,
-		};
+	/**
+	 * If a nonzero initialValue was passed, fetch the user belonging to that id on mount.
+	 * This effect should not happen on every initialValue change, since it might be coupled to the onChangeCallback.
+	 */
+	useEffect( async() => {
+		if ( initialValue !== 0 ) {
+			const user = await fetchUser( initialValue );
+			const selectObject = {
+				value: user.id,
+				label: user.name,
+			};
+			setSelectedPerson( selectObject );
 
-		const url = `${ REST_ROUTE }wp/v2/users`;
+			// Let wrapper know name if needed:
+			onChangeCallback( selectObject );
+		}
+	}, [] );
 
-		const allQueryParams = { ...params };
+	const handleSelectChange = useCallback( ( event ) => {
+		setSelectedPerson( event );
+		onChangeCallback( event );
+	} );
 
-		const newQueryParams = Object.keys( allQueryParams )
-			.filter( key => !! allQueryParams[ key ] )
-			.map( key => `${ key }=${ encodeURIComponent( allQueryParams[ key ] ) }` )
-			.join( "&" );
+	const handleInputChange = useCallback( ( event ) => {
+		setQuery( event.target.value );
+	}, [ setQuery ] );
 
-		const fullUrl = `${ url }?${ newQueryParams }`;
-		const usersResponse = await sendRequest( fullUrl, { method: "GET", headers: HEADERS } );
+	const loadUsers = useCallback( debounce( async( searchQuery ) => {
+		const usersResponse = await fetchUsers( searchQuery );
 		setUsers( usersResponse.map( ( user ) => {
 			return {
 				value: user.id,
@@ -62,21 +112,10 @@ function UserSelector( { value, onChange } ) {
 	}, 500 ), [] );
 
 	useEffect( () => {
-		fetchUsers( query );
+		loadUsers( query );
 	}, [ query ] );
 
-	useEffect( async() => {
-		if ( value !== 0 ) {
-			const user = await fetchUser( value );
-			console.log( "user: ", user, "value ", value );
-			setSelectedPerson( {
-				value: user.id,
-				label: user.name,
-			} );
-		}
-	}, [ value ] );
-
-	return <Combobox as="div" value={ selectedPerson } onChange={ onChange }>
+	return <Combobox as="div" value={ selectedPerson } onChange={ handleSelectChange }>
 		{
 			( { open } ) => {
 				return <Fragment>
@@ -84,33 +123,21 @@ function UserSelector( { value, onChange } ) {
 					<div className="yst-h-[45px] yst-max-w-sm yst-relative yst-mt-1">
 						<Combobox.Input
 							className="yst-w-full yst-rounded-md yst-border yst-border-gray-300 yst-bg-white yst-py-2 yst-pl-3 yst-pr-10 yst-shadow-sm focus:yst-border-primary-500 focus:yst-outline-none focus:yst-ring-1 focus:yst-ring-primary-500 sm:yst-text-sm"
-							onChange={ ( event ) => setQuery( event.target.value ) }
-							onClick={ () => setShowOptions( true ) }
-							onBlur={ ( event ) => {
-								// The button next to the input was not clicked
-								if ( event.relatedTarget !== event.target.nextSibling ) {
-									setShowOptions( false );
-								}
-							} }
-							displayValue={ ( person ) => person.label }
-							placeholder={ __( "Select a user", "wordpress-seo" ) }
+							onChange={ handleInputChange }
+							displayValue={ getDisplayValue }
+							placeholder={ placeholder }
 						/>
 						<Combobox.Button id="configuration-user-select-button" className="yst-absolute yst-inset-y-0 yst-right-0 yst-flex yst-items-center yst-rounded-r-md yst-px-2 focus:yst-outline-none">
 							<SelectorIcon className="yst-h-5 yst-w-5 yst-text-gray-400" aria-hidden="true" />
 						</Combobox.Button>
 
-						{ ( users.length > 0 && ( open || showOptions ) ) && (
+						{ ( users.length > 0 && open ) && (
 							<Combobox.Options static={ true } className="yst-absolute yst-z-10 yst-mt-1 yst-max-h-60 yst-w-full yst-overflow-auto yst-rounded-md yst-bg-white yst-py-1 yst-text-base yst-shadow-lg yst-ring-1 yst-ring-black yst-ring-opacity-5 focus:yst-outline-none sm:yst-text-sm">
 								{ users.map( ( person ) => {
 									return <Combobox.Option
 										key={ `user-${ person.value }` }
 										value={ person }
-										className={ ( { active } ) =>
-											classNames(
-												"yst-relative yst-cursor-default yst-select-none yst-py-2 yst-pl-3 yst-pr-9",
-												active ? "yst-bg-primary-500 yst-text-white" : "yst-text-gray-900"
-											)
-										}
+										className={ getOptionActiveStyles }
 									>
 										{ ( { active, selected } ) => (
 											<>
@@ -139,184 +166,14 @@ function UserSelector( { value, onChange } ) {
 	</Combobox>;
 }
 
-/**
- * Allows a user to be selected within a WordPress context.
- */
-class WordPressUserSelector extends Component {
-	/**
-	 * The WordPressUserSelector constructor.
-	 *
-	 * @param {Object} props The component props.
-	 */
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			selectedOption: null,
-			loading: !! this.props.value,
-		};
-
-		this.fetchUsers = debounce( this.fetchUsers, 500 ).bind( this );
-		this.fetchUser = this.fetchUser.bind( this );
-		this.mapUserToSelectOption = this.mapUserToSelectOption.bind( this );
-		this.onChange = this.onChange.bind( this );
-	}
-
-	/**
-	 * Renders the WordPressUserSelector component.
-	 *
-	 * @returns {wp.Element} The rendered component.
-	 */
-	render() {
-		return (
-			<Fragment>
-				<Select
-					placeholder={ __( "Select a user...", "wordpress-seo" ) }
-					isDisabled={ this.state.loading }
-					inputId={ this.props.name }
-					className={ "yoast-person-selector-container" }
-					classNamePrefix={ "yoast-person-selector" }
-					value={ this.state.selectedOption }
-					onChange={ this.onChange }
-					defaultOptions={ true }
-					loadOptions={ this.fetchUsers }
-				/>
-				<UserSelector
-					value={ this.props.value }
-					onChange={ this.props.onChange }
-				/>
-			</Fragment>
-		);
-	}
-
-	/**
-	 * If a user id is defined fetch the currently selected user.
-	 *
-	 * @returns {void}
-	 */
-	componentDidMount() {
-		if ( this.props.value ) {
-			this.fetchUser( this.props.value );
-		}
-	}
-
-	/**
-	 * Adds additional query parameters to an existing URL. Also encodes existing query parameters.
-	 *
-	 * @param {string} url    The URL.
-	 * @param {Object} params Params for in the query string.
-	 *
-	 * @returns {string} URI encoded query string.
-	 */
-	static addQueryParams( url, params ) {
-		const urlParts = url.split( "?" );
-
-		url = urlParts[ 0 ];
-
-		const allQueryParams = { ...params };
-
-		if ( urlParts.length === 2 ) {
-			urlParts[ 1 ].split( "&" ).forEach( part => {
-				const item = part.split( "=" );
-
-				allQueryParams[ item[ 0 ] ] = item[ 1 ];
-			} );
-		}
-
-		const newQueryParams = Object.keys( allQueryParams )
-			.filter( key => !! allQueryParams[ key ] )
-			.map( key => `${ key }=${ encodeURIComponent( allQueryParams[ key ] ) }` )
-			.join( "&" );
-
-		return `${ url }?${ newQueryParams }`;
-	}
-
-	/**
-	 * Handles the onChange event.
-	 *
-	 * @param {{ value: number, label: string }} option The selected option.
-	 *
-	 * @returns {void}
-	 */
-	onChange( option ) {
-		this.setState( {
-			selectedOption: option,
-			loading: false,
-		}, () => {
-			this.props.onChange( option.value, option.label );
-		} );
-	}
-
-	/**
-	 * Maps a WordPress user API result to a react-select option.
-	 *
-	 * @param {Object} user The WordPress user object.
-	 *
-	 * @returns {Object} The mapped user for react-select.
-	 */
-	mapUserToSelectOption( user ) {
-		return {
-			value: user.id,
-			label: user.name,
-		};
-	}
-
-	/**
-	 * Fetches a single WordPress user.
-	 *
-	 * Is only called from componentDidMount and assumes the component is already in a loading state.
-	 *
-	 * @param {string|number} id The user id.
-	 *
-	 * @returns {void}
-	 */
-	fetchUser( id ) {
-		sendRequest( `${ REST_ROUTE }wp/v2/users/${ id }`, { method: "GET", headers: HEADERS } )
-			.then( user => {
-				if ( user ) {
-					this.onChange( this.mapUserToSelectOption( user ) );
-					// Setting the state to `loading: false` is already done in the `onChange` function.
-					return;
-				}
-				this.setState( { loading: false } );
-			} )
-			.catch( () => {
-				this.setState( { loading: false } );
-			} );
-	}
-
-	/**
-	 * Searches for WordPress users.
-	 *
-	 * @param {string}   input    The search term.
-	 * @param {function} callback Callback to be called with users.
-	 *
-	 * @returns {void}
-	 */
-	fetchUsers( input, callback ) {
-		const params = {
-			/* eslint-disable-next-line camelcase */
-			per_page: 10,
-			search: input,
-		};
-
-		const url = WordPressUserSelector.addQueryParams( `${ REST_ROUTE }wp/v2/users`, params );
-
-		sendRequest( url, { method: "GET", headers: HEADERS } )
-			.then( users => {
-				const mappedUsers = users.map( this.mapUserToSelectOption );
-
-				callback( mappedUsers );
-			} );
-	}
-}
-
-export const WordPressUserSelectorPropTypes = {
-	name: PropTypes.string.isRequired,
-	value: PropTypes.number.isRequired,
-	onChange: PropTypes.func.isRequired,
+UserSelector.propTypes = {
+	initialValue: PropTypes.number,
+	onChangeCallback: PropTypes.func,
+	placeholder: PropTypes.string,
 };
 
-WordPressUserSelector.propTypes = WordPressUserSelectorPropTypes;
-
-export default WordPressUserSelector;
+UserSelector.defaultProps = {
+	initialValue: 0,
+	onChangeCallback: noop,
+	placeholder: __( "Select a user", "wordpress-seo" ),
+};

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
@@ -65,6 +65,7 @@ export default function UserSelector( { initialValue, onChangeCallback, placehol
 
 	return <YoastComboBox
 		value={ selectedPerson }
+		label={ __( "Name", "wordpress-seo" ) }
 		onChange={ handleSelectChange }
 		onInputChange={ handleInputChange }
 		options={ users }

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
@@ -1,12 +1,9 @@
 /* global wpApiSettings */
-import { Combobox } from "@headlessui/react";
-import { CheckIcon, SelectorIcon } from "@heroicons/react/solid";
-import { Fragment, useState, useEffect, useCallback } from "@wordpress/element";
+import { useState, useEffect, useCallback } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { debounce, noop } from "lodash";
 import { __ } from "@wordpress/i18n";
 import { sendRequest } from "@yoast/helpers";
-import classNames from "classnames";
 import YoastComboBox from "../../base/combo-box";
 
 const HEADERS = {

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
@@ -27,7 +27,10 @@ function fetchUsers( query = "" ) {
 /**
  * A user selector based on a headlessui combobox.
  *
- * @param {Object} props The props
+ * @param {Object}   props            The props.
+ * @param {Object}   initialValue     The option selected by default in the combo box select with shape {id, name}.
+ * @param {function} onChangeCallback Function to manage a selected option.
+ * @param {string}   placeholder      YoastCombobox text input placeholder.
  *
  * @returns {WPElement} A user selector based on a headlessui combobox.
  */

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
@@ -7,6 +7,7 @@ import { debounce, noop } from "lodash";
 import { __ } from "@wordpress/i18n";
 import { sendRequest } from "@yoast/helpers";
 import classNames from "classnames";
+import YoastComboBox from "../../base/combo-box";
 
 const HEADERS = {
 	"X-WP-NONCE": wpApiSettings.nonce,
@@ -35,31 +36,6 @@ function fetchUser( id ) {
 function fetchUsers( query = "" ) {
 	const url = `${ REST_ROUTE }wp/v2/users?per_page=10${ query ? `&search=${ encodeURIComponent( query ) }` : "" }`;
 	return sendRequest( url, { method: "GET", headers: HEADERS } );
-}
-
-/**
- * A function needed to extract the label to display when a person is selected.
- *
- * @param {*} person The object to get a display value for.
- *
- * @returns {string|null} The value to display. Returns null if there is no label.
- */
-function getDisplayValue( person ) {
-	return person && person.label ? person.label : null;
-}
-
-/**
- * Helper function to get active styles for select options.
- *
- * @param {boolean} options.active Whether the option is active.
- *
- * @returns {string} Styles for an active option.
- */
-function getOptionActiveStyles( { active } ) {
-	return classNames(
-		"yst-relative yst-cursor-default yst-select-none yst-py-2 yst-pl-3 yst-pr-9",
-		active ? "yst-bg-primary-500 yst-text-white" : "yst-text-gray-900"
-	);
 }
 
 /**
@@ -93,6 +69,7 @@ export default function UserSelector( { initialValue, onChangeCallback, placehol
 	}, [] );
 
 	const handleSelectChange = useCallback( ( event ) => {
+		setQuery( "" );
 		setSelectedPerson( event );
 		onChangeCallback( event );
 	} );
@@ -115,55 +92,13 @@ export default function UserSelector( { initialValue, onChangeCallback, placehol
 		loadUsers( query );
 	}, [ query ] );
 
-	return <Combobox as="div" value={ selectedPerson } onChange={ handleSelectChange }>
-		{
-			( { open } ) => {
-				return <Fragment>
-					<Combobox.Label className="yst-block yst-text-sm yst-font-medium yst-text-gray-700">{ __( "Name", "wordpress-seo" ) }</Combobox.Label>
-					<div className="yst-h-[45px] yst-max-w-sm yst-relative yst-mt-1">
-						<Combobox.Input
-							className="yst-w-full yst-rounded-md yst-border yst-border-gray-300 yst-bg-white yst-py-2 yst-pl-3 yst-pr-10 yst-shadow-sm focus:yst-border-primary-500 focus:yst-outline-none focus:yst-ring-1 focus:yst-ring-primary-500 sm:yst-text-sm"
-							onChange={ handleInputChange }
-							displayValue={ getDisplayValue }
-							placeholder={ placeholder }
-						/>
-						<Combobox.Button id="configuration-user-select-button" className="yst-absolute yst-inset-y-0 yst-right-0 yst-flex yst-items-center yst-rounded-r-md yst-px-2 focus:yst-outline-none">
-							<SelectorIcon className="yst-h-5 yst-w-5 yst-text-gray-400" aria-hidden="true" />
-						</Combobox.Button>
-
-						{ ( users.length > 0 && open ) && (
-							<Combobox.Options static={ true } className="yst-absolute yst-z-10 yst-mt-1 yst-max-h-60 yst-w-full yst-overflow-auto yst-rounded-md yst-bg-white yst-py-1 yst-text-base yst-shadow-lg yst-ring-1 yst-ring-black yst-ring-opacity-5 focus:yst-outline-none sm:yst-text-sm">
-								{ users.map( ( person ) => {
-									return <Combobox.Option
-										key={ `user-${ person.value }` }
-										value={ person }
-										className={ getOptionActiveStyles }
-									>
-										{ ( { active, selected } ) => (
-											<>
-												<span className={ classNames( "yst-block yst-truncate", selected && "yst-font-semibold" ) }>{ person.label }</span>
-
-												{ selected && (
-													<span
-														className={ classNames(
-															"yst-absolute yst-inset-y-0 yst-right-0 yst-flex yst-items-center yst-pr-4",
-															active ? "yst-text-white" : "yst-text-primary-500"
-														) }
-													>
-														<CheckIcon className="yst-h-5 yst-w-5" aria-hidden="true" />
-													</span>
-												) }
-											</>
-										) }
-									</Combobox.Option>;
-								} ) }
-							</Combobox.Options>
-						) }
-					</div>
-				</Fragment>;
-			}
-		}
-	</Combobox>;
+	return <YoastComboBox
+		value={ selectedPerson }
+		onChange={ handleSelectChange }
+		onInputChange={ handleInputChange }
+		options={ users }
+		placeholder={ placeholder }
+	/>;
 }
 
 UserSelector.propTypes = {

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
@@ -13,17 +13,6 @@ const HEADERS = {
 const REST_ROUTE = wpApiSettings.root;
 
 /**
- * Fetches a user.
- *
- * @param {Integer} id The id belonging to the user to fetch.
- *
- * @returns {Promise} Returns the request response as a promise.
- */
-function fetchUser( id ) {
-	return sendRequest( `${ REST_ROUTE }wp/v2/users/${ id }`, { method: "GET", headers: HEADERS } );
-}
-
-/**
  * Fetches a list of users. Filterable.
  *
  * @param {String} query A search string to search users by.
@@ -44,26 +33,11 @@ function fetchUsers( query = "" ) {
  */
 export default function UserSelector( { initialValue, onChangeCallback, placeholder } ) {
 	const [ users, setUsers ] = useState( [] );
-	const [ selectedPerson, setSelectedPerson ] = useState( null );
+	const [ selectedPerson, setSelectedPerson ] = useState( {
+		value: initialValue.id,
+		label: initialValue.name,
+	} );
 	const [ query, setQuery ] = useState( "" );
-
-	/**
-	 * If a nonzero initialValue was passed, fetch the user belonging to that id on mount.
-	 * This effect should not happen on every initialValue change, since it might be coupled to the onChangeCallback.
-	 */
-	useEffect( async() => {
-		if ( initialValue !== 0 ) {
-			const user = await fetchUser( initialValue );
-			const selectObject = {
-				value: user.id,
-				label: user.name,
-			};
-			setSelectedPerson( selectObject );
-
-			// Let wrapper know name if needed:
-			onChangeCallback( selectObject );
-		}
-	}, [] );
 
 	const handleSelectChange = useCallback( ( event ) => {
 		setQuery( "" );
@@ -99,13 +73,19 @@ export default function UserSelector( { initialValue, onChangeCallback, placehol
 }
 
 UserSelector.propTypes = {
-	initialValue: PropTypes.number,
+	initialValue: PropTypes.shape( {
+		id: PropTypes.number,
+		name: PropTypes.string,
+	} ),
 	onChangeCallback: PropTypes.func,
 	placeholder: PropTypes.string,
 };
 
 UserSelector.defaultProps = {
-	initialValue: 0,
+	initialValue: {
+		id: 0,
+		name: "",
+	},
 	onChangeCallback: noop,
 	placeholder: __( "Select a user", "wordpress-seo" ),
 };

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
@@ -1,5 +1,5 @@
 /* global wpApiSettings */
-import { useState, useEffect, useCallback } from "@wordpress/element";
+import { useState, useCallback } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { debounce, noop } from "lodash";
 import { __ } from "@wordpress/i18n";
@@ -20,7 +20,7 @@ const REST_ROUTE = wpApiSettings.root;
  * @returns {Promise} Returns the request response as a promise.
  */
 function fetchUsers( query = "" ) {
-	const url = `${ REST_ROUTE }wp/v2/users?per_page=10${ query ? `&search=${ encodeURIComponent( query ) }` : "" }`;
+	const url = `${ REST_ROUTE }wp/v2/users?per_page=20${ query ? `&search=${ encodeURIComponent( query ) }` : "" }`;
 	return sendRequest( url, { method: "GET", headers: HEADERS } );
 }
 
@@ -37,17 +37,10 @@ export default function UserSelector( { initialValue, onChangeCallback, placehol
 		value: initialValue.id,
 		label: initialValue.name,
 	} );
-	const [ query, setQuery ] = useState( "" );
-
 	const handleSelectChange = useCallback( ( event ) => {
-		setQuery( "" );
 		setSelectedPerson( event );
 		onChangeCallback( event );
 	} );
-
-	const handleInputChange = useCallback( ( event ) => {
-		setQuery( event.target.value );
-	}, [ setQuery ] );
 
 	const loadUsers = useCallback( debounce( async( searchQuery ) => {
 		const usersResponse = await fetchUsers( searchQuery );
@@ -59,15 +52,11 @@ export default function UserSelector( { initialValue, onChangeCallback, placehol
 		} ) );
 	}, 500 ), [] );
 
-	useEffect( () => {
-		loadUsers( query );
-	}, [ query ] );
-
 	return <YoastComboBox
 		value={ selectedPerson }
 		label={ __( "Name", "wordpress-seo" ) }
 		onChange={ handleSelectChange }
-		onInputChange={ handleInputChange }
+		onQueryChange={ loadUsers }
 		options={ users }
 		placeholder={ placeholder }
 	/>;

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -140,7 +140,6 @@ class Configuration_Workout_Integration implements Integration_Interface {
 		if ( \is_array( $selected_option ) ) {
 			$selected_option_label = $selected_option['label'];
 		}
-
 		$this->admin_asset_manager->add_inline_script(
 			'workouts',
 			\sprintf(
@@ -370,11 +369,11 @@ class Configuration_Workout_Integration implements Integration_Interface {
 		];
 		if ( $this->should_force_company() ) {
 			$options = [
-				[
-					'label' => __( 'Organization', 'wordpress-seo' ),
-					'value' => 'company',
-					'id'    => 'company',
-				],
+                [
+				'label' => \__( 'Organization', 'wordpress-seo' ),
+				'value' => 'company',
+				'id'    => 'company',
+                ],
 			];
 		}
 

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -369,11 +369,11 @@ class Configuration_Workout_Integration implements Integration_Interface {
 		];
 		if ( $this->should_force_company() ) {
 			$options = [
-                [
-				'label' => \__( 'Organization', 'wordpress-seo' ),
-				'value' => 'company',
-				'id'    => 'company',
-                ],
+				[
+					'label' => \__( 'Organization', 'wordpress-seo' ),
+					'value' => 'company',
+					'id'    => 'company',
+				],
 			];
 		}
 

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -282,9 +282,11 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	 * @return int|null The person id, null if empty.
 	 */
 	private function get_person_name() {
-		$user      = \get_userdata( $this->get_person_id() );
-		$user_name = $user->get( 'display_name' );
-		return ( $user_name !== false ) ? $user_name : '';
+		$user = \get_userdata( $this->get_person_id() );
+		if ( $user instanceof \WP_User ) {
+			return $user->get( 'display_name' );
+		}
+		return '';
 	}
 
 	/**

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -151,6 +151,7 @@ class Configuration_Workout_Integration implements Integration_Interface {
 					"companyLogo": "%s",
 					"companyLogoId": %d,
 					"personId": %d,
+					"personName": "%s",
 					"personLogo": "%s",
 					"personLogoId": %d,
 					"siteTagline": "%s",
@@ -180,6 +181,7 @@ class Configuration_Workout_Integration implements Integration_Interface {
 				$this->get_company_logo(),
 				$this->get_company_logo_id(),
 				$this->get_person_id(),
+				$this->get_person_name(),
 				$this->get_person_logo(),
 				$this->get_person_logo_id(),
 				$this->get_site_tagline(),
@@ -272,6 +274,17 @@ class Configuration_Workout_Integration implements Integration_Interface {
 	 */
 	private function get_person_id() {
 		return $this->options_helper->get( 'company_or_person_user_id' );
+	}
+
+	/**
+	 * Gets the person id from the option in the database.
+	 *
+	 * @return int|null The person id, null if empty.
+	 */
+	private function get_person_name() {
+		$user      = \get_userdata( $this->get_person_id() );
+		$user_name = $user->get( 'display_name' );
+		return ( $user_name !== false ) ? $user_name : '';
 	}
 
 	/**

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -179,7 +179,7 @@ class Configuration_Workout_Integration implements Integration_Interface {
 				$this->get_company_name(),
 				$this->get_company_logo(),
 				$this->get_company_logo_id(),
-				$this->get_person_id(),
+				0,
 				$this->get_person_logo(),
 				$this->get_person_logo_id(),
 				$this->get_site_tagline(),

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -179,7 +179,7 @@ class Configuration_Workout_Integration implements Integration_Interface {
 				$this->get_company_name(),
 				$this->get_company_logo(),
 				$this->get_company_logo_id(),
-				0,
+				$this->get_person_id(),
 				$this->get_person_logo(),
 				$this->get_person_logo_id(),
 				$this->get_site_tagline(),

--- a/src/integrations/admin/configuration-workout-integration.php
+++ b/src/integrations/admin/configuration-workout-integration.php
@@ -370,9 +370,11 @@ class Configuration_Workout_Integration implements Integration_Interface {
 		];
 		if ( $this->should_force_company() ) {
 			$options = [
-				'label' => __( 'Organization', 'wordpress-seo' ),
-				'value' => 'company',
-				'id'    => 'company',
+				[
+					'label' => __( 'Organization', 'wordpress-seo' ),
+					'value' => 'company',
+					'id'    => 'company',
+				],
 			];
 		}
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,7 @@
+const tailwindcssForms = require( "@tailwindcss/forms" )( {
+	strategy: "class",
+} );
+
 module.exports = {
 	content: [ "./packages/js/**/*.{html,js}" ],
 	theme: {
@@ -42,7 +46,9 @@ module.exports = {
 			margin: [ "last" ],
 		},
 	},
-	plugins: [],
+	plugins: [
+		tailwindcssForms,
+	],
 	important: true,
 	prefix: "yst-",
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3569,6 +3569,13 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
+"@tailwindcss/forms@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.5.0.tgz#d4bea2560a10aac642573e72d3b4d62a88960449"
+  integrity sha512-KzWugryEBFkmoaYcBE18rs6gthWCFHHO7cAZm2/hv3hwD67AzwP7udSCa22E7R1+CEJL/FfhYsJWrc0b1aeSzw==
+  dependencies:
+    mini-svg-data-uri "^1.2.3"
+
 "@tannin/compile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@tannin/compile/-/compile-1.1.0.tgz#1e4d1c5364cbfeffa1c20352c053e19ef20ffe93"
@@ -5412,6 +5419,9 @@
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
+
+"@yoast/browserslist-config@file:packages/browserslist-config":
+  version "1.2.2"
 
 "@yoast/grunt-plugin-tasks@https://github.com/Yoast/plugin-grunt-tasks.git#DUPP-194-upgrade-postcss-related-packages-for-tailwind":
   version "2.2.1"
@@ -10708,6 +10718,11 @@ eslint-config-prettier@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz#f4a4bd2832e810e8cc7c1411ec85b3e85c0c53f9"
   integrity sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==
+
+"eslint-config-yoast@file:packages/eslint":
+  version "5.0.17"
+  dependencies:
+    js-yaml "^3.6.0"
 
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
@@ -17246,6 +17261,11 @@ mini-css-extract-plugin@^0.9.0:
     normalize-url "1.9.1"
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
+
+mini-svg-data-uri@^1.2.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.4.3.tgz#43177b2e93766ba338931a3e2a84a3dfd3a222b8"
+  integrity sha512-gSfqpMRC8IxghvMcxzzmMnWpXAChSA+vy4cia33RgerMS8Fex95akUyQZPbxJJmeBGiGmK7n/1OpUX8ksRjIdA==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2299,10 +2299,10 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@headlessui/react@^1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.4.2.tgz#87e264f190dbebbf8dfdd900530da973dad24576"
-  integrity sha512-N8tv7kLhg9qGKBkVdtg572BvKvWhmiudmeEpOCyNwzOsZHCXBtl8AazGikIfUS+vBoub20Fse3BjawXDVPPdug==
+"@headlessui/react@^1.5":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.5.0.tgz#483b44ba2c8b8d4391e1d2c863898d7dd0cc0296"
+  integrity sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==
 
 "@heroicons/react@^1.0.5":
   version "1.0.5"
@@ -5412,9 +5412,6 @@
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
-
-"@yoast/browserslist-config@file:packages/browserslist-config":
-  version "1.2.2"
 
 "@yoast/grunt-plugin-tasks@https://github.com/Yoast/plugin-grunt-tasks.git#DUPP-194-upgrade-postcss-related-packages-for-tailwind":
   version "2.2.1"
@@ -10711,11 +10708,6 @@ eslint-config-prettier@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz#f4a4bd2832e810e8cc7c1411ec85b3e85c0c53f9"
   integrity sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==
-
-"eslint-config-yoast@file:packages/eslint":
-  version "5.0.17"
-  dependencies:
-    js-yaml "^3.6.0"
 
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"


### PR DESCRIPTION
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* HeadlessUI / TailwindUI released a nicely styled combobox that ALMOST covers the use cases we have with our wordpress user select. So let's use it!
* The exception is that the Combobox opens slightly differently (yet accessible), and that it is not async, like our current implementation (which is an async react-select from a package)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Uses a HeadlessUI combobox instead of an async react-select component for the first time configuration's user select.

## Relevant technical choices:

* Created an async wrapper for the base combobox component
* ~Implemented additional UX requirements with the exception of opening on click input, since that gave me some issues with aria-expanded booleans that were not within my control. Should pick up in a separate issue (DUPP 321) or create an issue with HeadlessUI.~ fixed here after all.
* We now return a saved user name from the PHP since it seemed silly to query this in "JS' time" while we have easy access in "PHP time".

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* The UserSelect in the person section should work as intended ™️ ... Note that in the design it is not a combobox. Rather, perhaps you can compare in functionality with the user select in the search-appearance settings (though of course we have different styling here).
* Select "Person" in the site representation step. If it is empty it should display a placeholder. (Devs can fake this by making this function in `configuration-workout-integration` (line 276) return false.)
```php
	/**
	 * Gets the person id from the option in the database.
	 *
	 * @return int|null The person id, null if empty.
	 */
	private function get_person_id() {
		return $this->options_helper->get( 'company_or_person_user_id' );
	}
```
* If you return false above to test the placeholder: undo those changes.
* Test whether saving users works.
* Verify that the alert appears upon user selection.
* Verify the options box opens and closes as expected.
* Verify the options box filters as expected when changing the input.
* Verify the selected option is highlighted in the dropdown.
* Verify clicking the input opens the options, and clicking outside closes it again (and refills the users).
* Verify keyboard navigation works (tabbing to the input field, using arrow up and down to navigate options, enter to submit, esc to close, etc.)

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* * The UserSelect in the person section should work as intended ™️ ... Note that in the design it is not a combobox. Rather, perhaps you can compare in functionality with the user select in the search-appearance settings (though of course we have different styling here).
* Select "Person" in the site representation step. If it is empty it should display a placeholder. (not sure QA can fake this, but perhaps with the factory reset it works).
* If you return false above to test the placeholder: undo those changes.
* Test whether saving users works.
* Verify that the alert appears upon user selection.
* Verify the options box opens and closes as expected.
* Verify the options box filters as expected when changing the input.
* Verify the selected option is highlighted in the dropdown.
* * Verify clicking the input opens the options, and clicking outside closes it again (and refills the users).
* Verify keyboard navigation works (tabbing to the input field, using arrow up and down to navigate options, enter to submit, esc to close, etc.)

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-288
Fixes DUPP-321