### PR TITLE
CI: switch to GitHub Actions - step 4: javascript checks

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,0 +1,66 @@
+name: CheckJS
+
+on:
+  # Run on pushes to select branches and on all pull requests.
+  push:
+    branches:
+      - master
+      - trunk
+      - 'release/**'
+      - 'hotfix/[0-9]+.[0-9]+*'
+      - 'feature/**'
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  yarn-lint-test:
+    runs-on: ubuntu-latest
+
+    name: "CheckJS"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # The ubuntu images come with Node, npm and yarn pre-installed.
+      # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
+
+      # This action also handles the caching of the Yarn dependencies.
+      # https://github.com/actions/setup-node
+      - name: Set up node and enable caching of dependencies
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+          cache: 'yarn'
+
+      - name: Yarn install
+        run: yarn install
+
+      - name: Show debug info
+        run: |
+          npm --version
+          node --version
+          yarn --version
+          grunt --version
+
+      - name: Run Javascript lint
+        run: yarn lint
+
+      # Check out the premium config repo ahead of running the tests to prevent issues with permissions.
+      - name: Checkout premium configuration
+        uses: actions/checkout@v3
+        with:
+          repository: Yoast/YoastSEO.js-premium-configuration
+          path: packages/yoastseo/premium-configuration
+          fetch-depth: 0
+          token: ${{ secrets.YOASTBOT_CI_PAT_DIST }}
+
+      - name: Run Javascript tests
+        run: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ stages:
 jobs:
   fast_finish: true
   include:
-    - php: 7.2
-      env: CHECKJS=1 TRAVIS_NODE_VERSION=14
     - php: 7.3.24
       env: WP_VERSION=latest WP_MULTISITE=1 COVERAGE=1
     - php: 5.6
@@ -110,13 +108,6 @@ cache:
 before_install:
   - if [[ -z "$CC_TEST_REPORTER_ID" ]]; then COVERAGE="0"; fi
   - if [[ "$COVERAGE" != "1" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
-  - |
-    if [[ "$CHECKJS" == "1" ]]; then
-      nvm install $TRAVIS_NODE_VERSION
-      curl -o- -L https://yarnpkg.com/install.sh | bash
-      export PATH=$HOME/.yarn/bin:$PATH
-      echo -e "machine github.com\n  login $CI_GITHUB_USER_TOKEN" > ~/.netrc
-    fi
 
 install:
   - |
@@ -151,11 +142,6 @@ install:
       travis_retry composer update --no-interaction
       travis_retry composer install --no-dev --no-interaction
       composer du
-    fi
-  - |
-    if [[ "$CHECKJS" == "1" ]]; then
-      yarn global add grunt-cli
-      yarn install
     fi
 
 before_script:
@@ -201,30 +187,9 @@ before_script:
   - curl --version
   - git --version
   - svn --version
-  - |
-    if [[ "$CHECKJS" == "1" ]]; then
-      npm --version
-      node --version
-      yarn --version
-      grunt --version
-    fi
   - locale -a
 
 script:
-  # JavaScript checks
-  - |
-    if [[ "$CHECKJS" == "1" ]]; then
-      travis_fold start "JavaScript.check" && travis_time_start
-      yarn lint
-      travis_time_finish && travis_fold end "JavaScript.check"
-    fi
-  # JavaScript tests
-  - |
-    if [[ "$CHECKJS" == "1" ]]; then
-      travis_fold start "JavaScript.tests" && travis_time_start
-      yarn test
-      travis_time_finish && travis_fold end "JavaScript.tests"
-    fi
   # PHP Unit
   - |
     if [[ "$PHPUNIT" == "1" && ${TRAVIS_PHP_VERSION:0:1} != "8" && $TRAVIS_PHP_VERSION != "nightly" ]]; then

--- a/config/grunt/task-config/eslint.js
+++ b/config/grunt/task-config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 159,
+			maxWarnings: 152,
 		},
 	},
 	tests: {

--- a/packages/search-metadata-previews/package.json
+++ b/packages/search-metadata-previews/package.json
@@ -12,7 +12,7 @@
   "license": "GPL-3.0",
   "scripts": {
     "test": "jest",
-    "lint": "eslint . --max-warnings=31",
+    "lint": "eslint . --max-warnings=17",
     "prepublishOnly": "rm -rf dist && cp -R src dist && cp package.json dist/package.json && json -I -f dist/package.json -e \"this.main='index.js'\" && cp .babelrc dist/.babelrc"
   },
   "dependencies": {

--- a/packages/yoastseo/grunt/config/shell.js
+++ b/packages/yoastseo/grunt/config/shell.js
@@ -66,10 +66,10 @@ module.exports = function( grunt ) {
 		let branch = grunt.config.get( "currentBranch" );
 
 		if ( process.env.CI ) {
-			if ( process.env.TRAVIS_PULL_REQUEST_BRANCH === "" ) {
-				branch = process.env.TRAVIS_BRANCH;
-			} else {
-				branch = process.env.TRAVIS_PULL_REQUEST_BRANCH;
+			if ( process.env.GITHUB_HEAD_REF !== "" ) {
+				branch = process.env.GITHUB_HEAD_REF;
+			} else if ( process.env.GITHUB_REF_NAME !== "" ) {
+				branch = process.env.GITHUB_REF_NAME;
 			}
 		}
 


### PR DESCRIPTION
## Context

* CI/QA is now run via GitHub Actions for the JS linting and testing checks

## Summary

This PR can be summarized in the following changelog entry:

* CI/QA is now run via GitHub Actions for the JS linting and testing checks

## Relevant technical choices:

This commit:
* Adds a GH Actions workflow for the Javascript related CI checks.
* Removes all references to that check from the `.travis.yml` configuration.
* Updates the warning thresholds in a couple of configuration files to reflect the current reality.

Notes:
1. Builds will run on:
    - Select pushes using branch filtering similar to before.
    - All pull requests.
    - When manually triggered.
        Note: manual triggering of builds has to be [explicitly allowed](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/). This is not a feature which is enabled by default.
2. If a previous GH actions run for the same branch hadn't finished yet when the same branch is pushed again, the previous run will be cancelled.
    In Travis, this was an option on the "Settings" page - "Auto cancellation" -, which was turned on for most, if not all, Yoast repos. The `concurrency` configuration in the GHA script emulates the same behaviour.
3. The standard Ubuntu 20 image used by this action comes preloaded with Node, NPM and Yarn, so - in contrast to Travis - those don't need to be set up explicitly via script commands.
    Ref: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
4. The build still uses the `setup-node` action as it allows for caching of the yarn dependencies for faster builds.
    The `node-version` key being passed, fixes the Node version to version 14, same as previously in Travis.
    Ref: https://github.com/actions/setup-node
5. Includes a "debug" step which will show the versions of the underlying tooling used, which should come in handy when the build would fail unexpectedly.
6. The `test` run has an implicit dependency on the `Yoast/YoastSEO.js-premium-configuration` repo and pulls that in via git as part of the test setup for particular tests (if it doesn't exist in the expected location already).
    As git needs permission to pull in this repo, I've elected to pull in the repo ahead of the test run.
    This has two advantages:
    1. It allows us to use predefined action runners to make sure the repo is checked out correctly and to the right subdirectory.
        The predefined action runner can use GitHub secret to get the SSH key needed, which saves a lot of hassle with setting up permissions.
    2. It removes this implicit point of failure from the _test_ run and makes it so the tests won't even run if the repo check out fails. ("Fail early" principle)
7. The `test` run may still need to check out a specific _branch_ in the `Yoast/YoastSEO.js-premium-configuration` repo.
    The code handling this in the `packages/yoastseo/grunt/config/shell.js` script has been adjusted to use the appropriate GitHub environment variables instead of the Travis ones.
    That code snippet has also been made slightly more stable by always checking that the environment variable used is actually set (not empty) before overwriting the default value for `branch`.
    Refs:
    * https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
    * https://docs.travis-ci.com/user/environment-variables/#default-environment-variables

Differences with the Travis implementation:
* In Travis, the `install` step always ran a `composer install`, including for the JS checks.
    I have determined that this step is not actually needed for the JS check, so it is not included in this script.

Additional observations:
* Both the `yarn install` as well as the `yarn test` run yield a lot of warnings. These were also previously thrown in Travis. These should be looked into separately and can be seen in the run transcripts.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

This workflow has been extensively tested already and needs no further testing.

Aside from the builds run for this PR, you can find the results of various specific tests also on [the "Actions" page](https://github.com/Yoast/wordpress-seo/actions).
For each job, it has been verified that the build(s) will actually show as failed when code has been altered to induce a fail condition.
