### PR TITLE
DUPP-289 Switch other social URLs to array

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -44,6 +44,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'open_graph_frontpage_desc',
 		'open_graph_frontpage_image',
 		'open_graph_frontpage_image_id',
+		'other_social_urls',
 		'pinterest_url',
 		'pinterestverify',
 		'twitter_site',
@@ -180,6 +181,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'wincher_website_id',
 		'wincher_automatically_add_keyphrases',
 		'first_time_install',
+		'other_social_urls',
 	];
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -77,6 +77,7 @@ class WPSEO_Upgrade {
 			'17.7.1-RC0' => 'upgrade_1771',
 			'17.9-RC0'   => 'upgrade_179',
 			'18.3-RC3'   => 'upgrade_183',
+			'18.3-ftc'   => 'upgrade_first_time_configuration',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -868,6 +869,23 @@ class WPSEO_Upgrade {
 	 */
 	private function upgrade_183() {
 		$this->delete_post_meta( 'yoast-structured-data-blocks-images-cache' );
+	}
+
+	/**
+	 * Performs the upgrade routine for the first time configuration.
+	 *
+	 * @TODO Set the right version number when the feature branch is merged.
+	 */
+	private function upgrade_first_time_configuration() {
+		$other = [];
+		$other[] = WPSEO_Options::get( 'instagram_url' );
+		$other[] = WPSEO_Options::get( 'linkedin_url' );
+		$other[] = WPSEO_Options::get( 'myspace_url' );
+		$other[] = WPSEO_Options::get( 'pinterest_url' );
+		$other[] = WPSEO_Options::get( 'youtube_url' );
+		$other[] = WPSEO_Options::get( 'wikipedia_url' );
+
+		WPSEO_Options::set( 'other_social_urls', $other );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -877,7 +877,7 @@ class WPSEO_Upgrade {
 	 * @TODO Set the right version number when the feature branch is merged.
 	 */
 	private function upgrade_first_time_configuration() {
-		$other = [];
+		$other   = [];
 		$other[] = WPSEO_Options::get( 'instagram_url' );
 		$other[] = WPSEO_Options::get( 'linkedin_url' );
 		$other[] = WPSEO_Options::get( 'myspace_url' );

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -885,7 +885,7 @@ class WPSEO_Upgrade {
 		$other[] = WPSEO_Options::get( 'youtube_url' );
 		$other[] = WPSEO_Options::get( 'wikipedia_url' );
 
-		WPSEO_Options::set( 'other_social_urls', $other );
+		WPSEO_Options::set( 'other_social_urls', array_unique( array_filter( $other ) ) );
 	}
 
 	/**

--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -44,6 +44,7 @@ class WPSEO_Option_Social extends WPSEO_Option {
 		'twitter_card_type'     => 'summary_large_image',
 		'youtube_url'           => '',
 		'wikipedia_url'         => '',
+		'other_social_urls'     => [],
 	];
 
 	/**
@@ -214,6 +215,23 @@ class WPSEO_Option_Social extends WPSEO_Option {
 				case 'opengraph':
 				case 'twitter':
 					$clean[ $key ] = ( isset( $dirty[ $key ] ) ? WPSEO_Utils::validate_bool( $dirty[ $key ] ) : false );
+					break;
+
+				/* Array fields. */
+				case 'other_social_urls':
+					$clean[ $key ] = $old[ $key ];
+
+					if ( isset( $dirty[ $key ] ) ) {
+						$items = $dirty[ $key ];
+						if ( ! is_array( $items ) ) {
+							$items = json_decode( $dirty[ $key ], true );
+						}
+
+						if ( is_array( $items ) ) {
+							$clean[ $key ] = $dirty[ $key ];
+						}
+					}
+
 					break;
 			}
 		}

--- a/tests/unit/inc/options/option-social-test.php
+++ b/tests/unit/inc/options/option-social-test.php
@@ -103,6 +103,27 @@ class Option_Social_Test extends TestCase {
 	}
 
 	/**
+	 * Tests validate_option with invalid array data.
+	 *
+	 * @dataProvider validate_option_invalid_array_data_provider
+	 * @covers       WPSEO_Option_Social::validate_option
+	 *
+	 * @param string $expected  The expected value.
+	 * @param array  $dirty     New value for the option.
+	 * @param array  $clean     Clean value for the option, normally the defaults.
+	 * @param array  $old       Old value of the option.
+	 * @param string $slug_name The option key.
+	 */
+	public function test_validate_option_with_invalid_array_data( $expected, $dirty, $clean, $old, $slug_name ) {
+		$instance = new Option_Social_Double();
+
+		$this->assertEquals(
+			$expected,
+			$instance->validate_option( $dirty, $clean, $old )
+		);
+	}
+
+	/**
 	 * Data for the test_validate_option_with_correct_data test.
 	 *
 	 * @return array The test data.
@@ -128,16 +149,38 @@ class Option_Social_Test extends TestCase {
 				'old'      => [],
 			],
 			[
-				'expected' => [ 'youtube_url' => 'https://www.youtube.com/yoast' ],
-				'dirty'    => [ 'youtube_url' => 'https://www.youtube.com/yoast' ],
-				'clean'    => [ 'youtube_url' => 'https://www.youtube.com/yoast' ],
+				'expected' => [ 'facebook_site' => 'https://facebook.com/yoast' ],
+				'dirty'    => [ 'facebook_site' => 'https://facebook.com/yoast' ],
+				'clean'    => [ 'facebook_site' => 'https://facebook.com/yoast' ],
 				'old'      => [],
 			],
 			[
-				'expected' => [ 'youtube_url' => 'https://www.youtube.com/yoasttube' ],
-				'dirty'    => [ 'youtube_url' => 'https://www.youtube.com/yoasttube' ],
-				'clean'    => [ 'youtube_url' => 'https://www.youtube.com/yoast' ],
+				'expected' => [ 'facebook_site' => 'https://facebook.com/yoastfb' ],
+				'dirty'    => [ 'facebook_site' => 'https://facebook.com/yoastfb' ],
+				'clean'    => [ 'facebook_site' => 'https://facebook.com/yoast' ],
 				'old'      => [],
+			],
+			[
+				'expected' => [
+					'other_social_urls' => [
+						'https://www.youtube.com/yoast',
+						'https://instagram.com/yoast',
+					]
+				],
+				'dirty'    => [
+					'other_social_urls' => [
+						'https://www.youtube.com/yoast',
+						'https://instagram.com/yoast',
+					]
+				],
+				'clean'    => [
+					'other_social_urls' => [
+						'https://www.youtube.com/yoast',
+					]
+				],
+				'old'      => [
+					'other_social_urls' => [],
+				],
 			],
 		];
 	}
@@ -157,11 +200,65 @@ class Option_Social_Test extends TestCase {
 				'slug_name' => 'facebook_site',
 			],
 			[
-				'expected'  => [ 'youtube_url' => 'https://www.youtube.com/yoast' ],
-				'dirty'     => [ 'youtube_url' => 'invalidurl' ],
-				'clean'     => [ 'youtube_url' => 'https://www.youtube.com/yoast' ],
-				'old'       => [ 'youtube_url' => 'https://www.youtube.com/yoast' ],
-				'slug_name' => 'youtube_url',
+				'expected'  => [ 'facebook_site' => 'https://facebook.com/yoast' ],
+				'dirty'     => [ 'facebook_site' => 'invalidurl' ],
+				'clean'     => [ 'facebook_site' => 'https://facebook.com/yoast' ],
+				'old'       => [ 'facebook_site' => 'https://facebook.com/yoast' ],
+				'slug_name' => 'facebook_site',
+			],
+		];
+	}
+
+	/**
+	 * Data for the test_validate_option test.
+	 *
+	 * @return array The test data.
+	 */
+	public function validate_option_invalid_array_data_provider() {
+		return [
+			[
+				'expected'  => [
+					'other_social_urls' => [
+						'https://www.youtube.com/yoast',
+						'https://instagram.com/yoast',
+					]
+				],
+				'dirty'     => 'not an array',
+				'clean'     => [
+					'other_social_urls' => [
+						'https://www.youtube.com/yoast',
+						'https://instagram.com/yoast',
+					]
+				],
+				'old'       => [
+					'other_social_urls' => [
+						'https://www.youtube.com/yoast',
+						'https://instagram.com/yoast',
+					]
+				],
+				'slug_name' => 'other_social_urls',
+			],
+			[
+				'expected'  => [
+					'other_social_urls' => [
+						'https://www.youtube.com/yoast',
+						'https://instagram.com/yoast',
+					]
+				],
+				'dirty'     => 'not an array',
+				'clean'     => [
+					'other_social_urls' => [
+						'https://www.youtube.com/yoast',
+						'https://instagram.com/yoast',
+					]
+				],
+				'old'       => [
+					'other_social_urls' => [
+						'https://www.youtube.com/yoast',
+						'https://instagram.com/yoast',
+					]
+				],
+				'slug_name' => 'other_social_urls',
 			],
 		];
 	}

--- a/tests/unit/inc/options/option-social-test.php
+++ b/tests/unit/inc/options/option-social-test.php
@@ -165,18 +165,18 @@ class Option_Social_Test extends TestCase {
 					'other_social_urls' => [
 						'https://www.youtube.com/yoast',
 						'https://instagram.com/yoast',
-					]
+					],
 				],
 				'dirty'    => [
 					'other_social_urls' => [
 						'https://www.youtube.com/yoast',
 						'https://instagram.com/yoast',
-					]
+					],
 				],
 				'clean'    => [
 					'other_social_urls' => [
 						'https://www.youtube.com/yoast',
-					]
+					],
 				],
 				'old'      => [
 					'other_social_urls' => [],
@@ -221,20 +221,20 @@ class Option_Social_Test extends TestCase {
 					'other_social_urls' => [
 						'https://www.youtube.com/yoast',
 						'https://instagram.com/yoast',
-					]
+					],
 				],
 				'dirty'     => 'not an array',
 				'clean'     => [
 					'other_social_urls' => [
 						'https://www.youtube.com/yoast',
 						'https://instagram.com/yoast',
-					]
+					],
 				],
 				'old'       => [
 					'other_social_urls' => [
 						'https://www.youtube.com/yoast',
 						'https://instagram.com/yoast',
-					]
+					],
 				],
 				'slug_name' => 'other_social_urls',
 			],

--- a/tests/unit/inc/options/option-social-test.php
+++ b/tests/unit/inc/options/option-social-test.php
@@ -238,28 +238,6 @@ class Option_Social_Test extends TestCase {
 				],
 				'slug_name' => 'other_social_urls',
 			],
-			[
-				'expected'  => [
-					'other_social_urls' => [
-						'https://www.youtube.com/yoast',
-						'https://instagram.com/yoast',
-					]
-				],
-				'dirty'     => 'not an array',
-				'clean'     => [
-					'other_social_urls' => [
-						'https://www.youtube.com/yoast',
-						'https://instagram.com/yoast',
-					]
-				],
-				'old'       => [
-					'other_social_urls' => [
-						'https://www.youtube.com/yoast',
-						'https://instagram.com/yoast',
-					]
-				],
-				'slug_name' => 'other_social_urls',
-			],
 		];
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to switch to a different structure for the social profiles options in preparation for the changes in the First-time configuration and the new Settings UI. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the structure of the Social options to accept an unlimited array of URLs beside the Facebook and Twitter profiles.

## Relevant technical choices:

* The validation just check if data is an array, without any check about elements being URLs.  This has been done to unblock this PR and make the change available for an upcoming PR that will provide changes to the API route.
* The PR includes an upgrade routine that will need to be adapted with the actual version number. The routine does not delete outdated social options, allowing user to downgrade without losses of data (as long as they don't change social options after upgrading)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install the Yoast Test Helper plugin
* set "Organization" in the Search Appearance
* visit SEO > Social and set URLs for all the social profiles, then save
* inspect the DB and search the `wpseo_social` option to see that the values are there
* in the Test Helper, set the Free `DB Version` to 18.2 and save
  * This will trigger the upgrade routine
* inspect the DB and search the `wpseo_social` option 
  * Check that there is a new `other_social_urls` array containing all the social profile URLs that are present in the old fields, except FB and TW.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* NA the full feature will be tested

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-289]


[DUPP-289]: https://yoast.atlassian.net/browse/DUPP-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ