### PR TITLE
Wordproof remove multisite compatibility

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -815,7 +815,11 @@ class Yoast_Form {
 		printf( '<div class="%s">', esc_attr( 'switch-container' . $help_class ) );
 		echo '<fieldset id="', $var_esc, '" class="fieldset-switch-toggle"><legend>', $label, '</legend>', $help;
 
-		echo $this->get_disabled_note( $variable );
+		// Show disabled note if attribute does not exists or does exist and is set to true.
+		if ( ! isset( $attr['show_disabled_note'] ) || ( $attr['show_disabled_note'] === true ) ) {
+			echo $this->get_disabled_note( $variable );
+		}
+
 		echo '<div class="switch-toggle switch-candy switch-yoast-seo">';
 
 		foreach ( $values as $key => $value ) {

--- a/admin/views/tabs/dashboard/integrations.php
+++ b/admin/views/tabs/dashboard/integrations.php
@@ -60,13 +60,20 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 				$name .= ' ' . new Premium_Badge_Presenter( $integration->name );
 			}
 
+			$attributes = [];
+
 			$disabled = false;
 			if ( $integration->premium === true && YoastSEO()->helpers->product->is_premium() === false ) {
-				$disabled = true;
+				$attributes = [ 'disabled' => $disabled ];
 			}
 
+			// If the integration is disabled, do not show note showing
+			// the integration is disabled by network admin.
 			if ( isset( $integration->disabled ) && $integration->disabled === true ) {
-				$disabled = true;
+				$attributes = [
+					'disabled'           => $disabled,
+					'show_disabled_note' => false,
+				];
 			}
 
 			$yform->toggle_switch(
@@ -77,7 +84,7 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 				],
 				$name,
 				$feature_help->get_button_html() . $feature_help->get_panel_html(),
-				[ 'disabled' => $disabled ]
+				$attributes
 			);
 
 			do_action( 'Yoast\WP\SEO\admin_integration_after', $integration );

--- a/admin/views/tabs/dashboard/integrations.php
+++ b/admin/views/tabs/dashboard/integrations.php
@@ -64,14 +64,14 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 
 			$disabled = false;
 			if ( $integration->premium === true && YoastSEO()->helpers->product->is_premium() === false ) {
-				$attributes = [ 'disabled' => $disabled ];
+				$attributes = [ 'disabled' => true ];
 			}
 
 			// If the integration is disabled, do not show note showing
 			// the integration is disabled by network admin.
 			if ( isset( $integration->disabled ) && $integration->disabled === true ) {
 				$attributes = [
-					'disabled'           => $disabled,
+					'disabled'           => true,
 					'show_disabled_note' => false,
 				];
 			}

--- a/admin/views/tabs/network/integrations.php
+++ b/admin/views/tabs/network/integrations.php
@@ -55,8 +55,12 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 					'off' => __( 'Disable', 'wordpress-seo' ),
 				],
 				$integration->name,
-				$feature_help->get_button_html() . $feature_help->get_panel_html()
+				$feature_help->get_button_html() . $feature_help->get_panel_html(),
+				[ 'disabled' => $integration->disabled ]
 			);
+
+			do_action( 'Yoast\WP\SEO\admin_network_integration_after', $integration );
+
 		}
 		?>
 	</div>

--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -101,7 +101,7 @@ class WPSEO_Option_MS extends WPSEO_Option {
 			"{$allow_prefix}semrush_integration_active"     => true,
 			"{$allow_prefix}zapier_integration_active"      => true,
 			"{$allow_prefix}wincher_integration_active"     => true,
-			"{$allow_prefix}wordproof_integration_active"   => true,
+			"{$allow_prefix}wordproof_integration_active"   => false,
 		];
 
 		if ( is_multisite() ) {

--- a/src/helpers/wordproof-helper.php
+++ b/src/helpers/wordproof-helper.php
@@ -57,18 +57,18 @@ class WordProof_Helper {
 	/**
 	 * Returns if conditionals are met. If not, the integration should be disabled.
 	 *
-	 * @param bool $returnConditional If the conditional class name that was unmet should be returned.
+	 * @param bool $return_conditional If the conditional class name that was unmet should be returned.
 	 *
 	 * @return bool|string Returns if the integration should be disabled.
 	 */
-	public function integration_is_disabled( $returnConditional = false ) {
+	public function integration_is_disabled( $return_conditional = false ) {
 		$conditionals = [ new WordProof_Plugin_Inactive_Conditional(), new Non_Multisite_Conditional() ];
 
 		foreach ( $conditionals as $conditional ) {
 			if ( ! $conditional->is_met() ) {
 
-				if ( $returnConditional === true ) {
-					return (new \ReflectionClass( $conditional ))->getShortName();
+				if ( $return_conditional === true ) {
+					return ( new \ReflectionClass( $conditional ) )->getShortName();
 				}
 
 				return true;

--- a/src/helpers/wordproof-helper.php
+++ b/src/helpers/wordproof-helper.php
@@ -57,13 +57,20 @@ class WordProof_Helper {
 	/**
 	 * Returns if conditionals are met. If not, the integration should be disabled.
 	 *
-	 * @return bool Returns if the integration should be disabled.
+	 * @param bool $returnConditional If the conditional class name that was unmet should be returned.
+	 *
+	 * @return bool|string Returns if the integration should be disabled.
 	 */
-	public function integration_is_disabled() {
-		$conditionals = [ new WordProof_Plugin_Inactive_Conditional() ];
+	public function integration_is_disabled( $returnConditional = false ) {
+		$conditionals = [ new WordProof_Plugin_Inactive_Conditional(), new Non_Multisite_Conditional() ];
 
 		foreach ( $conditionals as $conditional ) {
 			if ( ! $conditional->is_met() ) {
+
+				if ( $returnConditional === true ) {
+					return (new \ReflectionClass( $conditional ))->getShortName();
+				}
+
 				return true;
 			}
 		}

--- a/src/integrations/third-party/wordproof-integration-toggle.php
+++ b/src/integrations/third-party/wordproof-integration-toggle.php
@@ -65,6 +65,11 @@ class WordProof_Integration_Toggle implements Integration_Interface {
 		 * Add extra text after the integration toggle if the toggle is disabled.
 		 */
 		\add_action( 'Yoast\WP\SEO\admin_integration_after', [ $this, 'after_integration_toggle' ] );
+
+		/**
+		 * Add extra text after the network integration toggle if the toggle is disabled.
+		 */
+		\add_action( 'Yoast\WP\SEO\admin_network_integration_after', [ $this, 'after_network_integration_toggle' ] );
 	}
 
 	/**
@@ -119,7 +124,31 @@ class WordProof_Integration_Toggle implements Integration_Interface {
 	public function after_integration_toggle( $integration ) {
 		if ( $integration->setting === 'wordproof_integration_active' ) {
 			if ( $integration->disabled ) {
-				echo '<p>' . esc_html__( 'The WordProof Timestamp plugin needs to be disabled before you can activate this integration.', 'wordpress-seo' ) . '</p>';
+				
+				$conditional = $this->wordproof->integration_is_disabled( true );
+
+				if ( $conditional === 'Non_Multisite_Conditional' ) {
+					echo '<p>' . sprintf( esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ), 'WordProof' ) . '</p>';
+				}
+
+				if ( $conditional === 'WordProof_Plugin_Inactive_Conditional' ) {
+					echo '<p>' . esc_html__( 'The WordProof Timestamp plugin needs to be disabled before you can activate this integration.', 'wordpress-seo' ) . '</p>';
+				}
+
+			}
+		}
+	}
+
+	/**
+	 * Add an explainer when the network integration toggle is disabled.
+	 *
+	 * @param \Yoast_Feature_Toggle $integration The integration toggle class.
+	 */
+	public function after_network_integration_toggle( $integration ) {
+		if ( $integration->setting === 'wordproof_integration_active' ) {
+			if ( $integration->disabled ) {
+				/** Translators: %s expands to WordProof */
+				echo '<p>' . sprintf( esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ), 'WordProof' ) . '</p>';
 			}
 		}
 	}

--- a/src/integrations/third-party/wordproof-integration-toggle.php
+++ b/src/integrations/third-party/wordproof-integration-toggle.php
@@ -124,17 +124,20 @@ class WordProof_Integration_Toggle implements Integration_Interface {
 	public function after_integration_toggle( $integration ) {
 		if ( $integration->setting === 'wordproof_integration_active' ) {
 			if ( $integration->disabled ) {
-				
+
 				$conditional = $this->wordproof->integration_is_disabled( true );
 
 				if ( $conditional === 'Non_Multisite_Conditional' ) {
-					echo '<p>' . sprintf( esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ), 'WordProof' ) . '</p>';
+					echo '<p>' . sprintf(
+						/* translators: %s expands to WordProof */
+						esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ),
+						'WordProof'
+					) . '</p>';
 				}
 
 				if ( $conditional === 'WordProof_Plugin_Inactive_Conditional' ) {
 					echo '<p>' . esc_html__( 'The WordProof Timestamp plugin needs to be disabled before you can activate this integration.', 'wordpress-seo' ) . '</p>';
 				}
-
 			}
 		}
 	}
@@ -147,8 +150,11 @@ class WordProof_Integration_Toggle implements Integration_Interface {
 	public function after_network_integration_toggle( $integration ) {
 		if ( $integration->setting === 'wordproof_integration_active' ) {
 			if ( $integration->disabled ) {
-				/** Translators: %s expands to WordProof */
-				echo '<p>' . sprintf( esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ), 'WordProof' ) . '</p>';
+				echo '<p>' . sprintf(
+					/* translators: %s expands to WordProof */
+					esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ),
+					'WordProof'
+				) . '</p>';
 			}
 		}
 	}

--- a/src/integrations/third-party/wordproof.php
+++ b/src/integrations/third-party/wordproof.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Integrations\Third_Party;
 
 use WordProof\SDK\Helpers\PostMetaHelper;
 use WordProof\SDK\WordPressSDK;
+use Yoast\WP\SEO\Conditionals\Non_Multisite_Conditional;
 use Yoast\WP\SEO\Conditionals\Third_Party\WordProof_Plugin_Inactive_Conditional;
 use Yoast\WP\SEO\Config\WordProof_App_Config;
 use Yoast\WP\SEO\Config\WordProof_Translations;
@@ -46,7 +47,7 @@ class WordProof implements Integration_Interface {
 	 * @return array
 	 */
 	public static function get_conditionals() {
-		return [ WordProof_Plugin_Inactive_Conditional::class ];
+		return [ WordProof_Plugin_Inactive_Conditional::class, Non_Multisite_Conditional::class ];
 	}
 
 	/**


### PR DESCRIPTION
## Context

* This PR removes multisite compatibility for the WordProof integration
* Adds logic to display this to the user.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* This PR removes multisite compatibility for the WordProof integration

## Relevant technical choices:

* Adds attribute that is checked to hide the disabled_note for subsites
* Adds variable to wordproof_helper to return the conditional that is unmet to display proper message for the network admin
* added 'admin_network_integration_after' action, just like how it's used in integrations.php 

## Test instructions
1. Activate plugin on a multisite
2. The wordproof integration should be disabled
3. Text underneath the integration should display this to the user on subsites and on the site network integrations page.

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Some logic is added to the integration toggles. This is added to an attribute only used by the wordproof integration though.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
