### PR TITLE
P1-1205 - Create Twitter site validator

### DIFF
--- a/src/exceptions/validation/invalid-twitter-username-exception.php
+++ b/src/exceptions/validation/invalid-twitter-username-exception.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Yoast\WP\SEO\Exceptions\Validation;
+
+/**
+ * Invalid Twitter username validation exception class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- 4 words is fine.
+ */
+class Invalid_Twitter_Username_Exception extends Abstract_Validation_Exception {
+
+	/**
+	 * Constructs an invalid Twitter username validation exception instance.
+	 *
+	 * @param mixed $value The value that is not a valid Twitter username.
+	 */
+	public function __construct( $value ) {
+		parent::__construct(
+			\sprintf(
+			/* translators: %s expands to an invalid Twitter username. */
+				\esc_html__( '%s does not seem to be a valid Twitter Username. Please correct.', 'wordpress-seo' ),
+				'<strong>' . \esc_html( $value ) . '</strong>'
+			)
+		);
+	}
+}

--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -99,7 +99,10 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'twitter_site'                                        => [
 			'default' => '',
-			'types'   => [ 'string' ],
+			'types'   => [
+				'empty_string',
+				'twitter_username',
+			],
 		],
 		'wikipedia_url'                                       => [
 			'default' => '',

--- a/src/validators/twitter-username-validator.php
+++ b/src/validators/twitter-username-validator.php
@@ -58,7 +58,6 @@ class Twitter_Username_Validator extends Text_Field_Validator {
 				[
 					'pattern' => '`^http(?:s)?://(?:www\.)?twitter\.com/(?P<handle>[A-Za-z0-9_]{1,25})/?$`',
 					'groups'  => [ 'handle' ],
-
 				]
 			);
 		} catch ( Abstract_Validation_Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.

--- a/src/validators/twitter-username-validator.php
+++ b/src/validators/twitter-username-validator.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Yoast\WP\SEO\Validators;
+
+use Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Twitter_Username_Exception;
+
+/**
+ * The Twitter username validator class.
+ */
+class Twitter_Username_Validator extends Text_Field_Validator {
+
+	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- Reason: The parent validate can throw too.
+
+	/**
+	 * Holds the regex validator instance.
+	 *
+	 * @var Regex_Validator
+	 */
+	protected $regex_validator;
+
+	/**
+	 * Constructs a verification validator instance.
+	 *
+	 * @param Regex_Validator $regex_validator The regex validator.
+	 */
+	public function __construct( Regex_Validator $regex_validator ) {
+		$this->regex_validator = $regex_validator;
+	}
+
+	/**
+	 * Validates if a value is a Twitter username.
+	 *
+	 * @param mixed $value    The value to validate.
+	 * @param array $settings Optional settings.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Invalid_Type_Exception When the type of the value is not a string.
+	 * @throws Invalid_Twitter_Username_Exception When the value is not a valid Twitter username.
+	 *
+	 * @return string A valid string.
+	 */
+	public function validate( $value, array $settings = null ) {
+		$string = parent::validate( $value );
+
+		$twitter_username = \ltrim( $string, '@' );
+
+		try {
+			return $this->regex_validator->validate(
+				$twitter_username,
+				[ 'pattern' => '`^[A-Za-z0-9_]{1,25}$`' ]
+			);
+		} catch ( Abstract_Validation_Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
+		}
+
+		try {
+			return $this->regex_validator->validate(
+				$twitter_username,
+				[
+					'pattern' => '`^http(?:s)?://(?:www\.)?twitter\.com/(?P<handle>[A-Za-z0-9_]{1,25})/?$`',
+					'groups'  => [ 'handle' ],
+
+				]
+			);
+		} catch ( Abstract_Validation_Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
+		}
+
+		throw new Invalid_Twitter_Username_Exception( $twitter_username );
+	}
+}

--- a/src/validators/twitter-username-validator.php
+++ b/src/validators/twitter-username-validator.php
@@ -10,8 +10,6 @@ use Yoast\WP\SEO\Exceptions\Validation\Invalid_Twitter_Username_Exception;
  */
 class Twitter_Username_Validator extends Text_Field_Validator {
 
-	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- Reason: The parent validate can throw too.
-
 	/**
 	 * Holds the regex validator instance.
 	 *
@@ -27,6 +25,8 @@ class Twitter_Username_Validator extends Text_Field_Validator {
 	public function __construct( Regex_Validator $regex_validator ) {
 		$this->regex_validator = $regex_validator;
 	}
+
+	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- Reason: The parent validate can throw too.
 
 	/**
 	 * Validates if a value is a Twitter username.
@@ -65,4 +65,6 @@ class Twitter_Username_Validator extends Text_Field_Validator {
 
 		throw new Invalid_Twitter_Username_Exception( $string );
 	}
+
+	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
 }

--- a/src/validators/twitter-username-validator.php
+++ b/src/validators/twitter-username-validator.php
@@ -64,6 +64,6 @@ class Twitter_Username_Validator extends Text_Field_Validator {
 		} catch ( Abstract_Validation_Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
 		}
 
-		throw new Invalid_Twitter_Username_Exception( $twitter_username );
+		throw new Invalid_Twitter_Username_Exception( $string );
 	}
 }

--- a/tests/unit/validators/twitter-username-validator-test.php
+++ b/tests/unit/validators/twitter-username-validator-test.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Validators;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Twitter_Username_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\Validators\Regex_Validator;
+use Yoast\WP\SEO\Validators\Twitter_Username_Validator;
+
+/**
+ * Tests the \Yoast\WP\SEO\Validators\Twitter_Username_Validator class.
+ *
+ * @group options
+ * @group validators
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Validators\Twitter_Username_Validator
+ */
+class Twitter_Username_Validator_Test extends TestCase {
+
+	/**
+	 * Holds the instance to test.
+	 *
+	 * @var \Yoast\WP\SEO\Validators\Twitter_Username_Validator
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the regex validator mock.
+	 *
+	 * @var Mockery\Mock|Regex_Validator
+	 */
+	protected $regex_validator;
+
+	/**
+	 * Sets up the test fixtures.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
+		Monkey\Functions\stubs(
+			[
+				'wp_check_invalid_utf8' => null,
+				'wp_pre_kses_less_than' => null,
+			]
+		);
+
+		$this->regex_validator = new Regex_Validator();
+		$this->instance        = new Twitter_Username_Validator( $this->regex_validator );
+	}
+
+	/**
+	 * Tests if the needed attributes are set correctly.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_construct() {
+		$this->assertInstanceOf( Twitter_Username_Validator::class, $this->instance );
+		$this->assertInstanceOf(
+			Regex_Validator::class,
+			$this->getPropertyValue( $this->instance, 'regex_validator' )
+		);
+	}
+
+	/**
+	 * Tests validation.
+	 *
+	 * @dataProvider data_provider
+	 *
+	 * @covers ::validate
+	 *
+	 * @param mixed  $value     The value to test/validate.
+	 * @param mixed  $expected  The expected result.
+	 * @param string $exception The expected exception class. Optional, use when the expected result is false.
+	 *
+	 * @throws \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception When detecting an invalid value.
+	 */
+	public function test_validate( $value, $expected, $exception = '' ) {
+		if ( $exception !== '' ) {
+			$this->expectException( $exception );
+			$this->instance->validate( $value );
+
+			return;
+		}
+
+		$this->assertEquals( $expected, $this->instance->validate( $value ) );
+	}
+
+	/**
+	 * Data provider to test multiple scenarios.
+	 *
+	 * @return array A mapping of methods and expected inputs.
+	 */
+	public function data_provider() {
+		return [
+			'without_at_sign'             => [
+				'value'    => 'yoastdev',
+				'expected' => 'yoastdev',
+			],
+			'with_at_sign'                => [
+				'value'    => '@yoastdev',
+				'expected' => 'yoastdev',
+			],
+			'with_all_allowed_characters' => [
+				'value'    => '@Yoast_Dev1',
+				'expected' => 'Yoast_Dev1',
+			],
+			'url'                         => [
+				'value'    => 'https://twitter.com/yoastdev',
+				'expected' => 'yoastdev',
+			],
+			'url_invalid'                 => [
+				'value'     => 'https://twitter.com/@yoastdev',
+				'expected'  => false,
+				'exception' => Invalid_Twitter_Username_Exception::class,
+			],
+			'min_length'                  => [
+				'value'    => '1',
+				'expected' => '1',
+			],
+			'max_length'                  => [
+				'value'    => '0000000000000000000000025',
+				'expected' => '0000000000000000000000025',
+			],
+			'over_max_length'             => [
+				'value'     => '00000000000000000000000026',
+				'expected'  => false,
+				'exception' => Invalid_Twitter_Username_Exception::class,
+			],
+			'url_over_max_length'         => [
+				'value'     => 'https://twitter.com/00000000000000000000000026',
+				'expected'  => false,
+				'exception' => Invalid_Twitter_Username_Exception::class,
+			],
+			'unallowed_characters'        => [
+				'value'     => 'yoastdev!',
+				'expected'  => false,
+				'exception' => Invalid_Twitter_Username_Exception::class,
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds the Twitter username validator.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the Twitter username validator.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Tests should make sense and cover the code
* You can play around with requesting validations, using this code:
```php
function _test_validate( $value ) {
    /** @var \Yoast\WP\SEO\Validators\Twitter_Username_Validator $validator */
    $validator = YoastSEO()->classes->get( \Yoast\WP\SEO\Validators\Twitter_Username_Validator::class );
    echo 'Value: ';
    var_dump( $value );
    echo '<br>Result: ';
    try {
        var_dump( $validator->validate( $value ) );
    } catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
        echo $exception->getMessage();
    }
    echo '<br>';
}
_test_validate( 'https://twitter.com/MileyCyrus' );
```
* You can play with the setting of the username, using this code:
```php
function _test_set( $value ) {
    /** @var \Yoast\WP\SEO\Services\Options\Site_Options_Service $options */
    $options = YoastSEO()->classes->get( \Yoast\WP\SEO\Services\Options\Site_Options_Service::class );
    echo '<br>Before: ';
    var_dump( $options->twitter_site );
    echo '<br>After: ';
    try {
        $options->twitter_site = $value;
        var_dump( $options->twitter_site );
    } catch ( \Yoast\WP\SEO\Exceptions\Validation\Abstract_Validation_Exception $exception ) {
        echo $exception->getMessage();
    }
    echo '<br>';
}
_test_set( 'N0t@llowedChars!' );
```


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes P1-1205
