### PR TITLE
Add loading state to the ComboBox

### DIFF
--- a/packages/js/src/workouts/tailwind-components/base/combo-box.js
+++ b/packages/js/src/workouts/tailwind-components/base/combo-box.js
@@ -6,6 +6,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 
 import { getOptionActiveStyles } from "../helpers";
+import Spinner from "./spinner";
 
 /**
  * A function needed to extract the label to display when a person is selected.
@@ -33,7 +34,7 @@ function getDisplayValue( selectedOption ) {
  *
  * @returns {WPElement} The Yoast version of a Tailwind Combobox.
  */
-export default function YoastComboBox( { value, label, onChange, onQueryChange, options, placeholder } ) {
+export default function YoastComboBox( { value, label, onChange, onQueryChange, options, placeholder, isLoading } ) {
 	const [ filteredOptions, setFilteredOptions ] = useState( options );
 	const [ query, setQuery ] = useState( "" );
 
@@ -100,19 +101,18 @@ export default function YoastComboBox( { value, label, onChange, onQueryChange, 
 							/>
 							<SelectorIcon className="yst-h-5 yst-w-5 yst-text-gray-400 yst-inset-y-0 yst-right-0" aria-hidden="true" />
 						</Combobox.Button>
-
 						{ ( filteredOptions.length > 0 ) && (
 							<Combobox.Options className="yst-absolute yst-z-10 yst-mt-1 yst-max-h-60 yst-w-full yst-overflow-auto yst-rounded-md yst-bg-white yst-text-base yst-shadow-lg yst-ring-1 yst-ring-black yst-ring-opacity-5 focus:yst-outline-none sm:yst-text-sm">
-								{ filteredOptions.map( ( option ) => {
-									return <Combobox.Option
+								{ isLoading && <div className="yst-flex yst-bg-white yst-sticky yst-z-20 yst-top-0 yst-py-2 yst-pl-3 yst-pr-9 yst-my-0"><Spinner className="yst-text-primary-500 yst-h-4 yst-w-4 yst-mr-2 yst-self-center" />{ __( "loading...", "wordpress-seo" ) }</div> }
+								{ filteredOptions.map( ( option ) => (
+									<Combobox.Option
 										key={ `yst-option-${ option.value }` }
 										value={ option }
 										className={ getOptionBasedStyles( option.value, value.value ) }
 									>
-										{ ( { selected } ) => (
-											<>
+										{ ( { selected } ) => {
+											return <>
 												<span className={ classNames( "yst-block yst-truncate", selected && "yst-font-semibold" ) }>{ option.label }</span>
-
 												{ ( selected || value.value === option.value ) && (
 													<span
 														className={ "yst-absolute yst-inset-y-0 yst-right-0 yst-flex yst-items-center yst-pr-4 yst-text-white" }
@@ -120,10 +120,10 @@ export default function YoastComboBox( { value, label, onChange, onQueryChange, 
 														<CheckIcon className="yst-h-5 yst-w-5" aria-hidden="true" />
 													</span>
 												) }
-											</>
-										) }
-									</Combobox.Option>;
-								} ) }
+											</>;
+										} }
+									</Combobox.Option>
+								 ) ) }
 							</Combobox.Options>
 						) }
 					</div>
@@ -143,6 +143,7 @@ YoastComboBox.propTypes = {
 	label: PropTypes.string,
 	onQueryChange: PropTypes.func,
 	placeholder: PropTypes.string,
+	isLoading: PropTypes.bool,
 };
 
 YoastComboBox.defaultProps = {
@@ -150,4 +151,5 @@ YoastComboBox.defaultProps = {
 	label: "",
 	onQueryChange: null,
 	placeholder: __( "Select an option", "wordpress-seo" ),
+	isLoading: false,
 };

--- a/packages/js/src/workouts/tailwind-components/base/combo-box.js
+++ b/packages/js/src/workouts/tailwind-components/base/combo-box.js
@@ -103,7 +103,7 @@ export default function YoastComboBox( { value, label, onChange, onQueryChange, 
 						</Combobox.Button>
 						{ ( filteredOptions.length > 0 ) && (
 							<Combobox.Options className="yst-absolute yst-z-10 yst-mt-1 yst-max-h-60 yst-w-full yst-overflow-auto yst-rounded-md yst-bg-white yst-text-base yst-shadow-lg yst-ring-1 yst-ring-black yst-ring-opacity-5 focus:yst-outline-none sm:yst-text-sm">
-								{ isLoading && <div className="yst-flex yst-bg-white yst-sticky yst-z-20 yst-top-0 yst-py-2 yst-pl-3 yst-pr-9 yst-my-0"><Spinner className="yst-text-primary-500 yst-h-4 yst-w-4 yst-mr-2 yst-self-center" />{ __( "loading...", "wordpress-seo" ) }</div> }
+								{ isLoading && <div className="yst-flex yst-bg-white yst-sticky yst-z-20 yst-text-sm yst-italic yst-top-0 yst-py-2 yst-pl-3 yst-pr-9 yst-my-0"><Spinner className="yst-text-primary-500 yst-h-4 yst-w-4 yst-mr-2 yst-self-center" />{ __( "Loading...", "wordpress-seo" ) }</div> }
 								{ filteredOptions.map( ( option ) => (
 									<Combobox.Option
 										key={ `yst-option-${ option.value }` }
@@ -112,7 +112,7 @@ export default function YoastComboBox( { value, label, onChange, onQueryChange, 
 									>
 										{ ( { selected } ) => {
 											return <>
-												<span className={ classNames( "yst-block yst-truncate", selected && "yst-font-semibold" ) }>{ option.label }</span>
+												<span className={ classNames( "yst-block yst-truncate", ( selected || value.label === option.label ) && "yst-font-semibold" ) }>{ option.label }</span>
 												{ ( selected || value.value === option.value ) && (
 													<span
 														className={ "yst-absolute yst-inset-y-0 yst-right-0 yst-flex yst-items-center yst-pr-4 yst-text-white" }

--- a/packages/js/src/workouts/tailwind-components/base/combo-box.js
+++ b/packages/js/src/workouts/tailwind-components/base/combo-box.js
@@ -112,7 +112,7 @@ export default function YoastComboBox( { value, label, onChange, onQueryChange, 
 									>
 										{ ( { selected } ) => {
 											return <>
-												<span className={ classNames( "yst-block yst-truncate", ( selected || value.label === option.label ) && "yst-font-semibold" ) }>{ option.label }</span>
+												<span className={ classNames( "yst-block yst-truncate", ( selected || value.value === option.value ) && "yst-font-semibold" ) }>{ option.label }</span>
 												{ ( selected || value.value === option.value ) && (
 													<span
 														className={ "yst-absolute yst-inset-y-0 yst-right-0 yst-flex yst-items-center yst-pr-4 yst-text-white" }

--- a/packages/js/src/workouts/tailwind-components/base/spinner.js
+++ b/packages/js/src/workouts/tailwind-components/base/spinner.js
@@ -9,7 +9,7 @@ import classNames from "classnames";
  * @param {string} props.className Additional CSS class names.
  * @returns {WPElement} The Spinner component.
  */
-const Spinner = ( { color, size, className } ) => {
+const Spinner = ( { className } ) => {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
@@ -17,9 +17,6 @@ const Spinner = ( { color, size, className } ) => {
 			viewBox="0 0 24 24"
 			className={ classNames(
 				"yst-animate-spin",
-				`yst-w-${ size }`,
-				`yst-h-${ size }`,
-				`yst-text-${ color }`,
 				className
 			) }
 		>
@@ -30,14 +27,10 @@ const Spinner = ( { color, size, className } ) => {
 };
 
 Spinner.propTypes = {
-	color: PropTypes.string,
-	size: PropTypes.string,
 	className: PropTypes.string,
 };
 
 Spinner.defaultProps = {
-	color: "white",
-	size: "4",
 	className: "",
 };
 

--- a/packages/js/src/workouts/tailwind-components/helpers/index.js
+++ b/packages/js/src/workouts/tailwind-components/helpers/index.js
@@ -34,7 +34,7 @@ export function getOptionActiveStyles( { active, selected } ) {
 	return classNames(
 		"yst-relative yst-cursor-default yst-select-none yst-py-2 yst-pl-3 yst-pr-9 yst-my-0",
 		selected && "yst-bg-primary-500 yst-text-white",
-		( active && ! selected ) && "yst-bg-primary-200 yst-text-gray-900",
-		( ! active && ! selected ) && "yst-text-gray-900"
+		( active && ! selected ) && "yst-bg-primary-200 yst-text-gray-700",
+		( ! active && ! selected ) && "yst-text-gray-700"
 	);
 }

--- a/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
+++ b/packages/js/src/workouts/tailwind-components/steps/site-representation/user-selector.js
@@ -42,13 +42,17 @@ export default function UserSelector( { initialValue, onChangeCallback, placehol
 		value: initialValue.id,
 		label: initialValue.name,
 	} );
+	const [ isLoading, setIsLoading ] = useState( false );
+
 	const handleSelectChange = useCallback( ( event ) => {
 		setSelectedPerson( event );
 		onChangeCallback( event );
 	} );
 
 	const loadUsers = useCallback( debounce( async( searchQuery ) => {
+		setIsLoading( true );
 		const usersResponse = await fetchUsers( searchQuery );
+		setIsLoading( false );
 		setUsers( usersResponse.map( ( user ) => {
 			return {
 				value: user.id,
@@ -64,6 +68,7 @@ export default function UserSelector( { initialValue, onChangeCallback, placehol
 		onQueryChange={ loadUsers }
 		options={ users }
 		placeholder={ placeholder }
+		isLoading={ isLoading }
 	/>;
 }
 


### PR DESCRIPTION
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* User selection is actually async, so a loading state is a good way to signal that data is being fetched

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a loading state to the combobox to display a spinner while data is being fetched.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the site representation step.
* Set representation to person.
* Open the Name combobox.
* Start typing in the Name combobox.
* Notice the loading spinner.
* Try to break?

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes DUPP-332
