### PR TITLE
Add new badge to integration toggle

### DIFF
--- a/admin/views/class-yoast-feature-toggle.php
+++ b/admin/views/class-yoast-feature-toggle.php
@@ -88,6 +88,13 @@ class Yoast_Feature_Toggle {
 	protected $disabled = false;
 
 	/**
+	 * Whether the feature is new or not.
+	 *
+	 * @var bool
+	 */
+	protected $new = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * Sets the feature toggle arguments.
@@ -97,13 +104,14 @@ class Yoast_Feature_Toggle {
 	 *
 	 *     @type string $name            Required. Feature toggle identifier.
 	 *     @type string $setting         Required. Name of the setting the feature toggle is associated with.
-	 *     @type string $label           Feature toggle label.
+	 *     @type string $disabled        Whether the feature is premium or not.
 	 *     @type string $read_more_url   URL to learn more about the feature. Default empty string.
 	 *     @type string $read_more_label Label for the learn more link. Default empty string.
 	 *     @type string $extra           Additional help content for the feature. Default empty string.
 	 *     @type int    $order           Value to specify the feature toggle order. A lower value indicates
 	 *                                   a higher priority. Default 100.
 	 *     @type bool   $disabled        Disable the integration toggle. Default false.
+	 *     @type string $new             Whether the feature is new or not.
 	 * }
 	 *
 	 * @throws InvalidArgumentException Thrown when a required argument is missing.

--- a/admin/views/class-yoast-feature-toggle.php
+++ b/admin/views/class-yoast-feature-toggle.php
@@ -105,6 +105,7 @@ class Yoast_Feature_Toggle {
 	 *     @type string $name            Required. Feature toggle identifier.
 	 *     @type string $setting         Required. Name of the setting the feature toggle is associated with.
 	 *     @type string $disabled        Whether the feature is premium or not.
+	 *     @type string $label           Feature toggle label.
 	 *     @type string $read_more_url   URL to learn more about the feature. Default empty string.
 	 *     @type string $read_more_label Label for the learn more link. Default empty string.
 	 *     @type string $extra           Additional help content for the feature. Default empty string.

--- a/admin/views/tabs/dashboard/integrations.php
+++ b/admin/views/tabs/dashboard/integrations.php
@@ -8,6 +8,7 @@
  */
 
 use Yoast\WP\SEO\Presenters\Admin\Premium_Badge_Presenter;
+use Yoast\WP\SEO\Presenters\Admin\Badge_Presenter;
 
 if ( ! defined( 'WPSEO_VERSION' ) ) {
 	header( 'Status: 403 Forbidden' );
@@ -58,6 +59,10 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 			$name = $integration->name;
 			if ( ! empty( $integration->premium ) && $integration->premium === true ) {
 				$name .= ' ' . new Premium_Badge_Presenter( $integration->name );
+			}
+
+			if ( ! empty( $integration->new ) && $integration->new === true ) {
+				$name .= ' ' . new Badge_Presenter( $integration->name );
 			}
 
 			$attributes = [];

--- a/admin/views/tabs/network/integrations.php
+++ b/admin/views/tabs/network/integrations.php
@@ -7,6 +7,8 @@
  * @uses Yoast_Form $yform Form object.
  */
 
+use Yoast\WP\SEO\Presenters\Admin\Badge_Presenter;
+
 if ( ! defined( 'WPSEO_VERSION' ) ) {
 	header( 'Status: 403 Forbidden' );
 	header( 'HTTP/1.1 403 Forbidden' );
@@ -48,13 +50,18 @@ $integration_toggles = Yoast_Integration_Toggles::instance()->get_all();
 				$help_text
 			);
 
+			$name = $integration->name;
+			if ( ! empty( $integration->new ) && $integration->new === true ) {
+				$name .= ' ' . new Badge_Presenter( $integration->name );
+			}
+
 			$yform->toggle_switch(
 				WPSEO_Option::ALLOW_KEY_PREFIX . $integration->setting,
 				[
 					'on'  => __( 'Allow Control', 'wordpress-seo' ),
 					'off' => __( 'Disable', 'wordpress-seo' ),
 				],
-				$integration->name,
+				$name,
 				$feature_help->get_button_html() . $feature_help->get_panel_html(),
 				[ 'disabled' => $integration->disabled ]
 			);

--- a/src/integrations/third-party/wordproof-integration-toggle.php
+++ b/src/integrations/third-party/wordproof-integration-toggle.php
@@ -95,6 +95,7 @@ class WordProof_Integration_Toggle implements Integration_Interface {
 				'read_more_url'   => 'https://yoa.st/wordproof-integration',
 				'order'           => 16,
 				'disabled'        => $this->wordproof->integration_is_disabled(),
+				'new'         => true,
 			];
 		}
 
@@ -106,7 +107,7 @@ class WordProof_Integration_Toggle implements Integration_Interface {
 	 *
 	 * @param array $defaults Array containing default wpseo options.
 	 *
-	 * @return bool
+	 * @return array
 	 */
 	public function default_values( $defaults ) {
 		if ( $this->wordproof->integration_is_disabled() ) {

--- a/src/integrations/third-party/wordproof-integration-toggle.php
+++ b/src/integrations/third-party/wordproof-integration-toggle.php
@@ -95,7 +95,7 @@ class WordProof_Integration_Toggle implements Integration_Interface {
 				'read_more_url'   => 'https://yoa.st/wordproof-integration',
 				'order'           => 16,
 				'disabled'        => $this->wordproof->integration_is_disabled(),
-				'new'         => true,
+				'new'             => true,
 			];
 		}
 


### PR DESCRIPTION
## Context

* Add a new badge to integration toggles

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add a new badge to the WordProof integration toggle

## Relevant technical choices:

* Adding to the Yoast_Feature_Toggle class

## Test instructions

- go to the integrations tab
- WordProof should have the new badge

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- go to the integrations tab
- WordProof should have the new badge

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The integration toggles

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
