### PR TITLE
DUPP-337 Use parameter name from ArrayAccess interface in orm.php

### DIFF
--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2475,8 +2475,8 @@ class ORM implements \ArrayAccess {
 	/**
 	 * Sets the value of the key.
 	 *
-	 * @param string|int $offset   Key.
-	 * @param mixed      $value Value.
+	 * @param string|int $offset Key.
+	 * @param mixed      $value  Value.
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -2451,50 +2451,50 @@ class ORM implements \ArrayAccess {
 	/**
 	 * Checks whether the data has the key.
 	 *
-	 * @param mixed $key Key.
+	 * @param mixed $offset Key.
 	 *
 	 * @return bool Whether the data has the key.
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetExists( $key ) {
-		return \array_key_exists( $key, $this->data );
+	public function offsetExists( $offset ) {
+		return \array_key_exists( $offset, $this->data );
 	}
 
 	/**
 	 * Retrieves the value of the key.
 	 *
-	 * @param mixed $key Key.
+	 * @param mixed $offset Key.
 	 *
 	 * @return array|mixed|null The value.
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetGet( $key ) {
-		return $this->get( $key );
+	public function offsetGet( $offset ) {
+		return $this->get( $offset );
 	}
 
 	/**
 	 * Sets the value of the key.
 	 *
-	 * @param string|int $key   Key.
+	 * @param string|int $offset   Key.
 	 * @param mixed      $value Value.
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetSet( $key, $value ) {
-		if ( \is_null( $key ) ) {
+	public function offsetSet( $offset, $value ) {
+		if ( \is_null( $offset ) ) {
 			return;
 		}
-		$this->set( $key, $value );
+		$this->set( $offset, $value );
 	}
 
 	/**
 	 * Removes the given key from the data.
 	 *
-	 * @param mixed $key Key.
+	 * @param mixed $offset Key.
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetUnset( $key ) {
-		unset( $this->data[ $key ] );
-		unset( $this->dirty_fields[ $key ] );
+	public function offsetUnset( $offset ) {
+		unset( $this->data[ $offset ] );
+		unset( $this->dirty_fields[ $offset ] );
 	}
 
 	/*


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to use the same param names as in the ArrayAccess interface in ORM.


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the name of the parameter in ORM methods overloaded from ArrayAccess.


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This change should not affect anything outside the method. Possible impact would be in **Indexables**.



### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-337]


[DUPP-337]: https://yoast.atlassian.net/browse/DUPP-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ