### PR TITLE
Adds support for custom taxonomies as replacement variables

### DIFF
--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -1,6 +1,5 @@
 /* global moment */
-import { flow, get, isEqual, set } from "lodash";
-import map from "lodash/map";
+import { flow, get, isEqual, set, map } from "lodash";
 import { getContentTinyMce } from "../../lib/tinymce";
 import getContentLocale from "../../analysis/getContentLocale";
 

--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -248,8 +248,8 @@ export const getPostCategories = () => {
  *
  * @returns {string[]} The post's tags.
  */
-export const getPostTags = () => {
-	const tagChecklistElement = document.querySelectorAll( ".tagchecklist" );
+export const getPostTags = ( termID = "post_tag" ) => {
+	const tagChecklistElement = document.querySelectorAll( `#${ termID } .tagchecklist` );
 
 	if ( tagChecklistElement.length > 0 ) {
 		// Each tag is a <li> element containing a button and two text elements. The second text element contains the name of the tag.
@@ -310,7 +310,7 @@ export const getCustomTaxonomies = () => {
 	 */
 	names.forEach( name => {
 		const checkboxesElement = getCTCheckboxes( name );
-		const customTags = getPostTags();
+		const customTags = getPostTags( name );
 		if ( checkboxesElement.length === 0 ) {
 			customTaxonomies[ name ] = customTags;
 		} else {

--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -244,9 +244,11 @@ export const getPostCategories = () => {
 };
 
 /**
- * Gets the current post's tags from the document.
+ * Gets the current post's tags or custom tags from the document using the ID of the parent element.
  *
- * @returns {string[]} The post's tags.
+ * @param {String} termID The parent element id of the tags or custom tags.
+ *
+ * @returns {String[]} The post's tags
  */
 export const getPostTags = ( termID = "post_tag" ) => {
 	const tagChecklistElement = document.querySelectorAll( `#${ termID } .tagchecklist` );

--- a/packages/js/src/classic-editor/helpers/dom.js
+++ b/packages/js/src/classic-editor/helpers/dom.js
@@ -210,6 +210,25 @@ export const getPostMostUsedCategoryCheckboxes = () => {
 };
 
 /**
+ * Maps over a list of checked checkboxes elements and returns the value and the text content.
+ *
+ * @param {Array} checkedCheckboxes The array of checked checkboxes to map.
+ *
+ * @returns {Object[]} An array containing objects with the checked checkboxes value and text content.
+ */
+const getValuesFromCheckboxes = ( checkedCheckboxes ) => {
+	return checkedCheckboxes.map( checkbox => (
+		{
+			id: checkbox.value,
+			name: [ ...checkbox.parentElement.childNodes ]
+				.filter( node => node.nodeType === Node.TEXT_NODE )
+				.map( node => node.textContent )[ 0 ]
+				?.trim(),
+		}
+	) );
+};
+
+/**
  * Gets the current post's categories from the document.
  *
  * @returns {{name: string, id: string}[]} The post's categories.
@@ -220,15 +239,7 @@ export const getPostCategories = () => {
 
 	if ( checkboxes ) {
 		const checkedCheckboxes = checkboxes.filter( checkbox => checkbox.checked );
-		return checkedCheckboxes.map( checkbox => (
-			{
-				id: checkbox.value,
-				name: [ ...checkbox.parentElement.childNodes ]
-					.filter( node => node.nodeType === Node.TEXT_NODE )
-					.map( node => node.textContent )[ 0 ]
-					?.trim(),
-			}
-		) );
+		return getValuesFromCheckboxes( checkedCheckboxes );
 	}
 	return [];
 };
@@ -305,15 +316,7 @@ export const getCustomTaxonomies = () => {
 			customTaxonomies[ name ] = customTags;
 		} else {
 			const checkedCheckboxes = checkboxesElement.filter( checkbox => checkbox.checked );
-			customTaxonomies[ name ] = checkedCheckboxes.map( checkbox => (
-				{
-					id: checkbox.value,
-					value: [ ...checkbox.parentElement.childNodes ]
-						.filter( node => node.nodeType === Node.TEXT_NODE )
-						.map( node => node.textContent )[ 0 ]
-						?.trim(),
-				}
-			) );
+			customTaxonomies[ name ] = getValuesFromCheckboxes( checkedCheckboxes );
 		}
 	} );
 

--- a/packages/js/src/classic-editor/initial-state.js
+++ b/packages/js/src/classic-editor/initial-state.js
@@ -27,6 +27,7 @@ export const getInitialPostState = () => ( {
 		taxonomies: {
 			categories: dom.getPostCategories(),
 			tags: dom.getPostTags(),
+			customTaxonomies: dom.getCustomTaxonomies(),
 		},
 		locale: getContentLocale(),
 	},

--- a/packages/js/src/classic-editor/replacement-variables/configurations.js
+++ b/packages/js/src/classic-editor/replacement-variables/configurations.js
@@ -210,7 +210,18 @@ export const customTaxonomies = map(
 			__( "%s (custom taxonomy)", "wordpress-seo" ),
 			key
 		),
-		getReplacement: () => name,
+		getReplacement: () => {
+			const customTaxonomiesFromStore = select( SEO_STORE_NAME ).selectTerms( "customTaxonomies" );
+			let customTerm = "";
+			for ( const taxonomy in customTaxonomiesFromStore ) {
+				if ( taxonomy === name ) {
+					customTerm = customTaxonomiesFromStore[ taxonomy ].map( term => {
+						return ( typeof term === "object" ) ? term.value : term;
+					} );
+				}
+			}
+			return customTerm.join( ", " );
+		},
 	} )
 );
 

--- a/packages/js/src/classic-editor/replacement-variables/configurations.js
+++ b/packages/js/src/classic-editor/replacement-variables/configurations.js
@@ -216,7 +216,7 @@ export const customTaxonomies = map(
 			for ( const taxonomy in customTaxonomiesFromStore ) {
 				if ( taxonomy === name ) {
 					customTerm = customTaxonomiesFromStore[ taxonomy ].map( term => {
-						return ( typeof term === "object" ) ? term.value : term;
+						return ( typeof term === "object" ) ? term.name : term;
 					} );
 				}
 			}

--- a/packages/js/src/classic-editor/replacement-variables/configurations.js
+++ b/packages/js/src/classic-editor/replacement-variables/configurations.js
@@ -201,6 +201,28 @@ export const customFields = map(
 	} )
 );
 
+/**
+ * Gets the replacement for the custom taxonomies (CT) variable.
+ *
+ * @param {string} name The custom taxonomy name to check.
+ *
+ * @returns {string} The replacement for the custom taxonomies variable.
+ */
+export const getCTReplacement = ( name ) => {
+	const customTaxonomiesFromStore = select( SEO_STORE_NAME ).selectTerms( "customTaxonomies" );
+	let customTerm = [];
+	for ( const taxonomy in customTaxonomiesFromStore ) {
+		if ( customTaxonomiesFromStore.hasOwnProperty( taxonomy ) ) {
+			if ( taxonomy === name ) {
+				customTerm = customTaxonomiesFromStore[ taxonomy ].map( term => {
+					return ( typeof term === "object" ) ? term.name : term;
+				} );
+			}
+		}
+	}
+	return customTerm.join( ", " );
+};
+
 export const customTaxonomies = map(
 	get( window, "wpseoScriptData.analysis.plugins.replaceVars.replace_vars.custom_taxonomies", {} ),
 	( { name }, key ) => ( {
@@ -210,18 +232,7 @@ export const customTaxonomies = map(
 			__( "%s (custom taxonomy)", "wordpress-seo" ),
 			key
 		),
-		getReplacement: () => {
-			const customTaxonomiesFromStore = select( SEO_STORE_NAME ).selectTerms( "customTaxonomies" );
-			let customTerm = "";
-			for ( const taxonomy in customTaxonomiesFromStore ) {
-				if ( taxonomy === name ) {
-					customTerm = customTaxonomiesFromStore[ taxonomy ].map( term => {
-						return ( typeof term === "object" ) ? term.name : term;
-					} );
-				}
-			}
-			return customTerm.join( ", " );
-		},
+		getReplacement: () => getCTReplacement( name ),
 	} )
 );
 

--- a/packages/js/src/classic-editor/watcher.js
+++ b/packages/js/src/classic-editor/watcher.js
@@ -241,26 +241,27 @@ const createTagsSync = ( updateTerms ) => {
  */
 const createCustomTaxonomiesSync = ( updateTerms ) => {
 	const names = dom.getCTNames();
+	names.forEach( name => {
+		/**
+		 * Retrieves the hierarchical custom taxonomies from the DOM and syncs them to the SEO store.
+		 *
+		 * @returns {void}
+		 */
+		const syncCustomTaxonomies = () => {
+			updateTerms( { taxonomyType: `customTaxonomies.${ name }`, terms: dom.getCustomTaxonomies()[ name ] } );
+		};
 
-	/**
-	 * Retrieves the hierarchical custom taxonomies from the DOM and syncs them to the SEO store.
-	 *
-	 * @returns {void}
-	 */
-	const syncCustomTaxonomies = () => {
-		names.forEach( name => updateTerms( { taxonomyType: `customTaxonomies.${ name }`, terms: dom.getCustomTaxonomies()[ name ] } ) );
-	};
-
-	/**
-	 * Watches the hierarchical custom taxonomy checkboxes for changes,
-	 * and updates the custom taxonomies in the SEO store accordingly.
-	 *
-	 * @returns {void}
-	 */
-	const watchCTCheckboxes = () => {
-		// Sync the hierarchical custom taxonomies whenever there are changes in the checkboxes.
-		// Watch both the "All (Custom taxonomy name)" and "Most Used" sections.
-		names.forEach( name => {
+		/**
+		 * Watches the hierarchical custom taxonomy checkboxes for changes,
+		 * and updates the custom taxonomies in the SEO store accordingly.
+		 *
+		 * @returns {void}
+		 */
+		const watchCTCheckboxes = () => {
+			/**
+			 * Sync the hierarchical custom taxonomies whenever there are changes in the checkboxes.
+			 * Watch both the "All (Custom taxonomy name)" and "Most Used" sections.
+			 */
 			const checkboxes = [ ...dom.getCTCheckboxes( name ), ...dom.getMostUsedCTCheckboxes( name ) ];
 			checkboxes.forEach(
 				checkbox => {
@@ -268,26 +269,24 @@ const createCustomTaxonomiesSync = ( updateTerms ) => {
 					checkbox.addEventListener( "input", syncCustomTaxonomies );
 				}
 			);
-		} );
-	};
+		};
 
-	names.forEach( name => {
 		const CTChecklist = document.getElementById( `${ name }checklist` );
 		if ( CTChecklist ) {
-			/*
+			/**
 			 * Observe the hierarchical custom taxonomy checklist for changes and update the custom taxonomies if new custom taxonomies are added.
 			 * Consider only the "All (Custom taxonomy name)" section, because newly added custom taxonomies
 			 * will not end up in the "Most Used" section.
-			 */
+			 * */
 			const observer = new MutationObserver( () => {
 				updateTerms( { taxonomyType: `customTaxonomies.${ name }`, terms: dom.getCustomTaxonomies()[ name ] } );
 				watchCTCheckboxes();
 			} );
 			observer.observe( CTChecklist, { childList: true, subtree: true } );
 		}
-	} );
 
-	watchCTCheckboxes();
+		watchCTCheckboxes();
+	} );
 };
 
 /**

--- a/packages/js/tests/classic-editor/helpers/dom.test.js
+++ b/packages/js/tests/classic-editor/helpers/dom.test.js
@@ -102,6 +102,9 @@ describe( "a test for retrieving tags from the document", () => {
 
 	it( "should return the tags from the post", () => {
 		expect( dom.getPostTags() ).toEqual( [ "cat food", "cat snack" ] );
+		// Remove the previous tags elements after the test is run, so that this element wouldn't be returned next time the test
+		// For non-hierarchical taxonomy is run.
+		document.body.removeChild( tagsListElement );
 	} );
 } );
 
@@ -182,5 +185,105 @@ describe( "a test for retrieving term slug from the DOM", () => {
 	it( "should overwrite the term slug value with the new value that is passed", () => {
 		expect( dom.setTermSlug( "how-to-adopt-cat" ) ).toEqual( slugElement );
 		expect( dom.getTermSlug() ).toEqual( "how-to-adopt-cat" );
+	} );
+} );
+
+self.wpseoScriptData = {
+	analysis: {
+		plugins: {
+			replaceVars: {
+				replace_vars: {
+					custom_taxonomies: {
+						actors: {
+							description: "",
+							name: "actors",
+						},
+						directors: {
+							description: "",
+							name: "directors",
+						},
+					},
+				},
+			},
+		},
+	},
+};
+
+// Set to the document the hierarchical custom taxonomy elements.
+const actor1 = document.createElement( "input" );
+actor1.setAttribute( "type", "checkbox" );
+actor1.setAttribute( "value", "actor1" );
+
+const actor2 = document.createElement( "input" );
+actor2.setAttribute( "type", "checkbox" );
+actor2.setAttribute( "value", "actor2" );
+const actor3 = document.createElement( "input" );
+actor3.setAttribute( "type", "checkbox" );
+actor3.setAttribute( "value", "actor3" );
+
+const allActors = document.createElement( "div" );
+allActors.setAttribute( "id", "actorschecklist" );
+allActors.appendChild( actor1 );
+allActors.appendChild( actor2 );
+allActors.appendChild( actor3 );
+
+const mostUsedActors = document.createElement( "div" );
+mostUsedActors.setAttribute( "id", "actorschecklist-pop" );
+mostUsedActors.appendChild( actor1.cloneNode() );
+mostUsedActors.appendChild( actor2.cloneNode() );
+
+// Set to the document the non-hierarchical custom taxonomy elements.
+const director1 = document.createElement( "li" );
+const director1ChildNode1 = document.createElement( "button" );
+const director1ChildNode2 = document.createTextNode( "" );
+const director1ChildNode3 = document.createTextNode( "Steven Spielberg" );
+
+director1.appendChild( director1ChildNode1 );
+director1.appendChild( director1ChildNode2 );
+director1.appendChild( director1ChildNode3 );
+
+const director2 = document.createElement( "li" );
+const director2ChildNode1 = document.createElement( "button" );
+const director2ChildNode2 = document.createTextNode( "" );
+const director2ChildNode3 = document.createTextNode( "Spike Lee" );
+
+director2.appendChild( director2ChildNode1 );
+director2.appendChild( director2ChildNode2 );
+director2.appendChild( director2ChildNode3 );
+
+const nonHierarchicalCTElement = document.createElement( "ul" );
+nonHierarchicalCTElement.setAttribute( "class", "tagchecklist" );
+
+// Add new elements for the non-hierarchical custom taxonomies.
+nonHierarchicalCTElement.appendChild( director1 );
+nonHierarchicalCTElement.appendChild( director2 );
+
+document.body.appendChild( allActors );
+document.body.appendChild( mostUsedActors );
+document.body.appendChild( nonHierarchicalCTElement );
+
+describe( "a test for retrieving custom taxonomies from the DOM", () => {
+	const names = dom.getCTNames();
+	it( "should return the hierarchical custom taxonomies from the 'All custom taxonomies' section", () => {
+		expect( dom.getCTCheckboxes( names[ 0 ] ) ).toEqual( [ actor1, actor2, actor3 ] );
+		expect( dom.getCTCheckboxes( names[ 1 ] ) ).toEqual( [] );
+	} );
+	it( "should return the hierarchical custom taxonomies from the 'Most Used' section", () => {
+		expect( dom.getMostUsedCTCheckboxes(  names[ 0 ] ) ).toEqual( [ actor1, actor2 ] );
+		expect( dom.getMostUsedCTCheckboxes(  names[ 1 ] ) ).toEqual( [] );
+	} );
+	it( "should return the checked hierarchical custom taxonomies", () => {
+		expect( dom.getCustomTaxonomies()[ names[ 0 ] ] ).toEqual( [] );
+		actor1.checked = true;
+		expect( dom.getCustomTaxonomies()[ names[ 0 ] ][ 0 ].id ).toEqual( "actor1"  );
+		actor1.checked = false;
+		actor2.checked = true;
+		expect( dom.getCustomTaxonomies()[ names[ 0 ] ][ 0 ].id  ).toEqual( "actor2"  );
+		actor2.checked = false;
+		expect( dom.getCustomTaxonomies()[ names[ 0 ] ] ).toEqual( [] );
+	} );
+
+	it( "should return the non-hierarchical custom taxonomy from the post", () => {
+		expect( dom.getCustomTaxonomies()[ names[ 1 ] ] ).toEqual( [ "Steven Spielberg", "Spike Lee" ] );
 	} );
 } );

--- a/packages/js/tests/classic-editor/helpers/dom.test.js
+++ b/packages/js/tests/classic-editor/helpers/dom.test.js
@@ -99,13 +99,17 @@ describe( "a test for retrieving tags from the document", () => {
 	tagsListElement.appendChild( tag1 );
 	tagsListElement.appendChild( tag2 );
 
-	document.body.appendChild( tagsListElement );
+	const parentElement = document.createElement( "div" );
+	parentElement.setAttribute( "id", "post_tag" );
+	parentElement.appendChild( tagsListElement );
+
+	document.body.appendChild( parentElement );
 
 	it( "should return the tags from the post", () => {
 		expect( dom.getPostTags() ).toEqual( [ "cat food", "cat snack" ] );
 		// Remove the previous tags elements after the test is run, so that this element wouldn't be returned next time the test
 		// For non-hierarchical taxonomy is run.
-		document.body.removeChild( tagsListElement );
+		document.body.removeChild( parentElement );
 	} );
 } );
 
@@ -259,9 +263,16 @@ nonHierarchicalCTElement.setAttribute( "class", "tagchecklist" );
 nonHierarchicalCTElement.appendChild( director1 );
 nonHierarchicalCTElement.appendChild( director2 );
 
+// Set the parent element for the non-hierarchical custom taxonomies.
+const nonHierarchicalParentElement = document.createElement( "div" );
+nonHierarchicalParentElement.setAttribute( "id", "directors" );
+nonHierarchicalParentElement.appendChild( nonHierarchicalCTElement );
+
+document.body.appendChild( nonHierarchicalParentElement );
+
 document.body.appendChild( allActors );
 document.body.appendChild( mostUsedActors );
-document.body.appendChild( nonHierarchicalCTElement );
+document.body.appendChild( nonHierarchicalParentElement );
 
 describe( "a test for retrieving custom taxonomies from the DOM", () => {
 	const names = dom.getCTNames();

--- a/packages/js/tests/classic-editor/helpers/dom.test.js
+++ b/packages/js/tests/classic-editor/helpers/dom.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import * as dom from "../../../src/classic-editor/helpers/dom";
 import getContentLocale from "../../../src/analysis/getContentLocale";
 

--- a/packages/js/tests/classic-editor/initial-state.test.js
+++ b/packages/js/tests/classic-editor/initial-state.test.js
@@ -32,6 +32,21 @@ jest.mock( "../../src/classic-editor/helpers/dom", () => ( {
 		},
 	] ),
 	getPostTags: jest.fn( () => [ "cats", "dogs" ] ),
+	getCustomTaxonomies: jest.fn( () => {
+		return {
+			actors: [
+				{
+					id: "1",
+					name: "actor 1",
+				},
+				{
+					id: "2",
+					name: "actor 2",
+				},
+			],
+			directors: [ "Steven Spielberg", "Spike Lee" ],
+		};
+	} ),
 } ) );
 
 describe( "a test for getting the initial state of a post or a term", () => {
@@ -60,6 +75,17 @@ describe( "a test for getting the initial state of a post or a term", () => {
 			},
 		] );
 		expect( actual.editor.taxonomies.tags ).toEqual( [ "cats", "dogs" ] );
+		expect( actual.editor.taxonomies.customTaxonomies.actors ).toEqual( [
+			{
+				id: "1",
+				name: "actor 1",
+			},
+			{
+				id: "2",
+				name: "actor 2",
+			},
+		] );
+		expect( actual.editor.taxonomies.customTaxonomies.directors ).toEqual( [ "Steven Spielberg", "Spike Lee" ] );
 	} );
 
 	it( "returns the initial state of a term", () => {

--- a/packages/js/tests/classic-editor/replacement-variables/configurations.test.js
+++ b/packages/js/tests/classic-editor/replacement-variables/configurations.test.js
@@ -141,7 +141,7 @@ describe( "a test for getting the replacement of the tag variable in classic edi
 } );
 
 describe( "a test for getting the replacement of the custom taxonomies (CT) variable in classic editor", () => {
-	const names = map( get( window, "wpseoScriptData.analysis.plugins.replaceVars.replace_vars.custom_taxonomies", {} ), ( term => term.name ) );
+	const names = map( get( window, "wpseoScriptData.analysis.plugins.replaceVars.replace_vars.custom_taxonomies", {} ), ( ( { name } ) => name ) );
 
 	it( "should return the replacement for both hierarchical and non-hirarchical CT variable when the store " +
 		"doesn't return an empty object of custom taxonomies", () => {

--- a/packages/js/tests/classic-editor/replacement-variables/configurations.test.js
+++ b/packages/js/tests/classic-editor/replacement-variables/configurations.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { primaryCategory, tag, getCTReplacement } from "../../../src/classic-editor/replacement-variables/configurations";
 import * as data from "@wordpress/data";
 import { get, map } from "lodash";

--- a/packages/seo-store/src/editor/slice.js
+++ b/packages/seo-store/src/editor/slice.js
@@ -1,5 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { get } from "lodash";
+import { get, set } from "lodash";
 
 export const defaultEditorState = {
 	content: "",
@@ -35,9 +35,10 @@ const editorSlice = createSlice( {
 			state.featuredImage = action.payload;
 		},
 		updateTerms: ( state, action ) => {
-			const taxonomyType = action.payload.taxonomyType;
 			const terms = action.payload.terms;
-			state.taxonomies[ taxonomyType ] = terms;
+			const taxonomyType = action.payload.taxonomyType;
+
+			set( state, "taxonomies." + taxonomyType, terms );
 		},
 		updateLocale: ( state, action ) => {
 			state.locale = action.payload;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where non-hierarchical custom taxonomies variables didn't return the correct replacement in Classic editor.

## Relevant technical choices:

* This PR also introduces non-user facing changes in order to make the custom taxonomies replacement variable work in the new Classic editor integration. [Here](https://yoast.atlassian.net/wiki/spaces/LIN/pages/2378104851/Classic+editor+functionality+comparison+on+trunk+and+on+the+feature+branch) is the overview of which parts of custom taxonomies which this PR fixes (see the `Agnostic analysis` column).
* I added `/* eslint-disable camelcase */` to disable the camelcase warnings inside `configurations.tests.js` and `dom.tests.js`. I think it's okay to do this in a test file, otherwise the number of the warnings will increase when we use/mock window object that contains keys that don't follow camelcase style inside the test file.
* No unit tests are added for the changes made in `watcher.js` file, since they cannot be tested individually, but rather together with the other pre-existing codes in the file. Hence setting up the unit tests for that file is better to to be tackled on a separate issue (see [this issue](https://yoast.atlassian.net/browse/LINGO-1378) and [this issue](https://yoast.atlassian.net/browse/LINGO-1379))
* Check my comments for the other relevant technical choices.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Requirements:
   * Install and activate Classic editor
   * Install and activate Yoast test helper
   * Enable Post types & Taxonomies. Go to Tools -> Yoast test -> Post types & Taxonomies
   * Create some custom taxonomies (CT), both hierarchical and non-hierarchical. E.g. `categories` and `genre` under `Books`/`Movies`. For hierarchical CT, also create CT with assigned parents CT.
   * Install and activate CPT UI plugin
   * Create one hierarchical custom taxonomies and non-hierarchical custom taxonomies using CPT UI and assign it to a "Posts (WP Core)"
<img width="485" alt="4E435BB5-DCBE-4AA5-ADEF-4C8319A52292" src="https://user-images.githubusercontent.com/48715883/158569863-5b71995b-5790-4cce-82f3-a9f58f8059c7.png">

**To test hierarchical CT**
**Note**: if using Yoast test helper, the name for the hierarchical CT would be "Categories"

   * **Selecting CT from "Categories" section**
      * Create a new custom post (a book/movie)
      * Add a book/movie CT that you previously created to the post from "Categories" section
      * Add the`%%ct_book-category%%` replace var to the SEO title and meta description in snippet editor
      * Check that the CT is output in the SEO title and meta description in snippet editor
      * Change the CT of the post, also select multiple CT
      * Check that the new CT is output in the SEO title and meta description in snippet editor
      * Also test if the steps work when adding a new CT using the `Add new category` button in the editor
      
   * **Selecting CT from "Most used" section**
      * Create a new custom post (a book/movie)
      * Add/Check a book/movie CT from the "Most Used" section
      * Add the`%%ct_book-category%%` replace var to the SEO title and meta description in snippet editor
      * Confirm that when you check one or multiple CT in the "Most Used" section, the snippet variable output is updated according to your selections (multiple CT names should be separated by a comma (and a space)).
      
**To test non-hierarchical CT**
**Note**: if using Yoast test helper, the name for the non-hierarchical CT would be "Genres"

   * **Test with genres created from inside the custom post**
      * Create a new custom post (a book/movie)
      * Add `%%ct_book-genre%% ` variable in the SEO title field and in the meta description field
      * Create a genre in the `Genres` field
      * Confirm that the genre you just added is previewed in Google preview both in the SEO title and in Meta description
      * Create multiple genres separated by comma in the `Genres` field
      * Confirm that the genres you just added are also previewed in Google preview both in the SEO title and in Meta description
      * Remove one or two genres from the genres list
      * Confirm that the removed genres are no longer previewed in Google preview both in the SEO title and in Meta description
      * Remove all the selected genres
      * Confirm that no genre is previewed in Google preview both in the SEO title and in Meta description
      * Save your changes and confirm that your changes still hold

   * **Test with genres that were already created from `Choose from the most used tags/CT name`**
      * In a custom post, choose a genre from `Choose from the most used tags/CT name`
      <img width="285" alt="Screenshot 2022-03-14 at 11 56 30" src="https://user-images.githubusercontent.com/48715883/158158714-eeebcaf4-2753-4aff-8280-4e360958d40b.png">

      * Confirm that the genre you just added is also previewed in Google preview 

**To test multiple hierarchical and non-hierarchical taxonomies**
* Create a regular post/open an existing one
* Confirm that you can see both hierarchical and non-hierarchical custom taxonomies boxes inside the post
* Inside snippet editor (i.e. inside the SEO title and meta description), use replacement variables for "Categories", "Tags", and your hierarchical and non-hierarchical CTs
* Add categories, tags and custom taxonomies and confirm that they are correctly added/previewed in the snippet editor
* Also try to remove some of the (custom) taxonomies and confirm that the removed taxonomies are not previewed in the snippet editor
* Remove all taxonomies and confirm that no taxonomies are previewed in the snippet editor.
   * **Note**:  this step wouldn't work yet for tags in which it will be addressed in [a separate issue](https://yoast.atlassian.net/browse/LINGO-1372).

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/LINGO-1341
