### PR TITLE
Use identical method parameters as parent in dependency injection folder

### DIFF
--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -65,24 +65,24 @@ class Custom_Loader extends PhpFileLoader {
 	/**
 	 * Registers a set of classes as services using PSR-4 for discovery.
 	 *
-	 * @param Definition  $prototype        A definition to use as template.
-	 * @param string      $namespace_prefix The namespace prefix of classes in the scanned directory.
-	 * @param string      $search_directory The directory to look for classes, glob-patterns allowed.
-	 * @param string|null $exclude          A globed path of files to exclude.
+	 * @param Definition  $prototype A definition to use as template.
+	 * @param string      $namespace The namespace prefix of classes in the scanned directory.
+	 * @param string      $resource  The directory to look for classes, glob-patterns allowed.
+	 * @param string|null $exclude   A globed path of files to exclude.
 	 *
 	 * @return void
 	 *
 	 * @throws InvalidArgumentException If invalid arguments are supplied.
 	 */
-	public function registerClasses( Definition $prototype, $namespace_prefix, $search_directory, $exclude = null ) {
-		if ( \substr( $namespace_prefix, -1 ) !== '\\' ) {
-			throw new InvalidArgumentException( \sprintf( 'Namespace prefix must end with a "\\": %s.', $namespace_prefix ) );
+	public function registerClasses( Definition $prototype, $namespace, $resource, $exclude = null ) {
+		if ( \substr( $namespace, -1 ) !== '\\' ) {
+			throw new InvalidArgumentException( \sprintf( 'Namespace prefix must end with a "\\": %s.', $namespace ) );
 		}
-		if ( ! \preg_match( '/^(?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+\\\\)++$/', $namespace_prefix ) ) {
-			throw new InvalidArgumentException( \sprintf( 'Namespace is not a valid PSR-4 prefix: %s.', $namespace_prefix ) );
+		if ( ! \preg_match( '/^(?:[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+\\\\)++$/', $namespace ) ) {
+			throw new InvalidArgumentException( \sprintf( 'Namespace is not a valid PSR-4 prefix: %s.', $namespace ) );
 		}
 
-		$classes = $this->findClasses( $namespace_prefix, $search_directory, $exclude );
+		$classes = $this->findClasses( $namespace, $resource, $exclude );
 		// Prepare for deep cloning.
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Reason: There's no way for user input to get in between serialize and unserialize.
 		$serialized_prototype = \serialize( $prototype );

--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -117,22 +117,22 @@ class Custom_Loader extends PhpFileLoader {
 	/**
 	 * Finds classes based on a given pattern and exclude pattern.
 	 *
-	 * @param string $namespace_prefix The namespace prefix of classes in the scanned directory.
-	 * @param string $pattern          The directory to look for classes, glob-patterns allowed.
-	 * @param string $exclude          A globed path of files to exclude.
+	 * @param string $namespace      The namespace prefix of classes in the scanned directory.
+	 * @param string $pattern        The directory to look for classes, glob-patterns allowed.
+	 * @param string $excludePattern A globed path of files to exclude.
 	 *
 	 * @return array The found classes.
 	 *
 	 * @throws InvalidArgumentException If invalid arguments were supplied.
 	 */
-	private function findClasses( $namespace_prefix, $pattern, $exclude ) {
+	private function findClasses( $namespace, $pattern, $excludePattern ) {
 		$parameter_bag = $this->container->getParameterBag();
 
 		$exclude_paths  = [];
 		$exclude_prefix = null;
-		if ( $exclude ) {
-			$exclude = $parameter_bag->unescapeValue( $parameter_bag->resolveValue( $exclude ) );
-			foreach ( $this->glob( $exclude, true, $resource ) as $path => $info ) {
+		if ( $excludePattern ) {
+			$excludePattern = $parameter_bag->unescapeValue( $parameter_bag->resolveValue( $excludePattern ) );
+			foreach ( $this->glob( $excludePattern, true, $resource ) as $path => $info ) {
 				if ( $exclude_prefix === null ) {
 					$exclude_prefix = $resource->getPrefix();
 				}
@@ -152,7 +152,7 @@ class Custom_Loader extends PhpFileLoader {
 				$prefix_len = \strlen( $resource->getPrefix() );
 
 				if ( $exclude_prefix && \strpos( $exclude_prefix, $resource->getPrefix() ) !== 0 ) {
-					throw new InvalidArgumentException( \sprintf( 'Invalid "exclude" pattern when importing classes for "%s": make sure your "exclude" pattern (%s) is a subset of the "resource" pattern (%s)', $namespace_prefix, $exclude, $pattern ) );
+					throw new InvalidArgumentException( \sprintf( 'Invalid "exclude" pattern when importing classes for "%s": make sure your "exclude" pattern (%s) is a subset of the "resource" pattern (%s)', $namespace, $excludePattern, $pattern ) );
 				}
 			}
 
@@ -177,7 +177,7 @@ class Custom_Loader extends PhpFileLoader {
 			} catch ( ReflectionException $e ) {
 				$classes[ $class ] = \sprintf(
 					'While discovering services from namespace "%s", an error was thrown when processing the class "%s": "%s".',
-					$namespace_prefix,
+					$namespace,
 					$class,
 					$e->getMessage()
 				);

--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -114,6 +114,8 @@ class Custom_Loader extends PhpFileLoader {
 		}
 	}
 
+	// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- excludePattern parameter name must match parent, which is outside of our codebase.
+
 	/**
 	 * Finds classes based on a given pattern and exclude pattern.
 	 *
@@ -205,6 +207,8 @@ class Custom_Loader extends PhpFileLoader {
 
 		return $classes;
 	}
+
+	// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	/**
 	 * Normalizes all slashes in a file path to forward slashes.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* To be ready for PHP 8, we need to make sure overloaded child methods have the same signature as parent methods.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes parameters names of overloaded methods in the dependency injection folder to match the parent class.

## Relevant technical choices:

* Needed for PHP 8 compatibility.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Since this is a very vital piece of code for the plugin it may be best to have someone knowledgeable about the dependency injection container check this code.
* As far as I can tell the way to test this is by simply running composer install and seeing whether the plugin builds properly.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* QA cannot test this, as I am pretty sure an RC cannot be build when these classes fail.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes N/A
