### PR TITLE
Main_Test: set expectations in the test itself, not in the `set_up()` fixture method

### DIFF
--- a/tests/unit/main-test.php
+++ b/tests/unit/main-test.php
@@ -54,12 +54,6 @@ class Main_Test extends TestCase {
 
 		global $wpdb;
 		$wpdb = Mockery::mock( '\wpdb' );
-
-		// Some classes call the YoastSEO function in the constructor.
-		Monkey\Functions\expect( 'YoastSEO' )
-			->andReturn( $this->instance );
-		// Deprecated classes call _deprecated_function in the constructor.
-		Monkey\Functions\expect( '_deprecated_function' );
 	}
 
 	/**
@@ -68,6 +62,13 @@ class Main_Test extends TestCase {
 	 * @covers ::get_container
 	 */
 	public function test_surfaces() {
+
+		// Some classes call the YoastSEO function in the constructor.
+		Monkey\Functions\expect( 'YoastSEO' )
+			->andReturn( $this->instance );
+		// Deprecated classes call _deprecated_function in the constructor.
+		Monkey\Functions\expect( '_deprecated_function' );
+
 		$container = $this->instance->get_container();
 
 		foreach ( $container->getServiceIds() as $service_id ) {


### PR DESCRIPTION
## Context

* Improve tests

## Summary

This PR can be summarized in the following changelog entry:

* Improve tests

## Relevant technical choices:

The fixture methods should **never** contain expectations or assertions. Those belong in the actual tests.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This is a test-code only change. If the build passes, we're good.