### PR TITLE
CS/QA: use fully qualified globals

### DIFF
--- a/src/config/wordproof-translations.php
+++ b/src/config/wordproof-translations.php
@@ -18,7 +18,7 @@ class WordProof_Translations implements TranslationsInterface {
 	 */
 	public function getNoBalanceNotice() {
 		/* translators: %s expands to WordProof. */
-		return sprintf( __( 'You are out of timestamps. Please upgrade your account by opening the %s settings.', 'wordpress-seo' ), 'WordProof' );
+		return \sprintf( \__( 'You are out of timestamps. Please upgrade your account by opening the %s settings.', 'wordpress-seo' ), 'WordProof' );
 	}
 
 	/**
@@ -28,7 +28,7 @@ class WordProof_Translations implements TranslationsInterface {
 	 */
 	public function getTimestampSuccessNotice() {
 		/* translators: %s expands to WordProof. */
-		return sprintf( __( '%s has successfully timestamped this page.', 'wordpress-seo' ), 'WordProof' );
+		return \sprintf( \__( '%s has successfully timestamped this page.', 'wordpress-seo' ), 'WordProof' );
 	}
 
 	/**
@@ -38,7 +38,7 @@ class WordProof_Translations implements TranslationsInterface {
 	 */
 	public function getTimestampFailedNotice() {
 		/* translators: %s expands to WordProof. */
-		return sprintf( __( '%1$s failed to timestamp this page. Please check if you\'re correctly authenticated with %1$s and try to save this page again.', 'wordpress-seo' ), 'WordProof' );
+		return \sprintf( \__( '%1$s failed to timestamp this page. Please check if you\'re correctly authenticated with %1$s and try to save this page again.', 'wordpress-seo' ), 'WordProof' );
 	}
 
 	/**
@@ -48,7 +48,7 @@ class WordProof_Translations implements TranslationsInterface {
 	 */
 	public function getWebhookFailedNotice() {
 		/* translators: %s expands to WordProof. */
-		return sprintf( __( 'The timestamp is not retrieved by your site. Please try again or contact %1$s support.', 'wordpress-seo' ), 'WordProof' );
+		return \sprintf( \__( 'The timestamp is not retrieved by your site. Please try again or contact %1$s support.', 'wordpress-seo' ), 'WordProof' );
 	}
 
 	/**
@@ -58,7 +58,7 @@ class WordProof_Translations implements TranslationsInterface {
 	 */
 	public function getNotAuthenticatedNotice() {
 		/* translators: %s expands to WordProof. */
-		return sprintf( __( 'The timestamp is not created because you need to authenticate with %s first.', 'wordpress-seo' ), 'WordProof' );
+		return \sprintf( \__( 'The timestamp is not created because you need to authenticate with %s first.', 'wordpress-seo' ), 'WordProof' );
 	}
 
 	/**
@@ -67,7 +67,7 @@ class WordProof_Translations implements TranslationsInterface {
 	 * @return string The translation.
 	 */
 	public function getOpenAuthenticationButtonText() {
-		return __( 'Open authentication', 'wordpress-seo' );
+		return \__( 'Open authentication', 'wordpress-seo' );
 	}
 
 	/**
@@ -76,6 +76,6 @@ class WordProof_Translations implements TranslationsInterface {
 	 * @return string The translation.
 	 */
 	public function getOpenSettingsButtonText() {
-		return __( 'Open settings', 'wordpress-seo' );
+		return \__( 'Open settings', 'wordpress-seo' );
 	}
 }

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -450,7 +450,7 @@ class Current_Page_Helper {
 			return false;
 		}
 
-		return intval( $post->ID ) === intval( \get_option( 'wp_page_for_privacy_policy', false ) );
+		return \intval( $post->ID ) === \intval( \get_option( 'wp_page_for_privacy_policy', false ) );
 	}
 
 	/**

--- a/src/helpers/woocommerce-helper.php
+++ b/src/helpers/woocommerce-helper.php
@@ -66,6 +66,6 @@ class Woocommerce_Helper {
 			return false;
 		}
 
-		return intval( $post->ID ) === intval( \wc_terms_and_conditions_page_id() );
+		return \intval( $post->ID ) === \intval( \wc_terms_and_conditions_page_id() );
 	}
 }

--- a/src/helpers/wordproof-helper.php
+++ b/src/helpers/wordproof-helper.php
@@ -50,8 +50,8 @@ class WordProof_Helper {
 	 * @return bool Returns if the options are deleted
 	 */
 	public function remove_site_options() {
-		return delete_site_option( 'wordproof_access_token' )
-			&& delete_site_option( 'wordproof_source_id' );
+		return \delete_site_option( 'wordproof_access_token' )
+			&& \delete_site_option( 'wordproof_source_id' );
 	}
 
 	/**

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -222,7 +222,7 @@ class HelpScout_Beacon implements Integration_Interface {
 		}
 
 		// Store the data in a transient for 5 minutes to prevent overhead on every backend pageload.
-		\set_transient( 'yoast_beacon_session_data', $data, ( 5 * MINUTE_IN_SECONDS ) );
+		\set_transient( 'yoast_beacon_session_data', $data, ( 5 * \MINUTE_IN_SECONDS ) );
 
 		return WPSEO_Utils::format_json_encode( $data );
 	}
@@ -257,12 +257,12 @@ class HelpScout_Beacon implements Integration_Interface {
 		$memory_limit                 = \ini_get( 'memory_limit' );
 		$server_info['Memory limits'] = 'Server memory limit: ' . $memory_limit;
 
-		if ( $memory_limit !== WP_MEMORY_LIMIT ) {
-			$server_info['Memory limits'] .= ', WP_MEMORY_LIMIT: ' . WP_MEMORY_LIMIT;
+		if ( $memory_limit !== \WP_MEMORY_LIMIT ) {
+			$server_info['Memory limits'] .= ', WP_MEMORY_LIMIT: ' . \WP_MEMORY_LIMIT;
 		}
 
-		if ( $memory_limit !== WP_MAX_MEMORY_LIMIT ) {
-			$server_info['Memory limits'] .= ', WP_MAX_MEMORY_LIMIT: ' . WP_MAX_MEMORY_LIMIT;
+		if ( $memory_limit !== \WP_MAX_MEMORY_LIMIT ) {
+			$server_info['Memory limits'] .= ', WP_MAX_MEMORY_LIMIT: ' . \WP_MAX_MEMORY_LIMIT;
 		}
 
 		return $server_info;

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -185,14 +185,14 @@ class HelpScout_Beacon implements Integration_Interface {
 		// Short-circuit if we can get the needed data from a transient.
 		$transient_data = \get_transient( 'yoast_beacon_session_data' );
 
-		if ( is_array( $transient_data ) ) {
+		if ( \is_array( $transient_data ) ) {
 			return WPSEO_Utils::format_json_encode( $transient_data );
 		}
 
 		$current_user = \wp_get_current_user();
 
 		// Do not make these strings translatable! They are for our support agents, the user won't see them!
-		$data = array_merge(
+		$data = \array_merge(
 			[
 				'name'               => \trim( $current_user->user_firstname . ' ' . $current_user->user_lastname ),
 				'email'              => $current_user->user_email,
@@ -254,7 +254,7 @@ class HelpScout_Beacon implements Integration_Interface {
 		}
 
 		// Get the memory limits for the server and, if different, from WordPress as well.
-		$memory_limit                 = ini_get( 'memory_limit' );
+		$memory_limit                 = \ini_get( 'memory_limit' );
 		$server_info['Memory limits'] = 'Server memory limit: ' . $memory_limit;
 
 		if ( $memory_limit !== WP_MEMORY_LIMIT ) {
@@ -390,13 +390,13 @@ class HelpScout_Beacon implements Integration_Interface {
 		$indexing_reason    = $this->options->get( 'indexing_reason' );
 
 		$indexables_status .= ( $indexing_completed ) ? 'yes' : 'no';
-		$indexables_status .= ( $indexing_reason ) ? ', latest indexing reason: ' . esc_html( $indexing_reason ) : '';
+		$indexables_status .= ( $indexing_reason ) ? ', latest indexing reason: ' . \esc_html( $indexing_reason ) : '';
 
 		foreach ( [ 'free', 'premium' ] as $migration_name ) {
 			$current_status = $this->migration_status->get_error( $migration_name );
 
-			if ( is_array( $current_status ) && isset( $current_status['message'] ) ) {
-				$indexables_status .= ', migration error: ' . esc_html( $current_status['message'] );
+			if ( \is_array( $current_status ) && isset( $current_status['message'] ) ) {
+				$indexables_status .= ', migration error: ' . \esc_html( $current_status['message'] );
 			}
 		}
 
@@ -412,10 +412,10 @@ class HelpScout_Beacon implements Integration_Interface {
 		$site_locale = \get_locale();
 		$user_locale = \get_user_locale();
 
-		$language_settings = sprintf(
+		$language_settings = \sprintf(
 			'Site locale: %1$s, user locale: %2$s',
-			( is_string( $site_locale ) ) ? \esc_html( $site_locale ) : 'unknown',
-			( is_string( $user_locale ) ) ? \esc_html( $user_locale ) : 'unknown'
+			( \is_string( $site_locale ) ) ? \esc_html( $site_locale ) : 'unknown',
+			( \is_string( $user_locale ) ) ? \esc_html( $user_locale ) : 'unknown'
 		);
 
 		return $language_settings;

--- a/src/integrations/third-party/wordproof-integration-toggle.php
+++ b/src/integrations/third-party/wordproof-integration-toggle.php
@@ -83,15 +83,15 @@ class WordProof_Integration_Toggle implements Integration_Interface {
 		if ( \is_array( $integration_toggles ) ) {
 			$integration_toggles[] = (object) [
 				/* translators: %s expands to WordProof */
-				'name'            => sprintf( __( '%s integration', 'wordpress-seo' ), 'WordProof' ),
+				'name'            => \sprintf( \__( '%s integration', 'wordpress-seo' ), 'WordProof' ),
 				'setting'         => 'wordproof_integration_active',
-				'label'           => sprintf(
+				'label'           => \sprintf(
 				/* translators: %s expands to WordProof */
-					__( '%1$s can be used to timestamp your privacy page.', 'wordpress-seo' ),
+					\__( '%1$s can be used to timestamp your privacy page.', 'wordpress-seo' ),
 					'WordProof'
 				),
 				/* translators: %s expands to WordProof */
-				'read_more_label' => sprintf( __( 'Read more about how %s works.', 'wordpress-seo' ), 'WordProof ' ),
+				'read_more_label' => \sprintf( \__( 'Read more about how %s works.', 'wordpress-seo' ), 'WordProof ' ),
 				'read_more_url'   => 'https://yoa.st/wordproof-integration',
 				'order'           => 16,
 				'disabled'        => $this->wordproof->integration_is_disabled(),
@@ -129,15 +129,15 @@ class WordProof_Integration_Toggle implements Integration_Interface {
 				$conditional = $this->wordproof->integration_is_disabled( true );
 
 				if ( $conditional === 'Non_Multisite_Conditional' ) {
-					echo '<p>' . sprintf(
+					echo '<p>' . \sprintf(
 						/* translators: %s expands to WordProof */
-						esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ),
+						\esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ),
 						'WordProof'
 					) . '</p>';
 				}
 
 				if ( $conditional === 'WordProof_Plugin_Inactive_Conditional' ) {
-					echo '<p>' . esc_html__( 'The WordProof Timestamp plugin needs to be disabled before you can activate this integration.', 'wordpress-seo' ) . '</p>';
+					echo '<p>' . \esc_html__( 'The WordProof Timestamp plugin needs to be disabled before you can activate this integration.', 'wordpress-seo' ) . '</p>';
 				}
 			}
 		}
@@ -151,9 +151,9 @@ class WordProof_Integration_Toggle implements Integration_Interface {
 	public function after_network_integration_toggle( $integration ) {
 		if ( $integration->setting === 'wordproof_integration_active' ) {
 			if ( $integration->disabled ) {
-				echo '<p>' . sprintf(
+				echo '<p>' . \sprintf(
 					/* translators: %s expands to WordProof */
-					esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ),
+					\esc_html__( 'Currently, the %s integration is not available for multisites.', 'wordpress-seo' ),
 					'WordProof'
 				) . '</p>';
 			}

--- a/src/integrations/third-party/wordproof.php
+++ b/src/integrations/third-party/wordproof.php
@@ -111,7 +111,7 @@ class WordProof implements Integration_Interface {
 	public function disable_timestamp_for_previous_legal_page( $old_post_id, $new_post_id ) {
 
 		if ( $old_post_id !== $new_post_id ) {
-			delete_post_meta( $old_post_id, '_yoast_wpseo_wordproof_timestamp' );
+			\delete_post_meta( $old_post_id, '_yoast_wpseo_wordproof_timestamp' );
 		}
 	}
 
@@ -142,7 +142,7 @@ class WordProof implements Integration_Interface {
 			return false;
 		}
 
-		return boolval( PostMetaHelper::get( $post->ID, $this->post_meta_key ) );
+		return \boolval( PostMetaHelper::get( $post->ID, $this->post_meta_key ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Code consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

* CS/QA: use fully qualified global function calls
* CS/QA: use fully qualified global constants


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.