### PR TITLE
QA: enable test case

### DIFF
--- a/tests/unit/actions/importing/aioseo-custom-archive-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-custom-archive-settings-importing-action-test.php
@@ -347,6 +347,7 @@ class Aioseo_Custom_Archive_Settings_Importing_Action_Test extends TestCase {
 		return [
 			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
 			[ \json_encode( $missing_settings ), 'irrelevant', $missing_settings_expected, 0 ],
+			[ \json_encode( $malformed_settings ), 'irrelevant', $malformed_settings_expected, 0 ],
 		];
 	}
 }

--- a/tests/unit/actions/importing/aioseo-default-archive-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-default-archive-settings-importing-action-test.php
@@ -334,6 +334,7 @@ class Aioseo_Default_Archive_Settings_Importing_Action_Test extends TestCase {
 		return [
 			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
 			[ \json_encode( $missing_settings ), 'irrelevant', $missing_settings_expected, 0 ],
+			[ \json_encode( $malformed_settings ), 'irrelevant', $malformed_settings_expected, 0 ],
 		];
 	}
 }

--- a/tests/unit/actions/importing/aioseo-general-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-general-settings-importing-action-test.php
@@ -397,6 +397,7 @@ class Aioseo_General_Settings_Importing_Action_Test extends TestCase {
 		return [
 			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
 			[ \json_encode( $missing_settings ), 'irrelevant', $missing_settings_expected, 0 ],
+			[ \json_encode( $malformed_settings ), 'irrelevant', $malformed_settings_expected, 0 ],
 		];
 	}
 }

--- a/tests/unit/actions/importing/aioseo-posttype-defaults-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-posttype-defaults-settings-importing-action-test.php
@@ -380,6 +380,7 @@ class Aioseo_Posttype_Defaults_Settings_Importing_Action_Test extends TestCase {
 		return [
 			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
 			[ \json_encode( $missing_settings ), 'irrelevant', $missing_settings_expected, 0 ],
+			[ \json_encode( $malformed_settings ), 'irrelevant', $malformed_settings_expected, 0 ],
 		];
 	}
 }

--- a/tests/unit/actions/importing/aioseo-taxonomy-settings-importing-action-test.php
+++ b/tests/unit/actions/importing/aioseo-taxonomy-settings-importing-action-test.php
@@ -409,6 +409,7 @@ class Aioseo_Taxonomy_Settings_Importing_Action_Test extends TestCase {
 		return [
 			[ \json_encode( $full_settings ), $this->full_settings_to_import, $full_settings_expected, 1 ],
 			[ \json_encode( $missing_settings ), 'irrelevant', $missing_settings_expected, 0 ],
+			[ \json_encode( $malformed_settings ), 'irrelevant', $malformed_settings_expected, 0 ],
 		];
 	}
 }


### PR DESCRIPTION
## Context

* Improve test suite

## Summary

This PR can be summarized in the following changelog entry:

* Improve test suite

## Relevant technical choices:

Each of these data providers contained a set up to test "malformed settings", but none of the data providers actually included the malformed settings data in the returned array. In other words: these tests weren't running.

@leonidasmi I've marked you as reviewer more as a sanity check than anything else. Was there any particular reason why these tests hadn't been enabled before ? Or just something which accidentally got forgotten ?


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ This is a test-only change. If the build passes, we're good.