### PR TITLE
CS/QA: do not use double negatives

### DIFF
--- a/src/helpers/wincher-helper.php
+++ b/src/helpers/wincher-helper.php
@@ -30,7 +30,7 @@ class Wincher_Helper {
 			return false;
 		}
 
-		return ! ! WPSEO_Options::get( 'wincher_integration_active', true );
+		return (bool) WPSEO_Options::get( 'wincher_integration_active', true );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Code quality

## Summary

This PR can be summarized in the following changelog entry:

* Code quality

## Relevant technical choices:

Do not use double negatives to type cast a value. Use a proper type cast instead.

This improves readability and makes the code less bug-prone.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality. If the build passes (linting, test runs), we're good.