### PR TITLE
DUPP-349 CS/QA: fix inconsistent/incorrect return statement

### DIFF
--- a/src/actions/importing/aioseo/aioseo-cleanup-action.php
+++ b/src/actions/importing/aioseo/aioseo-cleanup-action.php
@@ -177,7 +177,7 @@ class Aioseo_Cleanup_Action extends Abstract_Aioseo_Importing_Action {
 	 */
 	public function truncate_query() {
 		if ( ! $this->aioseo_exists() ) {
-			return true;
+			return '';
 		}
 
 		$table = $this->get_aioseo_table();

--- a/src/actions/importing/aioseo/aioseo-cleanup-action.php
+++ b/src/actions/importing/aioseo/aioseo-cleanup-action.php
@@ -171,13 +171,14 @@ class Aioseo_Cleanup_Action extends Abstract_Aioseo_Importing_Action {
 	}
 
 	/**
-	 * Creates a TRUNCATE query string for emptying the AIOSEO indexable table.
+	 * Creates a TRUNCATE query string for emptying the AIOSEO indexable table, if it exists.
 	 *
 	 * @return string The query to use for importing or counting the number of items to import.
 	 */
 	public function truncate_query() {
 		if ( ! $this->aioseo_exists() ) {
-			return '';
+			// If the table doesn't exist, we need a string that will amount to a quick query that doesn't return false when ran.
+			return 'SELECT 1';
 		}
 
 		$table = $this->get_aioseo_table();


### PR DESCRIPTION
## Context

* We want to avoid throwing a database error, when the user tries to cleanup a setup where the AIOSEO indexable table has already been cleaned up manually.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where in certain edge cases a database error would show during AIOSEO clean up

## Relevant technical choices:

This method is supposed to return a string (based on the docblock) and the return value is passed on to `WPDB::query()`, which expects a string as well, so probably better to return an empty string than to return boolean `true`.

Alternatively, if there is a good reason to return `true` here, `bool` should be added to the return type and the reason for returning `true` should be documented inline.

@leonidasmi And this is another one where I'd like to ask you for a review as a sanity check. See the above reasoning for why I'm proposing the change.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Save at least one post while having AIOSEO active.
* Go to Yoast SEO->Tools->Import/export
* Once you're on that page, deactivate and uninstall AIOSEO in a different tab. Also, manually delete (drop) the _aioseo_post db table
* Click Clean Up while having All In One SEO Pack selected in the Import/Export page
* Check for debug errors and verify that you didnt get a `WordPress database error You have an error in your SQL syntax` error there


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/DUPP-349
