### PR TITLE
DUPP-348 AIOSEO Importer: bug fix - typo in property name

### DIFF
--- a/src/actions/importing/aioseo/aioseo-posts-importing-action.php
+++ b/src/actions/importing/aioseo/aioseo-posts-importing-action.php
@@ -140,7 +140,7 @@ class Aioseo_Posts_Importing_Action extends Abstract_Aioseo_Importing_Action {
 	 *
 	 * @var Image_Helper
 	 */
-	protected $image_helper;
+	protected $image;
 
 	/**
 	 * The indexable_to_postmeta helper.

--- a/src/services/importing/aioseo/aioseo-social-images-provider-service.php
+++ b/src/services/importing/aioseo/aioseo-social-images-provider-service.php
@@ -17,7 +17,7 @@ class Aioseo_Social_Images_Provider_Service {
 	 *
 	 * @var Image_Helper
 	 */
-	protected $image_helper;
+	protected $image;
 
 	/**
 	 * Class constructor.


### PR DESCRIPTION
## Context

* As per discussion with @jrfnl , dynamic properties are being deprecated in PHP 8.2, so we want to fix two of those within the AIOSEO importer.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a deprecation warning in PHP 8.2 that would be shown on AIOSEO imports

## Relevant technical choices:


## Test instructions

* Have AIOSEO active and Yoast deactivated
* Go to create a new post.
* For the new post, upload an image in its content and also go to the AIOSEO metabox->Social->Facebook->Image Source and select `Attached Image`. Also add a featured image.
* Save the post
* Go to Yoast SEO tools->Import/Export and perform an AIOSEO import
* Check the created post and confirm that the FB image got imported successfully. That is, the FB image for Yoast is the attached image, *not* the featured image
* Go to the db, in the Yoast indexable for that post and take a note of the `open_graph_image_id` 
* Go to Media->Library and one click the image you uploaded in the post. Your browser should take a URL of the `http://basic.wordpress.test/wp-admin/upload.php?item=XXXX` format. Confirm that the `item` parameter has the same value with `open_graph_image_id` you took note of before.