### PR TITLE
Tests: fix a few assertions

### DIFF
--- a/tests/integration/admin/test-class-yoast-network-admin.php
+++ b/tests/integration/admin/test-class-yoast-network-admin.php
@@ -79,14 +79,14 @@ class Yoast_Network_Admin_Test extends WPSEO_UnitTestCase {
 
 		$choices = $admin->get_site_choices();
 		$this->assertSame( $site->id, (int) key( $choices ) );
-		$this->assertContains( (string) $site->id, $choices[ $site->id ] );
-		$this->assertContains( $site->domain . $site->path, $choices[ $site->id ] );
+		$this->assertStringStartsWith( (string) $site->id, $choices[ $site->id ] );
+		$this->assertStringContainsString( $site->domain . $site->path, $choices[ $site->id ] );
 
 		$choices = $admin->get_site_choices( false, true );
 		$this->assertSame( $site->id, (int) key( $choices ) );
-		$this->assertContains( (string) $site->id, $choices[ $site->id ] );
-		$this->assertContains( $site->blogname, $choices[ $site->id ] );
-		$this->assertContains( $site->domain . $site->path, $choices[ $site->id ] );
+		$this->assertStringStartsWith( (string) $site->id, $choices[ $site->id ] );
+		$this->assertStringContainsString( $site->blogname, $choices[ $site->id ] );
+		$this->assertStringContainsString( $site->domain . $site->path, $choices[ $site->id ] );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Improve tests

## Summary

This PR can be summarized in the following changelog entry:

* Improve tests

## Relevant technical choices:

These assertions should have been updated when the PHPUnit Polyfills were introduced, but they have clearly fallen through the cracks as the tests were not run against WP Multisite previously (which they soon will be, which is how this was discovered).


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.