### PR TITLE
wordproof/wordpress-sdk 1.2.11

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -159,16 +159,16 @@
         },
         {
             "name": "wordproof/wordpress-sdk",
-            "version": "1.2.10",
+            "version": "1.2.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wordproof/wordpress-sdk.git",
-                "reference": "748c602593cdaf80c78b8e9b84d33da7d83e85bb"
+                "reference": "25cc44b2abc9ad082daa42e0eba40cbc62914a95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/748c602593cdaf80c78b8e9b84d33da7d83e85bb",
-                "reference": "748c602593cdaf80c78b8e9b84d33da7d83e85bb",
+                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/25cc44b2abc9ad082daa42e0eba40cbc62914a95",
+                "reference": "25cc44b2abc9ad082daa42e0eba40cbc62914a95",
                 "shasum": ""
             },
             "require": {
@@ -204,9 +204,9 @@
             "description": "WordPress SDK",
             "support": {
                 "issues": "https://github.com/wordproof/wordpress-sdk/issues",
-                "source": "https://github.com/wordproof/wordpress-sdk/tree/1.2.10"
+                "source": "https://github.com/wordproof/wordpress-sdk/tree/1.2.11"
             },
-            "time": "2022-03-11T07:02:37+00:00"
+            "time": "2022-03-14T06:57:36+00:00"
         },
         {
             "name": "yoast/i18n-module",


### PR DESCRIPTION
## Context

* Removes the unpkg CDN link for '@wordproof/uikit' and uses locally stored scripts.

## Summary

This PR can be summarized in the following changelog entry:

* Removes the unpkg CDN link for `@wordproof/uikit` and uses locally stored scripts.

## Relevant technical choices:

* modules are lazy-loaded to only load relevant data.

## Test instructions

* Go to your timestamped page
* Open the network tab in DevTools
* Make sure the uikit scripts are loaded from 'wordpress-sdk' vendor and no unpkg origin is used.
* Make sure the certificate link and modal are still loading and functioning correctly 


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Pages with a timestamp

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #
