### PR TITLE
Fix error on timestamp

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -159,16 +159,16 @@
         },
         {
             "name": "wordproof/wordpress-sdk",
-            "version": "1.2.11",
+            "version": "1.2.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wordproof/wordpress-sdk.git",
-                "reference": "25cc44b2abc9ad082daa42e0eba40cbc62914a95"
+                "reference": "6b2422571fb7d9a21be8ec707a1e41d0dac46045"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/25cc44b2abc9ad082daa42e0eba40cbc62914a95",
-                "reference": "25cc44b2abc9ad082daa42e0eba40cbc62914a95",
+                "url": "https://api.github.com/repos/wordproof/wordpress-sdk/zipball/6b2422571fb7d9a21be8ec707a1e41d0dac46045",
+                "reference": "6b2422571fb7d9a21be8ec707a1e41d0dac46045",
                 "shasum": ""
             },
             "require": {
@@ -204,9 +204,9 @@
             "description": "WordPress SDK",
             "support": {
                 "issues": "https://github.com/wordproof/wordpress-sdk/issues",
-                "source": "https://github.com/wordproof/wordpress-sdk/tree/1.2.11"
+                "source": "https://github.com/wordproof/wordpress-sdk/tree/1.2.12"
             },
-            "time": "2022-03-14T06:57:36+00:00"
+            "time": "2022-03-14T13:56:47+00:00"
         },
         {
             "name": "yoast/i18n-module",


### PR DESCRIPTION
## Context

https://yoast.slack.com/files/U01763ZA8NA/F036QNNM6HL/screencast_2022-03-10_11-12-43.mp4

* When updating your privacy policy within 4 seconds after the last save, a transient is returned. This causes a fatal error and the pages’ timestamp changes, but not the blockchain entry.

## Summary

This PR can be summarized in the following changelog entry:

* Fix thrown error when saving a page that should be timestamped

## Relevant technical choices:

* Within the debounce period, an error was thrown as the data from a transient was returned instead of a WP_Rest_Response. When a transient is returned, it is now returned as a WP_Rest_Response.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Enable the WordProof integration on your privacy policy.
1. Make a change to the page and update twice within 4 seconds.
1. The error log should be empty.
1. Verify that WordProof does see the page as valid.

I (Igor) needed these to see the original fatal:
* Install and Activate classic editor (I was testing within this editor).
* Install and activate Yoast Duplicate Post.
* Create new Privacy Policy page.
*Go to Privacy Policy page, edit it and enable Timestamp with WordProof.
* Update the page.
* Click Rewrite & Republish for this page

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The WordProof integration

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/P1-1296
