### PR TITLE
GH Actions/JS: split the workflow into two + separate test builds per package

### DIFF
--- a/.github/workflows/jslint.yml
+++ b/.github/workflows/jslint.yml
@@ -1,4 +1,4 @@
-name: CheckJS
+name: LintJS
 
 on:
   # Run on pushes to select branches and on all pull requests.
@@ -20,10 +20,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  yarn-lint-test:
+  yarn-lint:
     runs-on: ubuntu-latest
 
-    name: "CheckJS"
+    name: "LintJS"
 
     steps:
       - name: Checkout code
@@ -52,15 +52,3 @@ jobs:
 
       - name: Run Javascript lint
         run: yarn lint
-
-      # Check out the premium config repo ahead of running the tests to prevent issues with permissions.
-      - name: Checkout premium configuration
-        uses: actions/checkout@v3
-        with:
-          repository: Yoast/YoastSEO.js-premium-configuration
-          path: packages/yoastseo/premium-configuration
-          fetch-depth: 0
-          token: ${{ secrets.YOASTBOT_CI_PAT_DIST }}
-
-      - name: Run Javascript tests
-        run: yarn test

--- a/.github/workflows/jstest.yml
+++ b/.github/workflows/jstest.yml
@@ -1,0 +1,191 @@
+name: TestJS
+
+on:
+  # Run on pushes to select branches and on all pull requests.
+  push:
+    branches:
+      - master
+      - trunk
+      - 'release/**'
+      - 'hotfix/[0-9]+.[0-9]+*'
+      - 'feature/**'
+  pull_request:
+  # Also run this workflow every night at 04:30 (for a full test run).
+  schedule:
+    - cron: '30 4 * * *'
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  #########################################################################################
+  # For packages in this job, the full test suite is always run.
+  #########################################################################################
+  yarn-test-full:
+    # These tests will always run the full test suite, so no need to run it again from the cron job.
+    if: github.event_name != 'schedule'
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      # As these packages are all unique, don't stop the workflow when the test run of one package fails.
+      fail-fast: false
+      matrix:
+        package:
+          - 'analysis-report'
+          - 'browserslist-config'
+          - 'components'
+          - 'configuration-wizard'
+          - 'feature-flag'
+          - 'helpers'
+          - 'js'
+          - 'replacement-variable-editor'
+          - 'schema-blocks'
+          - 'search-metadata-previews'
+          - 'social-metadata-forms'
+          - 'social-metadata-previews'
+          - 'yoast-components'
+
+    name: "TestJS - ${{ matrix.package }} (full)"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # The ubuntu images come with Node, npm and yarn pre-installed.
+      # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
+
+      # This action also handles the caching of the Yarn dependencies.
+      # https://github.com/actions/setup-node
+      - name: Set up node and enable caching of dependencies
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+          cache: 'yarn'
+
+      - name: Yarn install
+        run: yarn install
+
+      - name: Show debug info
+        run: |
+          npm --version
+          node --version
+          yarn --version
+          grunt --version
+          yarn run jest --version
+
+      - name: Show Jest version
+        run: yarn run jest --version
+        working-directory: packages/${{ matrix.package }}
+
+      - name: Show Config
+        run: yarn test --showConfig
+        working-directory: packages/${{ matrix.package }}
+
+      - name: Run Javascript tests
+        run: yarn test --ci
+        working-directory: packages/${{ matrix.package }}
+
+
+  #########################################################################################
+  # For packages in this job, by default, only the tests related to changed files are run.
+  # Once a day, every day, the full test suite is run via a cron job.
+  # Packages should (only) be moved to this job if the full test run is exceedingly slow.
+  #########################################################################################
+  yarn-test-onlyChanged:
+    runs-on: ubuntu-latest
+
+    strategy:
+      # As these packages are all unique, don't stop the workflow when the test run of one package fails.
+      fail-fast: false
+      matrix:
+        include:
+          - package:              'yoastseo'
+            needs_premium_config: true
+
+    name: "TestJS - ${{ matrix.package }}${{ github.event_name == 'schedule' && ' (full)' || ' (onlyChanged)' }}"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # The base branch is used to allow the "regular" (PR/push) checks to only run the
+      # tests relevant for changes files.
+      - name: Determine the base branch
+        id: base_branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "::set-output name=NAME::$BASE_REF"
+            echo '::set-output name=CURRENT::$GITHUB_SHA'
+          else
+            echo '::set-output name=NAME::trunk'
+            echo '::set-output name=CURRENT::$GITHUB_REF'
+          fi
+
+     # Note: we need to actually check the branch out and then go back to the original branch
+     # as `changedSince` does not work if there is no local branch for the base ref.
+      - name: "Fetch base branch (for onlyChanged test runs)"
+        if: ${{ github.event_name != 'schedule' }}
+        run: |
+          git fetch --no-tags --depth=1 origin ${{ steps.base_branch.outputs.NAME }}
+          git checkout -b ${{ steps.base_branch.outputs.NAME }}
+          git checkout ${{ steps.base_branch.outputs.CURRENT }}
+
+      # Check out the premium config repo ahead of running the tests to prevent issues with permissions.
+      - name: Checkout premium configuration
+        if: ${{ matrix.needs_premium_config == true }}
+        uses: actions/checkout@v3
+        with:
+          repository: Yoast/YoastSEO.js-premium-configuration
+          path: packages/yoastseo/premium-configuration
+          fetch-depth: 0
+          token: ${{ secrets.YOASTBOT_CI_PAT_DIST }}
+
+      # The ubuntu images come with Node, npm and yarn pre-installed.
+      # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
+
+      # This action also handles the caching of the Yarn dependencies.
+      # https://github.com/actions/setup-node
+      - name: Set up node and enable caching of dependencies
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+          cache: 'yarn'
+
+      - name: Yarn install
+        run: yarn install
+
+      - name: Show debug info
+        run: |
+          npm --version
+          node --version
+          yarn --version
+          grunt --version
+          yarn run jest --version
+
+      - name: Show Jest version
+        run: yarn run jest --version
+        working-directory: packages/${{ matrix.package }}
+
+      - name: Show Config
+        run: yarn test --showConfig
+        working-directory: packages/${{ matrix.package }}
+
+      # The cron job will run the full test suite, in all other cases, only the relevant tests
+      # will be run based on the changed files.
+      - name: "Run Javascript tests - onlyChanged files"
+        if: ${{ github.event_name != 'schedule' }}
+        run: yarn test --ci --changedSince="${{ steps.base_branch.outputs.NAME }}"
+        working-directory: packages/${{ matrix.package }}
+
+      - name: Run Javascript tests - full test run
+        if: ${{ github.event_name == 'schedule' }}
+        run: yarn test --ci
+        working-directory: packages/${{ matrix.package }}

--- a/packages/yoastseo/grunt/config/eslint.js
+++ b/packages/yoastseo/grunt/config/eslint.js
@@ -6,7 +6,7 @@ module.exports = function( grunt ) {
 		target: {
 			src: [ "<%= files.js %>", "<%= files.jsDontLint %>" ],
 			options: {
-				maxWarnings: 22,
+				maxWarnings: 21,
 				fix: fix,
 			},
 		},
@@ -14,7 +14,7 @@ module.exports = function( grunt ) {
 			src: [ "<%= files.jsTests %>" ],
 			options: {
 				configFile: ".eslintrc-tests",
-				maxWarnings: 19,
+				maxWarnings: 6,
 				fix: fix,
 			},
 		},

--- a/packages/yoastseo/package.json
+++ b/packages/yoastseo/package.json
@@ -20,7 +20,7 @@
     "build": "grunt publish",
     "lint": "grunt check",
     "pretest": "yarn install-ci",
-    "test": "jest --runInBand",
+    "test": "jest",
     "install-ci": "grunt get-premium-configuration",
     "prepublishOnly": "grunt publish"
   },


### PR DESCRIPTION
## Context

* Make CI faster

## Summary

This PR can be summarized in the following changelog entry:

* Make CI faster

## Relevant technical choices:

### GH Actions/JS: split the workflow into two + separate test builds per package

The JS workflow was the slowest workflow, with a runtime of easily 10 minutes.

This commit fixes that by making the runs more modular.

* The JS lint task will now be run in a separate workflow. No other changes were made to the lint job.
* The JS test task has now been split into two different jobs:
    1. One job for small packages.
    2. One job for "big" packages.

The "small" packages job will:
* Run on select push events, PRs and on demand.
* NOT run via the cron job.
* Run the full test suite for each package, always.
* Run the tests for each package via a matrix, resulting in a separate build for each package.
* Runs with `fail-fast: false` as these runs are all unique so we don't want to job to stop on the first failure.

The "big" packages job will:
* Run on select push events, PRs and on demand AND via a nightly cron job.
* Will run a partial test suite for "normal" (push/PR) events, only running the relevant tests based on the changed files between the base branch and the current branch.
* Will run the full test suite for each package once a day via the cron job.
* Will run the tests for each package via a matrix, resulting in a separate build for each package.
    For now, there is only one package in this matrix, but the workflow has been set up to allow for moving packages between the two jobs in a straight-forward manner.
* Runs with `fail-fast: false` as these runs are all unique so we don't want to job to stop on the first failure.
* Only download the premium config for the `yoastseo` package, which actually needs it.

Note: in contrast to information found _"on the web"_ (and in contrast to the PHP CS workflow), the "base branch" for the changed file determination needs to exist in the CI local git repo for the `--changedSince` setting to work.
Using `origin/trunk` does not work (confirmed via testing the workflow).

This means the base branch needs to be checked out after having been fetched. After which we return back to the _real branch_ under test with a second checkout.

**End result: the run time of these workflows is now somewhere between 2-3 minutes.**

### JS Lint/YoastSEO: lower lint warning thresholds

.. to match current status.

### JS Test/YoastSEO: don't run the tests with runInBand

The `--runInBand` CLI argument to always run the tests serially, is mostly intended for debugging, but shouldn't be the default setting.

Ref: https://jestjs.io/docs/cli#--runinband

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ Please review the transcripts of these workflows in Actions as a way of verifying the PR.

Optionally, some lint/test errors can be introduced in one or more of the packages to ensure that the builds fail correctly, though this has previously already been tested with the original workflow.