### PR TITLE
DUPP-331 Update sameAs generation

### DIFF
--- a/src/generators/schema/organization.php
+++ b/src/generators/schema/organization.php
@@ -50,21 +50,12 @@ class Organization extends Abstract_Schema_Piece {
 	 * @return array An array of social profiles.
 	 */
 	private function fetch_social_profiles() {
-		$profiles        = [];
-		$social_profiles = [
-			'facebook_site',
-			'instagram_url',
-			'linkedin_url',
-			'myspace_url',
-			'youtube_url',
-			'pinterest_url',
-			'wikipedia_url',
-		];
-		foreach ( $social_profiles as $profile ) {
-			$social_profile = $this->helpers->options->get( $profile, '' );
-			if ( $social_profile !== '' ) {
-				$profiles[] = \urldecode( $social_profile );
-			}
+		$social_profiles = $this->helpers->options->get( 'other_social_urls', [] );
+		$profiles        = \array_map( '\urldecode', \array_filter( $social_profiles ) );
+
+		$facebook = $this->helpers->options->get( 'facebook_site', '' );
+		if ( $facebook !== '' ) {
+			$profiles[] = \urldecode( $facebook );
 		}
 
 		$twitter = $this->helpers->options->get( 'twitter_site', '' );

--- a/tests/unit/generators/schema/organization-test.php
+++ b/tests/unit/generators/schema/organization-test.php
@@ -297,8 +297,8 @@ class Organization_Test extends TestCase {
 			],
 			'Only Twitter' => [
 				'profiles_input'    => [
-					'facebook_site' => '',
-					'twitter_site'  => 'yoast',
+					'facebook_site'     => '',
+					'twitter_site'      => 'yoast',
 					'other_social_urls' => [],
 				],
 				'profiles_expected' => [
@@ -307,8 +307,8 @@ class Organization_Test extends TestCase {
 			],
 			'Some empty options' => [
 				'profiles_input'    => [
-					'facebook_site' => 'https://www.facebook.com/yoast/',
-					'twitter_site'  => 'yoast',
+					'facebook_site'     => 'https://www.facebook.com/yoast/',
+					'twitter_site'      => 'yoast',
 					'other_social_urls' => [
 						'',
 						'https://www.linkedin.com/company/yoast-com',
@@ -331,8 +331,8 @@ class Organization_Test extends TestCase {
 			],
 			'Duplicated URLs' => [
 				'profiles_input'    => [
-					'facebook_site' => 'https://www.facebook.com/yoast/',
-					'twitter_site'  => 'yoast',
+					'facebook_site'     => 'https://www.facebook.com/yoast/',
+					'twitter_site'      => 'yoast',
 					'other_social_urls' => [
 						'https://www.facebook.com/yoast/',
 						'https://www.linkedin.com/company/yoast-com',

--- a/tests/unit/generators/schema/organization-test.php
+++ b/tests/unit/generators/schema/organization-test.php
@@ -129,7 +129,7 @@ class Organization_Test extends TestCase {
 		foreach ( $profiles_input as $profile_type => $profile_value ) {
 			$this->options->expects( 'get' )
 				->once()
-				->with( $profile_type, '' )
+				->withSomeOfArgs( $profile_type )
 				->andReturn( $profile_value );
 		}
 		Filters\expectApplied( 'wpseo_schema_organization_social_profiles' )
@@ -189,7 +189,7 @@ class Organization_Test extends TestCase {
 		foreach ( $profiles_input as $profile_type => $profile_value ) {
 			$this->options->expects( 'get' )
 				->once()
-				->with( $profile_type, '' )
+				->withSomeOfArgs( $profile_type )
 				->andReturn( $profile_value );
 		}
 		Filters\expectApplied( 'wpseo_schema_organization_social_profiles' )
@@ -250,72 +250,98 @@ class Organization_Test extends TestCase {
 		return [
 			'Every possible social profile filled' => [
 				'profiles_input'    => [
-					'facebook_site' => 'https://www.facebook.com/yoast/',
-					'instagram_url' => 'https://www.instagram.com/yoast/',
-					'linkedin_url'  => 'https://www.linkedin.com/company/yoast-com',
-					'myspace_url'   => 'https://myspace.com/yoast/',
-					'youtube_url'   => 'https://www.youtube.com/yoast',
-					'pinterest_url' => 'https://www.pinterest.com/yoast/',
-					'wikipedia_url' => 'https://en.wikipedia.org/wiki/Yoast_SEO',
-					'twitter_site'  => 'yoast',
+					'facebook_site'     => 'https://www.facebook.com/yoast/',
+					'twitter_site'      => 'yoast',
+					'other_social_urls' => [
+						'https://www.instagram.com/yoast/',
+						'https://www.linkedin.com/company/yoast-com',
+						'https://myspace.com/yoast/',
+						'https://www.youtube.com/yoast',
+						'https://www.pinterest.com/yoast/',
+						'https://en.wikipedia.org/wiki/Yoast_SEO',
+					],
 				],
 				'profiles_expected' => [
-					'https://www.facebook.com/yoast/',
 					'https://www.instagram.com/yoast/',
 					'https://www.linkedin.com/company/yoast-com',
 					'https://myspace.com/yoast/',
 					'https://www.youtube.com/yoast',
 					'https://www.pinterest.com/yoast/',
 					'https://en.wikipedia.org/wiki/Yoast_SEO',
+					'https://www.facebook.com/yoast/',
 					'https://twitter.com/yoast',
 				],
 			],
 			'Without Twitter' => [
 				'profiles_input'    => [
-					'facebook_site' => 'https://www.facebook.com/yoast/',
-					'instagram_url' => 'https://www.instagram.com/yoast/',
-					'linkedin_url'  => 'https://www.linkedin.com/company/yoast-com',
-					'myspace_url'   => 'https://myspace.com/yoast/',
-					'youtube_url'   => 'https://www.youtube.com/yoast',
-					'pinterest_url' => 'https://www.pinterest.com/yoast/',
-					'wikipedia_url' => 'https://en.wikipedia.org/wiki/Yoast_SEO',
-					'twitter_site'  => '',
+					'facebook_site'     => 'https://www.facebook.com/yoast/',
+					'twitter_site'      => '',
+					'other_social_urls' => [
+						'https://www.instagram.com/yoast/',
+						'https://www.linkedin.com/company/yoast-com',
+						'https://myspace.com/yoast/',
+						'https://www.youtube.com/yoast',
+						'https://www.pinterest.com/yoast/',
+						'https://en.wikipedia.org/wiki/Yoast_SEO',
+					],
 				],
 				'profiles_expected' => [
-					'https://www.facebook.com/yoast/',
 					'https://www.instagram.com/yoast/',
 					'https://www.linkedin.com/company/yoast-com',
 					'https://myspace.com/yoast/',
 					'https://www.youtube.com/yoast',
 					'https://www.pinterest.com/yoast/',
 					'https://en.wikipedia.org/wiki/Yoast_SEO',
+					'https://www.facebook.com/yoast/',
 				],
 			],
 			'Only Twitter' => [
 				'profiles_input'    => [
 					'facebook_site' => '',
-					'instagram_url' => '',
-					'linkedin_url'  => '',
-					'myspace_url'   => '',
-					'youtube_url'   => '',
-					'pinterest_url' => '',
-					'wikipedia_url' => '',
 					'twitter_site'  => 'yoast',
+					'other_social_urls' => [],
 				],
 				'profiles_expected' => [
+					'https://twitter.com/yoast',
+				],
+			],
+			'Some empty options' => [
+				'profiles_input'    => [
+					'facebook_site' => 'https://www.facebook.com/yoast/',
+					'twitter_site'  => 'yoast',
+					'other_social_urls' => [
+						'',
+						'https://www.linkedin.com/company/yoast-com',
+						'https://myspace.com/yoast/',
+						'https://www.youtube.com/yoast',
+						'https://www.pinterest.com/yoast/',
+						'',
+						'https://en.wikipedia.org/wiki/Yoast_SEO',
+					],
+				],
+				'profiles_expected' => [
+					'https://www.linkedin.com/company/yoast-com',
+					'https://myspace.com/yoast/',
+					'https://www.youtube.com/yoast',
+					'https://www.pinterest.com/yoast/',
+					'https://en.wikipedia.org/wiki/Yoast_SEO',
+					'https://www.facebook.com/yoast/',
 					'https://twitter.com/yoast',
 				],
 			],
 			'Duplicated URLs' => [
 				'profiles_input'    => [
 					'facebook_site' => 'https://www.facebook.com/yoast/',
-					'instagram_url' => 'https://www.facebook.com/yoast/',
-					'linkedin_url'  => 'https://www.linkedin.com/company/yoast-com',
-					'myspace_url'   => 'https://myspace.com/yoast/',
-					'youtube_url'   => 'https://www.youtube.com/yoast',
-					'pinterest_url' => 'https://www.pinterest.com/yoast/',
-					'wikipedia_url' => 'https://en.wikipedia.org/wiki/Yoast_SEO',
 					'twitter_site'  => 'yoast',
+					'other_social_urls' => [
+						'https://www.facebook.com/yoast/',
+						'https://www.linkedin.com/company/yoast-com',
+						'https://myspace.com/yoast/',
+						'https://www.youtube.com/yoast',
+						'https://www.pinterest.com/yoast/',
+						'https://en.wikipedia.org/wiki/Yoast_SEO',
+						'https://myspace.com/yoast/',
+					],
 				],
 				'profiles_expected' => [
 					'https://www.facebook.com/yoast/',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make sure that the `sameAs` property in the `Organization` Schema piece is built using the new format options introduced in #18174 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the Schema generation to fetch social profiles in the new array format for the `sameAs` property

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* make sure you have set "Organization" (with a name and a logo) in Search Appearance
* inspect `wpseo_social` in the DB options table
  * if you tested DUPP-329, you should already see the options in the right format
  * otherwise, or for a more comprehensive test, you can set the value to the following. Note that the old options are empty, and the `other_social_urls` has some duplicated and empty fields that should not appear in the output:
```
a:19:{s:13:"facebook_site";s:26:"https://facebook.com/yoast";s:13:"instagram_url";s:0:"";s:12:"linkedin_url";s:0:"";s:11:"myspace_url";s:0:"";s:16:"og_default_image";s:0:"";s:19:"og_default_image_id";s:0:"";s:18:"og_frontpage_title";s:0:"";s:17:"og_frontpage_desc";s:0:"";s:18:"og_frontpage_image";s:0:"";s:21:"og_frontpage_image_id";s:0:"";s:9:"opengraph";b:1;s:13:"pinterest_url";s:0:"";s:15:"pinterestverify";s:0:"";s:7:"twitter";b:1;s:12:"twitter_site";s:5:"yoast";s:17:"twitter_card_type";s:19:"summary_large_image";s:11:"youtube_url";s:0:"";s:13:"wikipedia_url";s:0:"";s:17:"other_social_urls";a:9:{i:0;s:32:"https://www.instagram.com/yoast/";i:1;s:34:"https://www.linkedin.com/in/yoast/";i:2;s:29:"https://myspace.com/in/yoast/";i:3;s:31:"https://pinterest.com/in/yoast/";i:4;s:29:"https://youtube.com/in/yoast/";i:5;s:0:"";i:6;s:31:"https://en.wikipedia.org/yoast/";i:7;s:32:"https://www.instagram.com/yoast/";i:8;s:26:"https://facebook.com/yoast";}}
```
* visit the home page in the frontend and inspect the source
   * in the `Organization` piece you should find this property:
```
	            "sameAs": [
	                "https://www.instagram.com/yoast/",
	                "https://www.linkedin.com/in/yoast/",
	                "https://myspace.com/in/yoast/",
	                "https://pinterest.com/in/yoast/",
	                "https://youtube.com/in/yoast/",
	                "https://en.wikipedia.org/yoast/",
	                "https://facebook.com/yoast",
	                "https://twitter.com/yoast"
	            ],
```


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* NA the full feature will be tested

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes [DUPP-331]


[DUPP-331]: https://yoast.atlassian.net/browse/DUPP-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ