### PR TITLE
Bug: date() is affected by runtime timezone changes

### DIFF
--- a/admin/tracking/class-tracking-default-data.php
+++ b/admin/tracking/class-tracking-default-data.php
@@ -18,7 +18,7 @@ class WPSEO_Tracking_Default_Data implements WPSEO_Collection {
 	public function get() {
 		return [
 			'siteTitle'       => get_option( 'blogname' ),
-			'@timestamp'      => (int) date( 'Uv' ),
+			'@timestamp'      => (int) gmdate( 'Uv' ),
 			'wpVersion'       => $this->get_wordpress_version(),
 			'homeURL'         => home_url(),
 			'adminURL'        => admin_url(),


### PR DESCRIPTION
## Context

* I was just updating Yoast SEO on a client's site hosted on WordPress VIP and the sniffs detected this issue.

## Summary
This PR can be summarized in the following changelog entry:

* Fixes a bug where `date()` could return the incorrect date. Props to [BronsonQuick](https://github.com/BronsonQuick).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* When inspecting the data send to our tracking server ( make sure tracking is enabled ) it should contain the correct ( current ) date.
* On line 124 in `admin/tracking/class-tracking.php` put `var_dump( $collector->get_as_json() ); exit;` to output the data before the request is sent.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The data in our tracking request

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
