### PR TITLE
P1-1157 create options helper class on top of single site and multisite options classes

### DIFF
--- a/inc/class-wpseo-shortlinker.php
+++ b/inc/class-wpseo-shortlinker.php
@@ -114,7 +114,7 @@ class WPSEO_Shortlinker {
 	/**
 	 * Gets the number of days the plugin has been active.
 	 *
-	 * @return int The number of days the plugin is active.
+	 * @return string The number of days the plugin is active.
 	 */
 	private function get_days_active() {
 		$date_activated = WPSEO_Options::get( 'first_activated_on' );

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -141,14 +141,7 @@ class WPSEO_Options {
 	 * @return mixed
 	 */
 	public static function get_default( $option_name, $key ) {
-		if ( isset( static::$option_instances[ $option_name ] ) ) {
-			$defaults = static::$option_instances[ $option_name ]->get_defaults();
-			if ( isset( $defaults[ $key ] ) ) {
-				return $defaults[ $key ];
-			}
-		}
-
-		return null;
+		return YoastSEO()->helpers->options->get_default( $key );
 	}
 
 	/**
@@ -211,9 +204,7 @@ class WPSEO_Options {
 	 * @return array Array combining the values of all the options.
 	 */
 	public static function get_all() {
-		static::$option_values = static::get_options( static::get_option_names() );
-
-		return static::$option_values;
+		return YoastSEO()->helpers->options->get_options();
 	}
 
 	/**
@@ -247,19 +238,18 @@ class WPSEO_Options {
 	 * @return array Array containing the requested option.
 	 */
 	public static function get_option( $option_name ) {
-		$option = null;
 		if ( is_string( $option_name ) && ! empty( $option_name ) ) {
 			if ( isset( static::$option_instances[ $option_name ] ) ) {
 				if ( static::$option_instances[ $option_name ]->multisite_only !== true ) {
-					$option = get_option( $option_name );
+					return YoastSEO()->helpers->options->get_options( \array_keys( static::$option_instances[ $option_name ]->get_defaults() ) );
 				}
 				else {
-					$option = get_site_option( $option_name );
+					return get_site_option( $option_name );
 				}
 			}
 		}
 
-		return $option;
+		return null;
 	}
 
 	/**
@@ -271,14 +261,7 @@ class WPSEO_Options {
 	 * @return mixed Returns value if found, $default_value if not.
 	 */
 	public static function get( $key, $default_value = null ) {
-		if ( static::$option_values === null ) {
-			static::prime_cache();
-		}
-		if ( isset( static::$option_values[ $key ] ) ) {
-			return static::$option_values[ $key ];
-		}
-
-		return $default_value;
+		return YoastSEO()->helpers->options->get( $key, $default_value );
 	}
 
 	/**
@@ -302,23 +285,10 @@ class WPSEO_Options {
 	 * @param string $key   The key to set.
 	 * @param mixed  $value The value to set.
 	 *
-	 * @return mixed|null Returns value if found, $default if not.
+	 * @return bool Whether the save was successful.
 	 */
 	public static function set( $key, $value ) {
-		$lookup_table = static::get_lookup_table();
-
-		if ( isset( $lookup_table[ $key ] ) ) {
-			return static::save_option( $lookup_table[ $key ], $key, $value );
-		}
-
-		$patterns = static::get_pattern_table();
-		foreach ( $patterns as $pattern => $option ) {
-			if ( strpos( $key, $pattern ) === 0 ) {
-				return static::save_option( $option, $key, $value );
-			}
-		}
-
-		static::$option_values[ $key ] = $value;
+		return YoastSEO()->helpers->options->set( $key, $value );
 	}
 
 	/**
@@ -330,6 +300,8 @@ class WPSEO_Options {
 	 * @return mixed
 	 */
 	public static function get_autoloaded_option( $option, $default_value = false ) {
+		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+
 		$value = wp_cache_get( $option, 'options' );
 		if ( $value === false ) {
 			$passed_default = func_num_args() > 1;
@@ -384,9 +356,7 @@ class WPSEO_Options {
 	 * @return void
 	 */
 	public static function ensure_options_exist() {
-		foreach ( static::$option_instances as $instance ) {
-			$instance->maybe_add_option();
-		}
+		YoastSEO()->helpers->options->ensure_options();
 	}
 
 	/**
@@ -408,14 +378,7 @@ class WPSEO_Options {
 	 */
 	public static function reset() {
 		if ( ! is_multisite() ) {
-			$option_names = static::get_option_names();
-			if ( is_array( $option_names ) && $option_names !== [] ) {
-				foreach ( $option_names as $option_name ) {
-					delete_option( $option_name );
-					update_option( $option_name, get_option( $option_name ) );
-				}
-			}
-			unset( $option_names );
+			YoastSEO()->helpers->options->reset_options();
 		}
 		else {
 			// Reset MS blog based on network default blog setting.
@@ -497,6 +460,8 @@ class WPSEO_Options {
 	 * @return bool Returns true if the option is successfully saved in the database.
 	 */
 	public static function save_option( $wpseo_options_group_name, $option_name, $option_value ) {
+		_deprecated_function( __METHOD__, 'WPSEO xx.x', 'YoastSEO()->helpers->options->set' );
+
 		$options                 = static::get_option( $wpseo_options_group_name );
 		$options[ $option_name ] = $option_value;
 
@@ -557,6 +522,8 @@ class WPSEO_Options {
 	 * @return array The lookup table.
 	 */
 	private static function get_lookup_table() {
+		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+
 		$lookup_table = [];
 
 
@@ -576,6 +543,8 @@ class WPSEO_Options {
 	 * @return array The lookup table.
 	 */
 	private static function get_pattern_table() {
+		_deprecated_function( __METHOD__, 'WPSEO xx.x' );
+
 		$pattern_table = [];
 		foreach ( static::$options as $option_name => $option_class ) {
 			$instance = call_user_func( [ $option_class, 'get_instance' ] );

--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -20,6 +20,11 @@ class Options_Helper {
 	 */
 	protected $site_options_service;
 
+	/**
+	 * Constructs the Site_Options_Service instance.
+	 *
+	 * @param Site_Options_Service $site_options_service The site options service.
+	 */
 	public function __construct( Site_Options_Service $site_options_service ) {
 		$this->site_options_service = $site_options_service;
 	}
@@ -27,16 +32,16 @@ class Options_Helper {
 	/**
 	 * Retrieves a single field from any option for the SEO plugin. Keys are always unique.
 	 *
-	 * @param string $key           The key it should return.
-	 * @param mixed  $default_value The default value that should be returned if the key isn't set.
+	 * @param string $key      The key it should return.
+	 * @param mixed  $fallback The fallback value that should be returned if the key isn't set.
 	 *
 	 * @return mixed|null Returns value if found, $default_value if not.
 	 */
-	public function get( $key, $default_value = null ) {
+	public function get( $key, $fallback = null ) {
 		try {
 			return $this->site_options_service->__get( $key );
 		} catch ( Unknown_Exception $exception ) {
-			return $default_value;
+			return $fallback;
 		}
 	}
 
@@ -53,9 +58,9 @@ class Options_Helper {
 			$this->site_options_service->__set( $key, $value );
 
 			return true;
-		} catch ( Missing_Configuration_Key_Exception $exception ) {
-		} catch ( Unknown_Exception $exception ) {
-		} catch ( Abstract_Validation_Exception $exception ) {
+		} catch ( Missing_Configuration_Key_Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
+		} catch ( Unknown_Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
+		} catch ( Abstract_Validation_Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Deliberately left empty.
 		}
 
 		return false;
@@ -111,22 +116,22 @@ class Options_Helper {
 	 * @return string The title separator.
 	 */
 	public function get_title_separator() {
-		$default = $this->get_default( 'wpseo_titles', 'separator' );
+		$default = $this->get_default( 'separator' );
 
 		// Get the titles option and the separator options.
 		$separator         = $this->get( 'separator' );
-		$seperator_options = $this->get_separator_options();
+		$separator_options = $this->get_separator_options();
 
 		// This should always be set, but just to be sure.
-		if ( isset( $seperator_options[ $separator ] ) ) {
+		if ( isset( $separator_options[ $separator ] ) ) {
 			// Set the new replacement.
-			$replacement = $seperator_options[ $separator ];
+			$replacement = $separator_options[ $separator ];
 		}
-		elseif ( isset( $seperator_options[ $default ] ) ) {
-			$replacement = $seperator_options[ $default ];
+		elseif ( isset( $separator_options[ $default ] ) ) {
+			$replacement = $separator_options[ $default ];
 		}
 		else {
-			$replacement = \reset( $seperator_options );
+			$replacement = \reset( $separator_options );
 		}
 
 		/**
@@ -166,6 +171,8 @@ class Options_Helper {
 
 	/**
 	 * Get the available separator options.
+	 *
+	 * @codeCoverageIgnore We have to write test when this method contains own code.
 	 *
 	 * @return array
 	 */

--- a/src/services/options/abstract-options-service.php
+++ b/src/services/options/abstract-options-service.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Services\Options;
 
-use WPSEO_Options;
 use Yoast\WP\SEO\Exceptions\Option\Missing_Configuration_Key_Exception;
 use Yoast\WP\SEO\Exceptions\Option\Unknown_Exception;
 use Yoast\WP\SEO\Helpers\Validation_Helper;
@@ -45,6 +44,13 @@ abstract class Abstract_Options_Service {
 	 * @var array
 	 */
 	protected $values = null;
+
+	/**
+	 * Holds the cached option default values.
+	 *
+	 * @var array
+	 */
+	protected $defaults = null;
 
 	/**
 	 * Holds the validation helper instance.
@@ -135,15 +141,6 @@ abstract class Abstract_Options_Service {
 	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
 
 	/**
-	 * Retrieves all the options.
-	 *
-	 * @return array The options.
-	 */
-	public function get_all() {
-		return $this->get_values();
-	}
-
-	/**
 	 * Retrieves the options.
 	 *
 	 * @param string[] $keys Optionally request only these options.
@@ -167,13 +164,78 @@ abstract class Abstract_Options_Service {
 	}
 
 	/**
+	 * Saves the options if the database row does not exist.
+	 *
+	 * @return void
+	 */
+	public function ensure_options() {
+		if ( ! \get_option( $this->option_name ) ) {
+			\update_option( $this->option_name, $this->get_values() );
+		}
+	}
+
+	/**
+	 * Saves the options with their default values.
+	 *
+	 * @return void
+	 */
+	public function reset_options() {
+		\update_option( $this->option_name, $this->get_defaults() );
+	}
+
+	/**
+	 * Retrieves the default option values.
+	 *
+	 * @return array The default values.
+	 */
+	public function get_defaults() {
+		if ( $this->defaults === null ) {
+			return \array_combine(
+				\array_keys( $this->configurations ),
+				\array_column( $this->configurations, 'default' )
+			);
+		}
+
+		return $this->defaults;
+	}
+
+	/**
+	 * Retrieves the default option value.
+	 *
+	 * @param string $key The option key.
+	 *
+	 * @throws Unknown_Exception When the option does not exist.
+	 *
+	 * @return mixed The default value.
+	 */
+	public function get_default( $key ) {
+		if ( ! \array_key_exists( $key, $this->get_defaults() ) ) {
+			throw new Unknown_Exception( $key );
+		}
+
+		return $this->get_defaults()[ $key ];
+	}
+
+	/**
 	 * Retrieves the (cached) values.
 	 *
 	 * @return array The values.
 	 */
 	protected function get_values() {
 		if ( $this->values === null ) {
-			$this->values = WPSEO_Options::get_all();
+			$this->values = \get_option( $this->option_name );
+			// Database row does not exist. We need an array.
+			if ( ! $this->values ) {
+				$this->values = [];
+			}
+
+			// Fill with default value when the database value is missing.
+			$defaults = $this->get_defaults();
+			foreach ( $defaults as $option => $default_value ) {
+				if ( ! \array_key_exists( $option, $this->values ) ) {
+					$this->values[ $option ] = $default_value;
+				}
+			}
 		}
 
 		return $this->values;
@@ -188,9 +250,19 @@ abstract class Abstract_Options_Service {
 	 * @return void
 	 */
 	protected function set_option( $key, $value ) {
-		WPSEO_Options::set( $key, $value );
+		// Ensure the cache is filled.
+		if ( $this->values === null ) {
+			$this->get_values();
+		}
+
+		// Only save when changed.
+		if ( $value === $this->values[ $key ] ) {
+			return;
+		}
 
 		// Update the cache.
 		$this->values[ $key ] = $value;
+		// Save to the database.
+		\update_option( $this->option_name, $this->values );
 	}
 }

--- a/src/services/options/abstract-options-service.php
+++ b/src/services/options/abstract-options-service.php
@@ -130,11 +130,6 @@ abstract class Abstract_Options_Service {
 		// Validate, this can throw a Validation_Exception.
 		$value = $this->validation->validate_as( $value, $this->configurations[ $key ]['types'] );
 
-		// Only update when changed.
-		if ( $value === $this->get_values()[ $key ] ) {
-			return;
-		}
-
 		$this->set_option( $key, $value );
 	}
 
@@ -190,7 +185,7 @@ abstract class Abstract_Options_Service {
 	 */
 	public function get_defaults() {
 		if ( $this->defaults === null ) {
-			return \array_combine(
+			$this->defaults = \array_combine(
 				\array_keys( $this->configurations ),
 				\array_column( $this->configurations, 'default' )
 			);

--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -193,7 +193,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 
 		// Titles.
 		'activation_redirect_timestamp_free'                  => [
-			'default' => '',
+			'default' => 0,
 			'types'   => [ 'integer' ],
 		],
 		'alternate_website_name'                              => [
@@ -245,11 +245,11 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'empty_string', 'url' ],
 		],
 		'company_logo_id'                                     => [
-			'default' => '',
+			'default' => 0,
 			'types'   => [ 'integer' ],
 		],
 		'company_logo_meta'                                   => [
-			'default' => '',
+			'default' => false,
 			'types'   => [ 'string' ],
 		],
 		'company_name'                                        => [
@@ -268,7 +268,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			],
 		],
 		'company_or_person_user_id'                           => [
-			'default' => '',
+			'default' => false,
 			'types'   => [ 'integer' ],
 		],
 		'disable-attachment'                                  => [
@@ -357,7 +357,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'empty_string', 'url' ],
 		],
 		'open_graph_frontpage_image_id'                       => [
-			'default' => '',
+			'default' => 0,
 			'types'   => [ 'integer' ],
 		],
 		'open_graph_frontpage_title'                          => [
@@ -369,11 +369,11 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'empty_string', 'url' ],
 		],
 		'person_logo_id'                                      => [
-			'default' => '',
+			'default' => 0,
 			'types'   => [ 'integer' ],
 		],
 		'person_logo_meta'                                    => [
-			'default' => '',
+			'default' => false,
 			'types'   => [ 'string' ],
 		],
 		'person_name'                                         => [
@@ -393,7 +393,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			],
 		],
 		'rssafter'                                            => [
-			'default' => 'The post %%POSTLINK%% appeared first on %%BLOGLINK%%',
+			'default' => 'The post %%POSTLINK%% appeared first on %%BLOGLINK%%.',
 			'types'   => [ 'empty_string', 'wp_kses_post' ],
 		],
 		'rssbefore'                                           => [
@@ -455,11 +455,11 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'integer' ],
 		],
 		'social-image-id-archive-wpseo'                       => [
-			'default' => '',
+			'default' => 0,
 			'types'   => [ 'integer' ],
 		],
 		'social-image-id-author-wpseo'                        => [
-			'default' => '',
+			'default' => 0,
 			'types'   => [ 'integer' ],
 		],
 		'social-image-id-ptarchive-<PostTypeName>'            => [
@@ -582,7 +582,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'ms_verify' => true,
 		],
 		'custom_taxonomy_slugs'                               => [
-			'default' => '',
+			'default' => [],
 			'types'   => [ 'string' ],
 		],
 		'disableadvanced_meta'                                => [
@@ -648,7 +648,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			],
 		],
 		'first_activated_on'                                  => [
-			'default' => '',
+			'default' => false,
 			'types'   => [ 'integer' ],
 		],
 		'first_time_install'                                  => [
@@ -681,11 +681,11 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'ms_exclude' => true,
 		],
 		'import_cursors'                                      => [
-			'default' => '',
+			'default' => [],
 			'types'   => [ 'string' ],
 		],
 		'importing_completed'                                 => [
-			'default' => '',
+			'default' => [],
 			'types'   => [ 'string' ],
 		],
 		'indexables_indexing_completed'                       => [
@@ -701,7 +701,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'text_field' ],
 		],
 		'indexing_started'                                    => [
-			'default' => '',
+			'default' => null,
 			'types'   => [ 'integer' ],
 		],
 		'keyword_analysis_active'                             => [
@@ -710,7 +710,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'ms_verify' => true,
 		],
 		'license_server_version'                              => [
-			'default' => '',
+			'default' => false,
 			'types'   => [ 'string' ],
 		],
 		'ms_defaults_set'                                     => [
@@ -725,7 +725,13 @@ class Site_Options_Service extends Abstract_Options_Service {
 			],
 		],
 		'myyoast-oauth'                                       => [
-			'default' => '',
+			'default' => [
+				'config'        => [
+					'clientId' => null,
+					'secret'   => null,
+				],
+				'access_tokens' => [],
+			],
 			'types'   => [ 'string' ],
 		],
 		'permalink_structure'                                 => [
@@ -747,7 +753,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'ms_verify' => true,
 		],
 		'semrush_country_code'                                => [
-			'default' => '',
+			'default' => 'us',
 			'types'   => [ 'string' ],
 		],
 		'semrush_integration_active'                          => [
@@ -756,7 +762,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'ms_verify' => true,
 		],
 		'semrush_tokens'                                      => [
-			'default' => '',
+			'default' => [],
 			'types'   => [ 'string' ],
 		],
 		'should_redirect_after_install_free'                  => [
@@ -793,7 +799,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			],
 		],
 		'tracking'                                            => [
-			'default'   => null,
+			'default'   => false,
 			'types'     => [ 'boolean' ],
 			'ms_verify' => true,
 		],
@@ -811,7 +817,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'ms_verify' => true,
 		],
 		'wincher_tokens'                                      => [
-			'default' => '',
+			'default' => [],
 			'types'   => [ 'string' ],
 		],
 		'wincher_website_id'                                  => [
@@ -819,7 +825,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'types'   => [ 'string' ],
 		],
 		'workouts_data'                                       => [
-			'default' => '',
+			'default' => [ 'configuration' => [ 'finishedSteps' => [] ] ],
 			'types'   => [ 'string' ],
 		],
 		'yandexverify'                                        => [
@@ -839,7 +845,7 @@ class Site_Options_Service extends Abstract_Options_Service {
 			'ms_verify' => true,
 		],
 		'zapier_subscription'                                 => [
-			'default' => '',
+			'default' => [],
 			'types'   => [ 'string' ],
 		],
 	];

--- a/src/services/options/site-options-service.php
+++ b/src/services/options/site-options-service.php
@@ -269,7 +269,11 @@ class Site_Options_Service extends Abstract_Options_Service {
 		],
 		'company_or_person_user_id'                           => [
 			'default' => false,
-			'types'   => [ 'integer' ],
+			'types'   => [
+				'empty_string',
+				'boolean',
+				'integer',
+			],
 		],
 		'disable-attachment'                                  => [
 			'default' => true,

--- a/tests/integration/inc/options/test-class-wpseo-options.php
+++ b/tests/integration/inc/options/test-class-wpseo-options.php
@@ -164,28 +164,6 @@ class WPSEO_Options_Test extends WPSEO_UnitTestCase {
 	}
 
 	/**
-	 * Tests if unique keys are used in all options.
-	 *
-	 * @covers WPSEO_Option::get_option
-	 */
-	public function test_make_sure_keys_are_unique_over_options() {
-		$keys = [];
-
-		// Make sure the backfilling is not being done when determining "real" unique option names.
-		remove_all_actions( 'option_wpseo' );
-		remove_all_actions( 'option_wpseo_titles' );
-
-		foreach ( array_keys( WPSEO_Options::$options ) as $option_name ) {
-			$option_keys = array_keys( WPSEO_Options::get_option( $option_name ) );
-			$intersected = array_intersect( $option_keys, $keys );
-
-			$this->assertEquals( [], $intersected, 'Option keys must be unique (' . $option_name . ').' );
-
-			$keys = array_merge( $keys, $option_keys );
-		}
-	}
-
-	/**
 	 * Tests that multisite options are available via WPSEO_Options::get() in multisite.
 	 *
 	 * @group ms-required

--- a/tests/integration/ryte/test-class-ryte.php
+++ b/tests/integration/ryte/test-class-ryte.php
@@ -42,7 +42,7 @@ class WPSEO_Ryte_Test extends WPSEO_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->options_helper  = new Options_Helper();
+		$this->options_helper  = YoastSEO()->helpers->options;
 		$this->class_instance  = new WPSEO_Ryte_Double( $this->options_helper );
 		$this->option_instance = $this->class_instance->get_option();
 	}

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -3,7 +3,9 @@
 namespace Yoast\WP\SEO\Tests\Unit;
 
 use Brain\Monkey;
+use Mockery;
 use WPSEO_Options;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WPTestUtils\BrainMonkey\YoastTestCase;
 
 /**
@@ -27,7 +29,7 @@ abstract class TestCase extends YoastTestCase {
 		Monkey\Functions\stubs(
 			[
 				// Null makes it so the function returns its first argument.
-				'is_admin'             => false,
+				'is_admin' => false,
 			]
 		);
 
@@ -43,5 +45,29 @@ abstract class TestCase extends YoastTestCase {
 
 		// This is required to ensure backfill and other statics are set.
 		WPSEO_Options::get_instance();
+	}
+
+	/**
+	 * Creates an Options_Helper mock.
+	 *
+	 * @param int $get_times The amount of times the get is called. Defaults to 1.
+	 * @param int $set_times The amount of times the set is called. Defaults to 1.
+	 *
+	 * @return \Mockery\MockInterface|\Yoast\WP\SEO\Helpers\Options_Helper
+	 */
+	protected function get_options_helper_mock( $get_times = 1, $set_times = 1 ) {
+		$options_helper = Mockery::mock( Options_Helper::class );
+		$options_helper->expects( 'get' )->times( $get_times )->andReturnUsing(
+			static function ( $value, $default ) {
+				return $default;
+			}
+		);
+		$options_helper->expects( 'set' )->times( $set_times )->andReturnUsing(
+			static function ( $value ) {
+				return $value;
+			}
+		);
+
+		return $options_helper;
 	}
 }

--- a/tests/unit/admin/admin-features-test.php
+++ b/tests/unit/admin/admin-features-test.php
@@ -58,13 +58,14 @@ class Admin_Features_Test extends TestCase {
 
 		$product_helper = Mockery::mock( Product_Helper::class );
 		$product_helper->expects( 'is_premium' )->times( 5 )->andReturn( false );
-		$url_helper = Mockery::mock( Url_Helper::class );
+		$url_helper = Mockery::mock( \Yoast\WP\SEO\Helpers\Url_Helper::class );
 		$url_helper->expects( 'is_plugin_network_active' )->twice()->andReturn( false );
 
 		$helper_surface               = Mockery::mock( Helpers_Surface::class );
 		$helper_surface->current_page = $current_page_helper;
 		$helper_surface->product      = $product_helper;
 		$helper_surface->url          = $url_helper;
+		$helper_surface->options      = self::get_options_helper_mock( 10, 2 );
 
 		Monkey\Functions\expect( 'YoastSEO' )
 			->andReturn( (object) [ 'helpers' => $helper_surface ] );

--- a/tests/unit/admin/metabox/metabox-test.php
+++ b/tests/unit/admin/metabox/metabox-test.php
@@ -3,7 +3,9 @@
 namespace Yoast\WP\SEO\Tests\Unit\Admin\Metabox;
 
 use Brain\Monkey;
+use Mockery;
 use WPSEO_Metabox_Section_Additional;
+use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Admin\Metabox\Metabox_Double;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -36,6 +38,12 @@ class Metabox_Test extends TestCase {
 			->with( 'wpseo_manage_options' )
 			->once()
 			->andReturnTrue();
+
+		$helper_surface          = Mockery::mock( Helpers_Surface::class );
+		$helper_surface->options = self::get_options_helper_mock( 2, 0 );
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->andReturn( (object) [ 'helpers' => $helper_surface ] );
 
 		$this->instance = new Metabox_Double();
 	}

--- a/tests/unit/admin/tracking/tracking-test.php
+++ b/tests/unit/admin/tracking/tracking-test.php
@@ -3,8 +3,10 @@
 namespace Yoast\WP\SEO\Tests\Unit\Admin\Tracking;
 
 use Brain\Monkey;
-use WPSEO_Options;
+use Mockery;
 use WPSEO_Tracking;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -21,6 +23,13 @@ class WPSEO_Tracking_Test extends TestCase {
 	 */
 	protected function set_up() {
 		parent::set_up();
+
+		$helper_surface          = Mockery::mock( Helpers_Surface::class );
+		$helper_surface->options = Mockery::mock( Options_Helper::class );
+		$helper_surface->options->expects( 'get' )->with( 'tracking', null )->andReturn( true );
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->andReturn( (object) [ 'helpers' => $helper_surface ] );
 	}
 
 	/**
@@ -35,15 +44,11 @@ class WPSEO_Tracking_Test extends TestCase {
 			]
 		);
 
-		WPSEO_Options::set( 'tracking', true );
-
 		$instance = new WPSEO_Tracking( 'https://tracking.yoast.com/stats', ( \WEEK_IN_SECONDS * 2 ) );
 
 		$this->assertEquals( 0, $this->getPropertyValue( $instance, 'threshold' ) );
 		$this->assertEquals( '', $this->getPropertyValue( $instance, 'endpoint' ) );
 		$this->assertEquals( null, $this->getPropertyValue( $instance, 'current_time' ) );
-
-		WPSEO_Options::clear_cache();
 	}
 
 	/**
@@ -57,14 +62,11 @@ class WPSEO_Tracking_Test extends TestCase {
 				'wp_get_environment_type' => 'production',
 			]
 		);
-		WPSEO_Options::set( 'tracking', true );
 
 		$instance = new WPSEO_Tracking( 'https://tracking.yoast.com/stats', ( \WEEK_IN_SECONDS * 2 ) );
 
 		$this->assertEquals( ( \WEEK_IN_SECONDS * 2 ), $this->getPropertyValue( $instance, 'threshold' ) );
 		$this->assertEquals( 'https://tracking.yoast.com/stats', $this->getPropertyValue( $instance, 'endpoint' ) );
 		$this->assertEquals( \time(), $this->getPropertyValue( $instance, 'current_time' ) );
-
-		WPSEO_Options::clear_cache();
 	}
 }

--- a/tests/unit/admin/views/feature-toggles-test.php
+++ b/tests/unit/admin/views/feature-toggles-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Admin\Views;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Mockery;
+use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast_Feature_Toggle;
 use Yoast_Feature_Toggles;
@@ -105,8 +106,11 @@ class Yoast_Feature_Toggles_Test extends TestCase {
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->once()->andReturn( false );
 
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Functions\expect( 'YoastSEO' )->once()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+		$helpers_mock = (object) [
+			'product' => $product_helper_mock,
+			'options' => self::get_options_helper_mock( 2, 0 ),
+		];
+		Functions\expect( 'YoastSEO' )->times( 3 )->andReturn( (object) [ 'helpers' => $helpers_mock ] );
 
 		$instance = new Yoast_Feature_Toggles();
 		$result   = $instance->get_all();
@@ -168,8 +172,11 @@ class Yoast_Feature_Toggles_Test extends TestCase {
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->once()->andReturn( false );
 
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Functions\expect( 'YoastSEO' )->once()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+		$helpers_mock = (object) [
+			'product' => $product_helper_mock,
+			'options' => self::get_options_helper_mock( 2, 0 ),
+		];
+		Functions\expect( 'YoastSEO' )->times( 3 )->andReturn( (object) [ 'helpers' => $helpers_mock ] );
 
 		Filters\expectApplied( 'wpseo_feature_toggles' )
 			->once()

--- a/tests/unit/generators/schema-generator-test.php
+++ b/tests/unit/generators/schema-generator-test.php
@@ -21,6 +21,7 @@ use Yoast\WP\SEO\Helpers\Site_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
+use Yoast\WP\SEO\Services\Options\Site_Options_Service;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Context\Meta_Tags_Context_Mock;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
@@ -108,6 +109,13 @@ class Schema_Generator_Test extends TestCase {
 	protected $replace_vars_helper;
 
 	/**
+	 * Represents the options helper.
+	 *
+	 * @var Mockery\Mock|Options_Helper
+	 */
+	protected $options;
+
+	/**
 	 * Sets up the test.
 	 */
 	protected function set_up() {
@@ -119,11 +127,12 @@ class Schema_Generator_Test extends TestCase {
 		$this->html    = Mockery::mock( HTML_Helper::class )->makePartial();
 		$this->article = Mockery::mock( Article_Helper::class );
 		$this->date    = Mockery::mock( Date_Helper::class );
+		$this->options = Mockery::mock( Options_Helper::class );
 
 		$helpers = Mockery::mock( Helpers_Surface::class );
 
 		$helpers->current_page = $this->current_page;
-		$helpers->options      = Mockery::mock( Options_Helper::class )->makePartial();
+		$helpers->options      = $this->options;
 		$helpers->schema       = (object) [
 			'id'       => $this->id,
 			'html'     => $this->html,
@@ -223,6 +232,7 @@ class Schema_Generator_Test extends TestCase {
 	public function test_generate_with_no_blocks() {
 		$this->context->indexable->object_sub_type = 'super-custom-post-type';
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
+		$this->options->expects( 'get' )->andReturns( '' );
 
 		Monkey\Functions\expect( 'is_search' )
 			->andReturn( false );
@@ -294,6 +304,7 @@ class Schema_Generator_Test extends TestCase {
 	public function test_generate_with_blocks() {
 		$this->stubEscapeFunctions();
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
+		$this->options->expects( 'get' )->andReturns( '' );
 
 		$this->context->indexable->object_type     = 'post';
 		$this->context->indexable->object_sub_type = 'post';
@@ -477,6 +488,7 @@ class Schema_Generator_Test extends TestCase {
 	public function test_generate_with_block_not_having_generated_output() {
 		$this->stubEscapeFunctions();
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
+		$this->options->expects( 'get' )->andReturns( '' );
 
 		$this->context->indexable->object_type     = 'post';
 		$this->context->indexable->object_sub_type = 'post';
@@ -536,6 +548,7 @@ class Schema_Generator_Test extends TestCase {
 	public function test_validate_type_singular_array() {
 		$this->context->blocks = [];
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
+		$this->options->expects( 'get' )->andReturns( '' );
 
 		$this->context->indexable->object_type     = 'post';
 		$this->context->indexable->object_sub_type = 'post';
@@ -630,6 +643,7 @@ class Schema_Generator_Test extends TestCase {
 	public function test_validate_type_unique_array() {
 		$this->context->blocks = [];
 		$this->current_page->expects( 'is_paged' )->andReturns( false );
+		$this->options->expects( 'get' )->andReturns( '' );
 
 		$this->context->indexable->object_type     = 'post';
 		$this->context->indexable->object_sub_type = 'post';
@@ -727,6 +741,7 @@ class Schema_Generator_Test extends TestCase {
 			'post_modified_gmt' => 'date',
 		];
 		$this->context->has_image                  = false;
+		$this->options->expects( 'get' )->andReturns( '' );
 
 		Monkey\Functions\expect( 'post_password_required' )
 			->once()
@@ -832,6 +847,7 @@ class Schema_Generator_Test extends TestCase {
 	public function test_generate_with_search_page() {
 		$this->context->indexable->object_sub_type = 'super-custom-post-type';
 		$this->context->site_url                   = 'https://fake.url/';
+		$this->options->expects( 'get' )->andReturns( '' );
 
 		$this->context->schema_page_type = [
 			'CollectionPage',

--- a/tests/unit/helpers/options-helper-test.php
+++ b/tests/unit/helpers/options-helper-test.php
@@ -2,8 +2,14 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 
+use Brain\Monkey;
 use Mockery;
+use Yoast\WP\SEO\Exceptions\Option\Missing_Configuration_Key_Exception;
+use Yoast\WP\SEO\Exceptions\Option\Unknown_Exception;
+use Yoast\WP\SEO\Exceptions\Validation\Invalid_Twitter_Username_Exception;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Validation_Helper;
+use Yoast\WP\SEO\Services\Options\Site_Options_Service;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -20,17 +26,268 @@ class Options_Helper_Test extends TestCase {
 	 *
 	 * @var Options_Helper|Mockery\MockInterface
 	 */
-	private $instance;
+	protected $instance;
+
+	/**
+	 * Holds the site options service instance.
+	 *
+	 * @var Site_Options_Service|Mockery\Mock
+	 */
+	protected $site_options_service;
+
+	/**
+	 * Holds the validation helper instance.
+	 *
+	 * @var Validation_Helper|Mockery\Mock
+	 */
+	protected $validation;
 
 	/**
 	 * Prepares the test.
 	 */
 	protected function set_up() {
 		parent::set_up();
+		$this->stubEscapeFunctions();
+		$this->stubTranslationFunctions();
 
-		$this->instance = Mockery::mock( Options_Helper::class )
+		$this->validation           = Mockery::mock( Validation_Helper::class );
+		$this->site_options_service = Mockery::mock( Site_Options_Service::class, [ $this->validation ] );
+
+		$this->instance = Mockery::mock( Options_Helper::class, [ $this->site_options_service ] )
 			->shouldAllowMockingProtectedMethods()
 			->makePartial();
+	}
+
+	/**
+	 * Tests if given dependencies are set as expected.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf( Options_Helper::class, $this->instance );
+		$this->assertInstanceOf(
+			Site_Options_Service::class,
+			$this->getPropertyValue( $this->instance, 'site_options_service' )
+		);
+	}
+
+	/**
+	 * Tests the retrieval of an option value.
+	 *
+	 * @covers ::get
+	 *
+	 * @return void
+	 */
+	public function test_get() {
+		$this->site_options_service->expects( 'get_defaults' )->andReturn( [ 'foo' => 'bar' ] );
+
+		$this->assertEquals( 'bar', $this->instance->get( 'foo' ) );
+	}
+
+	/**
+	 * Tests the fallback of retrieving an option value.
+	 *
+	 * @covers ::get
+	 *
+	 * @return void
+	 */
+	public function test_get_fallback() {
+		$this->site_options_service->expects( 'get_defaults' )->andReturn( [] );
+
+		$this->assertEquals( 'fallback', $this->instance->get( 'foo', 'fallback' ) );
+	}
+
+	/**
+	 * Tests the setting of an option value.
+	 *
+	 * @covers ::set
+	 *
+	 * @return void
+	 */
+	public function test_set() {
+		Monkey\Functions\expect( 'update_option' )->once();
+
+		$this->site_options_service->expects( 'get_defaults' )->andReturn( [ 'twitter_site' => '' ] );
+		$this->validation->expects( 'validate_as' )->andReturn( 'yoast' );
+
+		$this->assertTrue( $this->instance->set( 'twitter_site', 'yoast' ) );
+	}
+
+	/**
+	 * Tests the setting of an option value failing.
+	 *
+	 * @covers ::set
+	 *
+	 * @return void
+	 */
+	public function test_set_catch_unknown() {
+		$this->assertFalse( $this->instance->set( 'unknown', '' ) );
+	}
+
+	/**
+	 * Tests the setting of an option value failing.
+	 *
+	 * @covers ::set
+	 *
+	 * @return void
+	 */
+	public function test_set_catch_missing() {
+		$this->site_options_service->expects( 'get_defaults' )
+			->andThrows( Missing_Configuration_Key_Exception::class );
+
+		$this->assertFalse( $this->instance->set( 'twitter_site', '' ) );
+	}
+
+	/**
+	 * Tests the setting of an option value failing.
+	 *
+	 * @covers ::set
+	 *
+	 * @return void
+	 */
+	public function test_set_catch_validation() {
+		$twitter_site = '#yoast';
+
+		$this->site_options_service->expects( 'get_defaults' )->andReturn( [ 'twitter_site' => '' ] );
+		$this->validation->expects( 'validate_as' )
+			->andThrows( Invalid_Twitter_Username_Exception::class );
+
+		$this->assertFalse( $this->instance->set( 'twitter_site', $twitter_site ) );
+	}
+
+	/**
+	 * Tests the retrieval of the default value of an option.
+	 *
+	 * @covers ::get_default
+	 *
+	 * @return void
+	 */
+	public function test_get_default() {
+		$this->site_options_service->expects( 'get_default' )->andReturn( '' );
+
+		$this->assertEquals( '', $this->instance->get_default( 'twitter_site' ) );
+	}
+
+	/**
+	 * Tests the retrieval of the default value of an option, unknown exception.
+	 *
+	 * @covers ::get_default
+	 *
+	 * @return void
+	 */
+	public function test_get_default_unknown() {
+		$this->site_options_service->expects( 'get_default' )->andThrows( Unknown_Exception::class );
+
+		$this->assertNull( $this->instance->get_default( 'twitter_site' ) );
+	}
+
+	/**
+	 * Tests the retrieval of a couple of options.
+	 *
+	 * @covers ::get_options
+	 *
+	 * @return void
+	 */
+	public function test_get_options() {
+		$options = [
+			'foo' => 'bar',
+			'baz' => 'qux',
+		];
+		$this->site_options_service->expects( 'get_options' )->andReturn( $options );
+
+		$this->assertEquals( $options, $this->instance->get_options( $options ) );
+	}
+
+	/**
+	 * Tests if the ensure_options of the site_options_service is called correctly.
+	 *
+	 * @covers ::ensure_options
+	 *
+	 * @return void
+	 */
+	public function test_ensure_options() {
+		$this->site_options_service->expects( 'ensure_options' )->once();
+
+		$this->instance->ensure_options();
+	}
+
+	/**
+	 * Tests if the reset_options of the site_options_service is called correctly.
+	 *
+	 * @covers ::reset_options
+	 *
+	 * @return void
+	 */
+	public function test_reset_options() {
+		$this->site_options_service->expects( 'reset_options' )->once();
+
+		$this->instance->reset_options();
+	}
+
+	/**
+	 * Tests the retrieval of the title separator.
+	 *
+	 * @covers ::get_title_separator
+	 *
+	 * @return void
+	 */
+	public function test_get_title_separator() {
+		$this->site_options_service->expects( 'get_default' )->andReturn( 'sc-dash' );
+		$this->site_options_service->expects( 'get_defaults' )->andReturn( [ 'separator' => 'sc-dash' ] );
+
+		$this->instance
+			->expects( 'get_separator_options' )
+			->once()
+			->andReturn(
+				[
+					'sc-dash' => '-',
+				]
+			);
+
+		Monkey\Filters\expectApplied( 'wpseo_replacements_filter_sep' )->andReturn( '-' );
+
+		$this->assertEquals( '-', $this->instance->get_title_separator() );
+	}
+
+	/**
+	 * Tests the retrieval of the title separator, default path.
+	 *
+	 * @covers ::get_title_separator
+	 *
+	 * @return void
+	 */
+	public function test_get_title_separator_default() {
+		$this->site_options_service->expects( 'get_default' )->andReturn( 'sc-dash' );
+		$this->site_options_service->expects( 'get_defaults' )->andReturn( [ 'separator' => '' ] );
+
+		$this->instance
+			->expects( 'get_separator_options' )
+			->once()
+			->andReturn(
+				[ 'sc-dash' => '-' ]
+			);
+
+		Monkey\Filters\expectApplied( 'wpseo_replacements_filter_sep' )->andReturn( '-' );
+
+		$this->assertEquals( '-', $this->instance->get_title_separator() );
+	}
+
+	/**
+	 * Tests the retrieval of the title separator, reset path.
+	 *
+	 * @covers ::get_title_separator
+	 *
+	 * @return void
+	 */
+	public function test_get_title_separator_reset() {
+		$this->site_options_service->expects( 'get_default' )->andReturn( 'sc-dash' );
+		$this->site_options_service->expects( 'get_defaults' )->andReturn( [ 'separator' => 'sc-dash' ] );
+
+		Monkey\Functions\expect( 'wp_list_pluck' )->once()->andReturn( [ '-', '*' ] );
+
+		Monkey\Filters\expectApplied( 'wpseo_replacements_filter_sep' )->andReturn( '-' );
+
+		$this->assertEquals( '-', $this->instance->get_title_separator() );
 	}
 
 	/**

--- a/tests/unit/inc/language-utils-test.php
+++ b/tests/unit/inc/language-utils-test.php
@@ -66,8 +66,11 @@ class Language_Utils_Test extends TestCase {
 
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->twice()->andReturn( false );
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Monkey\Functions\expect( 'YoastSEO' )->twice()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+		$helpers_mock = (object) [
+			'product' => $product_helper_mock,
+			'options' => self::get_options_helper_mock( 2, 0 ),
+		];
+		Monkey\Functions\expect( 'YoastSEO' )->times( 4 )->andReturn( (object) [ 'helpers' => $helpers_mock ] );
 
 		$shortlinker = new Shortlinker_Double();
 

--- a/tests/unit/inc/options/options-test.php
+++ b/tests/unit/inc/options/options-test.php
@@ -2,6 +2,9 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Inc\Options;
 
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Inc\Options\Options_Double;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -28,28 +31,50 @@ class Options_Test extends TestCase {
 	}
 
 	/**
-	 * Test getting settings values.
+	 * Test get calls the Options_Helper.
 	 *
 	 * @covers ::get
 	 */
 	public function test_get() {
-		$test = Options_Double::get( 'test' );
-		$this->assertEquals( $test, false );
+		$options_helper = Mockery::mock( Options_Helper::class );
+		$options_helper
+			->expects( 'get' )
+			->with( 'website_name', null );
 
-		$test = Options_Double::get( 'website_name' );
-		$this->assertEquals( $test, '' );
+		Monkey\Functions\expect( 'YoastSEO' )->andReturn(
+			(object) [
+				'helpers' =>
+					(object) [
+						'options' => $options_helper,
+					],
+			]
+		);
+
+		$this->assertNull( Options_Double::get( 'website_name' ) );
 	}
 
 	/**
-	 * Test setting settings values.
+	 * Test set calls the Options_Helper.
 	 *
 	 * @covers ::set
 	 */
 	public function test_set() {
-		$this->assertEquals( '', Options_Double::get( 'website_name' ) );
+		$options_helper = Mockery::mock( Options_Helper::class );
+		$options_helper
+			->expects( 'set' )
+			->with( 'website_name', 'Yoast' );
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->andReturn(
+				(object) [
+					'helpers' =>
+						(object) [
+							'options' => $options_helper,
+						],
+				]
+			);
 
 		Options_Double::set( 'website_name', 'Yoast' );
-		$this->assertEquals( 'Yoast', Options_Double::get( 'website_name' ) );
 	}
 
 	/**
@@ -63,6 +88,8 @@ class Options_Test extends TestCase {
 		$instance->register_hooks();
 
 		$this->assertNotFalse( \has_action( 'registered_taxonomy', [ $instance, 'clear_cache' ] ) );
+		$this->assertNotFalse( \has_action( 'unregistered_taxonomy', [ $instance, 'clear_cache' ] ) );
 		$this->assertNotFalse( \has_action( 'registered_post_type', [ $instance, 'clear_cache' ] ) );
+		$this->assertNotFalse( \has_action( 'unregistered_post_type', [ $instance, 'clear_cache' ] ) );
 	}
 }

--- a/tests/unit/inc/sitemaps/sitemaps-admin-test.php
+++ b/tests/unit/inc/sitemaps/sitemaps-admin-test.php
@@ -28,14 +28,7 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 	 *
 	 * @var Mockery\Mock
 	 */
-	private $mock_post;
-
-	/**
-	 * The options mock to use for the test.
-	 *
-	 * @var Mockery\LegacyMockInterface|Mockery\MockInterface|Options_Double
-	 */
-	private $options_mock;
+	protected $mock_post;
 
 	/**
 	 * Set up the class which will be tested.
@@ -46,7 +39,6 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 		parent::set_up();
 
 		$this->instance             = new WPSEO_Sitemaps_Admin();
-		$this->options_mock         = Mockery::mock( WPSEO_Options::class )->shouldAllowMockingProtectedMethods();
 		$this->mock_post            = Mockery::mock( '\WP_Post' )->makePartial();
 		$this->mock_post->post_type = 'post';
 	}
@@ -70,9 +62,9 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_cache_delete' )
 			->andReturn( true );
 
-		$this->options_mock
-			->shouldReceive( 'is_multisite' )
-			->andReturn( false );
+		Monkey\Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'helpers' => (object) [ 'options' => self::get_options_helper_mock( 1, 0 ) ] ] );
 
 		Monkey\Filters\expectApplied( 'wpseo_allow_xml_sitemap_ping' )
 			->never();
@@ -99,9 +91,9 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_cache_delete' )
 			->andReturn( true );
 
-		$this->options_mock
-			->shouldReceive( 'is_multisite' )
-			->andReturn( false );
+		Monkey\Functions\expect( 'YoastSEO' )
+			->once()
+			->andReturn( (object) [ 'helpers' => (object) [ 'options' => self::get_options_helper_mock( 1, 0 ) ] ] );
 
 		Monkey\Filters\expectApplied( 'wpseo_allow_xml_sitemap_ping' )
 			->once()
@@ -116,10 +108,11 @@ class WPSEO_Sitemaps_Admin_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_schedule_single_event' )
 			->once()
 			->withArgs(
-				static function( $timestamp, $function_name ) use ( $start ) {
+				static function ( $timestamp, $function_name ) use ( $start ) {
 					if ( $function_name === 'wpseo_ping_search_engines' ) {
 						return ( $timestamp < $start + 600 );
 					}
+
 					return false;
 				}
 			);

--- a/tests/unit/integrations/admin/migration-error-integration-test.php
+++ b/tests/unit/integrations/admin/migration-error-integration-test.php
@@ -7,6 +7,7 @@ use Mockery;
 use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Config\Migration_Status;
+use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Migration_Error_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -116,8 +117,11 @@ class Migration_Error_Integration_Test extends TestCase {
 
 		$product_helper_mock = Mockery::mock( Product_Helper::class );
 		$product_helper_mock->expects( 'is_premium' )->twice()->andReturn( false );
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Monkey\Functions\expect( 'YoastSEO' )->twice()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+		$helpers_mock = (object) [
+			'product' => $product_helper_mock,
+			'options' => self::get_options_helper_mock( 2, 0 ),
+		];
+		Monkey\Functions\expect( 'YoastSEO' )->times( 4 )->andReturn( (object) [ 'helpers' => $helpers_mock ] );
 
 		$expected  = '<div class="notice notice-error">';
 		$expected .= '<p>Yoast SEO had problems creating the database tables needed to speed up your site.</p>';

--- a/tests/unit/presenters/admin/migration-error-presenter-test.php
+++ b/tests/unit/presenters/admin/migration-error-presenter-test.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Tests\Unit\Presenters\Admin;
 
 use Brain\Monkey;
 use Mockery;
-use WPSEO_Shortlinker;
 use Yoast\WP\SEO\Presenters\Admin\Migration_Error_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -31,14 +30,19 @@ class Migration_Error_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'add_query_arg' )
 			->andReturn( 'https://yoa.st/3-6' );
 
-		$product_helper_mock = Mockery::mock( Product_Helper::class );
-		$product_helper_mock->expects( 'is_premium' )->twice()->andReturn( false );
-		$helpers_mock = (object) [ 'product' => $product_helper_mock ];
-		Monkey\Functions\expect( 'YoastSEO' )->twice()->andReturn( (object) [ 'helpers' => $helpers_mock ] );
+		$product_helper = Mockery::mock( \Yoast\WP\SEO\Helpers\Product_Helper::class );
+		$product_helper->expects( 'is_premium' )->andReturn( false );
+		$options_helper = Mockery::mock( \Yoast\WP\SEO\Helpers\Options_Helper::class );
+		$options_helper->expects( 'get' )->with( 'first_activated_on', null )->andReturn( 0 );
+		$helpers_mock = (object) [
+			'product' => $product_helper,
+			'options' => $options_helper,
+		];
+		Monkey\Functions\expect( 'YoastSEO' )->andReturn( (object) [ 'helpers' => $helpers_mock ] );
 
 		$expected  = '<div class="notice notice-error">';
 		$expected .= '<p>Yoast SEO had problems creating the database tables needed to speed up your site.</p>';
-		$expected .= '<p>Please read <a href="' . WPSEO_Shortlinker::get( 'https://yoa.st/3-6' ) . '">this help article</a> to find out how to resolve this problem.</p>';
+		$expected .= '<p>Please read <a href="https://yoa.st/3-6">this help article</a> to find out how to resolve this problem.</p>';
 		$expected .= '<p>Your site will continue to work normally, but won\'t take full advantage of Yoast SEO.</p>';
 		$expected .= '<details><summary>Show debug information</summary><p>test error</p></details>';
 		$expected .= '</div>';


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Use the options service in our `WPSEO_Options` class.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Calls the options service via the options helper.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Please test the whole feature instead of only this PR.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes https://yoast.atlassian.net/browse/P1-1157
