### PR TITLE
Fixes #16436. Allow filtering of indexable creation.

### DIFF
--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -38,27 +38,61 @@ class Current_Page_Helper {
 	 * @return string Page type.
 	 */
 	public function get_page_type() {
-		switch ( true ) {
-			case $this->is_search_result():
-				return 'Search_Result_Page';
-			case $this->is_static_posts_page():
-				return 'Static_Posts_Page';
-			case $this->is_home_static_page():
-				return 'Static_Home_Page';
-			case $this->is_home_posts_page():
-				return 'Home_Page';
-			case $this->is_simple_page():
-				return 'Post_Type';
-			case $this->is_post_type_archive():
-				return 'Post_Type_Archive';
-			case $this->is_term_archive():
-				return 'Term_Archive';
-			case $this->is_author_archive():
-				return 'Author_Archive';
-			case $this->is_date_archive():
-				return 'Date_Archive';
-			case $this->is_404():
-				return 'Error_Page';
+		$page_type_mapping = [
+			'search' => [
+				'type'           => 'Search_Result_Page',
+				'match_callback' => [ $this, 'is_search_result' ],
+			],
+			'static_posts_page' => [
+				'type'           => 'Static_Posts_Page',
+				'match_callback' => [ $this, 'is_static_posts_page' ],
+			],
+			'static_home_page' => [
+				'type'           => 'Static_Home_Page',
+				'match_callback' => [ $this, 'is_home_static_page' ],
+			],
+			'home_page' => [
+				'type'           => 'Home_Page',
+				'match_callback' => [ $this, 'is_home_posts_page' ],
+			],
+			'post_type' => [
+				'type'           => 'Post_Type',
+				'match_callback' => [ $this, 'is_simple_page' ],
+			],
+			'term_archive' => [
+				'type'           => 'Term_Archive',
+				'match_callback' => [ $this, 'is_term_archive' ],
+			],
+			'post_type_archive' => [
+				'type'           => 'Post_Type_Archive',
+				'match_callback' => [ $this, 'is_post_type_archive' ],
+			],
+			'author_archive' => [
+				'type'           => 'Author_Archive',
+				'match_callback' => [ $this, 'is_author_archive' ],
+			],
+			'date_archive' => [
+				'type'           => 'Date_Archive',
+				'match_callback' => [ $this, 'is_date_archive' ],
+			],
+			'404' => [
+				'type'           => 'Error_Page',
+				'match_callback' => [ $this, 'is_404' ],
+			],
+		];
+
+		/**
+		 * Filter: Allow changing and reordering the page type mapping.
+		 *
+		 * @api array $page_type_mapping The mapping.
+		 * @param Current_Page_Helper $this Helper with logic to determine current page.
+		 */
+		$page_type_mapping = \apply_filters( 'wpseo_frontend_page_type_mapping', $page_type_mapping, $this );
+
+		foreach ( $page_type_mapping as $page_type ) {
+			if ( $page_type['match_callback']() ) {
+				return $page_type['type'];
+			}
 		}
 
 		return 'Fallback';

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -112,34 +112,76 @@ class Indexable_Repository {
 	public function for_current_page() {
 		$indexable = false;
 
-		switch ( true ) {
-			case $this->current_page->is_simple_page():
-				$indexable = $this->find_by_id_and_type( $this->current_page->get_simple_page_id(), 'post' );
+		$indexable_mapping = [
+			'search' => [
+				'match_callback'    => [ $this->current_page, 'is_search_result' ],
+				'creation_callback' => function() {
+					return $this->find_for_system_page( 'search-result' );
+				},
+			],
+			'static_home_page' => [
+				'match_callback'    => [ $this->current_page, 'is_home_static_page' ],
+				'creation_callback' => function() {
+					return $this->find_by_id_and_type( $this->current_page->get_front_page_id(), 'post' );
+				},
+			],
+			'home_page' => [
+				'match_callback'    => [ $this->current_page, 'is_home_posts_page' ],
+				'creation_callback' => function() {
+					return $this->find_for_home_page();
+				},
+			],
+			'post_type' => [
+				'match_callback'    => [ $this->current_page, 'is_simple_page' ],
+				'creation_callback' => function() {
+					return $this->find_by_id_and_type( $this->current_page->get_simple_page_id(), 'post' );
+				},
+			],
+			'term_archive' => [
+				'match_callback'    => [ $this->current_page, 'is_term_archive' ],
+				'creation_callback' => function() {
+					return $this->find_by_id_and_type( $this->current_page->get_term_id(), 'term' );
+				},
+			],
+			'post_type_archive' => [
+				'match_callback'    => [ $this->current_page, 'is_post_type_archive' ],
+				'creation_callback' => function() {
+					return $this->find_for_post_type_archive( $this->current_page->get_queried_post_type() );
+				},
+			],
+			'author_archive' => [
+				'match_callback'    => [ $this->current_page, 'is_author_archive' ],
+				'creation_callback' => function() {
+					return $this->find_by_id_and_type( $this->current_page->get_author_id(), 'user' );
+				},
+			],
+			'date_archive' => [
+				'match_callback'    => [ $this->current_page, 'is_date_archive' ],
+				'creation_callback' => function() {
+					return $this->find_for_date_archive();
+				},
+			],
+			'404' => [
+				'match_callback'    => [ $this->current_page, 'is_404' ],
+				'creation_callback' => function() {
+					return $this->find_for_system_page( '404' );
+				},
+			],
+		];
+
+		/**
+		 * Filter: Allow changing and reordering the indexable mapping.
+		 *
+		 * @api array $indexable_mapping The mapping.
+		 * @param Indexable_Repository $this Helper with logic for creating indexables.
+		 */
+		$indexable_mapping = \apply_filters( 'wpseo_frontend_indexable_mapping', $indexable_mapping, $this );
+
+		foreach ( $indexable_mapping as $indexable_map ) {
+			if ( $indexable_map['match_callback']() ) {
+				$indexable = $indexable_map['creation_callback']();
 				break;
-			case $this->current_page->is_home_static_page():
-				$indexable = $this->find_by_id_and_type( $this->current_page->get_front_page_id(), 'post' );
-				break;
-			case $this->current_page->is_home_posts_page():
-				$indexable = $this->find_for_home_page();
-				break;
-			case $this->current_page->is_term_archive():
-				$indexable = $this->find_by_id_and_type( $this->current_page->get_term_id(), 'term' );
-				break;
-			case $this->current_page->is_date_archive():
-				$indexable = $this->find_for_date_archive();
-				break;
-			case $this->current_page->is_search_result():
-				$indexable = $this->find_for_system_page( 'search-result' );
-				break;
-			case $this->current_page->is_post_type_archive():
-				$indexable = $this->find_for_post_type_archive( $this->current_page->get_queried_post_type() );
-				break;
-			case $this->current_page->is_author_archive():
-				$indexable = $this->find_by_id_and_type( $this->current_page->get_author_id(), 'user' );
-				break;
-			case $this->current_page->is_404():
-				$indexable = $this->find_for_system_page( '404' );
-				break;
+			}
 		}
 
 		if ( $indexable === false ) {


### PR DESCRIPTION
## Summary
This changeset standardises the order in which the type of the indexable page is determined. It also adds two filters, so developers can manipulate the order and logic with which the indexables are created far easier than is currently the case.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry: changelog:bugfix, changelog: enhancement

* Fixes a bug where no SEO title would be found when a user visits a post type archive filtered by a taxonomy term.
* Adds two filters: `wpseo_frontend_page_type_mapping` and `wpseo_frontend_indexable_mapping`. These filters allow developers to change the order and logic of the creation of indexables.

## Relevant technical choices:

* I've limited the changes to the methods that already exist with this logic. It seems overkill to seperate these checks out into different files.
* I've normalised the order of the checks of both functions. This _possibly_ fixes a similair issue when a custom search result page is used.
* I've prioritised the `term_archive` line over the `post_type_archive` line, as I think in most cases the term archive title will be more specific and valuable than the post archive title.
* `static_posts_page` seems to be missing from the `Indexable_Repository::for_current_page` method. It is unclear if this is intentional.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See the reproduction in #16436.


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #16436
