### PR TITLE
Fixes #18176. Adds url validation for images from content.

### DIFF
--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -72,7 +72,7 @@ class WPSEO_Content_Images {
 	 */
 	private function get_img_tag_source( $image ) {
 		preg_match( '`src=(["\'])(.*?)\1`', $image, $matches );
-		if ( isset( $matches[2] ) ) {
+		if ( isset( $matches[2] ) && filter_var( $matches[2], FILTER_VALIDATE_URL ) ) {
 			return $matches[2];
 		}
 		return false;

--- a/tests/unit/inc/content-images-test.php
+++ b/tests/unit/inc/content-images-test.php
@@ -39,17 +39,19 @@ class Content_Images_Test extends TestCase {
 	public function test_get_images_from_content() {
 
 		Monkey\Functions\expect( 'get_home_url' )
-			->andReturn( 'one.wordpress.test' );
+			->andReturn( 'https://one.wordpress.test' );
 
 		$external_image1      = 'https://example.com/media/first_image.jpg';
 		$external_image2      = 'https://example.com/media/second_image.jpg';
 		$non_attachment_image = \get_home_url() . '/wp-content/plugins/wordpress-seo/tests/integration/assets/yoast.png';
+		$data_uri_image       = 'data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7';
 
 		$post_content = '<p>This is a post. It has several images:</p>
 			<img src="' . $external_image1 . '"/>
 			<img src="' . $external_image2 . '"/>
 			<img src="' . $external_image2 . '"/>
 			<img src="' . $non_attachment_image . '"/>
+			<img src="' . $data_uri_image . '"/>
 			<img src=""/>
 			<p> That were all the images. Done! </p>
 			<p>End of post</p>';


### PR DESCRIPTION
## Summary
`WPSEO_Content_Images::get_img_tag_source` now checks if the found source url for an image is an URL. This should avoid an issue where data uri's where being duplicated into the Schema.org part of a page when no featured image is set.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry: changelog: bugfix

* Fixes a bug where data uri's would be considered for Schema.org content when no featured image is set. Props to [NielsdeBlaauw](https://github.com/NielsdeBlaauw).

## Relevant technical choices:

* Adjusted test to return a URI scheme, as `get_home_url` does in WordPress.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See reproduction in issue #18176


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [x] QA should use the same steps as above.


## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes #18176
