### PR TITLE
P1 1270 no label formfield a11y

### DIFF
--- a/packages/ui-library/src/components/checkbox-group/index.js
+++ b/packages/ui-library/src/components/checkbox-group/index.js
@@ -62,7 +62,7 @@ CheckboxGroup.propTypes = {
 	id: PropTypes.string.isRequired,
 	name: PropTypes.string.isRequired,
 	values: PropTypes.arrayOf( PropTypes.string ),
-	label: PropTypes.node,
+	label: PropTypes.node.isRequired,
 	options: PropTypes.arrayOf( PropTypes.shape( {
 		value: PropTypes.string.isRequired,
 		label: PropTypes.string.isRequired,
@@ -74,7 +74,6 @@ CheckboxGroup.propTypes = {
 CheckboxGroup.defaultProps = {
 	children: null,
 	values: [],
-	label: null,
 	className: "",
 };
 

--- a/packages/ui-library/src/components/checkbox-group/stories.js
+++ b/packages/ui-library/src/components/checkbox-group/stories.js
@@ -41,6 +41,7 @@ Factory.args = {
 		{ value: "3", label: "Option 3" },
 		{ value: "4", label: "Option 4" },
 	],
+	label: "A Checkbox Group",
 };
 
 export const WithLabelAndDescription = Template.bind();

--- a/packages/ui-library/src/components/radio-group/index.js
+++ b/packages/ui-library/src/components/radio-group/index.js
@@ -74,7 +74,7 @@ RadioGroup.propTypes = {
 	id: PropTypes.string.isRequired,
 	name: PropTypes.string.isRequired,
 	value: PropTypes.string.isRequired,
-	label: PropTypes.node,
+	label: PropTypes.node.isRequired,
 	options: PropTypes.arrayOf( PropTypes.shape( {
 		value: PropTypes.string.isRequired,
 		label: PropTypes.string.isRequired,
@@ -86,7 +86,6 @@ RadioGroup.propTypes = {
 
 RadioGroup.defaultProps = {
 	children: null,
-	label: null,
 	variant: "default",
 	className: "",
 };

--- a/packages/ui-library/src/components/radio-group/stories.js
+++ b/packages/ui-library/src/components/radio-group/stories.js
@@ -43,6 +43,7 @@ Factory.args = {
 		{ value: "3", label: "Option 3" },
 		{ value: "4", label: "Option 4" },
 	],
+	label: "A Radio Group",
 };
 
 export const Variants = ( args ) => (
@@ -57,6 +58,7 @@ export const Variants = ( args ) => (
 				{ value: "3", label: "Option 3" },
 				{ value: "4", label: "Option 4" },
 			] }
+			label="Default Radio Group"
 			onChange={ noop }
 		/>
 		<hr />
@@ -64,7 +66,7 @@ export const Variants = ( args ) => (
 			id="radio-group-2"
 			name="name-2"
 			value="2"
-			label="Radio group with a label"
+			label="Inline-block Radio Group"
 			options={ [
 				{ value: "1", label: "1" },
 				{ value: "2", label: "2" },

--- a/packages/ui-library/src/components/select-field/index.js
+++ b/packages/ui-library/src/components/select-field/index.js
@@ -54,7 +54,7 @@ SelectField.propTypes = {
 	id: PropTypes.string.isRequired,
 	name: PropTypes.string.isRequired,
 	value: PropTypes.string,
-	label: PropTypes.node,
+	label: PropTypes.node.isRequired,
 	options: PropTypes.arrayOf( PropTypes.shape( {
 		value: PropTypes.string.isRequired,
 		label: PropTypes.string.isRequired,
@@ -67,7 +67,6 @@ SelectField.propTypes = {
 SelectField.defaultProps = {
 	children: null,
 	value: undefined,
-	label: null,
 	error: null,
 	className: "",
 };

--- a/packages/ui-library/src/components/select-field/stories.js
+++ b/packages/ui-library/src/components/select-field/stories.js
@@ -44,6 +44,7 @@ Factory.args = {
 		{ value: "3", label: "Option 3" },
 		{ value: "4", label: "Option 4" },
 	],
+	label: "A Select Field",
 };
 
 export const WithLabelAndDescription = Template.bind( {} );

--- a/packages/ui-library/src/components/text-field/index.js
+++ b/packages/ui-library/src/components/text-field/index.js
@@ -54,14 +54,13 @@ const TextField = ( {
 TextField.propTypes = {
 	id: PropTypes.string.isRequired,
 	onChange: PropTypes.func.isRequired,
-	label: PropTypes.node,
+	label: PropTypes.node.isRequired,
 	className: PropTypes.string,
 	description: PropTypes.node,
 	error: PropTypes.node,
 };
 
 TextField.defaultProps = {
-	label: null,
 	className: "",
 	description: null,
 	error: null,

--- a/packages/ui-library/src/components/text-field/stories.js
+++ b/packages/ui-library/src/components/text-field/stories.js
@@ -20,6 +20,7 @@ export default {
 	args: {
 		id: "input-field",
 		onChange: noop,
+		label: "A Text Field",
 	},
 };
 

--- a/packages/ui-library/src/components/textarea-field/index.js
+++ b/packages/ui-library/src/components/textarea-field/index.js
@@ -51,14 +51,13 @@ const TextareaField = ( {
 
 TextareaField.propTypes = {
 	id: PropTypes.string.isRequired,
-	label: PropTypes.node,
+	label: PropTypes.node.isRequired,
 	className: PropTypes.string,
 	description: PropTypes.node,
 	error: PropTypes.node,
 };
 
 TextareaField.defaultProps = {
-	label: null,
 	className: "",
 	description: null,
 	error: null,

--- a/packages/ui-library/src/components/textarea-field/stories.js
+++ b/packages/ui-library/src/components/textarea-field/stories.js
@@ -17,6 +17,7 @@ export default {
 	},
 	args: {
 		id: "textarea-field",
+		label: "A Textarea Field",
 	},
 };
 

--- a/packages/ui-library/src/components/toggle-field/index.js
+++ b/packages/ui-library/src/components/toggle-field/index.js
@@ -38,7 +38,7 @@ const ToggleField = ( {
 
 ToggleField.propTypes = {
 	children: PropTypes.node,
-	label: PropTypes.node,
+	label: PropTypes.node.isRequired,
 	checked: PropTypes.bool.isRequired,
 	onChange: PropTypes.func.isRequired,
 	className: PropTypes.string,
@@ -46,7 +46,6 @@ ToggleField.propTypes = {
 
 ToggleField.defaultProps = {
 	children: null,
-	label: null,
 	className: "",
 };
 

--- a/packages/ui-library/src/components/toggle-field/stories.js
+++ b/packages/ui-library/src/components/toggle-field/stories.js
@@ -33,6 +33,10 @@ Factory.parameters = {
 	controls: { disable: false },
 };
 
+Factory.args = {
+	label: "A Toggle Field",
+};
+
 export const WithLabelAndDescription = Template.bind( {} );
 WithLabelAndDescription.args = {
 	name: "name-1",

--- a/packages/ui-library/src/elements/checkbox/index.js
+++ b/packages/ui-library/src/elements/checkbox/index.js
@@ -42,12 +42,11 @@ Checkbox.propTypes = {
 	id: PropTypes.string.isRequired,
 	name: PropTypes.string.isRequired,
 	value: PropTypes.string.isRequired,
-	label: PropTypes.node,
+	label: PropTypes.node.isRequired,
 	className: PropTypes.string,
 };
 
 Checkbox.defaultProps = {
-	label: null,
 	className: "",
 };
 

--- a/packages/ui-library/src/elements/radio/index.js
+++ b/packages/ui-library/src/elements/radio/index.js
@@ -80,13 +80,12 @@ Radio.propTypes = {
 	name: PropTypes.string.isRequired,
 	id: PropTypes.string.isRequired,
 	value: PropTypes.string.isRequired,
-	label: PropTypes.node,
+	label: PropTypes.node.isRequired,
 	variant: PropTypes.oneOf( Object.keys( classNameMap.variant ) ),
 	className: PropTypes.string,
 };
 
 Radio.defaultProps = {
-	label: null,
 	variant: "default",
 	className: "",
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* [UI-Library] Makes sure that users of a screenreader don't potentially miss context on certain Input elements

## Summary

All Form field elements should have a Label for screen reader users. This PR ensures that by making the Label required on those Components.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/ui-library] All Form field elements should have a label for screen reader users. The `label` prop is now required.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open the UI Library Storybook
* Verify the following for all Form elements
    * The Label is required (red asterisk in the Factory)
    * Alle examples have a Label


### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release 
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]` and I have added test instructions for Shopify.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.

Fixes P1-1270